### PR TITLE
get rid of NamedTuple in kanpan

### DIFF
--- a/libs/mng_kanpan/imbue/mng_kanpan/tui.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/tui.py
@@ -8,7 +8,6 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from datetime import timezone
 from typing import Any
-from typing import NamedTuple
 
 from loguru import logger
 from pydantic import ConfigDict
@@ -25,6 +24,7 @@ from urwid.widget.listbox import SimpleFocusListWalker
 from urwid.widget.pile import Pile
 from urwid.widget.text import Text
 
+from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
@@ -385,7 +385,7 @@ def _execute_marks(state: _KanpanState) -> None:
     _start_batch_execution(state)
 
 
-class _BatchWorkItem(NamedTuple):
+class _BatchWorkItem(FrozenModel):
     name: AgentName
     key: str
     cmd: CustomCommand
@@ -973,7 +973,9 @@ def _get_link_cell_text(entry: AgentBoardEntry) -> str:
     return ""
 
 
-class _ColumnDef(NamedTuple):
+class _ColumnDef(FrozenModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     name: str
     header: str
     text_fn: Callable[[AgentBoardEntry], str]
@@ -983,12 +985,16 @@ class _ColumnDef(NamedTuple):
 
 # Single source of truth for all board column definitions (order matters)
 _BOARD_COLUMN_DEFS: list[_ColumnDef] = [
-    _ColumnDef("name", "  NAME", _get_name_cell_text, _get_name_cell_text, flexible=False),
-    _ColumnDef("state", "STATE", _get_state_cell_text, _get_state_cell_markup, flexible=False),
-    _ColumnDef("git", "GIT", _get_push_cell_text, _get_push_cell_text, flexible=False),
-    _ColumnDef("pr", "PR", _get_pr_cell_text, _get_pr_cell_text, flexible=False),
-    _ColumnDef("ci", "CI", _get_check_cell_text, _get_check_cell_markup, flexible=False),
-    _ColumnDef("link", "LINK", _get_link_cell_text, _get_link_cell_text, flexible=True),
+    _ColumnDef(
+        name="name", header="  NAME", text_fn=_get_name_cell_text, markup_fn=_get_name_cell_text, flexible=False
+    ),
+    _ColumnDef(
+        name="state", header="STATE", text_fn=_get_state_cell_text, markup_fn=_get_state_cell_markup, flexible=False
+    ),
+    _ColumnDef(name="git", header="GIT", text_fn=_get_push_cell_text, markup_fn=_get_push_cell_text, flexible=False),
+    _ColumnDef(name="pr", header="PR", text_fn=_get_pr_cell_text, markup_fn=_get_pr_cell_text, flexible=False),
+    _ColumnDef(name="ci", header="CI", text_fn=_get_check_cell_text, markup_fn=_get_check_cell_markup, flexible=False),
+    _ColumnDef(name="link", header="LINK", text_fn=_get_link_cell_text, markup_fn=_get_link_cell_text, flexible=True),
 ]
 
 


### PR DESCRIPTION
## Summary
- Convert `_BatchWorkItem` and `_ColumnDef` from `NamedTuple` to `FrozenModel` for consistency with the rest of kanpan's data types.
- `_ColumnDef` requires `arbitrary_types_allowed=True` due to its `Callable` fields.
- Positional constructor args converted to keyword args.

## Test plan
- [x] All 207 kanpan tests pass with coverage above threshold (83.54%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)