### PR TITLE
code-guardian: inconsistency report 2026-02-14-22-27-57

### DIFF
--- a/_tasks/inconsistencies/2026-02-14-22-27-57.md
+++ b/_tasks/inconsistencies/2026-02-14-22-27-57.md
@@ -1,0 +1,165 @@
+# Inconsistencies identified on 2026-02-14-22-27-57
+
+## 1. Constants missing `Final` type annotation (inconsistent with other constants)
+
+Description: The style guide requires constants to have `Final` type annotations. Approximately half the constants in the mngr library follow this rule, while the other half do not. Constants WITH `Final` appear in files like `utils/testing.py`, `utils/editor.py`, `cli/list.py`, `agents/base_agent.py`, `providers/local/instance.py`, and parts of `providers/modal/instance.py`. Constants WITHOUT `Final` appear in:
+
+- `utils/logging.py:29-34` -- `WARNING_COLOR`, `ERROR_COLOR`, `BUILD_COLOR`, `DEBUG_COLOR`, `TRACE_COLOR`, `RESET_COLOR` (6 constants lack `Final`, while 3 others in the same file have it)
+- `config/data_types.py:34-36` -- `USER_ID_FILENAME`, `PROFILES_DIRNAME`, `ROOT_CONFIG_FILENAME`
+- `primitives.py:222` -- `LOCAL_PROVIDER_NAME`
+- `providers/modal/backend.py:39-41` -- `MODAL_BACKEND_NAME`, `STATE_VOLUME_SUFFIX`, `MODAL_NAME_MAX_LENGTH`
+- `providers/modal/instance.py:98-102` -- `CONTAINER_SSH_PORT`, `DEFAULT_SANDBOX_TIMEOUT`, `SSH_CONNECT_TIMEOUT` (while 3 other constants in the same file DO have `Final`)
+- `providers/modal/constants.py:3` -- `MODAL_TEST_APP_PREFIX`
+- `providers/modal/routes/snapshot_and_shutdown.py:47` -- `VOLUME_NAME`
+- `providers/local/backend.py:14` -- `LOCAL_BACKEND_NAME`
+- `providers/ssh/backend.py:29` -- `SSH_BACKEND_NAME`
+- `cli/common_opts.py:33` -- `COMMON_OPTIONS_GROUP_NAME`
+- `main.py:266` -- `PLUGIN_COMMANDS`
+
+The inconsistency is especially stark within individual files (e.g., `utils/logging.py` and `providers/modal/instance.py`) where some constants have `Final` and others do not.
+
+Recommendation: Add `Final` type annotations to all module-level constants. This is a mechanical fix that can be done file-by-file.
+
+Decision: Accept
+
+## 2. `logger.info` used in library/provider code instead of `logger.debug`
+
+Description: The style guide says "Reserve `logger.info` for CLI/user-facing code. Library and API code should use `logger.debug`." However, `logger.info` is used extensively in provider and agent implementation code:
+
+- `providers/modal/instance.py:1306,1432,1548,1566,1608,1941,2011` -- 7 instances in Modal provider (creating hosts, stopping sandboxes, snapshot operations)
+- `providers/modal/backend.py:67` -- "Created Modal environment"
+- `agents/default_plugins/claude_agent.py:526,528,533,557,565` -- 5 instances in claude agent setup (installing claude, transferring settings/credentials)
+
+These are library internals, not CLI code. Meanwhile, the CLI modules in `cli/` correctly use `logger.info` for user-facing output, showing the convention is understood but not applied uniformly.
+
+Recommendation: Change `logger.info` to `logger.debug` in all provider and agent implementation code. The CLI layer should be the only place using `logger.info`.
+
+Decision: Accept
+
+## 3. Built-in `Exception` raised directly instead of library-specific error classes
+
+Description: The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)." Three instances raise bare `Exception`:
+
+- `providers/modal/backend.py:452` -- `raise Exception("Host is not an instance of Host class")`
+- `providers/modal/instance.py:607` -- `raise Exception(f"Host record not found on volume for {host_id}")`
+- `conftest.py:238` -- `raise Exception("No active Modal token found...")`
+
+The codebase has a well-defined error hierarchy in `errors.py` with `BaseMngrError` and specific subclasses. These three sites should use appropriate error classes from that hierarchy (or new ones if needed).
+
+Recommendation: Replace each bare `Exception` with an appropriate `BaseMngrError` subclass. For `conftest.py`, a test configuration error class may be appropriate, or a simple `BaseMngrError` subclass.
+
+Decision: Accept
+
+## 4. `NamedTuple` used instead of `FrozenModel`
+
+Description: The style guide says "Never use dataclasses or named tuples." Two classes use `NamedTuple`:
+
+- `utils/logging.py:232` -- `class BufferedMessage(NamedTuple)` with fields `formatted_message: str`, `is_stderr: bool`
+- `conftest.py:537` -- `class ModalSubprocessTestEnv(NamedTuple)` with fields `env: dict[str, str]`, `prefix: str`, `host_dir: Path`
+
+The rest of the codebase consistently uses `FrozenModel` for immutable data objects.
+
+Recommendation: Convert both classes to inherit from `FrozenModel` instead of `NamedTuple`.
+
+Decision: Accept
+
+## 5. Mutable types used for function input parameters instead of immutable abstract types
+
+Description: The style guide says "Always use immutable abstract types for function input parameters: `Sequence[T]` instead of `list[T]`, `Mapping[K, V]` instead of `dict[K, V]`, `AbstractSet[T]` instead of `set[T]`." Several functions violate this:
+
+- `utils/testing.py:357` -- `trusted_paths: list[Path]` (should be `Sequence[Path]`)
+- `imbue_common/enums.py:12` -- `last_values: list[str]` (should be `Sequence[str]`)
+- `imbue_common/ratchet_testing/ratchets.py:53` -- `visited: set[int]` (should be `AbstractSet[int]`)
+- `imbue_common/ratchet_testing/ratchets.py:112` -- `class_bases: dict[str, list[str]]` (should be `Mapping[str, Sequence[str]]`)
+- `conftest.py:449` -- `sessions: list[str]` (should be `Sequence[str]`)
+- `conftest.py:679` -- `apps: list[tuple[str, str]]` (should be `Sequence[tuple[str, str]]`)
+- `conftest.py:738` -- `volume_names: list[str]` (should be `Sequence[str]`)
+- `conftest.py:797` -- `environment_names: list[str]` (should be `Sequence[str]`)
+
+Meanwhile, much of the codebase correctly uses `Sequence`, `Mapping`, and `AbstractSet` for inputs, making these violations inconsistent.
+
+Recommendation: Replace mutable input parameter types with their immutable abstract equivalents.
+
+Decision: Accept
+
+## 6. `async def` used in Modal log utility
+
+Description: The style guide says "Never use `async`/`asyncio`." One function uses `async def`:
+
+- `providers/modal/log_utils.py:146` -- `async def put_log_content(self, log):`
+
+This appears to be required by the Modal SDK's interface contract (the method is on a class that implements a Modal callback protocol), so it may be unavoidable. However, it is inconsistent with the rest of the codebase which is entirely synchronous.
+
+Recommendation: If the Modal SDK requires this method to be async, document this with a comment explaining the exception. If it does not need to be async, convert it to a synchronous method.
+
+Decision: Accept
+
+## 7. `ValueError` raised directly in `concurrency_group` library
+
+Description: The style guide says "All exceptions should inherit from a library-specific base class." The concurrency_group library has its own `ConcurrencyGroupError` base class in `errors.py`, but one location raises `ValueError` directly:
+
+- `concurrency_group/concurrency_group.py:636` -- `raise ValueError("The exception group does not contain exactly one exception.")`
+
+Note: The `ValueError` instances in `imbue_common/primitives.py` (lines 14, 35, 55, 75, 95) are in primitive type constructors performing validation, which is a reasonable exception since these are low-level type wrappers where `ValueError` is the standard Python convention. The `concurrency_group` case is different because it's domain logic with an available error base class.
+
+Recommendation: Replace the `ValueError` in `concurrency_group.py:636` with a `ConcurrencyGroupError` subclass.
+
+Decision: Accept
+
+## 8. `TYPE_CHECKING` guard used in `interfaces/agent.py`
+
+Description: The style guide says "Avoid using the TYPE_CHECKING guard. Do not add it to files that do not already contain it." One file uses it:
+
+- `interfaces/agent.py:30` -- `if TYPE_CHECKING:` guard importing `CreateAgentOptions` and `OnlineHostInterface`
+
+The style guide notes this is "generally a sign of bad architecture that should be fixed some other way." No other file in the codebase uses `TYPE_CHECKING`.
+
+Recommendation: Investigate whether the circular import that necessitates `TYPE_CHECKING` can be resolved through architectural changes (e.g., moving the type to a shared data_types module, or restructuring the import graph).
+
+Decision: Accept
+
+## 9. Inconsistent dictionary variable naming (not using `value_by_key` pattern)
+
+Description: The style guide says dictionaries should use the `value_by_key` naming pattern. Many dictionary variables use generic names like `data`, `tags`, `params`, `options`, or `context` instead:
+
+- `interfaces/data_types.py:291` -- `user_tags: dict[str, str]` (should be `user_tag_value_by_key` or similar)
+- `interfaces/data_types.py:335,389` -- `tags: dict[str, str]`
+- `api/data_types.py:169` -- `tags: dict[str, str]`
+- `providers/modal/instance.py:181,195,205` -- `tags` and `user_tags` as `dict[str, str]`
+- `config/data_types.py:377` -- `options: dict[str, Any]`
+- `cli/common_opts.py:289` -- `params: dict[str, Any]`
+- `agents/base_agent.py:96,667` -- `data: dict[str, Any]`
+- `hosts/host.py:644` -- `data: dict[str, Any]`
+- `interfaces/host.py:274` -- `data: dict[str, Any]`
+- `interfaces/agent.py:217` -- `data: dict[str, Any]`
+
+Note: The `tags` and `user_tags` naming is widespread and consistently used across the codebase for tag dictionaries. Renaming all of these to `tag_value_by_tag_key` would be verbose and potentially reduce readability. This may be an acceptable deviation for well-understood domain concepts like "tags."
+
+Recommendation: Consider renaming the most generic cases (`data`, `params`, `options`, `context`) to follow the `value_by_key` pattern. For `tags`/`user_tags`, evaluate whether the readability tradeoff justifies an exception.
+
+Decision: Accept
+
+## 10. Default arguments in non-CLI/non-API functions
+
+Description: The style guide says "Avoid using default arguments in function and method signatures. Require callers to explicitly pass all parameters." While CLI entrypoints are exempt (per `non_issues.md`), default arguments are used in many internal functions:
+
+- `utils/logging.py:328` -- `buffer_size: int = DEFAULT_BUFFER_SIZE`
+- `utils/logging.py:409` -- `clear_screen: bool = True`
+- `hosts/host.py:388` -- `encoding: str = "utf-8"`
+- `hosts/host.py:528` -- `timeout_seconds: float = 300.0`
+- `interfaces/host.py:255` -- `timeout_seconds: float = 30.0`
+- `interfaces/host.py:435` -- `timeout_seconds: float = 5.0`
+- `providers/modal/instance.py:439` -- `use_cache: bool = True`
+- `providers/modal/instance.py:733` -- `timeout_seconds: float = SSH_CONNECT_TIMEOUT`
+- `agents/base_agent.py:423` -- `count: int = 1`
+- `errors.py:165` -- `auth_help: str | None = None`
+- `imbue_common/logging.py:17` -- `level: str = "INFO"`
+- `imbue_common/ids.py:20` -- `value: str | None = None`
+- `concurrency_group/event_utils.py:42,61,86` -- various default arguments
+- `concurrency_group/local_process.py:77,81,129` -- various default arguments
+
+This pattern is widespread enough that it may reflect an evolved convention not yet captured in the style guide. However, it creates an inconsistency where some callers pass parameters explicitly and others rely on defaults.
+
+Recommendation: This is a large-scale pattern that would require significant refactoring. Consider either updating the style guide to clarify which cases are acceptable (e.g., timeout parameters, optional callbacks) or systematically removing defaults and requiring explicit parameter passing.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 10 code-level inconsistencies in the codebase, ordered by importance
- Top issues: constants missing `Final` annotations (~22 instances), `logger.info` in library code (~15 instances), bare `Exception` raises (3 instances)
- Also found: `NamedTuple` usage (should be `FrozenModel`), mutable input param types, `async def` in log_utils, `ValueError` in concurrency_group, `TYPE_CHECKING` guard usage, dict naming, and widespread default arguments

## Test plan

- [ ] Review each identified inconsistency against the style guide
- [ ] Verify no items overlap with existing FIXMEs or non_issues.md entries
- [ ] Prioritize fixes based on severity ranking in the report

Generated with [Claude Code](https://claude.com/claude-code)