### PR TITLE
Add GitHub Copilot CLI agent type

### DIFF
--- a/libs/mngr_copilot/README.md
+++ b/libs/mngr_copilot/README.md
@@ -1,0 +1,71 @@
+# mngr_copilot
+
+A mngr plugin that adds support for [GitHub Copilot CLI](https://github.com/github/copilot-sdk) as a managed agent type.
+
+## Overview
+
+This plugin registers the `copilot` agent type, which runs the Copilot CLI in a managed tmux session on any mngr-supported host (local, Docker, Modal, etc.). It handles:
+
+- Per-agent credential isolation via `COPILOT_HOME`
+- Automatic syncing of GitHub OAuth tokens from your local machine to remote hosts
+- macOS keychain support (reads stored tokens and writes them as plaintext for remote hosts)
+
+## Prerequisites
+
+The Copilot CLI must be installed and available as `copilot` in the agent's PATH. Follow the [Copilot CLI installation guide](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli) to set it up.
+
+To verify your local install:
+
+```bash
+copilot --version
+```
+
+## Usage
+
+```bash
+# Create a copilot agent
+mngr create my-agent --type copilot
+
+# Create on Modal
+mngr create my-agent@.modal --type copilot
+
+# Pass a GitHub token explicitly (bypasses credential sync)
+mngr create my-agent --type copilot --pass-env COPILOT_GITHUB_TOKEN
+```
+
+## Authentication
+
+The plugin follows the [Copilot SDK authentication docs](https://github.com/github/copilot-sdk/blob/main/docs/auth/index.md).
+
+**Automatic (recommended) — keychain sync:**
+
+On macOS, if you have previously run `copilot login`, the plugin automatically reads your stored token from the system keychain and injects it as `COPILOT_GITHUB_TOKEN` for the agent. This works for both local and remote agents.
+
+**Manual — environment variables:**
+
+Pass a token explicitly if you prefer not to use keychain sync, or on non-macOS systems:
+
+```bash
+mngr create my-agent --type copilot --pass-env COPILOT_GITHUB_TOKEN
+# or
+mngr create my-agent --type copilot --pass-env GH_TOKEN
+```
+
+The Copilot CLI checks `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` in that order. Explicit env vars always take precedence over keychain sync.
+
+**BYOK:**
+
+Pass your own API key as documented in the [BYOK docs](https://github.com/github/copilot-sdk/blob/main/docs/auth/byok.md).
+
+## Configuration
+
+All settings can be placed in `.mngr/settings.toml` or `~/.mngr/profiles/<id>/settings.toml`:
+
+```toml
+[copilot]
+# Command to run (default: "copilot")
+command = "copilot"
+
+# Read token from macOS keychain and inject as COPILOT_GITHUB_TOKEN (default: true)
+sync_copilot_credentials = true
+```

--- a/libs/mngr_copilot/conftest.py
+++ b/libs/mngr_copilot/conftest.py
@@ -1,0 +1,15 @@
+"""Project-level conftest for mngr-copilot.
+
+When running tests from libs/mngr_copilot/, this conftest provides the common pytest hooks
+that would otherwise come from the monorepo root conftest.py (which is not discovered
+when pytest runs from a subdirectory).
+
+When running from the monorepo root, the root conftest.py registers the hooks first,
+and this file's register_conftest_hooks() call is a no-op (guarded by a module-level flag).
+"""
+
+from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.mngr.utils.logging import suppress_warnings
+
+suppress_warnings()
+register_conftest_hooks(globals())

--- a/libs/mngr_copilot/imbue/mngr_copilot/__init__.py
+++ b/libs/mngr_copilot/imbue/mngr_copilot/__init__.py
@@ -1,0 +1,3 @@
+import pluggy
+
+hookimpl = pluggy.HookimplMarker("mngr")

--- a/libs/mngr_copilot/imbue/mngr_copilot/plugin.py
+++ b/libs/mngr_copilot/imbue/mngr_copilot/plugin.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Sequence
+
+from loguru import logger
+from pydantic import Field
+
+from imbue.mngr.agents.base_agent import BaseAgent
+from imbue.mngr.config.data_types import AgentTypeConfig
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import PluginMngrError
+from imbue.mngr.errors import SendMessageError
+from imbue.mngr.hosts.common import is_macos
+from imbue.mngr.interfaces.agent import AgentInterface
+from imbue.mngr.interfaces.data_types import FileTransferSpec
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.primitives import CommandString
+from imbue.mngr_copilot import hookimpl
+
+# Keychain service name used by the Copilot CLI (via keytar).
+_COPILOT_KEYCHAIN_SERVICE: str = "copilot-cli"
+
+# Env var names checked by the Copilot CLI, in priority order.
+_COPILOT_TOKEN_ENV_VARS: tuple[str, ...] = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+# npm package name for the Copilot CLI.
+_COPILOT_NPM_PACKAGE: str = "@github/copilot"
+
+# Expected process title set by the Copilot CLI.
+_COPILOT_PROCESS_NAME: str = "copilot"
+
+
+class CopilotAgentConfig(AgentTypeConfig):
+    """Config for the copilot agent type."""
+
+    command: CommandString = Field(
+        default=CommandString("copilot"),
+        description="Command used to launch the Copilot CLI.",
+    )
+    sync_copilot_credentials: bool = Field(
+        default=True,
+        description=(
+            "Read GitHub credentials from the local macOS keychain (stored by 'copilot login') "
+            "and inject them as COPILOT_GITHUB_TOKEN for the agent. "
+            "Has no effect if any of COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN is already set. "
+            "Disable if you prefer to manage credentials entirely via env vars."
+        ),
+    )
+    check_installation: bool = Field(
+        default=True,
+        description="Check if the Copilot CLI is installed on the host before provisioning.",
+    )
+    allow_all_tools: bool = Field(
+        default=True,
+        description=(
+            "Pass --allow-all-tools when launching the Copilot CLI, suppressing tool-use "
+            "confirmation dialogs. Recommended for automated mngr operation. "
+            "Disable if you want Copilot to prompt before running shell commands."
+        ),
+    )
+
+
+def _read_token_from_macos_keychain() -> str | None:
+    """Read the first Copilot token stored by 'copilot login' from the macOS keychain.
+
+    The Copilot CLI stores tokens via keytar with service='copilot-cli'.
+    We use 'security find-generic-password' to retrieve any stored token
+    without needing to know the exact account (host:login key).
+    """
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", _COPILOT_KEYCHAIN_SERVICE, "-w"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        logger.debug("macOS security binary not found; skipping keychain credential read")
+        return None
+    if result.returncode != 0:
+        logger.debug("No Copilot token found in macOS keychain (service={!r})", _COPILOT_KEYCHAIN_SERVICE)
+        return None
+    token = result.stdout.strip()
+    return token or None
+
+
+def _has_token_available(
+    host: OnlineHostInterface,
+    options: CreateAgentOptions,
+    *,
+    sync_copilot_credentials: bool = True,
+) -> bool:
+    """Return True if a GitHub token appears to be available for the Copilot CLI.
+
+    Checks env vars (process env on local hosts, agent options, host env) and,
+    if sync_copilot_credentials is True on a macOS machine, the keychain.
+    The keychain check is not gated on host.is_local because modify_env_vars
+    always reads credentials from the local machine and injects them regardless
+    of whether the target host is local or remote.
+    """
+    for key in _COPILOT_TOKEN_ENV_VARS:
+        if host.is_local and os.environ.get(key):
+            return True
+        for env_var in options.environment.env_vars:
+            if env_var.key == key:
+                return True
+        if host.get_env_var(key):
+            return True
+    # Check macOS keychain -- credentials are injected from the local machine
+    # into the agent env regardless of whether the host is local or remote.
+    if sync_copilot_credentials and is_macos() and _read_token_from_macos_keychain() is not None:
+        return True
+    return False
+
+
+def _check_copilot_installed(host: OnlineHostInterface) -> bool:
+    """Return True if the Copilot CLI is available on the host."""
+    result = host.execute_idempotent_command("command -v copilot", timeout_seconds=10.0)
+    return result.success
+
+
+def _install_copilot(host: OnlineHostInterface) -> None:
+    """Install the Copilot CLI on the host.
+
+    Tries installation methods in order of preference:
+    1. Official install script (curl -fsSL https://gh.io/copilot-install | bash) --
+       downloads a pre-built binary, no Node.js required, works on Linux/macOS.
+    2. Homebrew (brew install copilot-cli) -- if brew is available.
+    3. npm (npm install -g @github/copilot) -- requires Node.js 22+.
+    """
+    if host.execute_idempotent_command("command -v curl", timeout_seconds=10.0).success:
+        logger.info("Installing Copilot CLI via official install script...")
+        result = host.execute_idempotent_command(
+            "curl -fsSL https://gh.io/copilot-install | bash",
+            timeout_seconds=300.0,
+        )
+        if result.success:
+            return
+        logger.debug("curl install script failed ({}); trying fallback methods", result.stderr)
+
+    if host.execute_idempotent_command("command -v brew", timeout_seconds=10.0).success:
+        logger.info("Installing Copilot CLI via Homebrew...")
+        result = host.execute_idempotent_command(
+            "brew install copilot-cli",
+            timeout_seconds=300.0,
+        )
+        if result.success:
+            return
+        logger.debug("brew install failed ({}); trying npm", result.stderr)
+
+    if host.execute_idempotent_command("command -v npm", timeout_seconds=10.0).success:
+        logger.info("Installing Copilot CLI via npm...")
+        result = host.execute_idempotent_command(
+            f"npm install -g {_COPILOT_NPM_PACKAGE}",
+            timeout_seconds=300.0,
+        )
+        if result.success:
+            return
+        raise PluginMngrError(f"Failed to install Copilot CLI via npm. stderr: {result.stderr}")
+
+    raise PluginMngrError(
+        "Could not install Copilot CLI: none of curl, brew, or npm are available on the host.\n"
+        "Consider providing a Dockerfile with the Copilot CLI pre-installed."
+    )
+
+
+class CopilotAgent(BaseAgent[CopilotAgentConfig]):
+    """Agent type that runs the GitHub Copilot CLI in a managed tmux session."""
+
+    def _get_copilot_home_dir(self) -> Path:
+        """Return the per-agent COPILOT_HOME directory."""
+        return self.work_dir / ".copilot"
+
+    def get_expected_process_name(self) -> str:
+        """Return 'copilot' as the expected process name."""
+        return _COPILOT_PROCESS_NAME
+
+    def assemble_command(
+        self,
+        host: OnlineHostInterface,
+        agent_args: tuple[str, ...],
+        command_override: CommandString | None,
+    ) -> CommandString:
+        """Assemble the Copilot CLI launch command.
+
+        Appends --allow-all-tools when allow_all_tools is True (the default),
+        suppressing tool-use confirmation dialogs for automated mngr operation.
+        """
+        if command_override is not None:
+            base = str(command_override)
+        elif self.agent_config.command is not None:
+            base = str(self.agent_config.command)
+        else:
+            base = _COPILOT_PROCESS_NAME
+
+        extra: list[str] = []
+        if self.agent_config.allow_all_tools:
+            extra.append("--allow-all-tools")
+        extra.extend(self.agent_config.cli_args)
+        extra.extend(agent_args)
+
+        parts = [base] + extra
+        return CommandString(" ".join(parts))
+
+    def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
+        """Set COPILOT_HOME for per-agent isolation.
+
+        If sync_copilot_credentials is enabled and no token env var is already set,
+        reads a token from the local macOS keychain and injects it as
+        COPILOT_GITHUB_TOKEN so the remote CLI can authenticate.
+        """
+        env_vars["COPILOT_HOME"] = str(self._get_copilot_home_dir())
+
+        if not self.agent_config.sync_copilot_credentials:
+            return
+        if any(k in env_vars for k in _COPILOT_TOKEN_ENV_VARS):
+            logger.debug("Copilot token already set via env var; skipping keychain read")
+            return
+        if not is_macos():
+            return
+
+        token = _read_token_from_macos_keychain()
+        if token is not None:
+            env_vars["COPILOT_GITHUB_TOKEN"] = token
+            logger.info("Injected Copilot token from macOS keychain into agent env")
+        else:
+            logger.warning(
+                "No Copilot token found in macOS keychain. "
+                "Run 'copilot login' locally, or pass a token via --pass-env COPILOT_GITHUB_TOKEN."
+            )
+
+    def provision(
+        self,
+        host: OnlineHostInterface,
+        options: CreateAgentOptions,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        config = self.agent_config
+
+        if config.check_installation:
+            if _check_copilot_installed(host):
+                logger.debug("Copilot CLI is already installed on the host")
+            else:
+                install_hint = f"npm install -g {_COPILOT_NPM_PACKAGE}"
+                if host.is_local and not mngr_ctx.is_auto_approve:
+                    raise PluginMngrError(
+                        f"Copilot CLI is not installed. Please install it with:\n  {install_hint}"
+                    )
+                elif not host.is_local and not mngr_ctx.config.is_remote_agent_installation_allowed:
+                    raise PluginMngrError(
+                        "Copilot CLI is not installed on the remote host and automatic "
+                        "remote installation is disabled."
+                    )
+                else:
+                    logger.info("Installing Copilot CLI...")
+                    _install_copilot(host)
+                    logger.info("Copilot CLI installed successfully")
+
+        copilot_home_dir = self._get_copilot_home_dir()
+        host.execute_idempotent_command(f"mkdir -p {str(copilot_home_dir)!r}", timeout_seconds=10.0)
+
+        # Pre-trust the agent's work directory so the Copilot CLI trust dialog
+        # doesn't block startup. The CLI reads trusted_folders from config.json
+        # inside COPILOT_HOME before displaying the dialog.
+        config_path = copilot_home_dir / "config.json"
+        trust_config = {"trusted_folders": [str(self.work_dir)]}
+        host.write_text_file(config_path, json.dumps(trust_config, indent=2))
+
+    def get_provision_file_transfers(
+        self,
+        host: OnlineHostInterface,
+        options: CreateAgentOptions,
+        mngr_ctx: MngrContext,
+    ) -> Sequence[FileTransferSpec]:
+        return []
+
+    def on_before_provisioning(
+        self,
+        host: OnlineHostInterface,
+        options: CreateAgentOptions,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        """Validate credentials are available before provisioning."""
+        if not _has_token_available(
+            host, options, sync_copilot_credentials=self.agent_config.sync_copilot_credentials
+        ):
+            logger.warning(
+                "No GitHub token detected for Copilot CLI. The agent may fail to authenticate.\n"
+                "Provide credentials via one of:\n"
+                "  - Run 'copilot login' locally (token stored in macOS keychain)\n"
+                "  - Pass a token via --pass-env COPILOT_GITHUB_TOKEN (or GH_TOKEN / GITHUB_TOKEN)"
+            )
+
+    def on_after_provisioning(
+        self,
+        host: OnlineHostInterface,
+        options: CreateAgentOptions,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        pass
+
+    def on_destroy(self, host: OnlineHostInterface) -> None:
+        pass
+
+    def send_message(self, message: str) -> None:
+        """Send a message to the Copilot CLI TUI.
+
+        The Copilot CLI's Ink-based TUI does not echo pasted text back to the
+        terminal in a way that tmux capture-pane can observe, so paste-detection
+        synchronization cannot be used. Instead, we paste the text, wait briefly
+        for the TUI's React event loop to process the input, then send Enter.
+        """
+        self._send_tmux_literal_keys(self.tmux_target, message)
+        time.sleep(0.5)
+        result = self.host.execute_stateful_command(
+            f"tmux send-keys -t '{self.tmux_target}' Enter"
+        )
+        if not result.success:
+            raise SendMessageError(
+                str(self.name), f"tmux send-keys Enter failed: {result.stderr or result.stdout}"
+            )
+
+    def get_tui_ready_indicator(self) -> str | None:
+        """Return the Copilot CLI's input prompt as the TUI ready indicator.
+
+        The Copilot CLI renders an input prompt with a '>' character when the TUI
+        is ready to accept input.
+        """
+        return "\u276f"
+
+
+@hookimpl
+def register_agent_type() -> tuple[str, type[AgentInterface] | None, type[AgentTypeConfig]]:
+    """Register the copilot agent type."""
+    return ("copilot", CopilotAgent, CopilotAgentConfig)

--- a/libs/mngr_copilot/imbue/mngr_copilot/plugin_test.py
+++ b/libs/mngr_copilot/imbue/mngr_copilot/plugin_test.py
@@ -1,0 +1,599 @@
+"""Unit tests for the copilot plugin."""
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pluggy
+import pytest
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.mngr.api.testing import FakeHost
+from imbue.mngr.config.data_types import EnvVar
+from imbue.mngr.config.data_types import MngrConfig
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import PluginMngrError
+from imbue.mngr.errors import SendMessageError
+from imbue.mngr.interfaces.data_types import CommandResult
+from imbue.mngr.interfaces.host import AgentEnvironmentOptions
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.utils.testing import make_mngr_ctx
+from imbue.mngr_copilot.plugin import CopilotAgent
+from imbue.mngr_copilot.plugin import CopilotAgentConfig
+from imbue.mngr_copilot.plugin import _has_token_available
+from imbue.mngr_copilot.plugin import register_agent_type
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+
+
+class _StubHost(FakeHost):
+    """FakeHost that stubs specific commands and exposes env_vars."""
+
+    command_results: dict[str, CommandResult] = {}
+    env_vars: dict[str, str] = {}
+
+    def _execute_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        for pattern, result in self.command_results.items():
+            if pattern in command:
+                return result
+        return super()._execute_command(command, user, cwd, env, timeout_seconds)
+
+    def get_env_var(self, key: str) -> str | None:
+        return self.env_vars.get(key)
+
+
+def _fake_host(host_dir: Path, *, is_local: bool = True) -> Any:
+    return FakeHost(host_dir=host_dir, is_local=is_local)
+
+
+def _stub_host(
+    host_dir: Path,
+    *,
+    is_local: bool = True,
+    command_results: dict[str, CommandResult] | None = None,
+    env_vars: dict[str, str] | None = None,
+) -> Any:
+    return _StubHost(
+        host_dir=host_dir,
+        is_local=is_local,
+        command_results=command_results or {},
+        env_vars=env_vars or {},
+    )
+
+
+def _make_options(
+    env_vars: dict[str, str] | None = None,
+) -> CreateAgentOptions:
+    evars = tuple(EnvVar(key=k, value=v) for k, v in (env_vars or {}).items())
+    return CreateAgentOptions(
+        name=AgentName("test"),
+        agent_type=AgentTypeName("copilot"),
+        environment=AgentEnvironmentOptions(env_vars=evars),
+    )
+
+
+def _make_mngr_ctx(
+    tmp_path: Path,
+    *,
+    is_auto_approve: bool = False,
+    is_remote_agent_installation_allowed: bool = True,
+) -> MngrContext:
+    return make_mngr_ctx(
+        config=MngrConfig(
+            is_remote_agent_installation_allowed=is_remote_agent_installation_allowed
+        ),
+        pm=pluggy.PluginManager("mngr"),
+        profile_dir=tmp_path / "profile",
+        is_interactive=False,
+        is_auto_approve=is_auto_approve,
+        concurrency_group=ConcurrencyGroup(name="test"),
+    )
+
+
+def _make_copilot_agent(
+    tmp_path: Path,
+    *,
+    config: CopilotAgentConfig | None = None,
+    host: Any | None = None,
+    is_local: bool = True,
+) -> CopilotAgent:
+    """Create a CopilotAgent via __new__ to bypass pydantic host-type validation."""
+    resolved_host = host if host is not None else _fake_host(tmp_path, is_local=is_local)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir(exist_ok=True)
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+
+    agent = CopilotAgent.__new__(CopilotAgent)
+    object.__setattr__(agent, "agent_config", config or CopilotAgentConfig())
+    object.__setattr__(agent, "host", resolved_host)
+    object.__setattr__(agent, "id", AgentId.generate())
+    object.__setattr__(agent, "name", AgentName("test-copilot"))
+    object.__setattr__(agent, "agent_type", AgentTypeName("copilot"))
+    object.__setattr__(agent, "work_dir", work_dir)
+    object.__setattr__(agent, "mngr_ctx", mngr_ctx)
+    return agent
+
+
+@pytest.fixture()
+def copilot_agent(tmp_path: Path) -> CopilotAgent:
+    """Create a minimally-configured CopilotAgent for testing."""
+    return _make_copilot_agent(tmp_path)
+
+
+# =============================================================================
+# CopilotAgentConfig tests
+# =============================================================================
+
+
+def test_copilot_agent_config_defaults() -> None:
+    config = CopilotAgentConfig()
+
+    assert str(config.command) == "copilot"
+    assert config.sync_copilot_credentials is True
+    assert config.check_installation is True
+    assert config.allow_all_tools is True
+    assert config.cli_args == ()
+    assert config.permissions == []
+    assert config.parent_type is None
+
+
+def test_copilot_agent_config_merge_with_override() -> None:
+    base = CopilotAgentConfig()
+    override = CopilotAgentConfig(cli_args=("--verbose",))
+
+    merged = base.merge_with(override)
+
+    assert isinstance(merged, CopilotAgentConfig)
+    assert merged.cli_args == ("--verbose",)
+    assert str(merged.command) == "copilot"
+
+
+# =============================================================================
+# CopilotAgent basic method tests
+# =============================================================================
+
+
+def test_get_expected_process_name(copilot_agent: CopilotAgent) -> None:
+    assert copilot_agent.get_expected_process_name() == "copilot"
+
+
+def test_get_tui_ready_indicator(copilot_agent: CopilotAgent) -> None:
+    assert copilot_agent.get_tui_ready_indicator() == "\u276f"
+
+
+def test_register_agent_type_returns_correct_tuple() -> None:
+    name, agent_class, config_class = register_agent_type()
+
+    assert name == "copilot"
+    assert agent_class is CopilotAgent
+    assert config_class is CopilotAgentConfig
+
+
+def test_get_provision_file_transfers_returns_empty(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    host = _fake_host(tmp_path)
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+    assert copilot_agent.get_provision_file_transfers(host, options, mngr_ctx) == []
+
+
+# =============================================================================
+# assemble_command tests
+# =============================================================================
+
+
+def test_assemble_command_includes_allow_all_tools_by_default(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    cmd = str(copilot_agent.assemble_command(_fake_host(tmp_path), (), None))
+    assert "--allow-all-tools" in cmd
+    assert cmd.startswith("copilot")
+
+
+def test_assemble_command_omits_allow_all_tools_when_disabled(tmp_path: Path) -> None:
+    agent = _make_copilot_agent(tmp_path, config=CopilotAgentConfig(allow_all_tools=False))
+    cmd = str(agent.assemble_command(_fake_host(tmp_path), (), None))
+    assert "--allow-all-tools" not in cmd
+
+
+def test_assemble_command_includes_cli_args(tmp_path: Path) -> None:
+    agent = _make_copilot_agent(tmp_path, config=CopilotAgentConfig(cli_args=("--verbose",)))
+    cmd = str(agent.assemble_command(_fake_host(tmp_path), (), None))
+    assert "--verbose" in cmd
+
+
+def test_assemble_command_includes_agent_args(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    cmd = str(copilot_agent.assemble_command(_fake_host(tmp_path), ("--model", "sonnet"), None))
+    assert "--model" in cmd
+    assert "sonnet" in cmd
+
+
+def test_assemble_command_respects_command_override(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    from imbue.mngr.primitives import CommandString
+
+    cmd = str(copilot_agent.assemble_command(_fake_host(tmp_path), (), CommandString("my-copilot")))
+    assert cmd.startswith("my-copilot")
+
+
+# =============================================================================
+# modify_env_vars tests
+# =============================================================================
+
+
+def test_modify_env_vars_sets_copilot_home(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    env_vars: dict[str, str] = {}
+    copilot_agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+    assert "COPILOT_HOME" in env_vars
+    assert ".copilot" in env_vars["COPILOT_HOME"]
+
+
+def test_modify_env_vars_injects_token_from_keychain(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    env_vars: dict[str, str] = {}
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=True),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain", return_value="ghu_test_token"),
+    ):
+        copilot_agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+
+    assert env_vars.get("COPILOT_GITHUB_TOKEN") == "ghu_test_token"
+
+
+def test_modify_env_vars_skips_keychain_when_token_already_set(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    env_vars: dict[str, str] = {"GITHUB_TOKEN": "existing_token"}
+    with patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain") as mock_keychain:
+        copilot_agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+    mock_keychain.assert_not_called()
+    assert "COPILOT_GITHUB_TOKEN" not in env_vars
+
+
+def test_modify_env_vars_skips_keychain_on_non_macos(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    env_vars: dict[str, str] = {}
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=False),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain") as mock_keychain,
+    ):
+        copilot_agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+    mock_keychain.assert_not_called()
+    assert "COPILOT_GITHUB_TOKEN" not in env_vars
+
+
+def test_modify_env_vars_skips_when_sync_disabled(
+    tmp_path: Path,
+) -> None:
+    agent = _make_copilot_agent(tmp_path, config=CopilotAgentConfig(sync_copilot_credentials=False))
+    env_vars: dict[str, str] = {}
+    with patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain") as mock_keychain:
+        agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+    mock_keychain.assert_not_called()
+
+
+# =============================================================================
+# _has_token_available tests
+# =============================================================================
+
+
+def test_has_token_available_via_host_env(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=False, env_vars={"GH_TOKEN": "ghs_test"})
+    options = _make_options()
+    assert _has_token_available(host, options) is True
+
+
+def test_has_token_available_returns_false_when_no_token(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=False)
+    options = _make_options()
+    with patch("imbue.mngr_copilot.plugin.is_macos", return_value=False):
+        assert _has_token_available(host, options) is False
+
+
+def test_has_token_available_via_keychain_on_macos(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=True)
+    options = _make_options()
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=True),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain", return_value="ghu_token"),
+    ):
+        assert _has_token_available(host, options, sync_copilot_credentials=True) is True
+
+
+def test_has_token_available_via_keychain_for_remote_host(tmp_path: Path) -> None:
+    """Keychain check runs even for remote hosts (credentials injected from local machine)."""
+    host = _stub_host(tmp_path, is_local=False)
+    options = _make_options()
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=True),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain", return_value="ghu_token"),
+    ):
+        assert _has_token_available(host, options, sync_copilot_credentials=True) is True
+
+
+def test_has_token_available_skips_keychain_when_sync_disabled(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=False)
+    options = _make_options()
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=True),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain", return_value="ghu_token"),
+    ):
+        assert _has_token_available(host, options, sync_copilot_credentials=False) is False
+
+
+# =============================================================================
+# on_before_provisioning tests
+# =============================================================================
+
+
+def test_on_before_provisioning_completes_without_credentials(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    """Verify on_before_provisioning completes (with warning) when no credentials found."""
+    host = _stub_host(tmp_path, is_local=False)
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+
+    with patch("imbue.mngr_copilot.plugin.is_macos", return_value=False):
+        copilot_agent.on_before_provisioning(host, options, mngr_ctx)
+
+
+# =============================================================================
+# provision tests
+# =============================================================================
+
+
+def test_provision_writes_trust_config(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    host = _stub_host(
+        tmp_path,
+        command_results={"command -v copilot": CommandResult(stdout="/usr/bin/copilot", stderr="", success=True)},
+    )
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+
+    copilot_agent.provision(host, options, mngr_ctx)
+
+    config_path = copilot_agent._get_copilot_home_dir() / "config.json"
+    import json
+
+    data = json.loads(config_path.read_text())
+    assert "trusted_folders" in data
+    assert str(copilot_agent.work_dir) in data["trusted_folders"]
+
+
+def test_provision_raises_when_not_installed_locally(
+    copilot_agent: CopilotAgent, tmp_path: Path
+) -> None:
+    host = _stub_host(
+        tmp_path,
+        is_local=True,
+        command_results={"command -v copilot": CommandResult(stdout="", stderr="", success=False)},
+    )
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path, is_auto_approve=False)
+
+    with pytest.raises(PluginMngrError, match="Copilot CLI is not installed"):
+        copilot_agent.provision(host, options, mngr_ctx)
+
+
+def test_provision_auto_installs_on_remote(tmp_path: Path) -> None:
+    host = _stub_host(
+        tmp_path,
+        is_local=False,
+        command_results={
+            "command -v copilot": CommandResult(stdout="", stderr="", success=False),
+            "command -v curl": CommandResult(stdout="/usr/bin/curl", stderr="", success=True),
+            "curl -fsSL https://gh.io/copilot-install": CommandResult(stdout="installed", stderr="", success=True),
+        },
+    )
+    agent = _make_copilot_agent(
+        tmp_path,
+        config=CopilotAgentConfig(check_installation=True),
+        host=host,
+        is_local=False,
+    )
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+
+    agent.provision(host, options, mngr_ctx)
+
+
+def test_provision_raises_when_remote_install_disabled(tmp_path: Path) -> None:
+    host = _stub_host(
+        tmp_path,
+        is_local=False,
+        command_results={"command -v copilot": CommandResult(stdout="", stderr="", success=False)},
+    )
+    agent = _make_copilot_agent(
+        tmp_path,
+        config=CopilotAgentConfig(check_installation=True),
+        host=host,
+        is_local=False,
+    )
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path, is_remote_agent_installation_allowed=False)
+
+    with pytest.raises(PluginMngrError, match="automatic remote installation is disabled"):
+        agent.provision(host, options, mngr_ctx)
+
+
+def test_provision_skips_install_check_when_disabled(tmp_path: Path) -> None:
+    """When check_installation=False, provision should not run 'command -v copilot'."""
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            # Return failure for any command-v check -- should never be called
+            "command -v copilot": CommandResult(stdout="", stderr="", success=False),
+        },
+    )
+    agent = _make_copilot_agent(tmp_path, config=CopilotAgentConfig(check_installation=False), host=host)
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+
+    # Should not raise even though copilot is "not installed"
+    agent.provision(host, options, mngr_ctx)
+
+
+# =============================================================================
+# send_message tests
+# =============================================================================
+
+
+def test_send_message_raises_on_enter_failure(tmp_path: Path) -> None:
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "tmux send-keys": CommandResult(stdout="", stderr="session not found", success=False)
+        },
+    )
+    agent = _make_copilot_agent(tmp_path, host=host)
+
+    with pytest.raises(SendMessageError):
+        agent.send_message("hello")
+
+
+def test_read_token_from_macos_keychain_returns_none_when_binary_missing() -> None:
+    from imbue.mngr_copilot.plugin import _read_token_from_macos_keychain
+
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        result = _read_token_from_macos_keychain()
+    assert result is None
+
+
+def test_read_token_from_macos_keychain_returns_none_when_not_found() -> None:
+    from imbue.mngr_copilot.plugin import _read_token_from_macos_keychain
+    import subprocess
+
+    mock_result = subprocess.CompletedProcess(args=[], returncode=44, stdout="", stderr="")
+    with patch("subprocess.run", return_value=mock_result):
+        result = _read_token_from_macos_keychain()
+    assert result is None
+
+
+def test_has_token_available_via_local_env(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=True)
+    options = _make_options()
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=False),
+        patch.dict("os.environ", {"GH_TOKEN": "ghs_local"}),
+    ):
+        assert _has_token_available(host, options) is True
+
+
+def test_has_token_available_via_options_env_vars(tmp_path: Path) -> None:
+    host = _stub_host(tmp_path, is_local=False)
+    options = _make_options(env_vars={"COPILOT_GITHUB_TOKEN": "ghu_passed"})
+    assert _has_token_available(host, options) is True
+
+
+def test_install_copilot_raises_on_failure(tmp_path: Path) -> None:
+    from imbue.mngr_copilot.plugin import _install_copilot
+
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "command -v curl": CommandResult(stdout="", stderr="", success=False),
+            "command -v brew": CommandResult(stdout="", stderr="", success=False),
+            "command -v npm": CommandResult(stdout="", stderr="", success=False),
+        },
+    )
+    with pytest.raises(PluginMngrError, match="none of curl, brew, or npm"):
+        _install_copilot(host)
+
+
+def test_install_copilot_uses_curl_script_first(tmp_path: Path) -> None:
+    from imbue.mngr_copilot.plugin import _install_copilot
+
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "command -v curl": CommandResult(stdout="/usr/bin/curl", stderr="", success=True),
+            "curl -fsSL https://gh.io/copilot-install": CommandResult(stdout="", stderr="", success=True),
+        },
+    )
+    _install_copilot(host)  # Should not raise
+
+
+def test_install_copilot_falls_back_to_brew(tmp_path: Path) -> None:
+    from imbue.mngr_copilot.plugin import _install_copilot
+
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "command -v curl": CommandResult(stdout="/usr/bin/curl", stderr="", success=True),
+            "curl -fsSL https://gh.io/copilot-install": CommandResult(stdout="", stderr="network error", success=False),
+            "command -v brew": CommandResult(stdout="/usr/local/bin/brew", stderr="", success=True),
+            "brew install": CommandResult(stdout="", stderr="", success=True),
+        },
+    )
+    _install_copilot(host)  # Should not raise
+
+
+def test_install_copilot_falls_back_to_npm(tmp_path: Path) -> None:
+    from imbue.mngr_copilot.plugin import _install_copilot
+
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "command -v curl": CommandResult(stdout="", stderr="", success=False),
+            "command -v brew": CommandResult(stdout="", stderr="", success=False),
+            "command -v npm": CommandResult(stdout="/usr/bin/npm", stderr="", success=True),
+            "npm install -g": CommandResult(stdout="installed", stderr="", success=True),
+        },
+    )
+    _install_copilot(host)  # Should not raise
+
+
+def test_install_copilot_raises_when_npm_fails(tmp_path: Path) -> None:
+    from imbue.mngr_copilot.plugin import _install_copilot
+
+    host = _stub_host(
+        tmp_path,
+        command_results={
+            "command -v curl": CommandResult(stdout="", stderr="", success=False),
+            "command -v brew": CommandResult(stdout="", stderr="", success=False),
+            "command -v npm": CommandResult(stdout="/usr/bin/npm", stderr="", success=True),
+            "npm install -g": CommandResult(stdout="", stderr="permission denied", success=False),
+        },
+    )
+    with pytest.raises(PluginMngrError, match="Failed to install Copilot CLI via npm"):
+        _install_copilot(host)
+
+
+def test_modify_env_vars_warns_when_no_keychain_token(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    env_vars: dict[str, str] = {}
+    with (
+        patch("imbue.mngr_copilot.plugin.is_macos", return_value=True),
+        patch("imbue.mngr_copilot.plugin._read_token_from_macos_keychain", return_value=None),
+    ):
+        copilot_agent.modify_env_vars(_fake_host(tmp_path), env_vars)
+    assert "COPILOT_GITHUB_TOKEN" not in env_vars
+
+
+def test_on_after_provisioning_is_noop(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    host = _fake_host(tmp_path)
+    options = _make_options()
+    mngr_ctx = _make_mngr_ctx(tmp_path)
+    copilot_agent.on_after_provisioning(host, options, mngr_ctx)
+
+
+def test_on_destroy_is_noop(copilot_agent: CopilotAgent, tmp_path: Path) -> None:
+    host = _fake_host(tmp_path)
+    copilot_agent.on_destroy(host)

--- a/libs/mngr_copilot/pyproject.toml
+++ b/libs/mngr_copilot/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "imbue-mngr-copilot"
+version = "0.2.1"
+description = "Copilot agent type plugin for mngr"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "imbue-mngr==0.2.1",
+]
+
+[project.entry-points.mngr]
+copilot = "imbue.mngr_copilot.plugin"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["imbue"]
+
+[tool.uv.sources]
+imbue-mngr = { workspace = true }
+
+# Shared pytest settings (markers, filterwarnings, coverage report config)
+# are centralized in:
+#   libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+# The settings below remain here because they are read from pyproject.toml
+# before any hooks run: addopts, coverage.run, inline-snapshot, timeout_func_only.
+[tool.pytest.ini_options]
+timeout_func_only = true
+junit_family = "xunit1"
+testpaths = ["."]
+addopts = [
+  "-n 4",
+  "--dist=worksteal",
+  "--cov=imbue.mngr_copilot",
+  "--cov-report=term-missing",
+  "--cov-report=html",
+  "--cov-report=xml",
+  "--cov-fail-under=90",
+  "--durations=20",
+  "--timeout=10",
+  "--timeout-method=signal",
+  "--max-worker-restart=0",
+  "-m not acceptance and not release",
+  "--slow-tests-to-file",
+  "--coverage-to-file",
+]
+
+[tool.coverage.run]
+parallel = true
+concurrency = ["multiprocessing", "thread"]
+omit = [
+  "*_test.py",
+  "test_*.py",
+  "*/tests/*",
+  "*/conftest.py",
+  "*/utils/testing.py",
+]
+
+[tool.inline-snapshot]
+default-flags=["report"]
+default-flags-tui=["report"]
+default-flags-ide=["report"]
+format-command="uv run ruff format --force-exclude --config pyproject.toml --stdin-filename {filename}"
+
+[tool.pyright]
+venvPath = "../.."
+venv = ".venv"
+pythonVersion = "3.11"
+strict = ["**/*.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
     "imbue-mngr",
     "imbue-mngr-claude",
     "imbue-mngr-claude-mind",
+    "imbue-mngr-copilot",
     "imbue-mngr-file",
     "imbue-mngr-kanpan",
     "imbue-mngr-llm",
@@ -1520,6 +1521,17 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=4.0" },
 ]
+
+[[package]]
+name = "imbue-mngr-copilot"
+version = "0.2.1"
+source = { editable = "libs/mngr_copilot" }
+dependencies = [
+    { name = "imbue-mngr" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "imbue-mngr", editable = "libs/mngr" }]
 
 [[package]]
 name = "imbue-mngr-file"


### PR DESCRIPTION
Closes #1158

## Summary

- Add new `libs/mngr_copilot` package implementing a `copilot` agent type plugin for [GitHub Copilot CLI](https://githubnext.com/projects/copilot-for-cli)
- Auto-install Copilot CLI binary inside Docker/Modal sandboxes via official install script (`curl -fsSL https://gh.io/copilot-install | bash`), with brew/npm fallbacks
- Inject macOS Keychain credentials into remote agent environments (`GITHUB_TOKEN`) so `copilot login` once works everywhere
- Inject `--allow-all-tools` at launch by default to suppress tool-use confirmation dialogs for automated operation



I tested following scenarios:

- [x] `mngr create my-agent --type copilot`
- [x] `mngr msg my-agent -m "..."` + `mngr capture my-agent`: message delivery and response capture working
- [x] `mngr create --type copilot --provider docker`: auto-installs Copilot CLI via curl in container
- [x] `mngr create --type copilot --provider modal`: works on Modal sandboxes