### PR TITLE
code-guardian: inconsistency report

### DIFF
--- a/_tasks/inconsistencies/2026-02-27-11-04-24.md
+++ b/_tasks/inconsistencies/2026-02-27-11-04-24.md
@@ -1,0 +1,171 @@
+# Inconsistencies identified on 2026-02-27-11-04-24
+
+## 1. SSH provider mixes NotImplementedError with custom exception types
+
+Description: The SSH provider (`libs/mngr/imbue/mngr/providers/ssh/instance.py`) is internally
+inconsistent in how it signals unsupported operations. For snapshot-related methods it uses the
+custom `SnapshotsNotSupportedError` (lines 213, 226), but for all other unsupported operations
+it raises the generic `NotImplementedError` (lines 132, 140, 147, 154, 236, 254, 261, 268).
+This is also inconsistent with the local provider (`providers/local/instance.py`), which uses
+custom exceptions like `LocalHostNotStoppableError` (line 203) and `LocalHostNotDestroyableError`
+(line 229) for its unsupported operations.
+
+Recommendation: Create custom exception types for unsupported provider operations (or use a single
+`OperationNotSupportedError` with a descriptive message) and use them consistently across all
+providers. This allows callers to catch and handle unsupported operations uniformly.
+
+Decision: Accept
+
+## 2. Inconsistent merge pattern in MngrConfig.merge_with()
+
+Description: In `libs/mngr/imbue/mngr/config/data_types.py`, the `merge_with()` method
+(lines 464-603) mixes two distinct patterns for merging scalar fields:
+
+Pattern A (ternary, immutable-style): used at lines 484, 490
+```python
+merged_pager = override.pager if override.pager is not None else self.pager
+```
+
+Pattern B (reassignment, mutable-style): used at lines 474-476, 479-481, 568-570, 573-575,
+577-579, 582-584
+```python
+merged_prefix = self.prefix
+if override.prefix is not None:
+    merged_prefix = override.prefix
+```
+
+Additionally, some variables in Pattern B lack the `merged_` prefix (`is_remote_agent_installation_allowed`
+at line 568, `is_allowed_in_pytest` at line 577), while all other merged scalars use the
+`merged_` prefix.
+
+Recommendation: Standardize on the ternary pattern (Pattern A) for all scalar field merges, as
+it is consistent with the project's immutability style. Also ensure all merged variable names
+use the `merged_` prefix consistently.
+
+Decision: Accept
+
+## 3. Missing type hints on functions
+
+Description: Two functions lack parameter and return type annotations:
+
+- `_handle_create(mngr_ctx, output_opts, opts)` in `libs/mngr/imbue/mngr/cli/create.py` line 522
+  has no type hints on any of its three parameters or its return type.
+
+- `_get_agent_refs_robustly(host, provider)` in `libs/mngr/imbue/mngr/api/list.py` line 683
+  has no type hints on either parameter or its return type.
+
+Both are private functions but are called from important code paths and should be fully typed
+per the style guide ("Always include complete type hints").
+
+Recommendation: Add proper type annotations to both functions.
+
+Decision: Accept
+
+## 4. Duplicated _output() helper function across CLI modules
+
+Description: Three CLI modules define byte-for-byte identical `_output()` functions:
+
+- `libs/mngr/imbue/mngr/cli/start.py` lines 49-52
+- `libs/mngr/imbue/mngr/cli/stop.py` lines 48-51
+- `libs/mngr/imbue/mngr/cli/destroy.py` lines 442-445
+
+All three are:
+```python
+def _output(message: str, output_opts: OutputOptions) -> None:
+    """Output a message according to the format."""
+    if output_opts.output_format == OutputFormat.HUMAN:
+        logger.info(message)
+```
+
+Similarly, `_output_result()` functions in `start.py` (lines 55-67) and `stop.py` (lines 54-66)
+are structurally identical, differing only in the key name ("started_agents" vs "stopped_agents")
+and event name ("start_result" vs "stop_result").
+
+Recommendation: Extract `_output()` into a shared CLI utility module. Consider whether
+`_output_result()` can also be generalized with a parameterized key/event name.
+
+Decision: Accept
+
+## 5. Inconsistent logging coverage across providers
+
+Description: The three provider implementations have wildly different logging verbosity:
+
+- **Modal provider** (`providers/modal/instance.py`): Comprehensive logging at all levels
+  (trace, debug, info, warning, error) throughout all operations.
+- **Local provider** (`providers/local/instance.py`): Minimal logging, primarily `logger.trace()`
+  for a few operations (lines 101, 106, 251, 268, 346-369).
+- **SSH provider** (`providers/ssh/instance.py`): No logging at all in the main implementation.
+
+This makes debugging provider issues inconsistent -- some providers give visibility into their
+operations while others are silent.
+
+Recommendation: Add at minimum `logger.debug()` calls for key operations (host listing,
+connection, agent discovery) in the local and SSH providers to match the logging coverage
+of the modal provider.
+
+Decision: Accept
+
+## 6. Variable reassignment in provider code
+
+Description: Several provider functions reassign parameters or local variables instead of
+creating new variables with descriptive names, violating the project's immutability style:
+
+- `libs/mngr/imbue/mngr/providers/ssh/backend.py` lines 86-100: `hosts` variable is reassigned
+  from the config value to an expanded dictionary.
+- `libs/mngr/imbue/mngr/providers/modal/backend.py` lines 395-409: Parameters
+  `environment_name` and `app_name` are truncated in-place via reassignment.
+
+Recommendation: Use new descriptive variable names (e.g., `expanded_hosts`,
+`truncated_environment_name`, `truncated_app_name`) instead of reassigning existing variables.
+
+Decision: Accept
+
+## 7. Inconsistent docstring presence on StartCliOptions
+
+Description: The CLI option classes `CreateCliOptions` (`cli/create.py` lines 138-148),
+`ListCliOptions` (`cli/list.py` lines 58-68), and `DestroyCliOptions` (`cli/destroy.py`
+lines 93-103) all include an explanatory note in their docstring:
+
+> "Note that this class VERY INTENTIONALLY DOES NOT use Field() decorators with descriptions..."
+
+However, `StartCliOptions` (`cli/start.py` lines 32-46) is missing this explanatory note,
+despite following the same pattern of not using Field() decorators.
+
+Recommendation: Add the same explanatory note to `StartCliOptions` for consistency.
+
+Decision: Accept
+
+## 8. Inconsistent NotImplementedError messages for unimplemented features
+
+Description: When raising errors for not-yet-implemented features in CLI code, the message
+format varies:
+
+- `cli/start.py` line 184: `raise NotImplementedError("--host is not implemented yet")`
+- `cli/destroy.py` line 206: `raise NotImplementedError("The --include option is not yet
+  implemented. See https://github.com/imbue-ai/mngr/issues/XXX for progress.")`
+
+Some include GitHub issue references (with placeholder "XXX"), some are terse, and the
+wording style varies.
+
+Recommendation: Standardize on a consistent format for NotImplementedError messages across
+CLI commands. Either always include a tracking reference or never include one (placeholder
+issue references are not useful).
+
+Decision: Accept
+
+## 9. Mutable input types in concurrency_group function signatures
+
+Description: Several functions in the `concurrency_group` library accept mutable types where
+the style guide specifies immutable abstract types should be used for inputs:
+
+- `concurrency_group/concurrency_group.py` line 373-374: `args: tuple = ()` and
+  `kwargs: dict | None = None` -- `kwargs` should be `Mapping[str, Any] | None`.
+- `concurrency_group/thread_utils.py` line 32: Same pattern with `kwargs: dict | None = None`.
+
+While `tuple` is already immutable, `dict` is mutable and should be `Mapping` per the style
+guide rule: "Use immutable abstract types for inputs: Sequence[T], Mapping[K, V],
+AbstractSet[T]".
+
+Recommendation: Change `dict` parameters to `Mapping[str, Any]` in function signatures.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

