### PR TITLE
fix observe crash on stale agent references

### DIFF
--- a/libs/mngr/imbue/mngr/api/discovery_events.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events.py
@@ -24,6 +24,7 @@ from imbue.imbue_common.logging import generate_log_event_id
 from imbue.imbue_common.pure import pure
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import BaseMngrError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
@@ -622,7 +623,7 @@ def _write_unfiltered_full_snapshot_logged(mngr_ctx: MngrContext, error_behavior
     """Run an unfiltered full snapshot, logging any errors instead of raising."""
     try:
         _write_unfiltered_full_snapshot(mngr_ctx, error_behavior)
-    except (MngrError, OSError) as e:
+    except (BaseMngrError, OSError) as e:
         logger.warning("Failed to write discovery snapshot: {}", e)
 
 
@@ -699,7 +700,7 @@ def run_discovery_stream(
             try:
                 _write_unfiltered_full_snapshot(mngr_ctx, error_behavior)
                 # The tail thread will pick up the new snapshot and emit it
-            except (MngrError, OSError) as e:
+            except (BaseMngrError, OSError) as e:
                 logger.warning("Discovery stream poll failed (continuing): {}", e)
     except KeyboardInterrupt:
         pass

--- a/libs/mngr/imbue/mngr/api/discovery_events.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events.py
@@ -25,7 +25,6 @@ from imbue.imbue_common.pure import pure
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import BaseMngrError
-from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
@@ -343,7 +342,7 @@ def emit_discovery_events_for_host(
         # Emit agent events with full certified_data from the host's filesystem
         for discovered_agent in discovered_agents:
             emit_agent_discovered(config, discovered_agent)
-    except (MngrError, OSError, ValueError) as e:
+    except (BaseMngrError, OSError, ValueError) as e:
         logger.warning("Failed to emit discovery events: {}", e)
 
 

--- a/libs/mngr/imbue/mngr/api/observe.py
+++ b/libs/mngr/imbue/mngr/api/observe.py
@@ -33,6 +33,7 @@ from imbue.mngr.api.discovery_events import parse_discovery_event_line
 from imbue.mngr.api.list import list_agents
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import BaseMngrError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.primitives import AgentId
@@ -381,7 +382,7 @@ class AgentObserver(MutableModel):
                     try:
                         with log_span("Performing periodic full state snapshot"):
                             self._do_full_state_snapshot()
-                    except (MngrError, OSError) as e:
+                    except (BaseMngrError, OSError) as e:
                         logger.warning("Periodic full state snapshot failed (continuing): {}", e)
             except KeyboardInterrupt:
                 pass
@@ -471,7 +472,7 @@ class AgentObserver(MutableModel):
             )
             with self._lock:
                 self._events_processes[host_id_str] = process
-        except (MngrError, OSError) as e:
+        except (BaseMngrError, OSError) as e:
             logger.debug("Failed to start activity stream for host {}: {}", host_name, e)
 
     def _stop_activity_stream(self, host_id_str: str) -> None:
@@ -519,7 +520,7 @@ class AgentObserver(MutableModel):
                     break
                 try:
                     self._fetch_and_emit_agent_state_for_host(hid)
-                except (MngrError, OSError) as e:
+                except (BaseMngrError, OSError) as e:
                     logger.warning("Failed to fetch agent state for host {}: {}", hid, e)
 
     def _fetch_and_emit_agent_state_for_host(self, host_id_str: str) -> None:

--- a/libs/mngr/imbue/mngr/api/observe.py
+++ b/libs/mngr/imbue/mngr/api/observe.py
@@ -400,7 +400,7 @@ class AgentObserver(MutableModel):
     def _start_discovery_stream(self) -> None:
         """Start the 'mngr observe --discovery-only' subprocess for host discovery."""
         self._discovery_stream_process = self._concurrency_group.run_process_in_background(
-            command=[self.mngr_binary, "observe", "--discovery-only", "--quiet"],
+            command=[self.mngr_binary, "observe", "--discovery-only", "--quiet", "--on-error", "continue"],
             on_output=self._on_discovery_stream_output,
         )
 


### PR DESCRIPTION
## Summary
- Pass `--on-error continue` to the discovery subprocess spawned by `AgentObserver`, so stale agent references (`AgentNotFoundOnHostError`) don't crash the entire observe loop
- Widen exception catches from `MngrError` to `BaseMngrError` in `discovery_events.py` and `observe.py` error handlers, since transient errors like `AgentNotFoundOnHostError` extend `BaseMngrError` (not `MngrError`) and were slipping through

## Context
The observer's own direct `list_agents` calls already used `ErrorBehavior.CONTINUE`. The inconsistency was that the child discovery subprocess inherited the CLI default of `ABORT`. Additionally, several `except MngrError` clauses missed `BaseMngrError` subclasses entirely.

## Test plan
- [x] 3292 unit/integration tests pass (106s)
- [x] 3475 tests pass with coverage (80.42%, autofix run)
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)