### PR TITLE
split publish workflow for pypi bootstrapping

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,16 +67,31 @@ jobs:
           fi
 
       - name: Build imbue-common
-        run: pyproject-build libs/imbue_common -o dist/
+        run: pyproject-build libs/imbue_common -o dist/imbue-common/
 
       - name: Build concurrency-group
-        run: pyproject-build libs/concurrency_group -o dist/
+        run: pyproject-build libs/concurrency_group -o dist/concurrency-group/
 
-      - name: Build mngr
-        run: pyproject-build libs/mngr -o dist/
+      - name: Build mng
+        run: pyproject-build libs/mngr -o dist/mng/
 
-      - name: Publish packages to PyPI
+      - name: Publish imbue-common
         uses: pypa/gh-action-pypi-publish@release/v1
+        continue-on-error: true
         with:
-          packages-dir: dist/
+          packages-dir: dist/imbue-common/
+          skip-existing: true
+
+      - name: Publish concurrency-group
+        uses: pypa/gh-action-pypi-publish@release/v1
+        continue-on-error: true
+        with:
+          packages-dir: dist/concurrency-group/
+          skip-existing: true
+
+      - name: Publish mng
+        uses: pypa/gh-action-pypi-publish@release/v1
+        continue-on-error: true
+        with:
+          packages-dir: dist/mng/
           skip-existing: true


### PR DESCRIPTION
## Summary
- Split the single publish step into 3 per-package steps with `continue-on-error: true`
- This allows bootstrapping PyPI packages one at a time using pending trusted publishers
- PyPI only allows one pending publisher per (owner, repo, workflow, environment) tuple, so we need to publish sequentially

## Plan
1. Merge this PR
2. Register pending publisher for `imbue-common`, run publish
3. Swap pending publisher to `concurrency-group`, run publish
4. Swap to `mng`, run publish
5. Add all 3 as normal trusted publishers
6. Revert to single publish step

Generated with [Claude Code](https://claude.com/claude-code)