### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-15-01-01-14.md
+++ b/_tasks/inconsistencies/2026-02-15-01-01-14.md
@@ -1,0 +1,127 @@
+# Inconsistencies identified on 2026-02-15-01-01-14
+
+## 1. `claude_web_view` app systematically violates the project style guide
+
+Description: The entire `apps/claude_web_view` package deviates from nearly every convention in the style guide. This is the single largest source of inconsistency in the codebase:
+
+- **Relative imports** (style guide: always use absolute imports): `apps/claude_web_view/imbue/claude_web_view/server.py:17-18`, `parser.py:8-14`, `watcher.py:10`, `cli.py:12` all use `from .module import ...` instead of absolute imports.
+- **async/asyncio usage** (style guide: never use `async` or `asyncio`): `server.py` and `watcher.py` are built entirely around async patterns (`asyncio.Queue`, `async def`, `await`, `asynccontextmanager`, etc.).
+- **`BaseModel` instead of `FrozenModel`** (style guide: frozen objects must inherit from `FrozenModel`): `models.py` defines 10 classes all inheriting from `BaseModel` directly (e.g., `TextBlock`, `ParsedMessage`, `SessionMetadata`, `SSEInitEvent`, etc.). `server.py:21` also defines `SendMessageRequest(BaseModel)`.
+- **Enum uses `(str, Enum)` with string literal values** (style guide: all enums should inherit from `UpperCaseStrEnum`, all values should be `auto()`): `models.py:11-16` defines `MessageRole(str, Enum)` with values `"user"`, `"assistant"`, `"system"`.
+- **Broad `except Exception:` clauses** (style guide: always catch specific exception types): `parser.py:61` catches `except Exception as e` and `watcher.py:37` catches `except Exception:` with `pass`.
+- **Module docstrings** (style guide: never create docstrings for modules): `models.py:1`, `parser.py:1`, `watcher.py:1`, `server.py:1` all have module-level docstrings.
+- **stdlib `logging`** (style guide: always use `loguru`): `cli.py:4` imports `logging` and uses `logging.getLogger()`.
+
+Recommendation: Bring the `claude_web_view` app into conformance with the style guide. The async/asyncio violation is the hardest to resolve since FastAPI's SSE streaming typically requires async. Consider whether this app should use a synchronous web framework instead, or document an explicit exception for this app. All other violations (imports, BaseModel, enum, error handling, logging) can be fixed incrementally.
+
+Decision: Accept
+
+## 2. `NamedTuple` used instead of `FrozenModel` in mngr library
+
+Description: The style guide says "Never use dataclasses or named tuples." Two classes in the mngr library use `NamedTuple`:
+
+- `libs/mngr/imbue/mngr/utils/logging.py:232-236`: `BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`.
+- `libs/mngr/imbue/mngr/conftest.py:537-542`: `ModalSubprocessTestEnv(NamedTuple)` with fields `env`, `prefix`, and `host_dir`.
+
+Both of these are in the core `mngr` library (not a peripheral app), making this a notable violation of the class hierarchy conventions.
+
+Recommendation: Convert both classes to `FrozenModel`. `BufferedMessage` is used as a lightweight tuple for buffered log output; `ModalSubprocessTestEnv` is used in test fixtures. Both can be straightforwardly converted. Note: `BufferedMessage` is stored in a `deque` for performance, so verify there is no meaningful performance regression from using `FrozenModel`.
+
+Decision: Accept
+
+## 3. `_ListIterationParams` uses raw `BaseModel` instead of `FrozenModel`
+
+Description: `libs/mngr/imbue/mngr/cli/list.py:551` defines `_ListIterationParams(BaseModel)` with `model_config = {"arbitrary_types_allowed": True}`. The style guide says all data classes must inherit from `FrozenModel` (for frozen objects) or `MutableModel` (for interfaces/implementations). Using raw `BaseModel` bypasses the project's model hierarchy.
+
+Recommendation: Convert to `FrozenModel`. If `arbitrary_types_allowed` is needed, it can be set on `FrozenModel` subclasses via `model_config` as well.
+
+Decision: Accept
+
+## 4. Constants missing `Final` type annotation
+
+Description: The style guide says "Always declare constants to be `Final`." Several UPPER_CASE constants are not declared as `Final`:
+
+- `libs/mngr/imbue/mngr/providers/modal/constants.py:3`: `MODAL_TEST_APP_PREFIX = "mngr-test-"` (no `Final[str]`)
+- `libs/mngr/imbue/mngr/utils/logging.py:29-34`: Six color constants (`WARNING_COLOR`, `ERROR_COLOR`, `BUILD_COLOR`, `DEBUG_COLOR`, `TRACE_COLOR`, `RESET_COLOR`) are all defined without `Final[str]`. Note that `BUILD_LEVEL_NO` on line 37 in the same file correctly uses `Final[int]`, making the inconsistency within the same file especially visible.
+
+Recommendation: Add `Final[str]` annotations to all of these constants. This is a straightforward fix.
+
+Decision: Accept
+
+## 5. `async def` method in Modal provider overriding external library
+
+Description: `libs/mngr/imbue/mngr/providers/modal/log_utils.py:154` defines `async def put_log_content(self, log)` in `_QuietOutputManager`, which inherits from Modal's `OutputManager`. The style guide says "Never use `async` or `asyncio`." This `async` method exists because it overrides Modal's own async interface.
+
+Recommendation: Document this as an accepted exception -- since `_QuietOutputManager` must override Modal's `OutputManager.put_log_content` (which is async), there is no way to avoid `async` here. Add a comment explaining why this is necessary.
+
+Decision: Accept
+
+## 6. Bare `raise` without `from` in `contrib/claude-code-transcripts`
+
+Description: The style guide says "Within an except clause, always use `raise ... from err` or `raise ... from None` when raising exceptions." The `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py` file has multiple violations:
+
+- Line 1191: `except subprocess.CalledProcessError as e:` raises `click.ClickException(...)` without `from e`
+- Line 1193: `except FileNotFoundError:` raises `click.ClickException(...)` without `from None`
+- Lines 1511, 1513: `httpx.RequestError` and `httpx.HTTPStatusError` handlers raise without `from e`
+- Lines 1888, 1890, 1924, 1926: Same pattern repeated for additional HTTP error handlers
+
+Recommendation: Add `from e` or `from None` to all of these raises. This preserves the exception chain and makes debugging easier.
+
+Decision: Accept
+
+## 7. Broad `except Exception:` clauses in core libraries
+
+Description: The style guide says "Never use a blanket `except:` clause! Always catch the narrowest specific exception type." Several locations use overly broad `except Exception:`:
+
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233`: `except Exception:` with `pass` after `tracked_thread.thread.join()`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:138`: `except Exception as e:` with logging
+
+The `concurrency_group` instance is the most concerning since it's a core library that silently swallows all exceptions.
+
+Recommendation: Replace with specific exception types. For the `thread.join()` case, `RuntimeError` is the most likely exception. For the sculptor_web case, identify the specific exceptions that the wrapped code can raise.
+
+Decision: Accept
+
+## 8. Direct `ValueError` raised in `imbue_common` primitives
+
+Description: The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)." The `libs/imbue_common/imbue/imbue_common/primitives.py` file raises bare `ValueError` in several primitive type constructors:
+
+- Line 14: `raise ValueError(f"{cls.__name__} cannot be empty")` (in `NonEmptyStr`)
+- Line 35: `raise ValueError(f"{cls.__name__} must be >= 0, got {value}")` (in `NonNegativeInt`)
+- Line 55: `raise ValueError(f"{cls.__name__} must be > 0, got {value}")` (in `PositiveInt`)
+- Line 75: `raise ValueError(f"{cls.__name__} must be >= 0, got {value}")` (in `NonNegativeFloat`)
+- Line 95: `raise ValueError(f"{cls.__name__} must be > 0, got {value}")` (in `PositiveFloat`)
+
+Similarly, `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636` raises `raise ValueError(...)`.
+
+The style guide's own example shows `InvalidProbabilityError` as a custom exception for the `Probability` primitive, suggesting primitives should define their own error classes.
+
+Recommendation: Create a base `ImbueCommonError(Exception)` and specific errors like `InvalidPrimitiveValueError(ImbueCommonError, ValueError)` for the primitives module. For `concurrency_group`, create a similar library-specific error type. This ensures callers can catch either the domain-specific or the built-in exception type.
+
+Decision: Accept
+
+## 9. Plain classes in `log_utils.py` do not follow the 3-class hierarchy
+
+Description: The style guide says there are only 3 types of classes: Frozen objects (FrozenModel), Interfaces (MutableModel + ABC), and Implementations (inheriting from interfaces). In `libs/mngr/imbue/mngr/providers/modal/log_utils.py`:
+
+- `_MultiWriter` (line 30): Plain class, not inheriting from any of the three base types
+- `ModalLoguruWriter` (line 68): Plain class with mutable attributes (`app_id`, `app_name`) but no FrozenModel/MutableModel inheritance
+
+These classes implement file-like writer interfaces but don't follow the project's class hierarchy.
+
+Recommendation: This is a low-priority issue since these classes implement external protocols (file-like objects) rather than domain interfaces. Consider converting `ModalLoguruWriter` to a `MutableModel` subclass since it has mutable state. `_MultiWriter` could also become a `MutableModel`. Alternatively, document this as an accepted exception for classes that must conform to external protocol requirements (Python's file-like interface).
+
+Decision: Accept
+
+## 10. stdlib `logging` used alongside `loguru` in mngr library
+
+Description: The style guide says "Always use `loguru` for logging." While `mngr` primarily uses `loguru`, stdlib `logging` is imported in two places within the core library:
+
+- `libs/mngr/imbue/mngr/utils/logging.py:2`: `import logging` used to suppress pyinfra warnings (`logging.getLogger("pyinfra").setLevel(logging.ERROR)`)
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:15`: `import logging`
+
+The `logging.py` usage is arguably justified (suppressing a third-party library's stdlib logger), but it's still a mixing of logging systems.
+
+Recommendation: For the pyinfra suppression case, consider using `loguru`'s interception of stdlib logging instead (via `loguru.logger.disable("pyinfra")`). Review the `snapshot_and_shutdown.py` usage to determine if it can be replaced with loguru. Low priority since these are not used for application logging but for third-party library management.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

Automated code-guardian scan identifying the 10 most important code-level inconsistencies in the codebase, ordered by severity:

1. **`claude_web_view` app systematically violates the style guide** -- relative imports, async/asyncio, BaseModel instead of FrozenModel, enum not using UpperCaseStrEnum, broad exception handling, stdlib logging
2. **NamedTuple used instead of FrozenModel** in `mngr/utils/logging.py` and `mngr/conftest.py`
3. **`_ListIterationParams` uses raw `BaseModel`** instead of FrozenModel in `mngr/cli/list.py`
4. **Constants missing `Final` annotations** in `modal/constants.py` and `utils/logging.py`
5. **`async def` in Modal provider** override (necessary for Modal API compatibility)
6. **Missing exception chaining** (`from e`/`from None`) in `contrib/claude-code-transcripts`
7. **Broad `except Exception:` clauses** in `concurrency_group` and `sculptor_web`
8. **Direct `ValueError` raised** in `imbue_common/primitives.py` instead of custom exceptions
9. **Plain classes not following 3-class hierarchy** in `modal/log_utils.py`
10. **stdlib `logging` mixed with `loguru`** in mngr library

Full report: `_tasks/inconsistencies/2026-02-15-01-01-14.md`

## Test plan
- [ ] Review each inconsistency for accuracy
- [ ] Prioritize which items to fix
- [ ] Create follow-up issues/tasks for fixes