### PR TITLE
Auto-restart agents when mind forward detects unavailable backends

### DIFF
--- a/apps/minds/imbue/minds/forwarding_server/agent_restarter.py
+++ b/apps/minds/imbue/minds/forwarding_server/agent_restarter.py
@@ -52,7 +52,7 @@ class AgentRestarter(MutableModel):
         now = time.monotonic()
 
         with self._lock:
-            last_attempt = self._last_attempt_by_agent.get(aid_str, 0.0)
+            last_attempt = self._last_attempt_by_agent.get(aid_str, float("-inf"))
             if now - last_attempt < self.cooldown_seconds:
                 return
             self._last_attempt_by_agent[aid_str] = now

--- a/apps/minds/imbue/minds/forwarding_server/agent_restarter.py
+++ b/apps/minds/imbue/minds/forwarding_server/agent_restarter.py
@@ -1,0 +1,83 @@
+"""Automatically restart agents whose backends are unavailable.
+
+When the forwarding server receives a request for an agent whose backend
+URL is unknown (e.g. the tmux session was killed), this module runs
+``mngr start <agent-id>`` in a background thread to restore the session.
+
+Restart attempts are debounced per agent: once a restart is triggered,
+no further attempts are made for that agent until the cooldown expires.
+"""
+
+import threading
+import time
+from typing import Final
+
+from loguru import logger
+from pydantic import Field
+from pydantic import PrivateAttr
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.imbue_common.mutable_model import MutableModel
+from imbue.minds.config.data_types import MNGR_BINARY
+from imbue.mngr.primitives import AgentId
+
+_DEFAULT_COOLDOWN_SECONDS: Final[float] = 30.0
+
+
+class AgentRestarter(MutableModel):
+    """Restarts agents whose backends are unavailable by running ``mngr start``.
+
+    Thread-safe: all state access is guarded by an internal lock.
+    Restart attempts are debounced per agent with a configurable cooldown.
+    """
+
+    mngr_binary: str = Field(default=MNGR_BINARY, frozen=True, description="Path to mngr binary")
+    cooldown_seconds: float = Field(
+        default=_DEFAULT_COOLDOWN_SECONDS,
+        frozen=True,
+        description="Minimum seconds between restart attempts for the same agent",
+    )
+
+    _last_attempt_by_agent: dict[str, float] = PrivateAttr(default_factory=dict)
+    _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+
+    def try_restart(self, agent_id: AgentId) -> None:
+        """Attempt to restart an agent if not recently attempted.
+
+        If a restart was already attempted within the cooldown period,
+        this call is a no-op. Otherwise, starts ``mngr start <agent-id>``
+        in a background thread.
+        """
+        aid_str = str(agent_id)
+        now = time.monotonic()
+
+        with self._lock:
+            last_attempt = self._last_attempt_by_agent.get(aid_str, 0.0)
+            if now - last_attempt < self.cooldown_seconds:
+                return
+            self._last_attempt_by_agent[aid_str] = now
+
+        thread = threading.Thread(
+            target=self._run_start,
+            args=(agent_id,),
+            daemon=True,
+            name="agent-restarter-{}".format(aid_str),
+        )
+        thread.start()
+
+    def _run_start(self, agent_id: AgentId) -> None:
+        """Run ``mngr start <agent-id>`` synchronously in a background thread."""
+        logger.info("Attempting to restart agent {} via mngr start", agent_id)
+        cg = ConcurrencyGroup(name="agent-restart-{}".format(agent_id))
+        with cg:
+            result = cg.run_process_to_completion(
+                command=[self.mngr_binary, "start", str(agent_id)],
+                is_checked_after=False,
+            )
+        if result.returncode == 0:
+            logger.info("Successfully restarted agent {}", agent_id)
+        else:
+            stderr = result.stderr.strip() if result.stderr else ""
+            stdout = result.stdout.strip() if result.stdout else ""
+            output = stderr or stdout
+            logger.warning("Failed to restart agent {} (exit code {}): {}", agent_id, result.returncode, output)

