### PR TITLE
Fix stop hook diff to compare against origin/main instead of local main

### DIFF
--- a/scripts/main_claude_stop_hook.sh
+++ b/scripts/main_claude_stop_hook.sh
@@ -179,8 +179,10 @@ if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]]; then
     log_info "Currently on base branch ($BASE_BRANCH) - no PR needed"
     IS_INFORMATIONAL_ONLY=true
 else
-    # Get files that have changed since the (now updated) base branch
-    CHANGED_FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || echo "")
+    # Get files that have changed since the (now updated) base branch.
+    # Use origin/$BASE_BRANCH since we fetched and merged it above -- the
+    # local $BASE_BRANCH ref may be stale if it hasn't been pulled.
+    CHANGED_FILES=$(git diff --name-only "origin/$BASE_BRANCH"...HEAD 2>/dev/null || echo "")
     if [[ -z "$CHANGED_FILES" ]]; then
         log_info "No files changed compared to $BASE_BRANCH - this was an informational session"
         IS_INFORMATIONAL_ONLY=true


### PR DESCRIPTION
The informational-session detection was diffing against the local $BASE_BRANCH ref, but the merge step uses origin/$BASE_BRANCH. If the local main hasn't been pulled, the diff includes other people's commits from origin/main, misidentifying the session's actual changes.