### PR TITLE
fix bug where using the modal template required modal to be specified as the provider elsewhere

### DIFF
--- a/.mng/settings.toml
+++ b/.mng/settings.toml
@@ -18,6 +18,7 @@ agent_type = "coder"
 add_command = ["reviewer_0='export IS_SANDBOX=1 && claude --dangerously-skip-permissions'"]
 
 [create_templates.modal]
+new_host = "modal"
 build_args = "dockerfile=libs/mng/imbue/mng/resources/Dockerfile context-dir=.mng/dev/build/ volume=code-review-json:/code_reviews"
 add_command = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && gh auth setup-git'"]
 agent_args = ["--dangerously-skip-permissions"]


### PR DESCRIPTION
note that this is our _internal_ template; this is only a problem for our own dev workflow

claude's summary:

## Summary

- The modal create template in `.mng/settings.toml` was missing `new_host = "modal"`, while the docker template had `new_host = "docker"`
- Without this, `mng create --template modal` tried to create a local git worktree at `/code/mng` (the container-internal target path) on the host machine
- On macOS this fails with `mkdir: /code: Read-only file system` since the root filesystem is read-only
- To reproduce: Modal must not be configured as the default provider (otherwise the host would be inferred as modal regardless). When using the local provider as default with `--template modal`, the missing `new_host` meant the template only set `target_path` and `build_args` without actually requesting a Modal host.

## Test plan

- [x] Manually verified: `mng create test-mdl --template modal` now progresses to Modal image building instead of failing at worktree creation
