### PR TITLE
fix gitignore check when .claude is a symlink

### DIFF
--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -917,8 +917,12 @@ def _has_api_credentials_available(
 def _check_settings_local_gitignored(host: OnlineHostInterface, repo_path: Path) -> None:
     """Verify .claude/settings.local.json is gitignored in the given repo path.
 
+    When .claude is a symlink, resolves it and checks the resolved path against
+    .gitignore instead (e.g. .agents/settings.local.json if .claude -> .agents).
+
     Raises PluginMngrError if the file is not gitignored. Silently returns
-    if the path is not a git repository.
+    if the path is not a git repository or if the .claude symlink target is
+    outside the repo (since git won't track it).
     """
     settings_relative = Path(".claude") / "settings.local.json"
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -958,7 +958,7 @@ def _check_settings_local_gitignored(host: OnlineHostInterface, repo_path: Path)
     )
     if not result.success:
         raise PluginMngrError(
-            f".claude/settings.local.json is not gitignored in {repo_path}.\n"
+            f"'{settings_relative}' is not gitignored in {repo_path}.\n"
             "mngr needs to write Claude hooks to this file, but it would appear as an unstaged change.\n"
             f"Add '{settings_relative}' to your .gitignore and try again. (original error: {result.stderr})"
         )

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -930,6 +930,27 @@ def _check_settings_local_gitignored(host: OnlineHostInterface, repo_path: Path)
     if not is_git_repo.success:
         return
 
+    # Resolve symlinks so git check-ignore doesn't fail with
+    # "fatal: pathspec '...' is beyond a symbolic link" when .claude is a symlink.
+    # Only runs when .claude is actually a symlink. Resolves both .claude and the
+    # repo root (in case repo_path itself contains symlinks) to compute the correct
+    # relative path for git check-ignore.
+    resolve_result = host.execute_idempotent_command(
+        "test -L .claude && realpath .claude && realpath .",
+        cwd=repo_path,
+        timeout_seconds=5.0,
+    )
+    if resolve_result.success:
+        lines = resolve_result.stdout.strip().splitlines()
+        if len(lines) == 2:
+            resolved_claude_dir = Path(lines[0])
+            resolved_repo_root = Path(lines[1])
+            try:
+                settings_relative = resolved_claude_dir.relative_to(resolved_repo_root) / "settings.local.json"
+            except ValueError:
+                # Symlink target is outside the repo -- git won't track it, so no gitignore needed.
+                return
+
     result = host.execute_idempotent_command(
         f"git check-ignore -q {shlex.quote(str(settings_relative))}",
         cwd=repo_path,
@@ -939,7 +960,7 @@ def _check_settings_local_gitignored(host: OnlineHostInterface, repo_path: Path)
         raise PluginMngrError(
             f".claude/settings.local.json is not gitignored in {repo_path}.\n"
             "mngr needs to write Claude hooks to this file, but it would appear as an unstaged change.\n"
-            f"Add '.claude/settings.local.json' to your .gitignore and try again. (original error: {result.stderr})"
+            f"Add '{settings_relative}' to your .gitignore and try again. (original error: {result.stderr})"
         )
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -54,6 +54,7 @@ from imbue.mngr_claude.plugin import ProvisioningContext
 from imbue.mngr_claude.plugin import WaitingReason
 from imbue.mngr_claude.plugin import _build_install_command_hint
 from imbue.mngr_claude.plugin import _build_settings_json
+from imbue.mngr_claude.plugin import _check_settings_local_gitignored
 from imbue.mngr_claude.plugin import _claude_json_has_primary_api_key
 from imbue.mngr_claude.plugin import _generate_installed_plugins_content
 from imbue.mngr_claude.plugin import _get_claude_version
@@ -803,6 +804,67 @@ def test_preflight_check_skips_when_not_git_repo(
         agent_config=config,
         mngr_ctx=temp_mngr_ctx,
     )
+
+
+def test_gitignore_check_passes_when_claude_is_symlink_and_resolved_path_gitignored(
+    local_provider: LocalProviderInstance, tmp_path: Path
+) -> None:
+    """gitignore check should pass when .claude is a symlink and the resolved path is gitignored."""
+    host = local_provider.create_host(HostName("localhost"))
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    init_git_repo(repo_dir, initial_commit=False)
+
+    # Create .agents directory and symlink .claude -> .agents
+    (repo_dir / ".agents").mkdir()
+    (repo_dir / ".claude").symlink_to(".agents")
+
+    # Gitignore the resolved path (what git actually sees)
+    (repo_dir / ".gitignore").write_text(".agents/settings.local.json\n")
+
+    # Should not raise
+    _check_settings_local_gitignored(host, repo_dir)
+
+
+def test_gitignore_check_raises_when_claude_is_symlink_and_resolved_path_not_gitignored(
+    local_provider: LocalProviderInstance, tmp_path: Path
+) -> None:
+    """gitignore check should raise when .claude is a symlink and the resolved path is not gitignored."""
+    host = local_provider.create_host(HostName("localhost"))
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    init_git_repo(repo_dir, initial_commit=False)
+
+    # Create .agents directory and symlink .claude -> .agents
+    (repo_dir / ".agents").mkdir()
+    (repo_dir / ".claude").symlink_to(".agents")
+
+    # Gitignore the symlink path (wrong -- git won't match this)
+    (repo_dir / ".gitignore").write_text(".claude/settings.local.json\n")
+
+    with pytest.raises(PluginMngrError, match="not gitignored") as exc_info:
+        _check_settings_local_gitignored(host, repo_dir)
+
+    # Error message should tell the user to add the resolved path, not the symlink path
+    assert ".agents/settings.local.json" in str(exc_info.value)
+
+
+def test_gitignore_check_skips_when_claude_symlink_points_outside_repo(
+    local_provider: LocalProviderInstance, tmp_path: Path
+) -> None:
+    """gitignore check should silently return when .claude symlink target is outside the repo."""
+    host = local_provider.create_host(HostName("localhost"))
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    init_git_repo(repo_dir, initial_commit=False)
+
+    # Create a directory outside the repo and symlink .claude to it
+    outside_dir = tmp_path / "outside_agents"
+    outside_dir.mkdir()
+    (repo_dir / ".claude").symlink_to(outside_dir)
+
+    # Should not raise -- target is outside the repo, git won't track it
+    _check_settings_local_gitignored(host, repo_dir)
 
 
 def test_configure_readiness_hooks_raises_when_not_gitignored(


### PR DESCRIPTION
## Summary
- `_check_settings_local_gitignored` fails with "fatal: pathspec is beyond a symbolic link" when `.claude` is a symlink (e.g. `.claude -> .agents`), then raises a misleading error telling users to add `.claude/settings.local.json` to `.gitignore`
- Fix: resolve symlinks via `realpath` before passing to `git check-ignore`, so the check and error message use the resolved path (e.g. `.agents/settings.local.json`)
- Handle edge case where symlink target is outside the repo (silently skip -- git won't track it)

## Test plan
- [x] 3 new unit tests: symlink with correct gitignore, symlink with wrong gitignore, symlink outside repo
- [x] 4 existing gitignore tests still pass
- [x] Full suite: 370 passed, 81.81% coverage
- [x] Manual verification in repo with `.claude -> .agents` symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)