### PR TITLE
update branch name references to remove provider

### DIFF
--- a/.claude/commands/wait-for-agent.md
+++ b/.claude/commands/wait-for-agent.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(uv run mng list *), Bash(while true; do*)
 
 The user's message contains an agent name and optional follow-up instructions. Extract the agent name (the first word) and treat everything after it as follow-up instructions.
 
-Note: the user may paste a git branch name like `mng/some-agent-local` or `mng/some-agent-docker` instead of the bare agent name. In that case, strip the `mng/` prefix and the `-local`/`-docker`/etc. provider suffix to get the actual agent name (e.g. `mng/better-tabcomplete-local` -> `better-tabcomplete`).
+Note: the user may paste a git branch name like `mng/some-agent` instead of the bare agent name. In that case, strip the `mng/` prefix to get the actual agent name (e.g. `mng/better-tabcomplete` -> `better-tabcomplete`).
 
 ## Polling Procedure
 

--- a/libs/mng/imbue/mng/hosts/host_test.py
+++ b/libs/mng/imbue/mng/hosts/host_test.py
@@ -364,10 +364,10 @@ def test_get_created_branch_name_returns_value_from_data_json(
 
     agent_dir = local_provider.host_dir / "agents" / str(agent.id)
     data = json.loads((agent_dir / "data.json").read_text())
-    data["created_branch_name"] = "mng/test-branch-local"
+    data["created_branch_name"] = "mng/test-branch"
     (agent_dir / "data.json").write_text(json.dumps(data))
 
-    assert agent.get_created_branch_name() == "mng/test-branch-local"
+    assert agent.get_created_branch_name() == "mng/test-branch"
 
 
 def test_get_created_branch_name_returns_none_when_absent(
@@ -396,9 +396,9 @@ def test_create_agent_state_stores_created_branch_name(
         command=CommandString("sleep 1"),
     )
 
-    agent = host.create_agent_state(temp_work_dir, options, created_branch_name="mng/my-branch-local")
+    agent = host.create_agent_state(temp_work_dir, options, created_branch_name="mng/my-branch")
 
-    assert agent.get_created_branch_name() == "mng/my-branch-local"
+    assert agent.get_created_branch_name() == "mng/my-branch"
 
 
 def test_create_agent_state_uses_explicit_agent_id(

--- a/libs/mng_kanpan/imbue/mng_kanpan/data_types_test.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/data_types_test.py
@@ -38,7 +38,7 @@ def test_pr_info_construction() -> None:
         title="Add feature X",
         state=PrState.OPEN,
         url="https://github.com/org/repo/pull/42",
-        head_branch="mng/my-agent-local",
+        head_branch="mng/my-agent",
         check_status=CheckStatus.PASSING,
         is_draft=False,
     )
@@ -46,7 +46,7 @@ def test_pr_info_construction() -> None:
     assert pr.title == "Add feature X"
     assert pr.state == PrState.OPEN
     assert pr.url == "https://github.com/org/repo/pull/42"
-    assert pr.head_branch == "mng/my-agent-local"
+    assert pr.head_branch == "mng/my-agent"
     assert pr.check_status == CheckStatus.PASSING
 
 
@@ -56,7 +56,7 @@ def test_pr_info_is_frozen() -> None:
         title="Add feature X",
         state=PrState.OPEN,
         url="https://github.com/org/repo/pull/42",
-        head_branch="mng/my-agent-local",
+        head_branch="mng/my-agent",
         check_status=CheckStatus.PASSING,
         is_draft=False,
     )
@@ -83,7 +83,7 @@ def test_agent_board_entry_with_pr() -> None:
         title="Fix bug",
         state=PrState.MERGED,
         url="https://github.com/org/repo/pull/10",
-        head_branch="mng/my-agent-local",
+        head_branch="mng/my-agent",
         check_status=CheckStatus.PASSING,
         is_draft=False,
     )
@@ -91,10 +91,10 @@ def test_agent_board_entry_with_pr() -> None:
         name=AgentName("my-agent"),
         state=AgentLifecycleState.DONE,
         provider_name=ProviderInstanceName("local"),
-        branch="mng/my-agent-local",
+        branch="mng/my-agent",
         pr=pr,
     )
-    assert entry.branch == "mng/my-agent-local"
+    assert entry.branch == "mng/my-agent"
     assert entry.pr is not None
     assert entry.pr.number == 10
 

--- a/libs/mng_kanpan/imbue/mng_kanpan/fetcher_test.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/fetcher_test.py
@@ -54,7 +54,7 @@ def _make_agent_info(
 
 def _make_pr_info(
     number: int = 1,
-    head_branch: str = "mng/test-local",
+    head_branch: str = "mng/test",
     state: PrState = PrState.OPEN,
     is_draft: bool = False,
 ) -> PrInfo:
@@ -94,9 +94,9 @@ def test_build_pr_branch_index_empty() -> None:
 
 
 def test_build_pr_branch_index_single_pr() -> None:
-    pr = _make_pr_info(number=1, head_branch="mng/agent-local")
+    pr = _make_pr_info(number=1, head_branch="mng/agent")
     result = _build_pr_branch_index((pr,))
-    assert result == {"mng/agent-local": pr}
+    assert result == {"mng/agent": pr}
 
 
 def test_build_pr_branch_index_different_branches() -> None:

--- a/libs/mng_kanpan/imbue/mng_kanpan/github_test.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/github_test.py
@@ -111,7 +111,7 @@ def test_parse_pr() -> None:
         "title": "Add feature X",
         "state": "OPEN",
         "url": "https://github.com/org/repo/pull/42",
-        "headRefName": "mng/my-agent-local",
+        "headRefName": "mng/my-agent",
         "statusCheckRollup": [
             {"status": "COMPLETED", "conclusion": "SUCCESS"},
         ],
@@ -121,7 +121,7 @@ def test_parse_pr() -> None:
     assert pr.title == "Add feature X"
     assert pr.state == PrState.OPEN
     assert pr.url == "https://github.com/org/repo/pull/42"
-    assert pr.head_branch == "mng/my-agent-local"
+    assert pr.head_branch == "mng/my-agent"
     assert pr.check_status == CheckStatus.PASSING
     assert pr.is_draft is False
 
@@ -132,7 +132,7 @@ def test_parse_pr_draft() -> None:
         "title": "WIP feature",
         "state": "OPEN",
         "url": "https://github.com/org/repo/pull/99",
-        "headRefName": "mng/wip-local",
+        "headRefName": "mng/wip",
         "statusCheckRollup": [],
         "isDraft": True,
     }
@@ -147,7 +147,7 @@ def test_parse_pr_merged_with_no_checks() -> None:
         "title": "Fix bug",
         "state": "MERGED",
         "url": "https://github.com/org/repo/pull/10",
-        "headRefName": "mng/fix-bug-local",
+        "headRefName": "mng/fix-bug",
         "statusCheckRollup": [],
     }
     pr = _parse_pr(raw)


### PR DESCRIPTION
## Summary
- Updated all remaining references from the old `mng/<name>-<provider>` branch format to the new `mng/<name>` format
- Simplified the wait-for-agent command docs (no longer mentions stripping provider suffixes)
- Updated test data in mng and mng_kanpan test files

## Test plan
- [x] All 2861 mng tests pass
- [x] All 52 mng_kanpan tests pass

Generated with [Claude Code](https://claude.com/claude-code)