### PR TITLE
always run pre-command scripts from repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,6 @@ current.tar.gz
 
 # ignore coverage files generated within subprojects
 cov.xml
+.autofix/
+test-results
+.reviews/

--- a/.gitignore
+++ b/.gitignore
@@ -269,6 +269,3 @@ current.tar.gz
 
 # ignore coverage files generated within subprojects
 cov.xml
-.autofix/
-test-results
-.reviews/

--- a/libs/mng/imbue/mng/cli/common_opts.py
+++ b/libs/mng/imbue/mng/cli/common_opts.py
@@ -232,7 +232,7 @@ def setup_command_context(
             ctx.parent.meta["is_error_reporting_enabled"] = True
 
     # Run pre-command scripts if configured for this command
-    _run_pre_command_scripts(mng_ctx.config, command_name, cg)
+    _run_pre_command_scripts(mng_ctx.config, command_name, cg, cwd=mng_ctx.project_root)
 
     # Store command metadata for lifecycle hooks (on_after_command, on_error)
     if ctx.parent is not None:
@@ -506,21 +506,25 @@ def _apply_plugin_option_overrides(
     )
 
 
-def _run_single_script(script: str, cg: ConcurrencyGroup) -> tuple[str, int, str, str]:
+def _run_single_script(script: str, cg: ConcurrencyGroup, cwd: Path | None = None) -> tuple[str, int, str, str]:
     """Run a single script and return (script, exit_code, stdout, stderr)."""
     try:
         result = cg.run_process_to_completion(
             ["sh", "-c", script],
+            cwd=cwd,
         )
         return (script, result.returncode if result.returncode is not None else 0, result.stdout, result.stderr)
     except ProcessError as e:
         return (script, e.returncode if e.returncode is not None else -1, e.stdout, e.stderr)
 
 
-def _run_pre_command_scripts(config: MngConfig, command_name: str, cg: ConcurrencyGroup) -> None:
+def _run_pre_command_scripts(
+    config: MngConfig, command_name: str, cg: ConcurrencyGroup, cwd: Path | None = None
+) -> None:
     """Run pre-command scripts configured for this command.
 
     Scripts are run in parallel and all must succeed (exit code 0).
+    When cwd is provided, scripts run with that as their working directory.
     Raises click.ClickException if any script fails.
     """
     scripts = config.pre_command_scripts.get(command_name)
@@ -532,7 +536,7 @@ def _run_pre_command_scripts(config: MngConfig, command_name: str, cg: Concurren
     futures: list[Future[tuple[str, int, str, str]]] = []
     with ConcurrencyGroupExecutor(parent_cg=cg, name="pre_command_scripts", max_workers=32) as executor:
         for script in scripts:
-            futures.append(executor.submit(_run_single_script, script, cg))
+            futures.append(executor.submit(_run_single_script, script, cg, cwd))
     for future in futures:
         script, exit_code, _stdout, stderr = future.result()
         if exit_code != 0:

--- a/libs/mng/imbue/mng/cli/common_opts.py
+++ b/libs/mng/imbue/mng/cli/common_opts.py
@@ -506,7 +506,7 @@ def _apply_plugin_option_overrides(
     )
 
 
-def _run_single_script(script: str, cg: ConcurrencyGroup, cwd: Path | None = None) -> tuple[str, int, str, str]:
+def _run_single_script(script: str, cg: ConcurrencyGroup, cwd: Path | None) -> tuple[str, int, str, str]:
     """Run a single script and return (script, exit_code, stdout, stderr)."""
     try:
         result = cg.run_process_to_completion(
@@ -518,9 +518,7 @@ def _run_single_script(script: str, cg: ConcurrencyGroup, cwd: Path | None = Non
         return (script, e.returncode if e.returncode is not None else -1, e.stdout, e.stderr)
 
 
-def _run_pre_command_scripts(
-    config: MngConfig, command_name: str, cg: ConcurrencyGroup, cwd: Path | None = None
-) -> None:
+def _run_pre_command_scripts(config: MngConfig, command_name: str, cg: ConcurrencyGroup, cwd: Path | None) -> None:
     """Run pre-command scripts configured for this command.
 
     Scripts are run in parallel and all must succeed (exit code 0).

--- a/libs/mng/imbue/mng/cli/common_opts_test.py
+++ b/libs/mng/imbue/mng/cli/common_opts_test.py
@@ -1,5 +1,6 @@
 """Tests for common_opts module."""
 
+from pathlib import Path
 from typing import Any
 
 import click
@@ -63,6 +64,24 @@ def test_run_single_script_captures_stderr(cg: ConcurrencyGroup) -> None:
     script, exit_code, stdout, stderr = _run_single_script("echo error >&2 && exit 1", cg)
     assert exit_code == 1
     assert "error" in stderr
+
+
+def test_run_single_script_uses_cwd(tmp_path: Path, cg: ConcurrencyGroup) -> None:
+    """_run_single_script should run the script in the specified cwd."""
+    script, exit_code, stdout, stderr = _run_single_script("pwd", cg, cwd=tmp_path)
+    assert exit_code == 0
+    assert stdout.strip() == str(tmp_path)
+
+
+def test_run_pre_command_scripts_uses_cwd(tmp_path: Path, mng_test_prefix: str, cg: ConcurrencyGroup) -> None:
+    """_run_pre_command_scripts should pass cwd to scripts."""
+    marker = tmp_path / "marker.txt"
+    config = MngConfig(
+        prefix=mng_test_prefix,
+        pre_command_scripts={"create": ["touch marker.txt"]},
+    )
+    _run_pre_command_scripts(config, "create", cg, cwd=tmp_path)
+    assert marker.exists()
 
 
 def test_run_pre_command_scripts_no_scripts(mng_test_prefix: str, cg: ConcurrencyGroup) -> None:

--- a/libs/mng/imbue/mng/cli/common_opts_test.py
+++ b/libs/mng/imbue/mng/cli/common_opts_test.py
@@ -45,7 +45,7 @@ def _make_click_context(
 
 def test_run_single_script_success(cg: ConcurrencyGroup) -> None:
     """_run_single_script should return exit code 0 for successful command."""
-    script, exit_code, stdout, stderr = _run_single_script("echo hello", cg)
+    script, exit_code, stdout, stderr = _run_single_script("echo hello", cg, cwd=None)
     assert script == "echo hello"
     assert exit_code == 0
     assert "hello" in stdout
@@ -54,14 +54,14 @@ def test_run_single_script_success(cg: ConcurrencyGroup) -> None:
 
 def test_run_single_script_failure(cg: ConcurrencyGroup) -> None:
     """_run_single_script should return non-zero exit code for failed command."""
-    script, exit_code, stdout, stderr = _run_single_script("exit 1", cg)
+    script, exit_code, stdout, stderr = _run_single_script("exit 1", cg, cwd=None)
     assert script == "exit 1"
     assert exit_code == 1
 
 
 def test_run_single_script_captures_stderr(cg: ConcurrencyGroup) -> None:
     """_run_single_script should capture stderr from failed command."""
-    script, exit_code, stdout, stderr = _run_single_script("echo error >&2 && exit 1", cg)
+    script, exit_code, stdout, stderr = _run_single_script("echo error >&2 && exit 1", cg, cwd=None)
     assert exit_code == 1
     assert "error" in stderr
 
@@ -88,7 +88,7 @@ def test_run_pre_command_scripts_no_scripts(mng_test_prefix: str, cg: Concurrenc
     """_run_pre_command_scripts should do nothing if no scripts configured."""
     config = MngConfig(prefix=mng_test_prefix, pre_command_scripts={})
     # Should not raise
-    _run_pre_command_scripts(config, "create", cg)
+    _run_pre_command_scripts(config, "create", cg, cwd=None)
 
 
 def test_run_pre_command_scripts_no_scripts_for_command(mng_test_prefix: str, cg: ConcurrencyGroup) -> None:
@@ -98,7 +98,7 @@ def test_run_pre_command_scripts_no_scripts_for_command(mng_test_prefix: str, cg
         pre_command_scripts={"other_command": ["echo hello"]},
     )
     # Should not raise
-    _run_pre_command_scripts(config, "create", cg)
+    _run_pre_command_scripts(config, "create", cg, cwd=None)
 
 
 def test_run_pre_command_scripts_success(mng_test_prefix: str, cg: ConcurrencyGroup) -> None:
@@ -108,7 +108,7 @@ def test_run_pre_command_scripts_success(mng_test_prefix: str, cg: ConcurrencyGr
         pre_command_scripts={"create": ["echo first", "echo second"]},
     )
     # Should not raise
-    _run_pre_command_scripts(config, "create", cg)
+    _run_pre_command_scripts(config, "create", cg, cwd=None)
 
 
 def test_run_pre_command_scripts_single_failure(mng_test_prefix: str, cg: ConcurrencyGroup) -> None:
@@ -118,7 +118,7 @@ def test_run_pre_command_scripts_single_failure(mng_test_prefix: str, cg: Concur
         pre_command_scripts={"create": ["exit 1"]},
     )
     with pytest.raises(click.ClickException) as exc_info:
-        _run_pre_command_scripts(config, "create", cg)
+        _run_pre_command_scripts(config, "create", cg, cwd=None)
     assert "Pre-command script(s) failed" in str(exc_info.value)
     assert "exit 1" in str(exc_info.value)
     assert "Exit code: 1" in str(exc_info.value)
@@ -131,7 +131,7 @@ def test_run_pre_command_scripts_multiple_failures(mng_test_prefix: str, cg: Con
         pre_command_scripts={"create": ["exit 1", "exit 2"]},
     )
     with pytest.raises(click.ClickException) as exc_info:
-        _run_pre_command_scripts(config, "create", cg)
+        _run_pre_command_scripts(config, "create", cg, cwd=None)
     error_message = str(exc_info.value)
     assert "Pre-command script(s) failed" in error_message
     # Both failures should be reported
@@ -145,7 +145,7 @@ def test_run_pre_command_scripts_partial_failure(mng_test_prefix: str, cg: Concu
         pre_command_scripts={"create": ["echo success", "exit 42"]},
     )
     with pytest.raises(click.ClickException) as exc_info:
-        _run_pre_command_scripts(config, "create", cg)
+        _run_pre_command_scripts(config, "create", cg, cwd=None)
     assert "Exit code: 42" in str(exc_info.value)
 
 
@@ -156,7 +156,7 @@ def test_run_pre_command_scripts_includes_stderr_in_error(mng_test_prefix: str, 
         pre_command_scripts={"create": ["echo 'my error message' >&2 && exit 1"]},
     )
     with pytest.raises(click.ClickException) as exc_info:
-        _run_pre_command_scripts(config, "create", cg)
+        _run_pre_command_scripts(config, "create", cg, cwd=None)
     assert "my error message" in str(exc_info.value)
 
 

--- a/libs/mng/imbue/mng/config/data_types.py
+++ b/libs/mng/imbue/mng/config/data_types.py
@@ -639,6 +639,10 @@ class MngContext(FrozenModel):
         default_factory=lambda: ConcurrencyGroup(name="default"),
         description="Top-level concurrency group for managing spawned processes",
     )
+    project_root: Path | None = Field(
+        default=None,
+        description="Project root directory (git worktree root), used as cwd for pre-command scripts",
+    )
 
     def get_plugin_config(self, name: str, config_type: type[PluginConfigT]) -> PluginConfigT:
         """Get a plugin's typed config, falling back to defaults if absent."""

--- a/libs/mng/imbue/mng/config/data_types.py
+++ b/libs/mng/imbue/mng/config/data_types.py
@@ -641,7 +641,7 @@ class MngContext(FrozenModel):
     )
     project_root: Path | None = Field(
         default=None,
-        description="Project root directory (git worktree root), used as cwd for pre-command scripts",
+        description="Project root directory (MNG_PROJECT_DIR, --context, or git worktree root)",
     )
 
     def get_plugin_config(self, name: str, config_type: type[PluginConfigT]) -> PluginConfigT:

--- a/libs/mng/imbue/mng/config/data_types.py
+++ b/libs/mng/imbue/mng/config/data_types.py
@@ -641,7 +641,7 @@ class MngContext(FrozenModel):
     )
     project_root: Path | None = Field(
         default=None,
-        description="Project root directory (MNG_PROJECT_DIR, --context, or git worktree root)",
+        description="Project root directory (--context or git worktree root)",
     )
 
     def get_plugin_config(self, name: str, config_type: type[PluginConfigT]) -> PluginConfigT:

--- a/libs/mng/imbue/mng/config/loader.py
+++ b/libs/mng/imbue/mng/config/loader.py
@@ -217,8 +217,14 @@ def load_config(
                 "Running mng within pytest is not allowed by the current configuration. This can happen when tests are poorly written, and load the .mng/settings.toml file from the root of the mng project"
             )
 
-    # Resolve project root (git worktree root) for use as cwd in pre-command scripts
-    project_root = context_dir or find_git_worktree_root(start=None, cg=concurrency_group)
+    # Resolve project root for use as cwd in pre-command scripts.
+    # Respect MNG_PROJECT_DIR (same precedence as resolve_project_config_dir).
+    env_project_dir = os.environ.get("MNG_PROJECT_DIR")
+    project_root = (
+        Path(env_project_dir)
+        if env_project_dir
+        else (context_dir or find_git_worktree_root(start=None, cg=concurrency_group))
+    )
 
     # Return MngContext containing both config and plugin manager
     return MngContext(

--- a/libs/mng/imbue/mng/config/loader.py
+++ b/libs/mng/imbue/mng/config/loader.py
@@ -42,6 +42,7 @@ from imbue.mng.primitives import PluginName
 from imbue.mng.primitives import ProviderInstanceName
 from imbue.mng.utils.env_utils import parse_bool_env
 from imbue.mng.utils.file_utils import atomic_write
+from imbue.mng.utils.git_utils import find_git_worktree_root
 from imbue.mng.utils.logging import LoggingConfig
 
 # Environment variable prefix for command config overrides.
@@ -216,6 +217,9 @@ def load_config(
                 "Running mng within pytest is not allowed by the current configuration. This can happen when tests are poorly written, and load the .mng/settings.toml file from the root of the mng project"
             )
 
+    # Resolve project root (git worktree root) for use as cwd in pre-command scripts
+    project_root = context_dir or find_git_worktree_root(start=None, cg=concurrency_group)
+
     # Return MngContext containing both config and plugin manager
     return MngContext(
         config=final_config,
@@ -223,6 +227,7 @@ def load_config(
         is_interactive=is_interactive,
         profile_dir=profile_dir,
         concurrency_group=concurrency_group,
+        project_root=project_root,
     )
 
 

--- a/libs/mng/imbue/mng/config/loader.py
+++ b/libs/mng/imbue/mng/config/loader.py
@@ -218,13 +218,9 @@ def load_config(
             )
 
     # Resolve project root for use as cwd in pre-command scripts.
-    # Respect MNG_PROJECT_DIR (same precedence as resolve_project_config_dir).
-    env_project_dir = os.environ.get("MNG_PROJECT_DIR")
-    project_root = (
-        Path(env_project_dir)
-        if env_project_dir
-        else (context_dir or find_git_worktree_root(start=None, cg=concurrency_group))
-    )
+    # Note: MNG_PROJECT_DIR is NOT used here because it points to the config
+    # directory (containing settings.toml), not the project root.
+    project_root = context_dir or find_git_worktree_root(start=None, cg=concurrency_group)
 
     # Return MngContext containing both config and plugin manager
     return MngContext(


### PR DESCRIPTION
## Summary

- Pre-command scripts (e.g. `make_tar_of_repo.sh`) configured in `.mng/settings.toml` failed with exit code 127 because `_run_single_script()` never set a working directory -- scripts using relative paths like `./scripts/...` inherited whatever the parent process's cwd happened to be.
- Added `project_root: Path | None` to `MngContext`, resolved during config loading from `--context` or `find_git_worktree_root()`, and passed as `cwd` to `run_process_to_completion`.
- Note: `MNG_PROJECT_DIR` is intentionally **not** used as the project root because it points to the config directory (containing `settings.toml`), not the actual project root.

## Test plan

- [x] New unit test verifies `_run_single_script` runs in specified cwd
- [x] New unit test verifies `_run_pre_command_scripts` passes cwd through to scripts
- [x] Full test suite: 3285 passed, 1 skipped, 82.70% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)