### PR TITLE
Fix over-prefixed tarball filename

### DIFF
--- a/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
@@ -271,7 +271,7 @@ def _install_mngr_editable_remote(
 ) -> None:
     """Install mngr in editable mode on a remote host by uploading a tarball."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        tarball_path = Path(tmpdir) / "imbue-mngr-repo.tar.gz"
+        tarball_path = Path(tmpdir) / "mngr-repo.tar.gz"
 
         # Create tarball of the monorepo using git archive
         with log_span("Packaging mngr monorepo for transfer"):


### PR DESCRIPTION
## Summary

Fix `imbue-mngr-repo.tar.gz` -> `mngr-repo.tar.gz` in provisioning.py.

This is a temporary filename for git archive output, not a PyPI package name. The original mng->mngr rename was too aggressive and added the `imbue-` prefix to it.

## Test plan

- [x] It's a string literal used as a temp filename -- no functional impact beyond the name

Generated with [Claude Code](https://claude.com/claude-code)