### PR TITLE
Register modal config class even when modal backend is disabled

### DIFF
--- a/libs/mng/imbue/mng/providers/registry.py
+++ b/libs/mng/imbue/mng/providers/registry.py
@@ -28,6 +28,7 @@ from imbue.mng.primitives import ProviderBackendName
 from imbue.mng.primitives import ProviderInstanceName
 from imbue.mng.providers.base_provider import BaseProviderInstance
 from imbue.mng.providers.docker.config import DockerProviderConfig
+from imbue.mng.providers.modal.config import ModalProviderConfig
 
 # Cache for registered backends
 _backend_registry: dict[ProviderBackendName, type[ProviderBackendInterface]] = {}
@@ -83,10 +84,13 @@ def _load_backends(pm: pluggy.PluginManager, *, include_modal: bool, include_doc
             _backend_registry[backend_name] = backend_class
             _config_registry[backend_name] = config_class
 
-    # Register docker config even when backend is not loaded, so config files
-    # referencing the docker backend can still be parsed
-    if not include_docker:
+    # Register config classes for built-in backends even when their backend is not
+    # loaded (excluded via include_* flags or blocked via disabled plugins), so
+    # config files referencing these backends can still be parsed.
+    if ProviderBackendName("docker") not in _config_registry:
         _config_registry[ProviderBackendName("docker")] = DockerProviderConfig
+    if ProviderBackendName("modal") not in _config_registry:
+        _config_registry[ProviderBackendName("modal")] = ModalProviderConfig
 
     _registry_state["backends_loaded"] = True
 


### PR DESCRIPTION
When the modal plugin is disabled (e.g. via [plugins.modal] enabled = false in user config), the modal backend module is blocked and never registers its config class. This caused config parsing to fail with "Provider 'modal' missing required 'backend' field" if any settings.toml referenced [providers.modal].

The fix mirrors the existing docker fallback: always register the config class for built-in backends in the config registry so settings files can reference them regardless of whether the backend is active. Changed the condition from checking the include_* flag to checking whether the backend is actually present in the registry, which correctly handles both the explicit-exclusion and blocked-by-disabled-plugin cases.