### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-17-11-04-50.md
+++ b/_tasks/inconsistencies/2026-02-17-11-04-50.md
@@ -91,7 +91,29 @@ Recommendation: Remove the docstring from `__init__.py`, leaving it completely b
 
 Decision: Accept
 
-## 10. Missing return type annotations on several functions
+## 10. Enum branching uses if/elif chains instead of match statements
+
+Description: Several locations branch on enum values using if/elif chains instead of match statements with `assert_never()`, which the style guide (lines 235-276) explicitly requires: "For enums, always use match statements."
+- `libs/mngr/imbue/mngr/hosts/common.py:35-83`: `get_activity_sources_for_idle_mode()` uses an if/elif chain over `IdleMode` enum (9 cases) with a final `else` raising `SwitchError` instead of a match statement with `assert_never()`.
+- `libs/mngr/imbue/mngr/api/pair.py:112-118`: if/elif chain for `SyncDirection` enum (FORWARD/REVERSE) instead of match.
+- `libs/mngr/imbue/mngr/cli/list.py:591-609`: Two if/elif/else chains for `OutputFormat` enum, raising `AssertionError` on unexpected format instead of using `assert_never()`.
+This is inconsistent with many other files that correctly use match statements (e.g., `cli/config.py`).
+
+Recommendation: Convert all if/elif chains that branch on enum values to match statements with `assert_never()` in the default case.
+
+Decision: Accept
+
+## 11. Broad except Exception handlers
+
+Description: Two locations use overly broad `except Exception:` handlers, violating the style guide (line 441: "Never use a blanket `except:` clause! Always catch the narrowest specific exception type"):
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233`: `except Exception: pass` in thread join timeout handling. Should catch a more specific exception type.
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:37`: `except Exception: pass  # Subscriber disconnected` when broadcasting to async queues. Should catch `asyncio.QueueFull` or another specific exception.
+
+Recommendation: Replace broad `except Exception:` with the narrowest applicable exception type. For thread join, use the specific timeout exception. For queue operations, catch `asyncio.QueueFull` or document why a broad catch is necessary.
+
+Decision: Accept
+
+## 12. Missing return type annotations on several functions
 
 Description: Several functions are missing return type annotations, violating the style guide (line 693-695: "Always include complete type hints"):
 - `libs/mngr/imbue/mngr/providers/modal/log_utils.py:142`: `def step_progress(text: str = ""):` -- missing return type.


### PR DESCRIPTION
## Summary

Automated code-guardian inconsistency report identifying 10 code-level inconsistencies, ordered by importance:

1. **claude_web_view uses plain BaseModel** instead of FrozenModel (11 classes)
2. **claude_web_view uses relative imports** instead of absolute imports (11 import lines)
3. **claude_web_view CLI uses argparse** instead of click
4. **NamedTuple usage** in core logging utils and conftest (2 classes)
5. **print() usage** instead of loguru in claude_web_view (12 instances)
6. **Module-level docstrings** in claude_web_view and sculptor_web (8 files)
7. **MessageRole enum** uses `(str, Enum)` instead of `UpperCaseStrEnum`
8. **Plain classes with mutable state** not following interface/implementation pattern (4 classes)
9. **Code in __init__.py** in claude_web_view
10. **Missing type annotations** in Modal log_utils (5 functions/parameters)

The majority of issues are concentrated in the `claude_web_view` app, which appears to have been written without following the project's style guide.

Generated with [Claude Code](https://claude.com/claude-code)