### PR TITLE
make git branch tab have the --base-branch -> --branch change

### DIFF
--- a/libs/mng/imbue/mng/cli/complete_test.py
+++ b/libs/mng/imbue/mng/cli/complete_test.py
@@ -648,11 +648,11 @@ def test_get_completions_git_branch_option(
     run_git_command(temp_git_repo_cwd, "branch", "develop")
     data = _make_cache_data(
         commands=["create"],
-        options_by_command={"create": ["--base-branch", "--name"]},
-        git_branch_options=["create.--base-branch"],
+        options_by_command={"create": ["--branch", "--name"]},
+        git_branch_options=["create.--branch"],
     )
     _write_command_cache(completion_cache_dir, data)
-    set_comp_env("mng create --base-branch ", "3")
+    set_comp_env("mng create --branch ", "3")
 
     result = _get_completions()
 
@@ -669,11 +669,11 @@ def test_get_completions_git_branch_option_with_prefix(
     run_git_command(temp_git_repo_cwd, "branch", "feature/foo")
     data = _make_cache_data(
         commands=["create"],
-        options_by_command={"create": ["--base-branch", "--name"]},
-        git_branch_options=["create.--base-branch"],
+        options_by_command={"create": ["--branch", "--name"]},
+        git_branch_options=["create.--branch"],
     )
     _write_command_cache(completion_cache_dir, data)
-    set_comp_env("mng create --base-branch dev", "3")
+    set_comp_env("mng create --branch dev", "3")
 
     result = _get_completions()
 
@@ -688,8 +688,8 @@ def test_get_completions_git_branch_option_not_triggered_for_other_options(
     """Options not in git_branch_options should not trigger git branch completion."""
     data = _make_cache_data(
         commands=["create"],
-        options_by_command={"create": ["--base-branch", "--name"]},
-        git_branch_options=["create.--base-branch"],
+        options_by_command={"create": ["--branch", "--name"]},
+        git_branch_options=["create.--branch"],
     )
     _write_command_cache(completion_cache_dir, data)
     set_comp_env("mng create --name ", "3")

--- a/libs/mng/imbue/mng/config/completion_writer.py
+++ b/libs/mng/imbue/mng/config/completion_writer.py
@@ -65,7 +65,7 @@ _AGENT_NAME_SUBCOMMANDS: Final[frozenset[str]] = frozenset(
 # to offer git branch completions.
 _GIT_BRANCH_OPTIONS: Final[frozenset[str]] = frozenset(
     {
-        "create.--base-branch",
+        "create.--branch",
     }
 )
 

--- a/libs/mng/imbue/mng/config/completion_writer_test.py
+++ b/libs/mng/imbue/mng/config/completion_writer_test.py
@@ -76,7 +76,7 @@ def test_write_cli_completions_cache_includes_git_branch_options(completion_cach
     group = click.Group(
         name="test",
         commands={
-            "create": click.Command("create", params=[click.Option(["--base-branch"])]),
+            "create": click.Command("create", params=[click.Option(["--branch"])]),
         },
     )
 
@@ -84,4 +84,4 @@ def test_write_cli_completions_cache_includes_git_branch_options(completion_cach
     cache_path = completion_cache_dir / COMMAND_COMPLETIONS_CACHE_FILENAME
     data = json.loads(cache_path.read_text())
     assert "git_branch_options" in data
-    assert "create.--base-branch" in data["git_branch_options"]
+    assert "create.--branch" in data["git_branch_options"]


### PR DESCRIPTION
it was still looking for --base-branch

---

## Summary
- The `--base-branch` CLI arg on `mng create` was renamed to `--branch`, but the tab completion system still referenced the old name
- This meant `mng create --branch <TAB>` silently stopped offering git branch completions
- Updated `_GIT_BRANCH_OPTIONS` in `completion_writer.py` and corresponding tests

## Test plan
- [x] All completion-related tests updated and passing
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)