### PR TITLE
Detect nested tmux in connect_to_agent and add is_nested_tmux_allowed config

### DIFF
--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -183,15 +183,15 @@ def default_connect_cli_opts() -> ConnectCliOptions:
 
 @pytest.fixture
 def intercepted_execvp_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[str]]]:
-    """Intercept os.execvp in connect_to_agent and return the captured calls.
+    """Intercept os.execvpe in connect_to_agent and return the captured calls.
 
-    os.execvp replaces the current process, making it impossible to test
+    os.execvpe replaces the current process, making it impossible to test
     CLI-level connect flows without interception. This fixture uses pytest
     monkeypatch to replace it with a simple recorder.
     """
     calls: list[tuple[str, list[str]]] = []
     monkeypatch.setattr(
-        "imbue.mngr.api.connect.os.execvp",
-        lambda program, args: calls.append((program, args)),
+        "imbue.mngr.api.connect.os.execvpe",
+        lambda program, args, env: calls.append((program, args)),
     )
     return calls

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -433,6 +433,10 @@ class MngrConfig(FrozenModel):
         "When False, raises an error if the agent is not already installed on the remote host. "
         "Defaults to True (allowed).",
     )
+    is_nested_tmux_allowed: bool = Field(
+        default=False,
+        description="Allow attaching to tmux sessions from within an existing tmux session by unsetting $TMUX",
+    )
     is_allowed_in_pytest: bool = Field(
         default=True,
         description="Set this to False to prevent loading this config in pytest runs",
@@ -546,6 +550,11 @@ class MngrConfig(FrozenModel):
         if override.is_remote_agent_installation_allowed is not None:
             is_remote_agent_installation_allowed = override.is_remote_agent_installation_allowed
 
+        # Merge is_nested_tmux_allowed (scalar - override wins if not None)
+        merged_is_nested_tmux_allowed = self.is_nested_tmux_allowed
+        if override.is_nested_tmux_allowed is not None:
+            merged_is_nested_tmux_allowed = override.is_nested_tmux_allowed
+
         is_allowed_in_pytest = self.is_allowed_in_pytest
         if override.is_allowed_in_pytest is not None:
             is_allowed_in_pytest = override.is_allowed_in_pytest
@@ -570,6 +579,7 @@ class MngrConfig(FrozenModel):
             pre_command_scripts=merged_pre_command_scripts,
             is_remote_agent_installation_allowed=is_remote_agent_installation_allowed,
             logging=merged_logging,
+            is_nested_tmux_allowed=merged_is_nested_tmux_allowed,
             is_allowed_in_pytest=is_allowed_in_pytest,
         )
 

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -174,6 +174,7 @@ def load_config(
     if config.logging is not None:
         config_dict["logging"] = config.logging
 
+    config_dict["is_nested_tmux_allowed"] = config.is_nested_tmux_allowed
     config_dict["is_allowed_in_pytest"] = config.is_allowed_in_pytest
     config_dict["pre_command_scripts"] = config.pre_command_scripts
 
@@ -496,6 +497,7 @@ def _parse_config(raw: dict[str, Any]) -> MngrConfig:
         _parse_create_templates(raw.pop("create_templates", {})) if "create_templates" in raw else {}
     )
     kwargs["logging"] = _parse_logging_config(raw.pop("logging", {})) if "logging" in raw else None
+    kwargs["is_nested_tmux_allowed"] = raw.pop("is_nested_tmux_allowed", None) if "is_nested_tmux_allowed" in raw else None
     kwargs["is_allowed_in_pytest"] = raw.pop("is_allowed_in_pytest", {}) if "is_allowed_in_pytest" in raw else None
     kwargs["pre_command_scripts"] = raw.pop("pre_command_scripts", {}) if "pre_command_scripts" in raw else None
 

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -332,6 +332,21 @@ class UnknownBackendError(ConfigError):
     """Unknown provider backend."""
 
 
+class NestedTmuxError(MngrError):
+    """Cannot attach to tmux session from inside another tmux session."""
+
+    def __init__(self, session_name: str) -> None:
+        self.session_name = session_name
+        super().__init__(
+            f"You're already in a tmux session. You can attach to the agent with:\n"
+            f"  tmux attach -t {session_name}"
+        )
+        self.user_help_text = (
+            "To allow mngr to attach automatically inside tmux, run:\n"
+            "  mngr config set --scope user is_nested_tmux_allowed true"
+        )
+
+
 class UnisonNotInstalledError(MngrError):
     """Raised when unison is not installed but is required for pair mode."""
 


### PR DESCRIPTION
When running mngr connect from within an existing tmux session, tmux refuses nested attachment by default. This change detects $TMUX before attempting tmux attach for local agents and raises a NestedTmuxError with a helpful message showing the exact tmux attach command. A new is_nested_tmux_allowed config field allows users to opt in to automatic nested attachment by unsetting $TMUX via os.execvpe.