### PR TITLE
Abort if config TOML exists but has syntax error

### DIFF
--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -261,8 +261,8 @@ def get_or_create_profile_dir(base_dir: Path) -> Path:
                 profile_dir = profiles_dir / profile_id
                 profile_dir.mkdir(parents=True, exist_ok=True)
                 return profile_dir
-        except tomllib.TOMLDecodeError:
-            pass
+        except tomllib.TOMLDecodeError as e:
+            logger.warning("Failed to parse config file {}: {}", config_path, e)
 
     # No valid config.toml or no profile specified -- create a new profile
     profile_id = uuid4().hex

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -243,7 +243,6 @@ def get_or_create_profile_dir(base_dir: Path) -> Path:
     profiles_dir = base_dir / PROFILES_DIRNAME
     profiles_dir.mkdir(parents=True, exist_ok=True)
 
-    # Parse config once and reuse the result to avoid duplicate warnings
     config_path = base_dir / ROOT_CONFIG_FILENAME
     root_config = try_load_toml(config_path)
     if root_config is not None:

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -1,5 +1,4 @@
 import os
-import tomllib
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -28,7 +27,6 @@ from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.config.data_types import split_cli_args_string
 from imbue.mngr.config.host_dir import read_default_host_dir
 from imbue.mngr.config.plugin_registry import get_plugin_config_class
-from imbue.mngr.config.pre_readers import find_profile_dir_lightweight
 from imbue.mngr.config.pre_readers import get_user_config_path
 from imbue.mngr.config.pre_readers import load_local_config
 from imbue.mngr.config.pre_readers import load_project_config
@@ -245,24 +243,15 @@ def get_or_create_profile_dir(base_dir: Path) -> Path:
     profiles_dir = base_dir / PROFILES_DIRNAME
     profiles_dir.mkdir(parents=True, exist_ok=True)
 
