### PR TITLE
let mng ask read the source code

### DIFF
--- a/libs/mng/imbue/mng/agents/default_plugins/headless_claude_agent.py
+++ b/libs/mng/imbue/mng/agents/default_plugins/headless_claude_agent.py
@@ -16,7 +16,7 @@ from imbue.mng.config.data_types import MngContext
 from imbue.mng.errors import NoCommandDefinedError
 from imbue.mng.errors import SendMessageError
 from imbue.mng.interfaces.agent import AgentInterface
-from imbue.mng.interfaces.agent import NoPermissionsAgentMixin
+from imbue.mng.interfaces.agent import SafePermissionsAgentMixin
 from imbue.mng.interfaces.agent import StreamingHeadlessAgentMixin
 from imbue.mng.interfaces.host import CreateAgentOptions
 from imbue.mng.interfaces.host import OnlineHostInterface
@@ -104,11 +104,12 @@ def _yield_text_deltas_from_lines(lines: list[str]) -> Iterator[str]:
             yield text
 
 
-class NoPermissionsClaudeAgent(ClaudeAgent, NoPermissionsAgentMixin):
-    """ClaudeAgent with no permissions granted (no tools, no trust needed).
+class SafePermissionsClaudeAgent(ClaudeAgent, SafePermissionsAgentMixin):
+    """ClaudeAgent whose permissions are safe enough to skip user confirmation.
 
     Skips trust validation and dialog dismissal during provisioning since
-    the agent cannot perform any actions that require permissions. All other
+    the agent's permissions are sufficiently restricted (e.g. read-only,
+    path-scoped) that user confirmation is unnecessary. All other
     provisioning (config dir setup, installation, hooks) runs normally.
     """
 
@@ -118,17 +119,17 @@ class NoPermissionsClaudeAgent(ClaudeAgent, NoPermissionsAgentMixin):
         options: CreateAgentOptions,
         mng_ctx: MngContext,
     ) -> None:
-        """No-op: skip trust/dialog validation for no-permissions agents."""
+        """No-op: skip trust/dialog validation for safe-permissions agents."""
 
     def _ensure_no_blocking_dialogs(self, source_path: Path | None, mng_ctx: MngContext) -> None:
-        """No-op: no permissions means no dialogs to check."""
+        """No-op: safe permissions means no dialogs to check."""
 
 
 class HeadlessClaudeAgentConfig(ClaudeAgentConfig):
     """Config for the headless_claude agent type."""
 
 
-class HeadlessClaude(NoPermissionsClaudeAgent, StreamingHeadlessAgentMixin):
+class HeadlessClaude(SafePermissionsClaudeAgent, StreamingHeadlessAgentMixin):
     """Agent type for non-interactive (headless) Claude usage.
 
     Runs `claude --print` with stdout redirected to a file so callers can

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -224,6 +224,56 @@ _EXECUTE_QUERY_PREFIX: Final[str] = (
 )
 
 
+_READ_ONLY_TOOLS: Final[str] = "Read,Glob,Grep"
+_MNG_REPO_URL: Final[str] = "https://github.com/imbue-ai/mng"
+
+
+def _find_mng_source_directory() -> Path | None:
+    """Find the mng project directory by walking up from this file.
+
+    Returns the project root (containing imbue/mng/) or None if not found.
+    Only requires the Python source tree to exist; docs/ may or may not be
+    present (the CLI docs are already injected from the help metadata registry).
+    """
+    candidate = Path(__file__).resolve().parents[3]
+    if (candidate / "imbue" / "mng").is_dir():
+        return candidate
+    return None
+
+
+def _build_source_access_context(source_directory: Path) -> str:
+    """Build system prompt section describing available source code access."""
+    parts = [
+        "\n\n# Source Code Access\n\n",
+        f"The mng source code is available on disk at: {source_directory}\n",
+        "You can use the Read, Glob, and Grep tools to explore it when answering questions.\n\n",
+        "Key directories:\n",
+    ]
+    is_docs_present = (source_directory / "docs").is_dir()
+    if is_docs_present:
+        parts.append(f"- {source_directory}/docs/ - User-facing documentation (markdown)\n")
+    parts += [
+        f"- {source_directory}/imbue/mng/ - Python source code\n",
+        f"- {source_directory}/imbue/mng/cli/ - CLI command implementations\n",
+        f"- {source_directory}/imbue/mng/agents/ - Agent type implementations\n",
+        f"- {source_directory}/imbue/mng/providers/ - Provider backends (docker, modal, local)\n",
+        f"- {source_directory}/imbue/mng/plugins/ - Plugin system\n",
+        f"- {source_directory}/imbue/mng/config/ - Configuration handling\n",
+    ]
+    return "".join(parts)
+
+
+def _build_web_access_context() -> str:
+    """Build system prompt section describing available web access."""
+    return (
+        "\n\n# Web Access\n\n"
+        "You have access to the WebFetch tool, restricted to the mng GitHub repository.\n"
+        f"The repository is at: {_MNG_REPO_URL}\n"
+        "Use WebFetch to read source files, documentation, issues, or pull requests\n"
+        "from the repository when the information is not available locally.\n"
+    )
+
+
 class ClaudeBackendInterface(MutableModel, ABC):
     """Abstraction over the claude backend for testability."""
 
@@ -250,13 +300,20 @@ def _destroy_on_exit(host: OnlineHostInterface, agent: AgentInterface) -> Iterat
 
 @contextmanager
 def _headless_claude_output(
-    mng_ctx: MngContext, prompt: str, system_prompt: str
+    mng_ctx: MngContext,
+    prompt: str,
+    system_prompt: str,
+    *,
+    allow_web: bool = False,
 ) -> Iterator[StreamingHeadlessAgentMixin]:
     """Create a HeadlessClaude agent, yield it, and destroy it on exit.
 
     Creates a temporary directory as the work path (no git branch creation),
     and passes claude args for headless operation (--system-prompt, --output-format
-    stream-json, --tools "", --no-session-persistence).
+    stream-json, --tools, --no-session-persistence).
+
+    When allow_web is True, the WebFetch tool is added to the tool list and
+    restricted to GitHub domains via --allowedTools.
     """
     provider = get_provider_instance(LOCAL_PROVIDER_NAME, mng_ctx)
     host_interface = provider.get_host(HostName("localhost"))
