### PR TITLE
retry modal rate limit errors

### DIFF
--- a/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
@@ -41,6 +41,7 @@ from imbue.mngr_modal.backend import _lookup_persistent_app_with_env_retry
 from imbue.mngr_modal.backend import register_provider_backend
 from imbue.mngr_modal.config import ModalMode
 from imbue.mngr_modal.config import ModalProviderConfig
+from imbue.mngr_modal.errors import ModalMngrError
 from imbue.mngr_modal.errors import NoSnapshotsModalMngrError
 from imbue.mngr_modal.instance import HOST_VOLUME_INFIX
 from imbue.mngr_modal.instance import HostRecord
@@ -1250,9 +1251,9 @@ def test_modal_volume_wrapper(testing_provider: ModalProviderInstance) -> None:
 
 
 def test_modal_volume_translates_rate_limit_error_to_mngr_error() -> None:
-    """ModalProxyRateLimitError from the proxy layer is translated to MngrError."""
+    """ModalProxyRateLimitError from the proxy layer is translated to ModalMngrError."""
     vol = ModalVolume.model_construct(modal_volume=_RateLimitingVolumeStub())
-    with pytest.raises(MngrError, match="rate limit exceeded"):
+    with pytest.raises(ModalMngrError, match="rate limit exceeded"):
         vol.listdir("/any")
 
 

--- a/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
@@ -6,6 +6,7 @@ Modal credentials or SSH connections.
 """
 
 import contextlib
+from collections.abc import Mapping
 from datetime import datetime
 from datetime import timezone
 from io import StringIO
@@ -64,10 +65,40 @@ from imbue.mngr_modal.testing import make_snapshot
 from imbue.mngr_modal.testing import make_testing_modal_interface
 from imbue.mngr_modal.testing import make_testing_provider
 from imbue.mngr_modal.testing import setup_host_with_sandbox
+from imbue.mngr_modal.volume import ModalVolume
 from imbue.mngr_modal.volume import _proxy_file_entry_type_to_volume_file_type
+from imbue.modal_proxy.data_types import FileEntry
 from imbue.modal_proxy.data_types import FileEntryType as ProxyFileEntryType
 from imbue.modal_proxy.errors import ModalProxyError
+from imbue.modal_proxy.errors import ModalProxyRateLimitError
+from imbue.modal_proxy.interface import VolumeInterface
 from imbue.modal_proxy.testing import TestingModalInterface
+
+
+class _RateLimitingVolumeStub(VolumeInterface):
+    """Stub that raises ModalProxyRateLimitError on every operation."""
+
+    def get_name(self) -> str | None:
+        return None
+
+    def listdir(self, path: str) -> list[FileEntry]:
+        raise ModalProxyRateLimitError("rate limit exceeded")
+
+    def read_file(self, path: str) -> bytes:
+        raise ModalProxyRateLimitError("rate limit exceeded")
+
+    def remove_file(self, path: str, *, recursive: bool = False) -> None:
+        raise ModalProxyRateLimitError("rate limit exceeded")
+
+    def write_files(self, file_contents_by_path: Mapping[str, bytes]) -> None:
+        raise ModalProxyRateLimitError("rate limit exceeded")
+
+    def reload(self) -> None:
+        pass
+
+    def commit(self) -> None:
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Host Record CRUD Tests
@@ -1216,6 +1247,13 @@ def test_modal_volume_wrapper(testing_provider: ModalProviderInstance) -> None:
     # Remove directory
     vol.write_files({"/rmdir/file.txt": b"x"})
     vol.remove_directory("/rmdir")
+
+
+def test_modal_volume_translates_rate_limit_error_to_mngr_error() -> None:
+    """ModalProxyRateLimitError from the proxy layer is translated to MngrError."""
+    vol = ModalVolume.model_construct(modal_volume=_RateLimitingVolumeStub())
+    with pytest.raises(MngrError, match="rate limit exceeded"):
+        vol.listdir("/any")
 
 
 # ---------------------------------------------------------------------------

--- a/libs/mngr_modal/imbue/mngr_modal/volume.py
+++ b/libs/mngr_modal/imbue/mngr_modal/volume.py
@@ -6,10 +6,10 @@ from typing import TypeVar
 
 from pydantic import Field
 
-from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import VolumeFile
 from imbue.mngr.interfaces.data_types import VolumeFileType
 from imbue.mngr.interfaces.volume import BaseVolume
+from imbue.mngr_modal.errors import ModalMngrError
 from imbue.modal_proxy.data_types import FileEntry as ProxyFileEntry
 from imbue.modal_proxy.data_types import FileEntryType as ProxyFileEntryType
 from imbue.modal_proxy.errors import ModalProxyInternalError
@@ -21,7 +21,7 @@ _R = TypeVar("_R")
 
 
 def _translate_transient_proxy_errors(func: Callable[_P, _R]) -> Callable[_P, _R]:
-    """Translate transient ModalProxy errors to MngrError at the mngr_modal boundary.
+    """Translate transient ModalProxy errors to ModalMngrError at the mngr_modal boundary.
 
     Rate-limit and internal errors that survive retry are translated so that
     the mngr layer's ``except (MngrError, OSError)`` guards can catch them
@@ -34,7 +34,7 @@ def _translate_transient_proxy_errors(func: Callable[_P, _R]) -> Callable[_P, _R
         try:
             return func(*args, **kwargs)
         except (ModalProxyRateLimitError, ModalProxyInternalError) as e:
-            raise MngrError(str(e)) from e
+            raise ModalMngrError(str(e)) from e
 
     return wrapper
 

--- a/libs/mngr_modal/imbue/mngr_modal/volume.py
+++ b/libs/mngr_modal/imbue/mngr_modal/volume.py
@@ -1,13 +1,42 @@
+from collections.abc import Callable
+from functools import wraps
 from typing import Mapping
+from typing import ParamSpec
+from typing import TypeVar
 
 from pydantic import Field
 
+from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import VolumeFile
 from imbue.mngr.interfaces.data_types import VolumeFileType
 from imbue.mngr.interfaces.volume import BaseVolume
 from imbue.modal_proxy.data_types import FileEntry as ProxyFileEntry
 from imbue.modal_proxy.data_types import FileEntryType as ProxyFileEntryType
+from imbue.modal_proxy.errors import ModalProxyInternalError
+from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.interface import VolumeInterface
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _translate_transient_proxy_errors(func: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Translate transient ModalProxy errors to MngrError at the mngr_modal boundary.
+
+    Rate-limit and internal errors that survive retry are translated so that
+    the mngr layer's ``except (MngrError, OSError)`` guards can catch them
+    instead of letting them crash the process.  Semantic errors like
+    ModalProxyNotFoundError are left untouched.
+    """
+
+    @wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return func(*args, **kwargs)
+        except (ModalProxyRateLimitError, ModalProxyInternalError) as e:
+            raise MngrError(str(e)) from e
+
+    return wrapper
 
 
 def _proxy_file_entry_type_to_volume_file_type(proxy_type: ProxyFileEntryType) -> VolumeFileType:
