### PR TITLE
Use Google mirror for Docker Hub pulls in CI to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y tmux git openssh-server unison
 
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -239,6 +244,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y tmux git openssh-server unison
+
+      - name: Configure Docker Hub mirror
+        run: |
+          echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Acceptance and release tests pull Docker Hub images (busybox, alpine, debian, python) which can hit unauthenticated rate limits. Configure the Docker daemon to use mirror.gcr.io, Google's free Docker Hub cache.