### PR TITLE
remove provider from branch names

### DIFF
--- a/libs/mng/imbue/mng/cli/test_destroy.py
+++ b/libs/mng/imbue/mng/cli/test_destroy.py
@@ -535,7 +535,7 @@ def test_destroy_remove_created_branch_deletes_branch(
     """Test that --remove-created-branch deletes the git branch after destroying a worktree agent."""
     agent_name = f"test-rm-branch-{int(time.time())}"
     session_name = f"{mng_test_prefix}{agent_name}"
-    branch_name = f"mng/{agent_name}-local"
+    branch_name = f"mng/{agent_name}"
 
     with tmux_session_cleanup(session_name):
         create_result = cli_runner.invoke(
@@ -584,7 +584,7 @@ def test_destroy_without_remove_created_branch_leaves_branch(
     """Test that destroy without --remove-created-branch leaves the git branch intact."""
     agent_name = f"test-keep-branch-{int(time.time())}"
     session_name = f"{mng_test_prefix}{agent_name}"
-    branch_name = f"mng/{agent_name}-local"
+    branch_name = f"mng/{agent_name}"
 
     with tmux_session_cleanup(session_name):
         create_result = cli_runner.invoke(

--- a/libs/mng/imbue/mng/hosts/host.py
+++ b/libs/mng/imbue/mng/hosts/host.py
@@ -71,6 +71,7 @@ from imbue.mng.primitives import AgentTypeName
 from imbue.mng.primitives import HostName
 from imbue.mng.primitives import HostState
 from imbue.mng.primitives import WorkDirCopyMode
+from imbue.mng.primitives import default_branch_name
 from imbue.mng.utils.env_utils import parse_env_file
 from imbue.mng.utils.git_utils import get_current_git_branch
 from imbue.mng.utils.git_utils import get_git_author_info
@@ -1440,10 +1441,9 @@ class Host(BaseHost, OnlineHostInterface):
             return options.git.new_branch_name
 
         agent_name = options.name or AgentName("agent")
-        provider_name = self.provider_instance.name
         branch_prefix = options.git.new_branch_prefix if options.git else "mng/"
 
-        return f"{branch_prefix}{agent_name}-{provider_name}"
+        return default_branch_name(agent_name, prefix=branch_prefix)
 
     def create_agent_state(
         self,

--- a/libs/mng/imbue/mng/primitives.py
+++ b/libs/mng/imbue/mng/primitives.py
@@ -230,6 +230,13 @@ class ProviderInstanceName(NonEmptyStr):
 
 LOCAL_PROVIDER_NAME: Final[ProviderInstanceName] = ProviderInstanceName("local")
 
+DEFAULT_BRANCH_PREFIX: Final[str] = "mng/"
+
+
+def default_branch_name(agent_name: "AgentName", prefix: str = DEFAULT_BRANCH_PREFIX) -> str:
+    """Build the default branch name for an agent."""
+    return f"{prefix}{agent_name}"
+
 
 class ProviderBackendName(NonEmptyStr):
     """Name of a provider backend."""

--- a/libs/mng_kanpan/imbue/mng_kanpan/fetcher.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/fetcher.py
@@ -16,6 +16,7 @@ from imbue.mng.interfaces.data_types import AgentInfo
 from imbue.mng.primitives import AgentName
 from imbue.mng.primitives import ErrorBehavior
 from imbue.mng.primitives import LOCAL_PROVIDER_NAME
+from imbue.mng.primitives import default_branch_name
 from imbue.mng.utils.git_utils import get_current_git_branch
 from imbue.mng_kanpan.data_types import AgentBoardEntry
 from imbue.mng_kanpan.data_types import BoardSnapshot
@@ -135,7 +136,7 @@ def _resolve_agent_branch(agent: AgentInfo, cg: ConcurrencyGroup) -> str | None:
     """Determine the git branch associated with an agent.
 
     For local agents with an accessible work_dir, reads the branch via git.
-    Falls back to the naming convention mng/<name>-<provider>.
+    Falls back to the naming convention mng/<name>.
     """
     if agent.host.provider_name == LOCAL_PROVIDER_NAME:
         work_dir = agent.work_dir
@@ -146,7 +147,7 @@ def _resolve_agent_branch(agent: AgentInfo, cg: ConcurrencyGroup) -> str | None:
             logger.debug("Could not determine git branch for agent {} at {}", agent.name, work_dir)
 
     # Fallback: naming convention
-    return f"mng/{agent.name}-{agent.host.provider_name}"
+    return default_branch_name(agent.name)
 
 
 def _get_commits_ahead(work_dir: Path | None, cg: ConcurrencyGroup) -> int | None:

--- a/libs/mng_kanpan/imbue/mng_kanpan/fetcher_test.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/fetcher_test.py
@@ -135,16 +135,16 @@ def test_build_pr_branch_index_merged_wins_over_closed() -> None:
 def test_resolve_agent_branch_local_with_git(tmp_path: Path) -> None:
     agent = _make_agent_info(name="my-agent", work_dir=tmp_path, provider_name="local")
     cg = MagicMock()
-    with patch("imbue.mng_kanpan.fetcher.get_current_git_branch", return_value="mng/my-agent-local"):
+    with patch("imbue.mng_kanpan.fetcher.get_current_git_branch", return_value="mng/my-agent"):
         branch = _resolve_agent_branch(agent, cg)
-    assert branch == "mng/my-agent-local"
+    assert branch == "mng/my-agent"
 
 
 def test_resolve_agent_branch_local_nonexistent_dir() -> None:
     agent = _make_agent_info(name="my-agent", work_dir=Path("/nonexistent/path"), provider_name="local")
     cg = MagicMock()
     branch = _resolve_agent_branch(agent, cg)
-    assert branch == "mng/my-agent-local"
+    assert branch == "mng/my-agent"
 
 
 def test_resolve_agent_branch_local_git_fails(tmp_path: Path) -> None:
@@ -152,14 +152,7 @@ def test_resolve_agent_branch_local_git_fails(tmp_path: Path) -> None:
     cg = MagicMock()
     with patch("imbue.mng_kanpan.fetcher.get_current_git_branch", return_value=None):
         branch = _resolve_agent_branch(agent, cg)
-    assert branch == "mng/my-agent-local"
-
-
-def test_resolve_agent_branch_remote() -> None:
-    agent = _make_agent_info(name="my-agent", work_dir=Path("/remote/path"), provider_name="modal")
-    cg = MagicMock()
-    branch = _resolve_agent_branch(agent, cg)
-    assert branch == "mng/my-agent-modal"
+    assert branch == "mng/my-agent"
 
 
 # === fetch_board_snapshot ===
@@ -191,7 +184,7 @@ def test_fetch_board_snapshot_integrates_agents_and_prs() -> None:
     agent1 = _make_agent_info(name="agent-1", state=AgentLifecycleState.RUNNING, provider_name="modal")
     agent2 = _make_agent_info(name="agent-2", state=AgentLifecycleState.DONE, provider_name="modal")
 
-    pr1 = _make_pr_info(number=42, head_branch="mng/agent-1-modal", state=PrState.OPEN)
+    pr1 = _make_pr_info(number=42, head_branch="mng/agent-1", state=PrState.OPEN)
     pr_result = FetchPrsResult(prs=(pr1,), error=None)
 
     mock_list_result = MagicMock()


### PR DESCRIPTION
## Summary
- Auto-generated branch names now use `mng/<agent-name>` instead of `mng/<agent-name>-<provider>`
- Extracted `default_branch_name()` into `primitives.py` as a shared function used by both `host.py` and kanpan's `fetcher.py`
- Updated tests to match the new convention

## Test plan
- [x] All 2349 unit/integration tests pass in `libs/mng`
- [x] All 52 tests pass in `libs/mng_kanpan`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)