### PR TITLE
Add "help" subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,4 @@ current.tar.gz
 
 # ignore coverage files generated within subprojects
 cov.xml
+.reviewer/

--- a/.gitignore
+++ b/.gitignore
@@ -272,4 +272,3 @@ current.tar.gz
 
 # ignore coverage files generated within subprojects
 cov.xml
-.reviewer/

--- a/libs/mngr/docs/commands/secondary/help.md
+++ b/libs/mngr/docs/commands/secondary/help.md
@@ -1,0 +1,74 @@
+<!-- This file is auto-generated. Do not edit directly. -->
+<!-- To modify, edit the command's help metadata and run: uv run python scripts/make_cli_docs.py -->
+
+# mngr help
+
+**Synopsis:**
+
+```text
+mngr help [<command> | <topic>]
+```
+
+Show help for a command or topic.
+
+Show help for a mngr command or topic. Without arguments, lists all
+available commands and help topics.
+
+For commands, 'mngr help <command>' is equivalent to 'mngr <command> --help'.
+Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
+
+For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
+
+Help topics provide documentation on concepts that span multiple commands,
+such as filter syntax and agent address format.
+
+**Usage:**
+
+```text
+mngr help [TOPIC]...
+```
+
+## Available Topics
+
+| Topic | Aliases | Description |
+| ----- | ------- | ----------- |
+| `filter` | `filters`, `cel` | CEL filter expression syntax for mngr commands |
+| `address` | `addr` | Agent address syntax for targeting agents and hosts |
+
+## Examples
+
+**Show help for the create command**
+
+```bash
+$ mngr help create
+```
+
+**Show help using a command alias**
+
+```bash
+$ mngr help c
+```
+
+**Show help for a subcommand**
+
+```bash
+$ mngr help snapshot create
+```
+
+**Show the filter syntax topic**
+
+```bash
+$ mngr help filter
+```
+
+**Show the address format topic**
+
+```bash
+$ mngr help address
+```
+
+**List all commands and topics**
+
+```bash
+$ mngr help
+```

--- a/libs/mngr/docs/commands/secondary/help.md
+++ b/libs/mngr/docs/commands/secondary/help.md
@@ -25,8 +25,19 @@ such as filter syntax and agent address format.
 **Usage:**
 
 ```text
-mngr help [TOPIC]...
+mngr help [OPTIONS] [TOPIC]...
 ```
+## Arguments
+
+- `TOPIC`: The topic (optional)
+
+**Options:**
+
+## Other Options
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
 ## Available Topics
 

--- a/libs/mngr/docs/commands/secondary/help.md
+++ b/libs/mngr/docs/commands/secondary/help.md
@@ -20,7 +20,7 @@ Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
 For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
 
 Help topics provide documentation on concepts that span multiple commands,
-such as filter syntax and agent address format.
+such as agent address format.
 
 **Usage:**
 
@@ -43,7 +43,6 @@ mngr help [OPTIONS] [TOPIC]...
 
 | Topic | Aliases | Description |
 | ----- | ------- | ----------- |
-| `filter` | `filters`, `cel` | CEL filter expression syntax for mngr commands |
 | `address` | `addr` | Agent address syntax for targeting agents and hosts |
 
 ## Examples
@@ -64,12 +63,6 @@ $ mngr help c
 
 ```bash
 $ mngr help snapshot create
-```
-
-**Show the filter syntax topic**
-
-```bash
-$ mngr help filter
 ```
 
 **Show the address format topic**

--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -18,6 +18,7 @@ from imbue.mngr.cli.destroy import destroy
 from imbue.mngr.cli.events import events
 from imbue.mngr.cli.exec import exec_command
 from imbue.mngr.cli.gc import gc
+from imbue.mngr.cli.help import help_command
 from imbue.mngr.cli.label import label
 from imbue.mngr.cli.limit import limit
 from imbue.mngr.cli.message import message
