### PR TITLE
Fix streaming list warnings repeating due to line-wrap miscounting

### DIFF
--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -53,6 +53,7 @@ from imbue.mngr.utils.terminal import ANSI_ERASE_TO_END
 from imbue.mngr.utils.terminal import ANSI_RESET
 from imbue.mngr.utils.terminal import StderrInterceptor
 from imbue.mngr.utils.terminal import ansi_cursor_up
+from imbue.mngr.utils.terminal import visual_line_count
 
 _DEFAULT_HUMAN_DISPLAY_FIELDS: Final[tuple[str, ...]] = (
     "name",
@@ -684,11 +685,12 @@ class _StreamingHumanRenderer(MutableModel):
     _column_widths: dict[str, int] = PrivateAttr(default_factory=dict)
     _warning_texts: list[str] = PrivateAttr(default_factory=list)
     _warning_line_count: int = PrivateAttr(default=0)
+    _terminal_width: int = PrivateAttr(default=120)
 
     def start(self) -> None:
         """Compute column widths and write the initial status line (TTY only)."""
-        terminal_width = shutil.get_terminal_size((120, 24)).columns
-        self._column_widths = _compute_column_widths(self.fields, terminal_width, self.custom_headers)
+        self._terminal_width = shutil.get_terminal_size((120, 24)).columns
+        self._column_widths = _compute_column_widths(self.fields, self._terminal_width, self.custom_headers)
 
         if self.is_tty:
             self.output.write(_format_status_line(0))
@@ -703,7 +705,7 @@ class _StreamingHumanRenderer(MutableModel):
 
             self.output.write(text)
             self._warning_texts.append(text)
-            self._warning_line_count += text.count("\n")
+            self._warning_line_count += visual_line_count(text, self._terminal_width)
 
             if self.is_tty:
                 # Re-write the status line below the warning

--- a/libs/mngr/imbue/mngr/utils/terminal.py
+++ b/libs/mngr/imbue/mngr/utils/terminal.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from collections.abc import Callable
 from types import TracebackType
@@ -5,6 +6,7 @@ from typing import Any
 from typing import Final
 from typing import Self
 
+from imbue.imbue_common.pure import pure
 from imbue.imbue_common.mutable_model import MutableModel
 
 ANSI_ERASE_LINE: Final[str] = "\r\x1b[K"
@@ -12,10 +14,35 @@ ANSI_ERASE_TO_END: Final[str] = "\x1b[J"
 ANSI_DIM_GRAY: Final[str] = "\x1b[38;5;245m"
 ANSI_RESET: Final[str] = "\x1b[0m"
 
+_ANSI_ESCAPE_RE: Final[re.Pattern[str]] = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
 
 def ansi_cursor_up(lines: int) -> str:
     """ANSI escape sequence to move the cursor up by the given number of lines."""
     return f"\x1b[{lines}A"
+
+
+@pure
+def visual_line_count(text: str, terminal_width: int) -> int:
+    """Count the number of visual terminal lines a text string occupies.
+
+    Accounts for ANSI escape sequences (which have zero visual width) and
+    terminal line wrapping when a line exceeds terminal_width.
+
+    The count represents how many lines the cursor moves down when the text
+    is written, which is the value needed for cursor-up to undo the write.
+    A trailing newline counts as a line break (the cursor moves to the next line).
+    """
+    stripped = _ANSI_ESCAPE_RE.sub("", text)
+    count = 0
+    for line in stripped.split("\n")[:-1]:
+        # Each segment between newlines takes at least 1 visual line,
+        # plus additional lines if it wraps past the terminal width.
+        if not line:
+            count += 1
+        else:
+            count += (len(line) + terminal_width - 1) // terminal_width
+    return count
 
 
 class StderrInterceptor(MutableModel):

--- a/libs/mngr/imbue/mngr/utils/terminal_test.py
+++ b/libs/mngr/imbue/mngr/utils/terminal_test.py
@@ -2,6 +2,7 @@ import sys
 from io import StringIO
 
 from imbue.mngr.utils.terminal import StderrInterceptor
+from imbue.mngr.utils.terminal import visual_line_count
 
 
 def test_interceptor_routes_writes_through_callback() -> None:
@@ -112,3 +113,46 @@ def test_interceptor_context_manager_installs_and_restores_stderr() -> None:
     with interceptor:
         assert sys.stderr is interceptor
     assert sys.stderr is original
+
+
+def test_visual_line_count_single_short_line() -> None:
+    assert visual_line_count("hello\n", terminal_width=80) == 1
+
+
+def test_visual_line_count_wrapping_line() -> None:
+    """A line longer than terminal width wraps to multiple visual lines."""
+    assert visual_line_count("x" * 200 + "\n", terminal_width=80) == 3
+
+
+def test_visual_line_count_exact_terminal_width() -> None:
+    """A line exactly equal to terminal width takes 1 visual line (no wrap)."""
+    assert visual_line_count("x" * 80 + "\n", terminal_width=80) == 1
+
+
+def test_visual_line_count_strips_ansi_codes() -> None:
+    """ANSI escape codes should not count toward visual width."""
+    text = "\x1b[1;38;5;178mWARNING: short message\x1b[0m\n"
+    assert visual_line_count(text, terminal_width=80) == 1
+
+
+def test_visual_line_count_ansi_with_wrapping() -> None:
+    """A long message with ANSI codes should wrap based on visible content only."""
+    # 100 visible chars with ANSI codes on a 50-wide terminal = 2 visual lines
+    text = "\x1b[1m" + "x" * 100 + "\x1b[0m\n"
+    assert visual_line_count(text, terminal_width=50) == 2
+
+
+def test_visual_line_count_multiple_newlines() -> None:
+    """Multiple lines each count independently."""
+    assert visual_line_count("line1\nline2\n", terminal_width=80) == 2
+
+
+def test_visual_line_count_empty_line_between_newlines() -> None:
+    """An empty line between newlines counts as 1 visual line."""
+    assert visual_line_count("line1\n\nline3\n", terminal_width=80) == 3
+
+
+def test_visual_line_count_no_trailing_newline() -> None:
+    """Text without a trailing newline: only count complete lines."""
+    assert visual_line_count("hello", terminal_width=80) == 0
+    assert visual_line_count("line1\nhello", terminal_width=80) == 1


### PR DESCRIPTION
## Summary
- The streaming renderer in `mngr list` pins warnings at the bottom of the table by erasing and re-writing them after each agent row. The cursor-up count used `text.count("\n")`, which doesn't account for visual line wrapping when a warning exceeds terminal width. This caused long warnings (e.g. Docker daemon unavailable with full exception chain + ANSI codes) to leave "ghost" copies before each row.
- Added `visual_line_count()` to `terminal.py` that strips ANSI escape codes and calculates actual visual lines accounting for terminal-width wrapping. The renderer now uses this for accurate cursor movement.

## Test plan
- [x] Unit tests for `visual_line_count` covering wrapping, ANSI stripping, exact-width, multi-line, and edge cases
- [x] All existing streaming renderer tests pass (142 in cli/list_test.py)
- [x] Full mngr test suite passes (3376 passed, 1 skipped)
- [x] Manually verified with Docker daemon stopped: warning appears once at the bottom of the table instead of repeating before each row