### PR TITLE
Frontload .gitignore check of the Claude agent type

### DIFF
--- a/libs/mngr/imbue/mngr/api/create.py
+++ b/libs/mngr/imbue/mngr/api/create.py
@@ -7,14 +7,17 @@ from imbue.imbue_common.logging import log_span
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.discovery_events import emit_discovery_events_for_host
 from imbue.mngr.api.providers import get_provider_instance
+from imbue.mngr.config.agent_config_registry import resolve_agent_type
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import DuplicateAgentNameError
 from imbue.mngr.hosts.host import HostLocation
+from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import CreateAgentOptions
 from imbue.mngr.interfaces.host import HostEnvironmentOptions
 from imbue.mngr.interfaces.host import NewHostOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.plugins.hookspecs import OnBeforeCreateArgs
+from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.utils.env_utils import parse_env_file
 
 
@@ -82,6 +85,21 @@ def create(
     target_host, agent_options, create_work_dir = _call_on_before_create_hooks(
         mngr_ctx, target_host, agent_options, create_work_dir
     )
+
+    # Run agent-type-specific preflight checks before creating the host.
+    # This lets agent types fail fast on configuration errors (e.g. missing
+    # gitignore entries) before expensive operations like host creation.
+    agent_type = agent_options.agent_type or AgentTypeName("claude")
+    resolved = resolve_agent_type(agent_type, mngr_ctx.config)
+    agent_class = cast(type[AgentInterface], resolved.agent_class)
+    with log_span("Running preflight checks for agent type {}", agent_type):
+        agent_class.preflight_check(
+            source_host=source_location.host,
+            source_path=source_location.path,
+            agent_options=agent_options,
+            agent_config=resolved.agent_config,
+            mngr_ctx=mngr_ctx,
+        )
 
     # Determine which provider to use and get the host
     is_new_host = isinstance(target_host, NewHostOptions)

--- a/libs/mngr/imbue/mngr/interfaces/agent.py
+++ b/libs/mngr/imbue/mngr/interfaces/agent.py
@@ -285,6 +285,35 @@ class AgentInterface(MutableModel, ABC, Generic[AgentConfigT]):
         ...
 
     # =========================================================================
+    # Preflight Checks (before host creation)
+    # =========================================================================
+
+    @classmethod
+    def preflight_check(
+        cls,
+        source_host: OnlineHostInterface,
+        source_path: Path,
+        agent_options: CreateAgentOptions,
+        agent_config: AgentTypeConfig,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        """Called before host creation to validate early prerequisites.
+
+        This classmethod runs at the very start of create(), after
+        on_before_create hooks but before the target host is resolved.
+        Agent types can override this to perform cheap validation that
+        would otherwise only surface much later (e.g., during provisioning).
+
+        Because no agent instance exists yet, this is a classmethod that
+        receives the source location, options, and config directly.
+
+        If validation fails, raise a PluginMngrError with a clear message.
+
+        IMPORTANT: This method should only perform read-only checks on
+        the source. Do not make any changes to the source host.
+        """
+
+    # =========================================================================
     # Provisioning Lifecycle
     # =========================================================================
 

--- a/libs/mngr/imbue/mngr/interfaces/agent.py
+++ b/libs/mngr/imbue/mngr/interfaces/agent.py
@@ -312,6 +312,7 @@ class AgentInterface(MutableModel, ABC, Generic[AgentConfigT]):
         IMPORTANT: This method should only perform read-only checks on
         the source. Do not make any changes to the source host.
         """
+        ...
 
     # =========================================================================
     # Provisioning Lifecycle

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -731,6 +731,35 @@ def _has_api_credentials_available(
     return False
 
 
+def _check_settings_local_gitignored(host: OnlineHostInterface, repo_path: Path) -> None:
+    """Verify .claude/settings.local.json is gitignored in the given repo path.
+
+    Raises PluginMngrError if the file is not gitignored. Silently returns
+    if the path is not a git repository.
+    """
+    settings_relative = Path(".claude") / "settings.local.json"
+
+    is_git_repo = host.execute_idempotent_command(
+        "git rev-parse --is-inside-work-tree",
+        cwd=repo_path,
+        timeout_seconds=5.0,
+    )
+    if not is_git_repo.success:
+        return
+
+    result = host.execute_idempotent_command(
+        f"git check-ignore -q {shlex.quote(str(settings_relative))}",
+        cwd=repo_path,
+        timeout_seconds=5.0,
+    )
+    if not result.success:
+        raise PluginMngrError(
+            f".claude/settings.local.json is not gitignored in {repo_path}.\n"
+            "mngr needs to write Claude hooks to this file, but it would appear as an unstaged change.\n"
+            f"Add '.claude/settings.local.json' to your .gitignore and try again. (original error: {result.stderr})"
+        )
+
+
 class DialogIndicator(FrozenModel, ABC):
     """Base class for dialog indicators that can block agent input."""
 
@@ -828,6 +857,23 @@ class CostThresholdDialogIndicator(DialogIndicator):
 
 class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
     """Agent implementation for Claude with session resumption support."""
+
+    @classmethod
+    def preflight_check(
+        cls,
+        source_host: OnlineHostInterface,
+        source_path: Path,
+        agent_options: CreateAgentOptions,
+        agent_config: AgentTypeConfig,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        """Validate that .claude/settings.local.json is gitignored in the source repo.
+
+        mngr writes readiness hooks to this file during provisioning. If it's not
+        gitignored, it would appear as an unstaged change. Checking early avoids
+        wasting time on host creation and work_dir setup before surfacing this error.
+        """
+        _check_settings_local_gitignored(source_host, source_path)
 
     def get_claude_config_dir(self) -> Path:
         """Return the per-agent Claude config directory path.
@@ -1125,25 +1171,9 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         settings_relative = Path(".claude") / "settings.local.json"
         settings_path = self.work_dir / settings_relative
 
-        # Only check gitignore if git is available and this is a git repository
-        is_git_repo = host.execute_idempotent_command(
-            "git rev-parse --is-inside-work-tree",
-            cwd=self.work_dir,
-            timeout_seconds=5.0,
-        )
-        if is_git_repo.success:
-            # Verify .claude/settings.local.json is gitignored to avoid unstaged changes
-            result = host.execute_idempotent_command(
-                f"git check-ignore -q {shlex.quote(str(settings_relative))}",
-                cwd=self.work_dir,
-                timeout_seconds=5.0,
-            )
-            if not result.success:
-                raise PluginMngrError(
-                    f".claude/settings.local.json is not gitignored in {self.work_dir}.\n"
-                    "mngr needs to write Claude hooks to this file, but it would appear as an unstaged change.\n"
-                    f"Add '.claude/settings.local.json' to your .gitignore and try again. (original error: {result.stderr})"
-                )
+        # Check gitignore. During create(), preflight_check already verified
+        # this on the source, but this covers other code paths (e.g. mngr provision).
+        _check_settings_local_gitignored(host, self.work_dir)
 
         hooks_config = build_readiness_hooks_config()
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -728,6 +728,71 @@ def test_uses_paste_detection_send_returns_true(
     assert agent.uses_paste_detection_send() is True
 
 
+def test_preflight_check_raises_when_not_gitignored(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """preflight_check should raise when .claude/settings.local.json is not gitignored in source."""
+    host = local_provider.create_host(HostName("localhost"))
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    init_git_repo(source_dir, initial_commit=False)
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+    config = ClaudeAgentConfig(check_installation=False)
+
+    with pytest.raises(PluginMngrError, match="not gitignored"):
+        ClaudeAgent.preflight_check(
+            source_host=host,
+            source_path=source_dir,
+            agent_options=options,
+            agent_config=config,
+            mngr_ctx=temp_mngr_ctx,
+        )
+
+
+def test_preflight_check_passes_when_gitignored(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """preflight_check should pass when .claude/settings.local.json is gitignored."""
+    host = local_provider.create_host(HostName("localhost"))
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    _init_git_with_gitignore(source_dir)
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+    config = ClaudeAgentConfig(check_installation=False)
+
+    # Should not raise
+    ClaudeAgent.preflight_check(
+        source_host=host,
+        source_path=source_dir,
+        agent_options=options,
+        agent_config=config,
+        mngr_ctx=temp_mngr_ctx,
+    )
+
+
+def test_preflight_check_skips_when_not_git_repo(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """preflight_check should skip gitignore check when source is not a git repo."""
+    host = local_provider.create_host(HostName("localhost"))
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+    config = ClaudeAgentConfig(check_installation=False)
+
+    # Should not raise (no git repo, no gitignore check)
+    ClaudeAgent.preflight_check(
+        source_host=host,
+        source_path=source_dir,
+        agent_options=options,
+        agent_config=config,
+        mngr_ctx=temp_mngr_ctx,
+    )
+
+
 def test_configure_readiness_hooks_raises_when_not_gitignored(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:


### PR DESCRIPTION
The Claude agent type implementation only checks that `.claude/settings.local.json` is gitignored after host creation. If the user doesn't have this in their `.gitignore` and is creating a remote agent, the failure only happens after host creation.

Add a method for agent types to do "preflight" checks.