### PR TITLE
improve kanpan footer wrapping in narrow terminals

### DIFF
--- a/libs/mng_kanpan/imbue/mng_kanpan/tui.py
+++ b/libs/mng_kanpan/imbue/mng_kanpan/tui.py
@@ -1430,7 +1430,7 @@ def run_kanpan(
     # Pack the left side so it gets exactly the space its text needs; the right
     # side (keybindings) gets the remainder and wraps when the terminal is narrow.
     footer_items: list[Any] = [("pack", footer_left_attr), AttrMap(footer_right, "footer")]
-    footer_columns = Columns(footer_items)
+    footer_columns = Columns(footer_items, dividechars=1)
     footer = Pile([Divider(), footer_columns])
 
     is_filtered = bool(include_filters or exclude_filters)


### PR DESCRIPTION
before:
<img width="533" height="90" alt="Screenshot 2026-03-25 at 3 11 56 PM" src="https://github.com/user-attachments/assets/21ba79ce-a3df-43dc-af1f-fe6dda022c90" />
<img width="542" height="123" alt="Screenshot 2026-03-25 at 3 12 33 PM" src="https://github.com/user-attachments/assets/b447080a-b472-471f-8391-47a9be3b4615" />
only wraps left column; no space between left and right column

after:
<img width="495" height="52" alt="Screenshot 2026-03-25 at 3 23 10 PM" src="https://github.com/user-attachments/assets/86bde60b-036c-4628-bbce-ab96dd2732be" />
<img width="250" height="156" alt="Screenshot 2026-03-25 at 3 23 29 PM" src="https://github.com/user-attachments/assets/14fd7b84-5182-4821-9ed4-d72eda6b6b7e" />
only wraps right column; at least one space between left and right column

## Summary
- Use `("pack", widget)` for the footer's left column (status text) so it gets exactly the width it needs, and the keybindings on the right get the remainder and wrap when the terminal is narrow -- instead of the status text getting squeezed into unreadable wrapping.
- Add `dividechars=1` so there's always a gap between the status text and keybindings.

## Test plan
- [x] All 269 kanpan tests pass with 85.97% coverage
- [ ] Manually verify in a narrow terminal that the keybindings wrap while "Last refresh: ..." stays readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)