### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-15-11-03-31.md
+++ b/_tasks/inconsistencies/2026-02-15-11-03-31.md
@@ -1,0 +1,152 @@
+# Inconsistencies identified on 2026-02-15-11-03-31
+
+## 1. Enum branching uses if/elif/else + SwitchError instead of match + assert_never
+
+Description: The style guide states "For enums, always use match statements" with `assert_never` for exhaustiveness checking. However, two files branch on enum values using if/elif/else chains with `SwitchError` instead:
+
+- `libs/mngr/imbue/mngr/hosts/common.py:30-83`: Function `get_activity_sources_for_idle_mode` branches on `IdleMode` enum using a 9-branch if/elif/else chain with `raise SwitchError(idle_mode)` in the else clause. This should be a match statement with `assert_never`.
+- `libs/mngr/imbue/mngr/hosts/host.py:891-896`: Method `_create_agent_work_dir` branches on `WorkDirCopyMode` enum using if/elif/else with `raise SwitchError(...)` in the else clause. This should be a match statement with `assert_never`.
+
+Meanwhile, the rest of the codebase (15 files in `cli/`, `api/`) correctly uses match statements with `assert_never` for enum branching. These two files in `hosts/` are the outliers.
+
+Recommendation: Convert both if/elif/else chains to match statements using `assert_never` for the default case. This will provide compile-time exhaustiveness checking when new enum values are added, which is safer than the runtime-only SwitchError.
+
+Decision: Accept
+
+## 2. BaseModel used directly instead of FrozenModel in production code
+
+Description: The style guide states "Frozen objects must inherit from FrozenModel" and "Never use dataclasses or named tuples." However, multiple production classes inherit directly from `BaseModel`:
+
+- `apps/claude_web_view/imbue/claude_web_view/models.py`: 10 classes (`TextBlock`, `ToolUseBlock`, `ToolResultBlock`, `ParsedMessage`, `SessionMetadata`, `SSEInitEvent`, `SSEMessageEvent`, `SSECompleteEvent`, `SSEErrorEvent`) all inherit from `BaseModel` instead of `FrozenModel`.
+- `apps/claude_web_view/imbue/claude_web_view/server.py:21`: `SendMessageRequest(BaseModel)` inherits from `BaseModel` instead of `FrozenModel`.
+- `libs/mngr/imbue/mngr/cli/list.py:551`: `_ListIterationParams(BaseModel)` inherits from `BaseModel` instead of `FrozenModel`.
+
+The rest of the codebase correctly uses `FrozenModel` for all data-bearing classes.
+
+Recommendation: Change all 12 classes to inherit from `FrozenModel` instead of `BaseModel`. This ensures consistent immutability guarantees and enables `model_copy_update` with the type-safe `to_update`/`field_ref` pattern.
+
+Decision: Accept
+
+## 3. claude_web_view enum uses (str, Enum) with hardcoded values instead of UpperCaseStrEnum with auto()
+
+Description: The style guide states "All enums should inherit from UpperCaseStrEnum" and "All values for enums should be auto()." However:
+
+- `apps/claude_web_view/imbue/claude_web_view/models.py:11-16`: `MessageRole` inherits from `(str, Enum)` instead of `UpperCaseStrEnum`, and uses hardcoded string values (`"user"`, `"assistant"`, `"system"`) instead of `auto()`.
+
+All other enums in the codebase (15 enums across `libs/mngr/primitives.py`, `libs/mngr/cli/config.py`, `libs/concurrency_group/concurrency_group.py`) correctly inherit from `UpperCaseStrEnum` and use `auto()`.
+
+Recommendation: Change `MessageRole` to inherit from `UpperCaseStrEnum` and use `auto()` for all values. Note: since this enum is used to parse Claude Code transcript JSONL files where the role values are lowercase strings like `"user"`, the parsing logic may need to be updated to handle the case mapping.
+
+Decision: Accept
+
+## 4. Entire module implementation in __init__.py (claude-code-transcripts)
+
+Description: The style guide states "Never put any code in an `__init__.py` file" (with a narrow exception for hookimpl lines). However:
+
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py`: Contains 2,085 lines of implementation code including CLI commands, HTML generation, API interaction, session parsing, credential handling, and more. This is the entire module's implementation in a single `__init__.py` file.
+
+All other `__init__.py` files in the codebase are correctly blank or contain only hookimpl markers.
+
+Recommendation: Refactor the module into properly organized files such as `cli.py`, `parser.py`, `html_generation.py`, `api.py`, `errors.py`, `data_types.py`, etc. This would also resolve several other style guide violations within this file (see items below).
+
+Decision: Accept
+
+## 5. Global keyword usage
+
+Description: The style guide states "Avoid using the `global` keyword. Instead, pass all state explicitly through from the top level of the program." Two files violate this:
+
+- `apps/sculptor_web/imbue/sculptor_web/main.py:151,162`: Uses `global _poll_thread` in `_start_polling()` and `_stop_polling()` functions, along with module-level mutable globals `_agent_list_state`, `_poll_thread`, and `_stop_event` (lines 48-51).
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:1225,1679`: Uses `global _github_repo` in `generate_html()` and `generate_html_from_session_data()` functions.
+
+Recommendation: Encapsulate the mutable state in a proper class (e.g., an implementation class inheriting from an interface) and pass it through function parameters or dependency injection, rather than using module-level globals.
+
+Decision: Accept
+
+## 6. Standard logging module used instead of loguru
+
+Description: The style guide states "Always use loguru for logging." However, two production files in mngr use the standard `logging` module:
+
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:15,110`: Imports `logging` and creates a logger via `logging.getLogger("snapshot_and_shutdown")`.
+- `libs/mngr/imbue/mngr/utils/logging.py:2`: Imports `logging` (used to suppress third-party library warnings via `logging.getLogger(...).setLevel(logging.WARNING)`).
+
+The `logging.py` usage is somewhat justified for interop with third-party libraries, but `snapshot_and_shutdown.py` should use loguru directly.
+
+Recommendation: Convert `snapshot_and_shutdown.py` to use `loguru.logger` instead of `logging.getLogger()`. The `logging.py` interop usage could remain as an exception documented with a comment explaining why.
+
+Decision: Accept
+
+## 7. Widespread use of mutable input types (list/dict) instead of immutable types (Sequence/Mapping) for function parameters
+
+Description: The style guide states "Function inputs should be typed using immutable abstract types rather than mutable concrete types" -- specifically `Sequence[T]` instead of `list[T]` and `Mapping[K, V]` instead of `dict[K, V]`. Multiple files violate this:
+
+- `libs/mngr/imbue/mngr/config/data_types.py:71,83`: Functions `merge_list_fields` and `merge_dict_fields` use `list[T]` and `dict[K, V]` parameters.
+- `libs/mngr/imbue/mngr/config/loader.py:341,356,447,465`: Multiple functions use `dict[str, Any]` and `dict[str, dict[str, Any]]` parameters.
+- `libs/mngr/imbue/mngr/cli/list.py:528,539,616,639,768`: Multiple functions use `list[AgentInfo]`, `list[str]`, `dict[str, int]` parameters.
+- `libs/mngr/imbue/mngr/cli/connect.py:232,321`: Functions use `list[AgentInfo]` parameters.
+- `libs/mngr/imbue/mngr/cli/clone.py:44`: Function uses `list[str]` parameters.
+
+This affects approximately 20+ functions across the mngr library.
+
+Recommendation: Systematically update function parameter types to use `Sequence`, `Mapping`, and `AbstractSet` from `collections.abc`. Return types should remain as concrete mutable types per the style guide.
+
+Decision: Accept
+
+## 8. Primitives raise ValueError directly instead of custom exception types
+
+Description: The style guide states "Never raise built-in Exceptions directly (except NotImplementedError). Instead, create a new type that inherits from both the base error class for the package and the built-in." The core primitives in imbue_common violate this:
+
+- `libs/imbue_common/imbue/imbue_common/primitives.py:14,35,55,75,95`: `NonEmptyStr`, `NonNegativeInt`, `PositiveInt`, `NonNegativeFloat`, and `PositiveFloat` all `raise ValueError(...)` directly.
+
+Notably, `Probability` (in the same file, line 119) correctly uses a custom `InvalidProbabilityError(ValueError)` -- showing the intended pattern is already partially implemented in this file.
+
+Recommendation: Create custom error types for each primitive (e.g., `InvalidNonEmptyStrError(ValueError)`, or a single `InvalidPrimitiveError(ValueError)` base class) following the pattern already established by `InvalidProbabilityError`. This also makes it possible for callers to catch specific primitive validation errors.
+
+Decision: Accept
+
+## 9. async/asyncio usage in claude_web_view
+
+Description: The style guide states "Never use async or asyncio." However, the claude_web_view app uses async extensively:
+
+- `apps/claude_web_view/imbue/claude_web_view/server.py`: Uses `asyncio`, `async def`, `await`, `AsyncGenerator`, and `@asynccontextmanager` throughout the FastAPI server implementation.
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py`: Uses `asyncio`, `async def`, `await`, and `awatch` for file watching.
+
+This is somewhat forced by the choice of FastAPI as the web framework, which is inherently async.
+
+Recommendation: If the no-async rule is to be strictly enforced, consider migrating to a synchronous web framework like Flask or using a synchronous WSGI server. Alternatively, document this as an explicit exception to the style guide for FastAPI-based apps where async is a framework requirement.
+
+Decision: Accept
+
+## 10. Boolean fields without is_ prefix in non-CLI data classes
+
+Description: The style guide states "Always prefix booleans with is_" (with an explicit exception for CLI options per non_issues.md). Several non-CLI data classes have boolean fields missing the `is_` prefix:
+
+- `libs/mngr/imbue/mngr/config/data_types.py:242`: `PluginConfig.enabled` should be `is_enabled`.
+- `apps/sculptor_web/imbue/sculptor_web/data_types.py:33`: `AgentDisplayInfo.start_on_boot` should be `is_start_on_boot` (or a clearer name like `is_started_on_boot`).
+- `libs/mngr/imbue/mngr/api/list.py:63`: `AgentInfo.start_on_boot` should be `is_start_on_boot`.
+
+Recommendation: Rename these fields to include the `is_` prefix. Note: `start_on_boot` is borderline since it reads naturally, but `enabled` is a clear-cut case where `is_enabled` would be more consistent with the rest of the codebase.
+
+Decision: Accept
+
+## 11. Missing error class hierarchy in contrib/claude-code-transcripts
+
+Description: The style guide states "All raised Exceptions should inherit from a base class that is specific to that library or app." The claude-code-transcripts package violates this:
+
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:489`: `CredentialsError` inherits directly from `Exception` rather than from a package-specific base error class.
+- Multiple `raise click.ClickException(...)` statements throughout the file (lines 1191, 1193, 1511, 1513, 1888, 1890, 1924, 1926) occur inside except blocks without using `from e` or `from None` for exception chaining.
+
+Recommendation: Create a `ClaudeCodeTranscriptsError(Exception)` base class and have `CredentialsError` inherit from it. Add proper exception chaining (`from e` or `from None`) to all `raise` statements inside except blocks.
+
+Decision: Accept
+
+## 12. Blanket except Exception: clauses
+
+Description: The style guide states "Never use a blanket except: clause! Always catch the narrowest specific exception type." Several files use overly broad exception handling:
+
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:37`: `except Exception: pass` with comment "Subscriber disconnected" -- should catch a specific queue or connection exception.
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233`: `except Exception: pass` silently swallows all exceptions from `thread.join()`.
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:108,148`: `except Exception:` returns defaults silently.
+
+Recommendation: Replace each `except Exception:` with the narrowest applicable exception type (e.g., `queue.Full`, `RuntimeError`, `json.JSONDecodeError`, etc.). If multiple exception types are possible, list them explicitly in a tuple.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

