### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-22-11-00-55.md
+++ b/_tasks/inconsistencies/2026-02-22-11-00-55.md
@@ -1,0 +1,154 @@
+# Inconsistencies identified on 2026-02-22-11-00-55
+
+## 1. claude_web_view app does not follow project style conventions
+
+Description: The `apps/claude_web_view` application diverges significantly from the project's style guide in multiple ways:
+
+- **Enum pattern**: `MessageRole(str, Enum)` at `apps/claude_web_view/imbue/claude_web_view/models.py:11` uses `str, Enum` instead of `UpperCaseStrEnum`, and has hardcoded string values (`"user"`, `"assistant"`, `"system"`) instead of `auto()`.
+- **BaseModel instead of FrozenModel**: 9 classes in `models.py` (lines 20, 27, 36, 48, 57, 66, 74, 81, 89) and 1 class in `server.py` (line 21) inherit directly from `BaseModel` instead of `FrozenModel`.
+- **Relative imports**: 6 files use relative imports (e.g., `from .parser import TranscriptParser` in `server.py:17`, `watcher.py:10`, `parser.py:8-14`, `cli.py:12`). The style guide says "Always use absolute imports, never relative imports".
+- **Async/asyncio usage**: `server.py` and `watcher.py` use `asyncio` extensively (async def, await, asyncio.Queue, etc.). The style guide says "Never use async or asyncio".
+- **Module docstring in __init__.py**: `apps/claude_web_view/imbue/claude_web_view/__init__.py:1` contains a module docstring, but the style guide says "Never create docstrings for modules" and "Never put any code in an __init__.py file".
+
+Recommendation: Refactor the claude_web_view app to follow the project's style conventions. This is a large effort but necessary for consistency across the monorepo. The async/asyncio usage may be required by FastAPI/uvicorn, in which case an explicit exception should be documented.
+
+Decision: Accept
+
+## 2. Inconsistent use of if/elif vs match statements when branching on enum values
+
+Description: Several CLI files use `if output_opts.output_format == OutputFormat.HUMAN` instead of `match` statements with `assert_never` when branching on the `OutputFormat` enum. This is inconsistent with other files like `pair.py`, `output_helpers.py`, and `gc.py` which correctly use `match` with `assert_never`. The affected locations all follow the same anti-pattern -- a simple if statement that only handles the HUMAN case with no else clause:
+
+- `libs/mngr/imbue/mngr/cli/destroy.py:444`
+- `libs/mngr/imbue/mngr/cli/rename.py:91` (and also line 195)
+- `libs/mngr/imbue/mngr/cli/start.py:51`
+- `libs/mngr/imbue/mngr/cli/stop.py:50`
+
+Additionally, `libs/mngr/imbue/mngr/cli/list.py` has two if/elif/else chains (lines 591-597 and 603-609) that branch on `OutputFormat` using if/elif instead of match.
+
+The style guide states: "For enums, always use match statements" and "All if/elif chains must end with an else clause."
+
+Recommendation: Convert all enum branching to use `match` statements with `assert_never` in the default case, matching the pattern already used in `pair.py` and `output_helpers.py`. For the simple `_output()` helper functions, this also ensures that adding a new `OutputFormat` variant will produce a type error at all relevant locations.
+
+Decision: Accept
+
+## 3. logger.info used in library/API code instead of logger.debug
+
+Description: The style guide states "Reserve logger.info for CLI/user-facing code" and "use logger.debug for library/API code". However, `logger.info` is used extensively in library/API code:
+
+- `libs/mngr/imbue/mngr/api/create.py`: lines 109, 116, 120
+- `libs/mngr/imbue/mngr/api/connect.py`: lines 152, 186
+- `libs/mngr/imbue/mngr/api/find.py`: lines 297, 319
+- `libs/mngr/imbue/mngr/api/pair.py`: lines 140, 149, 360
+- `libs/mngr/imbue/mngr/providers/modal/backend.py`: line 67
+- `libs/mngr/imbue/mngr/providers/modal/instance.py`: lines 1306, 1432, 1548, 1566, 1608, 1941, 2011
+
+All of these are in the `api/` or `providers/` modules, which are library code -- not CLI code. The CLI layer (in `cli/`) is where `logger.info` should be used.
+
+Recommendation: Change these to `logger.debug` or wrap them in `log_span()` calls. The CLI layer should be the only place that uses `logger.info`.
+
+Decision: Accept
+
+## 4. Inconsistent dict variable naming -- _dict suffix instead of value_by_key pattern
+
+Description: The style guide says "Always use value_by_key for dictionaries and mappings". Several places use `_dict` suffix or other non-conforming names for dict variables:
+
+- `libs/mngr/imbue/mngr/cli/create.py:1367`: `tags_dict: dict[str, str] = {}`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:2238`: `secret_dict: dict[str, str | None] = {}`
+- `libs/mngr/imbue/mngr/config/loader.py:130`: `config_dict: dict[str, Any] = {}`
+
+Similarly, several Field declarations on models use plain names like `tags`, `plugin`, `user_tags` for dict fields instead of the `value_by_key` pattern:
+
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:291`: `user_tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:335`: `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:400`: `plugin: dict[str, Any]`
+
+Recommendation: Rename dict variables and fields to follow the `value_by_key` pattern. For example, `tags_dict` should be `tag_value_by_name`, `secret_dict` should be `secret_value_by_name`, `user_tags` should be `user_tag_value_by_key`, etc.
+
+Decision: Accept
+
+## 5. Functions accept mutable list/dict parameter types instead of immutable Sequence/Mapping
+
+Description: The style guide states that function inputs should use immutable abstract types: `Sequence[T]` instead of `list[T]`, and `Mapping[K, V]` instead of `dict[K, V]`. Many functions violate this:
+
+Functions taking `list[T]` instead of `Sequence[T]`:
+- `libs/mngr/imbue/mngr/cli/connect.py:321`: `select_agent_interactively(agents: list[AgentInfo])`
+- `libs/mngr/imbue/mngr/cli/list.py:616`: `_emit_json_output(agents: list[AgentInfo], errors: list[ErrorInfo])`
+- `libs/mngr/imbue/mngr/cli/list.py:639`: `_emit_human_output(agents: list[AgentInfo], ...)`
+- `libs/mngr/imbue/mngr/cli/list.py:768`: `_sort_agents(agents: list[AgentInfo], ...)`
+- `libs/mngr/imbue/mngr/config/data_types.py:71`: `merge_list_fields(base: list[T], override: list[T] | None)`
+
+Functions taking `dict[K,V]` instead of `Mapping[K,V]`:
+- `libs/mngr/imbue/mngr/cli/config.py:104`: `_get_nested_value(data: dict[str, Any], ...)`
+- `libs/mngr/imbue/mngr/cli/config.py:183`: `_flatten_config(config: dict[str, Any], ...)`
+- `libs/mngr/imbue/mngr/config/data_types.py:83`: `merge_dict_fields(base: dict[K, V], ...)`
+- `libs/mngr/imbue/mngr/config/loader.py:341,438,447,465,483`: multiple parsing functions
+
+Recommendation: Change function parameter types to use `Sequence[T]` and `Mapping[K, V]` for inputs. Keep `list` and `dict` for return types.
+
+Decision: Accept
+
+## 6. unittest.mock usage in test files
+
+Description: The style guide explicitly prohibits `from unittest.mock import Mock, MagicMock, patch, create_autospec` or any other import from `unittest.mock`. Two test files violate this:
+
+- `libs/mngr/imbue/mngr/agents/default_plugins/test_claude_agent.py:8`: `from unittest.mock import patch`
+- `libs/mngr/imbue/mngr/providers/modal/test_modal_create.py:23-24`: `from unittest.mock import MagicMock` and `from unittest.mock import patch`
+
+Recommendation: Replace unittest.mock usage with concrete mock implementations that inherit from the relevant interface classes, as described in the style guide's "Creating mock implementations" section.
+
+Decision: Accept
+
+## 7. NamedTuple usage instead of FrozenModel
+
+Description: The style guide says "Never use dataclasses or named tuples". Two files use `NamedTuple`:
+
+- `libs/mngr/imbue/mngr/utils/logging.py:232`: `class BufferedMessage(NamedTuple):`
+- `libs/mngr/imbue/mngr/conftest.py:537`: `class ModalSubprocessTestEnv(NamedTuple):`
+
+Recommendation: Convert these to `FrozenModel` subclasses with proper `Field` declarations and descriptions.
+
+Decision: Accept
+
+## 8. _ListIterationParams inherits from BaseModel instead of FrozenModel
+
+Description: `libs/mngr/imbue/mngr/cli/list.py:551` defines `class _ListIterationParams(BaseModel):` which inherits directly from `BaseModel`. The style guide says there are only 3 types of classes: FrozenModel, ABC+MutableModel interfaces, and implementations. Data classes should use `FrozenModel`.
+
+Recommendation: Change `_ListIterationParams` to inherit from `FrozenModel` instead of `BaseModel`. The `model_config = {"arbitrary_types_allowed": True}` may need to be preserved.
+
+Decision: Accept
+
+## 9. Missing @pure decorators on pure functions
+
+Description: Several functions that appear to be pure (no side effects) are missing the `@pure` decorator. The style guide says "All pure functions should be marked with the @pure decorator."
+
+- `libs/mngr/imbue/mngr/cli/config.py:104`: `_get_nested_value()`
+- `libs/mngr/imbue/mngr/cli/config.py:160`: `_parse_value()`
+- `libs/mngr/imbue/mngr/cli/config.py:174`: `_format_value_for_display()`
+- `libs/mngr/imbue/mngr/cli/config.py:183`: `_flatten_config()`
+- `libs/mngr/imbue/mngr/cli/list.py:672`: `_parse_slice_spec()`
+- `libs/mngr/imbue/mngr/cli/list.py:705`: `_format_value_as_string()`
+- `libs/mngr/imbue/mngr/cli/list.py:728`: `_get_sortable_value()`
+- `libs/mngr/imbue/mngr/cli/list.py:775`: `_get_field_value()`
+- `libs/mngr/imbue/mngr/config/data_types.py:71`: `merge_list_fields()`
+- `libs/mngr/imbue/mngr/config/data_types.py:83`: `merge_dict_fields()`
+- `libs/mngr/imbue/mngr/agents/default_plugins/claude_config.py:384`: `hook_already_exists()`
+
+Recommendation: Add the `@pure` decorator from `imbue.imbue_common.pure` to each of these functions.
+
+Decision: Accept
+
+## 10. Direct raising of built-in ValueError in imbue_common primitives
+
+Description: The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)". The `imbue_common` primitives module raises bare `ValueError` in 5 locations:
+
+- `libs/imbue_common/imbue/imbue_common/primitives.py:14`: `raise ValueError(f"{cls.__name__} cannot be empty")`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:35`: `raise ValueError(f"{cls.__name__} must be >= 0, got {value}")`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:55`: `raise ValueError(f"{cls.__name__} must be > 0, got {value}")`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:75`: `raise ValueError(f"{cls.__name__} must be >= 0, got {value}")`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:95`: `raise ValueError(f"{cls.__name__} must be > 0, got {value}")`
+
+There is no base error class for `imbue_common` (only `SwitchError` in `errors.py`). Additionally, `concurrency_group/concurrency_group.py:636` raises `ValueError` directly despite having a `ConcurrencyGroupError` base class available.
+
+Recommendation: Create an `ImbueCommonError` base class in `imbue_common/errors.py`, then create specific error subclasses (e.g., `PrimitiveValidationError(ImbueCommonError, ValueError)`) for the primitive validation errors. For the concurrency group, use a `ConcurrencyGroupError` subclass instead of bare `ValueError`.
+
+Decision: Accept


### PR DESCRIPTION
## Summary
- Identified 10 code-level inconsistencies across the codebase, ordered by importance
- Key findings: claude_web_view app diverges significantly from style conventions, inconsistent enum branching patterns, logger.info misuse in library code, naming convention violations, and missing @pure decorators

## Test plan
- [ ] Review each inconsistency for accuracy and relevance
- [ ] Verify findings are not duplicated by existing FIXMEs or non_issues.md entries
- [ ] Prioritize fixes based on impact

Generated with [Claude Code](https://claude.com/claude-code)