### PR TITLE
don't say "time.sleep()" in FIXME (just "sleep" instead)

### DIFF
--- a/libs/mng/imbue/mng/api/events.py
+++ b/libs/mng/imbue/mng/api/events.py
@@ -470,7 +470,7 @@ def _follow_event_file_via_host(
                     if not has_logged:
                         logger.info("Event file not found yet, retrying in {}s", _RETRY_DELAY_SECONDS)
                         has_logged = True
-                    # FIXME: remove this--this is effectively a time.sleep().  Also, make a ratchet that prevents future such constructs (eg, ratchet against "Event().wait(")
+                    # FIXME: remove this--this is effectively a sleep.  Also, make a ratchet that prevents future such constructs (eg, ratchet against "Event().wait(")
                     #  Instead, here we should just be using tenacity to continually retry this type of error, log when it happens once, etc
                     threading.Event().wait(timeout=_RETRY_DELAY_SECONDS)
                     continue


### PR DESCRIPTION
## Summary
- Rephrased a FIXME comment in `events.py` that mentioned `time.sleep()` in prose, which the ratchet regex was matching as a real violation
- Changed "effectively a time.sleep()" to "effectively a sleep" -- same meaning, no longer triggers the ratchet

## Test plan
- [x] `test_prevent_time_sleep` ratchet test now passes
- [ ] Full mng test suite passes