### PR TITLE
validate --sort field in mng list

### DIFF
--- a/libs/mng/imbue/mng/cli/list.py
+++ b/libs/mng/imbue/mng/cli/list.py
@@ -2,16 +2,12 @@ import re
 import shutil
 import string
 import sys
-import types
 from collections.abc import Sequence
 from contextlib import nullcontext
 from enum import Enum
 from threading import Lock
 from typing import Any
 from typing import Final
-from typing import Union
-from typing import get_args
-from typing import get_origin
 
 import click
 from click_option_group import optgroup
@@ -20,7 +16,6 @@ from pydantic import BaseModel
 from pydantic import PrivateAttr
 from tabulate import tabulate
 
-from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mng.api.list import ErrorInfo
@@ -42,6 +37,8 @@ from imbue.mng.interfaces.data_types import AgentInfo
 from imbue.mng.primitives import AgentLifecycleState
 from imbue.mng.primitives import ErrorBehavior
 from imbue.mng.primitives import OutputFormat
+from imbue.mng.utils.model_field_utils import InvalidFieldPathError
+from imbue.mng.utils.model_field_utils import validate_field_path
 from imbue.mng.utils.terminal import ANSI_DIM_GRAY
 from imbue.mng.utils.terminal import ANSI_ERASE_LINE
 from imbue.mng.utils.terminal import ANSI_ERASE_TO_END
@@ -933,74 +930,12 @@ def _format_value_as_string(value: Any) -> str:
         return str(value)
 
 
-@pure
-def _resolve_model_type(annotation: Any) -> type[BaseModel] | None:
-    """Extract a BaseModel subclass from a type annotation, unwrapping Optional/list/tuple."""
-    origin = get_origin(annotation)
-
-    # Handle X | None (Optional types)
-    if origin is types.UnionType or origin is Union:
-        args = get_args(annotation)
-        if len(args) != 2 or type(None) not in args:
-            raise SwitchError(f"Cannot resolve non-optional union type: {annotation}")
-        inner = args[0] if args[1] is type(None) else args[1]
-        return _resolve_model_type(inner)
-
-    # Handle list[X]
-    elif origin is list:
-        args = get_args(annotation)
-        if not args or len(args) != 1:
-            raise SwitchError(f"Expected list[X], got: {annotation}")
-        return _resolve_model_type(args[0])
-
-    # Handle tuple[X, ...] (homogeneous variable-length tuples)
-    elif origin is tuple:
-        args = get_args(annotation)
-        if len(args) != 2 or args[1] is not Ellipsis:
-            raise SwitchError(f"Expected tuple[X, ...], got: {annotation}")
-        return _resolve_model_type(args[0])
-
-    # Handle dict[K, V] -- dynamic keys, stop validation
-    elif origin is dict:
-        return None
-
-    # No generic origin -- either a direct model class or a primitive type
-    elif origin is None:
-        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-            return annotation
-        return None
-
-    else:
-        raise SwitchError(f"Unhandled annotation origin: {origin} (from annotation {annotation})")
-
-
-@pure
 def _validate_sort_field(sort_field: str) -> None:
-    """Validate that the sort field refers to known fields by walking the model type hierarchy.
-
-    Raises click.BadParameter if the field is not recognized.
-    """
-    parts = sort_field.split(".")
-    current_model: type[BaseModel] = AgentInfo
-
-    for part in parts:
-        field_name = part.split("[")[0]
-
-        if field_name not in current_model.model_fields:
-            raise click.BadParameter(
-                f"Unknown sort field: '{sort_field}'. "
-                f"'{field_name}' is not a valid field. "
-                f"Valid fields at this level: {', '.join(sorted(current_model.model_fields.keys()))}",
-                param_hint="--sort",
-            )
-
-        # Resolve the type of this field to check deeper levels
-        field_info = current_model.model_fields[field_name]
-        next_model = _resolve_model_type(field_info.annotation)
-        if next_model is None:
-            # Reached a primitive, dict, or non-model type -- can't validate further
-            return
-        current_model = next_model
+    """Validate the --sort field and raise click.BadParameter if invalid."""
+    try:
+        validate_field_path(model=AgentInfo, field_path=sort_field)
+    except InvalidFieldPathError as e:
+        raise click.BadParameter(str(e), param_hint="--sort") from None
 
 
 # Pattern to match a field part with optional bracket notation

--- a/libs/mng/imbue/mng/cli/list_test.py
+++ b/libs/mng/imbue/mng/cli/list_test.py
@@ -8,12 +8,10 @@ from datetime import timezone
 from io import StringIO
 from typing import Any
 
-import click
 import pluggy
 import pytest
 from click.testing import CliRunner
 
