### PR TITLE
Replace branch prefix with format string for auto-generated branches

### DIFF
--- a/libs/mng/analysis/raw-types-2026-01-19.md
+++ b/libs/mng/analysis/raw-types-2026-01-19.md
@@ -138,9 +138,9 @@ Decision: Accept
 Description: In `libs/mng/imbue/mng/interfaces/host.py:346-358`, several git-related fields use plain strings:
 - `base_branch: str | None`
 - `new_branch_name: str | None`
-- `new_branch_prefix: str`
+- `new_branch_format: str`
 
-Recommendation: Create a `GitBranchName` type (extending `NonEmptyStr`) for branch names. The prefix could remain as `str` since empty prefix is valid (meaning no prefix).
+Recommendation: Create a `GitBranchName` type (extending `NonEmptyStr`) for branch names. The format string could remain as `str` since it uses Python format syntax with {name} and {provider} placeholders.
 
 Decision: Accept
 

--- a/libs/mng/docs/commands/primary/create.md
+++ b/libs/mng/docs/commands/primary/create.md
@@ -120,7 +120,7 @@ By default, `mng create` uses the "local" host. Use these options to change that
 | `--base-branch` | text | The starting point for the agent [default: current branch] | None |
 | `--new-branch` | text | Create a fresh branch (named TEXT if provided, otherwise auto-generated) [default: new branch] | `` |
 | `--no-new-branch` | boolean | Do not create a new branch; use the current branch directly. Incompatible with --worktree | None |
-| `--new-branch-prefix` | text | Prefix for auto-generated branch names | `mng/` |
+| `--new-branch-format` | text | Format string for auto-generated branch names. Available variables: {name} (agent name), {provider} (provider name) | `mng/{name}-{provider}` |
 | `--depth` | integer | Shallow clone depth [default: full] | None |
 | `--shallow-since` | text | Shallow clone since date | None |
 

--- a/libs/mng/future_specs/config.md
+++ b/libs/mng/future_specs/config.md
@@ -53,7 +53,7 @@ host = "ssh://user@server"
 
 # Command defaults
 [commands.create]
-new_branch_prefix = "agent/"
+new_branch_format = "agent/{name}-{provider}"
 connect = false
 ```
 
@@ -63,7 +63,7 @@ Command defaults allow you to set default values for CLI command parameters. The
 
 ```toml
 [commands.create]
-new_branch_prefix = "agent/"
+new_branch_format = "agent/{name}-{provider}"
 connect = false
 
 [commands.list]

--- a/libs/mng/imbue/mng/cli/config.py
+++ b/libs/mng/imbue/mng/cli/config.py
@@ -637,7 +637,7 @@ def _get_config_template() -> str:
 
 # Command defaults
 # [commands.create]
-# new_branch_prefix = "agent/"
+# new_branch_format = "agent/{name}-{provider}"
 # connect = false
 
 # Logging configuration

--- a/libs/mng/imbue/mng/cli/conftest.py
+++ b/libs/mng/imbue/mng/cli/conftest.py
@@ -108,7 +108,7 @@ def default_create_cli_opts() -> CreateCliOptions:
         include_gitignored=False,
         base_branch=None,
         new_branch="",
-        new_branch_prefix="mng/",
+        new_branch_format="mng/{name}-{provider}",
         depth=None,
         shallow_since=None,
         agent_env=(),

--- a/libs/mng/imbue/mng/cli/create.py
+++ b/libs/mng/imbue/mng/cli/create.py
@@ -188,7 +188,7 @@ class CreateCliOptions(CommonCliOptions):
     include_gitignored: bool
     base_branch: str | None
     new_branch: str | None
-    new_branch_prefix: str
+    new_branch_format: str
     depth: int | None
     shallow_since: str | None
     agent_env: tuple[str, ...]
@@ -406,7 +406,7 @@ class CreateCliOptions(CommonCliOptions):
     help="Do not create a new branch; use the current branch directly. Incompatible with --worktree",
 )
 @optgroup.option(
-    "--new-branch-prefix", default="mng/", show_default=True, help="Prefix for auto-generated branch names"
+    "--new-branch-format", default="mng/{name}-{provider}", show_default=True, help="Format string for auto-generated branch names. Available variables: {name} (agent name), {provider} (provider name)"
 )
 @optgroup.option("--depth", type=int, help="Shallow clone depth [default: full]")
 @optgroup.option("--shallow-since", help="Shallow clone since date")
