### PR TITLE
Fix offload sandbox to checkout main instead of old branch

### DIFF
--- a/offload-modal.toml
+++ b/offload-modal.toml
@@ -20,7 +20,7 @@ type = "default"
 # Discover tests locally using pytest --collect-only, exclude acceptance and release tests
 discover_command = "uv run pytest --collect-only -q -m 'not acceptance and not release' 2>/dev/null | grep '::'"
 # Run tests in the sandbox (source is baked into /app)
-run_command = "cd /code/mng && git fetch origin fix/junit-classname-nodeid && git checkout fix/junit-classname-nodeid && git apply /offload-upload/patch --allow-empty && uv sync --all-packages && uv run pytest -v --tb=short --no-cov -p no:xdist -o addopts= --junitxml=/tmp/junit.xml {tests}"
+run_command = "cd /code/mng && git fetch origin main && git checkout main && git apply /offload-upload/patch --allow-empty && uv sync --all-packages && uv run pytest -v --tb=short --no-cov -p no:xdist -o addopts= --junitxml=/tmp/junit.xml {tests}"
 
 [report]
 output_dir = "test-results"


### PR DESCRIPTION
## Summary
- Update `offload-modal.toml` to checkout `main` instead of the old `fix/junit-classname-nodeid` branch in sandboxes
- The old branch was merged into main but the config still referenced it, causing test discovery/execution mismatch

## Problem
When running `just test-offload` from main:
1. Test discovery runs locally on main - finds all tests including new ones added after the branch was merged
2. Sandbox checked out the older `fix/junit-classname-nodeid` branch which is 10+ commits behind main
3. Pytest tried to run tests that don't exist in the sandbox (e.g., `terminal_test.py`, new tests in `docker/instance_test.py`)
4. Tests failed

## Test plan
- [x] Ran `just test-offload` from main - 2916/2918 tests pass (2 failures are unrelated ratchet test issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)