### PR TITLE
Pre-install required packages in Modal's default image

### DIFF
--- a/libs/mng/imbue/mng/providers/modal/instance.py
+++ b/libs/mng/imbue/mng/providers/modal/instance.py
@@ -87,6 +87,7 @@ from imbue.mng.providers.modal.ssh_utils import load_or_create_host_keypair
 from imbue.mng.providers.modal.ssh_utils import load_or_create_ssh_keypair
 from imbue.mng.providers.modal.ssh_utils import wait_for_sshd
 from imbue.mng.providers.modal.volume import ModalVolume
+from imbue.mng.providers.ssh_host_setup import REQUIRED_HOST_PACKAGES
 from imbue.mng.providers.ssh_host_setup import build_add_known_hosts_command
 from imbue.mng.providers.ssh_host_setup import build_check_and_install_packages_command
 from imbue.mng.providers.ssh_host_setup import build_configure_ssh_command
@@ -942,7 +943,9 @@ class ModalProviderInstance(BaseProviderInstance):
         elif base_image:
             image = modal.Image.from_registry(base_image)
         else:
-            image = modal.Image.debian_slim()
+            # Pre-install required host packages so the runtime check in
+            # _check_and_install_packages is a no-op (no warnings, faster startup).
+            image = modal.Image.debian_slim().apt_install(*(pkg.package for pkg in REQUIRED_HOST_PACKAGES))
 
         return image
 

--- a/libs/mng/imbue/mng/providers/ssh_host_setup.py
+++ b/libs/mng/imbue/mng/providers/ssh_host_setup.py
@@ -2,11 +2,39 @@ import importlib.resources
 from pathlib import Path
 from typing import Final
 
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
 from imbue.mng import resources
 
 # Prefix used in shell output to identify warnings that should be shown to the user
 WARNING_PREFIX: Final[str] = "MNG_WARN:"
+
+
+class RequiredHostPackage(FrozenModel):
+    """An apt package that must be present on remote hosts for mng to function."""
+
+    package: str = Field(description="Apt package name (e.g. 'openssh-server')")
+    binary: str = Field(description="Binary name used when checking whether the package is installed")
+    check_cmd: str | None = Field(
+        default=None,
+        description="Custom shell command to check for the package, or None to use 'command -v <binary>'",
+    )
+
+
+# Packages that must be present on any remote host for mng to function.
+# Providers that build a default image should pre-install these; the runtime
+# check in build_check_and_install_packages_command will still install any
+# that are missing (with a warning).
+REQUIRED_HOST_PACKAGES: Final[tuple[RequiredHostPackage, ...]] = (
+    RequiredHostPackage(package="openssh-server", binary="sshd", check_cmd="test -x /usr/sbin/sshd"),
+    RequiredHostPackage(package="tmux", binary="tmux"),
+    RequiredHostPackage(package="curl", binary="curl"),
+    RequiredHostPackage(package="rsync", binary="rsync"),
+    RequiredHostPackage(package="git", binary="git"),
+    RequiredHostPackage(package="jq", binary="jq"),
+)
 
 
 @pure
@@ -22,18 +50,14 @@ def get_user_ssh_dir(user: str) -> Path:
 
 
 @pure
-def _build_package_check_snippet(binary: str, package: str, check_cmd: str | None) -> str:
-    """Build a shell snippet that checks for a binary and adds its package to the install list.
-
-    If check_cmd is provided, it is used as the existence check (e.g. "test -x /usr/sbin/sshd").
-    Otherwise, "command -v <binary> >/dev/null 2>&1" is used.
-    """
-    check = check_cmd if check_cmd is not None else f"command -v {binary} >/dev/null 2>&1"
+def _build_package_check_snippet(pkg: RequiredHostPackage) -> str:
+    """Build a shell snippet that checks for a package and adds it to the install list."""
+    check = pkg.check_cmd if pkg.check_cmd is not None else f"command -v {pkg.binary} >/dev/null 2>&1"
     return (
         f"if ! {check}; then "
-        f"echo '{WARNING_PREFIX}{package} is not pre-installed in the base image. "
-        f"Installing at runtime. For faster startup, consider using an image with {package} pre-installed.'; "
-        f'PKGS_TO_INSTALL="$PKGS_TO_INSTALL {package}"; '
+        f"echo '{WARNING_PREFIX}{pkg.package} is not pre-installed in the base image. "
+        f"Installing at runtime. For faster startup, consider using an image with {pkg.package} pre-installed.'; "
+        f'PKGS_TO_INSTALL="$PKGS_TO_INSTALL {pkg.package}"; '
         "fi"
     )
 
