### PR TITLE
Mirror add custom config support for verify-conversation and verify-architecture

### DIFF
--- a/scripts/stop_hook_gates.sh
+++ b/scripts/stop_hook_gates.sh
@@ -115,15 +115,29 @@ else
     AUTOFIX_CMD="/autofix"
 fi
 
+CONVO_EXTRA_ARGS=$(read_json_config "$REVIEWER_SETTINGS" "verify_conversation.append_to_prompt" "")
+if [[ -n "$CONVO_EXTRA_ARGS" ]]; then
+    CONVO_CMD="/verify-conversation ${CONVO_EXTRA_ARGS}"
+else
+    CONVO_CMD="/verify-conversation"
+fi
+
+ARCH_EXTRA_ARGS=$(read_json_config "$REVIEWER_SETTINGS" "verify_architecture.append_to_prompt" "")
+if [[ -n "$ARCH_EXTRA_ARGS" ]]; then
+    ARCH_CMD="/verify-architecture ${ARCH_EXTRA_ARGS}"
+else
+    ARCH_CMD="/verify-architecture"
+fi
+
 MISSING=()
 if [[ "$ARCH_NEEDED" == "true" ]]; then
-    MISSING+=("architecture verification (/verify-architecture)")
+    MISSING+=("architecture verification (${ARCH_CMD})")
 fi
 if [[ "$AUTOFIX_NEEDED" == "true" ]]; then
     MISSING+=("autofix (${AUTOFIX_CMD})")
 fi
 if [[ "$CONVO_NEEDED" == "true" ]]; then
-    MISSING+=("conversation review (/verify-conversation)")
+    MISSING+=("conversation review (${CONVO_CMD})")
 fi
 
 if [[ ${#MISSING[@]} -eq 0 ]]; then


### PR DESCRIPTION
ci is failing because the companion pr in code-guardian, https://github.com/imbue-ai/code-guardian/pull/8, isn't merged; those two should be merged at the same time

---

## Summary
- Mirror `stop_hook_gates.sh` changes from imbue-ai/code-guardian#8: add `verify_conversation.append_to_prompt` and `verify_architecture.append_to_prompt` config reading, so the stop hook includes custom args in the commands it suggests

## Companion PR
- https://github.com/imbue-ai/code-guardian/pull/8

## Note
The `test_shared_script_matches_code_guardian` acceptance test will fail until the companion PR merges to main in code-guardian.

## Test plan
- [ ] Merge companion PR first
- [ ] Verify `test_shared_scripts.py` acceptance test passes after companion merge

Generated with [Claude Code](https://claude.com/claude-code)