### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-20-11-02-03.md
+++ b/_tasks/inconsistencies/2026-02-20-11-02-03.md
@@ -1,0 +1,182 @@
+# Inconsistencies identified on 2026-02-20-11-02-03
+
+## 1. logger.info used in library/API/provider code instead of logger.debug
+
+Description: The style guide states: "Reserve `logger.info` for CLI/user-facing code where messages will be shown to users by default. Library and API code should use `logger.debug` for normal operations." However, there are ~18 instances of `logger.info` in library and API code where `logger.debug` should be used:
+
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1306` - `logger.info("Creating host {} in {} ...", name, self.name)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1432` - `logger.info("Stopping (terminating) Modal sandbox: {}", host_id)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1548` - `logger.info("Using most recent snapshot for restart", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1566` - `logger.info("Restoring Modal sandbox from snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1608` - `logger.info("Created sandbox from snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1941` - `logger.info("Created snapshot: id={}, name={}", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:2011` - `logger.info("Deleted snapshot", ...)`
+- `libs/mngr/imbue/mngr/providers/modal/backend.py:67` - `logger.info("Created Modal environment: {}", environment_name)`
+- `libs/mngr/imbue/mngr/api/create.py:109` - `logger.info("Starting agent {} ...", agent.name)`
+- `libs/mngr/imbue/mngr/api/create.py:116` - `logger.info("Sending initial message...")`
+- `libs/mngr/imbue/mngr/api/create.py:120` - `logger.info("Starting agent {} ...", agent.name)`
+- `libs/mngr/imbue/mngr/api/find.py:297` - `logger.info("Host is offline, starting it...", ...)`
+- `libs/mngr/imbue/mngr/api/find.py:319` - `logger.info("Agent {} is stopped, starting it", agent.name)`
+- `libs/mngr/imbue/mngr/api/pair.py:140` - `logger.info("Started continuous sync between {} and {}", ...)`
+- `libs/mngr/imbue/mngr/api/pair.py:149` - `logger.info("Stopped continuous sync")`
+- `libs/mngr/imbue/mngr/api/pair.py:360` - `logger.info(...)` (multi-line message)
+- `libs/mngr/imbue/mngr/api/connect.py:152` - `logger.info("Connecting to agent...")`
+- `libs/mngr/imbue/mngr/api/connect.py:186` - `logger.info("Running post-disconnect action: {}", argv)`
+
+No ratchet test exists for this pattern.
+
+Recommendation: Change all `logger.info` calls in `api/` and `providers/` code to `logger.debug`. Consider adding a ratchet test to prevent new `logger.info` calls from being introduced in library/API code.
+
+Decision: Accept
+
+## 2. Log message tense inconsistencies (present tense in regular logs, past tense in log_span)
+
+Description: The style guide states: "The verbs should be past tense (eg, end with 'ed') in normal log statements (which should be placed *after* the event) or active (eg '-ing' form) if using `log_span` (which should be placed *before* the event)." Two categories of violations exist:
+
+**log_span using past tense instead of "-ing" form:**
+- `libs/mngr/imbue/mngr/cli/common_opts.py:192` - `log_span("Started {} command", command_name)` should be `log_span("Starting {} command", command_name)`
+
+**Regular logger calls using present tense ("-ing" form) instead of past tense:**
+- `libs/mngr/imbue/mngr/cli/watch_mode.py:24` - `logger.info("Starting watch mode: refreshing every {} seconds", ...)` should use past tense
+- `libs/mngr/imbue/mngr/cli/create.py:815` - `logger.info("Sending edited message...")` should be "Sent edited message"
+- `libs/mngr/imbue/mngr/cli/create.py:1489` - `logger.info("Waiting for agent to stop...")` should be past tense
+- `libs/mngr/imbue/mngr/cli/issue_reporting.py:190` - `logger.info("Searching for existing issues...")` should be past tense
+- `libs/mngr/imbue/mngr/api/create.py:109,120` - `logger.info("Starting agent {} ...", ...)` should use past tense
+- `libs/mngr/imbue/mngr/api/create.py:116` - `logger.info("Sending initial message...")` should be past tense
+- `libs/mngr/imbue/mngr/api/connect.py:152` - `logger.info("Connecting to agent...")` should be past tense
+- `libs/mngr/imbue/mngr/api/connect.py:186` - `logger.info("Running post-disconnect action: {}", ...)` should be past tense
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1306` - `logger.info("Creating host {} in {} ...", ...)` should be past tense
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1432` - `logger.info("Stopping (terminating) Modal sandbox: {}", ...)` should be past tense
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1548` - `logger.info("Using most recent snapshot for restart", ...)` should be past tense
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1566` - `logger.info("Restoring Modal sandbox from snapshot", ...)` should be past tense
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:526` - `logger.info("Installing claude...")` should be past tense
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:533` - `logger.info("Transferring claude home directory settings to remote host...")` should be past tense
+
+Note: Some of these overlaps with Issue #1 (logger.info in library code). Fixing #1 would address many of these.
+
+Recommendation: Fix the log_span in common_opts.py to use "-ing" form. For regular logger calls, change to past tense form. Many of these are "before the event" logs that should either use log_span (with "-ing" form) or be moved after the event (with past tense).
+
+Decision: Accept
+
+## 3. logger.exception used for expected exceptions in gc.py
+
+Description: The style guide states: "Use `logger.exception` only for unexpected exceptions." In `libs/mngr/imbue/mngr/api/gc.py:659`, `logger.exception(exc)` is called when the error behavior is `CONTINUE`, which is an expected condition -- the caller explicitly chose to continue past errors rather than abort:
+
+```python
+def _handle_error(error_msg: str, error_behavior: ErrorBehavior, exc: Exception | None = None) -> None:
+    if error_behavior == ErrorBehavior.ABORT:
+        if exc:
+            raise exc
+        raise MngrError(error_msg)
+    else:
+        # CONTINUE - just log the error
+        if exc:
+            logger.exception(exc)  # Should be logger.error
+        else:
+            logger.error(error_msg)
+```
+
+Recommendation: Change `logger.exception(exc)` to `logger.error("Error during gc: {}", exc)` in the CONTINUE branch, since these are expected/handled exceptions.
+
+Decision: Accept
+
+## 4. snapshot_and_shutdown.py uses standard logging module instead of loguru
+
+Description: The file `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py` uses `import logging` (line 15) and `logger = logging.getLogger("snapshot_and_shutdown")` (line 110) instead of loguru. The style guide says "Always use loguru for logging." The file has a comment on line 8 saying "All code is self-contained in this file - no imports from the mngr codebase", which explains why loguru isn't used (loguru would be an external dependency that needs to be available in the Modal deployment environment). However, this creates an inconsistency with the rest of the codebase.
+
+Recommendation: If loguru is available in the Modal deployment environment, switch to `from loguru import logger`. If not, document this as an intentional exception. Either way, add a comment explaining the deviation from the standard logging approach.
+
+Decision: Accept
+
+## 5. Plain classes not inheriting from framework base classes
+
+Description: The style guide says there are "only 3 types of classes" -- FrozenModel (data), ABC+MutableModel (interfaces), and implementations. Several classes in the codebase don't follow this pattern:
+
+- `libs/mngr/imbue/mngr/utils/editor.py:47` - `EditorSession` is a mutable class with threading state (`_process`, `_is_started`, `_is_finished`, `_monitor_thread`, etc.) that doesn't inherit from any framework base class. It manages subprocess state and should be a MutableModel or at least an implementation of an interface.
+
+- `libs/mngr/imbue/mngr/cli/list.py:754` - `_AgentSortKey` is a callable class that doesn't inherit from any base class and uses mutable attribute assignment (`key.sort_field = sort_field` at line 771). It should either use FrozenModel with a constructor parameter or be replaced with a simple closure/partial.
+
+- `libs/mngr/imbue/mngr/utils/logging.py:297` - `LoggingSuppressor` is a stateful singleton-like class using class-level mutable state without inheriting from MutableModel.
+
+- `libs/mngr/imbue/mngr/cli/output_helpers.py:26` - `AbortError(BaseException)` doesn't inherit from `BaseMngrError`. The style guide says all raised exceptions should inherit from a package-specific base class. While the intentional use of `BaseException` (to avoid being caught by generic `except Exception`) is valid, it should also inherit from `BaseMngrError` for consistency.
+
+Recommendation: For `EditorSession`, consider making it inherit from `MutableModel` with an interface, or document why it's an exception. For `_AgentSortKey`, replace with `functools.partial` or a FrozenModel. For `LoggingSuppressor`, consider making it a MutableModel. For `AbortError`, add `BaseMngrError` to the inheritance chain.
+
+Decision: Accept
+
+## 6. Raising built-in TimeoutError directly in polling.py
+
+Description: The style guide states: "Never raise built-in Exceptions directly (except NotImplementedError). Instead, create a new type that inherits from both the base error class for the package and the built-in." In `libs/mngr/imbue/mngr/utils/polling.py:58`, `TimeoutError` is raised directly:
+
+```python
+raise TimeoutError(error_message)
+```
+
+This should be a custom exception like `PollingTimeoutError(BaseMngrError, TimeoutError)`.
+
+Recommendation: Create a `PollingTimeoutError` in `errors.py` that inherits from both `BaseMngrError` and `TimeoutError`, and use it in `polling.py`.
+
+Decision: Accept
+
+## 7. Inconsistent function naming: "get_" vs "find_" prefix in api/find.py
+
+Description: In `libs/mngr/imbue/mngr/api/find.py`, similar functions use different naming prefixes inconsistently:
+
+- Line 263: `get_host_from_list_by_id` (uses `get_`)
+- Line 271: `get_unique_host_from_list_by_name` (uses `get_`)
+- Line 333: `find_and_maybe_start_agent_by_name_or_id` (uses `find_`)
+- Line 415: `find_agents_by_identifiers_or_state` (uses `find_`)
+
+The `get_` functions operate on an existing list (pure filtering), while the `find_` functions involve side effects (starting hosts/agents) or more complex search logic. This semantic distinction is somewhat reasonable but not documented, and could cause confusion about which prefix to use for new functions.
+
+Recommendation: Either document the convention (e.g., `get_` for pure list operations, `find_` for complex lookups with side effects) or standardize on one prefix for all search-like operations in this module.
+
+Decision: Accept
+
+## 8. Boolean field names missing "is_" prefix in non-CLI FrozenModel classes
+
+Description: The style guide says "Always prefix booleans with `is_`" with an exemption for CLI-related fields. Several FrozenModel classes in API/interface code have boolean fields without the `is_` prefix:
+
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:173` - `CommandResult.success` should be `is_success`
+- `libs/mngr/imbue/mngr/api/list.py:63` - `AgentInfo.start_on_boot` should be `is_start_on_boot` or `starts_on_boot`
+- `libs/mngr/imbue/mngr/api/data_types.py:281` - `OnBeforeCreateArgs.create_work_dir` could be `is_create_work_dir` (though this may map to a CLI arg)
+
+Note: `start_on_boot` and `create_work_dir` may be borderline since they could correspond to CLI args, but `CommandResult.success` is purely an API data type and clearly should follow the convention.
+
+Recommendation: Rename `CommandResult.success` to `is_success`. Evaluate whether `start_on_boot` and `create_work_dir` should be renamed or documented as CLI-adjacent exceptions.
+
+Decision: Accept
+
+## 9. unittest.mock and monkeypatch.setattr usage in test files (tracked by ratchets)
+
+Description: The style guide explicitly forbids `unittest.mock` (Mock, MagicMock, patch) and `monkeypatch.setattr` in tests. While ratchet tests already track these (capped at 3 and 32 respectively), the violations still exist:
+
+**unittest.mock usage (3 instances):**
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent_test.py:8` - `from unittest.mock import patch`
+- `libs/mngr/imbue/mngr/providers/modal/instance_test.py:23` - `from unittest.mock import MagicMock`
+- `libs/mngr/imbue/mngr/providers/modal/instance_test.py:24` - `from unittest.mock import patch`
+
+**monkeypatch.setattr usage (32 instances across multiple files):**
+- `libs/mngr/imbue/mngr/cli/issue_reporting_test.py` - 14 instances
+- `libs/mngr/imbue/mngr/cli/list_test.py` - 7 instances (redirecting sys.stdout)
+- `libs/mngr/imbue/mngr/cli/ask_test.py` - 2 instances
+- `libs/mngr/imbue/mngr/cli/test_agent_utils.py` - 2 instances
+- `libs/mngr/imbue/mngr/api/connect_test.py` - 2 instances
+- `libs/mngr/imbue/mngr/api/test_pair.py` - 2 instances
+- `libs/mngr/imbue/mngr/cli/conftest.py` - 1 instance
+
+Recommendation: These are already tracked by ratchet tests and should be reduced over time. Prioritize replacing unittest.mock usage (only 3 instances) with concrete mock implementations, then incrementally address monkeypatch.setattr usages.
+
+Decision: Accept
+
+## 10. Error class in snapshot_and_shutdown.py doesn't follow error hierarchy
+
+Description: `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:26` defines `ConfigurationError(RuntimeError)` which doesn't inherit from `BaseMngrError` or `MngrError`. Similarly, `libs/mngr/imbue/mngr/cli/output_helpers.py:26` defines `AbortError(BaseException)` without inheriting from the package error hierarchy.
+
+The style guide says: "All raised Exceptions should inherit from a base class that is specific to that library or app."
+
+For `ConfigurationError`, this is somewhat justified by the file's self-contained nature (line 8: "All code is self-contained in this file"). For `AbortError`, it intentionally uses `BaseException` to avoid generic handlers, but still violates the error hierarchy convention.
+
+Recommendation: For `ConfigurationError`, this is an acceptable deviation given the self-contained deployment constraint. For `AbortError`, make it inherit from both `BaseMngrError` and `BaseException` if possible, or document the intentional deviation.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Code-guardian inconsistency report identifying 10 code-level inconsistencies ranked by importance
- Most significant finding: ~18 instances of `logger.info` in library/API/provider code where `logger.debug` should be used (no ratchet test exists for this)
- Other findings include log message tense violations, `logger.exception` for expected errors, plain classes not following framework hierarchy, and more

## Test plan

- [ ] Review each identified inconsistency for accuracy
- [ ] Prioritize fixes based on importance ranking
- [ ] Create follow-up issues or tasks for accepted fixes


Generated with [Claude Code](https://claude.com/claude-code)