### PR TITLE
try to get agents to not subvert the stop hook or skip recommendations from architecture verification

### DIFF
--- a/plugins/imbue-code-review/scripts/stop_hook_gates.sh
+++ b/plugins/imbue-code-review/scripts/stop_hook_gates.sh
@@ -133,10 +133,13 @@ for item in "${MISSING[@]}"; do
 done
 echo "" >&2
 if [[ ${#MISSING[@]} -gt 1 ]]; then
-    if [[ "$CONVO_NEEDED" == "true" ]]; then
-        echo "Run these before finishing. If possible, run /verify-conversation in the background while running the others." >&2
-    else
-        echo "Run these before finishing." >&2
+    GUIDANCE="Run these before finishing."
+    if [[ "$ARCH_NEEDED" == "true" ]] && [[ "$AUTOFIX_NEEDED" == "true" ]]; then
+        GUIDANCE="${GUIDANCE} Address any issues raised by /verify-architecture before running /autofix, since architecture changes may make autofix results obsolete."
     fi
+    if [[ "$CONVO_NEEDED" == "true" ]]; then
+        GUIDANCE="${GUIDANCE} If possible, run /verify-conversation in the background while running the others."
+    fi
+    echo "$GUIDANCE" >&2
 fi
 exit 2

--- a/plugins/imbue-code-review/scripts/stop_hook_gates.sh
+++ b/plugins/imbue-code-review/scripts/stop_hook_gates.sh
@@ -142,4 +142,9 @@ if [[ ${#MISSING[@]} -gt 1 ]]; then
     fi
     echo "$GUIDANCE" >&2
 fi
+# If any per-commit gate is enabled, note that gates may fire repeatedly.
+if [[ "$AUTOFIX_ENABLED" == "true" ]] || [[ "$CONVO_ENABLED" == "true" ]]; then
+    echo "" >&2
+    echo "Note: these gates may fire again after you make changes. /verify-conversation is incremental and only reviews new content. For /autofix, the default is to run the full check, but if your changes since the last autofix run are focused, you may pass instructions telling it to focus on the diff since the last run (while still providing the true base branch)." >&2
+fi
 exit 2


### PR DESCRIPTION
## Summary
- When both architecture verification and autofix gates are unsatisfied, the stop hook now tells agents to address architecture issues first, since architecture changes may make autofix results obsolete.
- Adds a note (when per-commit gates are enabled) that gates may fire repeatedly after new commits: `/verify-conversation` is incremental, and `/autofix` defaults to a full check but can be scoped to recent changes if the diff since the last run is focused.
- Refactors the guidance message from an if/else into an incremental string-accumulation pattern for better composability.

## Test plan
- [ ] Verify stop hook output when all three gates are unsatisfied includes architecture-before-autofix guidance and the repeated-gates note
- [ ] Verify stop hook output when only autofix and conversation review are unsatisfied does not include architecture guidance but does include the repeated-gates note
- [ ] Verify stop hook output when only architecture is unsatisfied does not include the repeated-gates note (architecture is per-branch, not per-commit)