### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-18-11-01-39.md
+++ b/_tasks/inconsistencies/2026-02-18-11-01-39.md
@@ -1,0 +1,123 @@
+# Inconsistencies identified on 2026-02-18-11-01-39
+
+## 1. claude_web_view app uses relative imports instead of absolute imports
+
+Description: The `apps/claude_web_view` app uses relative imports throughout, violating the style guide rule "Always use absolute imports, never relative imports." Files affected:
+- `apps/claude_web_view/imbue/claude_web_view/parser.py:8-14` -- 7 relative imports (`from .models import ...`)
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:12` -- `from .server import create_app`
+- `apps/claude_web_view/imbue/claude_web_view/server.py:17-18` -- `from .parser import ...`, `from .watcher import ...`
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:10` -- `from .parser import TranscriptParser`
+
+Recommendation: Convert all relative imports to absolute imports (e.g., `from imbue.claude_web_view.models import ...`). There is a ratchet test (`test_prevent_relative_imports`) that covers the mngr library source directory but not the apps directory. Consider extending ratchet coverage to apps as well.
+
+Decision: Accept
+
+## 2. claude_web_view uses str+Enum instead of UpperCaseStrEnum, and hardcoded values instead of auto()
+
+Description: In `apps/claude_web_view/imbue/claude_web_view/models.py:11-16`, `MessageRole` inherits from `str, Enum` instead of `UpperCaseStrEnum`, and uses hardcoded string values (`"user"`, `"assistant"`, `"system"`) instead of `auto()`. The style guide says "All enums should inherit from `UpperCaseStrEnum`" and "All values for enums should be `auto()`."
+
+Additionally, the same file uses `BaseModel` from pydantic directly instead of `FrozenModel` from imbue_common (lines 20-93), and has a module-level docstring (line 1) which the style guide prohibits.
+
+Recommendation: Change `MessageRole` to inherit from `UpperCaseStrEnum` with `auto()` values. Convert `BaseModel` usages to `FrozenModel`. Remove the module-level docstring. This will require updating downstream code that depends on the specific string values.
+
+Decision: Accept
+
+## 3. Bare Exception raises in modal provider code
+
+Description: Two locations in the modal provider raise bare `Exception` instead of using the custom error hierarchy:
+- `libs/mngr/imbue/mngr/providers/modal/backend.py:452` -- `raise Exception("Host is not an instance of Host class")`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:607` -- `raise Exception(f"Host record not found on volume for {host_id}")`
+
+The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)." The mngr library has `MngrError` as its base exception class with appropriate subclasses.
+
+Recommendation: Replace with specific custom exceptions from `imbue.mngr.errors`, e.g., a `TypeError`-inheriting subclass for the type check, and a `KeyError`-inheriting subclass for the missing host record.
+
+Decision: Accept
+
+## 4. async def method in modal log_utils.py
+
+Description: `libs/mngr/imbue/mngr/providers/modal/log_utils.py:154` defines `async def put_log_content(self, log)` inside `_QuietOutputManager`. The style guide explicitly says "Never use `async` or `asyncio`." This is an override of a Modal library method that requires the async signature for compatibility.
+
+Recommendation: This is likely a justified exception since it overrides an external library's async method. Document this exception with a comment explaining why async is needed here. However, also note the missing type annotation on the `log` parameter (line 154) and `renderable` parameter (lines 145, 150).
+
+Decision: Accept
+
+## 5. NamedTuple usage in mngr source code
+
+Description: `libs/mngr/imbue/mngr/utils/logging.py:232-236` defines `BufferedMessage(NamedTuple)` with two fields. The style guide says "Never use dataclasses or named tuples." Additionally, the ratchet test `test_prevent_namedtuple_usage` only checks for the function-call syntax `namedtuple(` and misses the class-based `class Foo(NamedTuple):` syntax, so this violation is not caught by existing ratchets.
+
+Recommendation: Convert `BufferedMessage` to a `FrozenModel` with `Field(description=...)` on each attribute. Also fix the ratchet test pattern to catch `NamedTuple` class inheritance (e.g., change pattern to `r"\bnamedtuple\s*\(|\bNamedTuple\b"`).
+
+Decision: Accept
+
+## 6. logger.info used in API/library code instead of logger.debug
+
+Description: The style guide says "Reserve `logger.info` for CLI/user-facing code... Library and API code should use `logger.debug`." However, the `api/` layer uses `logger.info` in many places:
+- `libs/mngr/imbue/mngr/api/create.py:109,116,120`
+- `libs/mngr/imbue/mngr/api/find.py:297,319`
+- `libs/mngr/imbue/mngr/api/connect.py:152,186`
+- `libs/mngr/imbue/mngr/api/pair.py:140,149,360`
+
+The `api/` module is library code called by `cli/`, so these should be `logger.debug` with `log_span` where applicable.
+
+Recommendation: Audit all `logger.info` calls in `api/` and convert to `logger.debug` or wrap in `log_span`. The CLI layer can add its own `logger.info` calls for user-facing messages.
+
+Decision: Accept
+
+## 7. ModalLoguruWriter bare re-raise without exception chaining in except block
+
+Description: In `libs/mngr/imbue/mngr/providers/modal/log_utils.py:86-90`, inside an `except ValueError as e:` block, the code uses bare `raise` (re-raising the same exception) in the else branch. While `raise` (re-raise) is acceptable in except blocks, the preceding branch silently swallows the "I/O operation on closed file" ValueError without logging it, which could mask real issues.
+
+Additionally, the same file has utility classes (`_MultiWriter` at line 30, `ModalLoguruWriter` at line 68) that are plain Python classes -- not `FrozenModel`, `MutableModel+ABC`, or implementations thereof. While these serve as adapters for external library interfaces and are somewhat justified, they are inconsistent with the three-class model.
+
+Recommendation: At minimum, add a `logger.trace` call when swallowing the "I/O operation on closed file" error for debugging visibility. Consider whether the adapter classes could use `MutableModel` as a base.
+
+Decision: Accept
+
+## 8. Inconsistent use of `from __future__ import annotations`
+
+Description: Only 13 out of ~85 non-test source files in the mngr library use `from __future__ import annotations`. There is no style guide rule about this, but the inconsistency means forward references work differently across files. Files using it include `hosts/host.py`, `interfaces/host.py`, `config/data_types.py`, `api/data_types.py`, and several others, while the majority of files do not use it.
+
+Recommendation: Decide on a project-wide policy: either add `from __future__ import annotations` to all files or remove it from the 13 that have it. Adding it everywhere would simplify forward references and be more consistent.
+
+Decision: Accept
+
+## 9. Broad `except Exception:` clauses in multiple files
+
+Description: Several files use overly broad `except Exception:` clauses, violating the style guide rule to "Always catch the narrowest specific exception type":
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py` -- `except Exception: pass`
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233` -- `except Exception: pass`
+- `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py:108,148` -- two `except Exception:` blocks
+
+Recommendation: Replace with specific exception types. For watcher.py, catch the specific disconnection exception. For concurrency_group, catch the specific thread/process exception.
+
+Decision: Accept
+
+## 10. Bare ValueError raise in concurrency_group library code
+
+Description: `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636` raises bare `ValueError("The exception group does not contain exactly one exception.")`. The concurrency_group library has its own `ConcurrencyGroupError` base class in `errors.py`, so this should use a custom exception.
+
+Recommendation: Create a specific error class (e.g., `ExceptionGroupError(ConcurrencyGroupError, ValueError)`) and use it instead of bare `ValueError`.
+
+Decision: Accept
+
+## 11. contrib/claude-code-transcripts has production code in __init__.py
+
+Description: `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py` contains production code (functions and classes). The style guide says "Never put any code in an `__init__.py` file." However, this is in the `contrib/` directory which may follow different conventions, and the ratchet tests only cover the mngr source directory.
+
+Recommendation: Move the code to dedicated module files and keep `__init__.py` empty. If `contrib/` is intentionally exempt from the style guide, document that exemption.
+
+Decision: Accept
+
+## 12. Module-level docstrings present in some files
+
+Description: The style guide says "Never create docstrings for modules." However, several files have module-level docstrings:
+- `apps/claude_web_view/imbue/claude_web_view/parser.py:1` -- `"""JSONL transcript parser for Claude Code sessions."""`
+- `apps/claude_web_view/imbue/claude_web_view/models.py:1` -- `"""Pydantic models for Claude Code transcript parsing."""`
+- `conftest.py:1` -- `"""Root conftest for enforcing test suite time limits..."""`
+
+These are outside the mngr library proper and so are not caught by existing ratchet tests.
+
+Recommendation: Remove module-level docstrings from files that have them. If the information is important, convert it to a comment instead. Consider extending ratchet coverage to apps and contrib directories.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 12 code-level inconsistencies across the codebase, ordered by importance
- Key findings include: relative imports in claude_web_view, enum style violations, bare Exception raises in modal provider, async def usage, NamedTuple escaping ratchet detection, and logger.info misuse in library code
- Report is at `_tasks/inconsistencies/2026-02-18-11-01-39.md`

## Test plan

- [ ] Review each inconsistency for accuracy
- [ ] Prioritize fixes based on severity
- [ ] Create follow-up tasks for accepted issues