### PR TITLE
fix inline imports ratchet

### DIFF
--- a/libs/mng/imbue/mng/utils/logging_test.py
+++ b/libs/mng/imbue/mng/utils/logging_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from typing import cast
 
+import paramiko.channel
 import pytest
 from loguru import logger
 
@@ -669,8 +670,6 @@ def test_paramiko_transport_log_patch_joins_list_messages() -> None:
 
 
 def _get_paramiko_traceback() -> types.TracebackType:
-    import paramiko.channel
-
     try:
         cast(Any, paramiko.channel.Channel._send)(None, b"test", None)
     except (AttributeError, TypeError, OSError) as e:


### PR DESCRIPTION
## Summary
- Moves inline `import paramiko.channel` to top-level imports in `logging_test.py`
- Fixes `test_prevent_inline_imports` ratchet which has been failing on main since c6578dc36

## Context
Commit c6578dc36 ("Suppress paramiko SFTP prefetch thread exceptions via threading.excepthook") added an inline `import paramiko.channel` inside `_get_paramiko_traceback()`. There was no reason for it to be inline -- paramiko is already a dependency used throughout the test file. This caused the inline imports ratchet to see 3 violations against a snapshot of 2.

## Test plan
- [x] `test_prevent_inline_imports` ratchet now passes
- [x] Full mng test suite passes (3108 tests)

Generated with [Claude Code](https://claude.com/claude-code)