### PR TITLE
clarify that when i said autofix should stop if the diff has unrelated changes, i meant that autofix should stop if the diff has unrelated changes

### DIFF
--- a/plugins/imbue-code-review/agents/validate-diff.md
+++ b/plugins/imbue-code-review/agents/validate-diff.md
@@ -17,7 +17,6 @@ Run `git diff {base}...HEAD` and skim the result. Answer these questions:
 
 1. Is the diff empty?
 2. Does it include significant unrelated changes (e.g. from merged-in feature branches)? Ignore minor cleanups or small incidental fixes -- only flag changes that look like a separate logical effort. If so, describe what seems unrelated.
-
 3. At a glance, does the scope of the changes look roughly complete for the stated goal, or does it look like only a partial solution or a work in progress?
 
 Keep your answer brief -- a detailed review happens later.

--- a/plugins/imbue-code-review/agents/validate-diff.md
+++ b/plugins/imbue-code-review/agents/validate-diff.md
@@ -17,6 +17,7 @@ Run `git diff {base}...HEAD` and skim the result. Answer these questions:
 
 1. Is the diff empty?
 2. Does it include significant unrelated changes (e.g. from merged-in feature branches)? Ignore minor cleanups or small incidental fixes -- only flag changes that look like a separate logical effort. If so, describe what seems unrelated.
+
 3. At a glance, does the scope of the changes look roughly complete for the stated goal, or does it look like only a partial solution or a work in progress?
 
 Keep your answer brief -- a detailed review happens later.

--- a/plugins/imbue-code-review/skills/autofix/SKILL.md
+++ b/plugins/imbue-code-review/skills/autofix/SKILL.md
@@ -33,7 +33,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then pass only the in-scope changes forward.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then when spawning the verify-and-fix agent in Phase 3, explicitly tell it to focus only on the in-scope changes and ignore the rest.
 - If it reports the work looks incomplete, note this but proceed -- autofix works on whatever is there.
 
 ### Phase 3: Fix Loop

--- a/plugins/imbue-code-review/skills/autofix/SKILL.md
+++ b/plugins/imbue-code-review/skills/autofix/SKILL.md
@@ -33,7 +33,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then when spawning the verify-and-fix agent in Phase 3, explicitly tell it to focus only on the in-scope changes and ignore the rest.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then when spawning the verify-and-fix agent in Phase 3, explicitly tell it to ignore the out-of-scope changes.
 - If it reports the work looks incomplete, note this but proceed -- autofix works on whatever is there.
 
 ### Phase 3: Fix Loop

--- a/plugins/imbue-code-review/skills/autofix/SKILL.md
+++ b/plugins/imbue-code-review/skills/autofix/SKILL.md
@@ -33,7 +33,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports significant unrelated changes, STOP and ask the user what the correct base branch is.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make -- even seemingly minor ones like import reordering or config tweaks), STOP and ask the user what the correct base branch is. These indicate the base branch is wrong. Do not dismiss them as "from a merge" or "not our doing" -- that is exactly the problem.
 - If it reports the work looks incomplete, note this but proceed -- autofix works on whatever is there.
 
 ### Phase 3: Fix Loop

--- a/plugins/imbue-code-review/skills/autofix/SKILL.md
+++ b/plugins/imbue-code-review/skills/autofix/SKILL.md
@@ -33,7 +33,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope for review. The fix agent reviews the entire diff and will make unwanted changes to code outside the task's scope. This applies regardless of how the extra changes got there -- wrong base branch, a merge, or incidental edits.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then pass only the in-scope changes forward.
 - If it reports the work looks incomplete, note this but proceed -- autofix works on whatever is there.
 
 ### Phase 3: Fix Loop

--- a/plugins/imbue-code-review/skills/autofix/SKILL.md
+++ b/plugins/imbue-code-review/skills/autofix/SKILL.md
@@ -33,7 +33,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make -- even seemingly minor ones like import reordering or config tweaks), STOP and ask the user what the correct base branch is. These indicate the base branch is wrong. Do not dismiss them as "from a merge" or "not our doing" -- that is exactly the problem.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope for review. The fix agent reviews the entire diff and will make unwanted changes to code outside the task's scope. This applies regardless of how the extra changes got there -- wrong base branch, a merge, or incidental edits.
 - If it reports the work looks incomplete, note this but proceed -- autofix works on whatever is there.
 
 ### Phase 3: Fix Loop

