### PR TITLE
Filter non-change events in ChangeHandler

### DIFF
--- a/libs/mng_recursive/imbue/mng_recursive/watcher_common.py
+++ b/libs/mng_recursive/imbue/mng_recursive/watcher_common.py
@@ -302,14 +302,26 @@ def mtime_poll_directories(
     return is_changed
 
 
+_NON_CHANGE_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {"opened", "closed", "closed_no_write"}
+)
+
+
 class ChangeHandler(FileSystemEventHandler):
-    """Watchdog handler that signals the main loop on any filesystem change."""
+    """Watchdog handler that signals the main loop on actual filesystem changes.
+
+    Ignores events that do not represent modifications (file opened, file
+    closed, file closed without write) since these are read-only operations
+    that should not trigger processing.
+    """
 
     def __init__(self, wake_event: threading.Event) -> None:
         super().__init__()
         self._wake_event = wake_event
 
     def on_any_event(self, event: FileSystemEvent) -> None:
+        if event.event_type in _NON_CHANGE_EVENT_TYPES:
+            return
         self._wake_event.set()
 
 

--- a/libs/mng_recursive/imbue/mng_recursive/watcher_common_test.py
+++ b/libs/mng_recursive/imbue/mng_recursive/watcher_common_test.py
@@ -4,11 +4,15 @@ import json
 import os
 import threading
 from pathlib import Path
-from typing import Any
-from typing import cast
-
 import pytest
 from loguru import logger
+from watchdog.events import FileClosedEvent
+from watchdog.events import FileClosedNoWriteEvent
+from watchdog.events import FileCreatedEvent
+from watchdog.events import FileDeletedEvent
+from watchdog.events import FileModifiedEvent
+from watchdog.events import FileMovedEvent
+from watchdog.events import FileOpenedEvent
 
 from imbue.mng_recursive.watcher_common import ChangeHandler
 from imbue.mng_recursive.watcher_common import load_watchers_section
@@ -296,12 +300,39 @@ def test_mtime_poll_directories_handles_multiple_directories(tmp_path: Path) -> 
 # -- ChangeHandler tests --
 
 
-def test_change_handler_sets_wake_event() -> None:
+def test_change_handler_sets_wake_event_on_modification() -> None:
     wake_event = threading.Event()
     handler = ChangeHandler(wake_event)
     assert not wake_event.is_set()
-    handler.on_any_event(cast(Any, None))
+    handler.on_any_event(FileModifiedEvent("test.txt"))
     assert wake_event.is_set()
+
+
+def test_change_handler_ignores_non_change_events() -> None:
+    wake_event = threading.Event()
+    handler = ChangeHandler(wake_event)
+
+    handler.on_any_event(FileOpenedEvent("test.txt"))
+    assert not wake_event.is_set()
+
+    handler.on_any_event(FileClosedEvent("test.txt"))
+    assert not wake_event.is_set()
+
+    handler.on_any_event(FileClosedNoWriteEvent("test.txt"))
+    assert not wake_event.is_set()
+
+
+def test_change_handler_wakes_on_create_delete_move() -> None:
+    for event_cls in (FileCreatedEvent, FileDeletedEvent):
+        wake_event = threading.Event()
+        handler = ChangeHandler(wake_event)
+        handler.on_any_event(event_cls("test.txt"))
+        assert wake_event.is_set(), f"Expected wake for {event_cls.__name__}"
+
+    wake_event = threading.Event()
+    handler = ChangeHandler(wake_event)
+    handler.on_any_event(FileMovedEvent("old.txt", "new.txt"))
+    assert wake_event.is_set(), "Expected wake for FileMovedEvent"
 
 
 # -- setup_watchdog_for_directories tests --


### PR DESCRIPTION
ChangeHandler.on_any_event now ignores FileOpened, FileClosed, and FileClosedNoWrite events since these represent read-only operations, not actual filesystem changes. This avoids unnecessary wake-ups of the watcher loop.