### PR TITLE
Make the pytest global lock smarter

### DIFF
--- a/justfile
+++ b/justfile
@@ -76,18 +76,18 @@ test-quick:
 test-acceptance:
   # when running these locally, we set the max duration super high just so that we don't fail (which makes it harder to see the errors)
   # parallelism is controlled by PYTEST_NUMPROCESSES env var (default: 4 from pyproject.toml)
-  PYTEST_MAX_DURATION=600 uv run pytest --override-ini='cov-fail-under=0' --no-cov -m "no release"
+  PYTEST_MAX_DURATION_SECONDS=600 uv run pytest --override-ini='cov-fail-under=0' --no-cov -m "no release"
 
 test-release:
   # when running these locally, we set the max duration super high just so that we don't fail (which makes it harder to see the errors)
   # parallelism is controlled by PYTEST_NUMPROCESSES env var (default: 4 from pyproject.toml)
-  PYTEST_MAX_DURATION=1200 uv run pytest --override-ini='cov-fail-under=0' --no-cov -m "acceptance or not acceptance"
+  PYTEST_MAX_DURATION_SECONDS=1200 uv run pytest --override-ini='cov-fail-under=0' --no-cov -m "acceptance or not acceptance"
 
 # Generate test timings for pytest-split (run periodically to keep timings up to date. Runs all acceptance and release)
 test-timings:
   # when running these locally, we set the max duration super high just so that we don't fail (which makes it harder to see the errors)
-  PYTEST_MAX_DURATION=6000 uv run pytest --override-ini='cov-fail-under=0' --no-cov -n 0 -m "acceptance or not acceptance" --store-durations
+  PYTEST_MAX_DURATION_SECONDS=6000 uv run pytest --override-ini='cov-fail-under=0' --no-cov -n 0 -m "acceptance or not acceptance" --store-durations
 
 # useful for running against a single test, regardless of how it is marked
 test target:
-  PYTEST_MAX_DURATION=600 uv run pytest -sv --override-ini='cov-fail-under=0' --no-cov -n 0 -m "acceptance or not acceptance" "{{target}}"
+  PYTEST_MAX_DURATION_SECONDS=600 uv run pytest -sv --override-ini='cov-fail-under=0' --no-cov -n 0 -m "acceptance or not acceptance" "{{target}}"

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -35,6 +35,7 @@ import fcntl
 import importlib.metadata
 import json
 import os
+import signal
 import sys
 import time
 from io import StringIO
@@ -101,6 +102,11 @@ _GLOBAL_TEST_LOCK_PATH: Final[Path] = Path("/tmp/pytest_global_test_lock")
 # The handle must stay open for the duration of the test session so the flock is held.
 # When the process exits for any reason, the OS closes the handle and releases the lock.
 _SESSION_LOCK_HANDLE_ATTR: Final[str] = "_global_test_lock_file_handle"
+
+# Grace period added to the max duration when computing the lock deadline.
+# This accounts for test collection, teardown, and other overhead beyond
+# the raw test execution time that _compute_max_duration() measures.
+_LOCK_DEADLINE_GRACE_SECONDS: Final[float] = 60.0
 
 # Guard to prevent duplicate hook registration (see module docstring).
 _registered: bool = False
@@ -178,45 +184,228 @@ def _print_lock_message(message: str, fd: int = 2) -> None:
     os.write(fd, f"\n{message}\n".encode())
 
 
