### PR TITLE
add pre-commit hook to compile style guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         name: "Compile style guide Python examples"
         entry: bash -c 'uv run python scripts/compile_style_guide.py && git diff --quiet scripts/style_guide.py'
         language: system
-        files: 'style_guide\.md$|scripts/compile_style_guide\.py$|scripts/style_guide\.py$'
+        files: '^style_guide\.md$|scripts/compile_style_guide\.py$|scripts/style_guide\.py$'
         pass_filenames: false
     -   id: clean-stale-workspace-dirs
 #        Without this, when a workspace member is removed, its directory and contents remain, which causes uv to explode with a cryptic error message any time you run any uv command

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,12 @@ repos:
         language: system
         files: 'libs/mngr/imbue/mngr/cli/.*\.py$|libs/mngr/imbue/mngr/main\.py$|scripts/make_cli_docs\.py$|libs/mngr/docs/commands/.*\.md$|^README\.md$|^libs/mngr/README\.md$'
         pass_filenames: false
+    -   id: compile-style-guide
+        name: "Compile style guide Python examples"
+        entry: bash -c 'uv run python scripts/compile_style_guide.py && git diff --quiet scripts/style_guide.py'
+        language: system
+        files: 'style_guide\.md$|scripts/compile_style_guide\.py$|scripts/style_guide\.py$'
+        pass_filenames: false
     -   id: clean-stale-workspace-dirs
 #        Without this, when a workspace member is removed, its directory and contents remain, which causes uv to explode with a cryptic error message any time you run any uv command
         name: "Clean stale workspace member directories"

--- a/scripts/style_guide.py
+++ b/scripts/style_guide.py
@@ -1058,30 +1058,6 @@ def list_todos(
 
 
 # === Example block 51 ===
-class MockTodoRepository(TodoRepositoryInterface):
-    """In-memory implementation for testing."""
-
-    mock_todos: dict[TodoId, TodoItem] = Field(default_factory=dict)
-
-    def save_todo(self, todo_item: TodoItem) -> None:
-        self.mock_todos[todo_item.todo_id] = todo_item
-
-    def get_todo_by_id(self, todo_id: TodoId) -> TodoItem | None:
-        return self.mock_todos.get(todo_id)
-
-    def delete_todo(self, todo_id: TodoId) -> None:
-        del self.mock_todos[todo_id]
-
-
-# === Example block 52 ===
-class FailingSaveMockRepository(MockTodoRepository):
-    """Mock that raises on save for error path testing."""
-
-    def save_todo(self, todo_item: TodoItem) -> None:
-        raise TodoStorageError("Simulated save failure")
-
-
-# === Example block 53 ===
 
 
 def test_format_todo_for_display_shows_checkbox_and_title() -> None:
@@ -1108,7 +1084,7 @@ def test_format_todo_for_display_shows_completed_marker_when_done() -> None:
     assert formatted_output == snapshot("[x] Send email")
 
 
-# === Example block 54 ===
+# === Example block 52 ===
 
 
 
@@ -1148,7 +1124,7 @@ def test_export_large_todo_dataset_to_json_produces_expected_output() -> None:
     )
 
 
-# === Example block 55 ===
+# === Example block 53 ===
 def test_add_todo_to_list_appends_todo_to_end_of_list() -> None:
     todo_list = TodoList(list_id=TodoListId.generate(), todos=())
     new_todo = create_test_todo(title="New task")
@@ -1159,7 +1135,7 @@ def test_add_todo_to_list_appends_todo_to_end_of_list() -> None:
     assert updated_list.todos[0] == new_todo
 
 
-# === Example block 56 ===
+# === Example block 54 ===
 
 
 
@@ -1202,7 +1178,7 @@ def test_sync_todo_list_to_remote_server_handles_response_correctly(
     assert sync_response.synced_count == snapshot(1)
 
 
-# === Example block 57 ===
+# === Example block 55 ===
 
 
 @pytest.mark.acceptance
@@ -1212,7 +1188,7 @@ def test_sync_todos_to_remote_server_succeeds_with_valid_credentials() -> None:
     ...
 
 
-# === Example block 58 ===
+# === Example block 56 ===
 
 
 @pytest.mark.release
@@ -1222,7 +1198,7 @@ def test_full_end_to_end_workflow_with_all_providers() -> None:
     ...
 
 
-# === Example block 59 ===
+# === Example block 57 ===
 
 
 class TodoSyncError(TodoAppError):


### PR DESCRIPTION
## Summary
- Add a pre-commit hook that runs `compile_style_guide.py` and fails if the compiled output (`scripts/style_guide.py`) is stale
- Regenerate `style_guide.py` to reflect current style guide content (2 removed example blocks, renumbered 59 -> 57)

## Test plan
- [x] Verified the new hook runs and passes during commit
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)