### PR TITLE
Fix bash syntax error when launching Modal agents

### DIFF
--- a/libs/mng/imbue/mng/agents/base_agent.py
+++ b/libs/mng/imbue/mng/agents/base_agent.py
@@ -230,8 +230,13 @@ class BaseAgent(AgentInterface[AgentConfigT]):
             return AgentLifecycleState.STOPPED
 
     def _get_command_basename(self, command: CommandString) -> str:
-        """Extract the basename from a command string."""
-        return command.split()[0].split("/")[-1] if command else ""
+        """Extract the basename from a command string.
+
+        Strips leading shell subshell syntax (e.g. '( script.sh ... ) &')
+        to find the actual command name.
+        """
+        stripped = str(command).lstrip("( ")
+        return stripped.split()[0].split("/")[-1] if stripped else ""
 
     def get_expected_process_name(self) -> str:
         """Get the expected process name for lifecycle state detection.

--- a/libs/mng/imbue/mng/agents/base_agent_test.py
+++ b/libs/mng/imbue/mng/agents/base_agent_test.py
@@ -1200,6 +1200,16 @@ def test_get_command_basename_single_word(
     assert agent._get_command_basename(CommandString("python3")) == "python3"
 
 
+def test_get_command_basename_strips_leading_subshell_syntax(
+    temp_mng_ctx: MngContext,
+) -> None:
+    """_get_command_basename should strip leading '(' from subshell-wrapped commands."""
+    stub = _StubHost()
+    agent = _create_agent_with_stub_host(temp_mng_ctx, stub)
+
+    assert agent._get_command_basename(CommandString("( /usr/bin/script.sh session ) &")) == "script.sh"
+
+
 # =========================================================================
 # get_reported_activity_record tests
 # =========================================================================

--- a/libs/mng/imbue/mng/api/connect.py
+++ b/libs/mng/imbue/mng/api/connect.py
@@ -51,7 +51,7 @@ def _build_ssh_activity_wrapper_script(session_name: str, host_dir: Path, agent_
         f"sleep 5; done) & "
         "MNG_ACTIVITY_PID=$!; "
         # resize all tmux windows to be the correct size and signal the agent that it needs to redraw. We do this with a delay so that it happens after attaching.
-        f"(sleep 5 && tmux list-windows -t '{session_name}' -F '#I' | xargs -I{{}} tmux resize-window -t '{session_name}':{{}} -A && sleep 1 && pkill -SIGWINCH -f {agent_command}) & "
+        f"(sleep 5 && tmux list-windows -t '{session_name}' -F '#I' | xargs -I{{}} tmux resize-window -t '{session_name}':{{}} -A && sleep 1 && pkill -SIGWINCH -f {shlex.quote(agent_command)}) & "
         # actually attach
         f"tmux attach -t '{session_name}'; "
         "kill $MNG_ACTIVITY_PID 2>/dev/null; "

--- a/libs/mng/imbue/mng/api/connect_test.py
+++ b/libs/mng/imbue/mng/api/connect_test.py
@@ -484,6 +484,26 @@ def test_ssh_wrapper_script_is_correctly_quoted_for_bash_c() -> None:
     assert parsed == ["bash", "-c", wrapper_script]
 
 
+def test_build_ssh_activity_wrapper_script_quotes_agent_command_with_metacharacters() -> None:
+    """Test that agent_command is shell-quoted to prevent syntax errors.
+
+    When agent_command contains shell metacharacters (e.g. '(' from a command
+    like '( script.sh ... ) &'), it must be quoted so that pkill -f receives
+    it as a literal pattern rather than as shell syntax.
+    """
+    script = _build_ssh_activity_wrapper_script("mng-test", Path("/mng"), "(")
+
+    # The '(' should be quoted (e.g. as '(') so bash doesn't interpret it as subshell syntax
+    assert "pkill -SIGWINCH -f '('" in script
+
+
+def test_build_ssh_activity_wrapper_script_quotes_normal_agent_command() -> None:
+    """Test that even normal agent_command values are properly quoted."""
+    script = _build_ssh_activity_wrapper_script("mng-test", Path("/mng"), "claude")
+
+    assert "pkill -SIGWINCH -f claude" in script
+
+
 # =========================================================================
 # Tests for nested tmux detection in connect_to_agent (local host)
 # =========================================================================

--- a/libs/mng_notifications/imbue/mng_notifications/cli.py
+++ b/libs/mng_notifications/imbue/mng_notifications/cli.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from imbue.mng.api.observe import ObserveLockError
 from imbue.mng.api.observe import acquire_observe_lock
+from imbue.mng.api.observe import get_default_events_base_dir
 from imbue.mng.api.observe import release_observe_lock
 from imbue.mng.cli.common_opts import add_common_options
 from imbue.mng.cli.common_opts import setup_command_context
@@ -35,7 +36,7 @@ def _get_plugin_config(mng_ctx: MngContext) -> NotificationsPluginConfig:
 def _is_observe_running(mng_ctx: MngContext) -> bool:
     """Check if mng observe is already running by trying to acquire its lock."""
     try:
-        fd = acquire_observe_lock(mng_ctx.config)
+        fd = acquire_observe_lock(get_default_events_base_dir(mng_ctx.config))
         release_observe_lock(fd)
         return False
     except ObserveLockError:

--- a/libs/mng_notifications/imbue/mng_notifications/test_watch.py
+++ b/libs/mng_notifications/imbue/mng_notifications/test_watch.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 
 from imbue.mng.api.observe import get_agent_states_events_path
+from imbue.mng.api.observe import get_default_events_base_dir
 from imbue.mng.config.data_types import MngContext
 from imbue.mng.utils.polling import wait_for
 from imbue.mng_notifications.config import NotificationsPluginConfig
@@ -15,7 +16,7 @@ from imbue.mng_notifications.watcher import watch_for_waiting_agents
 def test_watcher_detects_running_to_waiting_via_observe_events(
     temp_mng_ctx: MngContext,
 ) -> None:
-    events_path = get_agent_states_events_path(temp_mng_ctx.config)
+    events_path = get_agent_states_events_path(get_default_events_base_dir(temp_mng_ctx.config))
     events_path.parent.mkdir(parents=True, exist_ok=True)
 
     notifier = RecordingNotifier()

--- a/libs/mng_notifications/imbue/mng_notifications/watcher.py
+++ b/libs/mng_notifications/imbue/mng_notifications/watcher.py
@@ -6,6 +6,7 @@ from loguru import logger
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mng.api.events import parse_event_line
 from imbue.mng.api.observe import get_agent_states_events_path
+from imbue.mng.api.observe import get_default_events_base_dir
 from imbue.mng.config.data_types import MngContext
 from imbue.mng_notifications.config import NotificationsPluginConfig
 from imbue.mng_notifications.notifier import Notifier
@@ -29,7 +30,7 @@ def watch_for_waiting_agents(
     if stop_event is None:
         stop_event = threading.Event()
 
-    events_path = get_agent_states_events_path(mng_ctx.config)
+    events_path = get_agent_states_events_path(get_default_events_base_dir(mng_ctx.config))
     logger.info("Watching for agent state transitions in {}", events_path)
 
     last_size = _get_file_size(events_path)


### PR DESCRIPTION
From Claude:

The agent_command (from get_expected_process_name()) was interpolated
directly into the shell script without quoting. When it contained shell
metacharacters like '(' (from commands wrapped in subshell syntax),
this caused a bash syntax error on the remote host.

Two fixes:
1. Shell-quote agent_command with shlex.quote() in the pkill invocation
2. Strip leading subshell syntax '(' in _get_command_basename so it
   returns the actual process name instead of shell punctuation