### PR TITLE
mngr/target-path-local-docker-only

### DIFF
--- a/apps/minds/imbue/minds/forwarding_server/agent_creator.py
+++ b/apps/minds/imbue/minds/forwarding_server/agent_creator.py
@@ -241,6 +241,9 @@ def run_mngr_create(
                     str(mind_dir),
                     "-s",
                     "-v={}:{}".format(remote_data_dir, "/data/remote"),
+                    # stick the source into some canonical location
+                    "--target-path",
+                    "/code/",
                 ]
             )
             # If the source directory contains a Dockerfile, use it for the build


### PR DESCRIPTION
Move --target-path /code/ to local docker mode only.

Previously this flag was set for all launch modes, but it should only apply when using the local docker provider.