@@ -39,18 +68,23 @@ class ModalVolume(BaseVolume):
 
     modal_volume: VolumeInterface = Field(frozen=True, description="The underlying volume interface")
 
+    @_translate_transient_proxy_errors
     def listdir(self, path: str) -> list[VolumeFile]:
         entries = self.modal_volume.listdir(path)
         return [_proxy_file_entry_to_volume_file(e) for e in entries]
 
+    @_translate_transient_proxy_errors
     def read_file(self, path: str) -> bytes:
         return self.modal_volume.read_file(path)
 
+    @_translate_transient_proxy_errors
     def remove_file(self, path: str, *, recursive: bool = False) -> None:
         self.modal_volume.remove_file(path, recursive=recursive)
 
+    @_translate_transient_proxy_errors
     def remove_directory(self, path: str) -> None:
         self.modal_volume.remove_file(path, recursive=True)
 
+    @_translate_transient_proxy_errors
     def write_files(self, file_contents_by_path: Mapping[str, bytes]) -> None:
         self.modal_volume.write_files(file_contents_by_path)

--- a/libs/modal_proxy/imbue/modal_proxy/direct.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct.py
@@ -41,6 +41,7 @@ from imbue.modal_proxy.errors import ModalProxyError
 from imbue.modal_proxy.errors import ModalProxyInternalError
 from imbue.modal_proxy.errors import ModalProxyInvalidError
 from imbue.modal_proxy.errors import ModalProxyNotFoundError
+from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyRemoteError
 from imbue.modal_proxy.errors import ModalProxyTypeError
 from imbue.modal_proxy.interface import AppInterface
@@ -75,6 +76,8 @@ def _translate_modal_error(e: modal.exception.Error) -> ModalProxyError:
         return ModalProxyInvalidError(str(e))
     if isinstance(e, modal.exception.InternalError):
         return ModalProxyInternalError(str(e))
+    if isinstance(e, modal.exception.ResourceExhaustedError):
+        return ModalProxyRateLimitError(str(e))
     if isinstance(e, modal.exception.RemoteError):
         return ModalProxyRemoteError(str(e))
     return ModalProxyError(str(e))