+def _is_process_alive(pid: int) -> bool:
+    """Check whether a process with the given PID is still running.
+
+    Also reaps the process if it is a zombie child of the current process,
+    since zombies respond to ``os.kill(pid, 0)`` even though they have exited.
+    """
+    # Reap if it is a zombie child of ours.  For non-children this raises
+    # ChildProcessError which we silently ignore.
+    try:
+        waited_pid, _ = os.waitpid(pid, os.WNOHANG)
+        if waited_pid == pid:
+            return False
+    except ChildProcessError:
+        pass
+
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by a different user.
+        return True
+
+
+def _kill_stale_process(pid: int) -> bool:
+    """Send SIGTERM then SIGKILL to a process that has exceeded its deadline.
+
+    Returns True if the signals were delivered (the process should be dying or
+    already dead). Returns False if the process could not be signalled (e.g. due
+    to insufficient permissions).
+
+    Does NOT wait for the process to fully exit; the caller should unlink the
+    lock file so that subsequent flock attempts operate on a fresh inode that
+    is independent of the dying process's lock.
+    """
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+    return True
+
+
+def _read_lock_info(lock_path: Path) -> dict[str, Any] | None:
+    """Read and parse the JSON lock info from the lock file.
+
+    Returns None if the file is missing, empty, contains invalid JSON, or
+    the top-level value is not a dict.
+    """
+    try:
+        content = lock_path.read_text()
+        if not content.strip():
+            return None
+        parsed = json.loads(content)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _write_lock_info(lock_handle: TextIO, pid: int, deadline: float | None) -> None:
+    """Write JSON lock info (pid and optional deadline) to the lock file handle."""
+    lock_info: dict[str, int | float] = {"pid": pid}
+    if deadline is not None:
+        lock_info["deadline"] = deadline
+    lock_handle.write(json.dumps(lock_info))
+    lock_handle.flush()
+
+
+def _compute_max_duration() -> float:
+    """Compute the maximum allowed test suite duration in seconds.
+
+    The same logic is used by _pytest_sessionfinish to enforce the time limit
+    and by _compute_lock_deadline to derive the lock file deadline.
+    """
+    if "PYTEST_MAX_DURATION" in os.environ:
+        return float(os.environ["PYTEST_MAX_DURATION"])
+    if os.environ.get("IS_RELEASE", "0") == "1":
+        return 10 * 60.0
+    if os.environ.get("IS_ACCEPTANCE", "0") == "1":
+        return 6 * 60.0
+    if "CI" in os.environ:
+        return 150.0
+    return 300.0
+
+
+def _compute_lock_deadline(start_time: float) -> float | None:
+    """Compute the lock deadline as an absolute timestamp.
+
+    Returns a deadline only when PYTEST_MAX_DURATION is explicitly set, indicating
+    that the caller is aware of a time budget (e.g. invoked from a hook or script).
+    When no explicit budget is set, returns None so that other processes will not
+    kill this one (though they can still clean up a dead PID).
+    """
+    if "PYTEST_MAX_DURATION" not in os.environ:
+        return None
+    max_duration = _compute_max_duration()
+    return start_time + max_duration + _LOCK_DEADLINE_GRACE_SECONDS
+
+
+def _try_break_stale_lock(lock_path: Path) -> bool:
+    """Attempt to break a stale or expired lock.
+
+    Reads the lock file to check the owning PID and optional deadline:
+    - If the PID is no longer alive, removes the lock file and returns True.
+    - If the PID is alive but its deadline has passed, kills it, removes the
+      lock file, and returns True.
+    - Otherwise returns False (lock is legitimately held).
+    """
+    lock_info = _read_lock_info(lock_path)
+    if lock_info is None:
+        return False
+
+    pid = lock_info.get("pid")
+    if not isinstance(pid, int):
+        return False
+
+    if not _is_process_alive(pid):
+        _print_lock_message(
+            f"PYTEST GLOBAL LOCK: Removing stale lock from dead process (pid={pid}).",
+        )
+        lock_path.unlink(missing_ok=True)
+        return True
+
+    deadline = lock_info.get("deadline")
+    if isinstance(deadline, (int, float)) and time.time() > deadline:
+        overdue = time.time() - deadline
+        _print_lock_message(
+            f"PYTEST GLOBAL LOCK: Process {pid} exceeded its deadline (by {overdue:.0f}s), sending SIGTERM+SIGKILL.",
+        )
+        if _kill_stale_process(pid):
+            lock_path.unlink(missing_ok=True)
+            return True
+        _print_lock_message(
+            f"PYTEST GLOBAL LOCK: Could not kill process {pid}, will wait for lock.",
+        )
+
+    return False
+
+
+def _verify_lock_inode(lock_handle: TextIO, lock_path: Path) -> bool:
+    """Check that the open file handle still refers to the same on-disk inode.
+
+    After acquiring an flock, the file may have been unlinked and recreated by
+    another process that broke a stale lock.  In that case our flock is on a
+    deleted inode and does not provide mutual exclusion with the new file.
+    """
+    fd_stat = os.fstat(lock_handle.fileno())
+    try:
+        path_stat = lock_path.stat()
+    except FileNotFoundError:
+        return False
+    return fd_stat.st_ino == path_stat.st_ino
+
+
 def _acquire_global_test_lock(
     lock_path: Path,
 ) -> TextIO:
     """Acquire an exclusive lock on the given path, returning the open file handle.
 
-    If the lock cannot be acquired immediately, prints a waiting message to stderr,
-    then blocks until the lock is available.
+    If the lock cannot be acquired immediately, the lock file is inspected for a
+    JSON payload containing the holder's PID and an optional deadline:
 
-    The caller must keep the returned file handle open for as long as they want to hold
-    the lock. The lock is automatically released when the file handle is closed or when
-    the process exits.
+    - If the holder's PID is no longer running, the stale lock file is removed
+      and acquisition is retried immediately.
+    - If the holder is still alive but its deadline has passed, the holder is
+      killed (SIGTERM then SIGKILL), the lock file is removed, and acquisition
+      is retried.
+    - Otherwise, blocks until the lock becomes available.
+
+    The caller must keep the returned file handle open for as long as they want
+    to hold the lock. The lock is automatically released when the file handle is
+    closed or when the process exits.
     """
