### PR TITLE
Rework mng create --await-ready to be synchronous

### DIFF
--- a/libs/mng/docs/commands/primary/create.md
+++ b/libs/mng/docs/commands/primary/create.md
@@ -69,7 +69,7 @@ By default, `mng create` uses the "local" host. Use these options to change that
 | ---- | ---- | ----------- | ------- |
 | `--reuse`, `--no-reuse` | boolean | Reuse existing agent with the same name if it exists (idempotent create) | `False` |
 | `--connect`, `--no-connect` | boolean | Connect to the agent after creation [default: connect] | `True` |
-| `--await-ready`, `--no-await-ready` | boolean | Wait until agent is ready before returning [default: no-await-ready if --no-connect] | None |
+| `--await-ready`, `--no-await-ready` | boolean | Wait until agent is ready before returning [default: await-ready if --connect or --message/--edit-message; otherwise no-await-ready] | None |
 | `--await-agent-stopped`, `--no-await-agent-stopped` | boolean | Wait until agent has completely finished running before exiting. Useful for testing and scripting. First waits for agent to become ready, then waits for it to stop. [default: no-await-agent-stopped] | None |
 | `--ensure-clean`, `--no-ensure-clean` | boolean | Abort if working tree is dirty | `True` |
 | `--snapshot-source`, `--no-snapshot-source` | boolean | Snapshot source agent first [default: yes if --source-agent and not local] | None |


### PR DESCRIPTION
Previously, --no-connect --no-await-ready forked a background process via os.fork() to run agent creation. This was wrong. Now the flow is always synchronous:

- --await-ready controls whether we await the agent's ready signal
- --connect controls whether we connect to the agent afterward
- --no-connect still implies --no-await-ready by default

The auto default for --await-ready is now smarter: it defaults to true when --connect, --await-agent-stopped, or --message/--edit-message is given (since sending a message requires agent readiness). Explicit --no-await-ready with a message flag errors out early.

Removes _create_agent_in_background and the os.fork() machinery. Adds await_ready parameter to api_create() to control ready signal waiting.