### PR TITLE
add mng-modal and modal-proxy to publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Build mng
         run: pyproject-build libs/mng -o dist/
 
+      - name: Build modal-proxy
+        run: pyproject-build libs/modal_proxy -o dist/
+
+      - name: Build mng-modal
+        run: pyproject-build libs/mng_modal -o dist/
+
       - name: Build mng-claude
         run: pyproject-build libs/mng_claude -o dist/
 

--- a/libs/mng_claude/pyproject.toml
+++ b/libs/mng_claude/pyproject.toml
@@ -6,6 +6,10 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "mng==0.1.7",
+]
+
+[dependency-groups]
+dev = [
     "mng-modal==0.1.0",
 ]
 

--- a/libs/mng_modal/pyproject.toml
+++ b/libs/mng_modal/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mng==0.1.7",
     "modal==1.3.1",
-    "modal-proxy",
+    "modal-proxy==0.1.0",
     "dockerfile-parse>=2.0.0",
 ]
 

--- a/libs/modal_proxy/pyproject.toml
+++ b/libs/modal_proxy/pyproject.toml
@@ -5,11 +5,11 @@ description = "Abstraction layer over Modal SDK for mng: supports direct, testin
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "concurrency-group",
-    "imbue-common",
+    "concurrency-group==0.1.7",
+    "imbue-common==0.1.7",
     "mng==0.1.7",
     "modal==1.3.1",
-    "resource-guards",
+    "resource-guards==0.1.0",
 ]
 
 [build-system]

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -33,6 +33,12 @@ PACKAGES: Final[tuple[PackageInfo, ...]] = (
     PackageInfo(
         dir_name="mng", pypi_name="mng", internal_deps=("imbue-common", "concurrency-group", "resource-guards")
     ),
+    PackageInfo(
+        dir_name="modal_proxy",
+        pypi_name="modal-proxy",
+        internal_deps=("imbue-common", "concurrency-group", "mng", "resource-guards"),
+    ),
+    PackageInfo(dir_name="mng_modal", pypi_name="mng-modal", internal_deps=("mng", "modal-proxy")),
     PackageInfo(dir_name="mng_claude", pypi_name="mng-claude", internal_deps=("mng",)),
     PackageInfo(dir_name="mng_pair", pypi_name="mng-pair", internal_deps=("mng",)),
     PackageInfo(dir_name="mng_opencode", pypi_name="mng-opencode", internal_deps=("mng",)),

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1872,14 +1872,18 @@ version = "0.1.0"
 source = { editable = "libs/mng_claude" }
 dependencies = [
     { name = "mng" },
+]
+
+[package.dev-dependencies]
+dev = [
     { name = "mng-modal" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mng", editable = "libs/mng" },
-    { name = "mng-modal", editable = "libs/mng_modal" },
-]
+requires-dist = [{ name = "mng", editable = "libs/mng" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "mng-modal", editable = "libs/mng_modal" }]
 
 [[package]]
 name = "mng-claude-mind"


### PR DESCRIPTION
## Summary
- Add `modal-proxy` and `mng-modal` to the publish pipeline (PACKAGES graph, CI workflow)
- Make `mng-modal` a dev-only dependency of `mng-claude` (it's only used in test fixtures)
- Pin internal deps in `modal-proxy` and `mng-modal` pyproject.toml files for publish verification consistency

## Test plan
- [x] `uv run scripts/verify_publish.py` passes (graph + pin consistency)
- [x] `mng-claude` tests pass (326 passed, 81.59% coverage)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)