### PR TITLE
Add contents:read permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- Fix publish workflow failing with "Repository not found" on private repos
- When `permissions` is specified with only `id-token: write`, the default `contents: read` is lost
- Adding it back allows the checkout step to access the repo

Generated with [Claude Code](https://claude.com/claude-code)