### PR TITLE
remove outdated [experimental] tags

### DIFF
--- a/libs/mng/docs/commands/primary/connect.md
+++ b/libs/mng/docs/commands/primary/connect.md
@@ -59,7 +59,7 @@ mng connect [OPTIONS] [AGENT]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/create.md
+++ b/libs/mng/docs/commands/primary/create.md
@@ -188,7 +188,7 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/destroy.md
+++ b/libs/mng/docs/commands/primary/destroy.md
@@ -60,7 +60,7 @@ mng destroy [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/exec.md
+++ b/libs/mng/docs/commands/primary/exec.md
@@ -9,7 +9,7 @@
 mng [exec|x] [AGENTS...] COMMAND [--agent <AGENT>] [--all] [--user <USER>] [--cwd <DIR>] [--timeout <SECONDS>] [--on-error <MODE>]
 ```
 
-Execute a shell command on one or more agents' hosts [experimental].
+Execute a shell command on one or more agents' hosts.
 
 The command runs in each agent's work_dir by default. Use --cwd to override
 the working directory.
@@ -64,7 +64,7 @@ mng exec [OPTIONS] [AGENTS]... COMMAND
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/list.md
+++ b/libs/mng/docs/commands/primary/list.md
@@ -64,7 +64,7 @@ mng list [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/pair.md
+++ b/libs/mng/docs/commands/primary/pair.md
@@ -72,7 +72,7 @@ mng pair [OPTIONS] SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/pull.md
+++ b/libs/mng/docs/commands/primary/pull.md
@@ -103,7 +103,7 @@ mng pull [OPTIONS] SOURCE DESTINATION
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/push.md
+++ b/libs/mng/docs/commands/primary/push.md
@@ -70,7 +70,7 @@ mng push [OPTIONS] TARGET SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/rename.md
+++ b/libs/mng/docs/commands/primary/rename.md
@@ -43,7 +43,7 @@ mng rename [OPTIONS] CURRENT NEW-NAME
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/start.md
+++ b/libs/mng/docs/commands/primary/start.md
@@ -61,7 +61,7 @@ mng start [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/primary/stop.md
+++ b/libs/mng/docs/commands/primary/stop.md
@@ -56,7 +56,7 @@ mng stop [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/ask.md
+++ b/libs/mng/docs/commands/secondary/ask.md
@@ -39,7 +39,7 @@ mng ask [OPTIONS] [QUERY]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/cleanup.md
+++ b/libs/mng/docs/commands/secondary/cleanup.md
@@ -65,7 +65,7 @@ mng cleanup [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/config.md
+++ b/libs/mng/docs/commands/secondary/config.md
@@ -33,7 +33,7 @@ mng config [OPTIONS] COMMAND [ARGS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -73,7 +73,7 @@ mng config list [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -140,7 +140,7 @@ mng config get [OPTIONS] KEY
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -201,7 +201,7 @@ mng config set [OPTIONS] KEY VALUE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -259,7 +259,7 @@ mng config unset [OPTIONS] KEY
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -313,7 +313,7 @@ mng config edit [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -371,7 +371,7 @@ mng config path [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/events.md
+++ b/libs/mng/docs/commands/secondary/events.md
@@ -9,7 +9,7 @@
 mng events TARGET [EVENT_FILE] [--filter CEL] [--follow] [--tail N] [--head N]
 ```
 
-View events from an agent or host [experimental].
+View events from an agent or host.
 
 TARGET identifies an agent (by name or ID) or a host (by name or ID).
 The command first tries to match TARGET as an agent, then as a host.
@@ -55,7 +55,7 @@ mng events [OPTIONS] TARGET [EVENT_FILENAME]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/gc.md
+++ b/libs/mng/docs/commands/secondary/gc.md
@@ -62,7 +62,7 @@ mng gc [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/limit.md
+++ b/libs/mng/docs/commands/secondary/limit.md
@@ -84,7 +84,7 @@ mng limit [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/message.md
+++ b/libs/mng/docs/commands/secondary/message.md
@@ -58,7 +58,7 @@ mng message [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/plugin.md
+++ b/libs/mng/docs/commands/secondary/plugin.md
@@ -9,7 +9,7 @@
 mng [plugin|plug] <subcommand> [OPTIONS]
 ```
 
-Manage available and active plugins [experimental].
+Manage available and active plugins.
 
 Install, remove, view, enable, and disable plugins registered with mng.
 Plugins provide agent types, provider backends, CLI commands, and lifecycle hooks.
@@ -27,7 +27,7 @@ mng plugin [OPTIONS] COMMAND [ARGS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -42,7 +42,7 @@ mng plugin [OPTIONS] COMMAND [ARGS]...
 
 ## mng plugin list
 
-List discovered plugins [experimental].
+List discovered plugins.
 
 Shows all plugins registered with mng, including built-in plugins
 and any externally installed plugins.
@@ -61,7 +61,7 @@ mng plugin list [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -116,7 +116,7 @@ $ mng plugin list --format '{name}\t{enabled}'
 
 ## mng plugin add
 
-Install a plugin package [experimental].
+Install a plugin package.
 
 Provide exactly one of NAME (positional), --path, or --git. NAME is a PyPI
 package specifier (e.g., 'mng-pair' or 'mng-pair>=1.0'). --path installs
@@ -133,7 +133,7 @@ mng plugin add [OPTIONS] [NAME]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -182,7 +182,7 @@ $ mng plugin add --git https://github.com/user/mng-plugin.git
 
 ## mng plugin remove
 
-Uninstall a plugin package [experimental].
+Uninstall a plugin package.
 
 Provide exactly one of NAME (positional) or --path. For local paths,
 the package name is read from pyproject.toml.
@@ -198,7 +198,7 @@ mng plugin remove [OPTIONS] [NAME]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -234,7 +234,7 @@ $ mng plugin remove --path ./my-plugin
 
 ## mng plugin enable
 
-Enable a plugin [experimental].
+Enable a plugin.
 
 Sets plugins.<name>.enabled = true in the configuration file at the
 specified scope.
@@ -250,7 +250,7 @@ mng plugin enable [OPTIONS] NAME
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -292,7 +292,7 @@ $ mng plugin enable modal --format json
 
 ## mng plugin disable
 
-Disable a plugin [experimental].
+Disable a plugin.
 
 Sets plugins.<name>.enabled = false in the configuration file at the
 specified scope.
@@ -308,7 +308,7 @@ mng plugin disable [OPTIONS] NAME
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/provision.md
+++ b/libs/mng/docs/commands/secondary/provision.md
@@ -80,7 +80,7 @@ mng provision [OPTIONS] [AGENT]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/commands/secondary/snapshot.md
+++ b/libs/mng/docs/commands/secondary/snapshot.md
@@ -9,7 +9,7 @@
 mng [snapshot|snap] [create|list|destroy] [AGENTS...] [OPTIONS]
 ```
 
-Create, list, and destroy host snapshots [experimental].
+Create, list, and destroy host snapshots.
 
 Snapshots capture the complete filesystem state of a host, allowing it to be
 restored later. Because the snapshot is at the host level, the state of all
@@ -37,7 +37,7 @@ mng snapshot [OPTIONS] COMMAND [ARGS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -52,7 +52,7 @@ mng snapshot [OPTIONS] COMMAND [ARGS]...
 
 ## mng snapshot create
 
-Create a snapshot of agent host(s) [experimental].
+Create a snapshot of agent host(s).
 
 Positional arguments can be agent names/IDs or host names/IDs. Each
 identifier is automatically resolved: if it matches a known agent, that
@@ -102,7 +102,7 @@ mng snapshot create [OPTIONS] [IDENTIFIERS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -150,7 +150,7 @@ $ mng snapshot create my-agent --format '{snapshot_id}'
 
 ## mng snapshot list
 
-List snapshots for agent host(s) [experimental].
+List snapshots for agent host(s).
 
 Shows snapshot ID, name, creation time, size, and host for each snapshot.
 
@@ -190,7 +190,7 @@ mng snapshot list [OPTIONS] [IDENTIFIERS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |
@@ -238,7 +238,7 @@ $ mng snapshot list my-agent --format '{name}\t{size}\t{host_id}'
 
 ## mng snapshot destroy
 
-Destroy snapshots for agent host(s) [experimental].
+Destroy snapshots for agent host(s).
 
 Requires either --snapshot (to delete specific snapshots) or --all-snapshots
 (to delete all snapshots for the resolved hosts). A confirmation prompt is
@@ -276,7 +276,7 @@ mng snapshot destroy [OPTIONS] [AGENTS]...
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
 | `-q`, `--quiet` | boolean | Suppress all console output | `False` |
 | `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
 | `--log-file` | path | Path to log file (overrides default ~/.mng/events/logs/<timestamp>-<pid>.json) | None |

--- a/libs/mng/docs/concepts/agent_types.md
+++ b/libs/mng/docs/concepts/agent_types.md
@@ -81,7 +81,7 @@ Use a [plugin](./plugins.md) when you need to:
 Agent types come from installed plugins and your config:
 
 ```bash
-mng plugin list    # Shows installed plugins [experimental] (listing agent types per plugin [future])
+mng plugin list    # Shows installed plugins (listing agent types per plugin [future])
 ```
 
 Built-in plugins provide `claude` and `codex` by default.

--- a/libs/mng/docs/concepts/api.md
+++ b/libs/mng/docs/concepts/api.md
@@ -23,8 +23,8 @@ mng calls these on your plugin at specific points during command execution. Impl
 | `override_command_options`   | Override or modify command options after CLI parsing and config defaults, but before the command options object is created |
 | `on_before_create`           | Inspect and modify create arguments before any work is done                                                    |
 | `on_before_host_create`      | React before a new host is created [experimental]                                                              |
-| `on_host_created`            | React after a new host has been created [experimental]                                                         |
-| `on_agent_created`           | React after an agent is fully created and started [experimental]                                               |
+| `on_host_created`            | React after a new host has been created                                                                        |
+| `on_agent_created`           | React after an agent is fully created and started                                                              |
 | `on_before_agent_destroy`    | React before an online agent is destroyed [experimental]                                                       |
 | `on_agent_destroyed`         | React after an online agent has been destroyed [experimental]                                                  |
 | `on_before_host_destroy`     | React before a host is destroyed [experimental]                                                                |

--- a/libs/mng/docs/concepts/plugins.md
+++ b/libs/mng/docs/concepts/plugins.md
@@ -47,8 +47,8 @@ Called to collect files for baking into deployed images (ex: if you're scheduled
 
 | Hook                         | Description                                                                                                    |
 |------------------------------|----------------------------------------------------------------------------------------------------------------|
-| `get_files_for_deploy`       | Return files to include in deployment images (e.g., config files, settings). Paths starting with `~` go to the user's home directory; relative paths go to the project working directory. [experimental] |
-| `modify_env_vars_for_deploy` | Mutate the environment variables dict for deployment. Plugins can add, update, or remove env vars in place. Called after env vars are assembled from `--pass-env` and `--env-file` sources. [experimental] |
+| `get_files_for_deploy`       | Return files to include in deployment images (e.g., config files, settings). Paths starting with `~` go to the user's home directory; relative paths go to the project working directory. |
+| `modify_env_vars_for_deploy` | Mutate the environment variables dict for deployment. Plugins can add, update, or remove env vars in place. Called after env vars are assembled from `--pass-env` and `--env-file` sources. |
 
 ### Program lifecycle hooks
 
@@ -75,7 +75,7 @@ Called during `mng create` and `mng destroy` operations:
 | Hook                          | Description                                                                                       |
 |-------------------------------|---------------------------------------------------------------------------------------------------|
 | `on_before_host_create`       | Before creating a new host (receives host name and provider name). [experimental]                 |
-| `on_host_created`             | After a new host has been created via provider.create_host(). [experimental]                      |
+| `on_host_created`             | After a new host has been created via provider.create_host().                                     |
 | `on_before_host_destroy`      | Before destroying a host via provider.destroy_host(). [experimental]                              |
 | `on_host_destroyed`           | After a host has been destroyed. The Python object is still available for metadata. [experimental] |
 
@@ -108,7 +108,7 @@ Called during `mng create` and `mng destroy` operations:
 | `on_agent_state_dir_created`  | After the agent's state directory and data.json have been created, before provisioning. [experimental]               |
 | `on_before_provisioning`      | Before provisioning an agent (plugin hook, distinct from agent method). [experimental]                               |
 | `on_after_provisioning`       | After provisioning an agent (plugin hook, distinct from agent method). [experimental]                                |
-| `on_agent_created`            | After an agent is fully created and started. [experimental]                                                          |
+| `on_agent_created`            | After an agent is fully created and started.                                                                         |
 | `on_before_agent_destroy`     | Before an online agent is destroyed. Does not fire for offline host destruction. [experimental]                      |
 | `on_agent_destroyed`          | After an online agent has been destroyed. The Python object is still available for metadata. [experimental]          |
 

--- a/libs/mng/imbue/mng/cli/common_opts.py
+++ b/libs/mng/imbue/mng/cli/common_opts.py
@@ -126,7 +126,7 @@ def add_common_options(command: TDecorated) -> TDecorated:
         "output_format",
         default="human",
         show_default=True,
-        help="Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided [experimental], fields use standard python templating like 'name: {agent.name}' See below for available fields.",
+        help="Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields.",
     )(command)
     # Start the "Common" option group - applied last since decorators run in reverse order
     command = optgroup.group(COMMON_OPTIONS_GROUP_NAME)(command)

--- a/libs/mng/imbue/mng/cli/events.py
+++ b/libs/mng/imbue/mng/cli/events.py
@@ -207,7 +207,7 @@ def _emit_event_content(
 # Register help metadata for git-style help formatting
 CommandHelpMetadata(
     key="events",
-    one_line_description="View events from an agent or host [experimental]",
+    one_line_description="View events from an agent or host",
     synopsis="mng events TARGET [EVENT_FILE] [--filter CEL] [--follow] [--tail N] [--head N]",
     arguments_description=(
         "- `TARGET`: Agent or host name/ID whose events to view\n"

--- a/libs/mng/imbue/mng/cli/exec.py
+++ b/libs/mng/imbue/mng/cli/exec.py
@@ -271,7 +271,7 @@ def _emit_json_output(result: MultiExecResult) -> None:
 # Register help metadata for git-style help formatting
 CommandHelpMetadata(
     key="exec",
-    one_line_description="Execute a shell command on one or more agents' hosts [experimental]",
+    one_line_description="Execute a shell command on one or more agents' hosts",
     synopsis="mng [exec|x] [AGENTS...] COMMAND [--agent <AGENT>] [--all] [--user <USER>] [--cwd <DIR>] [--timeout <SECONDS>] [--on-error <MODE>]",
     arguments_description=(
         "- `AGENTS`: Name(s) or ID(s) of the agent(s) whose host will run the command\n"

--- a/libs/mng/imbue/mng/cli/plugin.py
+++ b/libs/mng/imbue/mng/cli/plugin.py
@@ -722,7 +722,7 @@ def _emit_plugin_toggle_result(
 # Register help metadata for git-style help formatting
 CommandHelpMetadata(
     key="plugin",
-    one_line_description="Manage available and active plugins [experimental]",
+    one_line_description="Manage available and active plugins",
     synopsis="mng [plugin|plug] <subcommand> [OPTIONS]",
     description="""Install, remove, view, enable, and disable plugins registered with mng.
 Plugins provide agent types, provider backends, CLI commands, and lifecycle hooks.""",
@@ -748,7 +748,7 @@ add_pager_help_option(plugin)
 
 CommandHelpMetadata(
     key="plugin.list",
-    one_line_description="List discovered plugins [experimental]",
+    one_line_description="List discovered plugins",
     synopsis="mng plugin list [OPTIONS]",
     description="""Shows all plugins registered with mng, including built-in plugins
 and any externally installed plugins.
@@ -771,7 +771,7 @@ add_pager_help_option(plugin_list)
 
 CommandHelpMetadata(
     key="plugin.add",
-    one_line_description="Install a plugin package [experimental]",
+    one_line_description="Install a plugin package",
     synopsis="mng plugin add [NAME] [OPTIONS]",
     description="""Provide exactly one of NAME (positional), --path, or --git. NAME is a PyPI
 package specifier (e.g., 'mng-pair' or 'mng-pair>=1.0'). --path installs
@@ -791,7 +791,7 @@ add_pager_help_option(plugin_add)
 
 CommandHelpMetadata(
     key="plugin.remove",
-    one_line_description="Uninstall a plugin package [experimental]",
+    one_line_description="Uninstall a plugin package",
     synopsis="mng plugin remove [NAME] [OPTIONS]",
     description="""Provide exactly one of NAME (positional) or --path. For local paths,
 the package name is read from pyproject.toml.""",
@@ -808,7 +808,7 @@ add_pager_help_option(plugin_remove)
 
 CommandHelpMetadata(
     key="plugin.enable",
-    one_line_description="Enable a plugin [experimental]",
+    one_line_description="Enable a plugin",
     synopsis="mng plugin enable NAME [OPTIONS]",
     description="""Sets plugins.<name>.enabled = true in the configuration file at the
 specified scope.""",
@@ -826,7 +826,7 @@ add_pager_help_option(plugin_enable)
 
 CommandHelpMetadata(
     key="plugin.disable",
-    one_line_description="Disable a plugin [experimental]",
+    one_line_description="Disable a plugin",
     synopsis="mng plugin disable NAME [OPTIONS]",
     description="""Sets plugins.<name>.enabled = false in the configuration file at the
 specified scope.""",

--- a/libs/mng/imbue/mng/cli/snapshot.py
+++ b/libs/mng/imbue/mng/cli/snapshot.py
@@ -875,7 +875,7 @@ def snapshot_destroy(ctx: click.Context, **kwargs: Any) -> None:
 
 CommandHelpMetadata(
     key="snapshot",
-    one_line_description="Create, list, and destroy host snapshots [experimental]",
+    one_line_description="Create, list, and destroy host snapshots",
     synopsis="mng [snapshot|snap] [create|list|destroy] [AGENTS...] [OPTIONS]",
     description="""Snapshots capture the complete filesystem state of a host, allowing it to be
 restored later. Because the snapshot is at the host level, the state of all
@@ -912,7 +912,7 @@ add_pager_help_option(snapshot)
 
 CommandHelpMetadata(
     key="snapshot.create",
-    one_line_description="Create a snapshot of agent host(s) [experimental]",
+    one_line_description="Create a snapshot of agent host(s)",
     synopsis="mng snapshot create [IDENTIFIERS...] [OPTIONS]",
     description="""Positional arguments can be agent names/IDs or host names/IDs. Each
 identifier is automatically resolved: if it matches a known agent, that
@@ -937,7 +937,7 @@ add_pager_help_option(snapshot_create)
 
 CommandHelpMetadata(
     key="snapshot.list",
-    one_line_description="List snapshots for agent host(s) [experimental]",
+    one_line_description="List snapshots for agent host(s)",
     synopsis="mng snapshot list [IDENTIFIERS...] [OPTIONS]",
     description="""Shows snapshot ID, name, creation time, size, and host for each snapshot.
 
@@ -963,7 +963,7 @@ add_pager_help_option(snapshot_list)
 
 CommandHelpMetadata(
     key="snapshot.destroy",
-    one_line_description="Destroy snapshots for agent host(s) [experimental]",
+    one_line_description="Destroy snapshots for agent host(s)",
     synopsis="mng snapshot destroy [AGENTS...] [OPTIONS]",
     description="""Requires either --snapshot (to delete specific snapshots) or --all-snapshots
 (to delete all snapshots for the resolved hosts). A confirmation prompt is

--- a/libs/mng/imbue/mng/plugins/hookspecs.py
+++ b/libs/mng/imbue/mng/plugins/hookspecs.py
@@ -67,7 +67,7 @@ def on_before_host_create(name: HostName, provider_name: ProviderInstanceName) -
 
 @hookspec
 def on_host_created(host: HostInterface, mng_ctx: MngContext) -> None:
-    """[experimental] Called after a new host has been created.
+    """Called after a new host has been created.
 
     This hook fires after provider.create_host() completes during `mng create`
     when a new host was created. It does not fire when an existing host is reused.
@@ -147,7 +147,7 @@ def on_after_provisioning(agent: AgentInterface, host: OnlineHostInterface, mng_
 
 @hookspec
 def on_agent_created(agent: AgentInterface, host: OnlineHostInterface) -> None:
-    """[experimental] Called after an agent has been fully created and started.
+    """Called after an agent has been fully created and started.
 
     This hook fires at the end of create(), after the agent is started.
     Plugins can use this to perform actions like logging, notifications,
@@ -372,7 +372,7 @@ def get_files_for_deploy(
     include_project_settings: bool,
     repo_root: Path,
 ) -> dict[Path, Path | str]:
-    """[experimental] Return files to include when deploying scheduled commands.
+    """Return files to include when deploying scheduled commands.
 
     Called during schedule deployment to collect files that should be baked
     into the deployment image. Each plugin can contribute files needed for
@@ -405,7 +405,7 @@ def modify_env_vars_for_deploy(
     mng_ctx: MngContext,
     env_vars: dict[str, str],
 ) -> None:
-    """[experimental] Mutate the env vars dict for scheduled command deployment.
+    """Mutate the env vars dict for scheduled command deployment.
 
     Called during schedule deployment after the initial environment variables
     have been assembled from --pass-env and --env-file sources. Each plugin


### PR DESCRIPTION
This PR removes `[experimental]` tags from various features that have been stabilized and are ready for general use.

## Summary
Removes `[experimental]` markers from documentation and code to reflect the stable status of several features that have been in use and are no longer considered experimental.

## Key Changes

- **Plugin management commands**: Removed `[experimental]` tags from:
  - Main `mng plugin` command and all subcommands (list, add, remove, enable, disable)
  - Plugin-related documentation in `libs/mng/docs/commands/secondary/plugin.md`
  - Plugin CLI implementation in `libs/mng/imbue/mng/cli/plugin.py`

- **Snapshot management commands**: Removed `[experimental]` tags from:
  - Main `mng snapshot` command and all subcommands (create, list, destroy)
  - Snapshot-related documentation in `libs/mng/docs/commands/secondary/snapshot.md`
  - Snapshot CLI implementation in `libs/mng/imbue/mng/cli/snapshot.py`

- **Other command features**: Removed `[experimental]` tags from:
  - `mng exec` command for executing shell commands on agent hosts
  - `mng events` command for viewing agent/host events
  - Format template feature in `--format` option across all commands

- **Plugin hook specifications**: Removed `[experimental]` tags from stable lifecycle hooks:
  - `on_host_created` hook
  - `on_agent_created` hook
  - `get_files_for_deploy` hook
  - `modify_env_vars_for_deploy` hook

- **Documentation updates**: Updated concept documentation in:
  - `libs/mng/docs/concepts/plugins.md`
  - `libs/mng/docs/concepts/api.md`
  - `libs/mng/docs/concepts/agent_types.md`

- **Common options**: Updated the `--format` option help text in `libs/mng/imbue/mng/cli/common_opts.py` to remove `[experimental]` marker from template feature description

## Implementation Details
All changes are documentation and metadata updates with no functional code changes. The `[experimental]` tags are removed from:
- Command help metadata (`one_line_description` fields)
- Documentation markdown files
- Hook specification docstrings
- Option help text

This reflects the maturity of these features and provides clearer messaging to users that these are stable, production-ready features.

https://claude.ai/code/session_01Wi45QpqLzLiUfQ4BkFcNZm