### PR TITLE
fix package name references

### DIFF
--- a/libs/mngr/docs/all_supported_agents.md
+++ b/libs/mngr/docs/all_supported_agents.md
@@ -19,7 +19,7 @@ The following agent types require installing an external plugin:
 
 | Type | Command | Description | Plugin |
 |------|---------|-------------|--------|
-| `opencode` | `opencode` | [OpenCode](https://github.com/sst/opencode) - An open-source AI coding assistant. | `mngr-opencode` |
+| `opencode` | `opencode` | [OpenCode](https://github.com/sst/opencode) - An open-source AI coding assistant. | `imbue-mngr-opencode` |
 
 ## Using Agent Types
 

--- a/libs/mngr/docs/commands/secondary/plugin.md
+++ b/libs/mngr/docs/commands/secondary/plugin.md
@@ -121,7 +121,7 @@ $ mngr plugin list --format '{name}\t{enabled}'
 Install a plugin package.
 
 All source types are repeatable and can be freely mixed in one command.
-NAME is a PyPI package specifier (e.g., 'mngr-pair' or 'mngr-pair>=1.0').
+NAME is a PyPI package specifier (e.g., 'imbue-mngr-pair' or 'imbue-mngr-pair>=1.0').
 --path installs from a local directory in editable mode.
 --git installs from a git URL.
 All plugins are installed in a single operation for speed.
@@ -164,13 +164,13 @@ mngr plugin add [OPTIONS] [NAMES]...
 **Install from PyPI**
 
 ```bash
-$ mngr plugin add mngr-pair
+$ mngr plugin add imbue-mngr-pair
 ```
 
 **Install with version constraint**
 
 ```bash
-$ mngr plugin add mngr-pair>=1.0
+$ mngr plugin add imbue-mngr-pair>=1.0
 ```
 
 **Install from a local path**
@@ -242,13 +242,13 @@ mngr plugin remove [OPTIONS] [NAMES]...
 **Remove by name**
 
 ```bash
-$ mngr plugin remove mngr-pair
+$ mngr plugin remove imbue-mngr-pair
 ```
 
 **Remove multiple by name**
 
 ```bash
-$ mngr plugin remove mngr-pair mngr-opencode
+$ mngr plugin remove imbue-mngr-pair imbue-mngr-opencode
 ```
 
 **Remove by local path**
@@ -260,7 +260,7 @@ $ mngr plugin remove --path ./my-plugin
 **Mix names and paths**
 
 ```bash
-$ mngr plugin remove mngr-pair --path ./my-plugin
+$ mngr plugin remove imbue-mngr-pair --path ./my-plugin
 ```
 
 ## mngr plugin enable
@@ -388,7 +388,7 @@ Interactive wizard to install recommended plugins.
 Presents a TUI with recommended plugins and lets you select which
 ones to install. Plugins are installed in a single operation.
 
-Pre-selects mngr-tutor by default. Use Space to toggle selections,
+Pre-selects imbue-mngr-tutor by default. Use Space to toggle selections,
 Enter to confirm, and q or Ctrl+C to cancel.
 
 **Usage:**
@@ -458,7 +458,7 @@ $ mngr plugin list --fields name,enabled
 **Install a plugin from PyPI**
 
 ```bash
-$ mngr plugin add mngr-pair
+$ mngr plugin add imbue-mngr-pair
 ```
 
 **Install a local plugin**
@@ -476,7 +476,7 @@ $ mngr plugin add pkg-a --path ./local-b --git https://example.com/c.git
 **Remove a plugin**
 
 ```bash
-$ mngr plugin remove mngr-pair
+$ mngr plugin remove imbue-mngr-pair
 ```
 
 **Enable a plugin**

--- a/libs/mngr/docs/concepts/plugins.md
+++ b/libs/mngr/docs/concepts/plugins.md
@@ -8,10 +8,10 @@ Only install plugins from sources you trust. Built-in plugins are maintained as 
 
 ```bash
 mngr plugin list                           # Show installed plugins
-mngr plugin add mngr-opencode              # Install from PyPI
+mngr plugin add imbue-mngr-opencode              # Install from PyPI
 mngr plugin add --path ./my-plugin         # Install from local path
 mngr plugin add --git https://github.com/user/repo.git  # Install from git
-mngr plugin remove mngr-opencode           # Uninstall by name
+mngr plugin remove imbue-mngr-opencode           # Uninstall by name
 mngr plugin remove --path ./my-plugin      # Uninstall by local path
 ```
 

--- a/libs/mngr/imbue/mngr/cli/ask.py
+++ b/libs/mngr/imbue/mngr/cli/ask.py
@@ -288,7 +288,7 @@ def _check_headless_claude_available() -> None:
             "The 'headless_claude' agent type is not available. "
             "The mngr_claude plugin may not be installed.\n"
             "Install it with:\n"
-            "  mngr plugin add mngr-claude"
+            "  mngr plugin add imbue-mngr-claude"
         )
 
 

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -231,8 +231,8 @@ def _parse_fields(fields_str: str | None) -> tuple[str, ...]:
 def _parse_pypi_package_name(specifier: str) -> str | None:
     """Extract the canonical package name from a PyPI requirement string.
 
-    Parses specifiers like 'mngr-opencode>=1.0' and returns just the name
-    ('mngr-opencode'). Returns None if the specifier is not a valid PyPI
+    Parses specifiers like 'imbue-mngr-opencode>=1.0' and returns just the name
+    ('imbue-mngr-opencode'). Returns None if the specifier is not a valid PyPI
     requirement.
     """
     try:
@@ -423,7 +423,7 @@ def plugin_remove(ctx: click.Context, **kwargs: Any) -> None:
 class _PypiSource(FrozenModel):
     """Plugin source: a PyPI package name (possibly with version constraint)."""
 
-    name: str = Field(description="PyPI package specifier (e.g. 'mngr-opencode>=1.0')")
+    name: str = Field(description="PyPI package specifier (e.g. 'imbue-mngr-opencode>=1.0')")
 
 
 class _PathSource(FrozenModel):
@@ -764,10 +764,10 @@ Plugins provide agent types, provider backends, CLI commands, and lifecycle hook
         ("List only active plugins", "mngr plugin list --active"),
         ("List plugins as JSON", "mngr plugin list --format json"),
         ("Show specific fields", "mngr plugin list --fields name,enabled"),
-        ("Install a plugin from PyPI", "mngr plugin add mngr-pair"),
+        ("Install a plugin from PyPI", "mngr plugin add imbue-mngr-pair"),
         ("Install a local plugin", "mngr plugin add --path ./my-plugin"),
         ("Install multiple plugins at once", "mngr plugin add pkg-a --path ./local-b --git https://example.com/c.git"),
-        ("Remove a plugin", "mngr plugin remove mngr-pair"),
+        ("Remove a plugin", "mngr plugin remove imbue-mngr-pair"),
         ("Enable a plugin", "mngr plugin enable modal"),
         ("Disable a plugin", "mngr plugin disable modal --scope user"),
     ),