@@ -268,6 +269,7 @@ _HELP_TEST_CASES: list[tuple[click.Command, list[str], str]] = [
     (destroy, ["--help"], "destroy"),
     (exec_command, ["--help"], "exec"),
     (gc, ["--help"], "gc"),
+    (help_command, ["--help"], "help"),
     (label, ["--help"], "label"),
     (limit, ["--help"], "limit"),
     (events, ["--help"], "events"),

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -385,10 +385,7 @@ EXAMPLES
       $ mngr list --exclude 'host.provider == "local"'
 
   List agents with names containing "prod" on Modal:
-      $ mngr list --include 'name.contains("prod") && host.provider == "modal"'
-
-  Stop all agents idle for more than an hour:
-      $ mngr stop --all --include 'idle_seconds > 3600'\
+      $ mngr list --include 'name.contains("prod") && host.provider == "modal"'\
 """,
     see_also=(
         ("list", "List agents with filtering and sorting"),

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -212,7 +212,7 @@ def _show_help_overview(ctx: click.Context) -> None:
     if all_metadata:
         output.write("COMMANDS\n")
         for key, meta in sorted(all_metadata.items()):
-            name_str = key
+            name_str = key.replace(".", " ")
             if meta.aliases:
                 name_str += f", {', '.join(meta.aliases)}"
             output.write(f"       {name_str:<28} {meta.one_line_description}\n")

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -409,7 +409,7 @@ optionally which host and provider) to target. The address format is:
 
 All parts are optional:
 
-  NAME                  Agent name only (local host assumed)
+  NAME                  Agent name only (searches all hosts; local in create)
   NAME@HOST             Agent on a specific existing host
   NAME@HOST.PROVIDER    Agent on a specific host with provider disambiguation
   NAME@.PROVIDER        Agent on a new host (auto-generated host name)
@@ -421,7 +421,9 @@ COMPONENTS
 
   NAME
       The agent name. Must be a valid identifier (lowercase letters, digits,
-      and hyphens). If omitted, a name is auto-generated.
+      and hyphens). If omitted, a name is auto-generated. Without a host
+      component, commands that target existing agents search across all
+      hosts and providers. In 'mngr create', it defaults to the local host.
 
   HOST
       The host name. Refers to an existing host unless --new-host is specified.

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -2,7 +2,7 @@
 
 Provides two types of help:
 1. Command help: ``mngr help create`` is equivalent to ``mngr create --help``
-2. Topic help: ``mngr help filter`` shows a standalone documentation page
+2. Topic help: ``mngr help address`` shows a standalone documentation page
 
 Both commands and topics support aliases (e.g., ``mngr help c`` for create,
 ``mngr help addr`` for address).
@@ -285,13 +285,12 @@ Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
 For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
 
 Help topics provide documentation on concepts that span multiple commands,
-such as filter syntax and agent address format.""",
+such as agent address format.""",
     additional_sections=(
         (
             "Available Topics",
             "| Topic | Aliases | Description |\n"
             "| ----- | ------- | ----------- |\n"
-            "| `filter` | `filters`, `cel` | CEL filter expression syntax for mngr commands |\n"
             "| `address` | `addr` | Agent address syntax for targeting agents and hosts |",
         ),
     ),
@@ -299,7 +298,6 @@ such as filter syntax and agent address format.""",
         ("Show help for the create command", "mngr help create"),
         ("Show help using a command alias", "mngr help c"),
         ("Show help for a subcommand", "mngr help snapshot create"),
-        ("Show the filter syntax topic", "mngr help filter"),
         ("Show the address format topic", "mngr help address"),
         ("List all commands and topics", "mngr help"),
     ),
@@ -311,88 +309,6 @@ add_pager_help_option(help_command)
 # =============================================================================
 # Topic page definitions
 # =============================================================================
-
-TopicHelpPage(
-    key="filter",
-    one_line_description="CEL filter expression syntax for mngr commands",
-    aliases=("filters", "cel"),
-    content="""\
-Several mngr commands support filtering using CEL (Common Expression
-Language) expressions. Filters are specified with --include and --exclude
-flags, where --include keeps only matching items and --exclude removes
-matching items. Multiple filters can be combined.
-
-OPERATORS
-
-  Comparison:  ==  !=  <  <=  >  >=
-  Logical:     &&  ||  !
-  Grouping:    ( )
-
-STRING METHODS
-
-  name.contains("prod")       Substring match
-  name.startsWith("staging-") Prefix match
-  name.endsWith("-dev")       Suffix match
-
-EXISTENCE CHECKS
-
-  has(url)                    True if the field exists and is set
-  has(host.ssh)               True if SSH access is configured
-
-SIMPLE EQUALITY FILTERS
-
-  name == "my-agent"                 Match by exact agent name
-  state == "RUNNING"                 Match by lifecycle state
-  host.provider == "docker"          Match by host provider
-  type == "claude"                   Match by agent type
-  labels.project == "mngr"           Match by label value
-
-COMPOUND EXPRESSIONS
-
-  state == "RUNNING" && host.provider == "modal"
-  state == "STOPPED" || state == "FAILED"
-  host.provider == "docker" && name.startsWith("test-")
-
-NUMERIC COMPARISONS
-
-  runtime_seconds > 3600             Running for more than an hour
-  idle_seconds < 300                 Active in the last 5 minutes
-  host.resource.memory_gb >= 8       Hosts with 8GB+ memory
-  host.uptime_seconds > 86400        Hosts running for more than a day
-
-SORTING
-
-  The --sort flag also accepts CEL expressions with optional direction:
-
-  --sort 'name'                      Sort by name ascending (default)
-  --sort 'name desc'                 Sort by name descending
-  --sort 'state, name asc'           Sort by state then name
-  --sort 'create_time desc'          Most recently created first
-
-COMMANDS THAT SUPPORT FILTERS
-
-  mngr list     --include, --exclude, --sort
-  mngr destroy  --include, --exclude (with --all)
-  mngr stop     --include, --exclude (with --all)
-  mngr start    --include, --exclude (with --all)
-
-EXAMPLES
-
-  List only running agents:
-      $ mngr list --include 'state == "RUNNING"'
-
-  List agents except those on local hosts:
-      $ mngr list --exclude 'host.provider == "local"'
-
-  List agents with names containing "prod" on Modal:
-      $ mngr list --include 'name.contains("prod") && host.provider == "modal"'\
-""",
-    see_also=(
-        ("list", "List agents with filtering and sorting"),
-        ("address", "Agent address syntax"),
-    ),
-).register()
-
 
 TopicHelpPage(
     key="address",
@@ -465,6 +381,5 @@ EXAMPLES
     see_also=(
         ("create", "Create and run an agent"),
         ("connect", "Connect to an existing agent"),
-        ("filter", "CEL filter expression syntax"),
     ),
 ).register()

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -109,7 +109,7 @@ def format_topic_help(topic: TopicHelpPage) -> str:
 
 
 def _resolve_command_chain(
-    cli_group: click.Group,
+    root_group: click.Group,
     parent_ctx: click.Context,
     parts: tuple[str, ...],
 ) -> list[click.Command] | None:
