### PR TITLE
Fix create templates: split new_host into new_host + provider

### DIFF
--- a/.mng/settings.toml
+++ b/.mng/settings.toml
@@ -6,7 +6,8 @@ default_destroyed_host_persisted_seconds = 10
 create = ["""bash -c './scripts/make_tar_of_repo.sh `cat .mng/image_commit_hash` .mng/dev/build'"""]
 
 [create_templates.docker]
-new_host = "docker"
+new_host = true
+provider = "docker"
 build_arg = ["--file=libs/mng/imbue/mng/resources/Dockerfile", ".mng/dev/build/"]
 target_path = "/code/mng"
 # the agent added these, but I kinda doubt we need them...
@@ -18,7 +19,8 @@ type = "coder"
 extra_window = ["reviewer_0='export IS_SANDBOX=1 && claude --dangerously-skip-permissions'"]
 
 [create_templates.modal]
-new_host = "modal"
+new_host = true
+provider = "modal"
 build_arg = ["file=libs/mng/imbue/mng/resources/Dockerfile", "context-dir=.mng/dev/build/", "volume=code-review-json:/code_reviews"]
 extra_window = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && git remote set-url origin https://github.com/imbue-ai/mng.git && gh auth setup-git'"]
 agent_args = ["--dangerously-skip-permissions"]


### PR DESCRIPTION
## Summary
- Commit e4baf638f changed `--new-host` from a string (provider name) to a boolean flag, but the `create_templates` in `.mng/settings.toml` were not updated
- `mng c -t modal` (and `-t docker`) failed with a pydantic validation error: `new_host` expected `bool`, got `"modal"`
- Split `new_host = "modal"` into `new_host = true` + `provider = "modal"` (same for docker)

## Test plan
- [ ] `mng c rsync-resource-guard -t modal --branch main:` no longer errors


Generated with [Claude Code](https://claude.com/claude-code)