### PR TITLE
publish mng-kanpan and mng-tutor on pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Build mng-opencode
         run: pyproject-build libs/mng_opencode -o dist/
 
+      - name: Build mng-kanpan
+        run: pyproject-build libs/mng_kanpan -o dist/
+
+      - name: Build mng-tutor
+        run: pyproject-build libs/mng_tutor -o dist/
+
       - name: Publish packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/libs/mng_kanpan/pyproject.toml
+++ b/libs/mng_kanpan/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "All-seeing agent tracker"
 requires-python = ">=3.11"
 dependencies = [
-    "mng==0.1.4",
+    "mng==0.1.5",
     "click>=8.0",
     "click-option-group>=0.5.6",
 ]

--- a/libs/mng_tutor/pyproject.toml
+++ b/libs/mng_tutor/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Interactive tutorial plugin for mng"
 requires-python = ">=3.11"
 dependencies = [
-    "mng==0.1.4",
+    "mng==0.1.5",
     "click>=8.0",
     "click-option-group>=0.5.6",
 ]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -32,6 +32,8 @@ PACKAGES: Final[tuple[PackageInfo, ...]] = (
     PackageInfo(dir_name="mng", pypi_name="mng", internal_deps=("imbue-common", "concurrency-group")),
     PackageInfo(dir_name="mng_pair", pypi_name="mng-pair", internal_deps=("mng",)),
     PackageInfo(dir_name="mng_opencode", pypi_name="mng-opencode", internal_deps=("mng",)),
+    PackageInfo(dir_name="mng_kanpan", pypi_name="mng-kanpan", internal_deps=("mng",)),
+    PackageInfo(dir_name="mng_tutor", pypi_name="mng-tutor", internal_deps=("mng",)),
 )
 
 PACKAGE_BY_PYPI_NAME: Final[dict[str, PackageInfo]] = {pkg.pypi_name: pkg for pkg in PACKAGES}


### PR DESCRIPTION
bumps their pinned mng versions to 0.1.5 also

---

## Summary
- Add build steps for mng-kanpan and mng-tutor in the publish workflow
- Add both packages to the PACKAGES graph in scripts/utils.py (used by verify_publish.py and release.py)
- Update stale mng dependency pins from 0.1.4 to 0.1.5 in both packages

## Test plan
- [x] `uv run scripts/verify_publish.py` passes (graph validation + pin consistency)
- [ ] CI passes