### PR TITLE
workaround for posix_spawn stale env bug (?) in subprocess spawning

### DIFF
--- a/libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py
+++ b/libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py
@@ -213,7 +213,7 @@ def run_local_command_modern_version(
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=env,
+                env=env if env is not None else os.environ.copy(),
             )
         except (OSError, ValueError) as e:
             raise ProcessSetupError(


### PR DESCRIPTION
don't know if this is entirely correct/if it has a downside i don't realize

---

## Summary
- On macOS, `subprocess.Popen` with `env=None` uses `posix_spawn`, which reads the process environment via `_NSGetEnviron()`. This can return a stale pointer if environment variables were modified since process start ([CPython #113119](https://github.com/python/cpython/issues/113119)).
- In `run_local_command_modern_version`, when `env` is `None`, we now pass `os.environ.copy()` explicitly so Popen always uses the current environment dict rather than the potentially-stale pointer.
- This fixes intermittent failures where `os.environ` modifications (e.g., PATH changes) were not visible to child processes.

## Test plan
- [x] All 3001 monorepo tests pass
- [x] No new test files needed -- this is a one-line correctness fix to existing behavior


🤖 Generated with [Claude Code](https://claude.com/claude-code)