@@ -1295,7 +1295,7 @@ def _parse_agent_opts(
             base_branch=opts.base_branch or _get_current_git_branch(source_location, mng_ctx),
             is_new_branch=is_new_branch,
             new_branch_name=new_branch if new_branch else None,
-            new_branch_prefix=opts.new_branch_prefix,
+            new_branch_format=opts.new_branch_format,
             depth=opts.depth,
             shallow_since=opts.shallow_since,
             is_git_synced=opts.include_git,

--- a/libs/mng/imbue/mng/config/loader.py
+++ b/libs/mng/imbue/mng/config/loader.py
@@ -521,8 +521,8 @@ def _parse_command_env_vars(environ: Mapping[str, str]) -> dict[str, CommandDefa
     See the comment at _ENV_COMMANDS_PREFIX for details.
 
     Examples:
-        MNG_COMMANDS_CREATE_NEW_BRANCH_PREFIX=agent/
-            -> commands["create"]["new_branch_prefix"] = "agent/"
+        MNG_COMMANDS_CREATE_NEW_BRANCH_FORMAT=agent/{name}-{provider}
+            -> commands["create"]["new_branch_format"] = "agent/{name}-{provider}"
 
         MNG_COMMANDS_CREATE_CONNECT=false
             -> commands["create"]["connect"] = "false"

--- a/libs/mng/imbue/mng/config/loader_test.py
+++ b/libs/mng/imbue/mng/config/loader_test.py
@@ -45,23 +45,23 @@ hookimpl = pluggy.HookimplMarker("mng")
 
 def test_parse_command_env_vars_single_param() -> None:
     """Test parsing a single command param from env var."""
-    environ = {"MNG_COMMANDS_CREATE_NEW_BRANCH_PREFIX": "agent/"}
+    environ = {"MNG_COMMANDS_CREATE_NEW_BRANCH_FORMAT": "agent/{name}-{provider}"}
     result = _parse_command_env_vars(environ)
 
     assert "create" in result
-    assert result["create"].defaults["new_branch_prefix"] == "agent/"
+    assert result["create"].defaults["new_branch_format"] == "agent/{name}-{provider}"
 
 
 def test_parse_command_env_vars_multiple_params_same_command() -> None:
     """Test parsing multiple params for the same command."""
     environ = {
-        "MNG_COMMANDS_CREATE_NEW_BRANCH_PREFIX": "agent/",
+        "MNG_COMMANDS_CREATE_NEW_BRANCH_FORMAT": "agent/{name}-{provider}",
         "MNG_COMMANDS_CREATE_CONNECT": "false",
     }
     result = _parse_command_env_vars(environ)
 
     assert "create" in result
-    assert result["create"].defaults["new_branch_prefix"] == "agent/"
+    assert result["create"].defaults["new_branch_format"] == "agent/{name}-{provider}"
     # Values are kept as strings - type conversion happens in click/pydantic
     assert result["create"].defaults["connect"] == "false"
 
@@ -104,11 +104,11 @@ def test_parse_command_env_vars_ignores_no_underscore_after_command() -> None:
 
 def test_parse_command_env_vars_lowercases_command_and_param() -> None:
     """Test that command and param names are lowercased."""
-    environ = {"MNG_COMMANDS_CREATE_NEW_BRANCH_PREFIX": "agent/"}
+    environ = {"MNG_COMMANDS_CREATE_NEW_BRANCH_FORMAT": "agent/{name}-{provider}"}
     result = _parse_command_env_vars(environ)
 
     assert "create" in result
-    assert "new_branch_prefix" in result["create"].defaults
+    assert "new_branch_format" in result["create"].defaults
 
 
 def test_parse_command_env_vars_empty_environ() -> None:

--- a/libs/mng/imbue/mng/hosts/host.py
+++ b/libs/mng/imbue/mng/hosts/host.py
@@ -72,6 +72,7 @@ from imbue.mng.primitives import HostName
 from imbue.mng.primitives import HostState
 from imbue.mng.primitives import WorkDirCopyMode
 from imbue.mng.utils.env_utils import parse_env_file
+from imbue.mng.utils.git_utils import format_branch_name
 from imbue.mng.utils.git_utils import get_current_git_branch
 from imbue.mng.utils.git_utils import get_git_author_info
 from imbue.mng.utils.git_utils import get_git_remote_url
@@ -1441,9 +1442,9 @@ class Host(BaseHost, OnlineHostInterface):
 
         agent_name = options.name or AgentName("agent")
         provider_name = self.provider_instance.name
-        branch_prefix = options.git.new_branch_prefix if options.git else "mng/"
+        branch_format = options.git.new_branch_format if options.git else "mng/{name}-{provider}"
 
-        return f"{branch_prefix}{agent_name}-{provider_name}"
+        return format_branch_name(branch_format, name=str(agent_name), provider=str(provider_name))
 
     def create_agent_state(
         self,

--- a/libs/mng/imbue/mng/hosts/test_host.py
+++ b/libs/mng/imbue/mng/hosts/test_host.py
@@ -1851,7 +1851,7 @@ def test_create_work_dir_generates_new_branch(
         agent_type=AgentTypeName("generic"),
         command=CommandString("sleep 1"),
         target_path=target_path,
-        git=AgentGitOptions(is_new_branch=True, new_branch_prefix="test/"),
+        git=AgentGitOptions(is_new_branch=True, new_branch_format="test/{name}-{provider}"),
     )
 
     work_dir = host.create_agent_work_dir(host, source_path, options).path
@@ -1899,7 +1899,7 @@ def test_create_work_dir_preserves_origin_remote(
         agent_type=AgentTypeName("generic"),
         command=CommandString("sleep 1"),
         target_path=target_path,
-        git=AgentGitOptions(is_new_branch=True, new_branch_prefix="test/"),
+        git=AgentGitOptions(is_new_branch=True, new_branch_format="test/{name}-{provider}"),
     )
 
     work_dir = host.create_agent_work_dir(host, source_path, options).path
@@ -1939,7 +1939,7 @@ def test_create_work_dir_works_without_origin_remote(
         agent_type=AgentTypeName("generic"),
         command=CommandString("sleep 1"),
         target_path=target_path,
-        git=AgentGitOptions(is_new_branch=True, new_branch_prefix="test/"),
+        git=AgentGitOptions(is_new_branch=True, new_branch_format="test/{name}-{provider}"),
     )
 
     work_dir = host.create_agent_work_dir(host, source_path, options).path

--- a/libs/mng/imbue/mng/interfaces/host.py
+++ b/libs/mng/imbue/mng/interfaces/host.py
@@ -494,9 +494,9 @@ class AgentGitOptions(FrozenModel):
         default=None,
         description="Name for the new branch (implies is_new_branch)",
     )
-    new_branch_prefix: str = Field(
-        default="mng/",
-        description="Prefix for auto-generated branch names",
+    new_branch_format: str = Field(
+        default="mng/{name}-{provider}",
+        description="Format string for auto-generated branch names. Available variables: {name} (agent name), {provider} (provider name)",
     )
     depth: int | None = Field(
         default=None,

--- a/libs/mng/imbue/mng/utils/git_utils.py
+++ b/libs/mng/imbue/mng/utils/git_utils.py
@@ -7,6 +7,7 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ProcessError
 from imbue.imbue_common.pure import pure
 from imbue.mng.errors import MngError
+from imbue.mng.errors import UserInputError
 
 
 @pure
@@ -293,3 +294,22 @@ def find_git_common_dir(path: Path, cg: ConcurrencyGroup) -> Path | None:
     except ProcessError as e:
         logger.trace("Failed to find main .git dir: {}", e)
         return None
+
+
+@pure
+def format_branch_name(format_string: str, *, name: str, provider: str) -> str:
+    """Format a branch name using a format string with named placeholders.
+
+    Available variables:
+        {name} - the agent name
+        {provider} - the provider name
+
+    Raises UserInputError if the format string contains unknown placeholders.
+    """
+    try:
+        return format_string.format_map({"name": name, "provider": provider})
+    except KeyError as e:
+        raise UserInputError(
+            f"Unknown variable {e} in branch format string {format_string!r}. "
+            f"Available variables: {{name}}, {{provider}}"
+        ) from None

--- a/libs/mng/imbue/mng/utils/git_utils_test.py
+++ b/libs/mng/imbue/mng/utils/git_utils_test.py
@@ -3,11 +3,15 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.mng.errors import UserInputError
 from imbue.mng.utils.git_utils import _parse_project_name_from_url
 from imbue.mng.utils.git_utils import derive_project_name_from_path
 from imbue.mng.utils.git_utils import find_git_common_dir
 from imbue.mng.utils.git_utils import find_git_worktree_root
+from imbue.mng.utils.git_utils import format_branch_name
 from imbue.mng.utils.git_utils import get_git_author_info
 from imbue.mng.utils.git_utils import get_git_remote_url
 from imbue.mng.utils.git_utils import is_git_repository
@@ -272,3 +276,44 @@ def test_get_git_remote_url_returns_none_for_non_git_dir(tmp_path: Path, cg: Con
     plain_dir = tmp_path / "plain"
     plain_dir.mkdir()
     assert get_git_remote_url(plain_dir, "origin", cg) is None
+
+
+# =============================================================================
+# Tests for format_branch_name
+# =============================================================================
+
+
+def test_format_branch_name_default_format() -> None:
+    """Test the default format string produces the expected branch name."""
+    result = format_branch_name("mng/{name}-{provider}", name="my-task", provider="local")
+    assert result == "mng/my-task-local"
+
+
+def test_format_branch_name_name_only() -> None:
+    """Test a format string that only uses the name variable."""
+    result = format_branch_name("feature/{name}", name="my-task", provider="modal")
+    assert result == "feature/my-task"
+
+
+def test_format_branch_name_provider_only() -> None:
+    """Test a format string that only uses the provider variable."""
+    result = format_branch_name("agents/{provider}", name="my-task", provider="modal")
+    assert result == "agents/modal"
+
+
+def test_format_branch_name_no_variables() -> None:
+    """Test a format string with no variables produces a literal string."""
+    result = format_branch_name("static-branch", name="my-task", provider="local")
+    assert result == "static-branch"
+
+
+def test_format_branch_name_provider_slash_name() -> None:
+    """Test the provider/name style that motivated this feature."""
+    result = format_branch_name("mng/{provider}/{name}", name="my-task", provider="modal")
+    assert result == "mng/modal/my-task"
+
+
+def test_format_branch_name_unknown_variable_raises() -> None:
+    """Test that unknown variables in the format string raise UserInputError."""
+    with pytest.raises(UserInputError, match="Unknown variable.*'unknown'"):
+        format_branch_name("{unknown}/{name}", name="my-task", provider="local")

--- a/libs/mng/tutorials/mega_tutorial.sh
+++ b/libs/mng/tutorials/mega_tutorial.sh
@@ -93,8 +93,9 @@ mng create my-task --context /tmp/my_random_folder --agent-command python -- scr
 mng create my-task
 git branch | grep mng/my-task
 
-# --new-branch-prefix controls the prefix for auto-generated branch names (default: mng/)
-mng create my-task --new-branch-prefix "feature/"
+# --new-branch-format controls the format for auto-generated branch names (default: mng/{name}-{provider})
+# available variables: {name} (agent name), {provider} (provider name)
+mng create my-task --new-branch-format "feature/{name}"
 git branch | grep feature/my-task
 
 # you can also specify a different base branch (instead of the current branch):


### PR DESCRIPTION
## Summary
This PR replaces the simple `new_branch_prefix` parameter with a more flexible `new_branch_format` parameter that uses Python format string syntax. This allows users to customize branch naming patterns using placeholders for agent name and provider name.

## Key Changes

- **New `format_branch_name()` function** in `git_utils.py`: Implements format string substitution with support for `{name}` and `{provider}` placeholders, raising `UserInputError` for unknown variables
- **Parameter rename**: Changed `new_branch_prefix` to `new_branch_format` across all interfaces:
  - CLI option `--new-branch-prefix` → `--new-branch-format`
  - `AgentGitOptions.new_branch_prefix` → `AgentGitOptions.new_branch_format`
  - `CreateCliOptions.new_branch_prefix` → `CreateCliOptions.new_branch_format`
- **Default value update**: Changed from `"mng/"` to `"mng/{name}-{provider}"` to maintain similar output while using the new format
- **Branch name generation**: Updated `_determine_branch_name()` in `host.py` to use the new `format_branch_name()` function instead of simple string concatenation
- **Comprehensive test coverage**: Added 6 new tests covering default format, single variable usage, no variables, provider/name style, and error handling for unknown variables
- **Documentation updates**: Updated CLI help text, config examples, tutorials, and API documentation to reflect the new format string syntax

## Implementation Details

The `format_branch_name()` function uses `str.format_map()` to safely substitute only the allowed variables (`name` and `provider`). Any attempt to use undefined variables in the format string will raise a `UserInputError` with a helpful message listing available variables.

The change is backward-incompatible in terms of the parameter name and default value, but the new default format produces equivalent branch names to the old behavior (e.g., `mng/my-task-local` instead of `mng/my-task-local`).

https://claude.ai/code/session_019q1gZmPSHJoCuPxrh6GY7x