### PR TITLE
show startup notice banner when thinking agent is blocked

### DIFF
--- a/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice.js
+++ b/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice.js
@@ -1,0 +1,127 @@
+/**
+ * Startup notice plugin for llm-webchat.
+ *
+ * Polls GET /api/agent-startup-status to detect when the thinking agent
+ * has not yet started its Claude Code session (e.g. because it is blocked
+ * on a startup dialog like the bypass-permissions confirmation).  Shows a
+ * dismissible banner at the top of the page with instructions to resolve
+ * the issue via `mngr connect`.
+ */
+window.addEventListener("load", function () {
+  "use strict";
+
+  var POLL_INTERVAL_MS = 3000;
+  var BANNER_ID = "startup-notice-banner";
+
+  // ── Base path ────────────────────────────────────────────────
+
+  function getBasePath() {
+    var meta = document.querySelector('meta[name="llm-webchat-base-path"]');
+    return ((meta && meta.getAttribute("content")) || "").replace(/\/+$/, "");
+  }
+
+  var basePath = getBasePath();
+
+  // ── State ────────────────────────────────────────────────────
+
+  var pollTimer = null;
+  var dismissed = false;
+
+  // ── DOM helpers ──────────────────────────────────────────────
+
+  function escapeHtml(text) {
+    var div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function removeBanner() {
+    var existing = document.getElementById(BANNER_ID);
+    if (existing) {
+      existing.remove();
+    }
+  }
+
+  function showBanner(agentName) {
+    if (dismissed) return;
+    if (document.getElementById(BANNER_ID)) return;
+
+    var banner = document.createElement("div");
+    banner.id = BANNER_ID;
+    banner.style.cssText = [
+      "position: fixed",
+      "top: 0",
+      "left: 0",
+      "right: 0",
+      "z-index: 10000",
+      "background: #fff3cd",
+      "color: #664d03",
+      "padding: 10px 16px",
+      "font-size: 14px",
+      "font-family: system-ui, -apple-system, sans-serif",
+      "display: flex",
+      "align-items: center",
+      "justify-content: space-between",
+      "border-bottom: 1px solid #ffecb5",
+      "box-shadow: 0 1px 3px rgba(0,0,0,0.1)",
+    ].join("; ");
+
+    var command = agentName ? "mngr connect " + escapeHtml(agentName) : "mngr connect <agent-name>";
+
+    banner.innerHTML =
+      '<span>The thinking agent is waiting at a startup prompt. Run ' +
+      '<code style="background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 3px; font-size: 13px;">' +
+      command +
+      "</code>" +
+      " to resolve it.</span>" +
+      '<button style="background: none; border: none; cursor: pointer; font-size: 18px; color: #664d03; padding: 0 4px; margin-left: 12px; line-height: 1;" title="Dismiss">&times;</button>';
+
+    banner.querySelector("button").addEventListener("click", function () {
+      dismissed = true;
+      removeBanner();
+    });
+
+    document.body.appendChild(banner);
+  }
+
+  // ── Polling ──────────────────────────────────────────────────
+
+  function poll() {
+    fetch(basePath + "/api/agent-startup-status")
+      .then(function (response) {
+        if (!response.ok) return null;
+        return response.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+
+        if (data.started) {
+          removeBanner();
+          stopPolling();
+        } else {
+          showBanner(data.agent_name);
+        }
+      })
+      .catch(function () {
+        // Silently ignore network errors during polling.
+      });
+  }
+
+  function startPolling() {
+    poll();
+    pollTimer = setInterval(poll, POLL_INTERVAL_MS);
+  }
+
+  function stopPolling() {
+    if (pollTimer !== null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  // ── Initialization ───────────────────────────────────────────
+
+  $llm.on("ready", function () {
+    startPolling();
+  });
+});

--- a/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice.py
+++ b/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice.py
@@ -1,0 +1,63 @@
+"""Startup notice endpoint for the webchat server.
+
+Exposes ``GET /api/agent-startup-status`` which checks whether the
+thinking agent's Claude Code session has started.  The companion
+JavaScript plugin (``webchat_startup_notice.js``) polls this endpoint
+and shows a banner when the session has not yet started, prompting
+the user to connect via ``mngr connect`` to resolve any blocking
+startup dialogs (e.g. the bypass-permissions confirmation).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from llm_webchat.hookspecs import hookimpl
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+
+_AGENT_STATE_DIR: Final[str] = os.environ.get("MNGR_AGENT_STATE_DIR", "")
+_AGENT_NAME: Final[str] = os.environ.get("MNGR_AGENT_NAME", "")
+
+
+def is_session_started(agent_state_dir: str) -> bool:
+    """Check whether the Claude Code session has started.
+
+    The SessionStart hook creates a ``session_started`` file in the agent
+    state directory when the session begins.  Its absence means the agent
+    is still blocked on a startup dialog.
+    """
+    if not agent_state_dir:
+        return True
+    return Path(agent_state_dir, "session_started").exists()
+
+
+def _startup_status_endpoint(request: Request) -> JSONResponse:
+    """Handler for GET /api/agent-startup-status."""
+    agent_state_dir: str = request.app.state.startup_notice_state_dir
+    agent_name: str = request.app.state.startup_notice_agent_name
+    started = is_session_started(agent_state_dir)
+    return JSONResponse(content={"started": started, "agent_name": agent_name})
+
+
+class StartupNoticePlugin(FrozenModel):
+    """Pluggy plugin that registers the /api/agent-startup-status endpoint."""
+
+    agent_state_dir: str = Field(default=_AGENT_STATE_DIR, description="Agent state directory to check for session_started")
+    agent_name: str = Field(default=_AGENT_NAME, description="Agent name shown in the connect command")
+
+    @hookimpl
+    def endpoint(self, app: FastAPI) -> None:
+        app.state.startup_notice_state_dir = self.agent_state_dir
+        app.state.startup_notice_agent_name = self.agent_name
+        app.add_api_route(
+            "/api/agent-startup-status",
+            _startup_status_endpoint,
+            methods=["GET"],
+        )

--- a/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice_test.py
+++ b/libs/mngr_llm/imbue/mngr_llm/resources/webchat_plugins/webchat_startup_notice_test.py
@@ -1,0 +1,77 @@
+"""Tests for the startup notice webchat plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from imbue.mngr_llm.resources.webchat_plugins.webchat_startup_notice import StartupNoticePlugin
+from imbue.mngr_llm.resources.webchat_plugins.webchat_startup_notice import is_session_started
+
+
+def test_is_session_started_returns_true_when_file_exists(tmp_path: Path) -> None:
+    (tmp_path / "session_started").touch()
+    assert is_session_started(str(tmp_path)) is True
+
+
+def test_is_session_started_returns_false_when_file_missing(tmp_path: Path) -> None:
+    assert is_session_started(str(tmp_path)) is False
+
+
+def test_is_session_started_returns_true_when_dir_empty_string() -> None:
+    """When MNGR_AGENT_STATE_DIR is unset, assume started (no banner needed)."""
+    assert is_session_started("") is True
+
+
+def test_startup_notice_plugin_registers_route() -> None:
+    app = FastAPI()
+    plugin = StartupNoticePlugin(agent_state_dir="", agent_name="")
+    plugin.endpoint(app=app)
+    api_routes = [route for route in app.routes if isinstance(route, APIRoute)]
+    route_paths = [route.path for route in api_routes]
+    assert "/api/agent-startup-status" in route_paths
+
+
+def test_startup_status_endpoint_returns_started_when_no_state_dir() -> None:
+    """When agent_state_dir is empty, the endpoint reports started=true."""
+    app = FastAPI()
+    plugin = StartupNoticePlugin(agent_state_dir="", agent_name="test-agent")
+    plugin.endpoint(app=app)
+    client = TestClient(app)
+    response = client.get("/api/agent-startup-status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["started"] is True
+    assert data["agent_name"] == "test-agent"
+
+
+def test_startup_status_endpoint_returns_not_started(tmp_path: Path) -> None:
+    """The endpoint returns started=false when session_started file is missing."""
+    app = FastAPI()
+    plugin = StartupNoticePlugin(agent_state_dir=str(tmp_path), agent_name="my-mind")
+    plugin.endpoint(app=app)
+    client = TestClient(app)
+    response = client.get("/api/agent-startup-status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["started"] is False
+    assert data["agent_name"] == "my-mind"
+
+
+def test_startup_status_endpoint_returns_started_after_file_created(tmp_path: Path) -> None:
+    """The endpoint reflects the session_started file appearing at runtime."""
+    app = FastAPI()
+    plugin = StartupNoticePlugin(agent_state_dir=str(tmp_path), agent_name="my-mind")
+    plugin.endpoint(app=app)
+    client = TestClient(app)
+
+    response = client.get("/api/agent-startup-status")
+    assert response.json()["started"] is False
+
+    (tmp_path / "session_started").touch()
+
+    response = client.get("/api/agent-startup-status")
+    assert response.json()["started"] is True

--- a/libs/mngr_llm/imbue/mngr_llm/resources/webchat_server.py
+++ b/libs/mngr_llm/imbue/mngr_llm/resources/webchat_server.py
@@ -36,6 +36,7 @@ from imbue.mngr_llm.resources.webchat_plugins.webchat_agents import AgentsPlugin
 from imbue.mngr_llm.resources.webchat_plugins.webchat_default_model import DefaultModelPlugin
 from imbue.mngr_llm.resources.webchat_plugins.webchat_injected_messages import InjectedMessagesPlugin
 from imbue.mngr_llm.resources.webchat_plugins.webchat_register_conversations import RegisterConversationsPlugin
+from imbue.mngr_llm.resources.webchat_plugins.webchat_startup_notice import StartupNoticePlugin
 from imbue.mngr_llm.resources.webchat_plugins.webchat_system_prompt import create_system_prompt_plugin
 
 _HOST_NAME: Final[str] = os.environ.get("MNG_HOST_NAME", "")
@@ -139,6 +140,13 @@ def _setup_default_model_plugin() -> None:
     get_plugin_manager().register(wrapped)
 
 
+def _setup_startup_notice_plugin() -> None:
+    """Create and register the startup-notice plugin with the llm-webchat plugin manager."""
+    plugin = StartupNoticePlugin()
+    wrapped = types.SimpleNamespace(endpoint=plugin.endpoint)
+    get_plugin_manager().register(wrapped)
+
+
 def _inject_plugin_static_files() -> None:
     """Register JS plugins and static files (CSS) with llm-webchat.
 
@@ -149,9 +157,10 @@ def _inject_plugin_static_files() -> None:
     agents_css = _resolve_resource_path("webchat_agents.css")
     injected_messages_js = _resolve_resource_path("webchat_injected_messages.js")
     default_model_js = _resolve_resource_path("webchat_default_model.js")
+    startup_notice_js = _resolve_resource_path("webchat_startup_notice.js")
     _prepend_to_env_list(
         "LLM_WEBCHAT_JAVASCRIPT_PLUGINS",
-        [agents_js, injected_messages_js, default_model_js],
+        [agents_js, injected_messages_js, default_model_js, startup_notice_js],
     )
     _prepend_to_env_list("LLM_WEBCHAT_STATIC_PATHS", [agents_css])
 
@@ -227,6 +236,7 @@ def main() -> None:
         _setup_default_model_plugin()
         _setup_injected_messages_plugin()
         _setup_register_conversations_plugin()
+        _setup_startup_notice_plugin()
         _setup_system_prompt_plugin()
         _inject_plugin_static_files()
         _bridge_web_server_port_env_var()


### PR DESCRIPTION
## Summary
- When a mind's thinking agent is stuck at a startup dialog (e.g. the bypass-permissions confirmation in dev mode), the web UI now shows a dismissible amber banner prompting the user to run `mngr connect <name>` to resolve it
- Detection works by polling `GET /api/agent-startup-status`, which checks for the `session_started` file that the SessionStart hook creates -- its absence while the agent process is alive means it hasn't gotten past startup dialogs yet
- Banner auto-removes once the session starts, and is dismissible via the X button

## Screenshot

<img width="2000" height="472" alt="1" src="https://github.com/user-attachments/assets/191f15c4-06cb-448b-9830-8a9153689277" />

## New files
- `webchat_startup_notice.py` -- Python plugin: exposes the status endpoint, reads from `MNGR_AGENT_STATE_DIR`
- `webchat_startup_notice.js` -- JS plugin: polls every 3s, injects/removes the banner
- `webchat_startup_notice_test.py` -- 7 unit tests

## Test plan
- [x] All 176 mngr_llm tests pass (52.80% coverage, above 40% threshold)
- [x] Manually verified in dev mode (screenshot above)
- [ ] CI passes