### PR TITLE
[TEST/DOC] Combined test and doc fixes from 6 agents

### DIFF
--- a/libs/mng/imbue/mng/e2e/test_create_basic.py
+++ b/libs/mng/imbue/mng/e2e/test_create_basic.py
@@ -24,10 +24,17 @@ def test_create_default(e2e: E2eSession) -> None:
     expect(result).to_succeed()
 
     list_result = e2e.run(
-        "mng list", comment="the defaults are the following: agent=claude, provider=local, project=current dir"
+        "mng list --format json",
+        comment="the defaults are the following: agent=claude, provider=local, project=current dir",
     )
     expect(list_result).to_succeed()
-    expect(list_result.stdout).to_match(r"my-task\s+(RUNNING|WAITING)")
+    parsed = json.loads(list_result.stdout)
+    agents = parsed["agents"]
+    matching = [a for a in agents if a["name"] == "my-task"]
+    assert len(matching) == 1
+    agent = matching[0]
+    # Default should create a worktree (not in-place)
+    assert "worktrees" in agent["work_dir"], f"Expected default create to use a worktree, got: {agent['work_dir']}"
 
 
 @pytest.mark.release
@@ -56,8 +63,10 @@ def test_create_in_place(e2e: E2eSession) -> None:
     assert len(matching) == 1
     agent_work_dir = matching[0]["work_dir"]
     # With --in-place, the work directory should be the session cwd (the temp git repo),
-    # not a generated worktree path.
-    assert "worktrees" not in agent_work_dir, f"Expected in-place work_dir to not be a worktree, got: {agent_work_dir}"
+    # not a generated worktree path. Use `pwd` to get the resolved cwd for comparison.
+    pwd_result = e2e.run("pwd", comment="get resolved cwd for comparison")
+    expect(pwd_result).to_succeed()
+    assert agent_work_dir == pwd_result.stdout.strip()
 
 
 @pytest.mark.release
@@ -116,6 +125,35 @@ def test_create_codex_agent(e2e: E2eSession) -> None:
     matching = [a for a in agents if a["name"] == "my-task"]
     assert len(matching) == 1
     assert matching[0]["type"] == "codex"
+    assert matching[0]["state"] in ("RUNNING", "WAITING")
+
+
+@pytest.mark.release
+@pytest.mark.tmux
+def test_create_codex_agent_not_installed(e2e: E2eSession) -> None:
+    """Unhappy path: creating a codex agent when codex is not installed should fail gracefully."""
+    e2e.write_tutorial_block("""
+    # you can also specify a different agent (ex: codex)
+    mng create my-task codex
+    """)
+    # Do NOT configure a custom command -- rely on the default 'codex' binary which is not installed
+    result = e2e.run(
+        "mng create my-task codex --no-ensure-clean",
+        comment="codex is not installed, so the agent should fail to start",
+    )
+    # The create command succeeds (agent state is created) but the process exits immediately
+    # because the codex binary doesn't exist
+    expect(result).to_succeed()
+
+    list_result = e2e.run("mng list --format json", comment="Check agent state after failed start")
+    expect(list_result).to_succeed()
+    parsed = json.loads(list_result.stdout)
+    agents = parsed["agents"]
+    matching = [a for a in agents if a["name"] == "my-task"]
+    assert len(matching) == 1
+    # The agent should be DONE since the codex command exited immediately
+    assert matching[0]["state"] == "DONE"
+    assert matching[0]["command"] == "codex"
 
 
 @pytest.mark.release
@@ -164,23 +202,55 @@ def test_create_named_agent(e2e: E2eSession) -> None:
 
 @pytest.mark.release
 @pytest.mark.tmux
+def test_create_named_agent_duplicate_name(e2e: E2eSession) -> None:
+    """Creating an agent with a name that already exists should fail."""
+    e2e.write_tutorial_block("""
+    # when creating agents to accomplish tasks, it's recommended that you give them a name to make it easier to manage them:
+    mng create my-task
+    # that command give the agent a name of "my-task". If you don't specify a name, mng will generate a random one for you.
+    """)
+    # Create the first agent
+    expect(
+        e2e.run(
+            "mng create my-task --command 'sleep 99999' --no-ensure-clean",
+            comment="Create the first agent with a given name",
+        )
+    ).to_succeed()
+
+    # Try to create another agent with the same name
+    duplicate_result = e2e.run(
+        "mng create my-task --command 'sleep 99999' --no-ensure-clean",
+        comment="Attempting to create a second agent with the same name should fail",
+    )
+    expect(duplicate_result).to_fail()
+    expect(duplicate_result.stderr).to_contain("already exists")
+
+
+@pytest.mark.release
+@pytest.mark.tmux
 def test_create_with_json_output(e2e: E2eSession) -> None:
     e2e.write_tutorial_block("""
     # you can control output format for scripting:
     mng create my-task --no-connect --format json
     # (--quiet suppresses all output)
     """)
-    expect(
-        e2e.run(
-            "mng create my-task --no-connect --command 'sleep 99999' --no-ensure-clean --format json",
-            comment="you can control output format for scripting",
-        )
-    ).to_succeed()
+    create_result = e2e.run(
+        "mng create my-task --no-connect --command 'sleep 99999' --no-ensure-clean --format json",
+        comment="you can control output format for scripting",
+    )
+    expect(create_result).to_succeed()
+
+    # The whole point of --format json is that create produces parseable JSON
+    create_json = json.loads(create_result.stdout)
+    assert "agent_id" in create_json
+    assert "host_id" in create_json
 
     list_result = e2e.run("mng list --format json", comment="Verify agent appears in JSON list")
     expect(list_result).to_succeed()
     parsed = json.loads(list_result.stdout)
-    assert len(parsed["agents"]) == 1
+    agents = parsed["agents"]
+    assert len(agents) == 1
+    assert agents[0]["name"] == "my-task"
 
 
 @pytest.mark.release
@@ -200,4 +270,4 @@ def test_create_headless(e2e: E2eSession) -> None:
 
     list_result = e2e.run("mng list", comment="Verify headless agent appears in list")
     expect(list_result).to_succeed()
-    expect(list_result.stdout).to_contain("my-task")
+    expect(list_result.stdout).to_match(r"my-task\s+(RUNNING|WAITING)")


### PR DESCRIPTION
Squashed IMPROVE_TEST commits from:
- mng-tmr/test-create-default-36944f: Verify default create uses a worktree via JSON output
- mng-tmr/test-create-in-place-8c6173: Replace negative worktree assertion with positive pwd-based check
- mng-tmr/test-create-codex-agent-62322b: Add state assertion and unhappy path test for codex agent creation
- mng-tmr/test-create-named-agent-c248ed: Add unhappy path test for duplicate named agent creation
- mng-tmr/test-create-with-json-output-8ec137: Verify JSON output from mng create --format json
- mng-tmr/test-create-headless-0532ab: Strengthen test_create_headless assertion to verify agent state