### PR TITLE
disable agent types from disabled plugins

### DIFF
--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -75,14 +75,16 @@ def _apply_custom_overrides_to_parent_config(
     fields like trust_working_directory).
     """
     explicitly_set_fields = custom_config.model_fields_set
-    if not explicitly_set_fields - {"parent_type"}:
+    # parent_type and plugin are routing metadata, not runtime config values.
+    _METADATA_FIELDS = {"parent_type", "plugin"}
+    if not explicitly_set_fields - _METADATA_FIELDS:
         return parent_config
 
     custom_values = custom_config.model_dump()
     updates: list[tuple[str, Any]] = []
 
     for field_name in explicitly_set_fields:
-        if field_name == "parent_type":
+        if field_name in _METADATA_FIELDS:
             continue
         elif field_name == "cli_args":
             # cli_args uses merge semantics (concatenation)

--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -11,6 +11,10 @@ from imbue.mngr.config.data_types import merge_cli_args
 from imbue.mngr.errors import MngrError
 from imbue.mngr.primitives import AgentTypeName
 
+# Fields on AgentTypeConfig that are routing metadata (not runtime config values).
+# These are skipped when applying custom overrides to a parent config.
+_METADATA_FIELDS: frozenset[str] = frozenset({"parent_type", "plugin"})
+
 # =============================================================================
 # Agent Config Registry
 # =============================================================================
@@ -75,8 +79,6 @@ def _apply_custom_overrides_to_parent_config(
     fields like trust_working_directory).
     """
     explicitly_set_fields = custom_config.model_fields_set
-    # parent_type and plugin are routing metadata, not runtime config values.
-    _METADATA_FIELDS = {"parent_type", "plugin"}
     if not explicitly_set_fields - _METADATA_FIELDS:
         return parent_config
 

