### PR TITLE
fix: use name-based tmux window targeting (base-index agnostic)

### DIFF
--- a/libs/mngr/imbue/mngr/agents/base_agent.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent.py
@@ -207,7 +207,7 @@ class BaseAgent(AgentInterface[AgentConfigT]):
 
             # Get pane state and pid in one command
             result = self.host.execute_idempotent_command(
-                f"tmux list-panes -t '{session_name}:0' "
+                f"tmux list-panes -t '{session_name}:agent' "
                 f"-F '#{{pane_dead}}|#{{pane_current_command}}|#{{pane_pid}}' 2>/dev/null | head -n 1",
                 timeout_seconds=5.0,
             )
@@ -282,13 +282,15 @@ class BaseAgent(AgentInterface[AgentConfigT]):
 
     @property
     def tmux_target(self) -> str:
-        """Tmux target for the agent's primary window (window 0).
+        """Tmux target for the agent's primary window (named 'agent').
 
-        Agents always run in window 0 of their tmux session. Using the bare
-        session name as a tmux target selects the *currently active* window,
-        which is wrong when additional windows exist (e.g., watchers, ttyd).
+        The primary window is named 'agent' at session creation time. Using a
+        name instead of an index (`:0`) makes targeting independent of the
+        user's tmux `base-index` setting. Using the bare session name would
+        select the *currently active* window, which is wrong when additional
+        windows exist (e.g., watchers, ttyd).
         """
-        return f"{self.session_name}:0"
+        return f"{self.session_name}:agent"
 
     def send_message(self, message: str) -> None:
         """Send a message to the running agent.

--- a/libs/mngr/imbue/mngr/agents/base_agent_test.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent_test.py
@@ -1,6 +1,7 @@
 """Tests for BaseAgent lifecycle state detection and data methods."""
 
 import json
+import shutil
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -118,7 +119,7 @@ def _create_running_agent(
 
     # Create a tmux session and run the expected command
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'sleep {sleep_duration}'",
+        f"tmux new-session -d -s '{session_name}' -n agent 'sleep {sleep_duration}'",
         timeout_seconds=5.0,
     )
 
@@ -176,7 +177,7 @@ def test_lifecycle_state_running_unknown_agent_type_when_different_process_exist
 
     # Create a tmux session with a different command (cat waits for input indefinitely)
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'cat'",
+        f"tmux new-session -d -s '{session_name}' -n agent 'cat'",
         timeout_seconds=5.0,
     )
 
@@ -205,7 +206,7 @@ def test_lifecycle_state_done_when_no_process_in_pane(
     # Create a tmux session, then manually stop the process inside it
     # First create it with a long-running command
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}'",
+        f"tmux new-session -d -s '{session_name}' -n agent",
         timeout_seconds=5.0,
     )
 
@@ -231,7 +232,7 @@ def test_lifecycle_state_waiting_when_no_active_file(
 
     # Create a tmux session and run the expected command
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'sleep 1000'",
+        f"tmux new-session -d -s '{session_name}' -n agent 'sleep 1000'",
         timeout_seconds=5.0,
     )
 
@@ -258,7 +259,7 @@ def test_lifecycle_state_running_when_active_file_created(
 
     # Create a tmux session and run the expected command
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'sleep 1000'",
+        f"tmux new-session -d -s '{session_name}' -n agent 'sleep 1000'",
         timeout_seconds=5.0,
     )
 
