### PR TITLE
Fix custom license identifiers for hatchling compatibility

### DIFF
--- a/apps/claude_web_chat/pyproject.toml
+++ b/apps/claude_web_chat/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "uvicorn>=0.34",
     "watchdog>=4.0",
 ]
-license = "FCL-1.0-MIT"
+license = "LicenseRef-FCL-1.0-MIT"
 license-files = [
     "LICENSE",
 ]

--- a/apps/cloudflare_forwarding/pyproject.toml
+++ b/apps/cloudflare_forwarding/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "modal>=1.3.1",
     "pydantic>=2.0",
 ]
-license = "FCL-1.0-MIT"
+license = "LicenseRef-FCL-1.0-MIT"
 license-files = [
     "LICENSE",
 ]

--- a/apps/minds/pyproject.toml
+++ b/apps/minds/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "uvicorn>=0.32.0",
     "websockets>=13.0",
 ]
-license = "FCL-1.0-MIT"
+license = "LicenseRef-FCL-1.0-MIT"
 license-files = [
     "LICENSE",
 ]


### PR DESCRIPTION
## Summary
- Changed `license = "FCL-1.0-MIT"` to `license = "LicenseRef-FCL-1.0-MIT"` in three app pyproject.toml files (cloudflare_forwarding, claude_web_chat, minds)
- Hatchling requires non-standard SPDX license identifiers to use the `LicenseRef-` prefix per PEP 639

## Test plan
- [x] Verified `uv build` succeeds for all three affected projects

Generated with [Claude Code](https://claude.com/claude-code)