### PR TITLE
Enable offload acceptance tests and print failure logs in CI

### DIFF
--- a/.github/workflows/test-offload-acceptance.yml
+++ b/.github/workflows/test-offload-acceptance.yml
@@ -54,6 +54,9 @@ jobs:
             cargo install offload@0.4.0
           fi
 
-#      - name: Run acceptance tests via offload
-#        continue-on-error: true  # Experimental - failures are logged but don't block
-#        run: just test-offload-acceptance
+      - name: Run acceptance tests via offload
+        run: just test-offload-acceptance
+
+      - name: Print offload failure logs
+        if: failure()
+        run: offload -c offload-modal-acceptance.toml logs --failures

--- a/.github/workflows/test-offload-acceptance.yml
+++ b/.github/workflows/test-offload-acceptance.yml
@@ -46,12 +46,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.4.0-${{ runner.os }}
+          key: cargo-offload-0.6.0-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null; then
-            cargo install offload@0.4.0
+          if ! command -v offload &> /dev/null || [[ "$(offload --version)" != *"0.6.0"* ]]; then
+            cargo install offload@0.6.0 --force
           fi
 
       - name: Run acceptance tests via offload


### PR DESCRIPTION
## Summary
- Uncomments the previously disabled offload acceptance test run step
- Adds a step to print failure logs via `offload -c offload-modal-acceptance.toml logs --failures` when the run fails, so test output is visible directly in the CI job

## Test plan
- [ ] Verify the offload acceptance workflow triggers on a PR
- [ ] Confirm failure logs are printed when tests fail