### PR TITLE
say to record whole output of commands before filtering in claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
+- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`) without also preserving the full unfiltered output. If the filter doesn't match what you expected, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
-- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`) without also preserving the full unfiltered output. If the filter doesn't match what you expected, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
+- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`, `head`, `tail`) without also preserving the full unfiltered output. If the filter doesn't match what you expected, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
-- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`, `head`, `tail`) without also preserving the full unfiltered output. If you later need something the filter discarded, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
+- Never pipe the output of a non-instant command through `grep`, `jq`, `awk`, `head`, `tail`, or similar without also preserving the full unfiltered output. If you later need something that was discarded, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
-- Never pipe the output of a non-instant command through `grep`, `jq`, `awk`, `head`, `tail`, or similar without also preserving the full unfiltered output. If you later need something that was discarded, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
+- Never pipe the output of a non-instant command through `grep`, `jq`, `awk`, `head`, `tail`, or similar without preserving the full output. If you later need something that was discarded, you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
-- Never pipe the output of a non-instant command through `grep`, `jq`, `awk`, `head`, `tail`, or similar without preserving the full output. If you later need something that was discarded, you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
+- Never pipe the output of a non-instant command through `grep`, `jq`, `awk`, `head`, `tail`, or similar without preserving the full output. If you later need something that was discarded, you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/some_command_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Only after doing all of the above should you begin writing code.
 # Important commands and conventions:
 
 - Never run `uv sync`, always run `uv sync --all-packages` instead
-- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`, `head`, `tail`) without also preserving the full unfiltered output. If the filter doesn't match what you expected, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
+- Never pipe the output of a non-instant command through a filter (e.g. `grep`, `jq`, `awk`, `head`, `tail`) without also preserving the full unfiltered output. If you later need something the filter discarded, the full output is gone and you have to rerun the entire command. Instead, write the output to a file first and then filter the file, or use `tee` to capture and filter simultaneously (e.g. `some_command | tee /tmp/full_output.txt | grep pattern`).
 
 # Always remember these guidelines:
 


### PR DESCRIPTION
## Summary
- Adds a bullet to "Important commands and conventions" advising to never pipe non-instant commands directly through filters (grep, jq, awk) without preserving the full output
- Recommends writing to a file first or using `tee`, so that if the filter misses something you don't have to rerun the entire command

## Test plan
- [ ] Read the new bullet and confirm it's clear and well-placed

Generated with [Claude Code](https://claude.com/claude-code)