### PR TITLE
code-guardian: inconsistency report 2026-02-14-23-35-17

### DIFF
--- a/_tasks/inconsistencies/2026-02-14-23-35-17.md
+++ b/_tasks/inconsistencies/2026-02-14-23-35-17.md
@@ -1,0 +1,184 @@
+# Inconsistencies identified on 2026-02-14-23-35-17
+
+## 1. claude_web_view app does not follow project conventions
+
+Description: The `apps/claude_web_view` package has numerous style guide violations concentrated in a single package, suggesting it was written without reference to the project style guide. Specific issues:
+
+- **Relative imports** used throughout instead of absolute imports (all files: `cli.py:12`, `parser.py:8-14`, `server.py:17-18`, `watcher.py:10`)
+- **BaseModel instead of FrozenModel**: 9 data model classes in `models.py` (lines 20-93) and 1 in `server.py` (line 21) inherit from `BaseModel` directly instead of `FrozenModel`
+- **Enum uses `str, Enum` instead of `UpperCaseStrEnum`**: `MessageRole` in `models.py:11` uses `(str, Enum)` with explicit string values instead of `UpperCaseStrEnum` with `auto()`
+- **async/asyncio used extensively**: `watcher.py` and `server.py` use async/await throughout (style guide says "Never use async or asyncio")
+- **Standard logging module** imported in `cli.py:4` instead of loguru
+- **`time.sleep()`** used in `cli.py:116` (style guide says "NEVER use time.sleep()")
+- **Module-level docstrings** on all 7 .py files (style guide says "Never create docstrings for modules")
+- **Data models in `models.py`** instead of `data_types.py` (style guide says frozen objects should be in `data_types.py`)
+- **Code in `__init__.py`**: `__init__.py` contains a module docstring
+
+Recommendation: Refactor the entire package to conform to project conventions. This is likely the highest-impact single change since it addresses ~10 different categories of violations in one package.
+
+Decision: Accept
+
+## 2. If/elif chains used on enum values instead of match statements
+
+Description: The style guide requires "For enums, always use match statements" with `assert_never` for exhaustiveness checking. Two locations use if/elif chains with `SwitchError` instead:
+
+- `libs/mngr/imbue/mngr/hosts/common.py:35-83`: `get_activity_sources_for_idle_mode()` uses a 9-branch if/elif chain on `IdleMode` enum with `SwitchError` in else
+- `libs/mngr/imbue/mngr/hosts/host.py:891-896`: `create_agent_work_dir()` uses an if/elif chain on `WorkDirCopyMode` enum with `SwitchError` in else
+
+Recommendation: Convert both to match statements with `assert_never` in the default case. This enables the type checker to catch missing cases when new enum values are added.
+
+Decision: Accept
+
+## 3. NamedTuple used instead of FrozenModel
+
+Description: The style guide explicitly says "Never use dataclasses or named tuples". Two locations use `NamedTuple`:
+
+- `libs/mngr/imbue/mngr/utils/logging.py:232-236`: `BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`
+- `libs/mngr/imbue/mngr/conftest.py:537-542`: `ModalSubprocessTestEnv(NamedTuple)` with fields `env`, `prefix`, `host_dir`
+
+Recommendation: Convert `BufferedMessage` to a `FrozenModel`. The conftest.py usage is in test infrastructure so is lower priority but should also be converted.
+
+Decision: Accept
+
+## 4. Mutable types used for function input parameters instead of immutable abstract types
+
+Description: The style guide requires function inputs to use immutable abstract types (`Sequence` instead of `list`, `Mapping` instead of `dict`). This pattern is violated widely across the codebase, particularly in:
+
+- `libs/mngr/imbue/mngr/cli/config.py`: multiple functions take `dict[str, Any]` params (lines 104, 183, 821)
+- `libs/mngr/imbue/mngr/cli/connect.py`: `_run_agent_selector` and `select_agent_interactively` take `list[AgentInfo]` (lines 232, 321)
+- `libs/mngr/imbue/mngr/cli/list.py`: multiple functions take `list[AgentInfo]` (lines 616, 639, 768)
+- `libs/mngr/imbue/mngr/config/loader.py`: many config parsing functions take `dict[str, Any]` (lines 341, 438, 447, 465, 483)
+- `libs/mngr/imbue/mngr/agents/base_agent.py`: methods take `dict[str, Any]` (lines 96, 667)
+- `libs/mngr/imbue/mngr/interfaces/host.py:274` and `interfaces/agent.py:217`: abstract methods take `dict[str, Any]`
+
+This is widespread (30+ violations) and particularly impactful in interface/abstract method signatures, since all implementations inherit the mutable parameter types.
+
+Recommendation: Prioritize fixing interface and abstract method signatures first (since they propagate to all implementations), then address CLI and config parsing functions. Use `Sequence[T]` for list params and `Mapping[K, V]` for dict params.
+
+Decision: Accept
+
+## 5. FrozenModel classes defined outside of data_types.py
+
+Description: The style guide says "Frozen objects should be contained in a file named `data_types.py` at the root of the package." Many FrozenModel classes are scattered across other files:
+
+- `libs/mngr/imbue/mngr/hosts/host.py:81`: `HostLocation(FrozenModel)`
+- `libs/mngr/imbue/mngr/api/find.py`: `ParsedSourceLocation` (line 35), `AgentMatch` (line 405)
+- `libs/mngr/imbue/mngr/api/list.py`: `AgentInfo` (line 51), `ErrorInfo` (line 81)
+- `libs/mngr/imbue/mngr/api/pair.py:35`: `GitSyncAction(FrozenModel)`
+- `libs/mngr/imbue/mngr/api/sync.py`: `SyncFilesResult` (line 79), `SyncGitResult` (line 105)
+- `libs/mngr/imbue/mngr/cli/common_opts.py:40`: `CommonCliOptions(FrozenModel)`
+- `libs/mngr/imbue/mngr/cli/create.py:1422`: `ParsedSourceString(FrozenModel)`
+- `libs/mngr/imbue/mngr/cli/help_formatter.py:21`: `CommandHelpMetadata(FrozenModel)`
+- `libs/mngr/imbue/mngr/cli/issue_reporting.py:32`: `ExistingIssue(FrozenModel)`
+- `libs/mngr/imbue/mngr/interfaces/host.py`: 7 FrozenModel classes (lines 449-657)
+- `libs/mngr/imbue/mngr/interfaces/agent.py:35`: `AgentStatus(FrozenModel)`
+- `libs/mngr/imbue/mngr/agents/agent_registry.py:114`: `ResolvedAgentType(FrozenModel)`
+- `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:33`: `FinishedProcess(FrozenModel)`
+
+Recommendation: Move these classes to the appropriate `data_types.py` file for each package/subpackage. For the `interfaces/host.py` FrozenModel classes (options classes), consider whether they belong in `interfaces/data_types.py` or the top-level `data_types.py`.
+
+Decision: Accept
+
+## 6. Module-level docstrings present in many files
+
+Description: The style guide says "Never create docstrings for modules." 18 non-test source files have module-level docstrings:
+
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1`
+- `libs/mngr/imbue/mngr/providers/modal/ssh_utils.py:1`
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh/backend.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh/instance.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh_host_setup.py:1`
+- `libs/mngr/imbue/mngr/cli/watch_mode.py:1`
+- `libs/mngr/imbue/mngr/cli/agent_utils.py:1`
+- `libs/mngr/imbue/mngr/api/sync.py:1`
+- `libs/mngr_opencode/imbue/mngr_opencode/plugin.py:1`
+- All 7 files in `apps/claude_web_view/`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:1`
+- `apps/sculptor_desktop/imbue/sculptor_desktop/main.py:1`
+
+Recommendation: Remove all module-level docstrings. If the information is important, convert it to a block comment at the top of the file (after imports).
+
+Decision: Accept
+
+## 7. Direct built-in exceptions raised instead of package-specific error classes
+
+Description: The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)." Several locations raise `ValueError` or `Exception` directly:
+
+- `libs/imbue_common/imbue/imbue_common/primitives.py`: 5 instances of `raise ValueError(...)` in `NonEmptyStr.__new__` (line 14), `NonNegativeInt.__new__` (line 35), `PositiveInt.__new__` (line 55), `NonNegativeFloat.__new__` (line 75), `PositiveFloat.__new__` (line 95)
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636`: `raise ValueError("The exception group does not contain exactly one exception.")`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:607`: `raise Exception(f"Host record not found on volume for {host_id}")`
+
+Note that `primitives.py` already has `InvalidProbabilityError` as a proper custom error class for `Probability`, making the `ValueError` usage in the other primitive classes inconsistent even within the same file.
+
+Recommendation: Create package-specific error classes for each primitive validator (following the existing `InvalidProbabilityError` pattern). Replace the bare `Exception` in `instance.py` with a proper `MngrError` subclass.
+
+Decision: Accept
+
+## 8. logger.info used in library/provider code instead of logger.debug
+
+Description: The style guide says "Reserve logger.info for CLI/user-facing code. Library and API code should use logger.debug for normal operations." The Modal provider uses `logger.info` for internal operations:
+
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1306`: `logger.info("Creating host {} in {} ...", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1432`: `logger.info("Stopping (terminating) Modal sandbox: {}", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1548`: `logger.info("Using most recent snapshot for restart", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1566`: `logger.info("Restoring Modal sandbox from snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1608`: `logger.info("Created sandbox from snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1941`: `logger.info("Created snapshot: id={}, name={}", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:2011`: `logger.info("Deleted snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/backend.py:67`: `logger.info("Created Modal environment: {}", ...)`
+
+Recommendation: Change these to `logger.debug` or wrap them with `log_span` for consistency with the rest of the provider code.
+
+Decision: Accept
+
+## 9. Global keyword used for mutable state management
+
+Description: The style guide says "Avoid using the global keyword. Instead, pass all state explicitly through from the top level of the program."
+
+- `apps/sculptor_web/imbue/sculptor_web/main.py:151,162`: `global _poll_thread` used to manage a background polling thread
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:1225,1679`: `global _github_repo` used for GitHub repository detection
+
+Recommendation: Refactor to pass state explicitly. For `sculptor_web`, the polling thread could be managed through an instance variable on a service class. For the contrib project, the `_github_repo` could be passed as a function parameter.
+
+Decision: Accept
+
+## 10. Boolean field names missing `is_` prefix on data models
+
+Description: The style guide says "Always prefix booleans with `is_`" (with an exemption for CLI options per non_issues.md). Several FrozenModel/MutableModel data classes have boolean fields without the prefix:
+
+- `apps/sculptor_web/imbue/sculptor_web/data_types.py:33`: `start_on_boot: bool` (should be `is_start_on_boot`)
+- `libs/mngr/imbue/mngr/api/data_types.py:281`: `create_work_dir: bool` (should be `is_create_work_dir`)
+- `libs/mngr/imbue/mngr/config/data_types.py:242`: `enabled: bool` (should be `is_enabled`)
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:173`: `success: bool` (should be `is_success`)
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:72`: `check_installation: bool` (should be `is_check_installation`)
+
+Recommendation: Rename these fields to use the `is_` prefix. Note that `start_on_boot` appears in both `sculptor_web` and `mngr/api/list.py`, so the rename should be coordinated.
+
+Decision: Accept
+
+## 11. Standard logging module used instead of loguru
+
+Description: The style guide says "Always use loguru for logging." Two non-script source files import the standard `logging` module:
+
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:4`: `import logging` used for `logging.getLogger()`
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:15`: `import logging` used for log output
+
+Note: `libs/mngr/imbue/mngr/utils/logging.py` also imports `logging` but this is a legitimate use case for suppressing third-party library warnings via the standard library's logger interface.
+
+Recommendation: Replace with loguru in both files.
+
+Decision: Accept
+
+## 12. Dictionary fields not following value_by_key naming convention
+
+Description: The style guide says "Always use `value_by_key` for dictionaries and mappings." Several FrozenModel fields use generic names instead:
+
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:277`: `plugin: dict[str, dict[str, Any]]` (should be `plugin_config_by_plugin_name` or similar)
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:335,389`: `tags: dict[str, str]` (should be `tag_value_by_tag_name`)
+- `libs/mngr/imbue/mngr/api/data_types.py:169`: `tags: dict[str, str]`
+- `apps/sculptor_web/imbue/sculptor_web/data_types.py:43`: `plugin: dict[str, Any]`
+
+Recommendation: Rename these fields to follow the `value_by_key` pattern.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Systematic code-level inconsistency audit of the codebase, identifying 12 categories of style guide violations ordered by importance
- Key findings include the `claude_web_view` app not following project conventions (relative imports, BaseModel, async, standard logging), if/elif chains on enums instead of match statements, NamedTuple usage, and mutable input parameter types
- Report written to `_tasks/inconsistencies/2026-02-14-23-35-17.md`

## Categories identified (by importance)

1. claude_web_view app wholesale convention violations (~10 categories)
2. If/elif on enum values instead of match statements (2 locations)
3. NamedTuple usage instead of FrozenModel (2 locations)
4. Mutable types for function input parameters (30+ violations)
5. FrozenModel classes outside data_types.py (30+ classes)
6. Module-level docstrings (18 files)
7. Direct built-in exception raises (7 locations)
8. logger.info in library/provider code (8 locations)
9. Global keyword usage (4 locations)
10. Boolean fields missing is_ prefix (5 locations)
11. Standard logging module instead of loguru (2 files)
12. Dictionary fields not following value_by_key convention (5 locations)

## Test plan

- [ ] Review report for accuracy and prioritization
- [ ] Verify no issues overlap with existing FIXMEs or non_issues.md entries

Generated with [Claude Code](https://claude.com/claude-code)