### PR TITLE
add copy_directory to OnlineHostInterface

### DIFF
--- a/libs/mng/imbue/mng/hosts/host.py
+++ b/libs/mng/imbue/mng/hosts/host.py
@@ -1324,6 +1324,23 @@ class Host(BaseHost, OnlineHostInterface):
             finally:
                 files_from_path.unlink(missing_ok=True)
 
+    def copy_directory(
+        self,
+        source_host: OnlineHostInterface,
+        source_path: Path,
+        target_path: Path,
+        extra_args: str | None = None,
+        exclude_git: bool = False,
+    ) -> None:
+        """Copy a directory from source_host:source_path to self:target_path using rsync."""
+        self._rsync_files(
+            source_host,
+            source_path,
+            target_path,
+            extra_args=extra_args,
+            exclude_git=exclude_git,
+        )
+
     def _rsync_files(
         self,
         source_host: OnlineHostInterface,

--- a/libs/mng/imbue/mng/interfaces/host.py
+++ b/libs/mng/imbue/mng/interfaces/host.py
@@ -464,6 +464,25 @@ class OnlineHostInterface(HostInterface, ABC):
         ...
 
     @abstractmethod
+    def copy_directory(
+        self,
+        source_host: OnlineHostInterface,
+        source_path: Path,
+        target_path: Path,
+        extra_args: str | None = None,
+        exclude_git: bool = False,
+    ) -> None:
+        """Copy a directory from source_host:source_path to self:target_path using rsync.
+
+        Handles all combinations of local/remote source and target:
+        - Local to local
+        - Local to remote (push via SSH)
+        - Remote to local (pull via SSH)
+        - Remote to remote (via local temp directory as intermediary)
+        """
+        ...
+
+    @abstractmethod
     def save_agent_data(self, agent_id: AgentId, agent_data: Mapping[str, object]) -> None:
         """Persist agent data to external storage.
 


### PR DESCRIPTION
adds a `copy_directory` method to `OnlineHostInterface` and makes `Host` implement it by passing through directly to `_rsync_files`