### PR TITLE
rename modal's dockerfile build arg to match docker

### DIFF
--- a/.mng/settings.toml
+++ b/.mng/settings.toml
@@ -19,7 +19,7 @@ add_command = ["reviewer_0='export IS_SANDBOX=1 && claude --dangerously-skip-per
 
 [create_templates.modal]
 new_host = "modal"
-build_args = "dockerfile=libs/mng/imbue/mng/resources/Dockerfile context-dir=.mng/dev/build/ volume=code-review-json:/code_reviews"
+build_args = "file=libs/mng/imbue/mng/resources/Dockerfile context-dir=.mng/dev/build/ volume=code-review-json:/code_reviews"
 add_command = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && gh auth setup-git'"]
 agent_args = ["--dangerously-skip-permissions"]
 target_path = "/code/mng"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ mng pair my-agent          # or sync changes continuously!
 > mng ask "How do I create a container on modal with custom packages installed by default?"
 
 Simply run:
-    mng create --in modal --build-arg "--dockerfile path/to/Dockerfile"
+    mng create --in modal --build-arg "--file path/to/Dockerfile"
 ```
 
 <!--

--- a/libs/mng/README.md
+++ b/libs/mng/README.md
@@ -115,7 +115,7 @@ mng pair my-agent          # or sync changes continuously!
 > mng ask "How do I create a container on modal with custom packages installed by default?"
 
 Simply run:
-    mng create --in modal --build-arg "--dockerfile path/to/Dockerfile"
+    mng create --in modal --build-arg "--file path/to/Dockerfile"
 ```
 
 <!--

--- a/libs/mng/docs/commands/primary/create.md
+++ b/libs/mng/docs/commands/primary/create.md
@@ -234,12 +234,12 @@ Provider: local
 
 Provider: modal
   Supported build arguments for the modal provider:
-    --dockerfile PATH     Path to the Dockerfile to build the sandbox image. Default: Dockerfile in context dir
+    --file PATH           Path to the Dockerfile to build the sandbox image. Default: Dockerfile in context dir
     --context-dir PATH    Build context directory for Dockerfile COPY/ADD instructions. Default: Dockerfile's directory
     --cpu COUNT           Number of CPU cores (0.25-16). Default: 1.0
     --memory GB           Memory in GB (0.5-32). Default: 1.0
     --gpu TYPE            GPU type to use (e.g., t4, a10g, a100, any). Default: no GPU
-    --image NAME          Base Docker image to use. Not required if using a dockerfile. Default: debian:bookworm-slim
+    --image NAME          Base Docker image to use. Not required if using --file. Default: debian:bookworm-slim
     --timeout SEC         Maximum sandbox lifetime in seconds. Default: 900 (15 min)
     --region NAME         Region to run the sandbox in (e.g., us-east, us-west, eu-west). Default: auto
     --secret VAR          Pass an environment variable as a secret to the image build. The value of

--- a/libs/mng/docs/core_plugins/providers/modal.md
+++ b/libs/mng/docs/core_plugins/providers/modal.md
@@ -36,7 +36,7 @@ mng create my-agent --in modal --build-args "gpu=h100 cpu=2 memory=8"
 | `context-dir` | Build context directory for Dockerfile COPY/ADD instructions | Dockerfile's directory |
 | `secret` | Environment variable name to pass as a secret during image build (can be specified multiple times) | None |
 | `cidr-allowlist` | Restrict network access to the specified CIDR range (can be specified multiple times) | None |
-| `dockerfile` | Path to a Dockerfile for building a custom image | None |
+| `file` | Path to a Dockerfile for building a custom image | None |
 | `offline` | Block all outbound network access from the sandbox | off |
 | `volume` | Mount a persistent Modal Volume (format: `name:/path`, can be specified multiple times) | None |
 | `docker-build-arg` | Override a Dockerfile ARG default value (format: `KEY=VALUE`, can be specified multiple times) | None |
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 Then use it with:
 
 ```bash
-mng create my-agent --in modal -b dockerfile=./Dockerfile -b offline
+mng create my-agent --in modal -b file=./Dockerfile -b offline
 ```
 
 ### Using Secrets During Image Build
@@ -89,10 +89,10 @@ The `secret` build argument allows passing environment variables as secrets to t
 
 ```bash
 # Pass a single secret
-mng create my-agent --in modal -b dockerfile=./Dockerfile -b secret=NPM_TOKEN
+mng create my-agent --in modal -b file=./Dockerfile -b secret=NPM_TOKEN
 
 # Pass multiple secrets
-mng create my-agent --in modal -b dockerfile=./Dockerfile -b secret=NPM_TOKEN -b secret=GH_TOKEN
+mng create my-agent --in modal -b file=./Dockerfile -b secret=NPM_TOKEN -b secret=GH_TOKEN
 ```
 
 In your Dockerfile, access the secret using `--mount=type=secret`:

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -37,7 +37,7 @@ _QUERY_PREFIX: Final[str] = (
     #
     "user: How do I create a container on modal with custom packages installed by default?\n"
     "response: Simply run:\n"
-    '    mng create --in modal --build-arg "--dockerfile path/to/Dockerfile"\n'
+    '    mng create --in modal --build-arg "--file path/to/Dockerfile"\n'
     "If you don't have a Dockerfile for your project, run:\n"
     "    mng bootstrap\n"
     "from the repo where you would like a Dockerfile created.\n\n"

--- a/libs/mng/imbue/mng/providers/modal/backend.py
+++ b/libs/mng/imbue/mng/providers/modal/backend.py
@@ -354,12 +354,12 @@ class ModalProviderBackend(ProviderBackendInterface):
     def get_build_args_help() -> str:
         return """\
 Supported build arguments for the modal provider:
-  --dockerfile PATH     Path to the Dockerfile to build the sandbox image. Default: Dockerfile in context dir
+  --file PATH           Path to the Dockerfile to build the sandbox image. Default: Dockerfile in context dir
   --context-dir PATH    Build context directory for Dockerfile COPY/ADD instructions. Default: Dockerfile's directory
   --cpu COUNT           Number of CPU cores (0.25-16). Default: 1.0
   --memory GB           Memory in GB (0.5-32). Default: 1.0
   --gpu TYPE            GPU type to use (e.g., t4, a10g, a100, any). Default: no GPU
-  --image NAME          Base Docker image to use. Not required if using a dockerfile. Default: debian:bookworm-slim
+  --image NAME          Base Docker image to use. Not required if using --file. Default: debian:bookworm-slim
   --timeout SEC         Maximum sandbox lifetime in seconds. Default: 900 (15 min)
   --region NAME         Region to run the sandbox in (e.g., us-east, us-west, eu-west). Default: auto
   --secret VAR          Pass an environment variable as a secret to the image build. The value of

--- a/libs/mng/imbue/mng/providers/modal/instance.py
+++ b/libs/mng/imbue/mng/providers/modal/instance.py
@@ -1368,7 +1368,7 @@ log "=== Shutdown script completed ==="
         parser.add_argument("--cpu", type=float, default=self.config.default_cpu)
         parser.add_argument("--memory", type=float, default=self.config.default_memory)
         parser.add_argument("--image", type=str, default=self.config.default_image)
-        parser.add_argument("--dockerfile", type=str, default=None)
+        parser.add_argument("--file", type=str, default=None, dest="dockerfile")
         parser.add_argument("--timeout", type=int, default=self.config.default_sandbox_timeout)
         parser.add_argument("--region", type=str, default=self.config.default_region)
         parser.add_argument("--context-dir", type=str, default=None)
@@ -1700,7 +1700,7 @@ log "=== Shutdown script completed ==="
 
         logger.info("Creating host {} in {} ...", name, self.name)
 
-        # Parse build arguments (including --dockerfile if specified)
+        # Parse build arguments (including --file if specified)
         config = self._parse_build_args(build_args)
         base_image = str(image) if image else config.image
         dockerfile_path = Path(config.dockerfile) if config.dockerfile else None
@@ -1709,7 +1709,7 @@ log "=== Shutdown script completed ==="
         if not base_image and not dockerfile_path:
             logger.warning(
                 "No image or Dockerfile specified -- building from mng default Dockerfile. "
-                "Consider using your own Dockerfile (-b --dockerfile=<path>) to include "
+                "Consider using your own Dockerfile (-b --file=<path>) to include "
                 "your project's dependencies for faster startup.",
             )
 

--- a/libs/mng/imbue/mng/providers/modal/test_modal_create.py
+++ b/libs/mng/imbue/mng/providers/modal/test_modal_create.py
@@ -191,7 +191,7 @@ def test_mng_create_with_dockerfile_on_modal(
     """Test creating an agent on Modal using a custom Dockerfile.
 
     This verifies that:
-    1. The --dockerfile build arg is correctly parsed by the modal provider
+    1. The --file build arg is correctly parsed by the modal provider
     2. Modal builds an image from the Dockerfile
     3. The sandbox runs with the custom image
     """
@@ -234,7 +234,7 @@ RUN echo "custom-dockerfile-marker" > /dockerfile-marker.txt
             "--source",
             str(temp_source_dir),
             "-b",
-            f"--dockerfile={dockerfile_path}",
+            f"--file={dockerfile_path}",
             "--",
             expected_output,
         ],
@@ -294,7 +294,7 @@ RUN echo "About to fail with marker: {unique_failure_marker}" && exit 1
             "--source",
             str(temp_source_dir),
             "-b",
-            f"--dockerfile={dockerfile_path}",
+            f"--file={dockerfile_path}",
             "--",
             "should-not-reach-here",
         ],
@@ -487,7 +487,7 @@ def test_mng_create_with_default_dockerfile_on_modal(
             "--source",
             str(temp_source_dir),
             "-b",
-            f"--dockerfile={dockerfile_path}",
+            f"--file={dockerfile_path}",
             "-b",
             f"context-dir={temp_dir_with_tar}",
             "--target-path",

--- a/libs/mng/imbue/mng/providers/modal/test_modal_idle_shutdown.py
+++ b/libs/mng/imbue/mng/providers/modal/test_modal_idle_shutdown.py
@@ -189,7 +189,7 @@ def test_idle_shutdown_creates_both_initial_and_idle_snapshots(
             "--timeout=120",
             # use our dockerfile since it should end up being cached and faster
             "-b",
-            "--dockerfile=libs/mng/imbue/mng/resources/Dockerfile",
+            "--file=libs/mng/imbue/mng/resources/Dockerfile",
             "-b",
             "context-dir=.mng/dev/build/",
             "--",

--- a/libs/mng/imbue/mng/providers/modal/test_modal_instance.py
+++ b/libs/mng/imbue/mng/providers/modal/test_modal_instance.py
@@ -615,7 +615,7 @@ def test_cidr_allowlist_restricts_network_access(real_modal_provider: ModalProvi
     try:
         host = real_modal_provider.create_host(
             HostName("test-cidr"),
-            build_args=[f"--dockerfile={dockerfile}", "--cidr-allowlist=192.0.2.0/24"],
+            build_args=[f"--file={dockerfile}", "--cidr-allowlist=192.0.2.0/24"],
         )
 
         # curl to a public IP should fail because it's outside the allowlist
@@ -671,7 +671,7 @@ def test_offline_blocks_all_network_access(real_modal_provider: ModalProviderIns
     try:
         host = real_modal_provider.create_host(
             HostName("test-offline"),
-            build_args=[f"--dockerfile={dockerfile}", "--offline"],
+            build_args=[f"--file={dockerfile}", "--offline"],
         )
 
         # curl to a public IP should fail because all outbound traffic is blocked

--- a/libs/mng/tutorials/mega_tutorial.sh
+++ b/libs/mng/tutorials/mega_tutorial.sh
@@ -153,10 +153,10 @@ mng create my-task --in modal --build-arg cpu=4 --build-arg memory=16 --build-ar
 # (-b is an alternative forms of --build-arg; see "mng create --help" for all provider-specific build args)
 # some other useful Modal build args: --region, --timeout, --offline (blocks network), --secret, --cidr-allowlist, --context-dir
 
-# the most important build args for Modal are probably "--dockerfile" and "--context-dir",
+# the most important build args for Modal are probably "--file" and "--context-dir",
 # which let you specify a custom Dockerfile and build context directory (respectively) for building the host environment.
 # This is how you can get custom dependencies, files, and setup steps on your Modal hosts. For example:
-mng create my-task --in modal --build-args "dockerfile=./Dockerfile.agent context-dir=./agent-context"
+mng create my-task --in modal --build-args "file=./Dockerfile.agent context-dir=./agent-context"
 # that command builds a Modal host using the Dockerfile at ./Dockerfile.agent and the build context at ./agent-context
 # (which is where the Dockerfile can COPY files from, and also where build args are evaluated from)
 # that command also demonstrates how to pass multiple build args in a single --build-args string (instead of using multiple --build-arg flags)


### PR DESCRIPTION
## Summary
- Renames the Modal provider's `--dockerfile` build arg to `--file`, matching the Docker provider's convention
- Both providers now use `--file` to specify a Dockerfile path
- Internal `SandboxConfig.dockerfile` field name is preserved (via argparse `dest="dockerfile"`)

## Test plan
- [x] All 2461 unit/integration tests pass
- [x] Verified `mng create --in modal -b "--file=<path>"` works end-to-end: created a Modal sandbox with a custom Dockerfile containing a marker file, confirmed the marker was present in the running sandbox


🤖 Generated with [Claude Code](https://claude.com/claude-code)