Automated code-guardian scan identifying 12 code-level inconsistencies in the codebase, ordered by severity:

1. **Enum branching uses if/elif/else + SwitchError instead of match + assert_never** -- `hosts/common.py` and `hosts/host.py` branch on enum values with if/elif chains while the rest of the codebase (15 files) correctly uses match statements
2. **BaseModel used directly instead of FrozenModel** -- 12 classes across `claude_web_view/models.py`, `claude_web_view/server.py`, and `mngr/cli/list.py`
3. **Enum uses `(str, Enum)` with hardcoded values** instead of `UpperCaseStrEnum` with `auto()` -- `claude_web_view/models.py:MessageRole`
4. **Entire module in `__init__.py`** -- `contrib/claude-code-transcripts` has 2,085 lines in `__init__.py`
5. **`global` keyword usage** -- `sculptor_web/main.py` and `claude-code-transcripts/__init__.py`
6. **Standard `logging` module instead of loguru** -- `modal/routes/snapshot_and_shutdown.py`
7. **Mutable input types** (`list`/`dict`) instead of `Sequence`/`Mapping` for function parameters -- ~20+ functions in mngr
8. **Primitives raise `ValueError` directly** instead of custom exception types -- `imbue_common/primitives.py`
9. **`async`/`asyncio` usage** in `claude_web_view` app (forced by FastAPI framework choice)
10. **Boolean fields without `is_` prefix** in non-CLI data classes
11. **Missing error class hierarchy** in `contrib/claude-code-transcripts`
12. **Blanket `except Exception:` clauses** in `claude_web_view`, `concurrency_group`, and `claude-code-transcripts`

Full report: `_tasks/inconsistencies/2026-02-15-11-03-31.md`

## Test plan
- [ ] Review each inconsistency for accuracy
- [ ] Prioritize which items to fix
- [ ] Create follow-up issues/tasks for fixes

Generated with [Claude Code](https://claude.com/claude-code)