@@ -117,13 +117,13 @@ def _resolve_command_chain(
 
     Walks through group hierarchies to support subcommands.
     For example, ("snapshot", "create") resolves to [snapshot_group, create_cmd].
-    Returns None if any part fails to resolve.
+    Returns None if any part fails to resolve or if an intermediate command is not a group.
     """
     if not parts:
         return None
 
     commands: list[click.Command] = []
-    current_group: click.Group = cli_group
+    current_group = root_group
     current_ctx = parent_ctx
 
     for i, part in enumerate(parts):
@@ -133,9 +133,9 @@ def _resolve_command_chain(
         commands.append(cmd)
 
         if i < len(parts) - 1:
-            if not hasattr(cmd, "get_command"):
+            if not isinstance(cmd, click.Group):
                 return None
-            current_group = cmd  # type: ignore[assignment]
+            current_group = cmd
             current_ctx = click.Context(cmd, info_name=cmd.name, parent=current_ctx)
 
     return commands
@@ -248,10 +248,13 @@ def help_command(ctx: click.Context, topic: tuple[str, ...]) -> None:
 
     root_ctx = ctx.parent
     assert root_ctx is not None
-    cli_group: click.Group = root_ctx.command  # type: ignore[assignment]
+    root_cmd = root_ctx.command
+    if not isinstance(root_cmd, click.Group):
+        _show_help_overview(ctx)
+        return
 
     # Try to resolve as a CLI command (supports aliases and subcommands)
-    commands = _resolve_command_chain(cli_group, root_ctx, topic)
+    commands = _resolve_command_chain(root_cmd, root_ctx, topic)
     if commands is not None:
         _show_command_help(ctx, commands)
         return

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -286,6 +286,15 @@ For subcommands, specify the full command path (e.g., 'mngr help snapshot create
 
 Help topics provide documentation on concepts that span multiple commands,
 such as filter syntax and agent address format.""",
+    additional_sections=(
+        (
+            "Available Topics",
+            "| Topic | Aliases | Description |\n"
+            "| ----- | ------- | ----------- |\n"
+            "| `filter` | `filters`, `cel` | CEL filter expression syntax for mngr commands |\n"
+            "| `address` | `addr` | Agent address syntax for targeting agents and hosts |",
+        ),
+    ),
     examples=(
         ("Show help for the create command", "mngr help create"),
         ("Show help using a command alias", "mngr help c"),

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -1,0 +1,459 @@
+"""Help command and standalone topic pages for the mngr CLI.
+
+Provides two types of help:
+1. Command help: ``mngr help create`` is equivalent to ``mngr create --help``
+2. Topic help: ``mngr help filter`` shows a standalone documentation page
+
+Both commands and topics support aliases (e.g., ``mngr help c`` for create,
+``mngr help addr`` for address).
+"""
+
+import sys
+from io import StringIO
+
+import click
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.pure import pure
+from imbue.mngr.cli.help_formatter import CommandHelpMetadata
+from imbue.mngr.cli.help_formatter import add_pager_help_option
+from imbue.mngr.cli.help_formatter import format_git_style_help
+from imbue.mngr.cli.help_formatter import get_all_help_metadata
+from imbue.mngr.cli.help_formatter import get_help_metadata
+from imbue.mngr.cli.help_formatter import run_pager
+from imbue.mngr.config.data_types import MngrConfig
+
+# =============================================================================
+# Topic help page data model and registry
+# =============================================================================
+
+
+class TopicHelpPage(FrozenModel):
+    """A standalone help topic page (not associated with any CLI command).
+
+    Topic pages document concepts that span multiple commands, such as
+    filter syntax or agent address format.
+    """
+
+    key: str = Field(description="Topic identifier (e.g., 'filter')")
+    one_line_description: str = Field(description="Brief one-line description")
+    content: str = Field(description="Full content of the topic page")
+    aliases: tuple[str, ...] = Field(default=(), description="Topic aliases (e.g., ('addr',) for 'address')")
+    see_also: tuple[tuple[str, str], ...] = Field(
+        default=(), description="See Also references as (name, description) tuples"
+    )
+
+    def register(self) -> None:
+        """Register this topic page in the global topic registry."""
+        _topic_registry[self.key] = self
+        for alias in self.aliases:
+            _topic_alias_to_canonical[alias] = self.key
+
+
+_topic_registry: dict[str, TopicHelpPage] = {}
+_topic_alias_to_canonical: dict[str, str] = {}
+
+
+def get_topic(name: str) -> TopicHelpPage | None:
+    """Look up a topic by name or alias."""
+    canonical = _topic_alias_to_canonical.get(name, name)
+    return _topic_registry.get(canonical)
+
+
+def get_all_topics() -> dict[str, TopicHelpPage]:
+    """Return a copy of the topic registry."""
+    return dict(_topic_registry)
+
+
+# =============================================================================
+# Formatting
+# =============================================================================
+
+
+@pure
+def format_topic_help(topic: TopicHelpPage) -> str:
+    """Format a topic help page in git-style man-page format."""
+    output = StringIO()
+
+    # NAME section
+    output.write("NAME\n")
+    name_str = topic.key
+    if topic.aliases:
+        name_str += f" ({', '.join(topic.aliases)})"
+    output.write(f"       {name_str} - {topic.one_line_description}\n")
+    output.write("\n")
+
+    # DESCRIPTION section
+    output.write("DESCRIPTION\n")
+    for line in topic.content.strip().split("\n"):
+        if line.strip():
+            output.write(f"       {line}\n")
+        else:
+            output.write("\n")
+    output.write("\n")
+
+    # SEE ALSO section
+    if topic.see_also:
+        output.write("SEE ALSO\n")
+        for name, description in topic.see_also:
+            output.write(f"       mngr help {name} - {description}\n")
+        output.write("\n")
+
+    return output.getvalue()
+
+
+# =============================================================================
+# Command resolution helpers
+# =============================================================================
+
+
+def _resolve_command_chain(
+    cli_group: click.Group,
+    parent_ctx: click.Context,
+    parts: tuple[str, ...],
+) -> list[click.Command] | None:
+    """Resolve a chain of command names into a list of click.Command objects.
+
+    Walks through group hierarchies to support subcommands.
+    For example, ("snapshot", "create") resolves to [snapshot_group, create_cmd].
+    Returns None if any part fails to resolve.
+    """
+    if not parts:
+        return None
+
+    commands: list[click.Command] = []
+    current_group: click.Group = cli_group
+    current_ctx = parent_ctx
+
+    for i, part in enumerate(parts):
+        cmd = current_group.get_command(current_ctx, part)
+        if cmd is None:
+            return None
+        commands.append(cmd)
+
+        if i < len(parts) - 1:
+            if not hasattr(cmd, "get_command"):
+                return None
+            current_group = cmd  # type: ignore[assignment]
+            current_ctx = click.Context(cmd, info_name=cmd.name, parent=current_ctx)
+
+    return commands
+
+
+def _get_config_from_ctx(ctx: click.Context) -> MngrConfig | None:
+    """Extract MngrConfig from a click context, if available."""
+    root_ctx = ctx.find_root()
+    if hasattr(root_ctx, "obj") and root_ctx.obj is not None and hasattr(root_ctx.obj, "config"):
+        config: MngrConfig = root_ctx.obj.config
+        return config
+    return None
+
+
+# =============================================================================
+# Help display functions
+# =============================================================================
+
+
+def _show_command_help(
+    ctx: click.Context,
+    commands: list[click.Command],
+) -> None:
+    """Show help for a resolved command chain, equivalent to ``--help``."""
+    root_ctx = ctx.parent
+    assert root_ctx is not None
+
+    # Build context chain: root -> intermediate groups -> target command.
+    # This gives _build_help_key the correct chain to produce the right
+    # dot-separated key (e.g., "snapshot.create").
+    parent_ctx = root_ctx
+    for cmd in commands[:-1]:
+        parent_ctx = click.Context(cmd, info_name=cmd.name, parent=parent_ctx)
+
+    target_cmd = commands[-1]
+    target_ctx = click.Context(target_cmd, info_name=target_cmd.name, parent=parent_ctx)
+
+    help_key = ".".join(cmd.name for cmd in commands if cmd.name is not None)
+    metadata = get_help_metadata(help_key)
+
+    help_text = format_git_style_help(target_ctx, target_cmd, metadata)
+    config = _get_config_from_ctx(ctx)
+    run_pager(help_text, config)
+
+
+def _show_topic_help(ctx: click.Context, topic: TopicHelpPage) -> None:
+    """Show a standalone topic help page through the pager."""
+    help_text = format_topic_help(topic)
+    config = _get_config_from_ctx(ctx)
+    run_pager(help_text, config)
+
+
+def _show_help_overview(ctx: click.Context) -> None:
+    """Show an overview of all available commands and topics."""
+    output = StringIO()
+
+    output.write("NAME\n")
+    output.write("       mngr help - Show help for a command or topic\n")
+    output.write("\n")
+
+    output.write("SYNOPSIS\n")
+    output.write("       mngr help [<command> | <topic>]\n")
+    output.write("\n")
+
+    output.write("DESCRIPTION\n")
+    output.write("       Show help for a mngr command or topic. Without arguments, lists\n")
+    output.write("       all available commands and help topics.\n")
+    output.write("\n")
+    output.write("       For commands, 'mngr help <command>' is equivalent to\n")
+    output.write("       'mngr <command> --help'. Command aliases are supported.\n")
+    output.write("\n")
+
+    all_metadata = get_all_help_metadata()
+    if all_metadata:
+        output.write("COMMANDS\n")
+        for key, meta in sorted(all_metadata.items()):
+            name_str = key
+            if meta.aliases:
+                name_str += f", {', '.join(meta.aliases)}"
+            output.write(f"       {name_str:<28} {meta.one_line_description}\n")
+        output.write("\n")
+
+    all_topics = get_all_topics()
+    if all_topics:
+        output.write("TOPICS\n")
+        for key, topic in sorted(all_topics.items()):
+            name_str = key
+            if topic.aliases:
+                name_str += f", {', '.join(topic.aliases)}"
+            output.write(f"       {name_str:<28} {topic.one_line_description}\n")
+        output.write("\n")
+
+    config = _get_config_from_ctx(ctx)
+    run_pager(output.getvalue(), config)
+
+
+# =============================================================================
+# Click command
+# =============================================================================
+
+
+@click.command(name="help")
+@click.argument("topic", nargs=-1)
+@click.pass_context
+def help_command(ctx: click.Context, topic: tuple[str, ...]) -> None:
+    """Show help for a command or topic."""
+    if not topic:
+        _show_help_overview(ctx)
+        return
+
+    root_ctx = ctx.parent
+    assert root_ctx is not None
+    cli_group: click.Group = root_ctx.command  # type: ignore[assignment]
+
+    # Try to resolve as a CLI command (supports aliases and subcommands)
+    commands = _resolve_command_chain(cli_group, root_ctx, topic)
+    if commands is not None:
+        _show_command_help(ctx, commands)
+        return
+
+    # Try as a standalone topic page
+    topic_page = get_topic(topic[0])
+    if topic_page is not None:
+        _show_topic_help(ctx, topic_page)
+        return
+
+    sys.stderr.write(f"No help found for '{' '.join(topic)}'.\n")
+    sys.stderr.write("Run 'mngr help' for a list of commands and topics.\n")
+    ctx.exit(1)
+
+
+# === Help metadata for the help command itself ===
+
+CommandHelpMetadata(
+    key="help",
+    one_line_description="Show help for a command or topic",
+    synopsis="mngr help [<command> | <topic>]",
+    description="""Show help for a mngr command or topic. Without arguments, lists all
+available commands and help topics.
+
+For commands, 'mngr help <command>' is equivalent to 'mngr <command> --help'.
+Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
+
+For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
+
+Help topics provide documentation on concepts that span multiple commands,
+such as filter syntax and agent address format.""",
+    examples=(
+        ("Show help for the create command", "mngr help create"),
+        ("Show help using a command alias", "mngr help c"),
+        ("Show help for a subcommand", "mngr help snapshot create"),
+        ("Show the filter syntax topic", "mngr help filter"),
+        ("Show the address format topic", "mngr help address"),
+        ("List all commands and topics", "mngr help"),
+    ),
+).register()
+
+add_pager_help_option(help_command)
+
+
+# =============================================================================
+# Topic page definitions
+# =============================================================================
+
+TopicHelpPage(
+    key="filter",
+    one_line_description="CEL filter expression syntax for mngr commands",
+    aliases=("filters", "cel"),
+    content="""\
+Several mngr commands support filtering using CEL (Common Expression
+Language) expressions. Filters are specified with --include and --exclude
+flags, where --include keeps only matching items and --exclude removes
+matching items. Multiple filters can be combined.
+
+OPERATORS
+
+  Comparison:  ==  !=  <  <=  >  >=
+  Logical:     &&  ||  !
+  Grouping:    ( )
+
+STRING METHODS
+
+  name.contains("prod")       Substring match
+  name.startsWith("staging-") Prefix match
+  name.endsWith("-dev")       Suffix match
+
+EXISTENCE CHECKS
+
+  has(url)                    True if the field exists and is set
+  has(host.ssh)               True if SSH access is configured
+
+SIMPLE EQUALITY FILTERS
+
+  name == "my-agent"                 Match by exact agent name
+  state == "RUNNING"                 Match by lifecycle state
+  host.provider == "docker"          Match by host provider
+  type == "claude"                   Match by agent type
+  labels.project == "mngr"           Match by label value
+
+COMPOUND EXPRESSIONS
+
+  state == "RUNNING" && host.provider == "modal"
+  state == "STOPPED" || state == "FAILED"
+  host.provider == "docker" && name.startsWith("test-")
+
+NUMERIC COMPARISONS
+
+  runtime_seconds > 3600             Running for more than an hour
+  idle_seconds < 300                 Active in the last 5 minutes
+  host.resource.memory_gb >= 8       Hosts with 8GB+ memory
+  host.uptime_seconds > 86400        Hosts running for more than a day
+
+SORTING
+
+  The --sort flag also accepts CEL expressions with optional direction:
+
+  --sort 'name'                      Sort by name ascending (default)
+  --sort 'name desc'                 Sort by name descending
+  --sort 'state, name asc'           Sort by state then name
+  --sort 'create_time desc'          Most recently created first
+
+COMMANDS THAT SUPPORT FILTERS
+
+  mngr list     --include, --exclude, --sort
+  mngr destroy  --include, --exclude (with --all)
+  mngr stop     --include, --exclude (with --all)
+  mngr start    --include, --exclude (with --all)
+
+EXAMPLES
+
+  List only running agents:
+      $ mngr list --include 'state == "RUNNING"'
+
+  List agents except those on local hosts:
+      $ mngr list --exclude 'host.provider == "local"'
+
+  List agents with names containing "prod" on Modal:
+      $ mngr list --include 'name.contains("prod") && host.provider == "modal"'
+
+  Stop all agents idle for more than an hour:
+      $ mngr stop --all --include 'idle_seconds > 3600'\
+""",
+    see_also=(
+        ("list", "List agents with filtering and sorting"),
+        ("address", "Agent address syntax"),
+    ),
+).register()
+
+
+TopicHelpPage(
+    key="address",
+    one_line_description="Agent address syntax for targeting agents and hosts",
+    aliases=("addr",),
+    content="""\
+Many mngr commands accept an agent address to specify which agent (and
+optionally which host and provider) to target. The address format is:
+
+  [NAME][@[HOST][.PROVIDER]]
+
+All parts are optional:
+
+  NAME                  Agent name only (local host assumed)
+  NAME@HOST             Agent on a specific existing host
+  NAME@HOST.PROVIDER    Agent on a specific host with provider disambiguation
+  NAME@.PROVIDER        Agent on a new host (auto-generated host name)
+  @HOST                 Auto-named agent on an existing host
+  @HOST.PROVIDER        Auto-named agent on an existing host with provider
+  @.PROVIDER            Auto-named agent on a new auto-named host
+
+COMPONENTS
+
+  NAME
+      The agent name. Must be a valid identifier (lowercase letters, digits,
+      and hyphens). If omitted, a name is auto-generated.
+
+  HOST
+      The host name. Refers to an existing host unless --new-host is specified.
+      If omitted with a provider (e.g., @.modal), a new host with an
+      auto-generated name is created.
+
+  PROVIDER
+      The provider backend name (e.g., local, docker, modal). Used to
+      disambiguate when multiple providers have hosts with the same name,
+      or to specify which provider should create a new host.
+
+COMMANDS THAT ACCEPT ADDRESSES
+
+  mngr create   Primary address argument for creating agents
+  mngr connect  Agent identifier (supports @HOST.PROVIDER disambiguation)
+  mngr destroy  Agent identifier(s)
+  mngr exec     Agent identifier(s)
+  mngr start    Agent identifier(s)
+  mngr stop     Agent identifier(s)
+  mngr list     --addrs flag outputs addresses for listed agents
+
+EXAMPLES
+
+  Create an agent locally:
+      $ mngr create my-agent
+
+  Create an agent in a new Docker container:
+      $ mngr create my-agent@.docker
+
+  Create an agent on an existing Modal host:
+      $ mngr create my-agent@my-host.modal
+
+  Create a new named host on Modal:
+      $ mngr create my-agent@my-host.modal --new-host
+
+  Connect to an agent, disambiguating by provider:
+      $ mngr connect my-agent@my-host.docker
+
+  Destroy an agent on a specific host:
+      $ mngr destroy my-agent@my-host\
+""",
+    see_also=(
+        ("create", "Create and run an agent"),
+        ("connect", "Connect to an existing agent"),
+        ("filter", "CEL filter expression syntax"),
+    ),
+).register()

--- a/libs/mngr/imbue/mngr/cli/help_test.py
+++ b/libs/mngr/imbue/mngr/cli/help_test.py
@@ -1,0 +1,239 @@
+"""Unit tests for the help command and topic pages."""
+
+import pluggy
+from click.testing import CliRunner
+
+from imbue.mngr.cli.help import TopicHelpPage
+from imbue.mngr.cli.help import format_topic_help
+from imbue.mngr.cli.help import get_all_topics
+from imbue.mngr.cli.help import get_topic
+from imbue.mngr.main import cli
+
+# =============================================================================
+# Topic registry tests
+# =============================================================================
+
+
+def test_get_topic_by_canonical_name() -> None:
+    """get_topic returns a topic when looked up by its canonical key."""
+    topic = get_topic("filter")
+    assert topic is not None
+    assert topic.key == "filter"
+
+
+def test_get_topic_by_alias() -> None:
+    """get_topic resolves aliases to the canonical topic."""
+    topic = get_topic("addr")
+    assert topic is not None
+    assert topic.key == "address"
+
+
+def test_get_topic_nonexistent() -> None:
+    """get_topic returns None for unknown topic names."""
+    assert get_topic("nonexistent-topic-xyz") is None
+
+
+def test_get_all_topics_contains_registered_topics() -> None:
+    """get_all_topics returns all registered topic pages."""
+    topics = get_all_topics()
+    assert "filter" in topics
+    assert "address" in topics
+
+
+# =============================================================================
+# Topic formatting tests
+# =============================================================================
+
+
+def test_format_topic_help_contains_name_section() -> None:
+    """format_topic_help includes a NAME section with key and description."""
+    topic = TopicHelpPage(
+        key="test-topic",
+        one_line_description="A test topic",
+        content="Some content here.",
+    )
+    output = format_topic_help(topic)
+    assert "NAME" in output
+    assert "test-topic - A test topic" in output
+
+
+def test_format_topic_help_contains_aliases() -> None:
+    """format_topic_help shows aliases in the NAME section."""
+    topic = TopicHelpPage(
+        key="test-topic",
+        one_line_description="A test topic",
+        aliases=("tt", "test"),
+        content="Some content here.",
+    )
+    output = format_topic_help(topic)
+    assert "test-topic (tt, test)" in output
+
+
+def test_format_topic_help_contains_description() -> None:
+    """format_topic_help includes a DESCRIPTION section with the content."""
+    topic = TopicHelpPage(
+        key="test-topic",
+        one_line_description="A test topic",
+        content="First line.\n\nSecond paragraph.",
+    )
+    output = format_topic_help(topic)
+    assert "DESCRIPTION" in output
+    assert "First line." in output
+    assert "Second paragraph." in output
+
+
+def test_format_topic_help_contains_see_also() -> None:
+    """format_topic_help includes a SEE ALSO section when references exist."""
+    topic = TopicHelpPage(
+        key="test-topic",
+        one_line_description="A test topic",
+        content="Some content.",
+        see_also=(("other-topic", "Related topic"),),
+    )
+    output = format_topic_help(topic)
+    assert "SEE ALSO" in output
+    assert "mngr help other-topic" in output
+
+
+def test_format_topic_help_omits_see_also_when_empty() -> None:
+    """format_topic_help omits SEE ALSO section when there are no references."""
+    topic = TopicHelpPage(
+        key="test-topic",
+        one_line_description="A test topic",
+        content="Some content.",
+    )
+    output = format_topic_help(topic)
+    assert "SEE ALSO" not in output
+
+
+# =============================================================================
+# CLI integration tests (via CliRunner)
+# =============================================================================
+
+
+def test_help_no_args_shows_overview(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help' with no args shows the overview with commands and topics."""
+    result = cli_runner.invoke(cli, ["help"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "COMMANDS" in result.output
+    assert "TOPICS" in result.output
+    assert "filter" in result.output
+    assert "address" in result.output
+
+
+def test_help_command_shows_command_help(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help create' shows the same help as 'mngr create --help'."""
+    result = cli_runner.invoke(cli, ["help", "create"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "NAME" in result.output
+    assert "mngr create" in result.output
+
+
+def test_help_command_alias(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help c' resolves the 'c' alias and shows help for 'create'."""
+    result = cli_runner.invoke(cli, ["help", "c"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "mngr create" in result.output
+
+
+def test_help_subcommand(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help snapshot create' shows help for the snapshot create subcommand."""
+    result = cli_runner.invoke(cli, ["help", "snapshot", "create"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "snapshot create" in result.output
+
+
+def test_help_subcommand_with_group_alias(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help snap create' resolves the 'snap' alias to 'snapshot'."""
+    result = cli_runner.invoke(cli, ["help", "snap", "create"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "snapshot create" in result.output
+
+
+def test_help_topic_filter(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help filter' shows the filter topic page."""
+    result = cli_runner.invoke(cli, ["help", "filter"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "CEL" in result.output
+    assert "DESCRIPTION" in result.output
+
+
+def test_help_topic_address(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help address' shows the address topic page."""
+    result = cli_runner.invoke(cli, ["help", "address"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "[NAME][@[HOST][.PROVIDER]]" in result.output
+
+
+def test_help_topic_alias(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help addr' resolves the alias and shows the address topic."""
+    result = cli_runner.invoke(cli, ["help", "addr"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "address" in result.output
+    assert "[NAME][@[HOST][.PROVIDER]]" in result.output
+
+
+def test_help_topic_filter_alias_cel(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help cel' resolves to the filter topic."""
+    result = cli_runner.invoke(cli, ["help", "cel"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "CEL" in result.output
+    assert "filter" in result.output
+
+
+def test_help_nonexistent_topic(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help nonexistent' exits with an error message."""
+    result = cli_runner.invoke(cli, ["help", "nonexistent-xyz"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "No help found" in result.output
+
+
+def test_help_help_shows_self(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help help' shows help for the help command itself."""
+    result = cli_runner.invoke(cli, ["help", "help"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "mngr help" in result.output
+    assert "command or topic" in result.output.lower()
+
+
+def test_help_list_alias(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help ls' resolves the alias and shows help for 'list'."""
+    result = cli_runner.invoke(cli, ["help", "ls"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "mngr list" in result.output

--- a/libs/mngr/imbue/mngr/cli/help_test.py
+++ b/libs/mngr/imbue/mngr/cli/help_test.py
@@ -16,9 +16,9 @@ from imbue.mngr.main import cli
 
 def test_get_topic_by_canonical_name() -> None:
     """get_topic returns a topic when looked up by its canonical key."""
-    topic = get_topic("filter")
+    topic = get_topic("address")
     assert topic is not None
-    assert topic.key == "filter"
+    assert topic.key == "address"
 
 
 def test_get_topic_by_alias() -> None:
@@ -36,7 +36,6 @@ def test_get_topic_nonexistent() -> None:
 def test_get_all_topics_contains_registered_topics() -> None:
     """get_all_topics returns all registered topic pages."""
     topics = get_all_topics()
-    assert "filter" in topics
     assert "address" in topics
 
 
@@ -120,7 +119,6 @@ def test_help_no_args_shows_overview(
     assert result.exit_code == 0
     assert "COMMANDS" in result.output
     assert "TOPICS" in result.output
-    assert "filter" in result.output
     assert "address" in result.output
 
 
@@ -165,17 +163,6 @@ def test_help_subcommand_with_group_alias(
     assert "snapshot create" in result.output
 
 
-def test_help_topic_filter(
-    cli_runner: CliRunner,
-    plugin_manager: pluggy.PluginManager,
-) -> None:
-    """'mngr help filter' shows the filter topic page."""
-    result = cli_runner.invoke(cli, ["help", "filter"], obj=plugin_manager, catch_exceptions=False)
-    assert result.exit_code == 0
-    assert "CEL" in result.output
-    assert "DESCRIPTION" in result.output
-
-
 def test_help_topic_address(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
@@ -195,17 +182,6 @@ def test_help_topic_alias(
     assert result.exit_code == 0
     assert "address" in result.output
     assert "[NAME][@[HOST][.PROVIDER]]" in result.output
-
-
-def test_help_topic_filter_alias_cel(
-    cli_runner: CliRunner,
-    plugin_manager: pluggy.PluginManager,
-) -> None:
-    """'mngr help cel' resolves to the filter topic."""
-    result = cli_runner.invoke(cli, ["help", "cel"], obj=plugin_manager, catch_exceptions=False)
-    assert result.exit_code == 0
-    assert "CEL" in result.output
-    assert "filter" in result.output
 
 
 def test_help_nonexistent_topic(

--- a/libs/mngr/imbue/mngr/main.py
+++ b/libs/mngr/imbue/mngr/main.py
@@ -26,6 +26,7 @@ from imbue.mngr.cli.destroy import destroy
 from imbue.mngr.cli.events import events
 from imbue.mngr.cli.exec import exec_command
 from imbue.mngr.cli.gc import gc
+from imbue.mngr.cli.help import help_command
 from imbue.mngr.cli.help_formatter import get_help_metadata
 from imbue.mngr.cli.issue_reporting import handle_not_implemented_error
 from imbue.mngr.cli.issue_reporting import handle_unexpected_error
@@ -321,6 +322,7 @@ BUILTIN_COMMANDS: list[click.Command] = [
     snapshot,
     config,
     gc,
+    help_command,
     label,
     plugin_command,
     observe,

--- a/scripts/make_cli_docs.py
+++ b/scripts/make_cli_docs.py
@@ -52,6 +52,7 @@ SECONDARY_COMMANDS = {
     "events",
     "file",
     "gc",
+    "help",
     "kanpan",
     "label",
     "limit",


### PR DESCRIPTION
This allows us to have pages that are not necessarily subcommands. Here we have `address` and `filter`.