### PR TITLE
fix ty warnings

### DIFF
--- a/libs/mng/imbue/mng/conftest.py
+++ b/libs/mng/imbue/mng/conftest.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 from typing import Generator
-from typing import cast
 from uuid import uuid4
 
 import docker
@@ -484,7 +483,7 @@ def local_host(local_provider: LocalProviderInstance) -> Host:
     (the concrete OnlineHostInterface implementation).
     """
     host = local_provider.create_host(HostName("localhost"))
-    return cast(Host, host)
+    return host
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]

--- a/libs/mng/imbue/mng/providers/docker/test_docker_integration.py
+++ b/libs/mng/imbue/mng/providers/docker/test_docker_integration.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import docker
 import docker.errors
+import docker.models.containers
 import pytest
 
 from imbue.mng.config.data_types import MngContext
@@ -426,6 +427,7 @@ def test_container_responds_to_sigterm(docker_provider: DockerProviderInstance) 
     container.reload()
     assert container.status in ("exited", "stopped")
     # Exit code 0 means clean shutdown via trap
+    assert container.attrs is not None
     assert container.attrs["State"]["ExitCode"] == 0
 
 

--- a/libs/mng_kanpan/imbue/mng_kanpan/tui_test.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/tui_test.py
@@ -301,7 +301,9 @@ def test_build_board_widgets_none_snapshot_shows_loading() -> None:
 def test_build_board_widgets_empty_snapshot_shows_no_agents() -> None:
     walker, _ = _build_board_widgets(_make_snapshot())
     assert len(walker) == 1
-    assert "No agents found" in str(walker[0].get_text()[0])
+    widget = walker[0]
+    assert isinstance(widget, Text)
+    assert "No agents found" in str(widget.get_text()[0])
 
 
 def test_build_board_widgets_with_entries_creates_sections() -> None:


### PR DESCRIPTION
## Summary
- Remove redundant `cast(Host, host)` in `conftest.py` since `create_host` already returns `Host`
- Add explicit `import docker.models.containers` to resolve `possibly-missing-attribute` warning on `docker.models`
- Add `assert container.attrs is not None` before subscripting nullable `attrs` dict
- Add `isinstance(widget, Text)` type narrowing in kanpan `tui_test.py` before calling `.get_text()`

## Not addressed
The `SelectableGroups` deprecation warnings in `conftest_hooks.py` remain. Fixing requires either a `cast()` (violates the cast ratchet at 0 for imbue_common) or removing the union type (causes `invalid-assignment` since `entry_points()` on Python 3.11 can return `SelectableGroups`). Will resolve naturally when min Python version is bumped to 3.12.

## Test plan
- [x] `ty check` passes with zero errors (only the 2 pre-existing `SelectableGroups` deprecation warnings remain)
- [x] libs/mng: 3157 passed, 1 skipped
- [x] libs/mng_kanpan: 207 passed
- [x] libs/imbue_common: 207 passed

Generated with [Claude Code](https://claude.com/claude-code)