### PR TITLE
Switch offload configs to pytest framework

### DIFF
--- a/offload-modal-acceptance.toml
+++ b/offload-modal-acceptance.toml
@@ -12,11 +12,10 @@ type = "modal"
 dockerfile = "libs/mng/imbue/mng/resources/Dockerfile"
 
 [framework]
-type = "default"
-discover_command = "uv run pytest --collect-only -q 2>/dev/null {filters} | grep '::'"
-# Run tests in the sandbox (source is baked into /app)
-run_command = "uv run pytest -v --tb=short --no-cov -p no:xdist -o addopts= --junitxml={result_file} {tests}"
-test_id_format = "{name}"
+type = "pytest"
+paths = ["."]
+command = "uv run pytest"
+run_args = "--no-cov -p no:xdist -o addopts="
 
 [groups.all]
 retry_count = 4

--- a/offload-modal.toml
+++ b/offload-modal.toml
@@ -11,11 +11,10 @@ type = "modal"
 dockerfile = "libs/mng/imbue/mng/resources/Dockerfile"
 
 [framework]
-type = "default"
-discover_command = "uv run pytest --collect-only -q {filters} 2>/dev/null | grep '::'"
-# Run tests in the sandbox (source is baked into /app)
-run_command = "uv run pytest -v --tb=short --no-cov -p no:xdist -o addopts= --junitxml={result_file} {tests}"
-test_id_format = "{name}"
+type = "pytest"
+paths = ["."]
+command = "uv run pytest"
+run_args = "--no-cov -p no:xdist -o addopts="
 
 [groups.all]
 retry_count = 0


### PR DESCRIPTION
## Summary

- Replaces the `default` framework (with inline `discover_command`/`run_command`) with the native `pytest` framework in both `offload-modal.toml` and `offload-modal-acceptance.toml`
- Uses the new `command` and `run_args` fields from [imbue-ai/offload#84](https://github.com/imbue-ai/offload/pull/84)

## Changes

**Before:**
```toml
[framework]
type = "default"
discover_command = "uv run pytest --collect-only -q {filters} 2>/dev/null | grep '::'"
run_command = "uv run pytest -v --tb=short --no-cov -p no:xdist -o addopts= --junitxml={result_file} {tests}"
test_id_format = "{name}"
```

**After:**
```toml
[framework]
type = "pytest"
paths = ["."]
command = "uv run pytest"
run_args = "--no-cov -p no:xdist -o addopts="
```

## Test plan

- [x] Depends on imbue-ai/offload#84 being merged and `offload` binary updated
- [x] Run `offload collect -c offload-modal.toml` to verify discovery works
- [x] Run `offload run -c offload-modal.toml` to verify execution works

🤖 Generated with [Claude Code](https://claude.com/claude-code)