### PR TITLE
Fix --snapshot flag being silently ignored during mng create

### DIFF
--- a/libs/mng/imbue/mng/api/create.py
+++ b/libs/mng/imbue/mng/api/create.py
@@ -206,6 +206,7 @@ def resolve_target_host(
                 start_args=target_host.build.start_args,
                 lifecycle=target_host.lifecycle,
                 known_hosts=target_host.environment.known_hosts,
+                snapshot=target_host.build.snapshot,
             )
 
         # Write host environment variables to the host env file (if creating a new host)

--- a/libs/mng/imbue/mng/interfaces/provider_instance.py
+++ b/libs/mng/imbue/mng/interfaces/provider_instance.py
@@ -91,8 +91,13 @@ class ProviderInstanceInterface(MutableModel, ABC):
         start_args: Sequence[str] | None = None,
         lifecycle: HostLifecycleOptions | None = None,
         known_hosts: Sequence[str] | None = None,
+        snapshot: SnapshotName | None = None,
     ) -> OnlineHostInterface:
-        """Create and start a new host with the given name and configuration."""
+        """Create and start a new host with the given name and configuration.
+
+        If snapshot is provided, the host is created from the snapshot image
+        instead of building a new one.
+        """
         ...
 
     @abstractmethod

--- a/libs/mng/imbue/mng/providers/base_provider.py
+++ b/libs/mng/imbue/mng/providers/base_provider.py
@@ -10,6 +10,7 @@ from imbue.mng.primitives import HostId
 from imbue.mng.primitives import HostName
 from imbue.mng.primitives import ImageReference
 from imbue.mng.primitives import SnapshotId
+from imbue.mng.primitives import SnapshotName
 
 
 class BaseProviderInstance(ProviderInstanceInterface):
@@ -28,6 +29,7 @@ class BaseProviderInstance(ProviderInstanceInterface):
         start_args: Sequence[str] | None = None,
         lifecycle: HostLifecycleOptions | None = None,
         known_hosts: Sequence[str] | None = None,
+        snapshot: SnapshotName | None = None,
     ) -> Host:
         raise NotImplementedError()
 

--- a/libs/mng/imbue/mng/providers/docker/instance.py
+++ b/libs/mng/imbue/mng/providers/docker/instance.py
@@ -710,6 +710,7 @@ kill -TERM 1
         start_args: Sequence[str] | None = None,
         lifecycle: HostLifecycleOptions | None = None,
         known_hosts: Sequence[str] | None = None,
+        snapshot: SnapshotName | None = None,
     ) -> Host:
         """Create a new Docker container host.
 

--- a/libs/mng/imbue/mng/providers/local/instance.py
+++ b/libs/mng/imbue/mng/providers/local/instance.py
@@ -180,6 +180,7 @@ class LocalProviderInstance(BaseProviderInstance):
         start_args: Sequence[str] | None = None,
         lifecycle: HostLifecycleOptions | None = None,
         known_hosts: Sequence[str] | None = None,
+        snapshot: SnapshotName | None = None,
     ) -> Host:
         """Create (or return) the local host.
 

--- a/libs/mng/imbue/mng/providers/ssh/instance.py
+++ b/libs/mng/imbue/mng/providers/ssh/instance.py
@@ -124,6 +124,7 @@ class SSHProviderInstance(BaseProviderInstance):
         start_args: Sequence[str] | None = None,
         lifecycle: HostLifecycleOptions | None = None,
         known_hosts: Sequence[str] | None = None,
+        snapshot: SnapshotName | None = None,
     ) -> Host:
         raise NotImplementedError("SSH provider does not support creating hosts")
 


### PR DESCRIPTION
The --snapshot flag was parsed from the CLI into NewHostBuildOptions but never passed to provider.create_host() in resolve_target_host(). Added snapshot parameter to the create_host interface and all provider implementations, and updated the Modal provider to use the snapshot image instead of building when a snapshot is provided.