### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-15-13-55-57.md
+++ b/_tasks/inconsistencies/2026-02-15-13-55-57.md
@@ -1,0 +1,142 @@
+# Inconsistencies identified on 2026-02-15-13-55-57
+
+## 1. claude_web_view uses BaseModel instead of FrozenModel, relative imports, async, and plain Enum
+
+Description: The `apps/claude_web_view/` application deviates from the project style guide in several ways:
+
+- **BaseModel instead of FrozenModel**: All model classes in `apps/claude_web_view/imbue/claude_web_view/models.py` (lines 20, 27, 36, 48, 57, 66, 74, 81, 89) and `server.py:21` use `BaseModel` directly instead of `FrozenModel`.
+- **Plain Enum instead of UpperCaseStrEnum**: `models.py:11` defines `MessageRole(str, Enum)` with hardcoded string values (`"user"`, `"assistant"`, `"system"`) instead of using `UpperCaseStrEnum` with `auto()`.
+- **Relative imports**: All files in this package use relative imports (e.g., `from .server import create_app` in `cli.py:12`, `from .models import ...` in `parser.py:8-14`, `from .parser import ...` in `server.py:17-18` and `watcher.py:10`).
+- **Async/asyncio**: `server.py` and `watcher.py` extensively use `async def` and `await`, which the style guide prohibits.
+- **Module-level docstring**: `models.py:1` has a module-level docstring, which the style guide says to never create.
+
+Recommendation: This app was likely written before the style guide was fully enforced. For the async usage, this may warrant a documented exception since FastAPI requires async for SSE endpoints. The other issues (FrozenModel, UpperCaseStrEnum, absolute imports, no module docstring) should be fixed to align with the rest of the codebase.
+
+Decision: Accept
+
+## 2. Dict field naming does not follow the `value_by_key` convention in many model classes
+
+Description: The style guide requires dict fields to follow the `value_by_key` naming pattern, but many model class fields use names like `tags`, `plugin`, `defaults`, `options`, `commands`, etc. Examples:
+
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:277` - `plugin: dict[str, dict[str, Any]]` (should be something like `plugin_data_by_plugin_name`)
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:291` - `user_tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:335` - `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:389` - `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:400` - `plugin: dict[str, Any]`
+- `libs/mngr/imbue/mngr/config/data_types.py:328` - `defaults: dict[str, Any]`
+- `libs/mngr/imbue/mngr/config/data_types.py:377` - `options: dict[str, Any]`
+- `libs/mngr/imbue/mngr/config/data_types.py:417` - `agent_types: dict[AgentTypeName, AgentTypeConfig]` (should be `agent_type_config_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:421` - `providers: dict[ProviderInstanceName, ProviderInstanceConfig]`
+- `libs/mngr/imbue/mngr/config/data_types.py:425` - `plugins: dict[PluginName, PluginConfig]`
+- `libs/mngr/imbue/mngr/config/data_types.py:433` - `commands: dict[str, CommandDefaults]`
+- `libs/mngr/imbue/mngr/config/data_types.py:437` - `create_templates: dict[CreateTemplateName, CreateTemplate]`
+- `libs/mngr/imbue/mngr/api/data_types.py:169` - `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/api/list.py:78` - `plugin: dict[str, Any]`
+- `libs/mngr/imbue/mngr/providers/ssh/config.py:30` - `hosts: dict[str, SSHHostConfig]`
+- `libs/mngr/imbue/mngr/providers/ssh/instance.py:52` - `hosts: dict[str, SSHHostConfig]`
+
+Recommendation: Rename dict fields to follow the `value_by_key` pattern (e.g., `tags` -> `tag_value_by_key`, `plugin` -> `plugin_data_by_name`, `agent_types` -> `agent_type_config_by_name`, etc.). This is a large-scale rename that should be done incrementally with careful testing. Some names like `tags` are borderline acceptable since tags are inherently key-value pairs, but the pattern should be consistent.
+
+Decision: Accept
+
+## 3. Variable re-assignment in merge methods instead of using ternary expressions
+
+Description: The style guide says "Never re-assign to the same function-scoped variable" and to "prefer to use ternary expressions." Several `merge_with` methods use the pattern of assigning a variable and then conditionally re-assigning it:
+
+- `libs/mngr/imbue/mngr/config/data_types.py:474-476` - `merged_prefix = self.prefix` then `merged_prefix = override.prefix`
+- `libs/mngr/imbue/mngr/config/data_types.py:479-481` - `merged_default_host_dir` same pattern
+- `libs/mngr/imbue/mngr/config/data_types.py:568-570` - `is_remote_agent_installation_allowed` same pattern
+- `libs/mngr/imbue/mngr/config/data_types.py:573-575` - `merged_is_nested_tmux_allowed` same pattern
+- `libs/mngr/imbue/mngr/config/data_types.py:577-579` - `is_allowed_in_pytest` same pattern
+- `libs/mngr/imbue/mngr/config/data_types.py:582-584` - `merged_logging` same pattern
+- `libs/mngr_opencode/imbue/mngr_opencode/plugin.py:40-42` - `merged_command` same pattern
+- `libs/mngr_opencode/imbue/mngr_opencode/plugin.py:48-50` - `merged_permissions` same pattern
+
+Note: some of these (line 484) already use the ternary pattern correctly, making the inconsistency more visible.
+
+Recommendation: Convert all `if override.X is not None: var = override.X` patterns to ternary expressions like `merged_X = override.X if override.X is not None else self.X`, matching the pattern already used at line 484. Alternatively, extract a shared helper for the "merge scalar field" pattern.
+
+Decision: Accept
+
+## 4. Inconsistent naming of merge variables -- some use `merged_` prefix, others don't
+
+Description: Within the same `merge_with` method in `libs/mngr/imbue/mngr/config/data_types.py`, some variables use the `merged_` prefix and others don't:
+
+- **With prefix**: `merged_prefix` (line 474), `merged_default_host_dir` (479), `merged_pager` (484), `merged_unset_vars` (487), `merged_enabled_backends` (490), `merged_agent_types` (493), `merged_providers` (507), `merged_plugins` (521), `merged_disabled_plugins` (535), `merged_commands` (538), `merged_create_templates` (552), `merged_pre_command_scripts` (566), `merged_logging` (582), `merged_is_nested_tmux_allowed` (573)
+- **Without prefix**: `is_remote_agent_installation_allowed` (568), `is_allowed_in_pytest` (577)
+
+This inconsistency makes the code harder to read and increases the risk of accidentally referencing the wrong variable.
+
+Recommendation: Add the `merged_` prefix to `is_remote_agent_installation_allowed` and `is_allowed_in_pytest` for consistency within the method.
+
+Decision: Accept
+
+## 5. `global` keyword usage in sculptor_web and claude-code-transcripts
+
+Description: The style guide says to "Avoid using the `global` keyword. Instead, pass all state explicitly through from the top level of the program."
+
+Violations:
+- `apps/sculptor_web/imbue/sculptor_web/main.py:151,162` - `global _poll_thread` used in `_start_polling()` and `_stop_polling()`
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:1225,1679` - `global _github_repo`
+
+Recommendation: Refactor to pass state explicitly. For sculptor_web, encapsulate the poll thread in a class. For claude-code-transcripts, pass `_github_repo` as a parameter to the functions that need it.
+
+Decision: Accept
+
+## 6. Broad `except Exception` catches in production code
+
+Description: The style guide says to "catch the narrowest specific exception type" and "Never use a blanket `except:` clause." Several files use overly broad `except Exception:` catches:
+
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:108` - `except Exception:` returning a default value
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:148` - `except Exception:` with `pass`
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:37` - `except Exception:` with `pass`
+- `apps/claude_web_view/imbue/claude_web_view/parser.py:61` - `except Exception as e:`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:138` - `except Exception as e:`
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233` - `except Exception:` with `pass`
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:275` - `except Exception as e:`
+- `libs/concurrency_group/imbue/concurrency_group/executor.py:48` - `except Exception as e:`
+- `scripts/josh/coordinator.py:445` - `except Exception as e:`
+
+Note: there is already a ratchet test tracking this (`test_ratchets.py:107`), so some of these may be tracked.
+
+Recommendation: Replace broad `except Exception` with specific exception types (e.g., `OSError`, `json.JSONDecodeError`, `RuntimeError`). The concurrency_group catches may be intentionally broad for cleanup safety, but should be documented with comments explaining why.
+
+Decision: Accept
+
+## 7. `_ListIterationParams` uses `BaseModel` directly instead of `FrozenModel` or `MutableModel`
+
+Description: `libs/mngr/imbue/mngr/cli/list.py:551` defines `class _ListIterationParams(BaseModel)` with `model_config = {"arbitrary_types_allowed": True}`. The style guide says there are only 3 types of classes: FrozenModel, MutableModel+ABC interfaces, and implementations. This class should be a FrozenModel since it's an immutable data object.
+
+Recommendation: Change to inherit from `FrozenModel` instead of `BaseModel`. If `arbitrary_types_allowed` is needed, add it via `model_config` on the FrozenModel subclass (FrozenModel already supports this).
+
+Decision: Accept
+
+## 8. `_MultiWriter` and `ModalLoguruWriter` are plain classes not inheriting from any model base
+
+Description: `libs/mngr/imbue/mngr/providers/modal/log_utils.py:30` and `:68` define `_MultiWriter` and `ModalLoguruWriter` as plain Python classes (not inheriting from FrozenModel, MutableModel, or any interface). They have mutable state (`_files`, `_timestamps`, `app_id`, `app_name`) but don't follow the style guide's class hierarchy.
+
+Recommendation: These writer classes serve as adapters for Modal's logging system. `ModalLoguruWriter` is public (no underscore prefix) and has mutable attributes, so it should be a `MutableModel`. `_MultiWriter` is private and could remain a plain class since it's an internal adapter, but ideally should also be a `MutableModel`.
+
+Decision: Accept
+
+## 9. `async def put_log_content` in `_QuietOutputManager`
+
+Description: `libs/mngr/imbue/mngr/providers/modal/log_utils.py:154` defines `async def put_log_content(self, log)` which violates the "Never use `async` or `asyncio`" rule. This is inside a subclass of Modal's `OutputManager`, which requires this method signature for compatibility.
+
+Recommendation: This is a necessary exception to the style guide since it overrides a method in Modal's framework. Add a comment explaining why async is required here (Modal's OutputManager interface mandates it).
+
+Decision: Accept
+
+## 10. Boolean fields missing `is_` prefix on non-CLI model classes
+
+Description: The style guide says "Always prefix booleans with `is_`" (with an exception for CLI options, which is a documented non-issue). Several non-CLI model classes have boolean fields without the `is_` prefix:
+
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:173` - `success: bool` (should be `is_success`)
+- `libs/mngr/imbue/mngr/api/list.py:63` - `start_on_boot: bool` (should be `is_start_on_boot`)
+- `libs/mngr/imbue/mngr/api/data_types.py:281` - `create_work_dir: bool` (should be `is_create_work_dir`)
+- `libs/mngr/imbue/mngr/config/data_types.py:242` - `enabled: bool` on `PluginConfig` (should be `is_enabled`)
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:51,55,59,63,72` - `sync_home_settings`, `sync_claude_json`, `sync_repo_settings`, `sync_claude_credentials`, `check_installation` all booleans without `is_` prefix
+
+Recommendation: Rename these fields to include the `is_` prefix. Note that `start_on_boot` and some claude_agent fields may border on being CLI-adjacent (they correspond to user-facing config), so evaluate case by case. The `success` and `enabled` fields are clear violations.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 10 code-level inconsistencies against the project style guide
- Report covers: relative imports, async usage, dict naming conventions, variable re-assignment patterns, global keyword usage, broad exception catches, BaseModel vs FrozenModel, boolean naming, and enum style violations
- Findings are ranked by importance, with the most impactful issues first

## Report location

`_tasks/inconsistencies/2026-02-15-13-55-57.md`

Generated with [Claude Code](https://claude.com/claude-code)