### PR TITLE
fix flaky test_on_after_provisioning_adopts_session_by_id

### DIFF
--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -2431,9 +2431,7 @@ def test_on_after_provisioning_adopts_session_by_id(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
     """on_after_provisioning should find session by ID, copy project dir, and write session ID."""
-    config = ClaudeAgentConfig(check_installation=False, auto_dismiss_dialogs=True)
-    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx, agent_config=config)
-    _init_git_with_gitignore(agent.work_dir)
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
 
     # Set up a session under ~/.claude/ (HOME is already a temp dir via autouse fixture)
     project_dir = Path.home() / ".claude" / "projects" / "test-project"
@@ -2451,7 +2449,6 @@ def test_on_after_provisioning_adopts_session_by_id(
     )
 
     with patch.dict("os.environ", {"CLAUDE_CONFIG_DIR": ""}):
-        agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
         agent.on_after_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
     # Session ID should be written
@@ -2503,9 +2500,7 @@ def test_on_after_provisioning_finds_session_despite_claude_config_dir(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
     """Session lookup should find sessions in ~/.claude/ even when CLAUDE_CONFIG_DIR points elsewhere."""
-    config = ClaudeAgentConfig(check_installation=False, auto_dismiss_dialogs=True)
-    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx, agent_config=config)
-    _init_git_with_gitignore(agent.work_dir)
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
 
     # Session lives under ~/.claude/ (HOME is already a temp dir via autouse fixture)
     project_dir = Path.home() / ".claude" / "projects" / "test-project"
@@ -2529,7 +2524,6 @@ def test_on_after_provisioning_finds_session_despite_claude_config_dir(
     with patch.dict(
         "os.environ", {"CLAUDE_CONFIG_DIR": str(agent_config_dir), "ORIGINAL_CLAUDE_CONFIG_DIR": home_claude}
     ):
-        agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
         agent.on_after_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
     assert (agent_state_dir / "claude_session_id").read_text() == target_session_id
@@ -2545,9 +2539,7 @@ def test_on_after_provisioning_adopts_session_from_jsonl_path(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
     """on_after_provisioning should accept a .jsonl file path and extract the session ID."""
-    config = ClaudeAgentConfig(check_installation=False, auto_dismiss_dialogs=True)
-    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx, agent_config=config)
-    _init_git_with_gitignore(agent.work_dir)
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
 
     # Create a session file at an arbitrary path
     project_dir = tmp_path / "my_sessions" / "some-project"
@@ -2563,7 +2555,6 @@ def test_on_after_provisioning_adopts_session_from_jsonl_path(
         plugin_data={"adopt_session": (str(session_file),)},
     )
 
-    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
     agent.on_after_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
     # Session ID should be the stem of the file


### PR DESCRIPTION
## Summary
- Remove unnecessary `provision()` calls from three `on_after_provisioning` tests that were causing intermittent timeouts against the 10-second pytest timeout
- `provision()` does expensive work (shell commands, git checks, background thread management, script provisioning) that `on_after_provisioning()` does not depend on
- Matches the pattern already used by the sibling test `test_on_after_provisioning_raises_when_session_not_found`, which calls `on_after_provisioning()` directly

## Test plan
- [x] All 370 tests in `libs/mngr_claude` pass (81.68% coverage)
- [x] Target test runs consistently in ~2s (down from occasional 7-8s)
- [x] Ran target test 10x in isolation and 10x with full suite -- no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)