### PR TITLE
include commit hash in autofix marker

### DIFF
--- a/plugins/imbue-code-review/agents/validate-diff.md
+++ b/plugins/imbue-code-review/agents/validate-diff.md
@@ -4,9 +4,6 @@ description: Quick sanity check on a branch's diff before detailed review.
 model: haiku
 ---
 
-Before doing anything, run this command: `rm -f .reviewer/outputs/autofix/*_verified.md`
-(to ensure that any previous validation results are cleared out and won't interfere with this run).
-
 You are doing a quick sanity check on a branch's diff before a more detailed review.
 
 You have been given:

--- a/plugins/imbue-code-review/agents/validate-diff.md
+++ b/plugins/imbue-code-review/agents/validate-diff.md
@@ -4,7 +4,7 @@ description: Quick sanity check on a branch's diff before detailed review.
 model: haiku
 ---
 
-Before doing anything, run this command: `rm .reviewer/outputs/autofix/verified.md`
+Before doing anything, run this command: `rm -f .reviewer/outputs/autofix/*_verified.md`
 (to ensure that any previous validation results are cleared out and won't interfere with this run).
 
 You are doing a quick sanity check on a branch's diff before a more detailed review.

--- a/plugins/imbue-code-review/agents/verify-and-fix.md
+++ b/plugins/imbue-code-review/agents/verify-and-fix.md
@@ -19,7 +19,7 @@ git diff <base_branch>...HEAD
 3. Understand the existing codebase patterns around the changed files.
 4. Read the issue categories file whose path you were given.
 
-If the diff is empty (no changes on the branch), create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/verified.md` then stop immediately -- there is nothing to verify or fix.
+If the diff is empty (no changes on the branch), create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/$(git rev-parse HEAD)_verified.md` then stop immediately -- there is nothing to verify or fix.
 
 # Step 2: Create Issue List
 
@@ -32,7 +32,7 @@ For each potential issue, note:
 
 Then, for each potential issue, briefly check: is this actually a problem, or does it fall under one of the listed exceptions for that issue type? Drop anything that clearly isn't a real issue. Keep everything else, regardless of severity.
 
-If there are no issues, create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/verified.md` then stop here. There is nothing to fix.
+If there are no issues, create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/$(git rev-parse HEAD)_verified.md` then stop here. There is nothing to fix.
 
 ## Record Issues
 
@@ -84,5 +84,5 @@ If tests pass, you are done.
 
 If tests fail, fix the failures and commit the fixes. Re-run the tests. Keep fixing and re-running until tests pass. The only acceptable exception is if you can prove a failure is preexisting by running the same test on the base branch and seeing it fail there too.
 
-Once tests pass, create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/verified.md`
+Once tests pass, create the verification marker by running `date -u +%Y-%m-%dT%H:%M:%SZ > .reviewer/outputs/autofix/$(git rev-parse HEAD)_verified.md`
 

--- a/plugins/imbue-code-review/scripts/stop_hook_gates.sh
+++ b/plugins/imbue-code-review/scripts/stop_hook_gates.sh
@@ -85,7 +85,7 @@ AUTOFIX_NEEDED=false
 CONVO_NEEDED=false
 ARCH_NEEDED=false
 
-if [[ "$AUTOFIX_ENABLED" == "true" ]] && [[ ! -f ".reviewer/outputs/autofix/verified.md" ]]; then
+if [[ "$AUTOFIX_ENABLED" == "true" ]] && [[ ! -f ".reviewer/outputs/autofix/${HASH}_verified.md" ]]; then
     AUTOFIX_NEEDED=true
 fi
 


### PR DESCRIPTION
## Summary
- The autofix verification marker was a static file (`verified.md`) that persisted across commits, so the stop hook would not re-gate after new changes
- Changed to `{HASH}_verified.md` to match the per-commit pattern used by the conversation review gate
- Updated all three touchpoints: the stop hook check, the verify-and-fix agent marker writes, and the validate-diff agent cleanup

## Test plan
- [ ] Run autofix on a branch, verify `{HASH}_verified.md` is created
- [ ] Make a new commit, verify the stop hook re-gates (old marker doesn't match new HEAD)
- [ ] Run autofix again, verify new marker is created with new hash

Generated with [Claude Code](https://claude.com/claude-code)