@@ -806,13 +806,13 @@ CommandHelpMetadata(
     one_line_description="Install a plugin package",
     synopsis="mngr plugin add [NAME...] [OPTIONS]",
     description="""All source types are repeatable and can be freely mixed in one command.
-NAME is a PyPI package specifier (e.g., 'mngr-pair' or 'mngr-pair>=1.0').
+NAME is a PyPI package specifier (e.g., 'imbue-mngr-pair' or 'imbue-mngr-pair>=1.0').
 --path installs from a local directory in editable mode.
 --git installs from a git URL.
 All plugins are installed in a single operation for speed.""",
     examples=(
-        ("Install from PyPI", "mngr plugin add mngr-pair"),
-        ("Install with version constraint", "mngr plugin add mngr-pair>=1.0"),
+        ("Install from PyPI", "mngr plugin add imbue-mngr-pair"),
+        ("Install with version constraint", "mngr plugin add imbue-mngr-pair>=1.0"),
         ("Install from a local path", "mngr plugin add --path ./my-plugin"),
         ("Install multiple local plugins", "mngr plugin add --path ./plugin-a --path ./plugin-b"),
         ("Install from a git URL", "mngr plugin add --git https://github.com/user/mngr-plugin.git"),
@@ -833,10 +833,10 @@ CommandHelpMetadata(
 For local paths, the package name is read from pyproject.toml.
 All plugins are removed in a single operation.""",
     examples=(
-        ("Remove by name", "mngr plugin remove mngr-pair"),
-        ("Remove multiple by name", "mngr plugin remove mngr-pair mngr-opencode"),
+        ("Remove by name", "mngr plugin remove imbue-mngr-pair"),
+        ("Remove multiple by name", "mngr plugin remove imbue-mngr-pair imbue-mngr-opencode"),
         ("Remove by local path", "mngr plugin remove --path ./my-plugin"),
-        ("Mix names and paths", "mngr plugin remove mngr-pair --path ./my-plugin"),
+        ("Mix names and paths", "mngr plugin remove imbue-mngr-pair --path ./my-plugin"),
     ),
     see_also=(
         ("plugin add", "Install a plugin package"),

--- a/libs/mngr/imbue/mngr/cli/plugin_install_wizard.py
+++ b/libs/mngr/imbue/mngr/cli/plugin_install_wizard.py
@@ -221,7 +221,7 @@ CommandHelpMetadata(
     description="""Presents a TUI with recommended plugins and lets you select which
 ones to install. Plugins are installed in a single operation.
 
-Pre-selects mngr-tutor by default. Use Space to toggle selections,
+Pre-selects imbue-mngr-tutor by default. Use Space to toggle selections,
 Enter to confirm, and q or Ctrl+C to cancel.""",
     examples=(("Launch the plugin install wizard", "mngr plugin install-wizard"),),
     see_also=(

--- a/libs/mngr/imbue/mngr/cli/plugin_install_wizard_test.py
+++ b/libs/mngr/imbue/mngr/cli/plugin_install_wizard_test.py
@@ -13,16 +13,16 @@ from imbue.mngr.plugin_catalog import RecommendedPlugin
 def test_recommended_plugins_contains_expected_packages() -> None:
     """RECOMMENDED_PLUGINS should include the published mngr-* plugins."""
     names = {p.package_name for p in RECOMMENDED_PLUGINS}
-    assert "mngr-opencode" in names
-    assert "mngr-pair" in names
-    assert "mngr-tutor" in names
+    assert "imbue-mngr-opencode" in names
+    assert "imbue-mngr-pair" in names
+    assert "imbue-mngr-tutor" in names
 
 
 def test_recommended_plugins_mngr_tutor_is_preselected() -> None:
-    """mngr-tutor should be the only pre-selected plugin."""
+    """imbue-mngr-tutor should be the only pre-selected plugin."""
     preselected = [p for p in RECOMMENDED_PLUGINS if p.is_preselected]
     assert len(preselected) == 1
-    assert preselected[0].package_name == "mngr-tutor"
+    assert preselected[0].package_name == "imbue-mngr-tutor"
 
 
 def test_recommended_plugins_all_have_descriptions() -> None:

--- a/libs/mngr/imbue/mngr/cli/plugin_test.py
+++ b/libs/mngr/imbue/mngr/cli/plugin_test.py
@@ -438,12 +438,12 @@ def test_emit_plugin_toggle_result_jsonl_has_event_type(capsys: pytest.CaptureFi
 
 def test_parse_pypi_package_name_valid_name() -> None:
     """_parse_pypi_package_name should return the package name for a valid specifier."""
-    assert _parse_pypi_package_name("mngr-opencode") == "mngr-opencode"
+    assert _parse_pypi_package_name("imbue-mngr-opencode") == "imbue-mngr-opencode"
 
 
 def test_parse_pypi_package_name_name_with_version() -> None:
     """_parse_pypi_package_name should return the package name for specifiers with versions."""
-    assert _parse_pypi_package_name("mngr-opencode>=1.0") == "mngr-opencode"
+    assert _parse_pypi_package_name("imbue-mngr-opencode>=1.0") == "imbue-mngr-opencode"
 
 
 def test_parse_pypi_package_name_invalid_format() -> None:
@@ -465,7 +465,7 @@ def test_get_installed_package_names_returns_package_names() -> None:
                 stdout = json.dumps(
                     [
                         {"name": "mngr", "version": "1.0.0"},
-                        {"name": "mngr-opencode", "version": "0.1.0"},
+                        {"name": "imbue-mngr-opencode", "version": "0.1.0"},
                         {"name": "pluggy", "version": "1.5.0"},
                     ]
                 )
@@ -473,7 +473,7 @@ def test_get_installed_package_names_returns_package_names() -> None:
             return Result()
 
     names = _get_installed_package_names(FakeConcurrencyGroup())
-    assert names == {"mngr", "mngr-opencode", "pluggy"}
+    assert names == {"mngr", "imbue-mngr-opencode", "pluggy"}
 
 
 def test_get_installed_package_names_empty_list() -> None:
@@ -526,12 +526,12 @@ def test_read_package_name_from_pyproject_missing_name(tmp_path: Path) -> None:
 def test_emit_plugin_add_result_json_format(capsys: pytest.CaptureFixture[str]) -> None:
     """_emit_plugin_add_result with JSON format should output valid JSON."""
     output_opts = OutputOptions(output_format=OutputFormat.JSON)
-    _emit_plugin_add_result("mngr-opencode", "mngr-opencode", True, output_opts)
+    _emit_plugin_add_result("imbue-mngr-opencode", "imbue-mngr-opencode", True, output_opts)
 
     captured = capsys.readouterr()
     data = json.loads(captured.out.strip())
-    assert data["specifier"] == "mngr-opencode"
-    assert data["package"] == "mngr-opencode"
+    assert data["specifier"] == "imbue-mngr-opencode"
+    assert data["package"] == "imbue-mngr-opencode"
     assert data["has_entry_points"] is True
 
 
@@ -556,22 +556,22 @@ def test_emit_plugin_add_result_jsonl_format(capsys: pytest.CaptureFixture[str])
 def test_emit_plugin_remove_result_json_format(capsys: pytest.CaptureFixture[str]) -> None:
     """_emit_plugin_remove_result with JSON format should output valid JSON."""
     output_opts = OutputOptions(output_format=OutputFormat.JSON)
-    _emit_plugin_remove_result("mngr-opencode", output_opts)
+    _emit_plugin_remove_result("imbue-mngr-opencode", output_opts)
 
     captured = capsys.readouterr()
     data = json.loads(captured.out.strip())
-    assert data["package"] == "mngr-opencode"
+    assert data["package"] == "imbue-mngr-opencode"
 
 
 def test_emit_plugin_remove_result_jsonl_format(capsys: pytest.CaptureFixture[str]) -> None:
     """_emit_plugin_remove_result with JSONL format should include event type."""
     output_opts = OutputOptions(output_format=OutputFormat.JSONL)
-    _emit_plugin_remove_result("mngr-opencode", output_opts)
+    _emit_plugin_remove_result("imbue-mngr-opencode", output_opts)
 
     captured = capsys.readouterr()
     data = json.loads(captured.out.strip())
     assert data["event"] == "plugin_removed"
-    assert data["package"] == "mngr-opencode"
+    assert data["package"] == "imbue-mngr-opencode"
 
 
 # =============================================================================
@@ -616,20 +616,20 @@ def test_parse_add_sources_no_source_raises_abort() -> None:
 
 def test_parse_add_sources_valid_pypi_name() -> None:
     """_parse_add_sources should return a list with _PypiSource for a valid PyPI name."""
-    opts = _make_plugin_cli_options(names=("mngr-opencode",))
+    opts = _make_plugin_cli_options(names=("imbue-mngr-opencode",))
     sources = _parse_add_sources(opts)
     assert len(sources) == 1
     assert isinstance(sources[0], _PypiSource)
-    assert sources[0].name == "mngr-opencode"
+    assert sources[0].name == "imbue-mngr-opencode"
 
 
 def test_parse_add_sources_valid_pypi_name_with_version() -> None:
     """_parse_add_sources should return a list with _PypiSource for a name with version constraint."""
-    opts = _make_plugin_cli_options(names=("mngr-opencode>=1.0",))
+    opts = _make_plugin_cli_options(names=("imbue-mngr-opencode>=1.0",))
     sources = _parse_add_sources(opts)
     assert len(sources) == 1
     assert isinstance(sources[0], _PypiSource)
-    assert sources[0].name == "mngr-opencode>=1.0"
+    assert sources[0].name == "imbue-mngr-opencode>=1.0"
 
 
 def test_parse_add_sources_multiple_names() -> None:
@@ -723,11 +723,11 @@ def test_parse_remove_sources_no_source_raises_abort() -> None:
 
 def test_parse_remove_sources_valid_pypi_name() -> None:
     """_parse_remove_sources should return a list with _PypiSource for a valid PyPI name."""
-    opts = _make_plugin_cli_options(names=("mngr-opencode",))
+    opts = _make_plugin_cli_options(names=("imbue-mngr-opencode",))
     sources = _parse_remove_sources(opts)
     assert len(sources) == 1
     assert isinstance(sources[0], _PypiSource)
-    assert sources[0].name == "mngr-opencode"
+    assert sources[0].name == "imbue-mngr-opencode"
 
 
 def test_parse_remove_sources_multiple_names() -> None:

--- a/libs/mngr/imbue/mngr/cli/test_plugin.py
+++ b/libs/mngr/imbue/mngr/cli/test_plugin.py
@@ -387,7 +387,7 @@ _MNGR_OPENCODE_DIR = Path(__file__).resolve().parents[5] / "libs" / "mngr_openco
 @pytest.mark.acceptance
 @pytest.mark.timeout(180)
 def test_plugin_add_path_and_remove_lifecycle() -> None:
-    """Test ``mngr plugin add --path`` and ``mngr plugin remove`` using the real mngr-opencode plugin.
+    """Test ``mngr plugin add --path`` and ``mngr plugin remove`` using the real imbue-mngr-opencode plugin.
 
     This is an acceptance test that operates on the real ``uv tool`` installation.
     Plugin add/remove uses ``uv tool install --with`` under the hood, which always
@@ -418,7 +418,7 @@ def test_plugin_add_path_and_remove_lifecycle() -> None:
     # -- Install via mngr plugin add --path --
     add_result = run_mngr("plugin", "add", "--path", str(_MNGR_OPENCODE_DIR), "--format", "json")
     add_output = json.loads(add_result.stdout)
-    assert add_output["package"] == "mngr-opencode"
+    assert add_output["package"] == "imbue-mngr-opencode"
 
     try:
         # -- Verify it shows up --
@@ -427,11 +427,11 @@ def test_plugin_add_path_and_remove_lifecycle() -> None:
         assert "opencode" in plugin_names_after_add
     finally:
         # -- Always clean up: remove via mngr plugin remove --
-        remove_result = run_mngr("plugin", "remove", "mngr-opencode", "--format", "json")
+        remove_result = run_mngr("plugin", "remove", "imbue-mngr-opencode", "--format", "json")
 
     # -- Verify the remove succeeded --
     remove_output = json.loads(remove_result.stdout)
-    assert remove_output["package"] == "mngr-opencode"
+    assert remove_output["package"] == "imbue-mngr-opencode"
 
     list_after_remove = run_mngr("plugin", "list", "--format", "json")
     plugin_names_after_remove = [p["name"] for p in json.loads(list_after_remove.stdout)["plugins"]]

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -343,7 +343,7 @@ def _parse_providers(
                     f" The plugin package that provides the"
                     f" '{backend}' backend may not be installed. If you installed mngr"
                     f" as a tool, try reinstalling with the plugin package"
-                    f" (e.g. --with 'mngr-{backend}')."
+                    f" (e.g. --with 'imbue-mngr-{backend}')."
                 )
             if strict:
                 raise ConfigParseError(msg) from e

--- a/libs/mngr/imbue/mngr/plugin_catalog.py
+++ b/libs/mngr/imbue/mngr/plugin_catalog.py
@@ -24,15 +24,15 @@ class RecommendedPlugin(FrozenModel):
 # Descriptions sourced from each plugin's pyproject.toml.
 RECOMMENDED_PLUGINS: Final[tuple[RecommendedPlugin, ...]] = (
     RecommendedPlugin(
-        package_name="mngr-opencode",
+        package_name="imbue-mngr-opencode",
         description="OpenCode agent type plugin for mngr",
     ),
     RecommendedPlugin(
-        package_name="mngr-pair",
+        package_name="imbue-mngr-pair",
         description="Pair command plugin for mngr - continuous file sync between agent and local directory",
     ),
     RecommendedPlugin(
-        package_name="mngr-tutor",
+        package_name="imbue-mngr-tutor",
         description="Interactive tutorial plugin for mngr",
         is_preselected=True,
     ),

--- a/libs/mngr/imbue/mngr/uv_tool_test.py
+++ b/libs/mngr/imbue/mngr/uv_tool_test.py
@@ -58,14 +58,14 @@ def test_tool_requirement_with_git() -> None:
 
 def test_requirement_to_with_arg_plain_name() -> None:
     """Plain name should produce --with name."""
-    requirement = ToolRequirement(name="mngr-opencode")
-    assert _requirement_to_with_arg(requirement) == ("--with", "mngr-opencode")
+    requirement = ToolRequirement(name="imbue-mngr-opencode")
+    assert _requirement_to_with_arg(requirement) == ("--with", "imbue-mngr-opencode")
 
 
 def test_requirement_to_with_arg_with_specifier() -> None:
     """Name with specifier should produce --with name+specifier."""
-    requirement = ToolRequirement(name="mngr-opencode", specifier=">=1.0")
-    assert _requirement_to_with_arg(requirement) == ("--with", "mngr-opencode>=1.0")
+    requirement = ToolRequirement(name="imbue-mngr-opencode", specifier=">=1.0")
+    assert _requirement_to_with_arg(requirement) == ("--with", "imbue-mngr-opencode>=1.0")
 
 
 def test_requirement_to_with_arg_editable() -> None:
@@ -130,7 +130,7 @@ def test_read_receipt_with_extras(tmp_path: Path) -> None:
         "[tool]\nrequirements = [\n"
         '  { name = "imbue-mngr" },\n'
         '  { name = "coolname" },\n'
-        '  { name = "mngr-opencode", editable = "/path/to/opencode" },\n'
+        '  { name = "imbue-mngr-opencode", editable = "/path/to/opencode" },\n'
         "]\n"
     )
 
@@ -138,7 +138,7 @@ def test_read_receipt_with_extras(tmp_path: Path) -> None:
     assert receipt.base.name == "imbue-mngr"
     assert len(receipt.extras) == 2
     assert receipt.extras[0].name == "coolname"
-    assert receipt.extras[1].name == "mngr-opencode"
+    assert receipt.extras[1].name == "imbue-mngr-opencode"
     assert receipt.extras[1].editable == "/path/to/opencode"
 
 
@@ -172,7 +172,7 @@ def test_read_receipt_with_git(tmp_path: Path) -> None:
     receipt_path.write_text(
         "[tool]\nrequirements = [\n"
         '  { name = "imbue-mngr" },\n'
-        '  { name = "mngr-opencode", git = "https://github.com/imbue-ai/mngr.git" },\n'
+        '  { name = "imbue-mngr-opencode", git = "https://github.com/imbue-ai/mngr.git" },\n'
         "]\n"
     )
 
@@ -224,7 +224,7 @@ def test_build_uv_tool_install_command_with_extras() -> None:
     base = ToolRequirement(name="imbue-mngr")
     extras = [
         ToolRequirement(name="coolname"),
-        ToolRequirement(name="mngr-opencode", editable="/path/to/opencode"),
+        ToolRequirement(name="imbue-mngr-opencode", editable="/path/to/opencode"),
     ]
     cmd = _build_uv_tool_install_command(base, extras)
     assert cmd == (
@@ -265,7 +265,7 @@ def _make_receipt(
 def test_build_uv_tool_install_add_appends_new_dep() -> None:
     """build_uv_tool_install_add should preserve existing extras and append."""
     receipt = _make_receipt(extras=[ToolRequirement(name="coolname")])
-    cmd = build_uv_tool_install_add(receipt, "mngr-opencode")
+    cmd = build_uv_tool_install_add(receipt, "imbue-mngr-opencode")
     assert cmd == (
         "uv",
         "tool",
@@ -275,7 +275,7 @@ def test_build_uv_tool_install_add_appends_new_dep() -> None:
         "--with",
         "coolname",
         "--with",
-        "mngr-opencode",
+        "imbue-mngr-opencode",
     )
 
 
@@ -314,10 +314,10 @@ def test_build_uv_tool_install_remove_filters_dep() -> None:
     receipt = _make_receipt(
         extras=[
             ToolRequirement(name="coolname"),
-            ToolRequirement(name="mngr-opencode"),
+            ToolRequirement(name="imbue-mngr-opencode"),
         ]
     )
-    cmd = build_uv_tool_install_remove(receipt, "mngr-opencode")
+    cmd = build_uv_tool_install_remove(receipt, "imbue-mngr-opencode")
     assert cmd == (
         "uv",
         "tool",
@@ -331,8 +331,8 @@ def test_build_uv_tool_install_remove_filters_dep() -> None:
 
 def test_build_uv_tool_install_remove_last_dep() -> None:
     """build_uv_tool_install_remove should work when removing the only extra."""
-    receipt = _make_receipt(extras=[ToolRequirement(name="mngr-opencode")])
-    cmd = build_uv_tool_install_remove(receipt, "mngr-opencode")
+    receipt = _make_receipt(extras=[ToolRequirement(name="imbue-mngr-opencode")])
+    cmd = build_uv_tool_install_remove(receipt, "imbue-mngr-opencode")
     assert cmd == ("uv", "tool", "install", "imbue-mngr", "--reinstall")
 
 
@@ -344,7 +344,7 @@ def test_build_uv_tool_install_remove_last_dep() -> None:
 def test_build_uv_tool_install_add_many_appends_all() -> None:
     """build_uv_tool_install_add_many should add all specifiers in one command."""
     receipt = _make_receipt(extras=[ToolRequirement(name="existing")])
-    cmd = build_uv_tool_install_add_many(receipt, ["mngr-pair", "mngr-tutor"])
+    cmd = build_uv_tool_install_add_many(receipt, ["imbue-mngr-pair", "imbue-mngr-tutor"])
     assert cmd == (
         "uv",
         "tool",
@@ -354,9 +354,9 @@ def test_build_uv_tool_install_add_many_appends_all() -> None:
         "--with",
         "existing",
         "--with",
-        "mngr-pair",
+        "imbue-mngr-pair",
         "--with",
-        "mngr-tutor",
+        "imbue-mngr-tutor",
     )
 
 
@@ -378,7 +378,7 @@ def test_build_uv_tool_install_add_many_empty_list() -> None:
 def test_build_uv_tool_install_add_many_no_existing_extras() -> None:
     """build_uv_tool_install_add_many should work with no prior extras."""
     receipt = _make_receipt()
-    cmd = build_uv_tool_install_add_many(receipt, ["mngr-opencode", "mngr-pair", "mngr-tutor"])
+    cmd = build_uv_tool_install_add_many(receipt, ["imbue-mngr-opencode", "imbue-mngr-pair", "imbue-mngr-tutor"])
     assert cmd == (
         "uv",
         "tool",
@@ -386,11 +386,11 @@ def test_build_uv_tool_install_add_many_no_existing_extras() -> None:
         "imbue-mngr",
         "--reinstall",
         "--with",
-        "mngr-opencode",
+        "imbue-mngr-opencode",
         "--with",
-        "mngr-pair",
+        "imbue-mngr-pair",
         "--with",
-        "mngr-tutor",
+        "imbue-mngr-tutor",
     )
 
 

--- a/libs/mngr_claude/README.md
+++ b/libs/mngr_claude/README.md
@@ -1,4 +1,4 @@
-# mngr-claude
+# imbue-mngr-claude
 
 Claude agent type plugin for [mngr](../../README.md).
 

--- a/libs/mngr_modal/README.md
+++ b/libs/mngr_modal/README.md
@@ -1,4 +1,4 @@
-# mngr-modal
+# imbue-mngr-modal
 
 Modal provider backend plugin for [mngr](../mngr/README.md).
 
@@ -6,10 +6,10 @@ This plugin enables mngr to create and manage agents running in [Modal](https://
 
 ## Installation
 
-`mngr-modal` is included by default when you install `mngr`. To install separately:
+`imbue-mngr-modal` is included by default when you install `mngr`. To install separately:
 
 ```bash
-uv pip install mngr-modal
+uv pip install imbue-mngr-modal
 ```
 
 ## Usage

--- a/libs/mngr_opencode/README.md
+++ b/libs/mngr_opencode/README.md
@@ -1,4 +1,4 @@
-# mngr-opencode
+# imbue-mngr-opencode
 
 Plugin that registers the `opencode` agent type for mngr.
 

--- a/libs/mngr_pair/README.md
+++ b/libs/mngr_pair/README.md
@@ -1,4 +1,4 @@
-# mngr-pair
+# imbue-mngr-pair
 
 Continuous file synchronization between an agent and your local directory.
 

--- a/libs/mngr_tutor/README.md
+++ b/libs/mngr_tutor/README.md
@@ -1,4 +1,4 @@
-# mngr-tutor
+# imbue-mngr-tutor
 
 Interactive tutorial for learning mngr commands.
 


### PR DESCRIPTION
## Summary

- Fixed error message in config loader that suggested `--with 'mngr-modal'` instead of `--with 'imbue-mngr-modal'`
- Updated all remaining `mngr-*` package name references to `imbue-mngr-*` across source code, CLI help text, docs, plugin catalog, READMEs, and tests (17 files)

## Test plan

- [x] All 3362 unit/integration tests pass with 82.65% coverage
- [ ] Verify `mngr plugin add imbue-mngr-pair` works with the new package names in help text
- [ ] Verify error message when a backend plugin is missing shows the correct `imbue-mngr-*` package name


🤖 Generated with [Claude Code](https://claude.com/claude-code)