### PR TITLE
code-guardian: inconsistency report 2026-02-27-11-03-03

### DIFF
--- a/_tasks/inconsistencies/2026-02-27-11-03-03.md
+++ b/_tasks/inconsistencies/2026-02-27-11-03-03.md
@@ -1,0 +1,132 @@
+# Inconsistencies identified on 2026-02-27-11-03-03
+
+## 1. `model_copy(update={...})` used instead of type-safe `model_copy_update`
+
+Description: Three places use the raw dictionary pattern `model_copy(update={"field": value})` instead of the type-safe `model_copy_update(to_update(...))` pattern required by the style guide. This bypasses type checking on field names and makes refactoring harder.
+
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/deploy.py:715`: `trigger = trigger.model_copy(update={"git_image_hash": head_hash})`
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/deploy.py:726`: `trigger = trigger.model_copy(update={"git_image_hash": commit_hash})`
+- `apps/changelings/imbue/changelings/cli/add.py:135`: `definition = definition.model_copy(update={"mng_profile": resolved_profile})`
+
+Recommendation: Replace all three with the type-safe pattern: `obj.model_copy_update(to_update(obj.field_ref().field_name, value))`
+
+Decision: Accept
+
+## 2. if/elif chains on enum values instead of match statements with assert_never
+
+Description: Five functions use if/elif/else chains to branch on enum values instead of match statements. The style guide explicitly requires match statements for enums so the type checker can verify exhaustiveness at compile time via `assert_never`.
+
+- `libs/mng/imbue/mng/hosts/common.py:43-91`: `get_activity_sources_for_idle_mode()` uses if/elif/else on `IdleMode` enum (9 branches) with `SwitchError` instead of `match`/`assert_never`
+- `libs/mng/imbue/mng/cli/list.py:783-789`: if/elif/else on `OutputFormat` enum
+- `libs/mng/imbue/mng/cli/list.py:798-804`: if/elif/else on `OutputFormat` enum
+- `libs/mng_pair/imbue/mng_pair/api.py:111-117`: if/elif/else on `SyncDirection` enum
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/deploy.py:762-783`: if/elif/else on `MngInstallMode` enum
+
+Recommendation: Convert all five to match statements with `assert_never` in the default case. The `hosts/common.py` case is the highest priority since it has 9 enum branches.
+
+Decision: Accept
+
+## 3. claude_web_view app uses BaseModel and (str, Enum) instead of FrozenModel and UpperCaseStrEnum
+
+Description: The `apps/claude_web_view/imbue/claude_web_view/models.py` file has pervasive style guide violations: `MessageRole` inherits from `(str, Enum)` with string literal values instead of `UpperCaseStrEnum` with `auto()`, and all 9 data classes inherit from `BaseModel` instead of `FrozenModel`. The server file (`server.py:19`) also has `SendMessageRequest(BaseModel)`.
+
+- `models.py:9`: `class MessageRole(str, Enum)` with `USER = "user"`, `ASSISTANT = "assistant"`, `SYSTEM = "system"`
+- `models.py:18,25,34,46,55,64,72,79,87`: `TextBlock`, `ToolUseBlock`, `ToolResultBlock`, `ParsedMessage`, `SessionMetadata`, `SSEInitEvent`, `SSEMessageEvent`, `SSECompleteEvent`, `SSEErrorEvent` all inherit from `BaseModel`
+- `server.py:19`: `class SendMessageRequest(BaseModel)`
+
+Recommendation: Change `MessageRole` to inherit from `UpperCaseStrEnum` with `auto()` values. Change all data classes to inherit from `FrozenModel`. This is an entire app that was written without following the project conventions.
+
+Decision: Accept
+
+## 4. Built-in exceptions raised directly instead of project-specific error classes
+
+Description: Multiple files raise raw built-in exceptions (`RuntimeError`, `ValueError`, `Exception`) instead of project-specific error classes that inherit from a library base error. The style guide says "Never raise built-in Exceptions directly (except NotImplementedError)."
+
+- `apps/changelings/imbue/changelings/deploy/cron_runner.py:60`: `raise Exception(f"{name} must be set")` -- worst violation, raises bare `Exception`
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/cron_runner.py:51,154,228`: Three `raise RuntimeError(...)` calls
+- `apps/changelings/imbue/changelings/deploy/cron_runner.py:226,409`: Two `raise RuntimeError(...)` calls
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:636`: `raise ValueError(...)`
+- `libs/imbue_common/imbue/imbue_common/primitives.py:14,35,55,75,95`: Five `raise ValueError(...)` in primitive validators
+
+Note: The cron_runner files have a comment "This file must NOT import anything from imbue.* packages" which explains why they cannot use project-specific errors. However, they could define local error classes within the file. The primitives.py case is somewhat expected since these are the lowest-level validators that may predate other error infrastructure.
+
+Recommendation: For the cron_runner files, define local error subclasses at the top of each file (e.g., `class CronRunnerError(RuntimeError): ...`). For primitives.py, consider creating `PrimitiveValidationError(ValueError)` in imbue_common. The bare `Exception` in changelings/cron_runner.py should be fixed immediately.
+
+Decision: Accept
+
+## 5. Module-level constants missing `Final` annotation
+
+Description: The style guide says "Always declare constants to be `Final`". Several module-level constants lack `Final` annotations.
+
+- `libs/mng/imbue/mng/utils/logging.py:30-35`: Six color constants (`WARNING_COLOR`, `ERROR_COLOR`, `BUILD_COLOR`, `DEBUG_COLOR`, `TRACE_COLOR`, `RESET_COLOR`) lack `Final` (while `BUILD_LEVEL_NO` on line 38 correctly uses `Final[int]`)
+- `libs/mng/imbue/mng/utils/deps.py:35-61`: Four `SystemDependency` constants (`RSYNC`, `TMUX`, `GIT`, `JQ`) lack `Final`
+- `libs/mng/imbue/mng/utils/rsync_utils.py:6-7`: Two regex pattern constants (`_FILES_TRANSFERRED_RE`, `_TOTAL_TRANSFERRED_SIZE_RE`) lack `Final`
+- `libs/mng/imbue/mng/utils/duration.py:6`: `_DURATION_PATTERN` lacks `Final`
+- `libs/mng/imbue/mng/cli/common_opts.py:39`: `COMMON_OPTIONS_GROUP_NAME` lacks `Final`
+- `libs/mng/imbue/mng/cli/list.py:928`: `_BRACKET_PATTERN` lacks `Final`
+
+Recommendation: Add `Final` type annotations to all module-level constants. The logging.py file is a particularly clear example since it already uses `Final` for one constant but not the others in the same block.
+
+Decision: Accept
+
+## 6. Interface classes defined outside of interfaces.py
+
+Description: The style guide says "If you are creating an interface class, create it in a file named `interfaces.py` at the root of the package". Two ABC interface classes are defined in non-standard locations.
+
+- `libs/mng/imbue/mng/api/sync.py:135`: `class GitContextInterface(MutableModel, ABC)` -- should be in interfaces.py
+- `libs/mng/imbue/mng/cli/ask.py:182`: `class ClaudeBackendInterface(MutableModel, ABC)` -- should be in interfaces.py
+
+Recommendation: Move both interface classes to `libs/mng/imbue/mng/interfaces/` (either the existing interfaces module or a new file within it). Update all imports accordingly.
+
+Decision: Accept
+
+## 7. _ListIterationParams uses BaseModel in core mng library
+
+Description: `libs/mng/imbue/mng/cli/list.py:739` defines `class _ListIterationParams(BaseModel)` directly inheriting from `BaseModel` instead of using `FrozenModel` or `MutableModel`. Unlike the claude_web_view app (which is entirely non-conformant), this is a single class in the core mng library.
+
+- The class sets `model_config = {"arbitrary_types_allowed": True}` which may be the reason it uses `BaseModel` directly, but `MutableModel` also supports this configuration.
+
+Recommendation: Change to inherit from `MutableModel` (since it holds a mutable `MngContext`) or `FrozenModel` with `model_config` override. If neither works due to `arbitrary_types_allowed`, add a comment explaining the deviation.
+
+Decision: Accept
+
+## 8. Blanket `except Exception:` clauses
+
+Description: The style guide says "Never use a blanket except: clause! Always catch the narrowest specific exception type." Four places use `except Exception:` which catches everything.
+
+- `libs/concurrency_group/imbue/concurrency_group/concurrency_group.py:233`: `except Exception: pass` when joining a thread
+- `apps/claude_web_view/imbue/claude_web_view/watcher.py:35`: `except Exception: pass` for queue put
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/verification.py:278`: `except Exception:` with cleanup and re-raise
+- `apps/changelings/imbue/changelings/deploy/verification.py:182`: `except Exception:` with cleanup and re-raise
+
+Recommendation: Replace with narrower exception types. For thread join, catch `RuntimeError`. For queue put, catch the specific queue or asyncio exception. For the verification cleanup cases, these re-raise so the impact is lower, but they should still catch a narrower type (e.g., `BaseException` if the intent is truly to catch everything including KeyboardInterrupt, or `Exception` with a comment explaining why).
+
+Decision: Accept
+
+## 9. Inconsistent dict field naming -- widespread lack of `_by_` convention
+
+Description: The style guide says "Always use `value_by_key` for dictionaries and mappings." Many dict-typed class fields and local variables do not follow this convention. The most impactful violations are on class fields in core data types:
+
+- `libs/mng/imbue/mng/interfaces/data_types.py`: `tags: dict[str, str]` (lines 374, 428, 478), `plugin: dict[str, Any]` (lines 298, 439, 482), `user_tags: dict[str, str]` (line 312), `labels: dict[str, str]` (line 478)
+- `libs/mng/imbue/mng/config/data_types.py`: `defaults: dict[str, Any]` (line 337), `options: dict[str, Any]` (line 395), `agent_types`, `providers`, `plugins`, `commands`, `create_templates`, `pre_command_scripts` in `MngConfig` (lines 435-462)
+- `libs/mng/imbue/mng/api/data_types.py:179`: `tags: dict[str, str]`
+
+Note: Some of these are user-facing configuration fields where renaming would be a breaking change (e.g., config file keys). The `MngConfig` fields like `agent_types: dict[AgentTypeName, AgentTypeConfig]` could arguably be named `agent_type_config_by_name`, but this would make config files verbose.
+
+Recommendation: Focus on internal data types first: rename `tags` to `tag_value_by_key`, `plugin` to `plugin_config_by_name`, `labels` to `label_value_by_key`. For configuration classes, assess the user-facing impact before renaming. Local variables like `merged`, `env_dict`, `files` should also be renamed in new code.
+
+Decision: Accept
+
+## 10. logger.info used in library/API code instead of logger.debug
+
+Description: The style guide says "Reserve logger.info for CLI/user-facing code. Library and API code should use logger.debug for normal operations." Several library modules use `logger.info` for normal operational messages.
+
+- `libs/mng/imbue/mng/utils/testing.py:607,610,613`: Three `logger.info` calls in `cleanup_old_test_environments()`
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/verification.py:60,108,123-126,136,197`: Five `logger.info` calls in verification library code
+- `libs/mng_schedule/imbue/mng_schedule/implementations/modal/deploy.py:716,720,727`: Multiple `logger.info` calls in deploy library code
+- `apps/changelings/imbue/changelings/deploy/verification.py`: Multiple `logger.info` calls
+- `apps/changelings/imbue/changelings/deploy/deploy.py`: Multiple `logger.info` calls
+
+Recommendation: Change `logger.info` to `logger.debug` in library/API code, or wrap with `log_span` for action-oriented logging. Keep `logger.info` only in CLI entry points.
+
+Decision: Accept


### PR DESCRIPTION
## Summary

Systematic code-level inconsistency audit of the codebase. Identified 10 issues ordered by importance:

1. **`model_copy(update={...})` used instead of type-safe `model_copy_update`** -- 3 instances bypass type checking
2. **if/elif chains on enum values instead of match/assert_never** -- 5 functions miss compile-time exhaustiveness
3. **claude_web_view uses BaseModel and (str, Enum)** -- entire app ignores FrozenModel/UpperCaseStrEnum conventions
4. **Built-in exceptions raised directly** -- RuntimeError, ValueError, bare Exception in multiple files
5. **Module-level constants missing `Final`** -- inconsistent within same files (e.g., logging.py)
6. **Interface classes defined outside interfaces.py** -- 2 ABC classes in wrong locations
7. **`_ListIterationParams` uses BaseModel in core mng** -- single class in list.py
8. **Blanket `except Exception:` clauses** -- 4 instances catch too broadly
9. **Dict fields lack `_by_` naming convention** -- widespread in data_types.py
10. **`logger.info` in library code** -- should be `logger.debug` per style guide

Full details in `_tasks/inconsistencies/2026-02-27-11-03-03.md`.

## Test plan

- [ ] Review each inconsistency and confirm it is a genuine style violation
- [ ] Prioritize fixes based on impact (items 1-4 are highest priority)

Generated with [Claude Code](https://claude.com/claude-code)