### PR TITLE
fix-issue skill

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue
 argument-hint: [issue]
-description: Fix a GitHub issue given its number or URL. Replicates the bug, finds root cause, and implements a fix.
+description: Fix a GitHub issue given its number or URL. Replicates the bug, finds root cause, implements a fix, and opens a PR.
 ---
 
 # Fix a GitHub Issue
@@ -37,6 +37,21 @@ If the fix involves a meaningful architectural choice (e.g., where to put new lo
 - Add or update tests to cover the fix.
 - Get all tests passing (`uv run pytest` in the relevant project directory).
 
-## 5. Commit the fix
+## 5. Open a PR
 
-Commit your changes with a message that references the issue number (e.g., "Fix <description> (#<issue_number>)"). A PR will be created automatically by the system.
+Create a branch if you're not already on one, then open a PR that closes the issue:
+
+```bash
+gh pr create --title "<concise title>" --body "$(cat <<'EOF'
+Closes #<issue_number>
+
+## Summary
+<what changed and why>
+
+## Test plan
+<how the fix is verified>
+EOF
+)"
+```
+
+The `Closes #<number>` keyword in the PR body automatically links and closes the issue when merged.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fix-issue
+argument-hint: [issue]
+description: Fix a GitHub issue given its number or URL. Replicates the bug, finds root cause, implements a fix, and opens a PR.
+---
+
+# Fix a GitHub Issue
+
+You are given a GitHub issue to fix: `$1`
+
+## 1. Understand the issue
+
+Fetch the issue details:
+
+```bash
+gh issue view $1 --json number,title,body,labels,comments
+```
+
+Read it carefully. If the issue is misguided, unclear to the point of being unactionable, or describes something that is already fixed, comment on the issue explaining why (prefix your comment with `[fix-issue]`) and stop.
+
+## 2. Reproduce and investigate (in parallel)
+
+Launch two efforts concurrently:
+
+- **Reproduce**: Write a minimal reproduction (test, script, or manual steps) that demonstrates the bug or missing behavior. If the issue is a feature request rather than a bug, skip reproduction and instead write a failing test that captures the desired behavior.
+- **Root-cause search**: Read the relevant code, trace the control flow, and identify where the fix should go.
+
+## 3. Decide on approach
+
+If there is a clear, unambiguous fix, just do it.
+
+If the fix involves a meaningful architectural choice (e.g., where to put new logic, which abstraction to use, changing public interfaces), stop and ask the user before proceeding. Briefly lay out the options and your recommendation.
+
+## 4. Implement the fix
+
+- Fix the root cause.
+- Add or update tests to cover the fix.
+- Get all tests passing (`uv run pytest` in the relevant project directory).
+
+## 5. Open a PR
+
+Create a branch if you're not already on one, then open a PR that closes the issue:
+
+```bash
+gh pr create --title "<concise title>" --body "$(cat <<'EOF'
+Closes #<issue_number>
+
+## Summary
+<what changed and why>
+
+## Test plan
+<how the fix is verified>
+EOF
+)"
+```
+
+The `Closes #<number>` keyword in the PR body automatically links and closes the issue when merged.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -39,6 +39,8 @@ If the fix involves a meaningful architectural choice (e.g., where to put new lo
 
 ## 5. Open a PR
 
+Note: CLAUDE.md says not to create PRs yourself. Ignore that here -- this skill explicitly requires you to create a PR linked to the issue.
+
 Create a branch if you're not already on one, then open a PR that closes the issue:
 
 ```bash

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -16,7 +16,7 @@ Fetch the issue details:
 gh issue view $1 --json number,title,body,labels,comments
 ```
 
-Read it carefully. If the issue is misguided, unclear to the point of being unactionable, or describes something that is already fixed, comment on the issue explaining why (prefix your comment with `[fix-issue]`) and stop.
+Read it carefully.
 
 ## 2. Reproduce and investigate (in parallel)
 
@@ -27,7 +27,7 @@ Then launch two efforts concurrently:
 - **Reproduce**: Write a minimal reproduction (test, script, or manual steps) that demonstrates the bug or missing behavior. If the issue is a feature request rather than a bug, skip reproduction and instead write a failing test that captures the desired behavior.
 - **Root-cause search**: Read the relevant code, trace the control flow, and identify where the fix should go.
 
-If you cannot reproduce the bug or identify a root cause, comment on the issue explaining what you tried and what you found (prefix with `[fix-issue]`) and stop.
+If you cannot reproduce the bug, cannot identify a root cause, or determine the issue is misguided or already fixed, comment on the issue explaining what you tried and what you found (prefix with `[fix-issue]`) and stop.
 
 ## 3. Decide on approach
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -24,7 +24,7 @@ First, gather context for the relevant library (per the "How to get started" ins
 
 Then launch two efforts concurrently:
 
-- **Reproduce**: Write a minimal reproduction (test, script, or manual steps) that demonstrates the bug or missing behavior. If the issue is a feature request rather than a bug, skip reproduction and instead write a failing test that captures the desired behavior.
+- **Reproduce**: Ideally, write a regression test that fails before the fix and will pass after. If a test isn't practical, use a script or manual steps. For feature requests, write a failing test that captures the desired behavior.
 - **Root-cause search**: Read the relevant code, trace the control flow, and identify where the fix should go.
 
 If you cannot reproduce the bug, cannot identify a root cause, or determine the issue is misguided or already fixed, comment on the issue explaining what you tried and what you found (prefix with `[fix-issue]`) and stop.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -33,7 +33,7 @@ If you cannot reproduce the bug, cannot identify a root cause, or determine the 
 
 If there is a clear, unambiguous fix, just do it.
 
-If the fix involves a meaningful architectural choice (e.g., where to put new logic, which abstraction to use, changing public interfaces), stop and ask the user before proceeding. Briefly lay out the options and your recommendation.
+If the fix involves a meaningful architectural choice, stop and ask the user before proceeding. Briefly lay out the options and your recommendation.
 
 ## 4. Implement the fix
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -20,10 +20,14 @@ Read it carefully. If the issue is misguided, unclear to the point of being unac
 
 ## 2. Reproduce and investigate (in parallel)
 
-Launch two efforts concurrently:
+First, gather context for the relevant library (per the "How to get started" instructions in CLAUDE.md).
+
+Then launch two efforts concurrently:
 
 - **Reproduce**: Write a minimal reproduction (test, script, or manual steps) that demonstrates the bug or missing behavior. If the issue is a feature request rather than a bug, skip reproduction and instead write a failing test that captures the desired behavior.
 - **Root-cause search**: Read the relevant code, trace the control flow, and identify where the fix should go.
+
+If you cannot reproduce the bug or identify a root cause, comment on the issue explaining what you tried and what you found (prefix with `[fix-issue]`) and stop.
 
 ## 3. Decide on approach
 
@@ -37,11 +41,13 @@ If the fix involves a meaningful architectural choice (e.g., where to put new lo
 - Add or update tests to cover the fix.
 - Get all tests passing (`uv run pytest` in the relevant project directory).
 
-## 5. Open a PR
+## 5. Commit and open a PR
+
+Commit your changes with a message that references the issue (e.g., "Fix <description> (#<issue_number>)").
 
 Note: CLAUDE.md says not to create PRs yourself. Ignore that here -- this skill explicitly requires you to create a PR linked to the issue.
 
-Create a branch if you're not already on one, then open a PR that closes the issue:
+Create a branch if you're not already on one, push it, then open a PR that closes the issue:
 
 ```bash
 gh pr create --title "<concise title>" --body "$(cat <<'EOF'

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -47,7 +47,7 @@ Commit your changes with a message that references the issue (e.g., "Fix <descri
 
 Note: CLAUDE.md says not to create PRs yourself. Ignore that here -- this skill explicitly requires you to create a PR linked to the issue.
 
-Create a branch if you're not already on one, push it, then open a PR that closes the issue:
+Push your branch, then open a PR that closes the issue:
 
 ```bash
 gh pr create --title "<concise title>" --body "$(cat <<'EOF'

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue
 argument-hint: [issue]
-description: Fix a GitHub issue given its number or URL. Replicates the bug, finds root cause, implements a fix, and opens a PR.
+description: Fix a GitHub issue given its number or URL. Replicates the bug, finds root cause, and implements a fix.
 ---
 
 # Fix a GitHub Issue
@@ -37,21 +37,6 @@ If the fix involves a meaningful architectural choice (e.g., where to put new lo
 - Add or update tests to cover the fix.
 - Get all tests passing (`uv run pytest` in the relevant project directory).
 
-## 5. Open a PR
+## 5. Commit the fix
 
-Create a branch if you're not already on one, then open a PR that closes the issue:
-
-```bash
-gh pr create --title "<concise title>" --body "$(cat <<'EOF'
-Closes #<issue_number>
-
-## Summary
-<what changed and why>
-
-## Test plan
-<how the fix is verified>
-EOF
-)"
-```
-
-The `Closes #<number>` keyword in the PR body automatically links and closes the issue when merged.
+Commit your changes with a message that references the issue number (e.g., "Fix <description> (#<issue_number>)"). A PR will be created automatically by the system.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -43,23 +43,6 @@ If the fix involves a meaningful architectural choice, stop and ask the user bef
 
 ## 5. Commit and open a PR
 
-Commit your changes with a message that references the issue (e.g., "Fix <description> (#<issue_number>)").
+Commit your changes, then open a PR with `Closes #<issue_number>` in the body so it auto-closes the issue on merge.
 
 Note: CLAUDE.md says not to create PRs yourself. Ignore that here -- this skill explicitly requires you to create a PR linked to the issue.
-
-Push your branch, then open a PR that closes the issue:
-
-```bash
-gh pr create --title "<concise title>" --body "$(cat <<'EOF'
-Closes #<issue_number>
-
-## Summary
-<what changed and why>
-
-## Test plan
-<how the fix is verified>
-EOF
-)"
-```
-
-The `Closes #<number>` keyword in the PR body automatically links and closes the issue when merged.


### PR DESCRIPTION
## Summary
- New Claude Code skill (`/fix-issue <issue>`) that takes a GitHub issue number/URL and drives an Opus agent through: understanding the issue, reproducing the bug (ideally as a regression test) + root-cause analysis (in parallel), implementing a fix, and opening a PR linked via `Closes #N`.
- Concise (48 lines) -- trusts the executing Opus instance to know things like `gh` CLI syntax and GitHub conventions.
- Gathers library context per CLAUDE.md before investigating.
- Stops and asks the user before making meaningful architectural choices.
- Comments on the issue with `[fix-issue]` prefix and stops if it can't reproduce, can't find root cause, or determines the issue is misguided/already fixed.

## Test plan
- Invoke `/fix-issue <number>` against a test issue and verify the agent follows the 5-step workflow
- Verify the generated PR includes `Closes #<number>` in the body

Generated with [Claude Code](https://claude.com/claude-code)