### PR TITLE
More followup to agent address support

### DIFF
--- a/libs/mng/imbue/mng/api/message.py
+++ b/libs/mng/imbue/mng/api/message.py
@@ -189,7 +189,7 @@ def _process_host_for_messaging(
 
             # Apply CEL filters if provided
             if compiled_include_filters or compiled_exclude_filters or not all_agents:
-                agent_context = _agent_to_cel_context(agent, host_ref.provider_name)
+                agent_context = _agent_to_cel_context(agent, str(host_ref.host_name), host_ref.provider_name)
                 is_included = apply_cel_filters_to_context(
                     context=agent_context,
                     include_filters=compiled_include_filters,
@@ -285,7 +285,7 @@ def _send_message_to_agent(
             raise MngError(error_msg) from e
 
 
-def _agent_to_cel_context(agent: AgentInterface, provider_name: str) -> dict[str, Any]:
+def _agent_to_cel_context(agent: AgentInterface, host_name: str, provider_name: str) -> dict[str, Any]:
     """Convert an agent to a CEL-friendly dict for filtering."""
     return {
         "id": str(agent.id),
@@ -294,6 +294,7 @@ def _agent_to_cel_context(agent: AgentInterface, provider_name: str) -> dict[str
         "state": agent.get_lifecycle_state().value,
         "host": {
             "id": str(agent.host_id),
+            "name": host_name,
             "provider": provider_name,
         },
     }

--- a/libs/mng/imbue/mng/api/message_test.py
+++ b/libs/mng/imbue/mng/api/message_test.py
@@ -58,13 +58,14 @@ def test_agent_to_cel_context_returns_expected_fields(
         ),
     )
 
-    context = _agent_to_cel_context(agent, "local")
+    context = _agent_to_cel_context(agent, "localhost", "local")
 
     assert context["id"] == str(agent.id)
     assert context["name"] == "cel-test-agent"
     assert context["type"] == "generic"
     assert context["state"] == AgentLifecycleState.STOPPED.value
     assert context["host"]["provider"] == "local"
+    assert context["host"]["name"] == "localhost"
     assert context["host"]["id"] == str(agent.host_id)
 
 

--- a/libs/mng/imbue/mng/cli/agent_addr.py
+++ b/libs/mng/imbue/mng/cli/agent_addr.py
@@ -164,9 +164,6 @@ def find_agents_by_addresses(
     # Parse all identifiers
     parsed: list[tuple[str, AgentAddress]] = [parse_identifier_as_address(raw) for raw in raw_identifiers]
 
-    # Check if any identifiers have host constraints
-    has_host_constraints = any(addr.has_host_component for _, addr in parsed)
-
     # Extract plain identifier strings (agent names/IDs)
     plain_identifiers = [ident for ident, _ in parsed]
 
@@ -178,11 +175,29 @@ def find_agents_by_addresses(
         mng_ctx=mng_ctx,
     )
 
+    return _post_filter_matches_by_addresses(raw_identifiers, parsed, matches)
+
+
+@pure
+def _post_filter_matches_by_addresses(
+    raw_identifiers: Sequence[str],
+    parsed: Sequence[tuple[str, AgentAddress]],
+    matches: Sequence[AgentMatch],
+) -> list[AgentMatch]:
+    """Post-filter agent matches by host/provider constraints from parsed addresses.
+
+    For identifiers without host/provider components, matches pass through unchanged.
+    For identifiers with host/provider components, only matches on the specified
+    host/provider are kept. Raises AgentNotFoundError if a constrained identifier
+    has no matching agents after filtering.
+    """
+    # Check if any identifiers have host constraints
+    has_host_constraints = any(addr.has_host_component for _, addr in parsed)
+
     # If no host constraints, return as-is
     if not has_host_constraints:
-        return matches
+        return list(matches)
 
-    # Post-filter by host/provider constraints from addresses.
     # Build a mapping from agent name -> list of addresses with host constraints
     name_to_addresses: dict[str, list[AgentAddress]] = {}
     for ident, addr in parsed:
@@ -203,7 +218,7 @@ def find_agents_by_addresses(
             filtered.append(match)
 
     # Check that all constrained identifiers have at least one match
-    for raw, (ident, addr) in zip(raw_identifiers, parsed, strict=False):
+    for raw, (ident, addr) in zip(raw_identifiers, parsed, strict=True):
         if not addr.has_host_component:
             continue
         has_match = any(str(m.agent_name) == ident or str(m.agent_id) == ident for m in filtered)

--- a/libs/mng/imbue/mng/cli/agent_addr_test.py
+++ b/libs/mng/imbue/mng/cli/agent_addr_test.py
@@ -3,15 +3,18 @@
 from pathlib import Path
 
 import pluggy
+import pytest
 from click.testing import CliRunner
 
 from imbue.mng.api.find import AgentMatch
 from imbue.mng.cli.agent_addr import AgentAddress
 from imbue.mng.cli.agent_addr import _address_matches_agent_match
 from imbue.mng.cli.agent_addr import _address_matches_host
+from imbue.mng.cli.agent_addr import _post_filter_matches_by_addresses
 from imbue.mng.cli.agent_addr import filter_agents_by_host_constraint
 from imbue.mng.cli.agent_addr import parse_identifier_as_address
 from imbue.mng.cli.stop import stop
+from imbue.mng.errors import AgentNotFoundError
 from imbue.mng.primitives import AgentId
 from imbue.mng.primitives import AgentName
 from imbue.mng.primitives import DiscoveredAgent
@@ -187,6 +190,96 @@ def test_filter_agents_by_provider() -> None:
     result = filter_agents_by_host_constraint(agents_by_host, address)
     assert len(result) == 1
     assert host2 in result
+
+
+# =============================================================================
+# _post_filter_matches_by_addresses tests
+# =============================================================================
+
+
+def test_post_filter_no_host_constraints_passes_all_through() -> None:
+    """Plain identifiers (no @) return all matches unchanged."""
+    matches = [_make_match("agent1", "host1", "local"), _make_match("agent2", "host2", "modal")]
+    parsed = [parse_identifier_as_address("agent1"), parse_identifier_as_address("agent2")]
+
+    result = _post_filter_matches_by_addresses(["agent1", "agent2"], parsed, matches)
+
+    assert len(result) == 2
+
+
+def test_post_filter_by_host_name() -> None:
+    """An address with host name filters to only that host's agents."""
+    match_host1 = _make_match("my-agent", "host1", "local")
+    match_host2 = _make_match("my-agent", "host2", "local")
+    matches = [match_host1, match_host2]
+    parsed = [parse_identifier_as_address("my-agent@host1")]
+
+    result = _post_filter_matches_by_addresses(["my-agent@host1"], parsed, matches)
+
+    assert len(result) == 1
+    assert result[0].host_name == HostName("host1")
+
+
+def test_post_filter_by_provider() -> None:
+    """An address with provider filters to only that provider's agents."""
+    match_local = _make_match("my-agent", "host1", "local")
+    match_modal = _make_match("my-agent", "host2", "modal")
+    matches = [match_local, match_modal]
+    parsed = [parse_identifier_as_address("my-agent@.modal")]
+
+    result = _post_filter_matches_by_addresses(["my-agent@.modal"], parsed, matches)
+
+    assert len(result) == 1
+    assert result[0].provider_name == ProviderInstanceName("modal")
+
+
+def test_post_filter_by_host_and_provider() -> None:
+    """An address with both host and provider requires both to match."""
+    match_right = _make_match("my-agent", "host1", "modal")
+    match_wrong_host = _make_match("my-agent", "host2", "modal")
+    match_wrong_provider = _make_match("my-agent", "host1", "local")
+    matches = [match_right, match_wrong_host, match_wrong_provider]
+    parsed = [parse_identifier_as_address("my-agent@host1.modal")]
+
+    result = _post_filter_matches_by_addresses(["my-agent@host1.modal"], parsed, matches)
+
+    assert len(result) == 1
+    assert result[0].host_name == HostName("host1")
+    assert result[0].provider_name == ProviderInstanceName("modal")
+
+
+def test_post_filter_mixed_constrained_and_unconstrained() -> None:
+    """Unconstrained identifiers pass through while constrained ones filter."""
+    match_a_host1 = _make_match("agent-a", "host1", "local")
+    match_a_host2 = _make_match("agent-a", "host2", "modal")
+    match_b = _make_match("agent-b", "host3", "local")
+    matches = [match_a_host1, match_a_host2, match_b]
+    parsed = [parse_identifier_as_address("agent-a@host1"), parse_identifier_as_address("agent-b")]
+
+    result = _post_filter_matches_by_addresses(["agent-a@host1", "agent-b"], parsed, matches)
+
+    # agent-a filtered to host1 only, agent-b passes through
+    assert len(result) == 2
+    result_names_and_hosts = [(str(m.agent_name), str(m.host_name)) for m in result]
+    assert ("agent-a", "host1") in result_names_and_hosts
+    assert ("agent-b", "host3") in result_names_and_hosts
+
+
+def test_post_filter_raises_when_constrained_identifier_has_no_match() -> None:
+    """Raises AgentNotFoundError if a host-constrained identifier matches nothing."""
+    match_wrong_host = _make_match("my-agent", "host2", "local")
+    matches = [match_wrong_host]
+    parsed = [parse_identifier_as_address("my-agent@host1")]
+
+    with pytest.raises(AgentNotFoundError, match="my-agent@host1"):
+        _post_filter_matches_by_addresses(["my-agent@host1"], parsed, matches)
+
+
+def test_post_filter_empty_matches_with_no_constraints() -> None:
+    """Empty matches with no constraints returns empty list."""
+    result = _post_filter_matches_by_addresses([], [], [])
+
+    assert result == []
 
 
 # =============================================================================

--- a/libs/mng/imbue/mng/cli/create.py
+++ b/libs/mng/imbue/mng/cli/create.py
@@ -810,7 +810,7 @@ def _try_reuse_existing_agent(
 
     if len(matching_agents) > 1:
         raise UserInputError(
-            f"Multiple agents found with name '{agent_name}', using the first one. Specify --host to target a specific host."
+            f"Multiple agents found with name '{agent_name}'. Use address syntax (e.g. '{agent_name}@HOST.PROVIDER') to target a specific host."
         )
 
     host_ref, agent_ref = matching_agents[0]

--- a/libs/mng/imbue/mng/cli/destroy.py
+++ b/libs/mng/imbue/mng/cli/destroy.py
@@ -395,7 +395,6 @@ def _partition_destroy_targets(
     """
     online_agents: list[tuple[AgentInterface, OnlineHostInterface]] = []
     offline_hosts: list[_OfflineHostToDestroy] = []
-    seen_hosts: set[str] = set()
 
     # Group matched agent IDs by host for the offline "all targeted" check
     matched_ids_by_host: dict[str, set[AgentId]] = {}
@@ -403,10 +402,6 @@ def _partition_destroy_targets(
         matched_ids_by_host.setdefault(str(match.host_id), set()).add(match.agent_id)
 
     for host_id_str, matched_ids in matched_ids_by_host.items():
-        if host_id_str in seen_hosts:
-            continue
-        seen_hosts.add(host_id_str)
-
         # Get the provider from any match on this host
         provider_name = next(m.provider_name for m in matches if str(m.host_id) == host_id_str)
         provider = get_provider_instance(provider_name, mng_ctx)

--- a/libs/mng/imbue/mng/cli/message.py
+++ b/libs/mng/imbue/mng/cli/message.py
@@ -147,12 +147,16 @@ def _message_impl(ctx: click.Context, **kwargs) -> None:
     include_filters = list(opts.include)
     if agent_identifiers:
         # Create a CEL filter that matches any of the provided identifiers.
-        # Parse agent addresses to extract the name/ID part for matching.
+        # Parse agent addresses to extract the name/ID part and host/provider constraints.
         ref_filters = []
         for ref in agent_identifiers:
-            plain_id, _ = parse_identifier_as_address(ref)
+            plain_id, address = parse_identifier_as_address(ref)
             ref_filter = f'(name == "{plain_id}" || id == "{plain_id}")'
-            ref_filters.append(ref_filter)
+            if address.host_name is not None:
+                ref_filter += f' && host.name == "{address.host_name}"'
+            if address.provider_name is not None:
+                ref_filter += f' && host.provider == "{address.provider_name}"'
+            ref_filters.append(f"({ref_filter})")
         combined_filter = " || ".join(ref_filters)
         include_filters.append(combined_filter)
 


### PR DESCRIPTION
My previous PRs were from agents with a broken reviewer setup, and my other agents' non-broken reviewers kept finding these issues.

---

Fix address handling in message cmd, dead code, and add post-filter tests

- message.py: Include host/provider constraints from parsed addresses in CEL filters instead of silently discarding them. Add host.name to the CEL context so host-name-based filtering works.
- create.py: Fix error message referencing non-existent --host flag to instead reference the address syntax (NAME@HOST.PROVIDER).
- agent_addr.py: Extract post-filtering logic into a testable pure function (_post_filter_matches_by_addresses) and fix zip(strict=False) to zip(strict=True) since the lists are always the same length.
- destroy.py: Remove redundant seen_hosts set (dict.items() already yields unique keys).
- agent_addr_test.py: Add 7 direct unit tests for post-filter logic covering host filtering, provider filtering, mixed constraints, and error cases.