### PR TITLE
move tabcomplete cache from tmp to ~/.mng

### DIFF
--- a/libs/mng/imbue/mng/cli/complete.py
+++ b/libs/mng/imbue/mng/cli/complete.py
@@ -1,4 +1,4 @@
-"""Lightweight tab completion entrypoint -- stdlib only, no third-party imports.
+"""Lightweight tab completion entrypoint -- no heavy third-party imports.
 
 Reads COMP_WORDS and COMP_CWORD from the environment (same protocol click
 uses), resolves the completion context from a JSON cache file, and prints
@@ -15,6 +15,8 @@ import sys
 import time
 from pathlib import Path
 
+from imbue.mng.config.host_dir import read_default_host_dir
+
 _COMMAND_COMPLETIONS_CACHE_FILENAME = ".command_completions.json"
 _AGENT_COMPLETIONS_CACHE_FILENAME = ".agent_completions.json"
 _BACKGROUND_REFRESH_COOLDOWN_SECONDS = 30
@@ -23,17 +25,12 @@ _BACKGROUND_REFRESH_COOLDOWN_SECONDS = 30
 def _get_completion_cache_dir() -> Path:
     """Return the directory used for completion cache files.
 
-    Mirrors get_completion_cache_dir() in completion_writer.py but uses only stdlib.
-    The host-dir resolution below duplicates read_default_host_dir() in
-    config/pre_readers.py; keep them in sync.
+    Mirrors get_completion_cache_dir() in completion_writer.py.
     """
     env_dir = os.environ.get("MNG_COMPLETION_CACHE_DIR")
     if env_dir:
         return Path(env_dir)
-    root_name = os.environ.get("MNG_ROOT_NAME", "mng")
-    env_host_dir = os.environ.get("MNG_HOST_DIR")
-    base_dir = Path(env_host_dir) if env_host_dir else Path(f"~/.{root_name}")
-    return base_dir.expanduser()
+    return read_default_host_dir()
 
 
 def _read_cache() -> dict:

--- a/libs/mng/imbue/mng/cli/completion_writer.py
+++ b/libs/mng/imbue/mng/cli/completion_writer.py
@@ -8,7 +8,7 @@ from typing import Final
 import click
 from loguru import logger
 
-from imbue.mng.config.pre_readers import read_default_host_dir
+from imbue.mng.config.host_dir import read_default_host_dir
 from imbue.mng.utils.click_utils import detect_alias_to_canonical
 from imbue.mng.utils.file_utils import atomic_write
 

--- a/libs/mng/imbue/mng/config/host_dir.py
+++ b/libs/mng/imbue/mng/config/host_dir.py
@@ -1,0 +1,20 @@
+"""Resolve the default mng host directory from environment variables.
+
+Stdlib-only so it can be imported from lightweight/fast-path modules
+(e.g. the tab-completion entrypoint) without pulling in third-party deps.
+"""
+
+import os
+from pathlib import Path
+
+
+def read_default_host_dir() -> Path:
+    """Return the default host directory derived from environment variables.
+
+    Resolves MNG_HOST_DIR (explicit override) or falls back to ~/.{MNG_ROOT_NAME}
+    (default: ~/.mng).
+    """
+    root_name = os.environ.get("MNG_ROOT_NAME", "mng")
+    env_host_dir = os.environ.get("MNG_HOST_DIR")
+    base_dir = Path(env_host_dir) if env_host_dir else Path(f"~/.{root_name}")
+    return base_dir.expanduser()

--- a/libs/mng/imbue/mng/config/loader.py
+++ b/libs/mng/imbue/mng/config/loader.py
@@ -25,12 +25,12 @@ from imbue.mng.config.data_types import MngContext
 from imbue.mng.config.data_types import PluginConfig
 from imbue.mng.config.data_types import ProviderInstanceConfig
 from imbue.mng.config.data_types import split_cli_args_string
+from imbue.mng.config.host_dir import read_default_host_dir
 from imbue.mng.config.plugin_registry import get_plugin_config_class
 from imbue.mng.config.pre_readers import find_profile_dir_lightweight
 from imbue.mng.config.pre_readers import get_user_config_path
 from imbue.mng.config.pre_readers import load_local_config
 from imbue.mng.config.pre_readers import load_project_config
-from imbue.mng.config.pre_readers import read_default_host_dir
 from imbue.mng.config.pre_readers import read_disabled_plugins
 from imbue.mng.config.pre_readers import try_load_toml
 from imbue.mng.errors import ConfigParseError

--- a/libs/mng/imbue/mng/config/pre_readers.py
+++ b/libs/mng/imbue/mng/config/pre_readers.py
@@ -8,6 +8,7 @@ from loguru import logger
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mng.config.consts import PROFILES_DIRNAME
 from imbue.mng.config.consts import ROOT_CONFIG_FILENAME
+from imbue.mng.config.host_dir import read_default_host_dir
 from imbue.mng.utils.git_utils import find_git_worktree_root
 
 # =============================================================================
@@ -81,20 +82,6 @@ def load_local_config(context_dir: Path | None, root_name: str, cg: ConcurrencyG
     if root is None:
         return None
     return try_load_toml(root / get_local_config_name(root_name))
-
-
-def read_default_host_dir() -> Path:
-    """Return the default host directory derived from environment variables.
-
-    Resolves MNG_HOST_DIR (explicit override) or falls back to ~/.{MNG_ROOT_NAME}
-    (default: ~/.mng). This is the single canonical implementation of host-dir
-    resolution from env vars; callers outside stdlib-only modules should use this
-    rather than duplicating the logic.
-    """
-    root_name = os.environ.get("MNG_ROOT_NAME", "mng")
-    env_host_dir = os.environ.get("MNG_HOST_DIR")
-    base_dir = Path(env_host_dir) if env_host_dir else Path(f"~/.{root_name}")
-    return base_dir.expanduser()
 
 
 # =============================================================================


### PR DESCRIPTION
mac clears out its tmp annoyingly often

---
claude's summary

## Summary
- macOS periodically purges files from `/var/folders/.../T/`, causing the tab completion cache to disappear until `mng list` runs again
- Move the default cache directory from `tempfile.gettempdir()/mng-completions-{uid}` to the mng host directory (`~/.mng`), using the same `MNG_HOST_DIR` / `MNG_ROOT_NAME` env var resolution as the config pre-readers
- Changes `_get_completion_cache_dir()` in `complete.py` and `get_completion_cache_dir()` in `completion_writer.py`

## Test plan
- [x] All 2461 tests pass in `libs/mng/` (tests use `MNG_COMPLETION_CACHE_DIR` explicitly, unaffected by default path change)
- [ ] CI passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>