### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-26-11-08-05.md
+++ b/_tasks/inconsistencies/2026-02-26-11-08-05.md
@@ -1,0 +1,105 @@
+# Inconsistencies identified on 2026-02-26-11-08-05
+
+## 1. claude_web_view app comprehensively diverges from project style conventions
+
+Description: The `apps/claude_web_view/` application does not follow the project's style guide in multiple fundamental ways, all concentrated in the same small set of files:
+
+- **BaseModel instead of FrozenModel**: 10 classes in `apps/claude_web_view/imbue/claude_web_view/models.py` (lines 20, 27, 36, 48, 57, 66, 74, 81, 89) and 1 class in `apps/claude_web_view/imbue/claude_web_view/server.py` (line 21) inherit directly from `BaseModel` instead of `FrozenModel`.
+- **Enum not using UpperCaseStrEnum**: `MessageRole` in `models.py` (line 11) inherits from `(str, Enum)` with hardcoded lowercase string values instead of `UpperCaseStrEnum` with `auto()`.
+- **Relative imports**: All 4 source files in `claude_web_view` use relative imports (`from .models import ...`, `from .parser import ...`, etc.) in `parser.py` (lines 8-14), `server.py` (lines 17-18), `watcher.py` (line 10), and `cli.py` (line 12).
+- **async/await usage**: `watcher.py` and `server.py` extensively use `async def`, `await`, and `import asyncio`, which the style guide forbids ("Never use async or asyncio").
+- **Module docstring in __init__.py**: `__init__.py` (line 1) contains a module docstring, which the style guide forbids.
+
+Recommendation: Bring `claude_web_view` into compliance with the project style guide. Replace `BaseModel` with `FrozenModel`, convert `MessageRole` to use `UpperCaseStrEnum` with `auto()`, switch to absolute imports, and evaluate whether the async code can be rewritten synchronously (or document an explicit exception for this app since it uses FastAPI). Note that changing `MessageRole` values from lowercase to uppercase may break compatibility with external APIs that expect lowercase role strings, so a migration path may be needed.
+
+Decision: Accept
+
+## 2. if/elif chains without else clause in core libraries
+
+Description: The style guide mandates "All if/elif chains must end with an else clause." There are violations in core library code:
+
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py` lines 477-485 (thread cleanup) and lines 487-495 (process cleanup): if/elif chains that silently drop items from lists without an explicit else.
+- `libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py` lines 167-171 (AST base class parsing) and lines 287-296 (import node checking): if/elif on isinstance checks without else.
+- `apps/claude_web_view/imbue/claude_web_view/parser.py` lines 113-137, 165-200, 182-192, 186-189: multiple if/elif chains on isinstance and block_type without else.
+- `conftest.py` lines 224-230: arg pattern matching without else.
+
+Additionally, `contrib/claude-code-transcripts/` has 8 violations and `scripts/` has 3, though these are less critical.
+
+Note: The existing ratchet test `test_prevent_if_elif_without_else` only scans the `libs/mngr/` subtree (where there are 0 violations). The violations in `libs/concurrency_group/`, `libs/imbue_common/`, `apps/`, `conftest.py`, and `scripts/` are outside its scan scope.
+
+Recommendation: Add explicit else clauses (either with `pass` for intentional no-ops or `raise SwitchError(...)` for unreachable cases). Expand the ratchet test scope to cover `libs/concurrency_group/`, `libs/imbue_common/`, and `apps/` directories.
+
+Decision: Accept
+
+## 3. NamedTuple usage instead of FrozenModel
+
+Description: The style guide says "Never use dataclasses or named tuples." Two instances of `NamedTuple` exist:
+
+- `libs/mngr/imbue/mngr/utils/logging.py` line 232: `BufferedMessage(NamedTuple)` with fields `formatted_message: str` and `is_stderr: bool`. Used by `BufferingStreamWrapper` to buffer log messages.
+- `libs/mngr/imbue/mngr/conftest.py` line 537: `ModalSubprocessTestEnv(NamedTuple)` with fields `env`, `prefix`, and `host_dir`. Used as test infrastructure.
+
+Recommendation: Convert `BufferedMessage` to a `FrozenModel`. The `conftest.py` usage is lower priority since it is test infrastructure, but should also be converted for consistency.
+
+Decision: Accept
+
+## 4. time.sleep() used in core library code
+
+Description: The style guide says "NEVER use time.sleep() (either in tests, or in the actual code). Instead, use polling with timeouts." Ironically, the core polling utility itself uses `time.sleep()`:
+
+- `libs/mngr/imbue/mngr/utils/polling.py` line 24: `time.sleep(poll_interval)` inside `poll_until_counted()`. This is the foundational polling function that other code delegates to.
+- `apps/claude_web_view/imbue/claude_web_view/cli.py` line 116: `time.sleep(0.5)`.
+- `scripts/modal_sandbox_list_bug_repro.py` line 203: `time.sleep(5)`.
+- `scripts/josh/workflow.py` line 107 and `scripts/josh/coordinator.py` line 515: `time.sleep()` in scripts.
+
+Recommendation: The `polling.py` usage is arguably necessary as the lowest-level implementation of polling. Consider using `threading.Event.wait()` with timeout instead, which is more responsive to cancellation. The `claude_web_view` and script usages should be converted to use the polling utility or `Event.wait()`.
+
+Decision: Accept
+
+## 5. Plain classes in concurrency_group don't follow FrozenModel/MutableModel+ABC pattern
+
+Description: The style guide says there are only 3 types of classes (FrozenModel, Interface=ABC+MutableModel, Implementation). Several classes in `libs/concurrency_group/` use plain `__init__`-based classes:
+
+- `local_process.py` line 23: `RunningProcess` - stateful class with `__init__` and mutable state, not inheriting from any base.
+- `concurrency_group.py` line 547: `RunningProcessWithOnLineCallback(RunningProcess)` - inherits from non-conforming `RunningProcess`.
+- `executor.py` line 13: `ConcurrencyGroupExecutor(AbstractContextManager)` - uses `__init__` with mutable state.
+- `thread_utils.py` line 25: `ObservableThread(threading.Thread)` - extends stdlib class.
+
+Recommendation: These classes manage low-level concurrency primitives where extending stdlib classes (like `threading.Thread`) is necessary. The `RunningProcess` and `ConcurrencyGroupExecutor` classes could potentially be refactored to use `MutableModel` as a base, but this may not be practical given their tight integration with subprocess/threading APIs. Consider documenting an explicit exception for the `concurrency_group` library, or refactoring where feasible.
+
+Decision: Accept
+
+## 6. _ListIterationParams uses raw BaseModel instead of FrozenModel
+
+Description: In `libs/mngr/imbue/mngr/cli/list.py` line 551, `_ListIterationParams` inherits from `BaseModel` with `model_config = {"arbitrary_types_allowed": True}`. This is in the core `mngr` library (not an external app) and should follow project conventions.
+
+Recommendation: Convert to `FrozenModel`. If `arbitrary_types_allowed` is needed, it can be set via `model_config` on `FrozenModel` as well, or the offending field types can be wrapped appropriately.
+
+Decision: Accept
+
+## 7. Exception chaining violations in contrib/claude-code-transcripts
+
+Description: The style guide says "Within an except clause, always use raise ... from e or raise ... from None when raising exceptions." In `contrib/claude-code-transcripts/src/claude_code_transcripts/__init__.py`, there are 8 instances of raising `click.ClickException` inside except blocks without exception chaining:
+
+- Lines 1191, 1193, 1511, 1513, 1888, 1890, 1924, 1926.
+
+All follow the pattern of catching specific exceptions (subprocess.CalledProcessError, FileNotFoundError, httpx.RequestError, httpx.HTTPStatusError) and raising click.ClickException without `from e` or `from None`.
+
+Recommendation: Add `from e` (when the exception is bound) or `from None` (when suppressing the chain) to each raise statement. Since these are user-facing CLI errors where the original exception detail may not be useful, `from None` is likely appropriate.
+
+Decision: Accept
+
+## 8. async override method in modal log_utils lacks type annotations
+
+Description: In `libs/mngr/imbue/mngr/providers/modal/log_utils.py` line 154, the method `async def put_log_content(self, log):` is defined without type annotations on the `log` parameter. The style guide requires "Always include complete type hints." Additionally, this method uses `async def`, which the style guide forbids.
+
+Recommendation: Add type annotations. The async usage here is likely required by the Modal SDK's `OutputManager` base class, which may necessitate a documented exception to the "no async" rule for Modal provider integration.
+
+Decision: Accept
+
+## 9. ConfigurationError in Modal snapshot route doesn't follow error hierarchy
+
+Description: In `libs/mngr/imbue/mngr/providers/modal/routes/snapshot_and_shutdown.py` line 26, `ConfigurationError(RuntimeError)` inherits directly from `RuntimeError` rather than from a project-specific base error class. The file's header comment states "All code is self-contained in this file - no imports from the mngr codebase" which explains this, but it still creates an inconsistency with the error hierarchy pattern used everywhere else.
+
+Recommendation: This is a self-contained Modal route handler that intentionally avoids mngr imports for deployment reasons. Document this as an explicit exception, or consider whether a lightweight error base class could be defined locally in the file.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identified 9 code-level inconsistencies across the codebase, ordered by importance
- The claude_web_view app comprehensively diverges from project style conventions (BaseModel instead of FrozenModel, relative imports, async/await, non-standard enum)
- Found if/elif chains missing else clauses in core libraries outside the existing ratchet test scope
- Identified NamedTuple usage where FrozenModel is required, time.sleep() in core library code, and exception chaining violations in contrib/

## Test plan

- [ ] Review each finding for accuracy and relevance
- [ ] Decide which inconsistencies to address and prioritize

Generated with [Claude Code](https://claude.com/claude-code)