### PR TITLE
Remove symbolic ref before pushing code repo

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -1417,13 +1417,6 @@ class Host(BaseHost, OnlineHostInterface):
             quoted_git_dir = shlex.quote(str(target_path / ".git"))
             quoted_target = shlex.quote(str(target_path))
             init_parts = [f"mkdir -p {quoted_target}", f"git init --bare {quoted_git_dir}"]
-            # When the target .git was seeded from an image that already
-            # contains the repo (e.g. Modal), refs/remotes/origin/HEAD may
-            # be a stale symref whose target is deleted by --mirror push,
-            # causing "inconsistent aliased update" errors. Remove it.
-            init_parts.append(
-                f"git -C {quoted_git_dir} symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true"
-            )
             if not self.is_local:
                 init_parts.append(f"git config --global --add safe.directory {quoted_target}")
             init_cmd = " && ".join(init_parts)

--- a/libs/mngr/imbue/mngr/resources/Dockerfile
+++ b/libs/mngr/imbue/mngr/resources/Dockerfile
@@ -53,7 +53,7 @@ ENV UV_LINK_MODE=copy
 COPY . /code/
 
 # extract our code into the project directory
-RUN mkdir -p /code/mngr/ && tar -xzf /code/current.tar.gz -C /code/mngr/ && rm /code/*.tar.gz && git config --global --add safe.directory /code/mngr/ && chown -R root:root /code/mngr/
+RUN mkdir -p /code/mngr/ && tar -xzf /code/current.tar.gz -C /code/mngr/ && rm /code/*.tar.gz && git config --global --add safe.directory /code/mngr/ && chown -R root:root /code/mngr/ && (git -C /code/mngr/ symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true)
 
 # set working directory to the project root -- this is where `mngr schedule`
 # will copy project deploy files and where scheduled commands will run


### PR DESCRIPTION
mngr's custom Dockerfile uploads a copy of the code at the target path, and `git push --mirror` will fail due to the existing symbolic ref there. So remove the ref there.