-from imbue.imbue_common.errors import SwitchError
 from imbue.mng.api.list import ListResult
 from imbue.mng.cli.conftest import make_test_agent_info
 from imbue.mng.cli.list import _StreamingHumanRenderer
@@ -29,10 +27,8 @@ from imbue.mng.cli.list import _get_sortable_value
 from imbue.mng.cli.list import _is_streaming_eligible
 from imbue.mng.cli.list import _parse_slice_spec
 from imbue.mng.cli.list import _render_format_template
-from imbue.mng.cli.list import _resolve_model_type
 from imbue.mng.cli.list import _should_use_streaming_mode
 from imbue.mng.cli.list import _sort_agents
-from imbue.mng.cli.list import _validate_sort_field
 from imbue.mng.cli.list import list_command
 from imbue.mng.interfaces.data_types import AgentInfo
 from imbue.mng.interfaces.data_types import SnapshotInfo
@@ -566,71 +562,6 @@ def test_sort_agents_by_name_descending() -> None:
     ]
     result = _sort_agents(agents, "name", reverse=True)
     assert [str(a.name) for a in result] == ["charlie", "bravo", "alpha"]
-
-
-# =============================================================================
-# Tests for _validate_sort_field
-# =============================================================================
-
-
-def test_validate_sort_field_accepts_valid_top_level_field() -> None:
-    """_validate_sort_field should accept known AgentInfo fields."""
-    _validate_sort_field("name")
-    _validate_sort_field("state")
-    _validate_sort_field("create_time")
-
-
-def test_validate_sort_field_accepts_valid_host_field() -> None:
-    """_validate_sort_field should accept known HostInfo fields."""
-    _validate_sort_field("host.name")
-    _validate_sort_field("host.state")
-    _validate_sort_field("host.provider_name")
-
-
-def test_validate_sort_field_accepts_dict_subkeys() -> None:
-    """_validate_sort_field should accept arbitrary sub-keys on dict-typed fields."""
-    _validate_sort_field("labels.project")
-    _validate_sort_field("plugin.chat_history.messages")
-    _validate_sort_field("host.tags.env")
-    _validate_sort_field("host.plugin.aws.iam_user")
-
-
-def test_validate_sort_field_rejects_unknown_top_level_field() -> None:
-    """_validate_sort_field should raise for unknown top-level fields."""
-    with pytest.raises(click.BadParameter, match="Unknown sort field"):
-        _validate_sort_field("akldfsdkfjdklfj")
-
-
-def test_validate_sort_field_rejects_unknown_host_field() -> None:
-    """_validate_sort_field should raise for unknown host sub-fields."""
-    with pytest.raises(click.BadParameter, match="'nonexistent_field' is not a valid field"):
-        _validate_sort_field("host.nonexistent_field")
-
-
-def test_validate_sort_field_accepts_deep_host_fields() -> None:
-    """_validate_sort_field should accept deeper nesting under known host fields."""
-    _validate_sort_field("host.resource.cpu.count")
-    _validate_sort_field("host.ssh.host")
-
-
-def test_validate_sort_field_rejects_unknown_deep_field() -> None:
-    """_validate_sort_field should reject invalid fields at any nesting depth."""
-    with pytest.raises(click.BadParameter, match="'nonexistent' is not a valid field"):
-        _validate_sort_field("host.resource.nonexistent")
-    with pytest.raises(click.BadParameter, match="'bogus' is not a valid field"):
-        _validate_sort_field("host.resource.cpu.bogus")
-
-
-def test_resolve_model_type_raises_on_non_optional_union() -> None:
-    """_resolve_model_type should raise SwitchError for unions that are not X | None."""
-    with pytest.raises(SwitchError, match="Cannot resolve non-optional union"):
-        _resolve_model_type(str | int)
-
-
-def test_resolve_model_type_raises_on_fixed_length_tuple() -> None:
-    """_resolve_model_type should raise SwitchError for tuple[X, Y] (not tuple[X, ...])."""
-    with pytest.raises(SwitchError, match="Expected tuple"):
-        _resolve_model_type(tuple[str, int])
 
 
 # =============================================================================
@@ -1649,7 +1580,7 @@ def test_list_command_rejects_invalid_sort_field(
     )
 
     assert result.exit_code != 0
