### PR TITLE
Add macOS keychain credential conversion for remote hosts

### DIFF
--- a/libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py
+++ b/libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py
@@ -13,6 +13,8 @@ import click
 from loguru import logger
 from pydantic import Field
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.errors import ProcessSetupError
 from imbue.imbue_common.logging import log_span
 from imbue.mngr import hookimpl
 from imbue.mngr.agents.base_agent import BaseAgent
@@ -28,6 +30,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import AgentStartError
 from imbue.mngr.errors import NoCommandDefinedError
 from imbue.mngr.errors import PluginMngrError
+from imbue.mngr.hosts.common import is_macos
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.data_types import FileTransferSpec
 from imbue.mngr.interfaces.data_types import RelativePath
@@ -69,6 +72,10 @@ class ClaudeAgentConfig(AgentTypeConfig):
         default=None,
         description="Extra folder to sync to the repo .claude/ folder in the agent work_dir."
         "(files are transferred after user settings, so they can override)",
+    )
+    convert_macos_credentials: bool = Field(
+        default=True,
+        description="Whether to convert macOS keychain credentials to flat files for remote hosts",
     )
     check_installation: bool = Field(
         default=True,
@@ -121,6 +128,22 @@ def _claude_json_has_primary_api_key() -> bool:
         return False
 
 
+def _read_macos_keychain_credential(label: str, concurrency_group: ConcurrencyGroup) -> str | None:
+    """Read a credential from the macOS keychain by label."""
+    try:
+        result = concurrency_group.run_process_to_completion(
+            ["security", "find-generic-password", "-l", label, "-w"],
+            is_checked_after=False,
+        )
+    except ProcessSetupError:
+        logger.debug("macOS security binary not found")
+        return None
+    if result.returncode != 0:
+        logger.debug("No keychain credential found for label {!r}", label)
+        return None
+    return result.stdout.strip()
+
+
 def _provision_background_scripts(host: OnlineHostInterface) -> None:
     """Write the background task scripts to $MNGR_HOST_DIR/commands/.
 
@@ -141,6 +164,7 @@ def _has_api_credentials_available(
     host: OnlineHostInterface,
     options: CreateAgentOptions,
     config: ClaudeAgentConfig,
+    concurrency_group: ConcurrencyGroup,
 ) -> bool:
     """Check whether API credentials appear to be available for Claude Code.
 
@@ -161,15 +185,26 @@ def _has_api_credentials_available(
     if host.get_env_var("ANTHROPIC_API_KEY"):
         return True
 
+    # Check credentials file or macOS keychain (OAuth tokens)
     credentials_path = Path.home() / ".claude" / ".credentials.json"
-    if credentials_path.exists():
+    is_oauth_available = credentials_path.exists() or (
+        config.convert_macos_credentials
+        and is_macos()
+        and _read_macos_keychain_credential("Claude Code-credentials", concurrency_group) is not None
+    )
+    if is_oauth_available:
         if host.is_local:
             return True
         if config.sync_claude_credentials:
             return True
 
-    # Check for primaryApiKey in ~/.claude.json
-    if _claude_json_has_primary_api_key():
+    # Check primaryApiKey in ~/.claude.json or macOS keychain (API key)
+    is_api_key_available = _claude_json_has_primary_api_key() or (
+        config.convert_macos_credentials
+        and is_macos()
+        and _read_macos_keychain_credential("Claude Code", concurrency_group) is not None
+    )
+    if is_api_key_available:
         if host.is_local:
             return True
         if config.sync_claude_json:
@@ -358,7 +393,7 @@ class ClaudeAgent(BaseAgent):
             logger.debug("Skipped claude installation check (check_installation=False)")
             return
 
-        if not _has_api_credentials_available(host, options, config):
+        if not _has_api_credentials_available(host, options, config, mngr_ctx.concurrency_group):
             logger.warning(
                 "No API credentials detected for Claude Code. The agent may fail to start.\n"
                 "Provide credentials via one of:\n"
@@ -558,6 +593,12 @@ class ClaudeAgent(BaseAgent):
                     # hack--add an extra key in there because otherwise we get prompted about skipping permissions:
                     claude_json_data = json.loads(claude_json_path.read_text())
                     claude_json_data["bypassPermissionsModeAccepted"] = True
+                    # If the local file lacks primaryApiKey, try the macOS keychain
+                    if not claude_json_data.get("primaryApiKey") and config.convert_macos_credentials and is_macos():
+                        keychain_api_key = _read_macos_keychain_credential("Claude Code", mngr_ctx.concurrency_group)
+                        if keychain_api_key is not None:
+                            logger.info("Merging macOS keychain API key into ~/.claude.json for remote host...")
+                            claude_json_data["primaryApiKey"] = keychain_api_key
                     host.write_text_file(Path(".claude.json"), json.dumps(claude_json_data, indent=2) + "\n")
                 else:
                     logger.debug("Skipped ~/.claude.json (file does not exist)")
@@ -567,6 +608,18 @@ class ClaudeAgent(BaseAgent):
                 if credentials_path.exists():
                     logger.info("Transferring ~/.claude/.credentials.json to remote host...")
                     host.write_text_file(Path(".claude/.credentials.json"), credentials_path.read_text())
+                elif config.convert_macos_credentials and is_macos():
+                    # No local credentials file, but keychain may have OAuth tokens
+                    keychain_credentials = _read_macos_keychain_credential(
+                        "Claude Code-credentials", mngr_ctx.concurrency_group
+                    )
+                    if keychain_credentials is not None:
+                        logger.info("Writing macOS keychain OAuth credentials to remote host...")
+                        host.write_text_file(Path(".claude/.credentials.json"), keychain_credentials)
+                    else:
+                        logger.debug(
+                            "Skipped ~/.claude/.credentials.json (file does not exist, no keychain credentials)"
+                        )
                 else:
                     logger.debug("Skipped ~/.claude/.credentials.json (file does not exist)")
 

--- a/libs/mngr/imbue/mngr/agents/default_plugins/claude_agent_test.py
+++ b/libs/mngr/imbue/mngr/agents/default_plugins/claude_agent_test.py
@@ -12,10 +12,13 @@ import pluggy
 import pytest
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.errors import ProcessSetupError
+from imbue.concurrency_group.subprocess_utils import FinishedProcess
 from imbue.mngr.agents.default_plugins.claude_agent import ClaudeAgent
 from imbue.mngr.agents.default_plugins.claude_agent import ClaudeAgentConfig
 from imbue.mngr.agents.default_plugins.claude_agent import _claude_json_has_primary_api_key
 from imbue.mngr.agents.default_plugins.claude_agent import _has_api_credentials_available
+from imbue.mngr.agents.default_plugins.claude_agent import _read_macos_keychain_credential
 from imbue.mngr.agents.default_plugins.claude_config import ClaudeDirectoryNotTrustedError
 from imbue.mngr.agents.default_plugins.claude_config import build_readiness_hooks_config
 from imbue.mngr.config.data_types import AgentTypeConfig
@@ -1035,6 +1038,12 @@ def credential_check_host(local_provider: LocalProviderInstance, tmp_path: Path,
 
 
 @pytest.fixture()
+def credential_check_cg(temp_mngr_ctx: MngrContext) -> ConcurrencyGroup:
+    """Provide the concurrency group for credential check tests."""
+    return temp_mngr_ctx.concurrency_group
+
+
+@pytest.fixture()
 def _local_credentials_file() -> None:
     """Create a ~/.claude/.credentials.json file for testing."""
     credentials_dir = Path.home() / ".claude"
@@ -1051,26 +1060,40 @@ def _make_non_local_host() -> OnlineHostInterface:
 
 
 def test_has_api_credentials_detects_env_var_on_local_host(
-    credential_check_host: Host, monkeypatch: pytest.MonkeyPatch
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """_has_api_credentials_available returns True when ANTHROPIC_API_KEY is in os.environ on local host."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
     config = ClaudeAgentConfig(check_installation=False)
 
-    assert _has_api_credentials_available(credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
-def test_has_api_credentials_ignores_env_var_on_remote_host(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_has_api_credentials_ignores_env_var_on_remote_host(
+    credential_check_cg: ConcurrencyGroup, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """_has_api_credentials_available ignores os.environ ANTHROPIC_API_KEY for remote hosts."""
     config = ClaudeAgentConfig(check_installation=False)
 
     # Set the key locally -- remote hosts should still return False because they don't inherit os.environ
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
-    assert _has_api_credentials_available(_make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is False
+    assert (
+        _has_api_credentials_available(
+            _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is False
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_detects_agent_env_var(credential_check_host: Host) -> None:
+def test_has_api_credentials_detects_agent_env_var(
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup
+) -> None:
     """_has_api_credentials_available returns True when ANTHROPIC_API_KEY is in agent env vars."""
     config = ClaudeAgentConfig(check_installation=False)
     options = CreateAgentOptions(
@@ -1080,48 +1103,79 @@ def test_has_api_credentials_detects_agent_env_var(credential_check_host: Host) 
         ),
     )
 
-    assert _has_api_credentials_available(credential_check_host, options, config) is True
+    assert _has_api_credentials_available(credential_check_host, options, config, credential_check_cg) is True
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_detects_host_env_var(credential_check_host: Host) -> None:
+def test_has_api_credentials_detects_host_env_var(
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup
+) -> None:
     """_has_api_credentials_available returns True when ANTHROPIC_API_KEY is in host env vars."""
     config = ClaudeAgentConfig(check_installation=False)
     credential_check_host.set_env_var("ANTHROPIC_API_KEY", "sk-test-key")
 
-    assert _has_api_credentials_available(credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env", "_local_credentials_file")
-def test_has_api_credentials_detects_credentials_file_local(credential_check_host: Host) -> None:
+def test_has_api_credentials_detects_credentials_file_local(
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup
+) -> None:
     """_has_api_credentials_available returns True when credentials file exists on local host."""
     config = ClaudeAgentConfig(check_installation=False)
 
-    assert _has_api_credentials_available(credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env", "_local_credentials_file")
-def test_has_api_credentials_detects_credentials_file_remote_with_sync() -> None:
+def test_has_api_credentials_detects_credentials_file_remote_with_sync(credential_check_cg: ConcurrencyGroup) -> None:
     """_has_api_credentials_available returns True when credentials file exists and sync is enabled for remote."""
     config = ClaudeAgentConfig(check_installation=False, sync_claude_credentials=True)
 
-    assert _has_api_credentials_available(_make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_returns_false_when_no_credentials(credential_check_host: Host) -> None:
+def test_has_api_credentials_returns_false_when_no_credentials(
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup
+) -> None:
     """_has_api_credentials_available returns False when no credential source is available."""
     config = ClaudeAgentConfig(check_installation=False)
 
-    assert _has_api_credentials_available(credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is False
+    assert (
+        _has_api_credentials_available(
+            credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is False
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env", "_local_credentials_file")
-def test_has_api_credentials_returns_false_remote_no_sync() -> None:
+def test_has_api_credentials_returns_false_remote_no_sync(credential_check_cg: ConcurrencyGroup) -> None:
     """_has_api_credentials_available returns False for remote host when credentials exist but sync is disabled."""
     config = ClaudeAgentConfig(check_installation=False, sync_claude_credentials=False)
 
-    assert _has_api_credentials_available(_make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is False
+    assert (
+        _has_api_credentials_available(
+            _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is False
+    )
 
 
 # =============================================================================
@@ -1173,30 +1227,49 @@ def test_claude_json_has_primary_api_key_returns_false_when_invalid_json() -> No
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_detects_primary_api_key_local(credential_check_host: Host) -> None:
+def test_has_api_credentials_detects_primary_api_key_local(
+    credential_check_host: Host, credential_check_cg: ConcurrencyGroup
+) -> None:
     """_has_api_credentials_available returns True when primaryApiKey exists in ~/.claude.json on local host."""
     _write_claude_json_with_primary_api_key()
     config = ClaudeAgentConfig(check_installation=False)
 
-    assert _has_api_credentials_available(credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_detects_primary_api_key_remote_with_sync() -> None:
+def test_has_api_credentials_detects_primary_api_key_remote_with_sync(credential_check_cg: ConcurrencyGroup) -> None:
     """_has_api_credentials_available returns True when primaryApiKey exists and sync_claude_json is enabled."""
     _write_claude_json_with_primary_api_key()
     config = ClaudeAgentConfig(check_installation=False, sync_claude_json=True)
 
-    assert _has_api_credentials_available(_make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is True
+    assert (
+        _has_api_credentials_available(
+            _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is True
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-def test_has_api_credentials_returns_false_primary_api_key_remote_no_sync() -> None:
+def test_has_api_credentials_returns_false_primary_api_key_remote_no_sync(
+    credential_check_cg: ConcurrencyGroup,
+) -> None:
     """_has_api_credentials_available returns False when primaryApiKey exists but sync_claude_json is disabled."""
     _write_claude_json_with_primary_api_key()
     config = ClaudeAgentConfig(check_installation=False, sync_claude_json=False)
 
-    assert _has_api_credentials_available(_make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config) is False
+    assert (
+        _has_api_credentials_available(
+            _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+        )
+        is False
+    )
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
@@ -1234,3 +1307,134 @@ def test_on_before_provisioning_succeeds_with_credentials(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
 
     agent.on_before_provisioning(host=host, options=_DEFAULT_CREDENTIAL_CHECK_OPTIONS, mngr_ctx=temp_mngr_ctx)
+
+
+# =============================================================================
+# macOS Keychain Credential Tests
+# =============================================================================
+
+
+def _make_mock_cg_with_result(result: FinishedProcess | Exception) -> ConcurrencyGroup:
+    """Create a mock ConcurrencyGroup that returns the given result from run_process_to_completion."""
+
+    def _run(*args: object, **kwargs: object) -> FinishedProcess:
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    return cast(ConcurrencyGroup, SimpleNamespace(run_process_to_completion=_run))
+
+
+def test_read_macos_keychain_credential_returns_value_on_success() -> None:
+    """_read_macos_keychain_credential returns the stripped stdout on success."""
+    mock_cg = _make_mock_cg_with_result(
+        FinishedProcess(
+            command=("security",),
+            returncode=0,
+            stdout="test-credential-value\n",
+            stderr="",
+            is_output_already_logged=False,
+        )
+    )
+
+    result = _read_macos_keychain_credential("some-label", mock_cg)
+
+    assert result == "test-credential-value"
+
+
+def test_read_macos_keychain_credential_returns_none_on_nonzero_exit() -> None:
+    """_read_macos_keychain_credential returns None when security returns non-zero exit code."""
+    mock_cg = _make_mock_cg_with_result(
+        FinishedProcess(
+            command=("security",), returncode=44, stdout="", stderr="not found", is_output_already_logged=False
+        )
+    )
+
+    result = _read_macos_keychain_credential("nonexistent-label", mock_cg)
+
+    assert result is None
+
+
+def test_read_macos_keychain_credential_returns_none_on_process_setup_error() -> None:
+    """_read_macos_keychain_credential returns None when security binary is not found."""
+    mock_cg = _make_mock_cg_with_result(
+        ProcessSetupError(command=("security",), stdout="", stderr="", is_output_already_logged=False)
+    )
+
+    result = _read_macos_keychain_credential("some-label", mock_cg)
+
+    assert result is None
+
+
+@pytest.mark.usefixtures("_no_api_key_in_env")
+def test_has_api_credentials_detects_keychain_on_local_macos(
+    credential_check_host: Host,
+    credential_check_cg: ConcurrencyGroup,
+) -> None:
+    """_has_api_credentials_available returns True on local macOS when keychain has credentials."""
+    config = ClaudeAgentConfig(check_installation=False)
+
+    with patch(
+        "imbue.mngr.agents.default_plugins.claude_agent.is_macos",
+        return_value=True,
+    ):
+        with patch(
+            "imbue.mngr.agents.default_plugins.claude_agent._read_macos_keychain_credential",
+            return_value='{"claudeAiOauth": {"accessToken": "test-token"}}',
+        ):
+            assert (
+                _has_api_credentials_available(
+                    credential_check_host, _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+                )
+                is True
+            )
+
+
+@pytest.mark.usefixtures("_no_api_key_in_env")
+def test_has_api_credentials_detects_keychain_on_remote_with_sync_enabled(
+    credential_check_cg: ConcurrencyGroup,
+) -> None:
+    """_has_api_credentials_available returns True on remote host when keychain has credentials and sync is enabled."""
+    config = ClaudeAgentConfig(check_installation=False, sync_claude_credentials=True)
+
+    with patch(
+        "imbue.mngr.agents.default_plugins.claude_agent.is_macos",
+        return_value=True,
+    ):
+        with patch(
+            "imbue.mngr.agents.default_plugins.claude_agent._read_macos_keychain_credential",
+            return_value="some-credential",
+        ):
+            assert (
+                _has_api_credentials_available(
+                    _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+                )
+                is True
+            )
+
+
+@pytest.mark.usefixtures("_no_api_key_in_env")
+def test_has_api_credentials_ignores_keychain_on_remote_with_sync_disabled(
+    credential_check_cg: ConcurrencyGroup,
+) -> None:
+    """_has_api_credentials_available returns False on remote host when sync is disabled even with keychain credentials."""
+    config = ClaudeAgentConfig(
+        check_installation=False,
+        sync_claude_credentials=False,
+        sync_claude_json=False,
+    )
+
+    with patch(
+        "imbue.mngr.agents.default_plugins.claude_agent.is_macos",
+        return_value=True,
+    ):
+        with patch(
+            "imbue.mngr.agents.default_plugins.claude_agent._read_macos_keychain_credential",
+            return_value="some-credential",
+        ):
+            assert (
+                _has_api_credentials_available(
+                    _make_non_local_host(), _DEFAULT_CREDENTIAL_CHECK_OPTIONS, config, credential_check_cg
+                )
+                is False
+            )


### PR DESCRIPTION
On macOS, Claude Code stores OAuth tokens and API keys in the system keychain rather than in flat files (~/.claude/.credentials.json and primaryApiKey in ~/.claude.json). The existing credential sync code silently skips these when the files don't exist, leaving remote Linux containers without authentication.

This adds keychain fallbacks inside the existing sync_claude_json and sync_claude_credentials provisioning blocks, gated by a new convert_macos_credentials config flag (default True):

- sync_claude_credentials: when the local .credentials.json doesn't exist, reads "Claude Code-credentials" from the macOS keychain and writes it to the remote host
- sync_claude_json: when the local .claude.json exists but lacks primaryApiKey, reads "Claude Code" from the keychain and merges it before writing

_has_api_credentials_available is updated to detect keychain credentials so the "no credentials" warning doesn't fire on macOS.

Keychain access uses ConcurrencyGroup.run_process_to_completion to conform to the subprocess usage ratchet.