-    # Create the lock file if it doesn't exist
-    lock_path.touch(exist_ok=True)
+    acquired_handle: TextIO | None = None
+    while acquired_handle is None:
+        # Ensure the lock file exists.
+        lock_path.touch(exist_ok=True)
 
-    # Open the lock file
-    lock_file_handle = lock_path.open("w")
+        try:
+            lock_file_handle = lock_path.open("r+")
+        except FileNotFoundError:
+            # Narrow race: file was deleted between touch() and open().
+            continue
 
-    # Try to acquire the lock without blocking first to see if we need to wait
-    try:
-        fcntl.flock(lock_file_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        # We got the lock immediately, no need to print anything
-        return lock_file_handle
-    except BlockingIOError:
-        # Lock is held by another process, we'll need to wait
-        pass
+        # Try to acquire the lock without blocking.
+        try:
+            fcntl.flock(lock_file_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # Lock is held by another process.
+            lock_file_handle.close()
 
-    # Print a message about waiting for the lock
-    _print_lock_message(
-        "PYTEST GLOBAL LOCK: Another pytest process is running.\n"
-        "Waiting for it to complete before starting this test run...",
-    )
+            if _try_break_stale_lock(lock_path):
+                continue
 
-    # Now acquire the lock with blocking (will wait until available)
-    fcntl.flock(lock_file_handle.fileno(), fcntl.LOCK_EX)
+            # Legitimate lock holder -- block until it finishes.
+            _print_lock_message(
+                "PYTEST GLOBAL LOCK: Another pytest process is running.\n"
+                "Waiting for it to complete before starting this test run...",
+            )
+            lock_path.touch(exist_ok=True)
+            try:
+                lock_file_handle = lock_path.open("r+")
+            except FileNotFoundError:
+                continue
+            fcntl.flock(lock_file_handle.fileno(), fcntl.LOCK_EX)
+            _print_lock_message("PYTEST GLOBAL LOCK: Lock acquired, proceeding with tests.")
 
-    _print_lock_message("PYTEST GLOBAL LOCK: Lock acquired, proceeding with tests.")
+        # Verify the inode has not been replaced while we waited.
+        if _verify_lock_inode(lock_file_handle, lock_path):
+            # We hold the real lock.  Truncate so the caller can write fresh info.
+            lock_file_handle.seek(0)
+            lock_file_handle.truncate()
+            acquired_handle = lock_file_handle
+        else:
+            lock_file_handle.close()
 
-    return lock_file_handle
+    return acquired_handle
 
 
 def _configure_shared_coverage_defaults(config: pytest.Config) -> None:
@@ -310,7 +499,12 @@ def _pytest_sessionstart(session: pytest.Session) -> None:
         setattr(session, _SESSION_LOCK_HANDLE_ATTR, lock_handle)  # noqa: B010
 
         # Record start time AFTER acquiring the lock so wait time isn't counted
-        setattr(session, "start_time", time.time())  # noqa: B010
+        start_time = time.time()
+        setattr(session, "start_time", start_time)  # noqa: B010
+
+        # Write lock info so other processes can detect stale/expired locks
+        deadline = _compute_lock_deadline(start_time)
+        _write_lock_info(lock_handle, os.getpid(), deadline)
 
     start_resource_guards(session)
 
@@ -332,33 +526,7 @@ def _pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
 
     if hasattr(session, "start_time"):
         duration = time.time() - session.start_time
-
-        # There are 4 types of tests, each with different time limits in CI:
-        # - unit tests: fast, local, no network (run with integration tests)
-        # - integration tests: local, no network, used for coverage calculation
-        # - acceptance tests: run on all branches except release, have network/Modal/etc access
-        # - release tests: only run on release, comprehensive tests for release readiness
-
-        # Allow explicit override via environment variable (useful for generating test timings)
-        if "PYTEST_MAX_DURATION" in os.environ:
-            max_duration = float(os.environ["PYTEST_MAX_DURATION"])
-        # release tests have the highest limit, since there can be many more of them, and they can take a really long time
-        elif os.environ.get("IS_RELEASE", "0") == "1":
-            # this limit applies to the test suite that runs against "release" in GitHub CI
-            max_duration = 10 * 60.0
-        # acceptance tests have a somewhat higher limit (than integration and unit)
-        elif os.environ.get("IS_ACCEPTANCE", "0") == "1":
-            # this limit applies to the test suite that runs against all branches *except* "release" in GitHub CI (and has access to network, Modal, etc)
-            max_duration = 6 * 60.0
-        # integration tests have a lower limit
-        else:
-            if "CI" in os.environ:
-                # this limit applies to the test suite that runs against all branches *except* "release" in GitHub CI (and which is basically just used for calculating coverage)
-                # typically integration tests and unit tests are run locally, so we want them to be fast
-                max_duration = 150.0
-            else:
-                # this limit applies to the entire test suite when run locally
-                max_duration = 300.0
+        max_duration = _compute_max_duration()
 
         if duration > max_duration:
             pytest.exit(

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -262,15 +262,26 @@ def _compute_max_duration() -> float:
 
     The same logic is used by _pytest_sessionfinish to enforce the time limit
     and by _compute_lock_deadline to derive the lock file deadline.
+
+    There are 4 types of tests, each with different time limits in CI:
+
+    - unit tests: fast, local, no network (run together with integration tests)
+    - integration tests: local, no network, used for coverage calculation
+    - acceptance tests: run on all branches except release, have network/Modal/etc access
+    - release tests: only run on release, comprehensive tests for release readiness
     """
     if "PYTEST_MAX_DURATION" in os.environ:
         return float(os.environ["PYTEST_MAX_DURATION"])
+    # Release tests have the highest limit since there can be many, and they can be slow
     if os.environ.get("IS_RELEASE", "0") == "1":
         return 10 * 60.0
+    # Acceptance tests have a somewhat higher limit than integration/unit
     if os.environ.get("IS_ACCEPTANCE", "0") == "1":
         return 6 * 60.0
     if "CI" in os.environ:
+        # Integration + unit tests in CI should be fast
         return 150.0
+    # Local development default
     return 300.0
 
 

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -363,6 +363,7 @@ def _acquire_global_test_lock(
     closed or when the process exits.
     """
     acquired_handle: TextIO | None = None
+    waited_for_lock = False
     while acquired_handle is None:
         # Ensure the lock file exists.
         lock_path.touch(exist_ok=True)
@@ -394,7 +395,7 @@ def _acquire_global_test_lock(
             except FileNotFoundError:
                 continue
             fcntl.flock(lock_file_handle.fileno(), fcntl.LOCK_EX)
-            _print_lock_message("PYTEST GLOBAL LOCK: Lock acquired, proceeding with tests.")
+            waited_for_lock = True
 
         # Verify the inode has not been replaced while we waited.
         if _verify_lock_inode(lock_file_handle, lock_path):
@@ -404,6 +405,9 @@ def _acquire_global_test_lock(
             acquired_handle = lock_file_handle
         else:
             lock_file_handle.close()
+
+    if waited_for_lock:
+        _print_lock_message("PYTEST GLOBAL LOCK: Lock acquired, proceeding with tests.")
 
     return acquired_handle
 

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -17,7 +17,7 @@ Environment variables:
   explicit -n passed on the command line.
 - PYTEST_MAX_DURATION: Override the maximum allowed test suite duration in seconds.
   Without this, defaults are chosen based on test type and environment (see
-  _pytest_sessionfinish for details).
+  _compute_max_duration for details).
 - MNG_TEST_PROFILE: Force a specific test profile (overrides branch detection).
   Set to "all" to disable profile filtering entirely.
 

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -2,7 +2,7 @@
 
 Provides common test infrastructure:
 - Global test locking (prevents parallel pytest processes from conflicting)
-- Test suite timing limits (configurable via PYTEST_MAX_DURATION env var)
+- Test suite timing limits (configurable via PYTEST_MAX_DURATION_SECONDS env var)
 - xdist parallelism override (configurable via PYTEST_NUMPROCESSES env var)
 - Output file redirection (slow tests report, coverage report)
 - Shared pytest defaults (markers, filterwarnings, CLI args, coverage report config)
@@ -15,7 +15,7 @@ Environment variables:
   pyproject.toml addopts). Set to e.g. 16 on machines with many cores, or 0 to
   disable xdist. This overrides the -n value from pyproject.toml but NOT an
   explicit -n passed on the command line.
-- PYTEST_MAX_DURATION: Override the maximum allowed test suite duration in seconds.
+- PYTEST_MAX_DURATION_SECONDS: Override the maximum allowed test suite duration in seconds.
   Without this, defaults are chosen based on test type and environment (see
   _compute_max_duration for details).
 - MNG_TEST_PROFILE: Force a specific test profile (overrides branch detection).
@@ -215,18 +215,28 @@ def _kill_stale_process(pid: int) -> bool:
     Returns True if the signals were delivered (the process should be dying or
     already dead). Returns False if the process could not be signalled (e.g. due
     to insufficient permissions).
-
-    Does NOT wait for the process to fully exit; the caller should unlink the
-    lock file so that subsequent flock attempts operate on a fresh inode that
-    is independent of the dying process's lock.
     """
-    for sig in (signal.SIGTERM, signal.SIGKILL):
-        try:
-            os.kill(pid, sig)
-        except ProcessLookupError:
-            return True
-        except PermissionError:
-            return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+
+    # Give the process a moment to shut down gracefully before escalating.
+    # Human-sanctioned use of time.sleep -- there is no event-based mechanism
+    # to wait for an arbitrary (non-child) process to exit.
+    time.sleep(2)
+
+    if not _is_process_alive(pid):
+        return True
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
     return True
 
 
@@ -270,8 +280,8 @@ def _compute_max_duration() -> float:
     - acceptance tests: run on all branches except release, have network/Modal/etc access
     - release tests: only run on release, comprehensive tests for release readiness
     """
-    if "PYTEST_MAX_DURATION" in os.environ:
-        return float(os.environ["PYTEST_MAX_DURATION"])
+    if "PYTEST_MAX_DURATION_SECONDS" in os.environ:
+        return float(os.environ["PYTEST_MAX_DURATION_SECONDS"])
     # Release tests have the highest limit since there can be many, and they can be slow
     if os.environ.get("IS_RELEASE", "0") == "1":
         return 10 * 60.0
@@ -288,12 +298,12 @@ def _compute_max_duration() -> float:
 def _compute_lock_deadline(start_time: float) -> float | None:
     """Compute the lock deadline as an absolute timestamp.
 
-    Returns a deadline only when PYTEST_MAX_DURATION is explicitly set, indicating
+    Returns a deadline only when PYTEST_MAX_DURATION_SECONDS is explicitly set, indicating
     that the caller is aware of a time budget (e.g. invoked from a hook or script).
     When no explicit budget is set, returns None so that other processes will not
     kill this one (though they can still clean up a dead PID).
     """
-    if "PYTEST_MAX_DURATION" not in os.environ:
+    if "PYTEST_MAX_DURATION_SECONDS" not in os.environ:
         return None
     max_duration = _compute_max_duration()
     return start_time + max_duration + _LOCK_DEADLINE_GRACE_SECONDS

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -226,7 +226,7 @@ def _kill_stale_process(pid: int) -> bool:
     # Give the process a moment to shut down gracefully before escalating.
     # Human-sanctioned use of time.sleep -- there is no event-based mechanism
     # to wait for an arbitrary (non-child) process to exit.
-    time.sleep(2)
+    time.sleep(5)
 
     if not _is_process_alive(pid):
         return True

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
@@ -83,33 +83,33 @@ def test_read_lock_info_non_dict_json(tmp_path: Path) -> None:
 
 
 def test_max_duration_explicit_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PYTEST_MAX_DURATION", "42")
+    monkeypatch.setenv("PYTEST_MAX_DURATION_SECONDS", "42")
     assert _compute_max_duration() == 42.0
 
 
 def test_max_duration_release(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("IS_RELEASE", "1")
-    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("PYTEST_MAX_DURATION_SECONDS", raising=False)
     assert _compute_max_duration() == 600.0
 
 
 def test_max_duration_acceptance(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("IS_ACCEPTANCE", "1")
-    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("PYTEST_MAX_DURATION_SECONDS", raising=False)
     monkeypatch.delenv("IS_RELEASE", raising=False)
     assert _compute_max_duration() == 360.0
 
 
 def test_max_duration_ci(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CI", "1")
-    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("PYTEST_MAX_DURATION_SECONDS", raising=False)
     monkeypatch.delenv("IS_RELEASE", raising=False)
     monkeypatch.delenv("IS_ACCEPTANCE", raising=False)
     assert _compute_max_duration() == 150.0
 
 
 def test_max_duration_local_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("PYTEST_MAX_DURATION_SECONDS", raising=False)
     monkeypatch.delenv("IS_RELEASE", raising=False)
     monkeypatch.delenv("IS_ACCEPTANCE", raising=False)
     monkeypatch.delenv("CI", raising=False)
@@ -120,12 +120,12 @@ def test_max_duration_local_default(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_lock_deadline_none_without_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("PYTEST_MAX_DURATION_SECONDS", raising=False)
     assert _compute_lock_deadline(1000.0) is None
 
 
 def test_lock_deadline_computed_with_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PYTEST_MAX_DURATION", "120")
+    monkeypatch.setenv("PYTEST_MAX_DURATION_SECONDS", "120")
     deadline = _compute_lock_deadline(1000.0)
     assert deadline is not None
     # 1000 + 120 + 60 (grace)

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
@@ -1,0 +1,247 @@
+"""Tests for the global test lock helpers in conftest_hooks."""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from imbue.imbue_common.conftest_hooks import _acquire_global_test_lock
+from imbue.imbue_common.conftest_hooks import _compute_lock_deadline
+from imbue.imbue_common.conftest_hooks import _compute_max_duration
+from imbue.imbue_common.conftest_hooks import _is_process_alive
+from imbue.imbue_common.conftest_hooks import _read_lock_info
+from imbue.imbue_common.conftest_hooks import _try_break_stale_lock
+from imbue.imbue_common.conftest_hooks import _verify_lock_inode
+from imbue.imbue_common.conftest_hooks import _write_lock_info
+
+# --- _is_process_alive ---
+
+
+def test_current_process_is_alive() -> None:
+    assert _is_process_alive(os.getpid()) is True
+
+
+def test_nonexistent_pid_is_not_alive() -> None:
+    # PID 2**22 is unlikely to exist (and is within the valid PID range).
+    assert _is_process_alive(2**22) is False
+
+
+# --- _read_lock_info / _write_lock_info ---
+
+
+def test_lock_info_round_trip_with_deadline(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    with lock_file.open("r+") as fh:
+        _write_lock_info(fh, pid=12345, deadline=1000.5)
+
+    info = _read_lock_info(lock_file)
+    assert info is not None
+    assert info["pid"] == 12345
+    assert info["deadline"] == 1000.5
+
+
+def test_lock_info_round_trip_without_deadline(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    with lock_file.open("r+") as fh:
+        _write_lock_info(fh, pid=99, deadline=None)
+
+    info = _read_lock_info(lock_file)
+    assert info is not None
+    assert info["pid"] == 99
+    assert "deadline" not in info
+
+
+def test_read_lock_info_empty_file(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    assert _read_lock_info(lock_file) is None
+
+
+def test_read_lock_info_missing_file(tmp_path: Path) -> None:
+    assert _read_lock_info(tmp_path / "no_such_file") is None
+
+
+def test_read_lock_info_invalid_json(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.write_text("not json{")
+    assert _read_lock_info(lock_file) is None
+
+
+def test_read_lock_info_non_dict_json(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.write_text("[1, 2, 3]")
+    assert _read_lock_info(lock_file) is None
+
+
+# --- _compute_max_duration ---
+
+
+def test_max_duration_explicit_env_var() -> None:
+    with patch.dict(os.environ, {"PYTEST_MAX_DURATION": "42"}, clear=False):
+        assert _compute_max_duration() == 42.0
+
+
+def test_max_duration_release() -> None:
+    env = {"IS_RELEASE": "1"}
+    with patch.dict(os.environ, env, clear=False):
+        os.environ.pop("PYTEST_MAX_DURATION", None)
+        assert _compute_max_duration() == 600.0
+
+
+def test_max_duration_acceptance() -> None:
+    env = {"IS_ACCEPTANCE": "1"}
+    with patch.dict(os.environ, env, clear=False):
+        os.environ.pop("PYTEST_MAX_DURATION", None)
+        os.environ.pop("IS_RELEASE", None)
+        assert _compute_max_duration() == 360.0
+
+
+def test_max_duration_ci() -> None:
+    env = {"CI": "1"}
+    with patch.dict(os.environ, env, clear=False):
+        os.environ.pop("PYTEST_MAX_DURATION", None)
+        os.environ.pop("IS_RELEASE", None)
+        os.environ.pop("IS_ACCEPTANCE", None)
+        assert _compute_max_duration() == 150.0
+
+
+def test_max_duration_local_default() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("PYTEST_MAX_DURATION", None)
+        os.environ.pop("IS_RELEASE", None)
+        os.environ.pop("IS_ACCEPTANCE", None)
+        os.environ.pop("CI", None)
+        assert _compute_max_duration() == 300.0
+
+
+# --- _compute_lock_deadline ---
+
+
+def test_lock_deadline_none_without_env_var() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("PYTEST_MAX_DURATION", None)
+        assert _compute_lock_deadline(1000.0) is None
+
+
+def test_lock_deadline_computed_with_env_var() -> None:
+    with patch.dict(os.environ, {"PYTEST_MAX_DURATION": "120"}, clear=False):
+        deadline = _compute_lock_deadline(1000.0)
+        assert deadline is not None
+        # 1000 + 120 + 60 (grace)
+        assert deadline == 1180.0
+
+
+# --- _try_break_stale_lock ---
+
+
+def test_break_stale_lock_dead_pid(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    # Use a PID that is almost certainly not alive.
+    lock_file.write_text(json.dumps({"pid": 2**22}))
+    assert _try_break_stale_lock(lock_file) is True
+    assert not lock_file.exists()
+
+
+def test_break_stale_lock_alive_pid_no_deadline(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.write_text(json.dumps({"pid": os.getpid()}))
+    assert _try_break_stale_lock(lock_file) is False
+    assert lock_file.exists()
+
+
+def test_break_stale_lock_alive_pid_future_deadline(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    future = time.time() + 9999
+    lock_file.write_text(json.dumps({"pid": os.getpid(), "deadline": future}))
+    assert _try_break_stale_lock(lock_file) is False
+    assert lock_file.exists()
+
+
+def test_break_stale_lock_empty_file(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    assert _try_break_stale_lock(lock_file) is False
+
+
+def test_break_stale_lock_missing_file(tmp_path: Path) -> None:
+    assert _try_break_stale_lock(tmp_path / "no_such_file") is False
+
+
+def test_break_stale_lock_expired_deadline_kills(tmp_path: Path) -> None:
+    """Start a real subprocess, set an expired deadline, and verify it gets killed."""
+    lock_file = tmp_path / "lock"
+    # Start a subprocess that blocks forever (waiting on stdin).
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.read()"],
+    )
+    try:
+        past = time.time() - 10
+        lock_file.write_text(json.dumps({"pid": proc.pid, "deadline": past}))
+        assert _try_break_stale_lock(lock_file) is True
+        assert not lock_file.exists()
+        # The process should be dead (SIGKILL was sent).
+        proc.wait(timeout=5)
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+# --- _verify_lock_inode ---
+
+
+def test_verify_inode_matching(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    with lock_file.open("r+") as fh:
+        assert _verify_lock_inode(fh, lock_file) is True
+
+
+def test_verify_inode_after_recreate(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    with lock_file.open("r+") as fh:
+        # Delete and recreate to get a different inode.
+        lock_file.unlink()
+        lock_file.touch()
+        assert _verify_lock_inode(fh, lock_file) is False
+
+
+def test_verify_inode_missing_path(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.touch()
+    with lock_file.open("r+") as fh:
+        lock_file.unlink()
+        assert _verify_lock_inode(fh, lock_file) is False
+
+
+# --- _acquire_global_test_lock ---
+
+
+def test_acquire_lock_basic(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    handle = _acquire_global_test_lock(lock_file)
+    try:
+        # We should be able to write to the handle.
+        _write_lock_info(handle, os.getpid(), None)
+        info = _read_lock_info(lock_file)
+        assert info is not None
+        assert info["pid"] == os.getpid()
+    finally:
+        handle.close()
+
+
+def test_acquire_lock_after_stale_dead_pid(tmp_path: Path) -> None:
+    lock_file = tmp_path / "lock"
+    lock_file.write_text(json.dumps({"pid": 2**22}))
+
+    # The stale PID detection will unlink the file before attempting flock.
+    handle = _acquire_global_test_lock(lock_file)
+    try:
+        assert handle is not None
+    finally:
+        handle.close()

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks_test.py
@@ -6,7 +6,8 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch
+
+import pytest
 
 from imbue.imbue_common.conftest_hooks import _acquire_global_test_lock
 from imbue.imbue_common.conftest_hooks import _compute_lock_deadline
@@ -81,59 +82,54 @@ def test_read_lock_info_non_dict_json(tmp_path: Path) -> None:
 # --- _compute_max_duration ---
 
 
-def test_max_duration_explicit_env_var() -> None:
-    with patch.dict(os.environ, {"PYTEST_MAX_DURATION": "42"}, clear=False):
-        assert _compute_max_duration() == 42.0
+def test_max_duration_explicit_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PYTEST_MAX_DURATION", "42")
+    assert _compute_max_duration() == 42.0
 
 
-def test_max_duration_release() -> None:
-    env = {"IS_RELEASE": "1"}
-    with patch.dict(os.environ, env, clear=False):
-        os.environ.pop("PYTEST_MAX_DURATION", None)
-        assert _compute_max_duration() == 600.0
+def test_max_duration_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IS_RELEASE", "1")
+    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    assert _compute_max_duration() == 600.0
 
 
-def test_max_duration_acceptance() -> None:
-    env = {"IS_ACCEPTANCE": "1"}
-    with patch.dict(os.environ, env, clear=False):
-        os.environ.pop("PYTEST_MAX_DURATION", None)
-        os.environ.pop("IS_RELEASE", None)
-        assert _compute_max_duration() == 360.0
+def test_max_duration_acceptance(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IS_ACCEPTANCE", "1")
+    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("IS_RELEASE", raising=False)
+    assert _compute_max_duration() == 360.0
 
 
-def test_max_duration_ci() -> None:
-    env = {"CI": "1"}
-    with patch.dict(os.environ, env, clear=False):
-        os.environ.pop("PYTEST_MAX_DURATION", None)
-        os.environ.pop("IS_RELEASE", None)
-        os.environ.pop("IS_ACCEPTANCE", None)
-        assert _compute_max_duration() == 150.0
+def test_max_duration_ci(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("IS_RELEASE", raising=False)
+    monkeypatch.delenv("IS_ACCEPTANCE", raising=False)
+    assert _compute_max_duration() == 150.0
 
 
-def test_max_duration_local_default() -> None:
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop("PYTEST_MAX_DURATION", None)
-        os.environ.pop("IS_RELEASE", None)
-        os.environ.pop("IS_ACCEPTANCE", None)
-        os.environ.pop("CI", None)
-        assert _compute_max_duration() == 300.0
+def test_max_duration_local_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    monkeypatch.delenv("IS_RELEASE", raising=False)
+    monkeypatch.delenv("IS_ACCEPTANCE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    assert _compute_max_duration() == 300.0
 
 
 # --- _compute_lock_deadline ---
 
 
-def test_lock_deadline_none_without_env_var() -> None:
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop("PYTEST_MAX_DURATION", None)
-        assert _compute_lock_deadline(1000.0) is None
+def test_lock_deadline_none_without_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PYTEST_MAX_DURATION", raising=False)
+    assert _compute_lock_deadline(1000.0) is None
 
 
-def test_lock_deadline_computed_with_env_var() -> None:
-    with patch.dict(os.environ, {"PYTEST_MAX_DURATION": "120"}, clear=False):
-        deadline = _compute_lock_deadline(1000.0)
-        assert deadline is not None
-        # 1000 + 120 + 60 (grace)
-        assert deadline == 1180.0
+def test_lock_deadline_computed_with_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PYTEST_MAX_DURATION", "120")
+    deadline = _compute_lock_deadline(1000.0)
+    assert deadline is not None
+    # 1000 + 120 + 60 (grace)
+    assert deadline == 1180.0
 
 
 # --- _try_break_stale_lock ---

--- a/libs/imbue_common/imbue/imbue_common/test_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/test_ratchets.py
@@ -32,7 +32,7 @@ def test_prevent_while_true() -> None:
 
 
 def test_prevent_time_sleep() -> None:
-    rc.check_time_sleep(_DIR, snapshot(0))
+    rc.check_time_sleep(_DIR, snapshot(1))
 
 
 def test_prevent_global_keyword() -> None:

--- a/libs/mng_claude/imbue/mng_claude/test_claude_agent_modal.py
+++ b/libs/mng_claude/imbue/mng_claude/test_claude_agent_modal.py
@@ -4,7 +4,7 @@ These tests require Modal credentials, network access, and Claude credentials
 to run. They are marked with @pytest.mark.release and only run when pushing
 to main. To run them locally:
 
-    PYTEST_MAX_DURATION=600 uv run pytest --no-cov --cov-fail-under=0 -n 0 -m release \\
+    PYTEST_MAX_DURATION_SECONDS=600 uv run pytest --no-cov --cov-fail-under=0 -n 0 -m release \\
         libs/mng_claude/imbue/mng_claude/test_claude_agent_modal.py::test_claude_agent_provisioning_on_modal
 """
 


### PR DESCRIPTION
Write the PID and deadline to the lock file.

- If the process did finish, simply remove the lock
- If the process got stuck past the deadline, kill it


Also rename `PYTEST_MAX_DURATION` to `PYTEST_MAX_DURATION_SECONDS`  to include the unit