--- a/apps/minds/imbue/minds/forwarding_server/agent_restarter_test.py
+++ b/apps/minds/imbue/minds/forwarding_server/agent_restarter_test.py
@@ -1,0 +1,59 @@
+from imbue.minds.forwarding_server.agent_restarter import AgentRestarter
+from imbue.mngr.primitives import AgentId
+
+
+def test_try_restart_debounces_within_cooldown() -> None:
+    """A second restart attempt for the same agent within the cooldown period is skipped."""
+    restarter = AgentRestarter(mngr_binary="true", cooldown_seconds=100.0)
+    agent_id = AgentId()
+
+    # First call should record the attempt
+    restarter.try_restart(agent_id)
+
+    # Capture the recorded time
+    with restarter._lock:
+        first_attempt = restarter._last_attempt_by_agent[str(agent_id)]
+
+    # Second call within cooldown should not update the timestamp
+    restarter.try_restart(agent_id)
+
+    with restarter._lock:
+        second_attempt = restarter._last_attempt_by_agent[str(agent_id)]
+
+    assert first_attempt == second_attempt
+
+
+def test_try_restart_allows_after_cooldown_expires() -> None:
+    """A restart attempt is allowed once the cooldown period has elapsed."""
+    restarter = AgentRestarter(mngr_binary="true", cooldown_seconds=0.0)
+    agent_id = AgentId()
+
+    restarter.try_restart(agent_id)
+
+    with restarter._lock:
+        first_attempt = restarter._last_attempt_by_agent[str(agent_id)]
+
+    # Manually expire the cooldown by backdating the last attempt
+    with restarter._lock:
+        restarter._last_attempt_by_agent[str(agent_id)] = first_attempt - 1.0
+
+    restarter.try_restart(agent_id)
+
+    with restarter._lock:
+        second_attempt = restarter._last_attempt_by_agent[str(agent_id)]
+
+    assert second_attempt > first_attempt
+
+
+def test_try_restart_tracks_agents_independently() -> None:
+    """Restart cooldowns are tracked per agent, not globally."""
+    restarter = AgentRestarter(mngr_binary="true", cooldown_seconds=100.0)
+    agent_a = AgentId()
+    agent_b = AgentId()
+
+    restarter.try_restart(agent_a)
+    restarter.try_restart(agent_b)
+
+    with restarter._lock:
+        assert str(agent_a) in restarter._last_attempt_by_agent
+        assert str(agent_b) in restarter._last_attempt_by_agent

--- a/apps/minds/imbue/minds/forwarding_server/app.py
+++ b/apps/minds/imbue/minds/forwarding_server/app.py
@@ -28,6 +28,7 @@ from websockets import ClientConnection
 from imbue.minds.forwarding_server.agent_creator import AgentCreationStatus
 from imbue.minds.forwarding_server.agent_creator import AgentCreator
 from imbue.minds.forwarding_server.agent_creator import LOG_SENTINEL
+from imbue.minds.forwarding_server.agent_restarter import AgentRestarter
 from imbue.minds.forwarding_server.auth import AuthStoreInterface
 from imbue.minds.forwarding_server.backend_resolver import BackendResolverInterface
 from imbue.minds.forwarding_server.cookie_manager import SESSION_COOKIE_NAME
@@ -103,8 +104,13 @@ def _get_backend_resolver(request: Request) -> BackendResolverInterface:
     return request.app.state.backend_resolver
 
 
+def _get_agent_restarter(request: Request) -> AgentRestarter | None:
+    return request.app.state.agent_restarter
+
+
 AuthStoreDep = Annotated[AuthStoreInterface, Depends(_get_auth_store)]
 BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]
+AgentRestarterDep = Annotated[AgentRestarter | None, Depends(_get_agent_restarter)]
 
 
 # -- Auth helpers --