-    # Try read-only lookup first
-    existing = find_profile_dir_lightweight(base_dir)
-    if existing is not None:
-        return existing
-
-    # Config specifies a profile ID but the directory doesn't exist yet -- create it
+    # Parse config once and reuse the result to avoid duplicate warnings
     config_path = base_dir / ROOT_CONFIG_FILENAME
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                root_config = tomllib.load(f)
-            profile_id = root_config.get("profile")
-            if profile_id:
-                profile_dir = profiles_dir / profile_id
-                profile_dir.mkdir(parents=True, exist_ok=True)
-                return profile_dir
-        except tomllib.TOMLDecodeError as e:
-            logger.warning("Failed to parse config file {}: {}", config_path, e)
+    root_config = try_load_toml(config_path)
+    if root_config is not None:
+        profile_id = root_config.get("profile")
+        if profile_id:
+            profile_dir = profiles_dir / profile_id
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            return profile_dir
 
     # No valid config.toml or no profile specified -- create a new profile
     profile_id = uuid4().hex

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -947,8 +947,8 @@ def test_get_or_create_profile_dir_creates_profile_dir_if_specified_but_missing(
     assert result.exists()
 
 
-def test_get_or_create_profile_dir_warns_and_creates_new_profile_for_invalid_config_toml(tmp_path: Path) -> None:
-    """get_or_create_profile_dir should warn and create a new profile when config.toml is invalid."""
+def test_get_or_create_profile_dir_raises_on_invalid_config_toml(tmp_path: Path) -> None:
+    """get_or_create_profile_dir should raise ConfigParseError when config.toml is invalid."""
     base_dir = tmp_path / "mngr"
     base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -956,23 +956,8 @@ def test_get_or_create_profile_dir_warns_and_creates_new_profile_for_invalid_con
     config_path = base_dir / "config.toml"
     config_path.write_text("[invalid toml syntax")
 
-    messages: list[str] = []
-    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
-    try:
-        result = get_or_create_profile_dir(base_dir)
-    finally:
-        logger.remove(sink_id)
-
-    # Should have created a new profile (with new config)
-    assert result.exists()
-    assert result.parent == base_dir / "profiles"
-
-    # config.toml should have been overwritten with valid content
-    new_content = config_path.read_text()
-    assert 'profile = "' in new_content
-
-    # Should have warned about the parse failure
-    assert any("Failed to parse config file" in m and str(config_path) in m for m in messages)
+    with pytest.raises(ConfigParseError, match="Failed to parse config file"):
+        get_or_create_profile_dir(base_dir)
 
 
 def test_get_or_create_profile_dir_handles_config_without_profile_key(tmp_path: Path) -> None:

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -947,8 +947,8 @@ def test_get_or_create_profile_dir_creates_profile_dir_if_specified_but_missing(
     assert result.exists()
 
 
-def test_get_or_create_profile_dir_handles_invalid_config_toml(tmp_path: Path) -> None:
-    """get_or_create_profile_dir should handle invalid config.toml by creating new profile."""
+def test_get_or_create_profile_dir_warns_and_creates_new_profile_for_invalid_config_toml(tmp_path: Path) -> None:
+    """get_or_create_profile_dir should warn and create a new profile when config.toml is invalid."""
     base_dir = tmp_path / "mngr"
     base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -956,7 +956,12 @@ def test_get_or_create_profile_dir_handles_invalid_config_toml(tmp_path: Path) -
     config_path = base_dir / "config.toml"
     config_path.write_text("[invalid toml syntax")
 
-    result = get_or_create_profile_dir(base_dir)
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        result = get_or_create_profile_dir(base_dir)
+    finally:
+        logger.remove(sink_id)
 
     # Should have created a new profile (with new config)
     assert result.exists()
@@ -965,6 +970,9 @@ def test_get_or_create_profile_dir_handles_invalid_config_toml(tmp_path: Path) -
     # config.toml should have been overwritten with valid content
     new_content = config_path.read_text()
     assert 'profile = "' in new_content
+
+    # Should have warned about the parse failure
+    assert any("Failed to parse config file" in m and str(config_path) in m for m in messages)
 
 
 def test_get_or_create_profile_dir_handles_config_without_profile_key(tmp_path: Path) -> None:

--- a/libs/mngr/imbue/mngr/config/pre_readers.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers.py
@@ -3,6 +3,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.consts import PROFILES_DIRNAME
 from imbue.mngr.config.consts import ROOT_CONFIG_FILENAME
@@ -15,13 +17,19 @@ from imbue.mngr.utils.git_utils import find_git_worktree_root
 
 
 def try_load_toml(path: Path | None) -> dict[str, Any] | None:
-    """Load and parse a TOML file, returning None if path is None, missing, or malformed."""
+    """Load and parse a TOML file, returning None if path is None or missing.
+
+    Warns and returns None if the file exists but contains invalid TOML.
+    """
     if path is None:
         return None
     try:
         with open(path, "rb") as f:
             return tomllib.load(f)
-    except (FileNotFoundError, tomllib.TOMLDecodeError):
+    except FileNotFoundError:
+        return None
+    except tomllib.TOMLDecodeError as e:
+        logger.warning("Failed to parse config file {}: {}", path, e)
         return None
 
 
@@ -84,7 +92,7 @@ def resolve_project_config_dir(
 
 
 def load_project_config(context_dir: Path | None, root_name: str, cg: ConcurrencyGroup) -> dict[str, Any] | None:
-    """Find and load the project config file, returning None if not found or malformed."""
+    """Find and load the project config file, returning None if not found or malformed (with a warning)."""
     project_dir = resolve_project_config_dir(context_dir, root_name, cg)
     if project_dir is None:
         return None
@@ -92,7 +100,7 @@ def load_project_config(context_dir: Path | None, root_name: str, cg: Concurrenc
 
 
 def load_local_config(context_dir: Path | None, root_name: str, cg: ConcurrencyGroup) -> dict[str, Any] | None:
-    """Find and load the local config file, returning None if not found or malformed."""
+    """Find and load the local config file, returning None if not found or malformed (with a warning)."""
     project_dir = resolve_project_config_dir(context_dir, root_name, cg)
     if project_dir is None:
         return None

--- a/libs/mngr/imbue/mngr/config/pre_readers.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers.py
@@ -3,12 +3,11 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from loguru import logger
-
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.consts import PROFILES_DIRNAME
 from imbue.mngr.config.consts import ROOT_CONFIG_FILENAME
 from imbue.mngr.config.host_dir import read_default_host_dir
+from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.utils.git_utils import find_git_worktree_root
 
 # =============================================================================
@@ -19,7 +18,7 @@ from imbue.mngr.utils.git_utils import find_git_worktree_root
 def try_load_toml(path: Path | None) -> dict[str, Any] | None:
     """Load and parse a TOML file, returning None if path is None or missing.
 
-    Warns and returns None if the file exists but contains invalid TOML.
+    Raises ConfigParseError if the file exists but contains invalid TOML.
     """
     if path is None:
         return None
@@ -29,8 +28,7 @@ def try_load_toml(path: Path | None) -> dict[str, Any] | None:
     except FileNotFoundError:
         return None
     except tomllib.TOMLDecodeError as e:
-        logger.warning("Failed to parse config file {}: {}", path, e)
-        return None
+        raise ConfigParseError(f"Failed to parse config file {path}: {e}") from e
 
 
 def find_profile_dir_lightweight(base_dir: Path) -> Path | None:
@@ -92,7 +90,7 @@ def resolve_project_config_dir(
 
 
 def load_project_config(context_dir: Path | None, root_name: str, cg: ConcurrencyGroup) -> dict[str, Any] | None:
-    """Find and load the project config file, returning None if not found or malformed (with a warning)."""
+    """Find and load the project config file, returning None if not found."""
     project_dir = resolve_project_config_dir(context_dir, root_name, cg)
     if project_dir is None:
         return None
@@ -100,7 +98,7 @@ def load_project_config(context_dir: Path | None, root_name: str, cg: Concurrenc
 
 
 def load_local_config(context_dir: Path | None, root_name: str, cg: ConcurrencyGroup) -> dict[str, Any] | None:
-    """Find and load the local config file, returning None if not found or malformed (with a warning)."""
+    """Find and load the local config file, returning None if not found."""
     project_dir = resolve_project_config_dir(context_dir, root_name, cg)
     if project_dir is None:
         return None

--- a/libs/mngr/imbue/mngr/config/pre_readers.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers.py
@@ -140,16 +140,21 @@ def _resolve_config_files(
         if raw is not None:
             configs.append(raw)
 
-    # Project + local config need the project root
+    # Project + local config need the project root.
+    # Resolve the directory inside the ConcurrencyGroup (it needs git lookups),
+    # but load the TOML files outside it so ConfigParseError propagates directly
+    # instead of being wrapped in ConcurrencyExceptionGroup.
     cg = ConcurrencyGroup(name="config-pre-reader")
     with cg:
-        raw_project = load_project_config(context_dir, root_name, cg)
-        raw_local = load_local_config(context_dir, root_name, cg)
+        project_dir = resolve_project_config_dir(context_dir, root_name, cg)
 
-    if raw_project is not None:
-        configs.append(raw_project)
-    if raw_local is not None:
-        configs.append(raw_local)
+    if project_dir is not None:
+        raw_project = try_load_toml(project_dir / "settings.toml")
+        if raw_project is not None:
+            configs.append(raw_project)
+        raw_local = try_load_toml(project_dir / "settings.local.toml")
+        if raw_local is not None:
+            configs.append(raw_local)
 
     return configs
 

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-from loguru import logger
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.pre_readers import get_local_config_name
@@ -15,6 +14,7 @@ from imbue.mngr.config.pre_readers import read_default_command
 from imbue.mngr.config.pre_readers import read_disabled_plugins
 from imbue.mngr.config.pre_readers import resolve_project_config_dir
 from imbue.mngr.config.pre_readers import try_load_toml
+from imbue.mngr.errors import ConfigParseError
 
 # =============================================================================
 # Tests for try_load_toml
@@ -31,17 +31,12 @@ def test_try_load_toml_returns_none_for_missing_file(tmp_path: Path) -> None:
     assert try_load_toml(tmp_path / "nonexistent.toml") is None
 
 
-def test_try_load_toml_warns_and_returns_none_for_malformed_toml(tmp_path: Path) -> None:
-    """try_load_toml should warn and return None when the file contains invalid TOML."""
+def test_try_load_toml_raises_on_malformed_toml(tmp_path: Path) -> None:
+    """try_load_toml should raise ConfigParseError when the file contains invalid TOML."""
     invalid_toml = tmp_path / "invalid.toml"
     invalid_toml.write_text("[invalid toml syntax")
-    messages: list[str] = []
-    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
-    try:
-        assert try_load_toml(invalid_toml) is None
-    finally:
-        logger.remove(sink_id)
-    assert any("Failed to parse config file" in m and str(invalid_toml) in m for m in messages)
+    with pytest.raises(ConfigParseError, match="Failed to parse config file"):
+        try_load_toml(invalid_toml)
 
 
 def test_try_load_toml_parses_valid_file(tmp_path: Path) -> None:

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.pre_readers import get_local_config_name
@@ -30,11 +31,17 @@ def test_try_load_toml_returns_none_for_missing_file(tmp_path: Path) -> None:
     assert try_load_toml(tmp_path / "nonexistent.toml") is None
 
 
-def test_try_load_toml_returns_none_for_malformed_toml(tmp_path: Path) -> None:
-    """try_load_toml should return None when the file contains invalid TOML."""
+def test_try_load_toml_warns_and_returns_none_for_malformed_toml(tmp_path: Path) -> None:
+    """try_load_toml should warn and return None when the file contains invalid TOML."""
     invalid_toml = tmp_path / "invalid.toml"
     invalid_toml.write_text("[invalid toml syntax")
-    assert try_load_toml(invalid_toml) is None
+    messages: list[str] = []
+    sink_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+    try:
+        assert try_load_toml(invalid_toml) is None
+    finally:
+        logger.remove(sink_id)
+    assert any("Failed to parse config file" in m and str(invalid_toml) in m for m in messages)
 
 
 def test_try_load_toml_parses_valid_file(tmp_path: Path) -> None:

--- a/libs/mngr/imbue/mngr/main.py
+++ b/libs/mngr/imbue/mngr/main.py
@@ -47,6 +47,7 @@ from imbue.mngr.cli.transcript import transcript
 from imbue.mngr.config.loader import block_disabled_plugins
 from imbue.mngr.config.pre_readers import read_disabled_plugins
 from imbue.mngr.errors import BaseMngrError
+from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.plugins import hookspecs
 from imbue.mngr.providers.registry import get_all_provider_args_help_sections
 from imbue.mngr.providers.registry import load_all_registries
@@ -354,7 +355,13 @@ cli.add_command(migrate)
 
 # Register plugin commands after built-in commands but before applying CLI options.
 # This ordering allows plugins to add CLI options to other plugin commands.
-PLUGIN_COMMANDS = _register_plugin_commands()
+# Wrapped in try/except because this runs at module import time, before Click's
+# exception handling is active, so ConfigParseError would produce a stack trace.
+try:
+    PLUGIN_COMMANDS = _register_plugin_commands()
+except ConfigParseError as e:
+    e.show()
+    sys.exit(1)
 
 for cmd in BUILTIN_COMMANDS + PLUGIN_COMMANDS:
     apply_plugin_cli_options(cmd)


### PR DESCRIPTION
Previously a config TOML with invalid syntax makes the entire file ignored silently.