### PR TITLE
don't require clean git state when specifying base branch for remote agents too

### DIFF
--- a/libs/mng/imbue/mng/cli/create.py
+++ b/libs/mng/imbue/mng/cli/create.py
@@ -591,13 +591,11 @@ def _create_agent(
             return CreateAgentResult(agent=agent, host=host), connection_opts
 
     # If ensure-clean is set, verify the source work_dir is clean.
-    # Skip the check when using worktree mode with an explicit base branch, since the
-    # agent will be created from that branch and uncommitted changes in the current
-    # working tree are irrelevant.
-    is_worktree_from_other_branch = (
-        agent_opts.git is not None and agent_opts.git.copy_mode == WorkDirCopyMode.WORKTREE and has_explicit_base
-    )
-    if opts.ensure_clean and not is_worktree_from_other_branch:
+    # Skip the check when using an explicit base branch, since the agent will be
+    # created from that branch and uncommitted changes in the current working tree
+    # are irrelevant (regardless of copy mode: worktree, clone, or copy).
+    is_from_explicit_base = agent_opts.git is not None and has_explicit_base
+    if opts.ensure_clean and not is_from_explicit_base:
         _ensure_clean_work_dir(setup.source_location)
 
     # figure out the target host (if we just have a reference)

--- a/libs/mng/imbue/mng/cli/test_create.py
+++ b/libs/mng/imbue/mng/cli/test_create.py
@@ -1001,3 +1001,52 @@ def test_ensure_clean_skipped_with_explicit_base_branch(
 
         # Wait for background session so cleanup can properly kill it
         wait_for_agent_session(session_name)
+
+
+@pytest.mark.tmux
+def test_ensure_clean_skipped_with_explicit_base_branch_copy_mode(
+    cli_runner: CliRunner,
+    temp_git_repo: Path,
+    temp_host_dir: Path,
+    mng_test_prefix: str,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """Ensure-clean check is skipped with an explicit base branch even in copy mode (not just worktree)."""
+    # Create a second branch to use as base
+    subprocess.run(
+        ["git", "branch", "other-branch"],
+        cwd=temp_git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Make the repo dirty
+    (temp_git_repo / "dirty.txt").write_text("uncommitted change")
+
+    agent_name = f"test-copy-base-clean-{int(time.time())}"
+    session_name = f"{mng_test_prefix}{agent_name}"
+
+    with tmux_session_cleanup(session_name):
+        result = cli_runner.invoke(
+            create,
+            [
+                "--name",
+                agent_name,
+                "--command",
+                "sleep 847192",
+                "--source",
+                str(temp_git_repo),
+                "--branch",
+                "other-branch:mng/*",
+                "--copy",
+                "--no-connect",
+            ],
+            obj=plugin_manager,
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, f"CLI failed with: {result.output}"
+        assert "uncommitted changes" not in result.output
+
+        # Wait for background session so cleanup can properly kill it
+        wait_for_agent_session(session_name)


### PR DESCRIPTION
not sure if this was limited to WORKTREE mode originally for a reason

---

## Summary
- The `--ensure-clean` skip logic required `WorkDirCopyMode.WORKTREE`, so remote targets (e.g. `-t modal`) that default to `COPY` mode would still require `--no-ensure-clean` even when `--branch main:` was specified.
- Removed the worktree-only requirement: the ensure-clean check is now skipped whenever an explicit base branch is provided, regardless of copy mode (worktree, clone, or copy).
- Added a test for the copy-mode case (`test_ensure_clean_skipped_with_explicit_base_branch_copy_mode`).

## Test plan
- [x] Existing `test_ensure_clean_rejects_dirty_worktree_by_default` still passes
- [x] Existing `test_ensure_clean_skipped_with_explicit_base_branch` (worktree mode) still passes
- [x] New `test_ensure_clean_skipped_with_explicit_base_branch_copy_mode` passes
- [x] Full test suite: 3222 passed, 2 failed (pre-existing `observe_test.py` failures), 83.31% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)