### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-16-11-05-56.md
+++ b/_tasks/inconsistencies/2026-02-16-11-05-56.md
@@ -1,0 +1,117 @@
+# Inconsistencies identified on 2026-02-16-11-05-56
+
+## 1. Boolean field naming inconsistency: `enabled` vs `is_enabled` in the same file
+
+Description: In `libs/mngr/imbue/mngr/config/data_types.py`, `ProviderInstanceConfig` uses `is_enabled: bool` (line 198) while `PluginConfig` uses `enabled: bool` (line 242). The style guide requires boolean fields to be prefixed with `is_` (unless they are CLI options or corresponding data class attributes). Both are internal configuration classes, not CLI options, so both should use `is_enabled`. This inconsistency exists within the same file.
+
+Recommendation: Rename `PluginConfig.enabled` to `PluginConfig.is_enabled` for consistency with `ProviderInstanceConfig.is_enabled` and the style guide convention.
+
+Decision: Accept
+
+## 2. `CommandResult.success` missing `is_` prefix
+
+Description: In `libs/mngr/imbue/mngr/interfaces/data_types.py:173`, the `CommandResult` FrozenModel has a field `success: bool = Field(description="True if the command succeeded (had an expected exit code)")`. The style guide says "Always prefix booleans with `is_`" unless they are CLI options. `CommandResult` is a core data type, not a CLI option class.
+
+Recommendation: Rename `CommandResult.success` to `CommandResult.is_success`.
+
+Decision: Accept
+
+## 3. MutableModel used without ABC for non-interface, non-implementation classes
+
+Description: The style guide defines exactly 3 types of classes: FrozenModel (data), Interface (ABC + MutableModel), and Implementation (inherits from interface). However, many classes use MutableModel without ABC and without inheriting from an interface, creating an unofficial fourth class type:
+- `libs/mngr/imbue/mngr/api/data_types.py:231` - `GcResult(MutableModel)`
+- `libs/mngr/imbue/mngr/api/pair.py:54` - `UnisonSyncer(MutableModel)`
+- `libs/mngr/imbue/mngr/api/message.py:26` - `MessageResult(MutableModel)`
+- `libs/mngr/imbue/mngr/api/list.py:141` - `ListResult(MutableModel)`
+- `libs/mngr/imbue/mngr/cli/list.py:393` - `_LimitedJsonlEmitter(MutableModel)`
+- `libs/mngr/imbue/mngr/cli/list.py:431` - `_StreamingHumanRenderer(MutableModel)`
+- `libs/mngr/imbue/mngr/cli/connect.py:136` - `AgentSelectorState(MutableModel)`
+- `libs/mngr/imbue/mngr/cli/connect.py:219` - `SelectorInputHandler(MutableModel)`
+- `libs/mngr/imbue/mngr/cli/create.py:94` - `_CachedAgentHostLoader(MutableModel)`
+- `libs/concurrency_group/imbue/concurrency_group/event_utils.py:10` - `ShutdownEvent(MutableModel)`
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:81` - `_TrackedThread(MutableModel)`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:40` - `AgentListState(MutableModel)`
+
+These classes use MutableModel as a convenient mutable pydantic base class rather than as an interface. The pattern is widespread enough that either the style guide should be updated to acknowledge this usage or these classes should be refactored to follow the interface/implementation pattern.
+
+Recommendation: Either update the style guide to acknowledge a fourth class type (stateful utility classes inheriting from MutableModel without ABC), or refactor these to use FrozenModel where possible and extract interfaces where mutation is needed.
+
+Decision: Accept
+
+## 4. `_ListIterationParams` inherits from `BaseModel` instead of `FrozenModel`
+
+Description: In `libs/mngr/imbue/mngr/cli/list.py:551`, `_ListIterationParams` inherits directly from `BaseModel` instead of `FrozenModel`. The style guide says frozen objects should inherit from `FrozenModel`. The comment `model_config = {"arbitrary_types_allowed": True}` suggests this was done to allow arbitrary types, but `FrozenModel` supports the same configuration.
+
+Recommendation: Change `_ListIterationParams(BaseModel)` to `_ListIterationParams(FrozenModel)` and add the `model_config` override.
+
+Decision: Accept
+
+## 5. `NamedTuple` usage in `utils/logging.py`
+
+Description: In `libs/mngr/imbue/mngr/utils/logging.py:232`, `BufferedMessage` is defined as a `NamedTuple`. The style guide explicitly states: "Never use dataclasses or named tuples."
+
+Recommendation: Convert `BufferedMessage` to a `FrozenModel` with two fields: `formatted_message: str` and `is_stderr: bool`.
+
+Decision: Accept
+
+## 6. `claude_web_view` app does not follow codebase conventions
+
+Description: The `apps/claude_web_view/` package has multiple deviations from the style guide in a single package:
+- `models.py` - All 9 classes inherit from `BaseModel` instead of `FrozenModel` (lines 20-93)
+- `models.py:11` - `MessageRole(str, Enum)` instead of `UpperCaseStrEnum` with `auto()` values
+- `server.py` and `watcher.py` - Use `async def` and `import asyncio` (style guide says "Never use async or asyncio")
+- `cli.py`, `parser.py`, `server.py`, `watcher.py` - Use relative imports (e.g., `from .models import ...`) instead of absolute imports
+- `cli.py` - Uses `argparse` instead of `click` for CLI argument parsing
+- `cli.py` - Uses stdlib `logging` instead of `loguru`
+
+Recommendation: Refactor `claude_web_view` to follow the codebase conventions: use `FrozenModel`, `UpperCaseStrEnum`, absolute imports, `click`, `loguru`, and synchronous code. The async usage may be required by the web framework (FastAPI/SSE), in which case this should be documented as an explicit exception.
+
+Decision: Accept
+
+## 7. `raise ValueError` in library code instead of domain-specific error
+
+Description: In `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636`, a bare `raise ValueError("The exception group does not contain exactly one exception.")` is used. The style guide says: "Never raise built-in Exceptions directly (except NotImplementedError). Instead, create a new type that inherits from both the base error class for the package and the built-in." The `concurrency_group` package already has its own error classes in `errors.py`.
+
+Recommendation: Create a new error class like `InvalidExceptionGroupError(ConcurrencyGroupError, ValueError)` in `errors.py` and use it instead.
+
+Decision: Accept
+
+## 8. Boolean field naming: `agent_is_ahead` / `local_is_ahead` use non-standard `is_` placement
+
+Description: In `libs/mngr/imbue/mngr/api/pair.py:38-42`, the `GitSyncAction` FrozenModel has fields `agent_is_ahead: bool` and `local_is_ahead: bool`. The style guide convention is to *prefix* booleans with `is_`, which would be `is_agent_ahead` and `is_local_ahead`. The current naming places `is` in the middle of the name.
+
+Recommendation: Rename to `is_agent_ahead` and `is_local_ahead` for consistency with the `is_` prefix convention.
+
+Decision: Accept
+
+## 9. `async def` in Modal log utilities
+
+Description: In `libs/mngr/imbue/mngr/providers/modal/log_utils.py:154`, there is an `async def put_log_content(self, log)` method. The style guide says "Never use `async` or `asyncio`." This appears to be required by the Modal SDK's output interface, which expects async methods.
+
+Recommendation: If the Modal SDK requires async methods for its output interface, document this as an explicit exception in the code with a comment explaining why. Otherwise, refactor to use synchronous code.
+
+Decision: Accept
+
+## 10. `snapshot_and_shutdown.py` uses stdlib `logging` instead of `loguru`
+
+Description: In `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:15,110`, stdlib `logging` is imported and used (`logger = logging.getLogger("snapshot_and_shutdown")`) instead of `loguru`. This is the only file in the core `mngr` library that uses stdlib logging for its own logging (as opposed to suppressing third-party loggers).
+
+Recommendation: Replace with `from loguru import logger` to match the rest of the codebase. If this runs in a Modal context where loguru is unavailable, document that as an exception.
+
+Decision: Accept
+
+## 11. Non-CLI boolean fields missing `is_` prefix in `ClaudeAgentConfig`
+
+Description: In `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:51-75`, `ClaudeAgentConfig` has several boolean fields without the `is_` prefix: `sync_home_settings`, `sync_claude_json`, `sync_repo_settings`, `sync_claude_credentials`, `check_installation`. These are config file fields loaded from TOML settings, not direct CLI options. While the non_issues.md exempts CLI boolean options, these are configuration model fields.
+
+Recommendation: Rename to `is_sync_home_settings`, `is_sync_claude_json`, `is_sync_repo_settings`, `is_sync_claude_credentials`, `is_check_installation`. Alternatively, if these are considered user-facing config that maps directly to TOML keys, add them to non_issues.md.
+
+Decision: Accept
+
+## 12. `contrib/claude-code-transcripts` has 81KB of code in `__init__.py`
+
+Description: The file `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py` contains ~2000 lines (81KB) of implementation code including function definitions, constants, module-level mutable state, and `global` keyword usage. The style guide says "Never put any code in an `__init__.py` file." Additionally, it uses `global _github_repo` (line 1225) which violates the "Avoid using the `global` keyword" rule.
+
+Recommendation: Move all code from `__init__.py` into proper module files (e.g., `parser.py`, `renderer.py`, `cli.py`) and leave `__init__.py` blank. Eliminate `global` keyword usage by passing state through function parameters.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 12 code-level inconsistencies in the codebase, ordered from most to least important
- Covers boolean naming inconsistencies, class hierarchy violations, style guide deviations, and convention mismatches
- Full report at `_tasks/inconsistencies/2026-02-16-11-05-56.md`

## Key findings

- Boolean naming inconsistency (`enabled` vs `is_enabled`) within the same file (`config/data_types.py`)
- Widespread use of `MutableModel` without `ABC` for non-interface classes (12 instances)
- `_ListIterationParams` inherits from `BaseModel` instead of `FrozenModel`
- `NamedTuple` usage in `utils/logging.py` (style guide forbids NamedTuples)
- `claude_web_view` app has 6+ convention violations (BaseModel, async, relative imports, argparse, stdlib logging, str Enum)
- Bare `ValueError` raised in library code instead of domain-specific error
- `async def` in Modal log utilities
- stdlib `logging` used instead of `loguru` in `snapshot_and_shutdown.py`
- 81KB `__init__.py` with global state in `contrib/claude-code-transcripts`

Generated with [Claude Code](https://claude.com/claude-code)