### PR TITLE
fix test that was actually installing dependencies

### DIFF
--- a/libs/mngr/README.md
+++ b/libs/mngr/README.md
@@ -2,7 +2,7 @@
 <!-- This is a copy of the top-level README.md, but with local paths replaced by GitHub links. -->
 <!-- To modify, edit README.md in the repo root and run: uv run python scripts/make_cli_docs.py -->
 
-# mngr: a Unix-style tool for managing agents
+# mngr: run any coding agent in parallel, anywhere
 
 [![GitHub Stars](https://img.shields.io/github/stars/imbue-ai/mngr?style=flat-square)](https://github.com/imbue-ai/mngr)
 [![PyPI](https://img.shields.io/pypi/v/imbue-mngr?style=flat-square)](https://pypi.org/project/imbue-mngr/)
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](https://github.com/imbue-ai/mngr/blob/main/./LICENSE)
 [![Open Issues](https://img.shields.io/github/issues/imbue-ai/mngr?style=flat-square)](https://github.com/imbue-ai/mngr/issues)
 
-Programmatically manage any agent, anywhere.
+`mngr` is a Unix-style tool for managing coding agents.
 
 Seamlessly scale from a single local Claude to 100s of agents across remote hosts, containers, and sandboxes.
 List all your agents, see which are blocked, and instantly connect to any of them to chat or debug.

--- a/libs/mngr/imbue/mngr/cli/check_deps_test.py
+++ b/libs/mngr/imbue/mngr/cli/check_deps_test.py
@@ -9,10 +9,13 @@ from imbue.mngr.cli.check_deps import _prompt_install_choice
 from imbue.mngr.cli.check_deps import _report_post_install_status
 from imbue.mngr.cli.check_deps import _run_installation
 from imbue.mngr.cli.check_deps import check_deps
+from imbue.mngr.utils.deps import ALL_DEPS
 from imbue.mngr.utils.deps import DependencyCategory
 from imbue.mngr.utils.deps import InstallMethod
 from imbue.mngr.utils.deps import OsName
 from imbue.mngr.utils.deps import SystemDependency
+from imbue.mngr.utils.deps import describe_install_commands
+from imbue.mngr.utils.deps import detect_os
 
 _EXISTING_DEP = SystemDependency(
     binary="python3",
@@ -77,12 +80,6 @@ def test_check_deps_no_flags(cli_runner: CliRunner) -> None:
     """Running 'mngr dependencies' with no flags outputs a status table."""
     result = cli_runner.invoke(check_deps, [])
     assert result.exit_code in (0, 1)
-    assert "System dependencies" in result.output
-
-
-def test_check_deps_all_flag(cli_runner: CliRunner) -> None:
-    """Running 'mngr dependencies --all' runs the full check/install flow."""
-    result = cli_runner.invoke(check_deps, ["--all"])
     assert "System dependencies" in result.output
 
 
@@ -203,6 +200,46 @@ def test_prompt_install_choice_interactive_choices(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(check_deps_mod, "read_tty_choice", lambda _prompt: "n")
     result = _prompt_install_choice(missing, missing_core, need_bash=False, os_name=OsName.LINUX)
     assert result is None
+
+
+def _install_identifier(dep: SystemDependency, os_name: OsName) -> str | None:
+    """Return the string that would appear in install commands for this dep, or None."""
+    if dep.install_method is None:
+        return None
+    if dep.install_method.custom_install_script is not None:
+        return dep.install_method.custom_install_script
+    if os_name == OsName.MACOS:
+        return dep.install_method.brew_package
+    if os_name == OsName.LINUX:
+        return dep.install_method.apt_package
+    return None
+
+
+def test_check_deps_all_flag_plans_correct_install_commands() -> None:
+    """The --all flow should plan installs for all missing deps and skip present ones.
+
+    Exercises the same logic as _check_deps_impl with install_all=True: compute
+    which deps are missing, generate the install commands, and verify that every
+    missing dep is covered while every present dep is excluded.
+    """
+    os_name = detect_os()
+    missing = [dep for dep in ALL_DEPS if not dep.is_available()]
+    present = [dep for dep in ALL_DEPS if dep.is_available()]
+
+    commands = describe_install_commands(missing, os_name)
+    joined = " ".join(commands)
+
+    # Every missing dep with a matching install method should appear in the commands
+    for dep in missing:
+        identifier = _install_identifier(dep, os_name)
+        if identifier is not None:
+            assert identifier in joined, f"Missing dep {dep.binary} should appear in install commands"
+
+    # Already-present deps should NOT appear in any install command
+    for dep in present:
+        identifier = _install_identifier(dep, os_name)
+        if identifier is not None:
+            assert identifier not in joined, f"Present dep {dep.binary} should NOT be in the install commands"
 
 
 def test_run_installation_with_deps_invokes_batch_install() -> None:

--- a/libs/mngr/imbue/mngr/cli/test_check_deps.py
+++ b/libs/mngr/imbue/mngr/cli/test_check_deps.py
@@ -1,0 +1,18 @@
+"""Release tests for the check_deps (mngr dependencies) command.
+
+These tests actually invoke package managers to install missing dependencies,
+so they are slow and require network access.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from imbue.mngr.cli.check_deps import check_deps
+
+
+@pytest.mark.release
+@pytest.mark.timeout(120)
+def test_check_deps_all_flag(cli_runner: CliRunner) -> None:
+    """Running 'mngr dependencies --all' runs the full check/install flow."""
+    result = cli_runner.invoke(check_deps, ["--all"])
+    assert "System dependencies" in result.output


### PR DESCRIPTION
the change to the README is from the hook

---

## Summary
- The unit test `test_check_deps_all_flag` was invoking `check_deps --all`, which runs real package manager operations (`brew install`, `apt-get install`, `curl | bash`) for missing deps, causing flaky timeouts in CI
- Moved the real end-to-end install test to a `@pytest.mark.release` test with a 120s timeout
- Replaced the unit test with `test_check_deps_all_flag_plans_correct_install_commands`, which verifies install command planning logic (missing deps get commands, present deps are excluded) without any network I/O

## Test plan
- [x] All 3418 unit/integration tests pass locally (82.92% coverage)
- [ ] CI passes on this branch
- [ ] Release test `test_check_deps_all_flag` runs successfully in release CI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>