### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-15-13-46-08.md
+++ b/_tasks/inconsistencies/2026-02-15-13-46-08.md
@@ -1,0 +1,134 @@
+# Inconsistencies identified on 2026-02-15-13-46-08
+
+## 1. claude_web_view app uses async/await despite style guide prohibition
+
+Description: The `apps/claude_web_view` app makes extensive use of `async`/`await` and `asyncio`, which the style guide explicitly forbids ("Never use `async` or `asyncio`"). The violation is pervasive across the app:
+- `apps/claude_web_view/imbue/claude_web_view/server.py` (lines 3, 6, 34, 42, 45, 90, 95, 111): Uses `asyncio`, `asynccontextmanager`, `AsyncGenerator`, and defines multiple `async def` functions.
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py` (lines 1-75): Entire file built on `asyncio` -- uses `asyncio.Queue`, `asyncio.Task`, `asyncio.Event`, `asyncio.create_task`, and defines four `async def` methods.
+
+Recommendation: This is a structural issue. If the app requires async behavior (e.g., for SSE streaming with FastAPI), this should either be documented as an explicit exception to the style guide, or the app should be rewritten to use synchronous patterns (e.g., using a synchronous web framework or threading).
+
+Decision: Accept
+
+## 2. claude_web_view app uses BaseModel directly instead of FrozenModel
+
+Description: The `apps/claude_web_view/imbue/claude_web_view/models.py` file defines 8 data classes (`TextBlock`, `ToolUseBlock`, `ToolResultBlock`, `ParsedMessage`, `SessionMetadata`, `SSEInitEvent`, `SSEMessageEvent`, `SSECompleteEvent`, `SSEErrorEvent`) that all inherit from `pydantic.BaseModel` instead of `FrozenModel`. The style guide says frozen objects must inherit from `FrozenModel` and "Never store application data in raw python dictionaries or mappings." Similarly, `server.py:21` defines `SendMessageRequest(BaseModel)`.
+
+Additionally, these models lack `Field(description=...)` annotations on their attributes, which the style guide requires for frozen objects.
+
+Recommendation: Convert all data classes to use `FrozenModel` with proper `Field(description=...)` annotations.
+
+Decision: Accept
+
+## 3. claude_web_view MessageRole enum uses (str, Enum) instead of UpperCaseStrEnum with auto()
+
+Description: In `apps/claude_web_view/imbue/claude_web_view/models.py:11`, the `MessageRole` enum inherits from `(str, Enum)` and uses hardcoded string values (`"user"`, `"assistant"`, `"system"`) instead of inheriting from `UpperCaseStrEnum` and using `auto()`. The style guide requires: "All enums should inherit from `UpperCaseStrEnum`", "All values for enums should be `auto()`."
+
+Recommendation: Change to `class MessageRole(UpperCaseStrEnum)` with `USER = auto()`, `ASSISTANT = auto()`, `SYSTEM = auto()`. Note: this may require updating any code that compares against the literal string values (since `auto()` values will be `"USER"`, `"ASSISTANT"`, `"SYSTEM"` instead of lowercase).
+
+Decision: Accept
+
+## 4. claude_web_view uses argparse instead of click for CLI
+
+Description: In `apps/claude_web_view/imbue/claude_web_view/cli.py:3`, the app uses `argparse` for its CLI. The style guide says: "Always use `click` to create commandline interfaces." The rest of the codebase (e.g., all of `libs/mngr/imbue/mngr/cli/`) consistently uses `click`.
+
+Recommendation: Rewrite the CLI to use `click` with proper `click.option()` decorators, and parse arguments into a structured `FrozenModel` as described in the style guide.
+
+Decision: Accept
+
+## 5. claude_web_view uses relative imports instead of absolute imports
+
+Description: All inter-module imports within `apps/claude_web_view` use relative imports (`from .models import ...`, `from .parser import ...`, `from .server import ...`, `from .watcher import ...`). The style guide says: "Always use absolute imports. Never use relative imports." Files affected:
+- `apps/claude_web_view/imbue/claude_web_view/parser.py` (lines 8-14): 7 relative imports
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py` (line 10): 1 relative import
+- `apps/claude_web_view/imbue/claude_web_view/server.py` (lines 17-18): 2 relative imports
+- `apps/claude_web_view/imbue/claude_web_view/cli.py` (line 12): 1 relative import
+
+Recommendation: Convert all relative imports to absolute imports (e.g., `from imbue.claude_web_view.models import ...`).
+
+Decision: Accept
+
+## 6. claude_web_view uses logging module instead of loguru
+
+Description: In `apps/claude_web_view/imbue/claude_web_view/cli.py:4,122`, the app imports and uses the standard `logging` module. The style guide says: "Always use `loguru` for logging."
+
+Recommendation: Replace `import logging` with `from loguru import logger` and use `loguru` for all logging.
+
+Decision: Accept
+
+## 7. Modal provider raises bare Exception instead of domain-specific error
+
+Description: Two locations in the modal provider raise bare `Exception` instead of using domain-specific error classes:
+- `libs/mngr/imbue/mngr/providers/modal/backend.py:452`: `raise Exception("Host is not an instance of Host class")`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:607`: `raise Exception(f"Host record not found on volume for {host_id}")`
+
+The style guide says: "Never raise built-in Exceptions directly (except NotImplementedError). Instead, create a new type that inherits from both the base error class for the package and the built-in." The `mngr` package already has `MngrError` as its base exception class in `errors.py`.
+
+Recommendation: Create specific error classes (e.g., `HostTypeError(MngrError, TypeError)` and `HostRecordNotFoundError(MngrError, KeyError)`) and use those instead.
+
+Decision: Accept
+
+## 8. Inconsistent error class usage in imbue_common primitives
+
+Description: In `libs/imbue_common/imbue/imbue_common/primitives.py`, the primitive type validators (`NonEmptyStr`, `NonNegativeInt`, `PositiveInt`, `NonNegativeFloat`, `PositiveFloat`) all raise bare `ValueError` directly (lines 14, 35, 55, 75, 95). However, the `Probability` class (line 119) correctly uses a custom `InvalidProbabilityError(ValueError)` class. This is internally inconsistent -- either all primitives should have custom error classes, or none should.
+
+Recommendation: Create custom error classes for each primitive type (e.g., `InvalidNonEmptyStrError`, `InvalidNonNegativeIntError`, etc.) following the pattern established by `InvalidProbabilityError`. Alternatively, create a single `InvalidPrimitiveValueError(ValueError)` base class that they all use.
+
+Decision: Accept
+
+## 9. claude_web_view TranscriptWatcher uses plain class with __init__ instead of pydantic model
+
+Description: `apps/claude_web_view/imbue/claude_web_view/watcher.py:13-21` defines `TranscriptWatcher` as a plain Python class with a `__init__` method. According to the style guide, stateful classes should inherit from `MutableModel` (with `ABC` if they are interfaces) and use `Field` declarations for attributes. The rest of the codebase follows this pattern consistently.
+
+Recommendation: Convert `TranscriptWatcher` to inherit from `MutableModel` with proper `Field` declarations.
+
+Decision: Accept
+
+## 10. claude_web_view has module-level docstrings
+
+Description: Every file in `apps/claude_web_view/imbue/claude_web_view/` has a module-level docstring (e.g., `"""File watcher for transcript updates."""`). The style guide explicitly says: "Never create docstrings for modules."
+
+Files affected: `__init__.py`, `__main__.py`, `cli.py`, `models.py`, `parser.py`, `server.py`, `watcher.py` (7 files total).
+
+Recommendation: Remove all module-level docstrings from these files.
+
+Decision: Accept
+
+## 11. Inline imports in claude_web_view and concurrency_group
+
+Description: Several files use inline imports (imports inside functions), which the style guide forbids:
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:111` -- `import threading` inside `main()`
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:114` -- `import time` inside `open_browser()`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:515` -- `import uvicorn` inside `run()`
+- `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:44` -- `from imbue.concurrency_group.errors import ProcessError` inside `check()` method
+
+Recommendation: Move all imports to the top of the file.
+
+Decision: Accept
+
+## 12. if/elif chains missing else clause in concurrency_group and ratchet_testing
+
+Description: The style guide says "All if/elif chains must end with an else clause." Several locations violate this:
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:477` and `:487`: if/elif chains for filtering threads and processes during cleanup lack else clauses.
+- `libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py:167` and `:287`: if/elif chains without else.
+- `apps/claude_web_view/imbue/claude_web_view/parser.py`: 5 occurrences at lines 113, 165, 170, 182, 186.
+
+Recommendation: Add explicit `else` clauses (with `pass` if appropriate, or `raise SwitchError(...)` if the case should never occur).
+
+Decision: Accept
+
+## 13. ValueError raised directly in concurrency_group
+
+Description: In `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636`, the `get_only_exception()` method raises `ValueError` directly. The `concurrency_group` library has its own error module (`errors.py`) but no appropriate error class for this case.
+
+Recommendation: Create a specific error class like `SingleExceptionExpectedError(ConcurrencyGroupError, ValueError)` in `concurrency_group/errors.py` and use it instead.
+
+Decision: Accept
+
+## 14. SendMessageRequest uses mutable default value
+
+Description: In `apps/claude_web_view/imbue/claude_web_view/server.py:25`, the `SendMessageRequest` model uses `files: list[str] = []` as a mutable default. While pydantic handles this safely at runtime, the style guide convention is to use `Field(default_factory=list)` for mutable defaults, as seen consistently throughout the codebase.
+
+Recommendation: Change to `files: list[str] = Field(default_factory=list, description="...")`.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identifies 14 code-level inconsistencies across the codebase, ordered by importance
- The majority of issues are concentrated in `apps/claude_web_view`, which diverges significantly from the style guide (async/await, BaseModel instead of FrozenModel, argparse instead of click, relative imports, logging instead of loguru, module docstrings)
- A few issues exist in core libraries: bare `Exception` raises in the modal provider, inconsistent error class usage in `imbue_common` primitives, and missing `else` clauses in if/elif chains

## Test plan

- [ ] Review each identified inconsistency for accuracy
- [ ] Decide which items to address vs. document as intentional exceptions
- [ ] For claude_web_view: decide whether to bring into style compliance or document as a special-purpose app with different conventions

Generated with [Claude Code](https://claude.com/claude-code)