### PR TITLE
Fix agent lifecycle state detection on macOS

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/common.py
+++ b/libs/mngr/imbue/mngr/hosts/common.py
@@ -147,14 +147,22 @@ def timestamp_to_datetime(timestamp: int | None) -> datetime | None:
 
 @pure
 def _parse_ps_output(ps_output: str) -> tuple[dict[str, list[str]], dict[str, str]]:
-    """Parse ps output into children-by-ppid and comm-by-pid mappings."""
+    """Parse ps output into children-by-ppid and comm-by-pid mappings.
+
+    The comm values are normalized to basenames because ``ps -o comm=``
+    returns full executable paths on some platforms (e.g. macOS returns
+    ``/Users/.../bin/claude`` instead of ``claude``).
+    """
     children_by_ppid: dict[str, list[str]] = {}
     comm_by_pid: dict[str, str] = {}
 
     for line in ps_output.strip().split("\n"):
         line_parts = line.split()
         if len(line_parts) >= 3:
-            pid, ppid, comm = line_parts[0], line_parts[1], line_parts[2]
+            pid, ppid = line_parts[0], line_parts[1]
+            # Join remaining parts to handle paths with spaces, then extract basename
+            comm_full = " ".join(line_parts[2:])
+            comm = comm_full.rsplit("/", 1)[-1]
             comm_by_pid[pid] = comm
             if ppid not in children_by_ppid:
                 children_by_ppid[ppid] = []

--- a/libs/mngr/imbue/mngr/hosts/common_test.py
+++ b/libs/mngr/imbue/mngr/hosts/common_test.py
@@ -199,6 +199,32 @@ def test_descendant_names_finds_nested_children() -> None:
     assert result == ["bash", "claude", "node"]
 
 
+def test_descendant_names_extracts_basename_from_full_paths() -> None:
+    """On macOS, ps -o comm= returns full executable paths. Verify basenames are extracted."""
+    ps_output = "200 100 /usr/bin/bash\n300 200 /Users/user/.local/bin/claude\n400 300 node\n"
+    result = get_descendant_process_names("100", ps_output)
+    assert result == ["bash", "claude", "node"]
+
+
+def test_descendant_names_handles_paths_with_spaces() -> None:
+    """Executable paths with spaces (e.g. macOS Application Support) are handled correctly."""
+    ps_output = "200 100 /Users/user/Library/Application Support/com.app/bin/claude\n"
+    result = get_descendant_process_names("100", ps_output)
+    assert result == ["claude"]
+
+
+def test_lifecycle_running_when_descendant_has_full_path() -> None:
+    """Agent is RUNNING when ps reports full path but basename matches expected process."""
+    ps_output = "200 123 /usr/bin/bash\n300 200 /Users/user/.local/bin/claude\n"
+    assert determine_lifecycle_state("0|2.1.73|123", True, "claude", ps_output) == AgentLifecycleState.RUNNING
+
+
+def test_lifecycle_waiting_when_descendant_has_full_path() -> None:
+    """Agent is WAITING when ps reports full path and active file is absent."""
+    ps_output = "200 123 /usr/bin/bash\n300 200 /Users/user/.local/bin/claude\n"
+    assert determine_lifecycle_state("0|2.1.73|123", False, "claude", ps_output) == AgentLifecycleState.WAITING
+
+
 # =========================================================================
 # resolve_expected_process_name tests
 # =========================================================================


### PR DESCRIPTION
## Summary

On macOS, `ps -o comm=` returns full executable paths (e.g. `/Users/user/.local/bin/claude`) instead of just the basename (`claude`). This caused `_parse_ps_output` to store full paths, so the expected process name `"claude"` never matched any descendant -- making all Claude Code agents show `REPLACED` instead of correctly transitioning between `RUNNING` and `WAITING`.

This is a general issue affecting all local agents on macOS, not specific to any particular agent type or framework.

**Symptoms:**
- `mngr list` shows running agents as `REPLACED` (or `RUNNING_UNKNOWN_AGENT_TYPE` for custom types without project config)
- `RUNNING` -> `WAITING` transitions are never detected by `mngr observe`
- `mngr wait <agent> WAITING` hangs indefinitely
- In the Minds framework, the thinking agent is never notified when working agents finish

**Fix:** Normalize `comm` values to basenames when parsing `ps` output. This also fixes the `SHELL_COMMANDS` membership check, which would similarly fail if a shell was reported as `/usr/bin/bash`.

**Verified:** `mngr list` now correctly reports `WAITING` for idle Claude Code agents on macOS (previously showed `REPLACED`).

## Test plan
- [x] New tests for basename extraction from full paths
- [x] New tests for paths containing spaces (e.g. macOS `Application Support`)
- [x] New integration tests for lifecycle detection with full-path ps output
- [x] All 3245 existing tests pass
- [x] Manually verified against live agents on macOS