### PR TITLE
Fix host sharing: generate unique work dirs for each agent on shared remote hosts

### DIFF
--- a/libs/mng/imbue/mng/hosts/host.py
+++ b/libs/mng/imbue/mng/hosts/host.py
@@ -943,7 +943,7 @@ class Host(BaseHost, OnlineHostInterface):
         else:
             # Different host (remote copy): generate a unique work directory so that
             # multiple agents sharing the same host each get their own directory.
-            target_path = self.host_dir / "worktrees" / str(AgentId.generate())
+            target_path = self.host_dir / "projects" / str(AgentId.generate())
             is_generated_work_dir = True
 
         self._mkdir(target_path)

--- a/libs/mng/imbue/mng/hosts/test_host.py
+++ b/libs/mng/imbue/mng/hosts/test_host.py
@@ -2435,7 +2435,7 @@ def test_create_work_dir_cross_host_generates_unique_paths(
     mng_test_prefix: str,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that cross-host work dir creation generates unique paths under host_dir/worktrees/.
+    """Test that cross-host work dir creation generates unique paths under host_dir/projects/.
 
     When no target_path is specified and source and target are on different hosts,
     each call should produce a unique directory so multiple agents on a shared host
@@ -2483,8 +2483,8 @@ def test_create_work_dir_cross_host_generates_unique_paths(
 
     work_dir_1 = target_host.create_agent_work_dir(source_host, source_path, options)
 
-    # The generated path should be under host_dir/worktrees/
-    assert str(work_dir_1).startswith(str(target_host.host_dir / "worktrees"))
+    # The generated path should be under host_dir/projects/
+    assert str(work_dir_1).startswith(str(target_host.host_dir / "projects"))
     assert (work_dir_1 / "file.txt").read_text() == "content"
 
     # Create a second agent on the same target host - should get a different path
@@ -2497,6 +2497,6 @@ def test_create_work_dir_cross_host_generates_unique_paths(
 
     work_dir_2 = target_host.create_agent_work_dir(source_host, source_path, options_2)
 
-    assert str(work_dir_2).startswith(str(target_host.host_dir / "worktrees"))
+    assert str(work_dir_2).startswith(str(target_host.host_dir / "projects"))
     assert work_dir_1 != work_dir_2
     assert (work_dir_2 / "file.txt").read_text() == "content"


### PR DESCRIPTION
When creating multiple agents on a shared remote host (e.g. `--host shared-host`), the second agent's `create_agent_work_dir` was reusing the same target path as the first agent. This caused `git push --mirror` to fail because the first agent had already converted the bare repo to a non-bare working copy.

The fix generates a unique directory under `host_dir/worktrees/<agent-id>` for each cross-host copy, matching the pattern already used by the worktree copy mode.