@@ -445,6 +451,33 @@ def _build_proxy_response(
     return response
 
 
+def _handle_backend_unavailable(
+    request: Request,
+    agent_id: AgentId,
+    agent_restarter: AgentRestarter | None,
+) -> Response:
+    """Handle a request when the agent's backend is unreachable.
+
+    Triggers a restart attempt (via ``mngr start``) to restore a killed tmux
+    session, and returns a loading page for HTML requests so the browser
+    retries automatically once the session is restored.
+    """
+    if agent_restarter is not None:
+        agent_restarter.try_restart(agent_id)
+
+    # For HTML-accepting requests, return a loading page that retries
+    # client-side after a short delay. This avoids saturating the
+    # browser's per-origin connection pool (typically 6 for HTTP/1.1)
+    # when a stale tab is pointed at an unavailable backend.
+    request_accept = request.headers.get("accept", "")
+    if "text/html" in request_accept:
+        return HTMLResponse(content=generate_backend_loading_html())
+    return Response(
+        status_code=502,
+        content="Backend unavailable for agent {}".format(agent_id),
+    )
+
+
 async def _handle_proxy_http(
     agent_id: str,
     server_name: str,
@@ -452,6 +485,7 @@ async def _handle_proxy_http(
     request: Request,
     auth_store: AuthStoreDep,
     backend_resolver: BackendResolverDep,
+    agent_restarter: AgentRestarterDep,
 ) -> Response:
     parsed_id = AgentId(agent_id)
     parsed_server = ServerName(server_name)
@@ -468,20 +502,8 @@ async def _handle_proxy_http(
 
     backend_url = backend_resolver.get_backend_url(parsed_id, parsed_server)
     if backend_url is None:
-        # Return immediately instead of holding the connection open.
-        # For HTML-accepting requests, return a loading page that retries
-        # client-side after a short delay. This avoids saturating the
-        # browser's per-origin connection pool (typically 6 for HTTP/1.1)
-        # when a stale tab is pointed at an unavailable backend.
-        request_accept = request.headers.get("accept", "")
-        if "text/html" in request_accept:
-            return HTMLResponse(content=generate_backend_loading_html())
-        return Response(
-            status_code=502,
-            content="Backend unavailable for agent {}, server {}".format(agent_id, server_name),
-        )
+        return _handle_backend_unavailable(request, parsed_id, agent_restarter)
 
-    assert backend_url is not None
     resolved_backend_url = backend_url
 
     # Check if SW is installed via cookie (scoped per server)
@@ -509,7 +531,17 @@ async def _handle_proxy_http(
     is_likely_sse = "text/event-stream" in accept_header or (request.method == "POST" and "api/chat/send" in path)
 
     if is_likely_sse:
-        return await _forward_http_request_streaming(
+        result = await _forward_http_request_streaming(
+            request=request,
+            backend_url=resolved_backend_url,
+            path=path,
+            agent_id=agent_id,
+            server_name=server_name,
+            http_client=tunnel_client,
+        )
+    else:
+        # Forward request to backend
+        result = await _forward_http_request(
             request=request,
             backend_url=resolved_backend_url,
             path=path,
@@ -518,17 +550,12 @@ async def _handle_proxy_http(
             http_client=tunnel_client,
         )
 
-    # Forward request to backend
-    result = await _forward_http_request(
-        request=request,
-        backend_url=resolved_backend_url,
-        path=path,
-        agent_id=agent_id,
-        server_name=server_name,
-        http_client=tunnel_client,
-    )
+    # If the backend refused the connection, the agent's tmux session may have
+    # been killed. Trigger a restart and show the loading page so the browser
+    # retries automatically once the session is restored.
+    if isinstance(result, Response) and result.status_code == 502:
+        return _handle_backend_unavailable(request, parsed_id, agent_restarter)
 
-    # If forwarding returned an error Response directly, return it
     if isinstance(result, Response):
         return result
 
@@ -901,6 +928,7 @@ def create_forwarding_server(
     http_client: httpx.AsyncClient | None,
     tunnel_manager: SSHTunnelManager | None = None,
     agent_creator: AgentCreator | None = None,
+    agent_restarter: AgentRestarter | None = None,
 ) -> FastAPI:
     """Create the forwarding server FastAPI application.
 
@@ -909,6 +937,9 @@ def create_forwarding_server(
 
     When agent_creator is provided, the server can create new agents from git URLs
     via the /create form and /api/create-agent API.
+
+    When agent_restarter is provided, the server will automatically attempt to
+    restart agents whose backends are unavailable (e.g. killed tmux sessions).
     """
     is_externally_managed_client = http_client is not None
 
@@ -923,6 +954,7 @@ def create_forwarding_server(
     app.state.backend_resolver = backend_resolver
     app.state.tunnel_manager = tunnel_manager
     app.state.agent_creator = agent_creator
+    app.state.agent_restarter = agent_restarter
     if http_client is not None:
         app.state.http_client = http_client
 

--- a/apps/minds/imbue/minds/forwarding_server/runner.py
+++ b/apps/minds/imbue/minds/forwarding_server/runner.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from imbue.minds.config.data_types import MindPaths
 from imbue.minds.forwarding_server.agent_creator import AgentCreator
+from imbue.minds.forwarding_server.agent_restarter import AgentRestarter
 from imbue.minds.forwarding_server.app import create_forwarding_server
 from imbue.minds.forwarding_server.auth import FileAuthStore
 from imbue.minds.forwarding_server.backend_resolver import MngrCliBackendResolver
@@ -37,6 +38,7 @@ def start_forwarding_server(
     stream_manager = MngrStreamManager(resolver=backend_resolver)
     tunnel_manager = SSHTunnelManager()
     agent_creator = AgentCreator(paths=paths)
+    agent_restarter = AgentRestarter()
 
     # Generate a one-time login URL for the user
     code = OneTimeCode(secrets.token_urlsafe(_ONE_TIME_CODE_LENGTH))
@@ -56,6 +58,7 @@ def start_forwarding_server(
         http_client=None,
         tunnel_manager=tunnel_manager,
         agent_creator=agent_creator,
+        agent_restarter=agent_restarter,
     )
 
     thread = Thread(target=_sleep_then_open, args=(login_url,))

--- a/apps/minds/imbue/minds/forwarding_server/test_forwarding_server.py
+++ b/apps/minds/imbue/minds/forwarding_server/test_forwarding_server.py
@@ -11,6 +11,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from imbue.minds.config.data_types import MindPaths
 from imbue.minds.forwarding_server.agent_creator import AgentCreator
+from imbue.minds.forwarding_server.agent_restarter import AgentRestarter
 from imbue.minds.forwarding_server.app import create_forwarding_server
 from imbue.minds.forwarding_server.auth import FileAuthStore
 from imbue.minds.forwarding_server.backend_resolver import BackendResolverInterface
@@ -78,6 +79,7 @@ def _create_test_forwarding_server(
     backend_resolver: BackendResolverInterface,
     http_client: httpx.AsyncClient | None,
     agent_creator: AgentCreator | None = None,
+    agent_restarter: AgentRestarter | None = None,
 ) -> tuple[TestClient, FileAuthStore]:
     """Create a forwarding server with the given backend resolver."""
     auth_dir = tmp_path / "auth"
@@ -88,6 +90,7 @@ def _create_test_forwarding_server(
         backend_resolver=backend_resolver,
         http_client=http_client,
         agent_creator=agent_creator,
+        agent_restarter=agent_restarter,
     )
     client = TestClient(app)
 
@@ -679,6 +682,65 @@ def test_mngr_cli_resolver_returns_loading_page_when_backend_unavailable(tmp_pat
     assert response.status_code == 200
     assert "Loading..." in response.text
     assert "location.reload()" in response.text
+
+
+def test_proxy_triggers_agent_restart_when_backend_unavailable(tmp_path: Path) -> None:
+    """When the backend is unavailable, the proxy triggers an agent restart attempt."""
+    agent_id = AgentId()
+    data_dir = tmp_path / "minds_data"
+
+    backend_resolver = MngrCliBackendResolver()
+    restarter = AgentRestarter(mngr_binary="true", cooldown_seconds=100.0)
+    client, auth_store = _create_test_forwarding_server(
+        tmp_path=data_dir,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        agent_restarter=restarter,
+    )
+
+    _authenticate_client(client=client, auth_store=auth_store)
+    client.cookies.set(f"sw_installed_{agent_id}_web", "1")
+
+    client.get(f"/agents/{agent_id}/web/", headers={"Accept": "text/html"})
+
+    # The restarter should have recorded an attempt for this agent
+    with restarter._lock:
+        assert str(agent_id) in restarter._last_attempt_by_agent
+
+
+def test_proxy_triggers_restart_and_shows_loading_on_connection_refused(tmp_path: Path) -> None:
+    """When the backend URL exists but the connection is refused, trigger restart and show loading page."""
+    agent_id = AgentId()
+    data_dir = tmp_path / "minds_data"
+
+    backend_resolver = make_resolver_with_data(
+        agents_json=make_agents_json(agent_id),
+        server_logs={str(agent_id): make_server_log("web", "http://dead-backend:9999")},
+    )
+
+    class _RefusingTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+    refusing_client = httpx.AsyncClient(transport=_RefusingTransport())
+    restarter = AgentRestarter(mngr_binary="true", cooldown_seconds=100.0)
+    client, auth_store = _create_test_forwarding_server(
+        tmp_path=data_dir,
+        backend_resolver=backend_resolver,
+        http_client=refusing_client,
+        agent_restarter=restarter,
+    )
+
+    _authenticate_client(client=client, auth_store=auth_store)
+    client.cookies.set(f"sw_installed_{agent_id}_web", "1")
+
+    response = client.get(f"/agents/{agent_id}/web/", headers={"Accept": "text/html"})
+    assert response.status_code == 200
+    assert "Loading..." in response.text
+    assert "location.reload()" in response.text
+
+    with restarter._lock:
+        assert str(agent_id) in restarter._last_attempt_by_agent
 
 
 def test_mngr_cli_resolver_landing_page_redirects_single_discovered_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- When a tmux session is killed, `mind forward` would show an infinite loading/error page with no recovery. Now the forwarding server automatically runs `mngr start <agent-id>` to restore the session.
- Handles both failure modes: backend URL not yet discovered (loading page loop) and backend URL known but connection refused (static 502 error).
- Restart attempts are debounced per agent (30s cooldown) to avoid spamming from the 1-second page reloads.

## Test plan
- [x] Manually verified: killed tmux, ran `mind forward`, page auto-recovers after a few seconds
- [x] 347 tests pass (full minds suite with coverage)
- [x] Unit tests for debouncing logic
- [x] Integration tests for both unavailable-backend and connection-refused restart paths