--- a/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
+++ b/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
@@ -25,7 +25,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports significant unrelated changes, you MUST stop and consult the user -- do not dismiss this or proceed on your own. Unrelated changes in the diff will cause the analysis agent to waste effort on irrelevant code and produce worse results. Explain that this skill can only verify one logical change at a time. Ask which change they want to focus on (e.g. the main goal of the branch vs. an incidental fix). Then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the changes that are not part of the chosen focus.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make -- even seemingly minor ones like import reordering or config tweaks), you MUST stop and consult the user. These indicate the base branch is wrong. Do not dismiss them as "from a merge" or "not our doing" -- that is exactly the problem. Ask the user what the correct base branch is, or which change to focus on if the branch intentionally contains multiple logical changes. Then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the changes that are not part of the chosen focus.
 - If it reports the work looks incomplete, flag that to the user and ask whether to proceed anyway.
 
 ## Phase 3: Spawn Analysis Agent

--- a/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
+++ b/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
@@ -25,7 +25,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make -- even seemingly minor ones like import reordering or config tweaks), you MUST stop and consult the user. These indicate the base branch is wrong. Do not dismiss them as "from a merge" or "not our doing" -- that is exactly the problem. Ask the user what the correct base branch is, or which change to focus on if the branch intentionally contains multiple logical changes. Then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the changes that are not part of the chosen focus.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), you MUST stop and consult the user. The analysis agent reviews the entire diff and will waste effort on irrelevant code, producing worse results. This applies regardless of how the extra changes got there -- wrong base branch, a merge, or incidental edits. Ask the user which changes should be in scope, or what the correct base branch is. Then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the out-of-scope changes.
 - If it reports the work looks incomplete, flag that to the user and ask whether to proceed anyway.
 
 ## Phase 3: Spawn Analysis Agent

--- a/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
+++ b/plugins/imbue-code-review/skills/verify-architecture/SKILL.md
@@ -25,7 +25,7 @@ Spawn a `validate-diff` Agent. Provide the base branch name and the problem desc
 
 Based on the agent's response:
 - If the diff is empty, STOP and ask the user whether the work has been committed yet or whether the base branch is wrong.
-- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), you MUST stop and consult the user. The analysis agent reviews the entire diff and will waste effort on irrelevant code, producing worse results. This applies regardless of how the extra changes got there -- wrong base branch, a merge, or incidental edits. Ask the user which changes should be in scope, or what the correct base branch is. Then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the out-of-scope changes.
+- If it reports changes that don't belong to this branch (i.e., changes you didn't make / the implementer agent wouldn't have made), STOP and ask the user which changes should be in scope. Downstream agents review the entire diff and will act on out-of-scope code -- regardless of how the extra changes got there (wrong base branch, stale local ref, a merge, or incidental edits). Ask the user for the correct base branch or which changes to focus on, then when spawning the analysis agent in Phase 3, explicitly tell it to ignore the out-of-scope changes.
 - If it reports the work looks incomplete, flag that to the user and ask whether to proceed anyway.
 
 ## Phase 3: Spawn Analysis Agent


### PR DESCRIPTION
## Summary
- Rewrites the diff validation instructions in autofix and verify-architecture skills to prevent agents from dismissing unrelated changes reported by validate-diff
- Leads with the consequence (downstream agents will act on out-of-scope code) rather than diagnosing the cause (wrong base branch), which agents were rationalizing past
- Frames the check as "changes you didn't make / the implementer agent wouldn't have made" instead of "significant unrelated changes"
- Unifies language across both skills

## Context
An agent running /verify-architecture saw validate-diff report unrelated changes (import reordering, justfile, cache file) and dismissed them as "came from the merge with main -- not our doing," then proceeded. The old instructions said "significant unrelated changes" and framed the only cause as "wrong base branch," giving the agent room to rationalize past the check.

## Test plan
- [ ] Run /autofix on a branch with merge artifacts and verify the agent stops instead of proceeding
- [ ] Run /verify-architecture on a branch with out-of-scope changes and verify the agent asks the user for scope