### PR TITLE
Add --connect-command to create and start subcommands

### DIFF
--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -180,6 +180,7 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 | `--retry` | integer | Number of connection retries | `3` |
 | `--retry-delay` | text | Delay between retries (e.g., 5s, 1m) | `5s` |
 | `--attach-command` | text | Command to run instead of attaching to main session | None |
+| `--connect-command` | text | Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set. | None |
 
 ## Automation
 

--- a/libs/mngr/docs/commands/primary/start.md
+++ b/libs/mngr/docs/commands/primary/start.md
@@ -59,6 +59,7 @@ mngr start [OPTIONS] [AGENTS]...
 | ---- | ---- | ----------- | ------- |
 | `--dry-run` | boolean | Show what would be started without actually starting | `False` |
 | `--connect`, `--no-connect` | boolean | Connect to the agent after starting (only valid for single agent) | `False` |
+| `--connect-command` | text | Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set. | None |
 
 ## Snapshot
 

--- a/libs/mngr/imbue/mngr/api/connect.py
+++ b/libs/mngr/imbue/mngr/api/connect.py
@@ -139,6 +139,25 @@ def _determine_post_disconnect_action(
         return None
 
 
+def run_connect_command(
+    connect_command: str,
+    agent_name: str,
+    session_name: str,
+    is_local: bool,
+) -> None:
+    """Run a custom connect command instead of the builtin connect_to_agent.
+
+    Sets environment variables so the command can reference the agent,
+    then replaces the current process.
+    """
+    env = dict(os.environ)
+    env["MNGR_AGENT_NAME"] = agent_name
+    env["MNGR_SESSION_NAME"] = session_name
+    env["MNGR_HOST_IS_LOCAL"] = "true" if is_local else "false"
+    logger.debug("Running custom connect command: {}", connect_command)
+    os.execvpe("sh", ["sh", "-c", connect_command], env)
+
+
 def connect_to_agent(
     agent: AgentInterface,
     host: OnlineHostInterface,

--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -139,6 +139,7 @@ def default_create_cli_opts() -> CreateCliOptions:
         retry=3,
         retry_delay="5s",
         attach_command=None,
+        connect_command=None,
         idle_timeout=None,
         idle_mode=None,
         activity_sources=None,

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -18,6 +18,7 @@ from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.connect import connect_to_agent
+from imbue.mngr.api.connect import run_connect_command
 from imbue.mngr.api.create import create as api_create
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.data_types import CreateAgentResult
@@ -158,6 +159,7 @@ class CreateCliOptions(CommonCliOptions):
     agent_type: str | None
     reuse: bool
     connect: bool
+    connect_command: str | None
     await_ready: bool | None
     await_agent_stopped: bool | None
     copy_work_dir: bool | None
@@ -504,6 +506,10 @@ class CreateCliOptions(CommonCliOptions):
 @optgroup.option("--retry", type=int, default=3, show_default=True, help="Number of connection retries")
 @optgroup.option("--retry-delay", default="5s", show_default=True, help="Delay between retries (e.g., 5s, 1m)")
 @optgroup.option("--attach-command", help="Command to run instead of attaching to main session")
+@optgroup.option(
+    "--connect-command",
+    help="Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set.",
+)
 @optgroup.group("Automation")
 @optgroup.option(
     "-y",
@@ -811,6 +817,16 @@ def _handle_create(
     return create_result, connection_opts, output_opts, opts, mngr_ctx
 
 
+def _resolve_connect_command(
+    opts_connect_command: str | None,
+    mngr_ctx: MngrContext,
+) -> str | None:
+    """Resolve the connect command from CLI option or global config."""
+    if opts_connect_command is not None:
+        return opts_connect_command
+    return mngr_ctx.config.connect_command
+
+
 def _post_create(
     create_result: CreateAgentResult,
     connection_opts: ConnectionOptions,
@@ -822,9 +838,19 @@ def _post_create(
     if opts.await_agent_stopped:
         _await_agent_stopped(create_result.agent)
 
-    # If --connect is set, connect to the agent
+    # If --connect is set, connect to the agent (or run the custom connect command)
     if opts.connect:
-        connect_to_agent(create_result.agent, create_result.host, mngr_ctx, connection_opts)
+        resolved_connect_command = _resolve_connect_command(opts.connect_command, mngr_ctx)
+        if resolved_connect_command is not None:
+            session_name = f"{mngr_ctx.config.prefix}{create_result.agent.name}"
+            run_connect_command(
+                resolved_connect_command,
+                str(create_result.agent.name),
+                session_name,
+                is_local=create_result.host.is_local,
+            )
+        else:
+            connect_to_agent(create_result.agent, create_result.host, mngr_ctx, connection_opts)
 
     # output the result
     _output_result(create_result, output_opts)

--- a/libs/mngr/imbue/mngr/cli/start_test.py
+++ b/libs/mngr/imbue/mngr/cli/start_test.py
@@ -15,6 +15,7 @@ def test_start_cli_options_fields() -> None:
         start_all=False,
         dry_run=True,
         connect=False,
+        connect_command=None,
         host=(),
         include=(),
         exclude=(),

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -461,6 +461,11 @@ class MngrConfig(FrozenModel):
         "When False, raises an error if the agent is not already installed on the remote host. "
         "Defaults to True (allowed).",
     )
+    connect_command: str | None = Field(
+        default=None,
+        description="Custom command to run instead of the builtin connect when create or start connects to agents. "
+        "The environment variables MNGR_AGENT_NAME and MNGR_SESSION_NAME are set before running the command.",
+    )
     is_nested_tmux_allowed: bool = Field(
         default=False,
         description="Allow attaching to tmux sessions from within an existing tmux session by unsetting $TMUX",
@@ -587,6 +592,11 @@ class MngrConfig(FrozenModel):
         if override.is_remote_agent_installation_allowed is not None:
             is_remote_agent_installation_allowed = override.is_remote_agent_installation_allowed
 
+        # Merge connect_command (scalar - override wins if not None)
+        merged_connect_command = (
+            override.connect_command if override.connect_command is not None else self.connect_command
+        )
+
         # Merge is_nested_tmux_allowed (scalar - override wins if not None)
         merged_is_nested_tmux_allowed = self.is_nested_tmux_allowed
         if override.is_nested_tmux_allowed is not None:
@@ -625,6 +635,7 @@ class MngrConfig(FrozenModel):
             create_templates=merged_create_templates,
             pre_command_scripts=merged_pre_command_scripts,
             is_remote_agent_installation_allowed=is_remote_agent_installation_allowed,
+            connect_command=merged_connect_command,
             logging=merged_logging,
             is_nested_tmux_allowed=merged_is_nested_tmux_allowed,
             is_error_reporting_enabled=merged_is_error_reporting_enabled,

--- a/libs/mngr/imbue/mngr/config/data_types_test.py
+++ b/libs/mngr/imbue/mngr/config/data_types_test.py
@@ -857,3 +857,22 @@ def test_mngr_config_merge_keeps_base_destroyed_host_persisted_seconds_when_over
     )
     merged = base.merge_with(override)
     assert merged.default_destroyed_host_persisted_seconds == 86400.0
+
+
+def test_mngr_config_merge_overrides_connect_command(mngr_test_prefix: str) -> None:
+    base = MngrConfig(prefix=mngr_test_prefix, connect_command="base-cmd")
+    override = MngrConfig(prefix=mngr_test_prefix, connect_command="override-cmd")
+    merged = base.merge_with(override)
+    assert merged.connect_command == "override-cmd"
+
+
+def test_mngr_config_merge_keeps_base_connect_command_when_override_none(mngr_test_prefix: str) -> None:
+    base = MngrConfig(prefix=mngr_test_prefix, connect_command="base-cmd")
+    override = MngrConfig.model_construct(prefix=mngr_test_prefix, connect_command=None)
+    merged = base.merge_with(override)
+    assert merged.connect_command == "base-cmd"
+
+
+def test_mngr_config_connect_command_defaults_to_none(mngr_test_prefix: str) -> None:
+    config = MngrConfig(prefix=mngr_test_prefix)
+    assert config.connect_command is None

--- a/libs/mngr/imbue/mngr/utils/test_ratchets.py
+++ b/libs/mngr/imbue/mngr/utils/test_ratchets.py
@@ -304,7 +304,7 @@ def test_prevent_direct_subprocess_usage() -> None:
     Test files are excluded from this check.
     """
     chunks = check_ratchet_rule(PREVENT_DIRECT_SUBPROCESS, _get_mngr_source_dir(), TEST_FILE_PATTERNS)
-    assert len(chunks) <= snapshot(45), PREVENT_DIRECT_SUBPROCESS.format_failure(chunks)
+    assert len(chunks) <= snapshot(46), PREVENT_DIRECT_SUBPROCESS.format_failure(chunks)
 
 
 def test_prevent_unittest_mock_imports() -> None:


### PR DESCRIPTION
When create or start connects to an agent, a custom command can now replace the builtin connect. This enables workflows like opening the connection in a new iTerm2 tab.

The command receives these environment variables:
- MNGR_AGENT_NAME
- MNGR_SESSION_NAME
- MNGR_HOST_IS_LOCAL ("true" or "false")