### PR TITLE
Skip global test lock for --collect-only

### DIFF
--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -497,6 +497,8 @@ def _pytest_sessionstart(session: pytest.Session) -> None:
     By acquiring the lock here, we ensure the controller holds it for the entire session.
 
     xdist workers skip lock acquisition since the controller already holds it.
+    ``--collect-only`` sessions also skip the lock since they only discover tests
+    without running them.
 
     IMPORTANT: The start_time is set AFTER the lock is acquired so that time spent
     waiting for the lock is not counted against the test suite time limit.

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -515,8 +515,9 @@ def _pytest_sessionstart(session: pytest.Session) -> None:
                     controller_cov_report.pop("term-missing", None)
                     controller_cov_report.pop("term", None)
 
-    # xdist workers should not acquire the lock - only the controller does
-    if _is_xdist_worker():
+    # xdist workers should not acquire the lock - only the controller does.
+    # --collect-only skips the lock because it only discovers tests without running them.
+    if _is_xdist_worker() or session.config.option.collectonly:
         setattr(session, "start_time", time.time())  # noqa: B010
     else:
         # Acquire the lock and store the handle on the session to keep it open


### PR DESCRIPTION
pytest --collect-only only discovers tests without running them, so it doesn't need the global lock. This lets collection finish quickly even when another test run is in progress.