### PR TITLE
draft: Fix CLI help output going to stderr when default command is disabled

### DIFF
--- a/libs/mngr/imbue/mngr/main.py
+++ b/libs/mngr/imbue/mngr/main.py
@@ -101,10 +101,12 @@ class AliasAwareGroup(DefaultCommandGroup):
     _config_key = "mngr"
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        # Click's default behavior for groups with no_args_is_help=True raises
-        # NoArgsIsHelpError, which writes help to stderr and exits with code 2.
-        # Override to write help to stdout and exit cleanly (like --help).
-        if not args and self.no_args_is_help and not ctx.resilient_parsing:
+        # When no args are given and no default command is configured,
+        # Click raises NoArgsIsHelpError which writes help to stderr with
+        # exit code 2. Override to write help to stdout and exit cleanly.
+        # When a default command IS configured (the normal case),
+        # DefaultCommandGroup.parse_args handles it by forwarding to that command.
+        if not args and not self._default_command and self.no_args_is_help and not ctx.resilient_parsing:
             sys.stdout.write(ctx.get_help())
             sys.stdout.write("\n")
             sys.stdout.flush()


### PR DESCRIPTION
some stuff would show up with doubled output

---
claude's summary:

## Summary

- When `_default_command` is empty (disabled via `commands.mngr.default_subcommand = ""`), `mngr` with no args now writes help to stdout with exit code 0, instead of Click's default `NoArgsIsHelpError` which writes to stderr with exit code 2
- Added regression test for this behavior using a standalone `AliasAwareGroup` with disabled default command

## The doubling issue

Click's `NoArgsIsHelpError` writes the full help text to stderr and exits with code 2. Tools that capture stdout and stderr separately (like the Claude Code Bash tool) display both streams, causing the help text to appear twice.

### Replicating

```bash
# Disable the default-to-create behavior
uv run mngr config set --scope project commands.mngr.default_subcommand ""
```

**Before fix** (on main):
```
$ uv run mngr
# Exit code 2, help text appears TWICE (once on stdout, once on stderr)
Usage: mngr [OPTIONS] COMMAND [ARGS]...
  ...
Usage: mngr [OPTIONS] COMMAND [ARGS]...
  ...
```

**After fix** (this branch):
```
$ uv run mngr
# Exit code 0, help text appears ONCE on stdout
Usage: mngr [OPTIONS] COMMAND [ARGS]...
  ...
```

```bash
# Clean up
uv run mngr config unset --scope project commands.mngr.default_subcommand
```