@@ -60,12 +84,7 @@ def build_check_and_install_packages_command(
     """
     script_lines = [
         "PKGS_TO_INSTALL=''",
-        _build_package_check_snippet(binary="sshd", package="openssh-server", check_cmd="test -x /usr/sbin/sshd"),
-        _build_package_check_snippet(binary="tmux", package="tmux", check_cmd=None),
-        _build_package_check_snippet(binary="curl", package="curl", check_cmd=None),
-        _build_package_check_snippet(binary="rsync", package="rsync", check_cmd=None),
-        _build_package_check_snippet(binary="git", package="git", check_cmd=None),
-        _build_package_check_snippet(binary="jq", package="jq", check_cmd=None),
+        *(_build_package_check_snippet(pkg) for pkg in REQUIRED_HOST_PACKAGES),
         # Install missing packages if any
         'if [ -n "$PKGS_TO_INSTALL" ]; then apt-get update -qq && apt-get install -y -qq $PKGS_TO_INSTALL; fi',
         # Create sshd run directory (required for sshd to start)

--- a/libs/mng/imbue/mng/providers/ssh_host_setup_test.py
+++ b/libs/mng/imbue/mng/providers/ssh_host_setup_test.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 
 import imbue.mng.resources as mng_resources
+from imbue.mng.providers.ssh_host_setup import RequiredHostPackage
 from imbue.mng.providers.ssh_host_setup import WARNING_PREFIX
 from imbue.mng.providers.ssh_host_setup import _build_package_check_snippet
 from imbue.mng.providers.ssh_host_setup import build_add_known_hosts_command
@@ -41,7 +42,8 @@ def test_valid_shell_command() -> None:
 
 def test_build_package_check_snippet_default_check() -> None:
     """When no check_cmd is given, should use 'command -v <binary>' and reference the package."""
-    snippet = _build_package_check_snippet(binary="tmux", package="tmux", check_cmd=None)
+    pkg = RequiredHostPackage(package="tmux", binary="tmux", check_cmd=None)
+    snippet = _build_package_check_snippet(pkg)
     assert "command -v tmux >/dev/null 2>&1" in snippet
     assert f"{WARNING_PREFIX}tmux is not pre-installed" in snippet
     assert 'PKGS_TO_INSTALL="$PKGS_TO_INSTALL tmux"' in snippet
@@ -49,7 +51,8 @@ def test_build_package_check_snippet_default_check() -> None:
 
 def test_build_package_check_snippet_custom_check() -> None:
     """When check_cmd is provided, should use that instead of the default."""
-    snippet = _build_package_check_snippet(binary="sshd", package="openssh-server", check_cmd="test -x /usr/sbin/sshd")
+    pkg = RequiredHostPackage(package="openssh-server", binary="sshd", check_cmd="test -x /usr/sbin/sshd")
+    snippet = _build_package_check_snippet(pkg)
     assert "test -x /usr/sbin/sshd" in snippet
     assert "command -v" not in snippet
     assert f"{WARNING_PREFIX}openssh-server is not pre-installed" in snippet


### PR DESCRIPTION
The default Modal image (debian_slim) lacked openssh-server, tmux, curl, rsync, git, and jq, causing warnings and slow runtime installation on every sandbox creation. Pre-install them via apt_install so the runtime check is a no-op.

Also introduce a RequiredHostPackage model and a single REQUIRED_HOST_PACKAGES constant as the source of truth for which packages must be present on remote hosts. Both the default image build and the runtime check-and-install logic now derive from this constant.