@@ -369,11 +370,11 @@ def test_uses_paste_detection_send_returns_false_by_default(
     assert test_agent.uses_paste_detection_send() is False
 
 
-def test_tmux_target_appends_window_zero(
+def test_tmux_target_appends_agent_window_name(
     test_agent: BaseAgent,
 ) -> None:
-    """tmux_target should return session_name:0 to always target window 0."""
-    assert test_agent.tmux_target == f"{test_agent.session_name}:0"
+    """tmux_target should return session_name:agent to target the named agent window."""
+    assert test_agent.tmux_target == f"{test_agent.session_name}:agent"
 
 
 def test_get_tui_ready_indicator_returns_none_by_default(
@@ -414,29 +415,25 @@ def test_check_paste_content_handles_empty_message() -> None:
 
 
 @pytest.mark.tmux
+@pytest.mark.skipif(shutil.which("timeout") is None, reason="requires GNU timeout (coreutils)")
 def test_send_enter_and_wait_for_signal_returns_true_when_signal_received(
     test_agent: BaseAgent,
 ) -> None:
     """Test that _send_enter_and_wait_for_signal returns True when tmux wait-for signal is received."""
     session_name = f"{test_agent.mngr_ctx.config.prefix}{test_agent.name}"
-    tmux_target = f"{session_name}:0"
+    tmux_target = f"{session_name}:agent"
     wait_channel = f"mngr-submit-{session_name}"
 
-    # Create a tmux session
+    # Run a shell that signals the channel on receiving Enter (simulates the
+    # UserPromptSubmit hook). Using `read` blocks until Enter is received,
+    # then `tmux wait-for -S` fires the signal — deterministic, no timing race.
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'bash'",
+        f"tmux new-session -d -s '{session_name}' -n agent "
+        f"\"bash -c 'read line && tmux wait-for -S {wait_channel}'\"",
         timeout_seconds=5.0,
     )
 
     try:
-        # Signal the channel from a background process after a short delay
-        # This simulates what the UserPromptSubmit hook does
-        test_agent.host.execute_idempotent_command(
-            f"( sleep 0.1 && tmux wait-for -S '{wait_channel}' ) &",
-            timeout_seconds=1.0,
-        )
-
-        # Call the method - it should receive the signal and return True
         result = test_agent._send_enter_and_wait_for_signal(tmux_target, wait_channel)
         assert result is True
     finally:
@@ -454,13 +451,13 @@ def test_send_enter_and_wait_for_signal_returns_false_on_timeout(
     # Use a shorter timeout so the test doesn't wait the full 2 seconds
     test_agent.enter_submission_timeout_seconds = 0.2
     session_name = f"{test_agent.mngr_ctx.config.prefix}{test_agent.name}"
-    tmux_target = f"{session_name}:0"
+    tmux_target = f"{session_name}:agent"
     # Use a unique channel that won't be signaled
     wait_channel = f"mngr-submit-never-signaled-{session_name}"
 
-    # Create a tmux session
+    # Create a tmux session with named agent window (matching tmux_target)
     test_agent.host.execute_idempotent_command(
-        f"tmux new-session -d -s '{session_name}' 'bash'",
+        f"tmux new-session -d -s '{session_name}' -n agent 'bash'",
         timeout_seconds=5.0,
     )
 

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2432,11 +2432,6 @@ class Host(BaseHost, OnlineHostInterface):
             "# Source user's default tmux config if it exists",
             "if-shell 'test -f ~/.tmux.conf' 'source-file ~/.tmux.conf'",
             "",
-            "# Override base-index: mngr hardcodes window :0 throughout",
-            "# (user's base-index 1 causes 'can't find window: 0' errors)",
-            "set -g base-index 0",
-            "set -g pane-base-index 0",
-            "",
         ]
 
         if self.is_local:
@@ -2800,6 +2795,7 @@ def _build_start_agent_shell_command(
     steps.append(
         f"tmux -f {shlex.quote(str(tmux_config_path))} new-session -d"
         f" -s {shlex.quote(session_name)}"
+        f" -n agent"
         f" -x 200 -y 50"
         f" -c {shlex.quote(str(agent.work_dir))}"
         f" {shlex.quote(env_shell_cmd)}"
@@ -2862,12 +2858,12 @@ def _build_start_agent_shell_command(
     # If we created additional windows, select the first window (the main agent)
     # before sending the agent command
     if additional_commands:
-        steps.append(f"tmux select-window -t {shlex.quote(session_name + ':0')}")
+        steps.append(f"tmux select-window -t {shlex.quote(session_name + ':agent')}")
 
     # Send the agent command as literal keys, then Enter to execute.
-    # Target window :0 explicitly so this works even after additional windows
-    # have been created (which changes the active window).
-    agent_window = shlex.quote(session_name + ":0")
+    # Target window :agent explicitly so this works even after additional
+    # windows have been created (which changes the active window).
+    agent_window = shlex.quote(session_name + ":agent")
     steps.append(f"tmux send-keys -t {agent_window} -l {shlex.quote(command)}")
     steps.append(f"tmux send-keys -t {agent_window} Enter")
 
@@ -2885,11 +2881,11 @@ def _build_start_agent_shell_command(
     )
     steps.append(activity_printf_cmd)
 
-    # Build the process activity monitor script (runs in the background, inspects window :0 where the agent is assumed to be running)
+    # Build the process activity monitor script (runs in the background, inspects the agent window)
     # Wait up to 10 seconds for the PANE_PID to appear (tmux can take a moment to start)
     max_wait_seconds = 10
     tmux_list_panes_cmd = (
-        f"tmux list-panes -t {shlex.quote(session_name) + ':0'} -F '#{{pane_pid}}' 2>/dev/null | head -n 1"
+        f"tmux list-panes -t {shlex.quote(session_name) + ':agent'} -F '#{{pane_pid}}' 2>/dev/null | head -n 1"
     )
     process_activity_path = activity_dir / ActivitySource.PROCESS.value.lower()
     monitor_script = (

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -2399,20 +2399,16 @@ def test_host_create_host_tmux_config_creates_file(
     assert "C-t" in content
 
 
-def test_host_create_host_tmux_config_overrides_base_index(
+def test_host_create_host_tmux_config_does_not_override_base_index(
     local_host: Host,
     temp_host_dir: Path,
 ) -> None:
-    """Config must set base-index 0 AFTER sourcing user config to override base-index 1."""
+    """Config must not override base-index — name-based targeting makes it unnecessary."""
     content = local_host._create_host_tmux_config().read_text()
 
-    assert "set -g base-index 0" in content
-    assert "set -g pane-base-index 0" in content
-
-    # Ordering matters: override must come after source-file or user config wins
-    source_pos = content.index("source-file")
-    assert content.index("set -g base-index 0") > source_pos
-    assert content.index("set -g pane-base-index 0") > source_pos
+    assert "source-file" in content
+    assert "set -g base-index" not in content
+    assert "set -g pane-base-index" not in content
 
 
 # =========================================================================

--- a/libs/mngr/imbue/mngr/hosts/test_host.py
+++ b/libs/mngr/imbue/mngr/hosts/test_host.py
@@ -796,7 +796,7 @@ def test_unset_vars_applied_during_agent_start(
 
 
 @pytest.mark.tmux
-def test_start_agents_window_zero_addressable_with_user_base_index_1(
+def test_start_agents_agent_window_addressable_with_user_base_index_1(
     temp_host_dir: Path,
     per_host_dir: Path,
     temp_work_dir: Path,
@@ -806,8 +806,8 @@ def test_start_agents_window_zero_addressable_with_user_base_index_1(
     active_concurrency_group: ConcurrencyGroup,
     tmp_home_dir: Path,
 ) -> None:
-    """Regression: window :0 must work when ~/.tmux.conf sets base-index 1."""
-    # Simulate user config that would break hardcoded :0 window targets
+    """Regression: agent window must work when ~/.tmux.conf sets base-index 1."""
+    # Simulate user config that would break index-based window targets
     (tmp_home_dir / ".tmux.conf").write_text("set -g base-index 1\nset -g pane-base-index 1\n")
 
     config = MngrConfig(default_host_dir=temp_host_dir, prefix=mngr_test_prefix)
@@ -841,10 +841,10 @@ def test_start_agents_window_zero_addressable_with_user_base_index_1(
 
     try:
         wait_for(
-            lambda: host.execute_idempotent_command(f"tmux has-session -t '{session_name}:0'").success,
+            lambda: host.execute_idempotent_command(f"tmux has-session -t '{session_name}:agent'").success,
             timeout=30.0,
             poll_interval=0.5,
-            error_message=f"tmux window {session_name}:0 not addressable after start_agents",
+            error_message=f"tmux window {session_name}:agent not addressable after start_agents",
         )
     finally:
         host.stop_agents([agent.id])


### PR DESCRIPTION
## Summary

When `~/.tmux.conf` sets `base-index 1`, mngr's hardcoded `:0` window targets fail with "can't find window: 0". Instead of overriding `base-index 0` in the generated config (suppressing the user's preference), this names the initial window `agent` and targets it by name.

- Add `-n agent` to `tmux new-session` so the primary window has a stable name
- Replace all `:0` references with `:agent` across `host.py` and `base_agent.py`
- Remove the `base-index 0` / `pane-base-index 0` override from the generated tmux config

Name-based targeting is index-agnostic — works with any `base-index` value. Additional windows already use names (`cmd-1`, `server`, etc.), so this is consistent with existing patterns.

## Changes

| File | Change |
|------|--------|
| `hosts/host.py` | Add `-n agent` to `new-session`, `:0`→`:agent` in 3 targets, remove base-index override |
| `agents/base_agent.py` | `tmux_target` returns `:agent`, `get_lifecycle_state` queries `:agent` |
| `hosts/host_test.py` | Assert config has no `base-index` override |
| `hosts/test_host.py` | Integration test targets `:agent` instead of `:0` |
| `agents/base_agent_test.py` | All tmux sessions use `-n agent`, targets use `:agent` |

## Test plan

- [x] `host_test.py` — 222 passed (unit tests for config generation + start command)
- [x] `test_host.py` — integration test with `base-index 1` in `~/.tmux.conf`
- [x] `base_agent_test.py` — 80 passed, 1 skipped (signal test requires GNU `timeout`)
- [x] Net -9 lines (44 added, 53 removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)