### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-23-11-06-37.md
+++ b/_tasks/inconsistencies/2026-02-23-11-06-37.md
@@ -1,0 +1,139 @@
+# Inconsistencies identified on 2026-02-23-11-06-37
+
+## 1. claude_web_view uses raw Pydantic BaseModel and stdlib Enum instead of FrozenModel and UpperCaseStrEnum
+
+Description: The `claude_web_view` app defines all its models using raw `pydantic.BaseModel` instead of the project's `FrozenModel` base class, and defines `MessageRole` as `class MessageRole(str, Enum)` instead of using `UpperCaseStrEnum`. This is the only place in the codebase where these patterns occur -- every other package (mngr, sculptor_web, concurrency_group) consistently uses `FrozenModel`/`MutableModel` and `UpperCaseStrEnum`.
+
+Files affected:
+- `apps/claude_web_view/imbue/claude_web_view/models.py:7` - imports `BaseModel` from pydantic
+- `apps/claude_web_view/imbue/claude_web_view/models.py:11` - `class MessageRole(str, Enum)` instead of `UpperCaseStrEnum`
+- `apps/claude_web_view/imbue/claude_web_view/models.py:20,27,36,48,57,66,74,81,89` - 9 model classes using `BaseModel`
+- `apps/claude_web_view/imbue/claude_web_view/server.py:21` - `SendMessageRequest(BaseModel)`
+
+Recommendation: Refactor all models to inherit from `FrozenModel` and change `MessageRole` to use `UpperCaseStrEnum` with `auto()` values.
+
+Decision: Accept
+
+## 2. imbue_common lacks a base exception class; its exceptions inherit directly from builtins
+
+Description: The style guide states "All raised Exceptions should inherit from a base class that is specific to that library or app." The `imbue_common` package has no package-specific base exception class. Its custom exceptions inherit directly from `ValueError`:
+
+- `libs/imbue_common/imbue/imbue_common/ids.py:11` - `class InvalidRandomIdError(ValueError)`
+- `libs/imbue_common/imbue/imbue_common/model_update.py:9` - `class NestedFieldUpdateError(ValueError)`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:110` - `class InvalidProbabilityError(ValueError)`
+- `libs/imbue_common/imbue/imbue_common/errors.py:1` - `class SwitchError(Exception)` - no base class
+
+Additionally, `libs/imbue_common/imbue/imbue_common/primitives.py` raises `ValueError` directly at lines 14, 35, 55, 75, 95 (in `NonEmptyStr`, `NonNegativeInt`, `PositiveInt`, `NonNegativeFloat`, `PositiveFloat`).
+
+Recommendation: Create a `BaseImbueCommonError(Exception)` base class in `imbue_common/errors.py` and have all custom exceptions inherit from it (with the appropriate builtin as a secondary base, e.g., `class InvalidRandomIdError(BaseImbueCommonError, ValueError)`). Replace direct `raise ValueError(...)` calls with custom exception types.
+
+Decision: Accept
+
+## 3. Dictionary field names do not follow the `*_by_*` naming convention
+
+Description: The style guide (line 667) says "Always use `value_by_key` for dictionaries and mappings." Many dictionary-typed class fields use names like `tags`, `plugins`, `providers`, `hosts` instead of `tags_by_key`, `plugins_by_name`, `providers_by_name`, `hosts_by_name`.
+
+Key violations in data model classes:
+- `libs/mngr/imbue/mngr/config/data_types.py:417` - `agent_types: dict[AgentTypeName, AgentTypeConfig]` (should be `agent_type_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:421` - `providers: dict[ProviderInstanceName, ProviderInstanceConfig]` (should be `provider_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:425` - `plugins: dict[PluginName, PluginConfig]` (should be `plugin_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:433` - `commands: dict[str, CommandDefaults]` (should be `command_defaults_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:437` - `create_templates: dict[CreateTemplateName, CreateTemplate]` (should be `create_template_by_name`)
+- `libs/mngr/imbue/mngr/config/data_types.py:441` - `pre_command_scripts: dict[str, list[str]]` (should be `pre_command_scripts_by_command`)
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:277` - `plugin: dict[str, dict[str, Any]]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:335` - `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/interfaces/data_types.py:389` - `tags: dict[str, str]`
+- `libs/mngr/imbue/mngr/providers/ssh/config.py:30` - `hosts: dict[str, SSHHostConfig]` (should be `host_by_name`)
+
+Registry variables also violate this:
+- `libs/mngr/imbue/mngr/agents/agent_registry.py:23` - `_agent_class_registry`
+- `libs/mngr/imbue/mngr/agents/agent_registry.py:24` - `_agent_config_registry`
+- `libs/mngr/imbue/mngr/providers/registry.py:29` - `_backend_registry`
+- `libs/mngr/imbue/mngr/config/plugin_registry.py:8` - `_plugin_config_registry`
+
+Recommendation: Rename dictionary fields and variables to follow the `value_by_key` pattern. This is a large change since some of these are in config models (affecting TOML key names), so it should be done carefully with migration support.
+
+Decision: Accept
+
+## 4. NamedTuple used in mngr utils/logging.py instead of FrozenModel
+
+Description: The style guide says "Never use dataclasses or named tuples." However, `libs/mngr/imbue/mngr/utils/logging.py:232` defines `class BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`. This should be a `FrozenModel` instead.
+
+Recommendation: Replace `BufferedMessage(NamedTuple)` with `BufferedMessage(FrozenModel)`.
+
+Decision: Accept
+
+## 5. Functions marked @pure that access environment variables or system state
+
+Description: The style guide defines pure functions as having "no side effects" and not performing "I/O operations." Three functions are marked `@pure` but access environment variables or query system state:
+
+- `libs/mngr/imbue/mngr/utils/editor.py:21` - `get_editor_command()` calls `os.environ.get("VISUAL")`, `os.environ.get("EDITOR")`, and `shutil.which()` (filesystem lookup)
+- `libs/mngr/imbue/mngr/cli/help_formatter.py:87` - `get_terminal_width()` calls `shutil.get_terminal_size()` (terminal state query)
+- `libs/mngr/imbue/mngr/cli/help_formatter.py:94` - `get_pager_command()` calls `os.environ.get("PAGER", "less")`
+
+Recommendation: Remove the `@pure` decorator from these three functions, or refactor them to accept the environment values as parameters.
+
+Decision: Accept
+
+## 6. claude_web_view uses print() for logging instead of loguru
+
+Description: The style guide says to use `loguru` for all logging. The `claude_web_view` app uses `print()` extensively for logging output, while the rest of the codebase uses `loguru`:
+
+- `apps/claude_web_view/imbue/claude_web_view/parser.py:63` - `print(f"Warning: Failed to parse line: {e}")`
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:86-87` - `print(f"Error: ...")` for error messages
+- `apps/claude_web_view/imbue/claude_web_view/cli.py:107` - `print(f"claude_web_view starting at {url}")`
+- `apps/claude_web_view/imbue/claude_web_view/server.py:97-107` - Multiple `print()` calls for message received debugging
+
+Every other package in the monorepo (mngr, sculptor_web, concurrency_group) uses `from loguru import logger` consistently.
+
+Recommendation: Replace `print()` calls with appropriate `loguru` logger calls (`logger.warning()`, `logger.error()`, `logger.info()`, `logger.debug()`).
+
+Decision: Accept
+
+## 7. claude_web_view uses async/asyncio while the style guide prohibits it
+
+Description: The style guide says "Never use `async` or `asyncio`." The `claude_web_view` app extensively uses async patterns:
+
+- `apps/claude_web_view/imbue/claude_web_view/server.py:3` - `import asyncio`
+- `apps/claude_web_view/imbue/claude_web_view/server.py:34,42,45,90,95,111` - 6 async function definitions
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:3` - `import asyncio`
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:32,40,62,67` - 4 async function definitions
+
+Note: The Modal provider at `libs/mngr/imbue/mngr/providers/modal/log_utils.py:154` also has one `async def` but this is required by Modal's API and is a reasonable exception. The `claude_web_view` usage is for FastAPI, which could potentially be replaced with a synchronous alternative.
+
+Recommendation: Evaluate whether `claude_web_view` can use a synchronous web framework. If FastAPI is required for SSE support, document this as an explicit exception to the style guide.
+
+Decision: Accept
+
+## 8. sculptor_web uses `global` keyword
+
+Description: The style guide says "Avoid using the `global` keyword." The `sculptor_web` app uses `global` in two places:
+
+- `apps/sculptor_web/imbue/sculptor_web/main.py:151` - `global _poll_thread` in `_start_polling()`
+- `apps/sculptor_web/imbue/sculptor_web/main.py:162` - `global _poll_thread` in `_stop_polling()`
+
+Recommendation: Refactor to use a module-level container object (like the dict pattern already used in `libs/mngr/imbue/mngr/main.py:33`) or a class to manage the polling state, avoiding the need for the `global` keyword.
+
+Decision: Accept
+
+## 9. mngr modal provider ConfigurationError does not inherit from package base exception
+
+Description: The style guide says all exceptions should inherit from a package-specific base class. `ConfigurationError` in the Modal provider inherits directly from `RuntimeError`:
+
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:26` - `class ConfigurationError(RuntimeError)` should inherit from a mngr error base class (e.g., `HostError` or `ProviderError`).
+
+Recommendation: Change to inherit from the appropriate mngr base exception class (e.g., `class ConfigurationError(HostError, RuntimeError)`).
+
+Decision: Accept
+
+## 10. AbortError inherits from BaseException instead of mngr base exception hierarchy
+
+Description: The `AbortError` class in the CLI module inherits directly from `BaseException` rather than from the mngr exception hierarchy:
+
+- `libs/mngr/imbue/mngr/cli/output_helpers.py:26` - `class AbortError(BaseException)`
+
+While the docstring explains this is intentional (to avoid being caught by generic `except Exception` handlers), it still violates the pattern of all exceptions inheriting from a package-specific base class.
+
+Recommendation: Consider making this inherit from `BaseMngrError` and `BaseException` (i.e., `class AbortError(BaseMngrError, BaseException)`) or document it as an explicit exception to the pattern.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 10 code-level inconsistencies across the codebase, ordered by importance
- Key findings:
  - `claude_web_view` app uses raw Pydantic `BaseModel` and stdlib `Enum` instead of `FrozenModel` and `UpperCaseStrEnum`
  - `imbue_common` package lacks a base exception class; exceptions inherit directly from builtins
  - Dictionary fields across config and interface models don't follow the `*_by_*` naming convention
  - `NamedTuple` used in `utils/logging.py` instead of `FrozenModel`
  - Three functions incorrectly marked `@pure` that access environment variables or system state
  - `claude_web_view` uses `print()` instead of `loguru` and `async/asyncio` against style guide
  - `sculptor_web` uses `global` keyword
  - Two exception classes don't inherit from package-specific base classes

## Test plan

- [ ] Review each inconsistency for accuracy and priority
- [ ] Decide which items to address and in what order

Generated with Claude Code (code-guardian skill)