@@ -272,6 +329,20 @@ def _headless_claude_output(
         (work_path / ".mng-system-prompt").write_text(system_prompt)
         (work_path / ".mng-prompt").write_text(prompt)
 
+        tools = _READ_ONLY_TOOLS + (",WebFetch" if allow_web else "")
+
+        allowed_tools_args: tuple[str, ...] = (
+            "--allowedTools",
+            _READ_ONLY_TOOLS,
+        )
+        if allow_web:
+            allowed_tools_args += (
+                "--allowedTools",
+                "WebFetch(domain:github.com)",
+                "--allowedTools",
+                "WebFetch(domain:raw.githubusercontent.com)",
+            )
+
         agent_args = (
             "--system-prompt",
             '"$(cat "$MNG_AGENT_WORK_DIR/.mng-system-prompt")"',
@@ -280,7 +351,10 @@ def _headless_claude_output(
             "--verbose",
             "--include-partial-messages",
             "--tools",
-            '""',
+            f'"{tools}"',
+            *allowed_tools_args,
+            "--permission-mode",
+            "dontAsk",
             "--no-session-persistence",
             '"$(cat "$MNG_AGENT_WORK_DIR/.mng-prompt")"',
         )
@@ -313,9 +387,12 @@ class HeadlessClaudeBackend(ClaudeBackendInterface):
     """Runs claude via a HeadlessClaude agent for proper agent lifecycle management."""
 
     mng_ctx: MngContext
+    allow_web: bool = False
 
     def query(self, prompt: str, system_prompt: str) -> Iterator[str]:
-        with _headless_claude_output(self.mng_ctx, prompt, system_prompt) as agent:
+        with _headless_claude_output(
+            self.mng_ctx, prompt, system_prompt, allow_web=self.allow_web
+        ) as agent:
             yield from agent.stream_output()
 
 
@@ -380,6 +457,7 @@ class AskCliOptions(CommonCliOptions):
 
     query: tuple[str, ...]
     execute: bool
+    allow_web: bool
 
 
 @click.command(name="ask")
@@ -390,6 +468,11 @@ class AskCliOptions(CommonCliOptions):
     is_flag=True,
     help="Execute the generated CLI command instead of just printing it",
 )
+@optgroup.option(
+    "--allow-web",
+    is_flag=True,
+    help="Allow fetching content from the mng GitHub repository",
+)
 @add_common_options
 @click.pass_context
 def ask(ctx: click.Context, **kwargs: Any) -> None:
@@ -398,6 +481,30 @@ def ask(ctx: click.Context, **kwargs: Any) -> None:
     except AbortError as e:
         logger.error("Aborted: {}", e.message)
         ctx.exit(1)
+
+
+def _run_ask_query(
+    backend: ClaudeBackendInterface,
+    query_string: str,
+    *,
+    execute: bool,
+    allow_web: bool,
+    output_format: OutputFormat,
+) -> None:
+    """Run a query against the claude backend and handle the response."""
+    system_prompt = _build_ask_context()
+    source_dir = _find_mng_source_directory()
+    if source_dir is not None:
+        system_prompt += _build_source_access_context(source_dir)
+    if allow_web:
+        system_prompt += _build_web_access_context()
+    chunks = backend.query(prompt=query_string, system_prompt=system_prompt)
+
+    if execute:
+        response = _accumulate_chunks(chunks)
+        _execute_response(response=response, output_format=output_format)
+    else:
+        _stream_or_accumulate_response(chunks=chunks, output_format=output_format)
 
 
 def _ask_impl(ctx: click.Context, **kwargs: Any) -> None:
@@ -418,16 +525,14 @@ def _ask_impl(ctx: click.Context, **kwargs: Any) -> None:
 
     emit_info("Thinking...", output_opts.output_format)
 
-    backend = HeadlessClaudeBackend(mng_ctx=mng_ctx)
-    system_prompt = _build_ask_context()
-    chunks = backend.query(prompt=query_string, system_prompt=system_prompt)
-
-    if opts.execute:
-        # Accumulate all chunks for execute mode (don't stream to user)
-        response = _accumulate_chunks(chunks)
-        _execute_response(response=response, output_format=output_opts.output_format)
-    else:
-        _stream_or_accumulate_response(chunks=chunks, output_format=output_opts.output_format)
+    backend = HeadlessClaudeBackend(mng_ctx=mng_ctx, allow_web=opts.allow_web)
+    _run_ask_query(
+        backend=backend,
+        query_string=query_string,
+        execute=opts.execute,
+        allow_web=opts.allow_web,
+        output_format=output_opts.output_format,
+    )
 
 
 def _stream_or_accumulate_response(chunks: Iterator[str], output_format: OutputFormat) -> None:
@@ -474,7 +579,7 @@ def _execute_response(response: str, output_format: OutputFormat) -> None:
 CommandHelpMetadata(
     key="ask",
     one_line_description="Chat with mng for help [experimental]",
-    synopsis="mng ask [--execute] QUERY...",
+    synopsis="mng ask [--execute] [--allow-web] QUERY...",
     description="""Ask a question and mng will generate the appropriate CLI command.
 If no query is provided, shows general help about available commands
 and common workflows.

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -227,14 +227,26 @@ _EXECUTE_QUERY_PREFIX: Final[str] = (
 _MNG_REPO_URL: Final[str] = "https://github.com/imbue-ai/mng"
 
 
+# Monorepo library directory names whose source the ask agent can read.
+# Keep in sync with scripts/utils.py PACKAGES -- validated by
+# test_monorepo_package_dirs_matches_release_packages in ask_test.py.
+_MONOREPO_PACKAGE_DIRS: Final[tuple[str, ...]] = (
+    "concurrency_group",
+    "imbue_common",
+    "mng",
+    "mng_kanpan",
+    "mng_opencode",
+    "mng_pair",
+    "mng_tutor",
+)
+
+
 def _find_source_directories() -> list[Path]:
     """Find source directories for mng and all related monorepo packages.
 
     For a source checkout (editable install / uv run), returns the project root
-    of every monorepo library that contributes to the ``imbue`` namespace.  This
-    includes mng itself, all plugins, and dependency libraries such as
-    imbue_common and concurrency_group.  Detected by the mng project root
-    containing a pyproject.toml.
+    of every library listed in ``_MONOREPO_PACKAGE_DIRS`` that exists on disk.
+    Detected by the mng project root containing a pyproject.toml.
 
     For a regular install (site-packages), all packages merge into a single
     ``imbue/`` directory, so a single path is returned.
@@ -258,25 +270,14 @@ def _find_source_directories() -> list[Path]:
 
 
 def _find_source_checkout_directories(mng_project_root: Path) -> list[Path]:
-    """Discover all monorepo library roots that are siblings of mng.
-
-    Scans the parent directory of mng's project root (typically ``libs/``) for
-    sibling packages that have both a ``pyproject.toml`` and an ``imbue/``
-    subdirectory.  This captures mng itself, all plugins (mng_opencode, etc.),
-    and dependency libraries (imbue_common, concurrency_group, etc.).
-    """
+    """Return project roots for all monorepo libraries listed in _MONOREPO_PACKAGE_DIRS."""
     libs_dir = mng_project_root.parent
     directories: list[Path] = []
-    for child in sorted(libs_dir.iterdir()):
-        if child.is_dir() and (child / "pyproject.toml").is_file() and (child / "imbue").is_dir():
-            directories.append(child)
-
-    # Ensure mng itself is always included (defensive).
-    if mng_project_root not in directories:
-        directories.append(mng_project_root)
-        directories.sort()
-
-    return directories
+    for dir_name in _MONOREPO_PACKAGE_DIRS:
+        candidate = libs_dir / dir_name
+        if candidate.is_dir():
+            directories.append(candidate)
+    return sorted(directories)
 
 
 def _find_mng_package_dir(source_directories: list[Path]) -> Path | None:

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -228,15 +228,30 @@ _MNG_REPO_URL: Final[str] = "https://github.com/imbue-ai/mng"
 
 
 def _find_mng_source_directory() -> Path | None:
-    """Find the mng project directory by walking up from this file.
+    """Find the mng source directory by walking up from this file.
 
-    Returns the project root (containing imbue/mng/) or None if not found.
-    Only requires the Python source tree to exist; docs/ may or may not be
-    present (the CLI docs are already injected from the help metadata registry).
+    For a source checkout (editable install / uv run), returns the project root
+    so that docs/ and other top-level files are included.  Detected by the
+    presence of pyproject.toml alongside the imbue/ package.
+
+    For a regular install (site-packages), returns the imbue/ directory so the
+    agent can still read the Python source, but is not scoped to all of
+    site-packages.
+
+    Returns None only if the directory structure is completely unexpected.
     """
-    candidate = Path(__file__).resolve().parents[3]
-    if (candidate / "imbue" / "mng").is_dir():
-        return candidate
+    # parents[0]=cli/, [1]=mng/, [2]=imbue/, [3]=project-root-or-site-packages
+    imbue_dir = Path(__file__).resolve().parents[2]
+    project_root = imbue_dir.parent
+
+    # Source checkout: project root has pyproject.toml
+    if (project_root / "pyproject.toml").is_file():
+        return project_root
+
+    # Installed package: scope to imbue/ (contains only mng)
+    if (imbue_dir / "mng").is_dir():
+        return imbue_dir
+
     return None
 
 
@@ -248,16 +263,25 @@ def _build_source_access_context(source_directory: Path) -> str:
         "You can use the Read, Glob, and Grep tools to explore it when answering questions.\n\n",
         "Key directories:\n",
     ]
+    # Determine the path to the mng package within source_directory.
+    # For a source checkout, source_directory is the project root and the
+    # package is at imbue/mng/.  For an installed package, source_directory
+    # is the imbue/ directory and the package is at mng/.
+    if (source_directory / "imbue" / "mng").is_dir():
+        mng_pkg = source_directory / "imbue" / "mng"
+    else:
+        mng_pkg = source_directory / "mng"
+
     is_docs_present = (source_directory / "docs").is_dir()
     if is_docs_present:
         parts.append(f"- {source_directory}/docs/ - User-facing documentation (markdown)\n")
     parts += [
-        f"- {source_directory}/imbue/mng/ - Python source code\n",
-        f"- {source_directory}/imbue/mng/cli/ - CLI command implementations\n",
-        f"- {source_directory}/imbue/mng/agents/ - Agent type implementations\n",
-        f"- {source_directory}/imbue/mng/providers/ - Provider backends (docker, modal, local)\n",
-        f"- {source_directory}/imbue/mng/plugins/ - Plugin system\n",
-        f"- {source_directory}/imbue/mng/config/ - Configuration handling\n",
+        f"- {mng_pkg}/ - Python source code\n",
+        f"- {mng_pkg}/cli/ - CLI command implementations\n",
+        f"- {mng_pkg}/agents/ - Agent type implementations\n",
+        f"- {mng_pkg}/providers/ - Provider backends (docker, modal, local)\n",
+        f"- {mng_pkg}/plugins/ - Plugin system\n",
+        f"- {mng_pkg}/config/ - Configuration handling\n",
     ]
     return "".join(parts)
 

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -224,7 +224,6 @@ _EXECUTE_QUERY_PREFIX: Final[str] = (
 )
 
 
-_READ_ONLY_TOOLS: Final[str] = "Read,Glob,Grep"
 _MNG_REPO_URL: Final[str] = "https://github.com/imbue-ai/mng"
 
 
@@ -298,12 +297,54 @@ def _destroy_on_exit(host: OnlineHostInterface, agent: AgentInterface) -> Iterat
             logger.debug("Failed to destroy ask agent {}", agent.name)
 
 
+def _build_read_only_tools_and_permissions(
+    source_directory: Path | None,
+    *,
+    allow_web: bool,
+) -> tuple[str, tuple[str, ...]]:
+    """Build the --tools value and --allowedTools args for the ask agent.
+
+    When source_directory is provided, Read/Glob/Grep are included and
+    path-scoped to that directory. When None, only WebFetch (if enabled)
+    is available.
+
+    Returns (tools_csv, allowed_tools_args).
+    """
+    tools_parts: list[str] = []
+    allowed_tools_args: tuple[str, ...] = ()
+
+    if source_directory is not None:
+        tools_parts.append("Read,Glob,Grep")
+        scope = f"//{source_directory}/**"
+        allowed_tools_args += (
+            "--allowedTools",
+            f"Read({scope})",
+            "--allowedTools",
+            f"Glob({scope})",
+            "--allowedTools",
+            f"Grep({scope})",
+        )
+
+    if allow_web:
+        tools_parts.append("WebFetch")
+        allowed_tools_args += (
+            "--allowedTools",
+            "WebFetch(domain:github.com)",
+            "--allowedTools",
+            "WebFetch(domain:raw.githubusercontent.com)",
+        )
+
+    tools_csv = ",".join(tools_parts)
+    return tools_csv, allowed_tools_args
+
+
 @contextmanager
 def _headless_claude_output(
     mng_ctx: MngContext,
     prompt: str,
     system_prompt: str,
     *,
+    source_directory: Path | None = None,
     allow_web: bool = False,
 ) -> Iterator[StreamingHeadlessAgentMixin]:
     """Create a HeadlessClaude agent, yield it, and destroy it on exit.
@@ -312,8 +353,8 @@ def _headless_claude_output(
     and passes claude args for headless operation (--system-prompt, --output-format
     stream-json, --tools, --no-session-persistence).
 
-    When allow_web is True, the WebFetch tool is added to the tool list and
-    restricted to GitHub domains via --allowedTools.
+    When source_directory is provided, Read/Glob/Grep tools are path-scoped to
+    that directory. When allow_web is True, WebFetch is restricted to GitHub domains.
     """
     provider = get_provider_instance(LOCAL_PROVIDER_NAME, mng_ctx)
     host_interface = provider.get_host(HostName("localhost"))
@@ -329,19 +370,9 @@ def _headless_claude_output(
         (work_path / ".mng-system-prompt").write_text(system_prompt)
         (work_path / ".mng-prompt").write_text(prompt)
 
-        tools = _READ_ONLY_TOOLS + (",WebFetch" if allow_web else "")
-
-        allowed_tools_args: tuple[str, ...] = (
-            "--allowedTools",
-            _READ_ONLY_TOOLS,
+        tools, allowed_tools_args = _build_read_only_tools_and_permissions(
+            source_directory, allow_web=allow_web,
         )
-        if allow_web:
-            allowed_tools_args += (
-                "--allowedTools",
-                "WebFetch(domain:github.com)",
-                "--allowedTools",
-                "WebFetch(domain:raw.githubusercontent.com)",
-            )
 
         agent_args = (
             "--system-prompt",
@@ -387,11 +418,16 @@ class HeadlessClaudeBackend(ClaudeBackendInterface):
     """Runs claude via a HeadlessClaude agent for proper agent lifecycle management."""
 
     mng_ctx: MngContext
+    source_directory: Path | None = None
     allow_web: bool = False
 
     def query(self, prompt: str, system_prompt: str) -> Iterator[str]:
         with _headless_claude_output(
-            self.mng_ctx, prompt, system_prompt, allow_web=self.allow_web
+            self.mng_ctx,
+            prompt,
+            system_prompt,
+            source_directory=self.source_directory,
+            allow_web=self.allow_web,
         ) as agent:
             yield from agent.stream_output()
 
@@ -487,15 +523,15 @@ def _run_ask_query(
     backend: ClaudeBackendInterface,
     query_string: str,
     *,
+    source_directory: Path | None,
     execute: bool,
     allow_web: bool,
     output_format: OutputFormat,
 ) -> None:
     """Run a query against the claude backend and handle the response."""
     system_prompt = _build_ask_context()
-    source_dir = _find_mng_source_directory()
-    if source_dir is not None:
-        system_prompt += _build_source_access_context(source_dir)
+    if source_directory is not None:
+        system_prompt += _build_source_access_context(source_directory)
     if allow_web:
         system_prompt += _build_web_access_context()
     chunks = backend.query(prompt=query_string, system_prompt=system_prompt)
@@ -525,10 +561,14 @@ def _ask_impl(ctx: click.Context, **kwargs: Any) -> None:
 
     emit_info("Thinking...", output_opts.output_format)
 
-    backend = HeadlessClaudeBackend(mng_ctx=mng_ctx, allow_web=opts.allow_web)
+    source_dir = _find_mng_source_directory()
+    backend = HeadlessClaudeBackend(
+        mng_ctx=mng_ctx, source_directory=source_dir, allow_web=opts.allow_web,
+    )
     _run_ask_query(
         backend=backend,
         query_string=query_string,
+        source_directory=source_dir,
         execute=opts.execute,
         allow_web=opts.allow_web,
         output_format=output_opts.output_format,

--- a/libs/mng/imbue/mng/cli/ask.py
+++ b/libs/mng/imbue/mng/cli/ask.py
@@ -227,62 +227,102 @@ _EXECUTE_QUERY_PREFIX: Final[str] = (
 _MNG_REPO_URL: Final[str] = "https://github.com/imbue-ai/mng"
 
 
-def _find_mng_source_directory() -> Path | None:
-    """Find the mng source directory by walking up from this file.
+def _find_source_directories() -> list[Path]:
+    """Find source directories for mng and all related monorepo packages.
 
     For a source checkout (editable install / uv run), returns the project root
-    so that docs/ and other top-level files are included.  Detected by the
-    presence of pyproject.toml alongside the imbue/ package.
+    of every monorepo library that contributes to the ``imbue`` namespace.  This
+    includes mng itself, all plugins, and dependency libraries such as
+    imbue_common and concurrency_group.  Detected by the mng project root
+    containing a pyproject.toml.
 
-    For a regular install (site-packages), returns the imbue/ directory so the
-    agent can still read the Python source, but is not scoped to all of
-    site-packages.
+    For a regular install (site-packages), all packages merge into a single
+    ``imbue/`` directory, so a single path is returned.
 
-    Returns None only if the directory structure is completely unexpected.
+    Returns an empty list only if the directory structure is completely
+    unexpected.
     """
     # parents[0]=cli/, [1]=mng/, [2]=imbue/, [3]=project-root-or-site-packages
     imbue_dir = Path(__file__).resolve().parents[2]
     project_root = imbue_dir.parent
 
-    # Source checkout: project root has pyproject.toml
+    # Source checkout: mng's project root has pyproject.toml.
     if (project_root / "pyproject.toml").is_file():
-        return project_root
+        return _find_source_checkout_directories(project_root)
 
-    # Installed package: scope to imbue/ (contains only mng)
+    # Installed package: scope to imbue/ (covers mng + plugins + deps)
     if (imbue_dir / "mng").is_dir():
-        return imbue_dir
+        return [imbue_dir]
 
+    return []
+
+
+def _find_source_checkout_directories(mng_project_root: Path) -> list[Path]:
+    """Discover all monorepo library roots that are siblings of mng.
+
+    Scans the parent directory of mng's project root (typically ``libs/``) for
+    sibling packages that have both a ``pyproject.toml`` and an ``imbue/``
+    subdirectory.  This captures mng itself, all plugins (mng_opencode, etc.),
+    and dependency libraries (imbue_common, concurrency_group, etc.).
+    """
+    libs_dir = mng_project_root.parent
+    directories: list[Path] = []
+    for child in sorted(libs_dir.iterdir()):
+        if child.is_dir() and (child / "pyproject.toml").is_file() and (child / "imbue").is_dir():
+            directories.append(child)
+
+    # Ensure mng itself is always included (defensive).
+    if mng_project_root not in directories:
+        directories.append(mng_project_root)
+        directories.sort()
+
+    return directories
+
+
+def _find_mng_package_dir(source_directories: list[Path]) -> Path | None:
+    """Locate the mng Python package directory among the source directories."""
+    for d in source_directories:
+        # Source checkout: project root contains imbue/mng/
+        if (d / "imbue" / "mng").is_dir():
+            return d / "imbue" / "mng"
+        # Installed: imbue/ dir contains mng/
+        if (d / "mng").is_dir() and (d / "mng" / "cli").is_dir():
+            return d / "mng"
     return None
 
 
-def _build_source_access_context(source_directory: Path) -> str:
+def _build_source_access_context(source_directories: list[Path]) -> str:
     """Build system prompt section describing available source code access."""
     parts = [
         "\n\n# Source Code Access\n\n",
-        f"The mng source code is available on disk at: {source_directory}\n",
-        "You can use the Read, Glob, and Grep tools to explore it when answering questions.\n\n",
-        "Key directories:\n",
+        "You can use the Read, Glob, and Grep tools to explore source code "
+        "when answering questions.\n\n",
     ]
-    # Determine the path to the mng package within source_directory.
-    # For a source checkout, source_directory is the project root and the
-    # package is at imbue/mng/.  For an installed package, source_directory
-    # is the imbue/ directory and the package is at mng/.
-    if (source_directory / "imbue" / "mng").is_dir():
-        mng_pkg = source_directory / "imbue" / "mng"
-    else:
-        mng_pkg = source_directory / "mng"
 
-    is_docs_present = (source_directory / "docs").is_dir()
-    if is_docs_present:
-        parts.append(f"- {source_directory}/docs/ - User-facing documentation (markdown)\n")
-    parts += [
-        f"- {mng_pkg}/ - Python source code\n",
-        f"- {mng_pkg}/cli/ - CLI command implementations\n",
-        f"- {mng_pkg}/agents/ - Agent type implementations\n",
-        f"- {mng_pkg}/providers/ - Provider backends (docker, modal, local)\n",
-        f"- {mng_pkg}/plugins/ - Plugin system\n",
-        f"- {mng_pkg}/config/ - Configuration handling\n",
-    ]
+    mng_pkg = _find_mng_package_dir(source_directories)
+    mng_root: Path | None = None
+
+    if mng_pkg is not None:
+        # The mng project root is two levels above imbue/mng/, or one above mng/.
+        mng_root = mng_pkg.parent.parent if (mng_pkg.parent.name == "imbue") else mng_pkg.parent
+        parts.append("Key mng directories:\n")
+        if (mng_root / "docs").is_dir():
+            parts.append(f"- {mng_root}/docs/ - User-facing documentation (markdown)\n")
+        parts += [
+            f"- {mng_pkg}/ - Python source code\n",
+            f"- {mng_pkg}/cli/ - CLI command implementations\n",
+            f"- {mng_pkg}/agents/ - Agent type implementations\n",
+            f"- {mng_pkg}/providers/ - Provider backends (docker, modal, local)\n",
+            f"- {mng_pkg}/plugins/ - Plugin system\n",
+            f"- {mng_pkg}/config/ - Configuration handling\n",
+        ]
+
+    other_dirs = [d for d in source_directories if d != mng_root]
+    if other_dirs:
+        parts.append("\nOther accessible source directories (plugins and dependencies):\n")
+        for d in other_dirs:
+            parts.append(f"- {d}/\n")
+
     return "".join(parts)
 
 
@@ -322,14 +362,14 @@ def _destroy_on_exit(host: OnlineHostInterface, agent: AgentInterface) -> Iterat
 
 
 def _build_read_only_tools_and_permissions(
-    source_directory: Path | None,
+    source_directories: list[Path],
     *,
     allow_web: bool,
 ) -> tuple[str, tuple[str, ...]]:
     """Build the --tools value and --allowedTools args for the ask agent.
 
-    When source_directory is provided, Read/Glob/Grep are included and
-    path-scoped to that directory. When None, only WebFetch (if enabled)
+    When source_directories is non-empty, Read/Glob/Grep are included and
+    path-scoped to those directories. When empty, only WebFetch (if enabled)
     is available.
 
     Returns (tools_csv, allowed_tools_args).
@@ -337,17 +377,18 @@ def _build_read_only_tools_and_permissions(
     tools_parts: list[str] = []
     allowed_tools_args: tuple[str, ...] = ()
 
-    if source_directory is not None:
+    if source_directories:
         tools_parts.append("Read,Glob,Grep")
-        scope = f"//{source_directory}/**"
-        allowed_tools_args += (
-            "--allowedTools",
-            f"Read({scope})",
-            "--allowedTools",
-            f"Glob({scope})",
-            "--allowedTools",
-            f"Grep({scope})",
-        )
+        for source_directory in source_directories:
+            scope = f"//{source_directory}/**"
+            allowed_tools_args += (
+                "--allowedTools",
+                f"Read({scope})",
+                "--allowedTools",
+                f"Glob({scope})",
+                "--allowedTools",
+                f"Grep({scope})",
+            )
 
     if allow_web:
         tools_parts.append("WebFetch")
@@ -368,7 +409,7 @@ def _headless_claude_output(
     prompt: str,
     system_prompt: str,
     *,
-    source_directory: Path | None = None,
+    source_directories: list[Path] | None = None,
     allow_web: bool = False,
 ) -> Iterator[StreamingHeadlessAgentMixin]:
     """Create a HeadlessClaude agent, yield it, and destroy it on exit.
@@ -377,8 +418,9 @@ def _headless_claude_output(
     and passes claude args for headless operation (--system-prompt, --output-format
     stream-json, --tools, --no-session-persistence).
 
-    When source_directory is provided, Read/Glob/Grep tools are path-scoped to
-    that directory. When allow_web is True, WebFetch is restricted to GitHub domains.
+    When source_directories is non-empty, Read/Glob/Grep tools are path-scoped
+    to those directories. When allow_web is True, WebFetch is restricted to
+    GitHub domains.
     """
     provider = get_provider_instance(LOCAL_PROVIDER_NAME, mng_ctx)
     host_interface = provider.get_host(HostName("localhost"))
@@ -395,7 +437,7 @@ def _headless_claude_output(
         (work_path / ".mng-prompt").write_text(prompt)
 
         tools, allowed_tools_args = _build_read_only_tools_and_permissions(
-            source_directory, allow_web=allow_web,
+            source_directories or [], allow_web=allow_web,
         )
 
         agent_args = (
@@ -442,7 +484,7 @@ class HeadlessClaudeBackend(ClaudeBackendInterface):
     """Runs claude via a HeadlessClaude agent for proper agent lifecycle management."""
 
     mng_ctx: MngContext
-    source_directory: Path | None = None
+    source_directories: list[Path] = []
     allow_web: bool = False
 
     def query(self, prompt: str, system_prompt: str) -> Iterator[str]:
@@ -450,7 +492,7 @@ class HeadlessClaudeBackend(ClaudeBackendInterface):
             self.mng_ctx,
             prompt,
             system_prompt,
-            source_directory=self.source_directory,
+            source_directories=self.source_directories,
             allow_web=self.allow_web,
         ) as agent:
             yield from agent.stream_output()
@@ -547,15 +589,15 @@ def _run_ask_query(
     backend: ClaudeBackendInterface,
     query_string: str,
     *,
-    source_directory: Path | None,
+    source_directories: list[Path],
     execute: bool,
     allow_web: bool,
     output_format: OutputFormat,
 ) -> None:
     """Run a query against the claude backend and handle the response."""
     system_prompt = _build_ask_context()
-    if source_directory is not None:
-        system_prompt += _build_source_access_context(source_directory)
+    if source_directories:
+        system_prompt += _build_source_access_context(source_directories)
     if allow_web:
         system_prompt += _build_web_access_context()
     chunks = backend.query(prompt=query_string, system_prompt=system_prompt)
@@ -585,14 +627,14 @@ def _ask_impl(ctx: click.Context, **kwargs: Any) -> None:
 
     emit_info("Thinking...", output_opts.output_format)
 
-    source_dir = _find_mng_source_directory()
+    source_dirs = _find_source_directories()
     backend = HeadlessClaudeBackend(
-        mng_ctx=mng_ctx, source_directory=source_dir, allow_web=opts.allow_web,
+        mng_ctx=mng_ctx, source_directories=source_dirs, allow_web=opts.allow_web,
     )
     _run_ask_query(
         backend=backend,
         query_string=query_string,
-        source_directory=source_dir,
+        source_directories=source_dirs,
         execute=opts.execute,
         allow_web=opts.allow_web,
         output_format=output_opts.output_format,

--- a/libs/mng/imbue/mng/cli/ask_test.py
+++ b/libs/mng/imbue/mng/cli/ask_test.py
@@ -1,3 +1,5 @@
+import importlib
+import importlib.util
 import json
 from collections.abc import Iterator
 from pathlib import Path
@@ -14,6 +16,7 @@ from imbue.mng.cli.ask import _build_read_only_tools_and_permissions
 from imbue.mng.cli.ask import _build_source_access_context
 from imbue.mng.cli.ask import _build_web_access_context
 from imbue.mng.cli.ask import _execute_response
+from imbue.mng.cli.ask import _MONOREPO_PACKAGE_DIRS
 from imbue.mng.cli.ask import _find_source_checkout_directories
 from imbue.mng.cli.ask import _find_source_directories
 from imbue.mng.cli.ask import _run_ask_query
@@ -295,19 +298,24 @@ def test_find_source_directories_returns_empty_when_not_found(
 # =============================================================================
 
 
-def test_find_source_checkout_directories_includes_all_monorepo_libs() -> None:
-    """All libs/ packages with pyproject.toml should be discovered."""
+def test_monorepo_package_dirs_matches_release_packages() -> None:
+    """_MONOREPO_PACKAGE_DIRS must stay in sync with scripts/utils.py PACKAGES."""
+    repo_root = Path(__file__).resolve().parents[5]
+    spec = importlib.util.spec_from_file_location("scripts.utils", repo_root / "scripts" / "utils.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    release_dir_names = {pkg.dir_name for pkg in mod.PACKAGES}
+    assert set(_MONOREPO_PACKAGE_DIRS) == release_dir_names
+
+
+def test_find_source_checkout_directories_returns_listed_packages() -> None:
+    """Should return project roots for all packages listed in _MONOREPO_PACKAGE_DIRS."""
     mng_project_root = Path(__file__).resolve().parents[3]
-    libs_dir = mng_project_root.parent
     result = _find_source_checkout_directories(mng_project_root)
-
-    # Build expected set: every libs/ subdirectory with a pyproject.toml and imbue/ dir.
-    expected = set()
-    for child in libs_dir.iterdir():
-        if child.is_dir() and (child / "pyproject.toml").is_file() and (child / "imbue").is_dir():
-            expected.add(child)
-
-    assert set(result) == expected
+    result_names = {d.name for d in result}
+    assert result_names == set(_MONOREPO_PACKAGE_DIRS)
 
 
 # =============================================================================

--- a/libs/mng/imbue/mng/cli/ask_test.py
+++ b/libs/mng/imbue/mng/cli/ask_test.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterator
+from pathlib import Path
 
 import pluggy
 import pytest
@@ -9,7 +10,11 @@ import imbue.mng.cli.ask as ask_module
 from imbue.mng.cli.ask import ClaudeBackendInterface
 from imbue.mng.cli.ask import _accumulate_chunks
 from imbue.mng.cli.ask import _build_ask_context
+from imbue.mng.cli.ask import _build_source_access_context
+from imbue.mng.cli.ask import _build_web_access_context
 from imbue.mng.cli.ask import _execute_response
+from imbue.mng.cli.ask import _find_mng_source_directory
+from imbue.mng.cli.ask import _run_ask_query
 from imbue.mng.cli.ask import _show_command_summary
 from imbue.mng.cli.ask import ask
 from imbue.mng.errors import MngError
@@ -239,3 +244,124 @@ def test_show_command_summary_jsonl(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     data = json.loads(captured.out.strip())
     assert data["event"] == "commands"
+
+
+# =============================================================================
+# Tests for _find_mng_source_directory
+# =============================================================================
+
+
+def test_find_mng_source_directory_returns_path() -> None:
+    """Should find the mng source directory when running from the source tree."""
+    result = _find_mng_source_directory()
+    assert result is not None
+    assert (result / "imbue" / "mng").is_dir()
+
+
+def test_find_mng_source_directory_returns_none_when_not_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Should return None when the source tree is not found."""
+    fake_file = tmp_path / "a" / "b" / "c" / "ask.py"
+    fake_file.parent.mkdir(parents=True)
+    fake_file.touch()
+    monkeypatch.setattr(ask_module, "__file__", str(fake_file))
+    result = _find_mng_source_directory()
+    assert result is None
+
+
+# =============================================================================
+# Tests for _build_source_access_context
+# =============================================================================
+
+
+def test_build_source_access_context_contains_key_info(tmp_path: Path) -> None:
+    """Should include the source directory path and key directories."""
+    (tmp_path / "imbue" / "mng" / "cli").mkdir(parents=True)
+    (tmp_path / "docs").mkdir()
+    context = _build_source_access_context(tmp_path)
+    assert str(tmp_path) in context
+    assert "Source Code Access" in context
+    assert "docs/" in context
+    assert "imbue/mng/" in context
+
+
+def test_build_source_access_context_omits_docs_when_missing(tmp_path: Path) -> None:
+    """Should omit docs directory reference when docs/ does not exist."""
+    (tmp_path / "imbue" / "mng").mkdir(parents=True)
+    context = _build_source_access_context(tmp_path)
+    assert "docs/" not in context
+
+
+# =============================================================================
+# Tests for _build_web_access_context
+# =============================================================================
+
+
+def test_build_web_access_context_contains_github_info() -> None:
+    """Should include GitHub repository reference."""
+    context = _build_web_access_context()
+    assert "Web Access" in context
+    assert "github.com/imbue-ai/mng" in context
+    assert "WebFetch" in context
+
+
+# =============================================================================
+# Tests for _run_ask_query
+# =============================================================================
+
+
+def test_run_ask_query_includes_source_context() -> None:
+    """System prompt should include source access context when source directory exists."""
+    backend = FakeClaude(responses=["mng list"])
+    _run_ask_query(
+        backend=backend,
+        query_string="test query",
+        execute=False,
+        allow_web=False,
+        output_format=OutputFormat.HUMAN,
+    )
+    assert len(backend.system_prompts) == 1
+    assert "Source Code Access" in backend.system_prompts[0]
+
+
+def test_run_ask_query_includes_web_context_when_enabled() -> None:
+    """System prompt should include web access context when allow_web is True."""
+    backend = FakeClaude(responses=["mng list"])
+    _run_ask_query(
+        backend=backend,
+        query_string="test query",
+        execute=False,
+        allow_web=True,
+        output_format=OutputFormat.HUMAN,
+    )
+    assert len(backend.system_prompts) == 1
+    assert "Web Access" in backend.system_prompts[0]
+
+
+def test_run_ask_query_excludes_web_context_when_disabled() -> None:
+    """System prompt should not include web access context when allow_web is False."""
+    backend = FakeClaude(responses=["mng list"])
+    _run_ask_query(
+        backend=backend,
+        query_string="test query",
+        execute=False,
+        allow_web=False,
+        output_format=OutputFormat.HUMAN,
+    )
+    assert len(backend.system_prompts) == 1
+    assert "Web Access" not in backend.system_prompts[0]
+
+
+def test_ask_with_allow_web_flag(
+    fake_claude: FakeClaude,
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """The --allow-web flag should be accepted without error."""
+    fake_claude.responses.append("mng list")
+    result = cli_runner.invoke(
+        ask, ["--allow-web", "how", "to", "list?"], obj=plugin_manager, catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "mng list" in result.output

--- a/libs/mng/imbue/mng/cli/ask_test.py
+++ b/libs/mng/imbue/mng/cli/ask_test.py
@@ -252,15 +252,29 @@ def test_show_command_summary_jsonl(capsys: pytest.CaptureFixture[str]) -> None:
 # =============================================================================
 
 
-def test_find_mng_source_directory_returns_path() -> None:
-    """Should find the mng source directory when running from the source tree."""
+def test_find_mng_source_directory_returns_project_root_for_source_checkout() -> None:
+    """Should return the project root (with pyproject.toml) when running from source."""
     result = _find_mng_source_directory()
     assert result is not None
+    assert (result / "pyproject.toml").is_file()
     assert (result / "imbue" / "mng").is_dir()
 
 
+def test_find_mng_source_directory_returns_imbue_dir_for_installed_package(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Should return the imbue/ directory when installed (no pyproject.toml)."""
+    # Simulate site-packages/imbue/mng/cli/ask.py
+    fake_file = tmp_path / "imbue" / "mng" / "cli" / "ask.py"
+    fake_file.parent.mkdir(parents=True)
+    fake_file.touch()
+    monkeypatch.setattr(ask_module, "__file__", str(fake_file))
+    result = _find_mng_source_directory()
+    assert result == tmp_path / "imbue"
+
+
 def test_find_mng_source_directory_returns_none_when_not_found(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Should return None when the source tree is not found."""
     fake_file = tmp_path / "a" / "b" / "c" / "ask.py"
@@ -292,6 +306,16 @@ def test_build_source_access_context_omits_docs_when_missing(tmp_path: Path) -> 
     (tmp_path / "imbue" / "mng").mkdir(parents=True)
     context = _build_source_access_context(tmp_path)
     assert "docs/" not in context
+
+
+def test_build_source_access_context_installed_package(tmp_path: Path) -> None:
+    """When source_directory is the imbue/ dir, paths should use mng/ not imbue/mng/."""
+    imbue_dir = tmp_path / "imbue"
+    (imbue_dir / "mng" / "cli").mkdir(parents=True)
+    context = _build_source_access_context(imbue_dir)
+    assert str(imbue_dir / "mng") + "/" in context
+    # Should NOT contain doubled imbue/imbue/mng path
+    assert "imbue/imbue" not in context
 
 
 # =============================================================================

--- a/libs/mng/imbue/mng/cli/ask_test.py
+++ b/libs/mng/imbue/mng/cli/ask_test.py
@@ -10,6 +10,7 @@ import imbue.mng.cli.ask as ask_module
 from imbue.mng.cli.ask import ClaudeBackendInterface
 from imbue.mng.cli.ask import _accumulate_chunks
 from imbue.mng.cli.ask import _build_ask_context
+from imbue.mng.cli.ask import _build_read_only_tools_and_permissions
 from imbue.mng.cli.ask import _build_source_access_context
 from imbue.mng.cli.ask import _build_web_access_context
 from imbue.mng.cli.ask import _execute_response
@@ -307,16 +308,57 @@ def test_build_web_access_context_contains_github_info() -> None:
 
 
 # =============================================================================
+# Tests for _build_read_only_tools_and_permissions
+# =============================================================================
+
+
+def test_build_tools_with_source_directory_scopes_read_tools(tmp_path: Path) -> None:
+    """Read/Glob/Grep should be included and path-scoped to source_directory."""
+    tools, args = _build_read_only_tools_and_permissions(tmp_path, allow_web=False)
+    assert tools == "Read,Glob,Grep"
+    assert f"Read(//{tmp_path}/**)" in args
+    assert f"Glob(//{tmp_path}/**)" in args
+    assert f"Grep(//{tmp_path}/**)" in args
+
+
+def test_build_tools_without_source_directory_excludes_read_tools() -> None:
+    """When source_directory is None, no Read/Glob/Grep tools should be included."""
+    tools, args = _build_read_only_tools_and_permissions(None, allow_web=False)
+    assert tools == ""
+    assert args == ()
+
+
+def test_build_tools_with_web_includes_webfetch() -> None:
+    """WebFetch should be included and domain-scoped when allow_web is True."""
+    tools, args = _build_read_only_tools_and_permissions(None, allow_web=True)
+    assert tools == "WebFetch"
+    assert "WebFetch(domain:github.com)" in args
+    assert "WebFetch(domain:raw.githubusercontent.com)" in args
+
+
+def test_build_tools_with_source_and_web_includes_all(tmp_path: Path) -> None:
+    """Both read tools and WebFetch should be included when both are enabled."""
+    tools, args = _build_read_only_tools_and_permissions(tmp_path, allow_web=True)
+    assert "Read,Glob,Grep" in tools
+    assert "WebFetch" in tools
+    assert f"Read(//{tmp_path}/**)" in args
+    assert "WebFetch(domain:github.com)" in args
+
+
+# =============================================================================
 # Tests for _run_ask_query
 # =============================================================================
 
 
 def test_run_ask_query_includes_source_context() -> None:
     """System prompt should include source access context when source directory exists."""
+    source_dir = _find_mng_source_directory()
+    assert source_dir is not None
     backend = FakeClaude(responses=["mng list"])
     _run_ask_query(
         backend=backend,
         query_string="test query",
+        source_directory=source_dir,
         execute=False,
         allow_web=False,
         output_format=OutputFormat.HUMAN,
@@ -325,12 +367,28 @@ def test_run_ask_query_includes_source_context() -> None:
     assert "Source Code Access" in backend.system_prompts[0]
 
 
+def test_run_ask_query_excludes_source_context_when_none() -> None:
+    """System prompt should not include source access context when source_directory is None."""
+    backend = FakeClaude(responses=["mng list"])
+    _run_ask_query(
+        backend=backend,
+        query_string="test query",
+        source_directory=None,
+        execute=False,
+        allow_web=False,
+        output_format=OutputFormat.HUMAN,
+    )
+    assert len(backend.system_prompts) == 1
+    assert "Source Code Access" not in backend.system_prompts[0]
+
+
 def test_run_ask_query_includes_web_context_when_enabled() -> None:
     """System prompt should include web access context when allow_web is True."""
     backend = FakeClaude(responses=["mng list"])
     _run_ask_query(
         backend=backend,
         query_string="test query",
+        source_directory=None,
         execute=False,
         allow_web=True,
         output_format=OutputFormat.HUMAN,
@@ -345,6 +403,7 @@ def test_run_ask_query_excludes_web_context_when_disabled() -> None:
     _run_ask_query(
         backend=backend,
         query_string="test query",
+        source_directory=None,
         execute=False,
         allow_web=False,
         output_format=OutputFormat.HUMAN,

--- a/libs/mng/imbue/mng/cli/ask_test.py
+++ b/libs/mng/imbue/mng/cli/ask_test.py
@@ -14,7 +14,8 @@ from imbue.mng.cli.ask import _build_read_only_tools_and_permissions
 from imbue.mng.cli.ask import _build_source_access_context
 from imbue.mng.cli.ask import _build_web_access_context
 from imbue.mng.cli.ask import _execute_response
-from imbue.mng.cli.ask import _find_mng_source_directory
+from imbue.mng.cli.ask import _find_source_checkout_directories
+from imbue.mng.cli.ask import _find_source_directories
 from imbue.mng.cli.ask import _run_ask_query
 from imbue.mng.cli.ask import _show_command_summary
 from imbue.mng.cli.ask import ask
@@ -248,19 +249,23 @@ def test_show_command_summary_jsonl(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 # =============================================================================
-# Tests for _find_mng_source_directory
+# Tests for _find_source_directories
 # =============================================================================
 
 
-def test_find_mng_source_directory_returns_project_root_for_source_checkout() -> None:
-    """Should return the project root (with pyproject.toml) when running from source."""
-    result = _find_mng_source_directory()
-    assert result is not None
-    assert (result / "pyproject.toml").is_file()
-    assert (result / "imbue" / "mng").is_dir()
+def test_find_source_directories_returns_monorepo_libs_for_source_checkout() -> None:
+    """Should return multiple project roots when running from a source checkout."""
+    result = _find_source_directories()
+    assert len(result) > 1
+    # Every returned directory should have a pyproject.toml.
+    for d in result:
+        assert (d / "pyproject.toml").is_file(), f"Missing pyproject.toml in {d}"
+    # mng itself must be included.
+    mng_roots = [d for d in result if (d / "imbue" / "mng").is_dir()]
+    assert len(mng_roots) == 1
 
 
-def test_find_mng_source_directory_returns_imbue_dir_for_installed_package(
+def test_find_source_directories_returns_imbue_dir_for_installed_package(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Should return the imbue/ directory when installed (no pyproject.toml)."""
@@ -269,20 +274,40 @@ def test_find_mng_source_directory_returns_imbue_dir_for_installed_package(
     fake_file.parent.mkdir(parents=True)
     fake_file.touch()
     monkeypatch.setattr(ask_module, "__file__", str(fake_file))
-    result = _find_mng_source_directory()
-    assert result == tmp_path / "imbue"
+    result = _find_source_directories()
+    assert result == [tmp_path / "imbue"]
 
 
-def test_find_mng_source_directory_returns_none_when_not_found(
+def test_find_source_directories_returns_empty_when_not_found(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    """Should return None when the source tree is not found."""
+    """Should return empty list when the source tree is not found."""
     fake_file = tmp_path / "a" / "b" / "c" / "ask.py"
     fake_file.parent.mkdir(parents=True)
     fake_file.touch()
     monkeypatch.setattr(ask_module, "__file__", str(fake_file))
-    result = _find_mng_source_directory()
-    assert result is None
+    result = _find_source_directories()
+    assert result == []
+
+
+# =============================================================================
+# Tests for _find_source_checkout_directories
+# =============================================================================
+
+
+def test_find_source_checkout_directories_includes_all_monorepo_libs() -> None:
+    """All libs/ packages with pyproject.toml should be discovered."""
+    mng_project_root = Path(__file__).resolve().parents[3]
+    libs_dir = mng_project_root.parent
+    result = _find_source_checkout_directories(mng_project_root)
+
+    # Build expected set: every libs/ subdirectory with a pyproject.toml and imbue/ dir.
+    expected = set()
+    for child in libs_dir.iterdir():
+        if child.is_dir() and (child / "pyproject.toml").is_file() and (child / "imbue").is_dir():
+            expected.add(child)
+
+    assert set(result) == expected
 
 
 # =============================================================================
@@ -294,7 +319,7 @@ def test_build_source_access_context_contains_key_info(tmp_path: Path) -> None:
     """Should include the source directory path and key directories."""
     (tmp_path / "imbue" / "mng" / "cli").mkdir(parents=True)
     (tmp_path / "docs").mkdir()
-    context = _build_source_access_context(tmp_path)
+    context = _build_source_access_context([tmp_path])
     assert str(tmp_path) in context
     assert "Source Code Access" in context
     assert "docs/" in context
@@ -304,7 +329,7 @@ def test_build_source_access_context_contains_key_info(tmp_path: Path) -> None:
 def test_build_source_access_context_omits_docs_when_missing(tmp_path: Path) -> None:
     """Should omit docs directory reference when docs/ does not exist."""
     (tmp_path / "imbue" / "mng").mkdir(parents=True)
-    context = _build_source_access_context(tmp_path)
+    context = _build_source_access_context([tmp_path])
     assert "docs/" not in context
 
 
@@ -312,10 +337,22 @@ def test_build_source_access_context_installed_package(tmp_path: Path) -> None:
     """When source_directory is the imbue/ dir, paths should use mng/ not imbue/mng/."""
     imbue_dir = tmp_path / "imbue"
     (imbue_dir / "mng" / "cli").mkdir(parents=True)
-    context = _build_source_access_context(imbue_dir)
+    context = _build_source_access_context([imbue_dir])
     assert str(imbue_dir / "mng") + "/" in context
     # Should NOT contain doubled imbue/imbue/mng path
     assert "imbue/imbue" not in context
+
+
+def test_build_source_access_context_lists_other_directories(tmp_path: Path) -> None:
+    """Plugin and dependency directories should appear in the context."""
+    mng_root = tmp_path / "mng"
+    (mng_root / "imbue" / "mng" / "cli").mkdir(parents=True)
+    plugin_root = tmp_path / "mng_opencode"
+    (plugin_root / "imbue" / "mng_opencode").mkdir(parents=True)
+    (plugin_root / "pyproject.toml").touch()
+    context = _build_source_access_context([mng_root, plugin_root])
+    assert str(plugin_root) in context
+    assert "plugins and dependencies" in context
 
 
 # =============================================================================
@@ -337,24 +374,36 @@ def test_build_web_access_context_contains_github_info() -> None:
 
 
 def test_build_tools_with_source_directory_scopes_read_tools(tmp_path: Path) -> None:
-    """Read/Glob/Grep should be included and path-scoped to source_directory."""
-    tools, args = _build_read_only_tools_and_permissions(tmp_path, allow_web=False)
+    """Read/Glob/Grep should be included and path-scoped to source directories."""
+    tools, args = _build_read_only_tools_and_permissions([tmp_path], allow_web=False)
     assert tools == "Read,Glob,Grep"
     assert f"Read(//{tmp_path}/**)" in args
     assert f"Glob(//{tmp_path}/**)" in args
     assert f"Grep(//{tmp_path}/**)" in args
 
 
-def test_build_tools_without_source_directory_excludes_read_tools() -> None:
-    """When source_directory is None, no Read/Glob/Grep tools should be included."""
-    tools, args = _build_read_only_tools_and_permissions(None, allow_web=False)
+def test_build_tools_with_multiple_source_directories(tmp_path: Path) -> None:
+    """Each source directory should get its own scoped Read/Glob/Grep entries."""
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    tools, args = _build_read_only_tools_and_permissions([dir_a, dir_b], allow_web=False)
+    assert tools == "Read,Glob,Grep"
+    assert f"Read(//{dir_a}/**)" in args
+    assert f"Read(//{dir_b}/**)" in args
+    assert f"Glob(//{dir_a}/**)" in args
+    assert f"Glob(//{dir_b}/**)" in args
+
+
+def test_build_tools_without_source_directories_excludes_read_tools() -> None:
+    """When source_directories is empty, no Read/Glob/Grep tools should be included."""
+    tools, args = _build_read_only_tools_and_permissions([], allow_web=False)
     assert tools == ""
     assert args == ()
 
 
 def test_build_tools_with_web_includes_webfetch() -> None:
     """WebFetch should be included and domain-scoped when allow_web is True."""
-    tools, args = _build_read_only_tools_and_permissions(None, allow_web=True)
+    tools, args = _build_read_only_tools_and_permissions([], allow_web=True)
     assert tools == "WebFetch"
     assert "WebFetch(domain:github.com)" in args
     assert "WebFetch(domain:raw.githubusercontent.com)" in args
@@ -362,7 +411,7 @@ def test_build_tools_with_web_includes_webfetch() -> None:
 
 def test_build_tools_with_source_and_web_includes_all(tmp_path: Path) -> None:
     """Both read tools and WebFetch should be included when both are enabled."""
-    tools, args = _build_read_only_tools_and_permissions(tmp_path, allow_web=True)
+    tools, args = _build_read_only_tools_and_permissions([tmp_path], allow_web=True)
     assert "Read,Glob,Grep" in tools
     assert "WebFetch" in tools
     assert f"Read(//{tmp_path}/**)" in args
@@ -375,14 +424,14 @@ def test_build_tools_with_source_and_web_includes_all(tmp_path: Path) -> None:
 
 
 def test_run_ask_query_includes_source_context() -> None:
-    """System prompt should include source access context when source directory exists."""
-    source_dir = _find_mng_source_directory()
-    assert source_dir is not None
+    """System prompt should include source access context when source directories exist."""
+    source_dirs = _find_source_directories()
+    assert source_dirs
     backend = FakeClaude(responses=["mng list"])
     _run_ask_query(
         backend=backend,
         query_string="test query",
-        source_directory=source_dir,
+        source_directories=source_dirs,
         execute=False,
         allow_web=False,
         output_format=OutputFormat.HUMAN,
@@ -391,13 +440,13 @@ def test_run_ask_query_includes_source_context() -> None:
     assert "Source Code Access" in backend.system_prompts[0]
 
 
-def test_run_ask_query_excludes_source_context_when_none() -> None:
-    """System prompt should not include source access context when source_directory is None."""
+def test_run_ask_query_excludes_source_context_when_empty() -> None:
+    """System prompt should not include source access context when source_directories is empty."""
     backend = FakeClaude(responses=["mng list"])
     _run_ask_query(
         backend=backend,
         query_string="test query",
-        source_directory=None,
+        source_directories=[],
         execute=False,
         allow_web=False,
         output_format=OutputFormat.HUMAN,
@@ -412,7 +461,7 @@ def test_run_ask_query_includes_web_context_when_enabled() -> None:
     _run_ask_query(
         backend=backend,
         query_string="test query",
-        source_directory=None,
+        source_directories=[],
         execute=False,
         allow_web=True,
         output_format=OutputFormat.HUMAN,
@@ -427,7 +476,7 @@ def test_run_ask_query_excludes_web_context_when_disabled() -> None:
     _run_ask_query(
         backend=backend,
         query_string="test query",
-        source_directory=None,
+        source_directories=[],
         execute=False,
         allow_web=False,
         output_format=OutputFormat.HUMAN,

--- a/libs/mng/imbue/mng/cli/test_ask.py
+++ b/libs/mng/imbue/mng/cli/test_ask.py
@@ -1,0 +1,79 @@
+"""Release tests for the ask command's source directory detection.
+
+These tests install mng from PyPI into a temporary virtualenv and verify
+that the installed package layout is compatible with _find_source_directories.
+"""
+
+import json
+import subprocess
+import textwrap
+import venv
+from pathlib import Path
+
+import pytest
+
+from imbue.mng.cli.ask import _MONOREPO_PACKAGE_DIRS
+
+
+@pytest.mark.acceptance
+def test_installed_package_layout_detected_correctly(tmp_path: Path) -> None:
+    """In a pip-installed env, source detection should return [site-packages/imbue/].
+
+    Installs mng and all published plugins from PyPI into a temporary venv,
+    then runs the same detection logic that _find_source_directories uses
+    to verify it correctly identifies the installed layout.
+    """
+    venv_dir = tmp_path / "venv"
+    venv.create(venv_dir, with_pip=True)
+    pip = str(venv_dir / "bin" / "pip")
+    python = str(venv_dir / "bin" / "python3")
+
+    # Install mng and all published plugins from PyPI.
+    pypi_names = [d.replace("_", "-") for d in _MONOREPO_PACKAGE_DIRS]
+    subprocess.run([pip, "install", *pypi_names], check=True, capture_output=True)
+
+    # Run the detection logic inside the installed venv.  We inline the
+    # logic rather than importing _find_source_directories because the
+    # PyPI version may not have it yet.
+    script = textwrap.dedent("""\
+        import json
+        from pathlib import Path
+
+        ask_file = Path(__import__("imbue.mng.cli.ask", fromlist=["ask"]).__file__).resolve()
+        imbue_dir = ask_file.parents[2]
+        project_root = imbue_dir.parent
+
+        has_pyproject = (project_root / "pyproject.toml").is_file()
+        has_mng_subdir = (imbue_dir / "mng").is_dir()
+
+        print(json.dumps({
+            "imbue_dir": str(imbue_dir),
+            "project_root": str(project_root),
+            "has_pyproject": has_pyproject,
+            "has_mng_subdir": has_mng_subdir,
+            "imbue_contents": sorted(
+                p.name for p in imbue_dir.iterdir()
+                if p.is_dir() and not p.name.startswith(".")
+            ),
+        }))
+    """)
+    result = subprocess.run(
+        [python, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    info = json.loads(result.stdout)
+
+    # Should NOT be detected as a source checkout.
+    assert not info["has_pyproject"], (
+        f"Installed env incorrectly detected as source checkout: {info['project_root']}"
+    )
+
+    # Should detect the imbue/ directory.
+    assert info["has_mng_subdir"], "imbue/mng/ not found in installed layout"
+
+    # All published packages should be present under imbue/.
+    imbue_contents = set(info["imbue_contents"])
+    for pkg_dir in _MONOREPO_PACKAGE_DIRS:
+        assert pkg_dir in imbue_contents, f"Missing {pkg_dir} in installed imbue/ directory"

--- a/libs/mng/imbue/mng/interfaces/agent.py
+++ b/libs/mng/imbue/mng/interfaces/agent.py
@@ -398,12 +398,12 @@ class AgentInterface(MutableModel, ABC):
         ...
 
 
-class NoPermissionsAgentMixin:
-    """Marker mixin for agents that are granted no permissions.
+class SafePermissionsAgentMixin:
+    """Marker mixin for agents whose granted permissions are safe enough to skip user confirmation.
 
-    These agents have no tool access and cannot perform destructive actions
-    (e.g. configured with --tools ""). Because no permissions are granted,
-    trust validation and permission dialogs are unnecessary during provisioning.
+    These agents may have tool access, but their permissions are sufficiently
+    restricted (e.g. read-only tools scoped to a specific directory) that trust
+    validation and permission dialogs are unnecessary during provisioning.
     """
 
 


### PR DESCRIPTION

## Summary
- Give `mng ask` read-only access to the mng source code via Read, Glob, and Grep tools (previously it had no tools at all), so it can look up implementation details when answering questions
- Add `--allow-web` flag that additionally enables WebFetch restricted to `github.com` and `raw.githubusercontent.com`, for reading issues/PRs/docs from the repo
- Extract system prompt assembly into `_run_ask_query` so the source-access and web-access context sections are composed in one place

## Details

The headless claude agent previously ran with `--tools ""` (no tools). This changes it to:
- Always: `--tools "Read,Glob,Grep"` with `--allowedTools Read,Glob,Grep` and `--permission-mode dontAsk`
- With `--allow-web`: additionally includes `WebFetch` in the tool list, restricted to GitHub domains via `--allowedTools "WebFetch(domain:github.com)"` and `--allowedTools "WebFetch(domain:raw.githubusercontent.com)"`

The system prompt is enriched with the on-disk source tree location (auto-detected by walking up from `ask.py`) and, when `--allow-web` is set, a note about the available GitHub access.

## Test plan
- [x] `_find_mng_source_directory` finds the source tree and returns None when not in the tree
- [x] `_build_source_access_context` includes/omits docs directory based on existence
- [x] `_build_web_access_context` includes GitHub info
- [x] `_run_ask_query` composes source context always, web context only when enabled
- [x] `--allow-web` CLI flag is accepted
- [x] All 28 ask tests pass

https://claude.ai/code/session_01P6ioKexZAqMkD4vv16BxXi