### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-21-11-01-53.md
+++ b/_tasks/inconsistencies/2026-02-21-11-01-53.md
@@ -1,0 +1,81 @@
+# Inconsistencies identified on 2026-02-21-11-01-53
+
+## 1. claude_web_view app does not follow project conventions
+
+Description: The `apps/claude_web_view/` app deviates from the project's style guide in multiple significant ways. All 10 model classes in `imbue/claude_web_view/models.py` inherit from `BaseModel` directly instead of `FrozenModel` (lines 20, 27, 36, 48, 57, 66, 74, 81, 89), and `server.py:21` has `SendMessageRequest(BaseModel)` as well. The `MessageRole` enum (models.py:11-16) inherits from `str, Enum` with hardcoded string values instead of `UpperCaseStrEnum` with `auto()`. All 4 source files use relative imports (e.g. `from .models import ...` in parser.py:8-14, server.py:17-18, watcher.py:10, cli.py:12) instead of absolute imports. The app uses `asyncio` and `async def` extensively (watcher.py:3, server.py:3) despite the style guide prohibiting async. It also uses stdlib `logging` (cli.py:4) instead of `loguru`.
+
+Recommendation: This app appears to have been developed outside the project's normal conventions. Migrate the models to `FrozenModel`, the enum to `UpperCaseStrEnum`, all imports to absolute form, and logging to `loguru`. The async usage is more structural -- FastAPI naturally uses async, so either accept this as an exception for web apps or switch to a sync-compatible framework.
+
+Decision: Accept
+
+## 2. Many module-level constants missing Final annotation
+
+Description: The style guide requires all constants to be declared as `Final`, but approximately 19 out of 22 UPPER_CASE module-level constants in the mngr library are missing the `Final` annotation. Examples include: `WARNING_COLOR`, `ERROR_COLOR`, `BUILD_COLOR`, `DEBUG_COLOR`, `TRACE_COLOR`, `RESET_COLOR` in `utils/logging.py:29-34`; `LOCAL_PROVIDER_NAME` in `primitives.py:222`; `USER_ID_FILENAME`, `PROFILES_DIRNAME`, `ROOT_CONFIG_FILENAME` in `config/data_types.py:34-36`; `MODAL_BACKEND_NAME`, `STATE_VOLUME_SUFFIX`, `MODAL_NAME_MAX_LENGTH` in `providers/modal/backend.py:39-41`; `CONTAINER_SSH_PORT`, `DEFAULT_SANDBOX_TIMEOUT`, `SSH_CONNECT_TIMEOUT` in `providers/modal/instance.py:98-102`; `LOCAL_BACKEND_NAME` in `providers/local/backend.py:14`; `SSH_BACKEND_NAME` in `providers/ssh/backend.py:29`; `COMMON_OPTIONS_GROUP_NAME` in `cli/common_opts.py:33`; `MODAL_TEST_APP_PREFIX` in `providers/modal/constants.py:3`.
+
+Recommendation: Add `Final` type annotations to all these constants. For example, change `WARNING_COLOR = "\x1b[1;38;5;178m"` to `WARNING_COLOR: Final[str] = "\x1b[1;38;5;178m"`. Some constants like `LOCAL_PROVIDER_NAME = ProviderInstanceName("local")` would become `LOCAL_PROVIDER_NAME: Final[ProviderInstanceName] = ProviderInstanceName("local")`.
+
+Decision: Accept
+
+## 3. Boolean fields missing is_ prefix
+
+Description: Several boolean fields on FrozenModel classes lack the `is_` prefix required by the style guide. The field `success: bool` on `CommandResult` in `interfaces/data_types.py:173` should be `is_success`. The field `create_work_dir: bool` on `CreateAgentOnHostOptions` in `api/data_types.py:281` should be `is_create_work_dir` or similar. The field `start_on_boot: bool` on `AgentInfo` in `api/list.py:63` and on `AgentListItem` in `apps/sculptor_web/imbue/sculptor_web/data_types.py:33` should be `is_start_on_boot`. Note: the non_issues.md says CLI functions and data classes with CLI-corresponding attributes are exempt, but these are domain model fields, not CLI parameters.
+
+Recommendation: Rename `success` to `is_success`, `create_work_dir` to `is_create_work_dir`, and `start_on_boot` to `is_start_on_boot`. Update all references accordingly.
+
+Decision: Accept
+
+## 4. NamedTuple used instead of FrozenModel
+
+Description: The style guide explicitly states "Never use dataclasses or named tuples." Two classes use `NamedTuple`: `BufferedMessage` in `utils/logging.py:232` and `ModalSubprocessTestEnv` in `conftest.py:537`. The `BufferedMessage` class has fields `formatted_message: str` and `is_stderr: bool` and is used in the logging buffering system. While the conftest.py usage is in test infrastructure, the `BufferedMessage` in production code is a clear violation.
+
+Recommendation: Convert `BufferedMessage` to inherit from `FrozenModel` instead of `NamedTuple`. This may require minor adjustments to how it is constructed and destructured, but will align with the project's data modeling conventions.
+
+Decision: Accept
+
+## 5. ConfigurationError in snapshot_and_shutdown.py doesn't follow error hierarchy
+
+Description: In `providers/modal/routes/snapshot_and_shutdown.py:26`, `ConfigurationError` inherits from `RuntimeError` directly instead of from the mngr error hierarchy (`BaseMngrError` or a provider-specific base). The style guide says "All raised Exceptions should inherit from a base class that is specific to that library or app. Never raise built-in Exceptions directly (except NotImplementedError)." Additionally, the function at line 110 uses `logging.getLogger("snapshot_and_shutdown")` (stdlib logging) instead of `loguru`.
+
+Recommendation: Have `ConfigurationError` inherit from both `BaseMngrError` (or `ProviderError`) and `RuntimeError`. Replace the stdlib `logging.getLogger` call with `loguru`'s `logger`. Note: this file runs inside Modal's serverless environment, which may have constraints on loguru availability; if so, document the exception.
+
+Decision: Accept
+
+## 6. _ListIterationParams inherits from BaseModel instead of FrozenModel or MutableModel
+
+Description: In `cli/list.py:551`, the class `_ListIterationParams` inherits directly from `BaseModel` instead of `FrozenModel` or `MutableModel`. The style guide says all data classes should use `FrozenModel` for immutable data or `MutableModel` for mutable state. While this class has `model_config = {"arbitrary_types_allowed": True}` which may have motivated the direct `BaseModel` usage, `FrozenModel` should also support this configuration.
+
+Recommendation: Change `_ListIterationParams(BaseModel)` to `_ListIterationParams(FrozenModel)` and verify that `arbitrary_types_allowed` works with `FrozenModel`. If it does not, add support in `FrozenModel` or document why this exception is necessary.
+
+Decision: Accept
+
+## 7. FileNotFoundError raised directly in host.py
+
+Description: In `hosts/host.py:244`, a built-in `FileNotFoundError` is raised directly: `raise FileNotFoundError(f"File not found: {remote_filename}") from e`. The style guide says "Never raise built-in Exceptions directly (except NotImplementedError). Instead, create a new type that inherits from both the base error class for the package and the built-in."
+
+Recommendation: Create a custom exception like `RemoteFileNotFoundError(HostError, FileNotFoundError)` in `errors.py` and raise that instead. This keeps the error catchable as `FileNotFoundError` while fitting into the mngr error hierarchy.
+
+Decision: Accept
+
+## 8. Dictionary fields not using value_by_key naming pattern
+
+Description: The style guide says "Always use `value_by_key` for dictionaries and mappings." Several dict fields use names like `hosts`, `tags`, `plugin`, `defaults`, `options` instead of the `value_by_key` pattern. Notable examples: `hosts: dict[str, SSHHostConfig]` in `providers/ssh/config.py:30` (should be `host_config_by_name` or similar), `tags: dict[str, str]` in `interfaces/data_types.py:335,389` and `api/data_types.py:169`, `plugin: dict[str, Any]` in `api/list.py:78` and `interfaces/data_types.py:400`.
+
+Recommendation: Rename dictionary fields to follow the `value_by_key` pattern: `hosts` -> `host_config_by_host_name`, `tags` -> `tag_value_by_key`, `plugin` -> `plugin_data_by_name`. Some generic cases like `defaults` and `options` in config data types may be acceptable as-is since their keys are truly dynamic and the names are already conventional.
+
+Decision: Accept
+
+## 9. Global state and global keyword usage in sculptor_web and logging
+
+Description: The style guide says "Avoid using the `global` keyword. Instead, pass all state explicitly through from the top level of the program." The file `apps/sculptor_web/imbue/sculptor_web/main.py` uses `global _poll_thread` at lines 151 and 162, and maintains module-level mutable state via `_agent_list_state` and `_poll_thread` (lines 49-50). While this pattern is somewhat common for background thread management, it violates the functional style guidance.
+
+Recommendation: Refactor the polling state into a class (an Implementation class inheriting from an interface) that encapsulates the thread and state management, passed as a dependency to the FastHTML routes. This would bring the code in line with the project's preference for explicit state management through Implementation classes.
+
+Decision: Accept
+
+## 10. Module-level executable code in snapshot_and_shutdown.py
+
+Description: The style guide says "Never write code outside a function (except for the call to `main()`, the declaration of constants, and imports.)" The file `providers/modal/routes/snapshot_and_shutdown.py:30-48` has extensive module-level executable code: conditional environment variable reading, file I/O (`Path.read_text()`, `Path.write_text()`), and Modal resource creation (`modal.Image`, `modal.App`, `modal.Volume`). While this is partly driven by Modal's deployment model (which requires module-level app/image definitions), the file I/O and environment variable logic could be encapsulated in functions.
+
+Recommendation: This is partially a Modal framework constraint, but the environment variable logic and file I/O (lines 30-38) could be wrapped in a function. Document the Modal-specific module-level requirements as an accepted exception if they truly cannot be moved into functions.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 10 code-level inconsistencies across the codebase, ordered by importance
- Top issues: claude_web_view app not following project conventions, missing Final annotations on constants, boolean fields missing is_ prefix
- Full report in `_tasks/inconsistencies/2026-02-21-11-01-53.md`

## Test plan

- [x] Report reviewed for accuracy against style guide
- [x] Cross-referenced with non_issues.md to avoid false positives  
- [x] Cross-referenced with existing FIXMEs to avoid duplicates