### PR TITLE
Query user's default-command via tmux show-option instead of hardcoding bash

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/test_host.py
+++ b/libs/mngr/imbue/mngr/hosts/test_host.py
@@ -1963,8 +1963,8 @@ def test_new_tmux_window_inherits_env_vars(
 ) -> None:
     """Test that new tmux windows created by the user also have env vars.
 
-    This verifies that the default-command is set on the tmux session so that
-    any new window/pane created by the user will automatically source the env files.
+    This verifies that the default-command sources env files so that any new
+    window/pane created by the user will have the agent's env vars available.
     """
     config = MngrConfig(default_host_dir=temp_host_dir, prefix=mngr_test_prefix)
     mngr_ctx = MngrContext(config=config, pm=plugin_manager, profile_dir=temp_profile_dir)
@@ -1998,7 +1998,7 @@ def test_new_tmux_window_inherits_env_vars(
 
     try:
         # Create a new window in the session (simulating what a user would do)
-        # This window should inherit the default-command which sources env files
+        # This window should inherit env vars via tmux set-environment
         subprocess.run(
             ["tmux", "new-window", "-t", session_name, "-n", "user-window"],
             check=True,


### PR DESCRIPTION
Previously, default-command was set on the tmux session to always exec bash. This forced bash on every new window the user created, overriding their configured shell.

Now, after creating the session (which loads ~/.tmux.conf), the user's original default-command is queried via tmux show-option -A and saved as MNGR_SAVED_DEFAULT_TMUX_COMMAND in the tmux session environment. The env shell command uses ${MNGR_SAVED_DEFAULT_TMUX_COMMAND:-bash}, so the initial agent window (created before the variable exists) gets bash, while user-created windows and the default-command get the user's shell.