### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-19-11-10-14.md
+++ b/_tasks/inconsistencies/2026-02-19-11-10-14.md
@@ -1,0 +1,181 @@
+# Inconsistencies identified on 2026-02-19-11-10-14
+
+## 1. Constants missing `Final` annotation
+
+Description: Several module-level constants are declared without the `Final` type annotation, while other constants in the same files or adjacent modules correctly use `Final`. This creates an inconsistency in how constants are declared across the codebase.
+
+Files with missing `Final` annotations:
+- `libs/mngr/imbue/mngr/utils/logging.py:29-34` -- `WARNING_COLOR`, `ERROR_COLOR`, `BUILD_COLOR`, `DEBUG_COLOR`, `TRACE_COLOR`, `RESET_COLOR` all lack `Final`, while `BUILD_LEVEL_NO` on line 37 in the same file correctly uses `Final[int]`
+- `libs/mngr/imbue/mngr/providers/local/backend.py:14` -- `LOCAL_BACKEND_NAME` lacks `Final`
+- `libs/mngr/imbue/mngr/providers/ssh/backend.py:29` -- `SSH_BACKEND_NAME` lacks `Final`
+- `libs/mngr/imbue/mngr/providers/modal/backend.py:39-41` -- `MODAL_BACKEND_NAME`, `STATE_VOLUME_SUFFIX`, `MODAL_NAME_MAX_LENGTH` lack `Final`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:98-102` -- `CONTAINER_SSH_PORT`, `DEFAULT_SANDBOX_TIMEOUT`, `SSH_CONNECT_TIMEOUT` lack `Final`, while `TAG_HOST_ID`, `TAG_HOST_NAME`, `TAG_USER_PREFIX` on lines 107-109 in the same file correctly use `Final[str]`
+- `libs/mngr/imbue/mngr/config/data_types.py:34-36` -- `USER_ID_FILENAME`, `PROFILES_DIRNAME`, `ROOT_CONFIG_FILENAME` lack `Final`
+- `libs/mngr/imbue/mngr/cli/common_opts.py:33` -- `COMMON_OPTIONS_GROUP_NAME` lacks `Final`
+
+Recommendation: Add `Final` type annotations to all module-level constants. The most glaring inconsistency is within single files (e.g., `logging.py` and `modal/instance.py`) where some constants use `Final` and others do not.
+
+Decision: Accept
+
+## 2. Dict fields not following `_by_` naming convention
+
+Description: The style guide requires dictionaries and mappings to use `value_by_key` naming. Several `FrozenModel` classes use generic names like `providers`, `plugins`, `commands` for dict fields instead of the prescribed pattern.
+
+Key violations in `libs/mngr/imbue/mngr/config/data_types.py`:
+- Line 417: `agent_types: dict[AgentTypeName, AgentTypeConfig]` should be `agent_type_config_by_name`
+- Line 421: `providers: dict[ProviderInstanceName, ProviderInstanceConfig]` should be `provider_config_by_name`
+- Line 425: `plugins: dict[PluginName, PluginConfig]` should be `plugin_config_by_name`
+- Line 433: `commands: dict[str, CommandDefaults]` should be `command_defaults_by_name`
+- Line 437: `create_templates: dict[CreateTemplateName, CreateTemplate]` should be `create_template_by_name`
+- Line 441: `pre_command_scripts: dict[str, list[str]]` should be `pre_command_scripts_by_command`
+
+Other violations:
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:291` -- `user_tags: dict[str, str]` should be `user_tag_by_name`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:335` -- `tags: dict[str, str]` should be `tag_by_name`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:389` -- `tags: dict[str, str]` should be `tag_by_name`
+- `libs/mngr/imbue/mngr/providers/ssh/config.py:30` -- `hosts: dict[str, SSHHostConfig]` should be `host_config_by_name`
+- `libs/mngr/imbue/mngr/providers/ssh/instance.py:52` -- `hosts: dict[str, SSHHostConfig]` should be `host_config_by_name`
+- `libs/mngr/imbue/mngr/api/data_types.py:169` -- `tags: dict[str, str]` should be `tag_by_name`
+
+Note: Generic `plugin: dict[str, Any]` fields in interfaces/data_types.py (lines 277, 400) and api/list.py (line 78) are borderline -- they are truly dynamic dicts used for plugin extensibility, so the `_by_` pattern may not apply as naturally.
+
+Recommendation: Rename the dict fields to follow the `value_by_key` pattern. Start with `config/data_types.py` since `MngrConfig` is a central data structure referenced throughout the codebase. This will be a significant refactor due to the ripple effect on all call sites.
+
+Decision: Accept
+
+## 3. `logger.info` used in library/API code instead of `logger.debug`
+
+Description: The style guide specifies that `logger.info` should be reserved for CLI/user-facing code, and library/API code should use `logger.debug` for normal operations. The Modal provider (which is library code, not CLI code) uses `logger.info` in multiple places.
+
+Violations in `libs/mngr/imbue/mngr/providers/modal/instance.py`:
+- Line 1306: `logger.info("Creating host {} in {} ...", name, self.name)`
+- Line 1432: `logger.info("Stopping (terminating) Modal sandbox: {}", host_id)`
+- Line 1548: `logger.info("Using most recent snapshot for restart", ...)`
+- Line 1566: `logger.info("Restoring Modal sandbox from snapshot", ...)`
+- Line 1608: `logger.info("Created sandbox from snapshot", ...)`
+- Line 1941: `logger.info("Created snapshot: id={}, name={}", ...)`
+- Line 2011: `logger.info("Deleted snapshot", ...)`
+
+Violation in `libs/mngr/imbue/mngr/providers/modal/backend.py`:
+- Line 67: `logger.info("Created Modal environment: {}", environment_name)`
+
+Recommendation: Change all `logger.info` calls in provider code to `logger.debug`, or wrap them with `log_span` where appropriate (e.g., the "Creating host" message would be better as a `log_span` around the creation operation).
+
+Decision: Accept
+
+## 4. NamedTuple usage instead of FrozenModel
+
+Description: The style guide states "Never use dataclasses or named tuples." Two NamedTuple classes exist in non-test code.
+
+Violations:
+- `libs/mngr/imbue/mngr/utils/logging.py:232` -- `class BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`
+- `libs/mngr/imbue/mngr/conftest.py:537` -- `class ModalSubprocessTestEnv(NamedTuple)` (test configuration, but in conftest.py which is not a test file)
+
+Recommendation: Convert `BufferedMessage` to a `FrozenModel`. For `ModalSubprocessTestEnv` in conftest.py, converting to FrozenModel is also preferred for consistency, though being in test infrastructure makes it lower priority.
+
+Decision: Accept
+
+## 5. Interface classes defined outside of `interfaces/` module
+
+Description: The style guide says "If you are creating an interface class, create it in a file named `interfaces.py` at the root of the package." Two interface classes are defined in non-interface files.
+
+Violations:
+- `libs/mngr/imbue/mngr/api/sync.py:136` -- `class GitContextInterface(MutableModel, ABC)` is defined in the API layer instead of `interfaces/`
+- `libs/mngr/imbue/mngr/cli/ask.py:182` -- `class ClaudeBackendInterface(MutableModel, ABC)` is defined in the CLI layer instead of `interfaces/`
+
+Recommendation: Move these interface classes to the `interfaces/` module. This also ensures proper layer separation (interfaces should be at a lower layer than API and CLI code).
+
+Decision: Accept
+
+## 6. Functions marked `@pure` that access external state
+
+Description: The `@pure` decorator indicates a function has no side effects and depends only on its inputs. Three functions are marked `@pure` but read external state (`os.environ`, terminal size).
+
+Violations:
+- `libs/mngr/imbue/mngr/cli/help_formatter.py:87-91` -- `get_terminal_width()` is `@pure` but calls `shutil.get_terminal_size()` which queries system state
+- `libs/mngr/imbue/mngr/cli/help_formatter.py:94-106` -- `get_pager_command()` is `@pure` but reads `os.environ.get("PAGER")`
+- `libs/mngr/imbue/mngr/utils/editor.py:21-41` -- `get_editor_command()` is `@pure` but reads `os.environ.get("VISUAL")` and `os.environ.get("EDITOR")` and calls `shutil.which()`
+
+Recommendation: Remove the `@pure` decorator from these functions since they read external state. They depend on environment variables and system state, which makes them impure by definition.
+
+Decision: Accept
+
+## 7. Standard `logging` module used instead of `loguru`
+
+Description: The style guide says "Always use `loguru` for logging." One production code file uses the standard `logging` module directly for its own logging (not just to suppress third-party logs).
+
+Violation:
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:15,110,194` -- Uses `import logging` and `logging.getLogger("snapshot_and_shutdown")` for its own logging. The file header explicitly says "All code is self-contained in this file - no imports from the mngr codebase," which explains the choice but is still inconsistent with the project-wide standard.
+
+Note: Other files like `utils/logging.py:2,96-97` and `apps/claude_web_view/imbue/claude_web_view/cli.py:4,122` use the standard `logging` module only to suppress third-party library logs (pyinfra, uvicorn), which is acceptable.
+
+Recommendation: For `snapshot_and_shutdown.py`, since it explicitly avoids mngr imports (it runs inside Modal), consider whether loguru can be added as a standalone dependency, or document this as an intentional exception.
+
+Decision: Accept
+
+## 8. `success: bool` field missing `is_` prefix in `CommandResult`
+
+Description: The style guide says "Always prefix booleans with `is_`." The `CommandResult` class uses `success: bool` instead of `is_successful: bool`.
+
+Violation:
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:173` -- `success: bool = Field(description="True if the command succeeded (had an expected exit code)")` should be `is_successful: bool`
+
+Note: The non_issues.md exempts "missing `is_` prefix for boolean options in CLI functions and data classes," but `CommandResult` is in the interfaces layer, not a CLI data type. This is a core domain object.
+
+Recommendation: Rename `success` to `is_successful` in `CommandResult` and update all references.
+
+Decision: Accept
+
+## 9. Mutable types used for function parameters instead of immutable abstract types
+
+Description: The style guide says function inputs should use immutable abstract types: `Sequence[T]` instead of `list[T]`, `Mapping[K, V]` instead of `dict[K, V]`, and `AbstractSet[T]` instead of `set[T]`. Many functions across the codebase use mutable concrete types for parameters.
+
+Notable violations (selected, not exhaustive):
+- `libs/mngr/imbue/mngr/cli/list.py:616` -- `agents: list[AgentInfo]` should be `Sequence[AgentInfo]`
+- `libs/mngr/imbue/mngr/cli/list.py:639` -- `agents: list[AgentInfo]` should be `Sequence[AgentInfo]`
+- `libs/mngr/imbue/mngr/cli/list.py:768` -- `agents: list[AgentInfo]` should be `Sequence[AgentInfo]`
+- `libs/mngr/imbue/mngr/cli/connect.py:232,321` -- `agents: list[AgentInfo]` should be `Sequence[AgentInfo]`
+- `libs/mngr/imbue/mngr/config/data_types.py:71` -- `base: list[T], override: list[T]` should be `Sequence[T]`
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_config.py:384` -- `existing_hooks: list[dict[str, Any]]` should be `Sequence[Mapping[str, Any]]`
+- `libs/mngr/imbue/mngr/config/loader.py:341,438,447,465,483` -- multiple functions taking `dict[str, Any]` should be `Mapping[str, Any]`
+
+Recommendation: Gradually update function parameter types to use immutable abstract types. Prioritize the most-called functions first. Note that some functions (like those in loader.py that parse raw config dicts) may legitimately need `dict` if they mutate the input, but this should be rare given the functional style.
+
+Decision: Accept
+
+## 10. Enum in `claude_web_view` not using `UpperCaseStrEnum`
+
+Description: The style guide says "All enums should inherit from `UpperCaseStrEnum`" and "All values for enums should be `auto()`." One enum in the apps directory uses a different pattern.
+
+Violation:
+- `apps/claude_web_view/imbue/claude_web_view/models.py:11-16` -- `class MessageRole(str, Enum)` uses hard-coded string values (`"user"`, `"assistant"`, `"system"`) instead of inheriting from `UpperCaseStrEnum` and using `auto()`
+
+Recommendation: Convert to `UpperCaseStrEnum` with `auto()` values. Note that this may require updating any code that compares against the string values `"user"`, `"assistant"`, `"system"` since the auto-generated values would be `"USER"`, `"ASSISTANT"`, `"SYSTEM"`.
+
+Decision: Accept
+
+## 11. Utility classes not following the 3-class pattern
+
+Description: The style guide says "In our functional programs, there are only 3 types of classes: Frozen objects (FrozenModel), Interfaces (ABC+MutableModel), and Implementations." Several utility classes don't fit any of these three categories.
+
+Violations:
+- `libs/mngr/imbue/mngr/utils/logging.py:297` -- `class LoggingSuppressor` is a plain class with class-level methods
+- `libs/mngr/imbue/mngr/cli/help_formatter.py` -- `class GitStyleHelpMixin` is a mixin class for click formatting
+- `libs/mngr/imbue/mngr/providers/modal/log_utils.py` -- `class ModalLoguruWriter` is a utility writer class
+- `libs/mngr/imbue/mngr/utils/editor.py` -- `class EditorSession` is a utility session class
+
+Recommendation: Consider whether these classes should become Implementations of an Interface, or whether their logic can be restructured into functions. For cases like `LoggingSuppressor` that manage context-dependent state, an Interface + Implementation pattern would be more consistent. For simpler cases, converting to module-level functions may suffice.
+
+Decision: Accept
+
+## 12. Inline imports in application code
+
+Description: The style guide says to avoid inline imports (imports inside function bodies).
+
+Violations:
+- `apps/sculptor_web/imbue/sculptor_web/main.py:515` -- `import uvicorn` inside `run()` function
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:111,114` -- `import threading` and `import time` inside function bodies
+
+Recommendation: Move these imports to the top of their respective files.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identifies 12 code-level inconsistencies across the codebase, ordered by importance
- Key findings include: missing `Final` annotations on constants, dict fields not following `_by_` naming convention, `logger.info` used in library code, NamedTuple usage where FrozenModel is required, interface classes outside `interfaces/` module, impure functions marked `@pure`, and other style guide deviations
- Full report in `_tasks/inconsistencies/2026-02-19-11-10-14.md`

## Test plan

- [ ] Review report for accuracy and prioritization
- [ ] Confirm no reported issues overlap with existing FIXMEs or non_issues.md entries