### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-24-11-06-50.md
+++ b/_tasks/inconsistencies/2026-02-24-11-06-50.md
@@ -1,0 +1,218 @@
+# Inconsistencies identified on 2026-02-24-11-06-50
+
+## 1. NamedTuple usage in production code (style guide bans named tuples)
+
+Description: The style guide explicitly states "Never use dataclasses or named tuples." Two production-code files use `NamedTuple`:
+
+- `libs/mngr/imbue/mngr/utils/logging.py:232` -- `BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`
+- `libs/mngr/imbue/mngr/conftest.py:537` -- `ModalSubprocessTestEnv(NamedTuple)` with fields `env`, `prefix`, `host_dir`
+
+The ratchet test `test_prevent_namedtuple_usage` only catches functional `namedtuple()` calls, not class-based `NamedTuple` inheritance, so these slip through.
+
+Recommendation: Convert these to `FrozenModel` subclasses with `Field(description=...)` on each attribute.
+
+Decision: Accept
+
+## 2. Inconsistent boolean naming: `enabled` vs `is_enabled` in same config file
+
+Description: In `libs/mngr/imbue/mngr/config/data_types.py`, two closely related config classes use opposite naming conventions for the same semantic concept:
+
+- Line 198: `ProviderInstanceConfig` uses `is_enabled: bool | None` (correct per style guide)
+- Line 242: `PluginConfig` uses `enabled: bool` (missing `is_` prefix)
+
+The style guide says "Always prefix booleans with `is_`" and `non_issues.md` only exempts CLI functions and data classes that correspond to CLI args. `PluginConfig` is a config data type, not a CLI option.
+
+Recommendation: Rename `enabled` to `is_enabled` in `PluginConfig` for consistency with `ProviderInstanceConfig` in the same file.
+
+Decision: Accept
+
+## 3. Module docstrings in production code files (style guide bans them)
+
+Description: The style guide states "Never create docstrings for modules." However, 13 production code files have module-level docstrings:
+
+- `libs/mngr/imbue/mngr/api/pull.py:1`
+- `libs/mngr/imbue/mngr/api/push.py:1`
+- `libs/mngr/imbue/mngr/api/sync.py:1`
+- `libs/mngr/imbue/mngr/cli/agent_utils.py:1`
+- `libs/mngr/imbue/mngr/cli/watch_mode.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh_host_setup.py:1`
+- `libs/mngr/imbue/mngr/providers/modal/ssh_utils.py:1`
+- `libs/mngr/imbue/mngr/providers/modal/instance.py:1`
+- `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh/backend.py:1`
+- `libs/mngr/imbue/mngr/providers/ssh/instance.py:1`
+- `libs/mngr_opencode/imbue/mngr_opencode/plugin.py:1`
+- `libs/imbue_common/examples/ratchets_example.py:1`
+
+There is no ratchet test catching this, so it is likely to keep growing.
+
+Recommendation: Remove module docstrings from all files. Consider adding a ratchet test to prevent future additions.
+
+Decision: Accept
+
+## 4. imbue_common has no base error class; exceptions inherit directly from builtins
+
+Description: The style guide says "All raised Exceptions should inherit from a base class that is specific to that library." The `imbue_common` library has no such base class. Its exceptions each inherit directly from builtins:
+
+- `libs/imbue_common/imbue/imbue_common/errors.py:1` -- `SwitchError(Exception)` (no library base, no specific builtin)
+- `libs/imbue_common/imbue/imbue_common/primitives.py:110` -- `InvalidProbabilityError(ValueError)` (no library base)
+- `libs/imbue_common/imbue/imbue_common/ids.py:11` -- `InvalidRandomIdError(ValueError)` (no library base)
+- `libs/imbue_common/imbue/imbue_common/model_update.py:9` -- `NestedFieldUpdateError(ValueError)` (no library base)
+- `libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py:86` -- `RatchetsError(Exception)` (serves as local base but not connected to library base)
+
+Additionally, `primitives.py` raises bare `ValueError` at lines 14, 35, 55, 75, 95 for `NonEmptyStr`, `NonNegativeInt`, `PositiveInt`, `NonNegativeFloat`, `PositiveFloat`. The style guide says "Never raise built-in Exceptions directly."
+
+Recommendation: Create a `BaseMngrCommonError(Exception)` in `imbue_common/errors.py` and have all custom exceptions inherit from it alongside their builtin parent. Create custom error types for each primitive validation failure.
+
+Decision: Accept
+
+## 5. `@pure` decorator applied to impure functions in ratchet_testing
+
+Description: The style guide says all pure functions should be marked `@pure` and the decorator is advisory. However, in `libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py`, `@pure` is applied to functions that are demonstrably impure:
+
+- Line 199: `get_ratchet_failures` is marked `@pure` but calls subprocess (`git ls-files`, `git blame`) and reads files from disk
+- Line 335: `check_regex_ratchet` is marked `@pure` but delegates to `get_ratchet_failures`
+
+Meanwhile, multiple genuinely pure functions in other files lack the decorator entirely.
+
+Recommendation: Remove `@pure` from `get_ratchet_failures` and `check_regex_ratchet`. Audit the rest of the codebase for pure functions missing the decorator.
+
+Decision: Accept
+
+## 6. Private (_-prefixed) names imported across module boundaries
+
+Description: The style guide says private names prefixed with `_` should not be imported outside their defining module. In `libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py` lines 8-10, three private names are imported from `core.py`:
+
+- `_get_chunk_commit_date`
+- `_get_non_ignored_files_with_extension`
+- `_parse_file_ast`
+
+The project's own ratchet test `test_prevent_importing_underscore_prefixed_names_in_non_test_code` would catch this, but `ratchets.py` is likely excluded because it is in the same subpackage or because the ratchet testing infrastructure imports it.
+
+Recommendation: Make these functions public (remove the `_` prefix) since they are clearly part of the ratchet testing API, or refactor so `ratchets.py` does not need to import them directly.
+
+Decision: Accept
+
+## 7. Cross-package dependency inversion in imbue_common test
+
+Description: `libs/imbue_common/imbue/imbue_common/logging_test.py:9` imports `from imbue.mngr.errors import BaseMngrError`. This creates a dependency from the lower-level `imbue_common` library to the higher-level `mngr` library, violating the layered import architecture. `imbue_common` is supposed to be a foundation library with no upward dependencies.
+
+Recommendation: Create a test-local exception class or use an exception defined within `imbue_common` itself for the test.
+
+Decision: Accept
+
+## 8. Missing `Field(description=...)` on model attributes in concurrency_group
+
+Description: The style guide says "Attributes should have their description captured in the `description` attribute of the pydantic `Field` object." Several models in `concurrency_group` lack this:
+
+- `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:36-41` -- `FinishedProcess(FrozenModel)` has 6 fields, all without `Field(description=...)`
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:82-84` -- `_TrackedThread(MutableModel)` has 2 fields without descriptions
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:100-106` -- `ConcurrencyGroup(MutableModel)` has fields `name`, `exit_timeout_seconds`, `shutdown_timeout_seconds`, `parent` all without `Field(description=...)`
+
+Recommendation: Add `Field(description=...)` to all model attributes in the concurrency_group library.
+
+Decision: Accept
+
+## 9. Raising bare `ValueError` in concurrency_group
+
+Description: In `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636`, the `get_only_exception` method raises a bare `ValueError`:
+
+```python
+raise ValueError("The exception group does not contain exactly one exception.")
+```
+
+The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)." The concurrency_group library does have a custom error hierarchy (`ConcurrencyGroupError` in errors.py) that should be used.
+
+Recommendation: Create a custom exception like `ExceptionGroupSizeError(ConcurrencyGroupError, ValueError)` and use it instead.
+
+Decision: Accept
+
+## 10. Boolean fields missing `is_` prefix in ClaudeAgentConfig
+
+Description: In `libs/mngr/imbue/mngr/agents/default_plugins/claude_agent.py:44-75`, `ClaudeAgentConfig(AgentTypeConfig)` has several boolean fields without the `is_` prefix:
+
+- Line 51: `sync_home_settings: bool`
+- Line 55: `sync_claude_json: bool`
+- Line 59: `sync_repo_settings: bool`
+- Line 63: `sync_claude_credentials: bool`
+- Line 72: `check_installation: bool`
+
+The `non_issues.md` exemption says "missing 'is_' prefix for boolean options in CLI functions and data classes" is fine, which likely applies here since `AgentTypeConfig` fields correspond to CLI/config options. However, these are config model fields, not direct CLI parameters, so the exemption is borderline.
+
+Recommendation: Clarify whether `AgentTypeConfig` subclass fields fall under the CLI exemption. If not, prefix with `is_` (e.g., `is_sync_home_settings_enabled`). If they do, add this to `non_issues.md` explicitly.
+
+Decision: Accept
+
+## 11. Mutable `list` used as function parameter type instead of `Sequence` in multiple places
+
+Description: The style guide says function inputs should use immutable abstract types: "Use `Sequence[T]` instead of `list[T]`." Multiple functions across the codebase accept `list` parameters:
+
+In mngr:
+- `libs/mngr/imbue/mngr/cli/connect.py:232` -- `_run_agent_selector(agents: list[AgentInfo])`
+- `libs/mngr/imbue/mngr/cli/connect.py:321` -- `select_agent_interactively(agents: list[AgentInfo])`
+- `libs/mngr/imbue/mngr/cli/list.py:616` -- `_emit_json_output(agents: list[AgentInfo], errors: list[ErrorInfo])`
+- `libs/mngr/imbue/mngr/cli/list.py:639` -- `_emit_human_output(agents: list[AgentInfo], ...)`
+- `libs/mngr/imbue/mngr/cli/list.py:768` -- `_sort_agents(agents: list[AgentInfo], ...) -> list[AgentInfo]`
+
+In concurrency_group:
+- `libs/concurrency_group/imbue/concurrency_group/event_utils.py:79` -- `__init__(self, events: list[ReadOnlyEvent])`
+
+This is a widespread pattern rather than an isolated case.
+
+Recommendation: Change function parameter types from `list[T]` to `Sequence[T]` (from `collections.abc`). Return types should remain `list[T]` per the style guide.
+
+Decision: Accept
+
+## 12. Plain Python classes with mutable state instead of MutableModel in concurrency_group
+
+Description: The style guide says there are only 3 types of classes: FrozenModel (frozen objects), MutableModel+ABC (interfaces), and implementations (inheriting from interfaces). Several classes in concurrency_group are plain Python classes with mutable state:
+
+- `libs/concurrency_group/imbue/concurrency_group/local_process.py:23` -- `RunningProcess` (plain class, mutable state)
+- `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:64` -- `PartialOutputContainer` (plain class, mutable state)
+- `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:93` -- `OutputGatherer` (plain class, mutable state)
+- `libs/concurrency_group/imbue/concurrency_group/executor.py:13` -- `ConcurrencyGroupExecutor` (plain class, mutable state)
+
+These don't fit the FrozenModel/Interface/Implementation pattern prescribed by the style guide.
+
+Recommendation: Refactor these classes to either use MutableModel with an interface, or document them as exceptions to the pattern (e.g., because they must inherit from stdlib classes like `threading.Thread`).
+
+Decision: Accept
+
+## 13. `ConcurrencyGroup` inherits from `MutableModel` without an ABC interface
+
+Description: In `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:87`, `ConcurrencyGroup(MutableModel, AbstractContextManager)` is a concrete class inheriting directly from `MutableModel` without an ABC interface. The style guide says MutableModel classes should have `ABC` -- they should be interfaces, with concrete implementations inheriting from them.
+
+`ConcurrencyGroup` is used directly as a concrete class throughout the codebase, so it acts as both interface and implementation simultaneously.
+
+Recommendation: Either add `ABC` to the inheritance and create a concrete implementation, or document this as an intentional exception since `ConcurrencyGroup` is a utility class rather than a domain object.
+
+Decision: Accept
+
+## 14. Missing return type annotations on methods in concurrency_group
+
+Description: Several methods in `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py` are missing return type annotations:
+
+- Line 259: `def _raise_if_not_active(self):` -- missing `-> None`
+- Line 265: `def _raise_if_any_strands_or_ancestors_failed(self):` -- missing `-> None`
+- Line 622: `def __str__(self):` -- missing `-> str`
+
+The style guide says "Always include complete type hints."
+
+Recommendation: Add the missing return type annotations.
+
+Decision: Accept
+
+## 15. Inline import in FinishedProcess.check() method
+
+Description: In `libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py:44`, `FinishedProcess.check()` contains an inline import:
+
+```python
+def check(self) -> Self:
+    from imbue.concurrency_group.errors import ProcessError
+```
+
+The style guide says "You may use inline imports when initially generating code, but remove them during the testing phase." This inline import likely exists to avoid a circular import between `subprocess_utils.py` and `errors.py`.
+
+Recommendation: Restructure the module dependencies to eliminate the circular import, or move `FinishedProcess` into a separate data_types module that doesn't need to import from errors.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identifies 15 code-level inconsistencies across the monorepo, ordered by importance
- Key findings: NamedTuple usage where FrozenModel is required, inconsistent boolean naming in config types, module docstrings in production code, missing error base class in imbue_common, @pure on impure functions, and several concurrency_group style guide deviations
- Full report at `_tasks/inconsistencies/2026-02-24-11-06-50.md`

## Test plan

- [ ] Review each identified inconsistency for accuracy
- [ ] Verify none of the findings are listed in non_issues.md
- [ ] Confirm findings are not already covered by existing FIXMEs

Generated with [Claude Code](https://claude.com/claude-code)