--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -119,18 +119,27 @@ def resolve_agent_type(
     """
     custom_config = config.agent_types.get(agent_type)
 
-    # Determine which plugin this agent type depends on: custom types with a
-    # parent_type depend on the parent's plugin; otherwise the type name
-    # itself is the plugin identifier.
-    effective_plugin = str(agent_type)
-    if custom_config is not None and custom_config.parent_type is not None:
-        effective_plugin = str(custom_config.parent_type)
-    if effective_plugin in config.disabled_plugins:
-        raise MngrError(
-            f"Agent type '{agent_type}' cannot be used because plugin "
-            f"'{effective_plugin}' is disabled. Enable the plugin with: "
-            f"mngr plugin enable {effective_plugin}"
-        )
+    # Walk the parent chain to check if this type or any ancestor depends on
+    # a disabled plugin.  The chain is: agent_type -> parent_type -> parent's
+    # parent_type -> ... until we hit a type with no parent_type or one that
+    # is not defined in config.agent_types.
+    checked = str(agent_type)
+    current = custom_config
+    seen: set[str] = set()
+    while True:
+        if checked in config.disabled_plugins:
+            raise MngrError(
+                f"Agent type '{agent_type}' cannot be used because plugin "
+                f"'{checked}' is disabled. Enable the plugin with: "
+                f"mngr plugin enable {checked}"
+            )
+        if checked in seen:
+            break
+        seen.add(checked)
+        if current is None or current.parent_type is None:
+            break
+        checked = str(current.parent_type)
+        current = config.agent_types.get(current.parent_type)
 
     if custom_config is not None and custom_config.parent_type is not None:
         parent_type = custom_config.parent_type

--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -8,6 +8,7 @@ from imbue.mngr.config.agent_class_registry import get_agent_class
 from imbue.mngr.config.data_types import AgentTypeConfig
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import merge_cli_args
+from imbue.mngr.errors import MngrError
 from imbue.mngr.primitives import AgentTypeName
 
 # =============================================================================
@@ -112,8 +113,24 @@ def resolve_agent_type(
 
     For plugin-registered or direct command types, returns the registered
     class and config directly.
+
+    Raises MngrError if the agent type (or its parent type) belongs to a
+    disabled plugin.
     """
     custom_config = config.agent_types.get(agent_type)
+
+    # Determine which plugin this agent type depends on: custom types with a
+    # parent_type depend on the parent's plugin; otherwise the type name
+    # itself is the plugin identifier.
+    effective_plugin = str(agent_type)
+    if custom_config is not None and custom_config.parent_type is not None:
+        effective_plugin = str(custom_config.parent_type)
+    if effective_plugin in config.disabled_plugins:
+        raise MngrError(
+            f"Agent type '{agent_type}' cannot be used because plugin "
+            f"'{effective_plugin}' is disabled. Enable the plugin with: "
+            f"mngr plugin enable {effective_plugin}"
+        )
 
     if custom_config is not None and custom_config.parent_type is not None:
         parent_type = custom_config.parent_type

--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -99,6 +99,35 @@ def _apply_custom_overrides_to_parent_config(
     return parent_config.model_copy_update(*updates)
 
 
+def _check_agent_type_not_disabled(
+    agent_type: AgentTypeName,
+    config: MngrConfig,
+) -> None:
+    """Raise MngrError if the agent type or any ancestor in its parent chain is disabled.
+
+    Walks the chain: agent_type -> parent_type -> parent's parent_type -> ...
+    until we hit a type with no parent_type or one that is not defined in
+    config.agent_types.
+    """
+    custom_config = config.agent_types.get(agent_type)
+    checked: str | None = str(agent_type)
+    current_cfg = custom_config
+    seen: set[str] = set()
+    while checked is not None and checked not in seen:
+        if checked in config.disabled_plugins:
+            raise MngrError(
+                f"Agent type '{agent_type}' cannot be used because plugin "
+                f"'{checked}' is disabled. Enable the plugin with: "
+                f"mngr plugin enable {checked}"
+            )
+        seen.add(checked)
+        if current_cfg is not None and current_cfg.parent_type is not None:
+            checked = str(current_cfg.parent_type)
+            current_cfg = config.agent_types.get(current_cfg.parent_type)
+        else:
+            checked = None
+
+
 def resolve_agent_type(
     agent_type: AgentTypeName,
     config: MngrConfig,
@@ -117,29 +146,9 @@ def resolve_agent_type(
     Raises MngrError if the agent type (or its parent type) belongs to a
     disabled plugin.
     """
-    custom_config = config.agent_types.get(agent_type)
+    _check_agent_type_not_disabled(agent_type, config)
 
-    # Walk the parent chain to check if this type or any ancestor depends on
-    # a disabled plugin.  The chain is: agent_type -> parent_type -> parent's
-    # parent_type -> ... until we hit a type with no parent_type or one that
-    # is not defined in config.agent_types.
-    checked = str(agent_type)
-    current = custom_config
-    seen: set[str] = set()
-    while True:
-        if checked in config.disabled_plugins:
-            raise MngrError(
-                f"Agent type '{agent_type}' cannot be used because plugin "
-                f"'{checked}' is disabled. Enable the plugin with: "
-                f"mngr plugin enable {checked}"
-            )
-        if checked in seen:
-            break
-        seen.add(checked)
-        if current is None or current.parent_type is None:
-            break
-        checked = str(current.parent_type)
-        current = config.agent_types.get(current.parent_type)
+    custom_config = config.agent_types.get(agent_type)
 
     if custom_config is not None and custom_config.parent_type is not None:
         parent_type = custom_config.parent_type

--- a/libs/mngr/imbue/mngr/config/agent_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry.py
@@ -105,22 +105,34 @@ def _check_agent_type_not_disabled(
 ) -> None:
     """Raise MngrError if the agent type or any ancestor in its parent chain is disabled.
 
+    At each level, uses the explicit ``plugin`` field if set, otherwise
+    falls back to ``parent_type`` (if set) or the type name -- mirroring
+    how ``_parse_providers`` resolves the plugin for a provider block.
+
     Walks the chain: agent_type -> parent_type -> parent's parent_type -> ...
     until we hit a type with no parent_type or one that is not defined in
     config.agent_types.
     """
-    custom_config = config.agent_types.get(agent_type)
+    current_cfg = config.agent_types.get(agent_type)
     checked: str | None = str(agent_type)
-    current_cfg = custom_config
     seen: set[str] = set()
     while checked is not None and checked not in seen:
+        seen.add(checked)
+        # If this level has an explicit plugin field, use it and stop walking.
+        if current_cfg is not None and current_cfg.plugin is not None:
+            if current_cfg.plugin in config.disabled_plugins:
+                raise MngrError(
+                    f"Agent type '{agent_type}' cannot be used because plugin "
+                    f"'{current_cfg.plugin}' is disabled. Enable the plugin with: "
+                    f"mngr plugin enable {current_cfg.plugin}"
+                )
+            return
         if checked in config.disabled_plugins:
             raise MngrError(
                 f"Agent type '{agent_type}' cannot be used because plugin "
                 f"'{checked}' is disabled. Enable the plugin with: "
                 f"mngr plugin enable {checked}"
             )
-        seen.add(checked)
         if current_cfg is not None and current_cfg.parent_type is not None:
             checked = str(current_cfg.parent_type)
             current_cfg = config.agent_types.get(current_cfg.parent_type)

--- a/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
@@ -382,6 +382,33 @@ def test_resolve_agent_type_raises_when_parent_type_plugin_disabled() -> None:
         reset_agent_config_registry()
 
 
+def test_resolve_agent_type_raises_when_grandparent_plugin_disabled() -> None:
+    """resolve_agent_type should walk the full parent chain and catch a disabled grandparent."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        register_agent_class("root-plugin", _FakeAgentClass)
+        register_agent_config("root-plugin", AgentTypeConfig)
+
+        config = MngrConfig(
+            agent_types={
+                AgentTypeName("mid-type"): AgentTypeConfig(
+                    parent_type=AgentTypeName("root-plugin"),
+                ),
+                AgentTypeName("leaf-type"): AgentTypeConfig(
+                    parent_type=AgentTypeName("mid-type"),
+                ),
+            },
+            disabled_plugins=frozenset({"root-plugin"}),
+        )
+
+        with pytest.raises(MngrError, match="plugin 'root-plugin' is disabled"):
+            resolve_agent_type(AgentTypeName("leaf-type"), config)
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
 def test_resolve_agent_type_allows_non_disabled_plugin() -> None:
     """resolve_agent_type should work normally when the plugin is not disabled."""
     reset_agent_class_registry()

--- a/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
@@ -409,6 +409,48 @@ def test_resolve_agent_type_raises_when_grandparent_plugin_disabled() -> None:
         reset_agent_config_registry()
 
 
+def test_resolve_agent_type_uses_explicit_plugin_field() -> None:
+    """resolve_agent_type should use the explicit plugin field when set."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        set_default_agent_class(_FakeAgentClass)
+
+        config = MngrConfig(
+            agent_types={
+                AgentTypeName("my-type"): AgentTypeConfig(plugin="real-plugin"),
+            },
+            disabled_plugins=frozenset({"real-plugin"}),
+        )
+
+        with pytest.raises(MngrError, match="plugin 'real-plugin' is disabled"):
+            resolve_agent_type(AgentTypeName("my-type"), config)
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
+def test_resolve_agent_type_explicit_plugin_field_overrides_name() -> None:
+    """An explicit plugin field pointing to an enabled plugin should allow resolution even if the type name matches a disabled plugin."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        set_default_agent_class(_FakeAgentClass)
+
+        config = MngrConfig(
+            agent_types={
+                AgentTypeName("disabled-name"): AgentTypeConfig(plugin="enabled-plugin"),
+            },
+            disabled_plugins=frozenset({"disabled-name"}),
+        )
+
+        result = resolve_agent_type(AgentTypeName("disabled-name"), config)
+        assert result.agent_class is _FakeAgentClass
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
 def test_resolve_agent_type_allows_non_disabled_plugin() -> None:
     """resolve_agent_type should work normally when the plugin is not disabled."""
     reset_agent_class_registry()

--- a/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from imbue.mngr.config.agent_class_registry import get_agent_class
 from imbue.mngr.config.agent_class_registry import register_agent_class
 from imbue.mngr.config.agent_class_registry import reset_agent_class_registry
+from imbue.mngr.config.agent_class_registry import set_default_agent_class
 from imbue.mngr.config.agent_config_registry import _apply_custom_overrides_to_parent_config
 from imbue.mngr.config.agent_config_registry import get_agent_config_class
 from imbue.mngr.config.agent_config_registry import list_registered_agent_config_types
@@ -329,6 +330,70 @@ def test_resolve_agent_type_preserves_subclass_fields() -> None:
         assert isinstance(resolved_config, _SubclassAgentConfig)
         assert resolved_config.extra_bool is True
         assert resolved_config.extra_str == "custom-value"
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
+# =============================================================================
+# resolve_agent_type disabled plugin tests
+# =============================================================================
+
+
+def test_resolve_agent_type_raises_when_plugin_disabled() -> None:
+    """resolve_agent_type should raise MngrError when the agent type's plugin is disabled."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        set_default_agent_class(_FakeAgentClass)
+        register_agent_class("my-plugin", _FakeAgentClass)
+        register_agent_config("my-plugin", AgentTypeConfig)
+
+        config = MngrConfig(disabled_plugins=frozenset({"my-plugin"}))
+
+        with pytest.raises(MngrError, match="plugin 'my-plugin' is disabled"):
+            resolve_agent_type(AgentTypeName("my-plugin"), config)
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
+def test_resolve_agent_type_raises_when_parent_type_plugin_disabled() -> None:
+    """resolve_agent_type should raise when a custom type's parent_type plugin is disabled."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        register_agent_class("parent-plugin", _FakeAgentClass)
+        register_agent_config("parent-plugin", AgentTypeConfig)
+
+        config = MngrConfig(
+            agent_types={
+                AgentTypeName("child-type"): AgentTypeConfig(
+                    parent_type=AgentTypeName("parent-plugin"),
+                ),
+            },
+            disabled_plugins=frozenset({"parent-plugin"}),
+        )
+
+        with pytest.raises(MngrError, match="plugin 'parent-plugin' is disabled"):
+            resolve_agent_type(AgentTypeName("child-type"), config)
+    finally:
+        reset_agent_class_registry()
+        reset_agent_config_registry()
+
+
+def test_resolve_agent_type_allows_non_disabled_plugin() -> None:
+    """resolve_agent_type should work normally when the plugin is not disabled."""
+    reset_agent_class_registry()
+    reset_agent_config_registry()
+    try:
+        register_agent_class("enabled-plugin", _FakeAgentClass)
+        register_agent_config("enabled-plugin", AgentTypeConfig)
+
+        config = MngrConfig(disabled_plugins=frozenset({"other-plugin"}))
+
+        result = resolve_agent_type(AgentTypeName("enabled-plugin"), config)
+        assert result.agent_class is _FakeAgentClass
     finally:
         reset_agent_class_registry()
         reset_agent_config_registry()

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -153,6 +153,11 @@ class AgentTypeConfig(FrozenModel):
         default=None,
         description="Base type to inherit from (must be a plugin-provided or command type, not another custom type)",
     )
+    plugin: str | None = Field(
+        default=None,
+        description="Plugin that provides this agent type. Defaults to parent_type (if set) or the type name. "
+        "Used to skip parsing when the plugin is disabled.",
+    )
     command: CommandString | None = Field(
         default=None,
         description="Command to run for this agent type",

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -358,6 +358,29 @@ def _normalize_cli_args_for_construct(raw_config: dict[str, Any]) -> dict[str, A
     return {**raw_config, "cli_args": normalized}
 
 
+def _has_disabled_ancestor(
+    name: str,
+    raw_types: dict[str, dict[str, Any]],
+    disabled_plugins: frozenset[str],
+) -> bool:
+    """Check if an agent type or any ancestor in its parent chain is disabled."""
+    current = name
+    seen: set[str] = set()
+    while True:
+        if current in disabled_plugins:
+            return True
+        if current in seen:
+            return False
+        seen.add(current)
+        raw = raw_types.get(current)
+        if raw is None:
+            return False
+        parent = raw.get("parent_type")
+        if parent is None:
+            return False
+        current = parent
+
+
 def _parse_agent_types(
     raw_types: dict[str, dict[str, Any]],
     disabled_plugins: frozenset[str],
@@ -377,8 +400,9 @@ def _parse_agent_types(
         # has trust_working_directory). Without this, unregistered custom type names
         # fall back to the base AgentTypeConfig which rejects parent-specific fields.
         parent_type = raw_config.get("parent_type")
-        plugin = parent_type if parent_type is not None else name
-        if plugin in disabled_plugins:
+        # Walk the parent chain through raw_types to check if this type or
+        # any ancestor depends on a disabled plugin.
+        if _has_disabled_ancestor(name, raw_types, disabled_plugins):
             continue
         config_class = get_agent_config_class(parent_type if parent_type is not None else name)
         _check_unknown_fields(raw_config, config_class, f"agent_types.{name}", strict=strict)

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -364,21 +364,15 @@ def _has_disabled_ancestor(
     disabled_plugins: frozenset[str],
 ) -> bool:
     """Check if an agent type or any ancestor in its parent chain is disabled."""
-    current = name
+    current: str | None = name
     seen: set[str] = set()
-    while True:
+    while current is not None and current not in seen:
         if current in disabled_plugins:
             return True
-        if current in seen:
-            return False
         seen.add(current)
         raw = raw_types.get(current)
-        if raw is None:
-            return False
-        parent = raw.get("parent_type")
-        if parent is None:
-            return False
-        current = parent
+        current = raw.get("parent_type") if raw is not None else None
+    return False
 
 
 def _parse_agent_types(

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -363,14 +363,25 @@ def _has_disabled_ancestor(
     raw_types: dict[str, dict[str, Any]],
     disabled_plugins: frozenset[str],
 ) -> bool:
-    """Check if an agent type or any ancestor in its parent chain is disabled."""
+    """Check if an agent type or any ancestor in its parent chain is disabled.
+
+    At each level, uses the explicit ``plugin`` field if set, otherwise
+    falls back to ``parent_type`` (if set) or the type name -- mirroring
+    how ``_parse_providers`` resolves the plugin for a provider block.
+    """
     current: str | None = name
     seen: set[str] = set()
     while current is not None and current not in seen:
-        if current in disabled_plugins:
-            return True
         seen.add(current)
         raw = raw_types.get(current)
+        # Determine the plugin identity for this level.
+        plugin: str | None = raw.get("plugin") if raw is not None else None
+        if plugin is not None:
+            # Explicit plugin field -- check it and stop walking (the field
+            # already tells us which plugin this whole sub-chain depends on).
+            return plugin in disabled_plugins
+        if current in disabled_plugins:
+            return True
         current = raw.get("parent_type") if raw is not None else None
     return False
 

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -360,12 +360,14 @@ def _normalize_cli_args_for_construct(raw_config: dict[str, Any]) -> dict[str, A
 
 def _parse_agent_types(
     raw_types: dict[str, dict[str, Any]],
+    disabled_plugins: frozenset[str],
     *,
     strict: bool = True,
 ) -> dict[AgentTypeName, AgentTypeConfig]:
     """Parse agent type configs using the registry.
 
     Uses model_construct to bypass validation and explicitly set None for unset fields.
+    Agent type blocks whose plugin is disabled are silently skipped.
     """
     agent_types: dict[AgentTypeName, AgentTypeConfig] = {}
 
@@ -375,6 +377,9 @@ def _parse_agent_types(
         # has trust_working_directory). Without this, unregistered custom type names
         # fall back to the base AgentTypeConfig which rejects parent-specific fields.
         parent_type = raw_config.get("parent_type")
+        plugin = parent_type if parent_type is not None else name
+        if plugin in disabled_plugins:
+            continue
         config_class = get_agent_config_class(parent_type if parent_type is not None else name)
         _check_unknown_fields(raw_config, config_class, f"agent_types.{name}", strict=strict)
         normalized_config = _normalize_cli_args_for_construct(raw_config)
@@ -553,7 +558,9 @@ def parse_config(
     kwargs["connect_command"] = raw.pop("connect_command", None)
     kwargs["is_remote_agent_installation_allowed"] = raw.pop("is_remote_agent_installation_allowed", None)
     kwargs["agent_types"] = (
-        _parse_agent_types(raw.pop("agent_types", {}), strict=strict) if "agent_types" in raw else {}
+        _parse_agent_types(raw.pop("agent_types", {}), disabled_plugins=disabled_plugins, strict=strict)
+        if "agent_types" in raw
+        else {}
     )
     kwargs["providers"] = (
         _parse_providers(raw.pop("providers", {}), disabled_plugins=disabled_plugins, strict=strict)

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -371,6 +371,21 @@ def test_parse_agent_types_skips_custom_type_with_disabled_parent() -> None:
         reset_agent_config_registry()
 
 
+def test_parse_agent_types_skips_type_with_disabled_grandparent() -> None:
+    """_parse_agent_types should walk the full parent chain and skip if any ancestor is disabled."""
+    raw = {
+        "root-plugin": {"cli_args": "--root"},
+        "mid-type": {"parent_type": "root-plugin"},
+        "leaf-type": {"parent_type": "mid-type"},
+        "unrelated": {"cli_args": "--ok"},
+    }
+    result = _parse_agent_types(raw, disabled_plugins=frozenset({"root-plugin"}))
+    assert AgentTypeName("root-plugin") not in result
+    assert AgentTypeName("mid-type") not in result
+    assert AgentTypeName("leaf-type") not in result
+    assert AgentTypeName("unrelated") in result
+
+
 # =============================================================================
 # Tests for _parse_plugins
 # =============================================================================

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -281,14 +281,14 @@ def test_parse_providers_unknown_backend_mentions_disabled_plugins() -> None:
 def test_parse_agent_types_parses_valid_agent() -> None:
     """_parse_agent_types should parse valid agent type configs."""
     raw = {"claude": {"cli_args": "--verbose"}}
-    result = _parse_agent_types(raw)
+    result = _parse_agent_types(raw, disabled_plugins=frozenset())
     assert AgentTypeName("claude") in result
     assert result[AgentTypeName("claude")].cli_args == ("--verbose",)
 
 
 def test_parse_agent_types_handles_empty_dict() -> None:
     """_parse_agent_types should handle empty dict."""
-    result = _parse_agent_types({})
+    result = _parse_agent_types({}, disabled_plugins=frozenset())
     assert result == {}
 
 
@@ -296,13 +296,13 @@ def test_parse_agent_types_raises_on_unknown_fields() -> None:
     """_parse_agent_types should raise ConfigParseError for unknown fields by default."""
     raw = {"claude": {"cli_args": "--verbose", "bogus_option": True}}
     with pytest.raises(ConfigParseError, match="Unknown fields in agent_types.claude.*bogus_option"):
-        _parse_agent_types(raw)
+        _parse_agent_types(raw, disabled_plugins=frozenset())
 
 
 def test_parse_agent_types_warns_on_unknown_fields_when_not_strict(log_warnings: list[str]) -> None:
     """_parse_agent_types with strict=False should warn about unknown fields and strip them."""
     raw = {"claude": {"cli_args": "--verbose", "bogus_option": True}}
-    result = _parse_agent_types(raw, strict=False)
+    result = _parse_agent_types(raw, disabled_plugins=frozenset(), strict=False)
     assert AgentTypeName("claude") in result
     assert result[AgentTypeName("claude")].cli_args == ("--verbose",)
     assert "bogus_option" not in raw["claude"]
@@ -323,7 +323,7 @@ def test_parse_agent_types_uses_parent_type_config_class() -> None:
 
         # A custom type referencing parent_type should accept the parent's fields
         raw = {"worker": {"parent_type": "test-parent", "extra_field": True, "cli_args": "--verbose"}}
-        result = _parse_agent_types(raw)
+        result = _parse_agent_types(raw, disabled_plugins=frozenset())
 
         worker_config = result[AgentTypeName("worker")]
         assert isinstance(worker_config, _TestParentConfig)
@@ -342,7 +342,31 @@ def test_parse_agent_types_rejects_unknown_fields_even_with_parent_type() -> Non
 
         raw = {"worker": {"parent_type": "test-parent", "totally_bogus": True}}
         with pytest.raises(ConfigParseError, match="Unknown fields in agent_types.worker.*totally_bogus"):
-            _parse_agent_types(raw)
+            _parse_agent_types(raw, disabled_plugins=frozenset())
+    finally:
+        reset_agent_config_registry()
+
+
+def test_parse_agent_types_skips_disabled_plugin_type() -> None:
+    """_parse_agent_types should skip agent types whose name matches a disabled plugin."""
+    raw = {
+        "claude": {"cli_args": "--verbose"},
+        "codex": {"cli_args": "--debug"},
+    }
+    result = _parse_agent_types(raw, disabled_plugins=frozenset({"claude"}))
+    assert AgentTypeName("claude") not in result
+    assert AgentTypeName("codex") in result
+
+
+def test_parse_agent_types_skips_custom_type_with_disabled_parent() -> None:
+    """_parse_agent_types should skip custom types whose parent_type is a disabled plugin."""
+    reset_agent_config_registry()
+    try:
+        register_agent_config("test-parent", _TestParentConfig)
+
+        raw = {"worker": {"parent_type": "test-parent", "extra_field": True}}
+        result = _parse_agent_types(raw, disabled_plugins=frozenset({"test-parent"}))
+        assert AgentTypeName("worker") not in result
     finally:
         reset_agent_config_registry()
 

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -386,6 +386,20 @@ def test_parse_agent_types_skips_type_with_disabled_grandparent() -> None:
     assert AgentTypeName("unrelated") in result
 
 
+def test_parse_agent_types_uses_explicit_plugin_field() -> None:
+    """_parse_agent_types should use an explicit plugin field to determine the owning plugin."""
+    raw = {"my-type": {"plugin": "real-plugin", "cli_args": "--verbose"}}
+    result = _parse_agent_types(raw, disabled_plugins=frozenset({"real-plugin"}))
+    assert AgentTypeName("my-type") not in result
+
+
+def test_parse_agent_types_explicit_plugin_overrides_name() -> None:
+    """An explicit plugin field pointing to an enabled plugin should keep the type even if name matches a disabled plugin."""
+    raw = {"disabled-name": {"plugin": "enabled-plugin", "cli_args": "--verbose"}}
+    result = _parse_agent_types(raw, disabled_plugins=frozenset({"disabled-name"}))
+    assert AgentTypeName("disabled-name") in result
+
+
 # =============================================================================
 # Tests for _parse_plugins
 # =============================================================================


### PR DESCRIPTION
caught by new e2e test, yay

---

## Summary
- `resolve_agent_type()` now checks `config.disabled_plugins` and raises `MngrError` when the agent type (or its parent type) belongs to a disabled plugin
- `_parse_agent_types()` now takes `disabled_plugins` and silently skips agent type config blocks from disabled plugins, matching the existing pattern in `_parse_providers()`

## Context
When a plugin was disabled via `mngr plugin disable`, its hooks were blocked but agent types already registered in the `_agent_class_registry` could still be resolved. The provider system already handled this correctly via `_parse_providers()` checking `disabled_plugins`. This change adds the equivalent check for agent types.

## Test plan
- [x] Added tests for `resolve_agent_type` raising on disabled plugin types (direct and parent_type)
- [x] Added tests for `_parse_agent_types` skipping disabled plugin types (direct and parent_type)
- [x] Updated existing `_parse_agent_types` tests to pass the new required `disabled_plugins` parameter
- [x] All 3197 tests pass in libs/mngr