### PR TITLE
Migration script fixes from real agent testing

### DIFF
--- a/scripts/migrate_code_mng_to_mngr.sh
+++ b/scripts/migrate_code_mng_to_mngr.sh
@@ -309,13 +309,14 @@ for dir in libs/mng libs/mng_*; do
         renamed_libs=$((renamed_libs + 1))
     elif [ -d "$dir" ] && [ -d "$newdir" ]; then
         # Both exist (after merging main reintroduces old paths).
-        # The new dir has the correct content; remove the old one.
+        # Copy untracked files to new dir first, then remove old.
         if [ "$DRY_RUN" = true ]; then
-            dry "would remove reintroduced $dir (already have $newdir)"
+            dry "would merge $dir into $newdir and remove $dir"
         else
+            cp -a -n "$dir"/. "$newdir"/ 2>/dev/null || true
             git rm -rf "$dir" 2>/dev/null || true
             rm -rf "$dir"
-            ok "Removed reintroduced $dir"
+            ok "Merged $dir into $newdir and removed"
         fi
         renamed_libs=$((renamed_libs + 1))
     fi


### PR DESCRIPTION
## Summary

Fixes discovered by running the migration on real agent branches (publish-skills-for-real, kanpan, offload) and watching them merge main.

**Code migration script:**
- Handle reintroduced `.mng/` and `libs/mng*/` after merging main (copy untracked files to new dir, then remove old)
- Remove broken symlinks with `mng` in the name (left after merge)
- `cleanup_old_mng_dirs` function runs at step 4 AND after `uv lock` (step 9 recreates `__pycache__`)
- Re-clean known artifacts in old dirs before checking if empty

**State migration script:**
- Fix worktree `.git` pointers (both directions) when main checkout is renamed
- `uv sync --reinstall --all-packages` to regenerate stale venv shebangs

**Bug fix:**
- Fix over-prefixed tarball filename: `imbue-mngr-repo.tar.gz` -> `mngr-repo.tar.gz`

## Test plan

- [x] Tested on take2-warnings-in-ls: 2695 passed after `--reinstall` fix
- [x] publish-skills-for-real, kanpan, offload all successfully migrated and merged main
- [x] All issues agents encountered are now handled by the script

Generated with [Claude Code](https://claude.com/claude-code)