-    assert "Unknown sort field" in result.output
+    assert "Unknown field path" in result.output
 
 
 def test_list_command_rejects_invalid_host_sort_field(
@@ -1668,7 +1599,7 @@ def test_list_command_rejects_invalid_host_sort_field(
     )
 
     assert result.exit_code != 0
-    assert "Unknown sort field" in result.output
+    assert "Unknown field path" in result.output
     assert "'nonexistent' is not a valid field" in result.output
 
 

--- a/libs/mng/imbue/mng/utils/model_field_utils.py
+++ b/libs/mng/imbue/mng/utils/model_field_utils.py
@@ -1,0 +1,97 @@
+import types
+from typing import Any
+from typing import Union
+from typing import get_args
+from typing import get_origin
+
+from pydantic import BaseModel
+
+from imbue.imbue_common.errors import SwitchError
+from imbue.imbue_common.pure import pure
+
+
+class InvalidFieldPathError(ValueError):
+    """Raised when a dotted field path does not match the model's field hierarchy."""
+
+    def __init__(self, full_path: str, invalid_segment: str, valid_fields: frozenset[str]) -> None:
+        self.full_path = full_path
+        self.invalid_segment = invalid_segment
+        self.valid_fields = valid_fields
+        super().__init__(
+            f"Unknown field path: '{full_path}'. "
+            f"'{invalid_segment}' is not a valid field. "
+            f"Valid fields at this level: {', '.join(sorted(valid_fields))}"
+        )
+
+
+@pure
+def resolve_model_type(annotation: Any) -> type[BaseModel] | None:
+    """Extract a BaseModel subclass from a type annotation, unwrapping Optional/list/tuple.
+
+    Returns None for primitive types and dict (dynamic keys).
+    Raises SwitchError for annotation forms that are not handled.
+    """
+    origin = get_origin(annotation)
+
+    # Handle X | None (Optional types)
+    if origin is types.UnionType or origin is Union:
+        args = get_args(annotation)
+        if len(args) != 2 or type(None) not in args:
+            raise SwitchError(f"Cannot resolve non-optional union type: {annotation}")
+        inner = args[0] if args[1] is type(None) else args[1]
+        return resolve_model_type(inner)
+
+    # Handle list[X]
+    elif origin is list:
+        args = get_args(annotation)
+        if not args or len(args) != 1:
+            raise SwitchError(f"Expected list[X], got: {annotation}")
+        return resolve_model_type(args[0])
+
+    # Handle tuple[X, ...] (homogeneous variable-length tuples)
+    elif origin is tuple:
+        args = get_args(annotation)
+        if len(args) != 2 or args[1] is not Ellipsis:
+            raise SwitchError(f"Expected tuple[X, ...], got: {annotation}")
+        return resolve_model_type(args[0])
+
+    # Handle dict[K, V] -- dynamic keys, stop resolution
+    elif origin is dict:
+        return None
+
+    # No generic origin -- either a direct model class or a primitive type
+    elif origin is None:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return annotation
+        return None
+
+    else:
+        raise SwitchError(f"Unhandled annotation origin: {origin} (from annotation {annotation})")
+
+
+@pure
+def validate_field_path(model: type[BaseModel], field_path: str) -> None:
+    """Validate that a dotted field path refers to known fields in the model hierarchy.
+
+    Raises InvalidFieldPathError if any segment of the path is not recognized.
+    """
+    parts = field_path.split(".")
+    current_model = model
+
+    for part in parts:
+        field_name = part.split("[")[0]
+
+        if field_name not in current_model.model_fields:
+            raise InvalidFieldPathError(
+                full_path=field_path,
+                invalid_segment=field_name,
+                valid_fields=frozenset(current_model.model_fields.keys()),
+            )
+
+        # Resolve the type of this field to check deeper levels
+        field_info = current_model.model_fields[field_name]
+        next_model = resolve_model_type(field_info.annotation)
+        if next_model is None:
+            # Reached a primitive, dict, or non-model type -- can't validate further
+            return
+        current_model = next_model

--- a/libs/mng/imbue/mng/utils/model_field_utils_test.py
+++ b/libs/mng/imbue/mng/utils/model_field_utils_test.py
@@ -1,0 +1,110 @@
+"""Tests for model field path utilities."""
+
+import pytest
+from pydantic import BaseModel
+from pydantic import Field
+
+from imbue.imbue_common.errors import SwitchError
+from imbue.mng.interfaces.data_types import AgentInfo
+from imbue.mng.utils.model_field_utils import InvalidFieldPathError
+from imbue.mng.utils.model_field_utils import resolve_model_type
+from imbue.mng.utils.model_field_utils import validate_field_path
+
+# =============================================================================
+# Tests for resolve_model_type
+# =============================================================================
+
+
+class _InnerModel(BaseModel):
+    """Test model for nesting."""
+
+    value: str = Field(description="test")
+
+
+def test_resolve_model_type_returns_direct_model() -> None:
+    assert resolve_model_type(_InnerModel) is _InnerModel
+
+
+def test_resolve_model_type_unwraps_optional() -> None:
+    assert resolve_model_type(_InnerModel | None) is _InnerModel
+
+
+def test_resolve_model_type_unwraps_list() -> None:
+    assert resolve_model_type(list[_InnerModel]) is _InnerModel
+
+
+def test_resolve_model_type_unwraps_tuple() -> None:
+    assert resolve_model_type(tuple[_InnerModel, ...]) is _InnerModel
+
+
+def test_resolve_model_type_returns_none_for_dict() -> None:
+    assert resolve_model_type(dict[str, str]) is None
+
+
+def test_resolve_model_type_returns_none_for_primitive() -> None:
+    assert resolve_model_type(str) is None
+    assert resolve_model_type(int) is None
+
+
+def test_resolve_model_type_raises_on_non_optional_union() -> None:
+    with pytest.raises(SwitchError, match="Cannot resolve non-optional union"):
+        resolve_model_type(str | int)
+
+
+def test_resolve_model_type_raises_on_fixed_length_tuple() -> None:
+    with pytest.raises(SwitchError, match="Expected tuple"):
+        resolve_model_type(tuple[str, int])
+
+
+# =============================================================================
+# Tests for validate_field_path
+# =============================================================================
+
+
+def test_validate_field_path_accepts_valid_top_level_field() -> None:
+    validate_field_path(model=AgentInfo, field_path="name")
+    validate_field_path(model=AgentInfo, field_path="state")
+    validate_field_path(model=AgentInfo, field_path="create_time")
+
+
+def test_validate_field_path_accepts_valid_host_field() -> None:
+    validate_field_path(model=AgentInfo, field_path="host.name")
+    validate_field_path(model=AgentInfo, field_path="host.state")
+    validate_field_path(model=AgentInfo, field_path="host.provider_name")
+
+
+def test_validate_field_path_accepts_dict_subkeys() -> None:
+    validate_field_path(model=AgentInfo, field_path="labels.project")
+    validate_field_path(model=AgentInfo, field_path="plugin.chat_history.messages")
+    validate_field_path(model=AgentInfo, field_path="host.tags.env")
+    validate_field_path(model=AgentInfo, field_path="host.plugin.aws.iam_user")
+
+
+def test_validate_field_path_accepts_deep_host_fields() -> None:
+    validate_field_path(model=AgentInfo, field_path="host.resource.cpu.count")
+    validate_field_path(model=AgentInfo, field_path="host.ssh.host")
+
+
+def test_validate_field_path_rejects_unknown_top_level_field() -> None:
+    with pytest.raises(InvalidFieldPathError, match="'akldfsdkfjdklfj' is not a valid field"):
+        validate_field_path(model=AgentInfo, field_path="akldfsdkfjdklfj")
+
+
+def test_validate_field_path_rejects_unknown_host_field() -> None:
+    with pytest.raises(InvalidFieldPathError, match="'nonexistent_field' is not a valid field"):
+        validate_field_path(model=AgentInfo, field_path="host.nonexistent_field")
+
+
+def test_validate_field_path_rejects_unknown_deep_field() -> None:
+    with pytest.raises(InvalidFieldPathError, match="'nonexistent' is not a valid field"):
+        validate_field_path(model=AgentInfo, field_path="host.resource.nonexistent")
+    with pytest.raises(InvalidFieldPathError, match="'bogus' is not a valid field"):
+        validate_field_path(model=AgentInfo, field_path="host.resource.cpu.bogus")
+
+
+def test_validate_field_path_error_includes_valid_fields() -> None:
+    with pytest.raises(InvalidFieldPathError) as exc_info:
+        validate_field_path(model=AgentInfo, field_path="nonexistent")
+    assert "name" in str(exc_info.value)
+    assert exc_info.value.invalid_segment == "nonexistent"
+    assert "name" in exc_info.value.valid_fields


### PR DESCRIPTION
## Summary
- `mng ls --sort <invalid_field>` now errors instead of silently doing nothing
- Validates sort field by recursively walking the Pydantic model type hierarchy (AgentInfo -> HostInfo -> HostResources -> CpuResources, etc.)
- Stops validation at dict-typed fields (labels, plugin, host.tags, host.plugin) since they have dynamic keys
- Strict type resolution: raises on non-optional unions, fixed-length tuples, and unhandled annotation origins
- Generic utilities (`resolve_model_type`, `validate_field_path`, `InvalidFieldPathError`) extracted to `mng/utils/model_field_utils.py` for reuse; CLI has a thin wrapper that converts to `click.BadParameter`

## Test plan
- [x] Unit tests for `resolve_model_type` covering Optional, list, tuple, dict, primitives, and error cases
- [x] Unit tests for `validate_field_path` covering valid fields, dict sub-keys, and rejection at every nesting depth
- [x] Integration tests via CLI runner for invalid top-level and host-level sort fields
- [x] Full libs/mng test suite passes (2984 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)