@@ -161,9 +164,11 @@ def _unwrap_secret(iface: SecretInterface) -> modal.Secret:
 # Retry parameters for volume operations
 # ---------------------------------------------------------------------------
 
-_VOLUME_RETRY = retry_if_exception_type((modal.exception.InternalError, StreamTerminatedError, ProtocolError))
-_VOLUME_STOP = stop_after_attempt(3)
-_VOLUME_WAIT = wait_exponential(multiplier=1, min=1, max=3)
+_VOLUME_RETRY = retry_if_exception_type(
+    (modal.exception.InternalError, StreamTerminatedError, ProtocolError, modal.exception.ResourceExhaustedError)
+)
+_VOLUME_STOP = stop_after_attempt(5)
+_VOLUME_WAIT = wait_exponential(multiplier=1, min=1, max=10)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/modal_proxy/imbue/modal_proxy/direct_test.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct_test.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Mapping
 from typing import Sequence
 
+import modal.exception
 import pytest
 from modal.stream_type import StreamType as ModalStreamType
 from modal.volume import FileEntryType as ModalFileEntryType
@@ -18,11 +19,13 @@ from imbue.modal_proxy.direct import DirectVolume
 from imbue.modal_proxy.direct import _to_file_entry_type
 from imbue.modal_proxy.direct import _to_modal_stream_type
 from imbue.modal_proxy.direct import _translate_modal_cli_not_found
+from imbue.modal_proxy.direct import _translate_modal_error
 from imbue.modal_proxy.direct import _unwrap_app
 from imbue.modal_proxy.direct import _unwrap_image
 from imbue.modal_proxy.direct import _unwrap_secret
 from imbue.modal_proxy.direct import _unwrap_volume
 from imbue.modal_proxy.errors import ModalProxyError
+from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyTypeError
 from imbue.modal_proxy.interface import AppInterface
 from imbue.modal_proxy.interface import ImageInterface
@@ -170,3 +173,13 @@ def test_translate_modal_cli_not_found_raises_for_modal() -> None:
 def test_translate_modal_cli_not_found_reraises_for_other() -> None:
     with pytest.raises(FileNotFoundError):
         _translate_modal_cli_not_found(_make_file_not_found("other_binary"))
+
+
+# --- Error translation tests ---
+
+
+def test_translate_resource_exhausted_to_rate_limit_error() -> None:
+    modal_err = modal.exception.ResourceExhaustedError("VolumeListFiles rate limit exceeded")
+    result = _translate_modal_error(modal_err)
+    assert isinstance(result, ModalProxyRateLimitError)
+    assert "rate limit" in str(result)

--- a/libs/modal_proxy/imbue/modal_proxy/errors.py
+++ b/libs/modal_proxy/imbue/modal_proxy/errors.py
@@ -22,5 +22,9 @@ class ModalProxyInternalError(ModalProxyError):
     """Raised on transient Modal internal errors."""
 
 
+class ModalProxyRateLimitError(ModalProxyError):
+    """Raised when a Modal API rate limit is exceeded."""
+
+
 class ModalProxyRemoteError(ModalProxyError):
     """Raised on Modal remote execution errors."""


### PR DESCRIPTION
## Summary
- Add `ResourceExhaustedError` to Modal volume retry config (5 attempts, 1-10s exponential backoff) so rate-limited `VolumeListFiles` calls are automatically retried
- Add `ModalProxyRateLimitError` to the error taxonomy for callers to distinguish rate limits from other errors
- Translate transient proxy errors (rate limit, internal) to `ModalMngrError` at the mngr_modal boundary so mngr's existing `except (MngrError, OSError)` guards catch them if retries exhaust

## Context
Multiple concurrent `mngr events` processes spawned by `mngr observe` (via `mngr notify`) all call `volume.listdir()` simultaneously during event source discovery, hitting Modal's `VolumeListFiles` rate limit. The existing retry config only covered `InternalError`/`StreamTerminatedError`/`ProtocolError`, so `ResourceExhaustedError` crashed the entire process.

## Test plan
- [x] `libs/modal_proxy` tests: 68 passed
- [x] `libs/mngr_modal` tests: 374 passed
- [x] `libs/mngr` tests: 3331 passed
- [x] New test: `test_translate_resource_exhausted_to_rate_limit_error` verifies error mapping
- [x] New test: `test_modal_volume_translates_rate_limit_error_to_mngr_error` verifies boundary translation

Generated with [Claude Code](https://claude.com/claude-code)