### PR TITLE
Add dedicated ratchet against os.fork, separate from subprocess ratchet

### DIFF
--- a/apps/changelings/imbue/changelings/test_ratchets.py
+++ b/apps/changelings/imbue/changelings/test_ratchets.py
@@ -34,6 +34,7 @@ from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MODEL_COP
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MONKEYPATCH_SETATTR
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_NAMEDTUPLE
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_NUM_PREFIX
+from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_OS_FORK
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_PANDAS_IMPORT
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_PYTEST_MARK_INTEGRATION
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_RELATIVE_IMPORTS
@@ -309,6 +310,17 @@ def test_prevent_pytest_mark_integration() -> None:
 
 
 # --- Process management ---
+
+
+def test_prevent_os_fork() -> None:
+    """Prevent usage of os.fork and os.forkpty.
+
+    Forking is incompatible with threading: a forked child inherits only the calling
+    thread, leaving mutexes held by other threads permanently locked and shared state
+    inconsistent. Code should use the subprocess module to launch subprocesses instead.
+    """
+    chunks = check_ratchet_rule(PREVENT_OS_FORK, _get_changelings_source_dir(), _SELF_EXCLUSION)
+    assert len(chunks) <= snapshot(0), PREVENT_OS_FORK.format_failure(chunks)
 
 
 def test_prevent_direct_subprocess_usage() -> None:

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
@@ -404,7 +404,7 @@ PREVENT_DIRECT_SUBPROCESS = RegexRatchetRule(
     rule_name="direct subprocess/os.exec usage",
     rule_description=(
         "Do not use subprocess.Popen, subprocess.run, subprocess.call, subprocess.check_call, "
-        "subprocess.check_output, os.exec*, os.spawn*, os.fork*, os.system, or os.popen directly. "
+        "subprocess.check_output, os.exec*, os.spawn*, os.system, or os.popen directly. "
         "Instead, use run_process_to_completion from ConcurrencyGroup and ensure a ConcurrencyGroup "
         "is passed down to the call site. This ensures all spawned processes get cleaned up properly. "
         "See libs/concurrency_group/ for details."
@@ -412,8 +412,22 @@ PREVENT_DIRECT_SUBPROCESS = RegexRatchetRule(
     pattern_string=(
         r"\bfrom\s+subprocess\s+import\b(Popen|run|call|check_call|check_output|getoutput|getstatusoutput)"
         r"|\bsubprocess\.(Popen|run|call|check_call|check_output|getoutput|getstatusoutput)\b"
-        r"|\bos\.(exec\w+|spawn\w+|fork\w*|system|popen)\b"
-        r"|\bfrom\s+os\s+import\b.*\b(exec\w+|spawn\w+|fork\w*|system|popen)\b"
+        r"|\bos\.(exec\w+|spawn\w+|system|popen)\b"
+        r"|\bfrom\s+os\s+import\b.*\b(exec\w+|spawn\w+|system|popen)\b"
+    ),
+)
+
+PREVENT_OS_FORK = RegexRatchetRule(
+    rule_name="os.fork usage",
+    rule_description=(
+        "Do not use os.fork or os.forkpty. Forking is incompatible with threading: a forked child "
+        "inherits only the calling thread, leaving mutexes held by other threads permanently locked "
+        "and shared state inconsistent. Use the subprocess module to launch subprocesses instead. "
+        "The remaining uses of os.fork will be removed from the codebase entirely."
+    ),
+    pattern_string=(
+        r"\bos\.fork\w*\b"
+        r"|\bfrom\s+os\s+import\b.*\bfork\w*\b"
     ),
 )
 

--- a/libs/mng/imbue/mng/utils/test_ratchets.py
+++ b/libs/mng/imbue/mng/utils/test_ratchets.py
@@ -34,6 +34,7 @@ from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MODEL_COP
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MONKEYPATCH_SETATTR
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_NAMEDTUPLE
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_NUM_PREFIX
+from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_OS_FORK
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_PANDAS_IMPORT
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_PYTEST_MARK_INTEGRATION
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_RELATIVE_IMPORTS
@@ -274,7 +275,10 @@ def test_prevent_code_in_init_files() -> None:
     """Ensure __init__.py files contain no code (except pluggy hookimpl at the root)."""
     violations = find_code_in_init_files(
         _get_mng_source_dir(),
-        allowed_root_init_lines={"import pluggy", 'hookimpl = pluggy.HookimplMarker("mng")'},
+        allowed_root_init_lines={
+            "import pluggy",
+            'hookimpl = pluggy.HookimplMarker("mng")',
+        },
     )
     assert len(violations) <= snapshot(0), (
         "Code found in __init__.py files (should be empty per style guide):\n"
@@ -297,6 +301,18 @@ def test_prevent_assert_isinstance_usage() -> None:
     assert len(chunks) <= snapshot(0), PREVENT_ASSERT_ISINSTANCE.format_failure(chunks)
 
 
+def test_prevent_os_fork() -> None:
+    """Prevent usage of os.fork and os.forkpty.
+
+    Forking is incompatible with threading: a forked child inherits only the calling
+    thread, leaving mutexes held by other threads permanently locked and shared state
+    inconsistent. Code should use the subprocess module to launch subprocesses instead.
+    The remaining uses will be removed from the codebase entirely.
+    """
+    chunks = check_ratchet_rule(PREVENT_OS_FORK, _get_mng_source_dir(), _SELF_EXCLUSION)
+    assert len(chunks) <= snapshot(3), PREVENT_OS_FORK.format_failure(chunks)
+
+
 def test_prevent_direct_subprocess_usage() -> None:
     """Prevent direct usage of subprocess and os process-spawning functions.
 
@@ -311,7 +327,7 @@ def test_prevent_direct_subprocess_usage() -> None:
     # Docker provider uses subprocess for docker build/run CLI pass-through.
     # connect.py uses os.execvp/os.execvpe for process replacement (not child spawning).
     chunks = check_ratchet_rule(PREVENT_DIRECT_SUBPROCESS, _get_mng_source_dir(), TEST_FILE_PATTERNS)
-    assert len(chunks) <= snapshot(47), PREVENT_DIRECT_SUBPROCESS.format_failure(chunks)
+    assert len(chunks) <= snapshot(46), PREVENT_DIRECT_SUBPROCESS.format_failure(chunks)
 
 
 def test_prevent_unittest_mock_imports() -> None:


### PR DESCRIPTION
Forking is incompatible with threading: a forked child inherits only the calling thread, leaving mutexes held by other threads permanently locked. Code should use the subprocess module instead. The remaining os.fork uses will be removed from the codebase entirely.