### PR TITLE
Fix two bugs breaking Modal agent creation

### DIFF
--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -1689,13 +1689,22 @@ def _generate_claude_json(version: str | None, current_time: datetime | None = N
     }
 
 
+_MKDIR_BATCH_SIZE: Final[int] = 50
+
+
 def _parallel_file_transfer(transfers: Sequence[tuple[Path, bytes]], host, mngr_ctx):
-    remote_folders: list[str] = []
-    for dest_path, _dest_contents in transfers:
-        remote_folders.append(shlex.quote(str(dest_path.parent)))
-    mkdir_result = host.execute_idempotent_command(f"mkdir -p {' '.join(remote_folders)}")
-    if not mkdir_result.success:
-        raise MngrError(f"Failed to create directories: {mkdir_result.stderr}")
+    # Deduplicate parent directories -- many files share the same parent, and
+    # sending all 1000+ paths in a single mkdir command can exceed the OS
+    # argument length limit ("/bin/bash: File name too long").
+    unique_dirs = sorted({str(dest_path.parent) for dest_path, _ in transfers})
+
+    # Batch mkdir calls so no single command exceeds OS argument limits.
+    for i in range(0, len(unique_dirs), _MKDIR_BATCH_SIZE):
+        batch = unique_dirs[i : i + _MKDIR_BATCH_SIZE]
+        args = " ".join(shlex.quote(d) for d in batch)
+        mkdir_result = host.execute_idempotent_command(f"mkdir -p {args}")
+        if not mkdir_result.success:
+            raise MngrError(f"Failed to create directories: {mkdir_result.stderr}")
 
     # then upload them all in parallel
     count = 0

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -1155,10 +1155,15 @@ class ModalProviderInstance(BaseProviderInstance):
                 stderr=StreamType.DEVNULL,
             )
 
-    def _get_ssh_info_from_sandbox(self, sandbox: SandboxInterface) -> tuple[str, int]:
-        """Extract SSH connection info from a running sandbox."""
+    def _get_ssh_info_from_sandbox(self, sandbox: SandboxInterface, *, tunnel_timeout: int = 50) -> tuple[str, int]:
+        """Extract SSH connection info from a running sandbox.
+
+        ``tunnel_timeout`` is forwarded to the Modal SDK's ``tunnels()`` call
+        and controls how many seconds the backend will wait for the sandbox to
+        be ready before raising ``SandboxTimeoutError``.
+        """
         try:
-            tunnels = sandbox.tunnels()
+            tunnels = sandbox.tunnels(timeout=tunnel_timeout)
         except ModalProxyError as e:
             if _is_sandbox_timeout(e):
                 raise ModalSandboxTimeoutMngrError("Sandbox failed to come online fast enough") from e
@@ -1255,8 +1260,10 @@ class ModalProviderInstance(BaseProviderInstance):
                         ),
                     )
 
-            # Get SSH connection info
-            ssh_host, ssh_port = self._get_ssh_info_from_sandbox(sandbox)
+            # Get SSH connection info.
+            # Use the sandbox timeout as the tunnel timeout so that the tunnel
+            # request waits long enough for image builds and container startup.
+            ssh_host, ssh_port = self._get_ssh_info_from_sandbox(sandbox, tunnel_timeout=config.timeout)
             logger.trace("Found SSH endpoint available", ssh_host=ssh_host, ssh_port=ssh_port)
 
             # Get SSH keypairs

--- a/libs/modal_proxy/imbue/modal_proxy/direct.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct.py
@@ -316,8 +316,8 @@ class DirectSandbox(SandboxInterface):
         return DirectExecProcess.model_construct(process=process)
 
     @_translate_exceptions
-    def tunnels(self) -> dict[int, TunnelInfo]:
-        raw_tunnels = self.sandbox.tunnels()
+    def tunnels(self, *, timeout: int = 50) -> dict[int, TunnelInfo]:
+        raw_tunnels = self.sandbox.tunnels(timeout=timeout)
         return {port: TunnelInfo(tcp_socket=tunnel.tcp_socket) for port, tunnel in raw_tunnels.items()}
 
     @_translate_exceptions

--- a/libs/modal_proxy/imbue/modal_proxy/interface.py
+++ b/libs/modal_proxy/imbue/modal_proxy/interface.py
@@ -148,8 +148,13 @@ class SandboxInterface(MutableModel, ABC):
         ...
 
     @abstractmethod
-    def tunnels(self) -> dict[int, TunnelInfo]:
-        """Get tunnel connection info for exposed ports."""
+    def tunnels(self, *, timeout: int = 50) -> dict[int, TunnelInfo]:
+        """Get tunnel connection info for exposed ports.
+
+        Blocks until tunnel metadata is available or the timeout is reached.
+        If the sandbox is not ready within ``timeout`` seconds, a
+        ``SandboxTimeoutError`` is raised by the Modal backend.
+        """
         ...
 
     @abstractmethod

--- a/libs/modal_proxy/imbue/modal_proxy/testing.py
+++ b/libs/modal_proxy/imbue/modal_proxy/testing.py
@@ -237,7 +237,7 @@ class TestingSandbox(SandboxInterface):
             exec_proc._completed_text = finished.stdout
             return exec_proc
 
-    def tunnels(self) -> dict[int, TunnelInfo]:
+    def tunnels(self, *, timeout: int = 50) -> dict[int, TunnelInfo]:
         if self._is_terminated:
             raise ModalProxyError("Sandbox has been terminated")
         # Return a fixed tunnel for SSH port 22 -> localhost:22222


### PR DESCRIPTION
1. The wait for SSH info seems to start while the sandbox is still building, so the default timeout of 50s is way too low. Pass the sandbox timeout through the Modal API for this.
2. When the user's `~/.claude` has a lot of files, the `mkdir` call to create the directory structure can fail because it has too many arguments. This PR fixes this jankily by batching the calls, but we should really just use `rsync` here to upload the relevant subdirectories under `~/.claude`.

  However, when attempting that fix, Claude ran into errors in testing - the test fixture's fake host doesn't expose SSH info, so can't support rsync 😔. So I'm punting the proper fix to a followup PR...