### PR TITLE
Style guide: framework base classes vs mixins

### DIFF
--- a/style_guide.md
+++ b/style_guide.md
@@ -1040,6 +1040,39 @@ There will often be multiple different implementation classes for a single inter
 
 Implementation classes should be contained within their own named module off of the root of the package (ex: if the package is `foobar` and the interface being implemented is `DatabaseInterface`, then the implementations should go in `foobar.database`)
 
+## Framework base classes
+
+Sometimes we need to subclass third-party framework classes (e.g. `click.Group`, `django.views.View`). These don't fit into the frozen/interface/implementation taxonomy above -- they are extension points dictated by the framework, not domain concepts. This is fine; the three-class rule applies to our own domain code.
+
+When multiple framework subclasses need to share behavior, use a concrete base class in the framework's inheritance hierarchy, not a mixin. Mixins add indirection and make the class hierarchy harder to follow. A straightforward base class is almost always clearer.
+
+```python
+# Good: concrete base class
+class CachedCompletionGroup(click.Group):
+    """Base class for groups that read completions from a static cache."""
+
+    _completion_cache_key: str
+
+    def shell_complete(self, ctx, incomplete):
+        ...
+
+
+class _ConfigGroup(CachedCompletionGroup):
+    _completion_cache_key = "config"
+
+
+# Bad: mixin that could just be a base class
+class CachedCompletionMixin:
+    _completion_cache_key: str
+
+    def shell_complete(self, ctx, incomplete):
+        ...
+
+
+class _ConfigGroup(CachedCompletionMixin, click.Group):
+    _completion_cache_key = "config"
+```
+
 # Functions and methods
 
 All functions and methods should have a single, clear purpose. Because of this, the names of functions and methods should be very precise and self-documenting. It is acceptable for the names to become fairly long. It should be very obvious what a function or method does just from reading its name


### PR DESCRIPTION
accidentally built on https://github.com/imbue-ai/mng/pull/538

## Summary

- Adds a new section to the style guide covering framework base classes (subclasses of third-party classes like `click.Group`)
- Clarifies that these don't need to fit the frozen/interface/implementation taxonomy
- Recommends concrete base classes over mixins when sharing behavior across framework subclasses

## Test plan

- [x] Style guide only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)