- Identifies 9 code-level inconsistencies across the codebase, ordered by importance
- Top issues: mixed exception types in SSH provider, inconsistent merge patterns in config, missing type hints, duplicated CLI helpers, uneven logging across providers

## Report contents

1. SSH provider mixes `NotImplementedError` with `SnapshotsNotSupportedError` (also inconsistent with local provider's custom exceptions)
2. `MngrConfig.merge_with()` mixes ternary and reassignment patterns for scalar merges, plus inconsistent `merged_` prefix naming
3. Missing type hints on `_handle_create` and `_get_agent_refs_robustly`
4. Byte-for-byte duplicated `_output()` helper across start/stop/destroy CLI modules
5. Wildly different logging coverage across providers (modal: comprehensive, local: minimal, SSH: none)
6. Variable reassignment in provider code violating immutability style
7. `StartCliOptions` missing explanatory docstring note present in other CLI options classes
8. Inconsistent `NotImplementedError` message formats for unimplemented CLI features
9. Mutable `dict` input types in `concurrency_group` function signatures

## Test plan

- [x] Report file created at `_tasks/inconsistencies/2026-02-27-11-04-24.md`
- [ ] Review each finding for accuracy and relevance
- [ ] Prioritize which inconsistencies to address first

Generated with [Claude Code](https://claude.com/claude-code)