### PR TITLE
fix bug in finding .claude.json when ORIGINAL_CLAUDE_CONFIG_DIR is set

### DIFF
--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
@@ -455,7 +455,7 @@ PREVENT_HARDCODED_CLAUDE_DIR = RegexRatchetRule(
         "Use the accessor functions from claude_config.py instead of hardcoding "
         "Path.home() / '.claude' or Path.home() / '.claude.json'. "
         "For the config directory: get_claude_config_dir() / get_user_claude_config_dir(). "
-        "For the config file: get_claude_config_path() / get_user_claude_config_path(). "
+        "For the user config file: find_user_claude_config(). "
         "This allows paths to be overridden via CLAUDE_CONFIG_DIR "
         "and ORIGINAL_CLAUDE_CONFIG_DIR environment variables."
     ),

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -113,19 +113,24 @@ def get_claude_config_path() -> Path:
     return Path.home() / ".claude.json"
 
 
-def get_user_claude_config_path() -> Path:
-    """Return the path to the user-scope Claude config file (.claude.json).
+def find_user_claude_config() -> Path:
+    """Find the user-scope Claude config file (.claude.json).
 
-    Inside an mngr agent, $CLAUDE_CONFIG_DIR points to the agent's config dir.
-    Use this function to get the user's original .claude.json path.
+    Searches candidate locations and returns the first that exists. If no
+    config file exists on disk yet, returns the default creation path
+    (~/.claude.json).
 
-    Resolution order:
-    1. If $ORIGINAL_CLAUDE_CONFIG_DIR is set, check two locations:
-       a. $ORIGINAL_CLAUDE_CONFIG_DIR/.claude.json (per-agent / custom CLAUDE_CONFIG_DIR convention)
-       b. Parent dir: e.g. ~/.claude -> ~/.claude.json (default layout where the config
-          file lives *beside* the config dir, not inside it)
-       Returns whichever exists, preferring (a). If neither exists, returns (a).
-    2. Falls back to get_claude_config_path()
+    Inside an mngr agent, $CLAUDE_CONFIG_DIR points to the agent's isolated
+    config dir. This function looks for the *user's* original config instead.
+
+    Search order when $ORIGINAL_CLAUDE_CONFIG_DIR is set:
+    1. $ORIGINAL_CLAUDE_CONFIG_DIR/.claude.json (custom CLAUDE_CONFIG_DIR convention)
+    2. Parent of $ORIGINAL_CLAUDE_CONFIG_DIR / .claude.json (default layout where the
+       config file lives *beside* the config dir: ~/.claude/ dir -> ~/.claude.json file)
+    3. Falls through to ~/.claude.json (default creation path)
+
+    Without $ORIGINAL_CLAUDE_CONFIG_DIR:
+    1. ~/.claude.json (Claude Code's default location)
     """
     original = os.environ.get("ORIGINAL_CLAUDE_CONFIG_DIR")
     if original:
@@ -136,8 +141,8 @@ def get_user_claude_config_path() -> Path:
         beside = original_path.parent / ".claude.json"
         if beside.exists():
             return beside
-        return inside
-    return get_claude_config_path()
+
+    return Path.home() / ".claude.json"
 
 
 def get_claude_config_backup_path() -> Path:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -119,13 +119,24 @@ def get_user_claude_config_path() -> Path:
     Inside an mngr agent, $CLAUDE_CONFIG_DIR points to the agent's config dir.
     Use this function to get the user's original .claude.json path.
 
-    Resolution order mirrors get_user_claude_config_dir():
-    1. $ORIGINAL_CLAUDE_CONFIG_DIR/.claude.json
+    Resolution order:
+    1. If $ORIGINAL_CLAUDE_CONFIG_DIR is set, check two locations:
+       a. $ORIGINAL_CLAUDE_CONFIG_DIR/.claude.json (per-agent / custom CLAUDE_CONFIG_DIR convention)
+       b. Parent dir: e.g. ~/.claude -> ~/.claude.json (default layout where the config
+          file lives *beside* the config dir, not inside it)
+       Returns whichever exists, preferring (a). If neither exists, returns (a).
     2. Falls back to get_claude_config_path()
     """
     original = os.environ.get("ORIGINAL_CLAUDE_CONFIG_DIR")
     if original:
-        return Path(original) / ".claude.json"
+        original_path = Path(original)
+        inside = original_path / ".claude.json"
+        if inside.exists():
+            return inside
+        beside = original_path.parent / ".claude.json"
+        if beside.exists():
+            return beside
+        return inside
     return get_claude_config_path()
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -101,18 +101,6 @@ def get_user_claude_config_dir() -> Path:
     return get_claude_config_dir()
 
 
-def get_claude_config_path() -> Path:
-    """Return the path to the Claude config file (.claude.json).
-
-    When $CLAUDE_CONFIG_DIR is set, returns $CLAUDE_CONFIG_DIR/.claude.json.
-    Otherwise returns ~/.claude.json (Claude Code's default location).
-    """
-    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
-    if env_dir:
-        return Path(env_dir) / ".claude.json"
-    return Path.home() / ".claude.json"
-
-
 def find_user_claude_config() -> Path:
     """Find the user-scope Claude config file (.claude.json).
 
@@ -144,11 +132,6 @@ def find_user_claude_config() -> Path:
         if candidate.exists():
             return candidate
     return candidates[0]
-
-
-def get_claude_config_backup_path() -> Path:
-    """Return the path to the Claude config backup file (.claude.json.bak)."""
-    return get_claude_config_path().with_suffix(".json.bak")
 
 
 # =============================================================================

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -143,7 +143,7 @@ def find_user_claude_config() -> Path:
     for candidate in candidates:
         if candidate.exists():
             return candidate
-    return candidates[-1]
+    return candidates[0]
 
 
 def get_claude_config_backup_path() -> Path:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -116,33 +116,34 @@ def get_claude_config_path() -> Path:
 def find_user_claude_config() -> Path:
     """Find the user-scope Claude config file (.claude.json).
 
-    Searches candidate locations and returns the first that exists. If no
-    config file exists on disk yet, returns the default creation path
-    (~/.claude.json).
+    Returns the first candidate path that exists on disk. If none exist,
+    returns the last candidate as the default creation path.
 
     Inside an mngr agent, $CLAUDE_CONFIG_DIR points to the agent's isolated
     config dir. This function looks for the *user's* original config instead.
 
-    Search order when $ORIGINAL_CLAUDE_CONFIG_DIR is set:
+    Candidate paths when $ORIGINAL_CLAUDE_CONFIG_DIR is set:
     1. $ORIGINAL_CLAUDE_CONFIG_DIR/.claude.json (custom CLAUDE_CONFIG_DIR convention)
     2. Parent of $ORIGINAL_CLAUDE_CONFIG_DIR / .claude.json (default layout where the
        config file lives *beside* the config dir: ~/.claude/ dir -> ~/.claude.json file)
-    3. Falls through to ~/.claude.json (default creation path)
 
     Without $ORIGINAL_CLAUDE_CONFIG_DIR:
     1. ~/.claude.json (Claude Code's default location)
     """
+    candidates: list[Path] = []
+
     original = os.environ.get("ORIGINAL_CLAUDE_CONFIG_DIR")
     if original:
         original_path = Path(original)
-        inside = original_path / ".claude.json"
-        if inside.exists():
-            return inside
-        beside = original_path.parent / ".claude.json"
-        if beside.exists():
-            return beside
+        candidates.append(original_path / ".claude.json")
+        candidates.append(original_path.parent / ".claude.json")
 
-    return Path.home() / ".claude.json"
+    candidates.append(Path.home() / ".claude.json")
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[-1]
 
 
 def get_claude_config_backup_path() -> Path:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -117,7 +117,7 @@ def find_user_claude_config() -> Path:
     """Find the user-scope Claude config file (.claude.json).
 
     Returns the first candidate path that exists on disk. If none exist,
-    returns the last candidate as the default creation path.
+    returns the first candidate as the default creation path.
 
     Inside an mngr agent, $CLAUDE_CONFIG_DIR points to the agent's isolated
     config dir. This function looks for the *user's* original config instead.

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -752,3 +752,43 @@ def test_get_user_claude_config_path_falls_back_to_claude_config_dir(
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
     result = get_user_claude_config_path()
     assert result == custom_dir / ".claude.json"
+
+
+def test_get_user_claude_config_path_finds_beside_dir_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ORIGINAL_CLAUDE_CONFIG_DIR=~/.claude and only ~/.claude.json exists, returns it.
+
+    The default Claude Code layout stores .claude.json beside the config dir
+    (~/.claude.json), not inside it (~/.claude/.claude.json). When an agent's
+    ORIGINAL_CLAUDE_CONFIG_DIR points to ~/.claude, the function should find
+    the config file at the beside-dir location.
+    """
+    claude_dir = Path.home() / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(claude_dir))
+
+    # Only the beside-dir config exists (default Claude Code layout)
+    beside_config = Path.home() / ".claude.json"
+    beside_config.write_text(json.dumps({"projects": {}}, indent=2))
+
+    result = get_user_claude_config_path()
+    assert result == beside_config
+
+
+def test_get_user_claude_config_path_prefers_inside_dir_when_both_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both inside-dir and beside-dir configs exist, prefers inside-dir."""
+    claude_dir = Path.home() / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(claude_dir))
+
+    # Both files exist
+    inside_config = claude_dir / ".claude.json"
+    inside_config.write_text(json.dumps({"inside": True}, indent=2))
+    beside_config = Path.home() / ".claude.json"
+    beside_config.write_text(json.dumps({"beside": True}, indent=2))
+
+    result = get_user_claude_config_path()
+    assert result == inside_config

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -15,11 +15,11 @@ from imbue.mngr_claude.claude_config import check_effort_callout_dismissed
 from imbue.mngr_claude.claude_config import check_source_directory_trusted
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import find_project_config
+from imbue.mngr_claude.claude_config import find_user_claude_config
 from imbue.mngr_claude.claude_config import get_claude_config_backup_path
 from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_claude_config_path
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
-from imbue.mngr_claude.claude_config import get_user_claude_config_path
 from imbue.mngr_claude.claude_config import is_source_directory_trusted
 from imbue.mngr_claude.claude_config import remove_claude_trust_for_path
 
@@ -723,41 +723,53 @@ def test_get_claude_config_backup_path_derives_from_config_path(
     assert result == custom_dir / ".claude.json.bak"
 
 
-# Tests for get_user_claude_config_path
+# Tests for find_user_claude_config
 
 
-def test_get_user_claude_config_path_defaults_to_home() -> None:
-    """Without env vars, returns ~/.claude.json."""
-    result = get_user_claude_config_path()
+def test_find_user_claude_config_defaults_to_home() -> None:
+    """Without env vars and no file on disk, returns ~/.claude.json."""
+    result = find_user_claude_config()
     assert result == Path.home() / ".claude.json"
 
 
-def test_get_user_claude_config_path_respects_original_env_var(
+def test_find_user_claude_config_returns_default_path() -> None:
+    """Without env vars, returns ~/.claude.json when it exists."""
+    config = Path.home() / ".claude.json"
+    config.write_text(json.dumps({}, indent=2))
+
+    result = find_user_claude_config()
+    assert result == config
+
+
+def test_find_user_claude_config_defaults_to_home_with_original_dir_but_no_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With ORIGINAL_CLAUDE_CONFIG_DIR set, returns path inside that dir."""
+    """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns ~/.claude.json."""
     user_dir = tmp_path / "user-claude"
-    agent_dir = tmp_path / "agent-claude"
+    user_dir.mkdir()
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(user_dir))
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(agent_dir))
-    result = get_user_claude_config_path()
-    assert result == user_dir / ".claude.json"
+
+    result = find_user_claude_config()
+    assert result == Path.home() / ".claude.json"
 
 
-def test_get_user_claude_config_path_falls_back_to_claude_config_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Without ORIGINAL_CLAUDE_CONFIG_DIR, uses CLAUDE_CONFIG_DIR."""
-    custom_dir = tmp_path / "custom-claude"
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
-    result = get_user_claude_config_path()
-    assert result == custom_dir / ".claude.json"
+def test_find_user_claude_config_finds_inside_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With ORIGINAL_CLAUDE_CONFIG_DIR set, finds .claude.json inside it."""
+    user_dir = tmp_path / "user-claude"
+    user_dir.mkdir()
+    monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(user_dir))
+
+    inside = user_dir / ".claude.json"
+    inside.write_text(json.dumps({}, indent=2))
+
+    result = find_user_claude_config()
+    assert result == inside
 
 
-def test_get_user_claude_config_path_finds_beside_dir_config(
+def test_find_user_claude_config_finds_beside_dir(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When ORIGINAL_CLAUDE_CONFIG_DIR=~/.claude and only ~/.claude.json exists, returns it.
+    """Finds ~/.claude.json (beside ~/.claude/) when only beside-dir config exists.
 
     The default Claude Code layout stores .claude.json beside the config dir
     (~/.claude.json), not inside it (~/.claude/.claude.json). When an agent's
@@ -768,15 +780,14 @@ def test_get_user_claude_config_path_finds_beside_dir_config(
     claude_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(claude_dir))
 
-    # Only the beside-dir config exists (default Claude Code layout)
     beside_config = Path.home() / ".claude.json"
     beside_config.write_text(json.dumps({"projects": {}}, indent=2))
 
-    result = get_user_claude_config_path()
+    result = find_user_claude_config()
     assert result == beside_config
 
 
-def test_get_user_claude_config_path_prefers_inside_dir_when_both_exist(
+def test_find_user_claude_config_prefers_inside_dir_when_both_exist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When both inside-dir and beside-dir configs exist, prefers inside-dir."""
@@ -784,11 +795,25 @@ def test_get_user_claude_config_path_prefers_inside_dir_when_both_exist(
     claude_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(claude_dir))
 
-    # Both files exist
     inside_config = claude_dir / ".claude.json"
     inside_config.write_text(json.dumps({"inside": True}, indent=2))
     beside_config = Path.home() / ".claude.json"
     beside_config.write_text(json.dumps({"beside": True}, indent=2))
 
-    result = get_user_claude_config_path()
+    result = find_user_claude_config()
     assert result == inside_config
+
+
+def test_find_user_claude_config_ignores_claude_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ORIGINAL_CLAUDE_CONFIG_DIR, ignores CLAUDE_CONFIG_DIR (per-agent dir)."""
+    custom_dir = tmp_path / "custom-claude"
+    custom_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
+
+    # File exists in per-agent dir but not at ~/.claude.json
+    config = custom_dir / ".claude.json"
+    config.write_text(json.dumps({}, indent=2))
+
+    # Should return the default user path, not the per-agent path
+    result = find_user_claude_config()
+    assert result == Path.home() / ".claude.json"

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -741,16 +741,16 @@ def test_find_user_claude_config_returns_default_path() -> None:
     assert result == config
 
 
-def test_find_user_claude_config_defaults_to_beside_dir_with_original_dir_but_no_files(
+def test_find_user_claude_config_defaults_to_inside_dir_with_original_dir_but_no_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns the beside-dir path."""
+    """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns the inside-dir path."""
     user_dir = tmp_path / "user-claude"
     user_dir.mkdir()
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(user_dir))
 
     result = find_user_claude_config()
-    assert result == tmp_path / ".claude.json"
+    assert result == user_dir / ".claude.json"
 
 
 def test_find_user_claude_config_finds_inside_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -741,16 +741,16 @@ def test_find_user_claude_config_returns_default_path() -> None:
     assert result == config
 
 
-def test_find_user_claude_config_defaults_to_home_with_original_dir_but_no_files(
+def test_find_user_claude_config_defaults_to_beside_dir_with_original_dir_but_no_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns ~/.claude.json."""
+    """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns the beside-dir path."""
     user_dir = tmp_path / "user-claude"
     user_dir.mkdir()
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(user_dir))
 
     result = find_user_claude_config()
-    assert result == Path.home() / ".claude.json"
+    assert result == tmp_path / ".claude.json"
 
 
 def test_find_user_claude_config_finds_inside_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -16,24 +16,10 @@ from imbue.mngr_claude.claude_config import check_source_directory_trusted
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import find_project_config
 from imbue.mngr_claude.claude_config import find_user_claude_config
-from imbue.mngr_claude.claude_config import get_claude_config_backup_path
 from imbue.mngr_claude.claude_config import get_claude_config_dir
-from imbue.mngr_claude.claude_config import get_claude_config_path
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
 from imbue.mngr_claude.claude_config import is_source_directory_trusted
 from imbue.mngr_claude.claude_config import remove_claude_trust_for_path
-
-
-def test_get_claude_config_path_returns_home_dot_claude_json() -> None:
-    """Test that get_claude_config_path returns ~/.claude.json."""
-    result = get_claude_config_path()
-    assert result == Path.home() / ".claude.json"
-
-
-def test_get_claude_config_backup_path_returns_home_dot_claude_json_bak() -> None:
-    """Test that get_claude_config_backup_path returns ~/.claude.json.bak."""
-    result = get_claude_config_backup_path()
-    assert result == Path.home() / ".claude.json.bak"
 
 
 def test_find_project_config_exact_match() -> None:
@@ -73,7 +59,7 @@ def test_find_project_config_empty_projects() -> None:
 
 def test_check_source_directory_trusted_succeeds_when_trusted(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted passes when directory is trusted."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -90,7 +76,7 @@ def test_check_source_directory_trusted_succeeds_when_trusted(tmp_path: Path) ->
 
 def test_check_source_directory_trusted_succeeds_for_subdirectory(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted passes for subdirectory of trusted path."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     project_root = tmp_path / "project"
     source_path = project_root / "src" / "components"
     project_root.mkdir()
@@ -109,7 +95,7 @@ def test_check_source_directory_trusted_succeeds_for_subdirectory(tmp_path: Path
 
 def test_check_source_directory_trusted_raises_when_not_trusted(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when hasTrustDialogAccepted=false."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -134,12 +120,12 @@ def test_check_source_directory_trusted_raises_when_no_config_file(tmp_path: Pat
     # Config file doesn't exist (HOME points to tmp_path via autouse fixture)
 
     with pytest.raises(ClaudeDirectoryNotTrustedError):
-        check_source_directory_trusted(get_claude_config_path(), source_path)
+        check_source_directory_trusted(find_user_claude_config(), source_path)
 
 
 def test_check_source_directory_trusted_raises_when_empty_config(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when config file is empty."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -151,7 +137,7 @@ def test_check_source_directory_trusted_raises_when_empty_config(tmp_path: Path)
 
 def test_check_source_directory_trusted_raises_when_not_in_projects(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when source not in projects."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -164,7 +150,7 @@ def test_check_source_directory_trusted_raises_when_not_in_projects(tmp_path: Pa
 
 def test_check_source_directory_trusted_raises_when_trust_field_missing(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when hasTrustDialogAccepted is missing."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -181,7 +167,7 @@ def test_check_source_directory_trusted_raises_when_trust_field_missing(tmp_path
 
 def test_check_source_directory_trusted_raises_json_error_for_invalid_json() -> None:
     """Test that check_source_directory_trusted lets JSONDecodeError bubble up."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
 
     config_file.write_text("{ invalid json }")
 
@@ -198,7 +184,7 @@ def test_add_claude_trust_creates_config_when_none_exists(tmp_path: Path) -> Non
     source_path.mkdir()
 
     # HOME points to a test-isolated temp dir (autouse setup_test_mngr_env)
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     assert not config_file.exists()
 
     add_claude_trust_for_path(config_file, source_path)
@@ -210,7 +196,7 @@ def test_add_claude_trust_creates_config_when_none_exists(tmp_path: Path) -> Non
 
 def test_add_claude_trust_adds_entry_to_existing_config(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path adds entry to existing config."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -229,8 +215,8 @@ def test_add_claude_trust_adds_entry_to_existing_config(tmp_path: Path) -> None:
 
 def test_add_claude_trust_is_noop_when_already_trusted(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path is a no-op when path is already trusted."""
-    config_file = get_claude_config_path()
-    backup_file = get_claude_config_backup_path()
+    config_file = find_user_claude_config()
+    backup_file = find_user_claude_config().with_suffix(".json.bak")
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -253,7 +239,7 @@ def test_add_claude_trust_is_noop_when_already_trusted(tmp_path: Path) -> None:
 
 def test_add_claude_trust_updates_entry_when_trust_is_false(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path updates entry when hasTrustDialogAccepted is False."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -277,7 +263,7 @@ def test_add_claude_trust_updates_entry_when_trust_is_false(tmp_path: Path) -> N
 
 def test_add_claude_trust_handles_empty_config_file(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path handles empty config file."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -294,7 +280,7 @@ def test_add_claude_trust_handles_empty_config_file(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_removes_mngr_created_entry(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path removes mngr-created entries."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -322,7 +308,7 @@ def test_remove_claude_trust_removes_mngr_created_entry(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_skips_non_mngr_entry(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path skips entries not created by mngr."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -344,7 +330,7 @@ def test_remove_claude_trust_skips_non_mngr_entry(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_returns_false_when_not_found(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path returns False when entry doesn't exist."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -367,14 +353,14 @@ def test_remove_claude_trust_returns_false_when_no_config(tmp_path: Path) -> Non
 
     # Config file doesn't exist (HOME points to tmp_path via autouse fixture)
 
-    result = remove_claude_trust_for_path(get_claude_config_path(), worktree_path)
+    result = remove_claude_trust_for_path(find_user_claude_config(), worktree_path)
 
     assert result is False
 
 
 def test_remove_claude_trust_returns_false_on_error(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path returns False on errors."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -388,7 +374,7 @@ def test_remove_claude_trust_returns_false_on_error(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_returns_false_when_empty_config(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path returns False when config file is empty."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -404,7 +390,7 @@ def test_remove_claude_trust_returns_false_when_empty_config(tmp_path: Path) -> 
 
 def test_check_effort_callout_dismissed_succeeds_when_dismissed() -> None:
     """Test that check_effort_callout_dismissed passes when effortCalloutDismissed is true."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config = {"effortCalloutDismissed": True}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -414,7 +400,7 @@ def test_check_effort_callout_dismissed_succeeds_when_dismissed() -> None:
 
 def test_check_effort_callout_dismissed_raises_when_not_dismissed() -> None:
     """Test that check_effort_callout_dismissed raises when effortCalloutDismissed is false."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config = {"effortCalloutDismissed": False}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -424,7 +410,7 @@ def test_check_effort_callout_dismissed_raises_when_not_dismissed() -> None:
 
 def test_check_effort_callout_dismissed_raises_when_field_missing() -> None:
     """Test that check_effort_callout_dismissed raises when effortCalloutDismissed is absent."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -435,12 +421,12 @@ def test_check_effort_callout_dismissed_raises_when_field_missing() -> None:
 def test_check_effort_callout_dismissed_raises_when_no_config() -> None:
     """Test that check_effort_callout_dismissed raises when config file doesn't exist."""
     with pytest.raises(ClaudeEffortCalloutNotDismissedError):
-        check_effort_callout_dismissed(get_claude_config_path())
+        check_effort_callout_dismissed(find_user_claude_config())
 
 
 def test_check_effort_callout_dismissed_raises_when_empty_config() -> None:
     """Test that check_effort_callout_dismissed raises when config file is empty."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config_file.write_text("")
 
     with pytest.raises(ClaudeEffortCalloutNotDismissedError):
@@ -449,7 +435,7 @@ def test_check_effort_callout_dismissed_raises_when_empty_config() -> None:
 
 def test_dismiss_effort_callout_sets_field() -> None:
     """Test that dismiss_effort_callout sets effortCalloutDismissed to true."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -462,8 +448,8 @@ def test_dismiss_effort_callout_sets_field() -> None:
 
 def test_dismiss_effort_callout_is_noop_when_already_set() -> None:
     """Test that dismiss_effort_callout is a no-op when already dismissed."""
-    config_file = get_claude_config_path()
-    backup_file = get_claude_config_backup_path()
+    config_file = find_user_claude_config()
+    backup_file = find_user_claude_config().with_suffix(".json.bak")
     config = {"effortCalloutDismissed": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -474,7 +460,7 @@ def test_dismiss_effort_callout_is_noop_when_already_set() -> None:
 
 def test_dismiss_effort_callout_creates_config_when_none_exists() -> None:
     """Test that dismiss_effort_callout creates config file if it doesn't exist."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     assert not config_file.exists()
 
     dismiss_effort_callout(config_file)
@@ -486,7 +472,7 @@ def test_dismiss_effort_callout_creates_config_when_none_exists() -> None:
 
 def test_dismiss_effort_callout_handles_empty_config() -> None:
     """Test that dismiss_effort_callout handles empty config file."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config_file.write_text("")
 
     dismiss_effort_callout(config_file)
@@ -500,7 +486,7 @@ def test_dismiss_effort_callout_handles_empty_config() -> None:
 
 def test_acknowledge_cost_threshold_sets_field() -> None:
     """Test that acknowledge_cost_threshold sets hasAcknowledgedCostThreshold to true."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -513,8 +499,8 @@ def test_acknowledge_cost_threshold_sets_field() -> None:
 
 def test_acknowledge_cost_threshold_is_noop_when_already_set() -> None:
     """Test that acknowledge_cost_threshold is a no-op when already acknowledged."""
-    config_file = get_claude_config_path()
-    backup_file = get_claude_config_backup_path()
+    config_file = find_user_claude_config()
+    backup_file = find_user_claude_config().with_suffix(".json.bak")
     config = {"hasAcknowledgedCostThreshold": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -525,7 +511,7 @@ def test_acknowledge_cost_threshold_is_noop_when_already_set() -> None:
 
 def test_acknowledge_cost_threshold_creates_config_when_none_exists() -> None:
     """Test that acknowledge_cost_threshold creates config file if it doesn't exist."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     assert not config_file.exists()
 
     acknowledge_cost_threshold(config_file)
@@ -537,7 +523,7 @@ def test_acknowledge_cost_threshold_creates_config_when_none_exists() -> None:
 
 def test_acknowledge_cost_threshold_handles_empty_config() -> None:
     """Test that acknowledge_cost_threshold handles empty config file."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     config_file.write_text("")
 
     acknowledge_cost_threshold(config_file)
@@ -551,7 +537,7 @@ def test_acknowledge_cost_threshold_handles_empty_config() -> None:
 
 def test_check_claude_dialogs_dismissed_checks_trust(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed checks trust for source_path."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -565,7 +551,7 @@ def test_check_claude_dialogs_dismissed_checks_trust(tmp_path: Path) -> None:
 
 def test_check_claude_dialogs_dismissed_checks_effort_callout(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed checks effort callout."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -583,7 +569,7 @@ def test_check_claude_dialogs_dismissed_checks_effort_callout(tmp_path: Path) ->
 
 def test_check_claude_dialogs_dismissed_passes_when_all_set(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed passes when all dialogs are set."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -602,7 +588,7 @@ def test_check_claude_dialogs_dismissed_passes_when_all_set(tmp_path: Path) -> N
 
 def test_auto_dismiss_claude_dialogs_sets_all(tmp_path: Path) -> None:
     """Test that auto_dismiss_claude_dialogs sets all dialog fields."""
-    config_file = get_claude_config_path()
+    config_file = find_user_claude_config()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -643,7 +629,7 @@ def test_functions_work_with_non_global_config_path(tmp_path: Path) -> None:
     assert updated["effortCalloutDismissed"] is True
 
     # Global config should be untouched
-    global_config = get_claude_config_path()
+    global_config = find_user_claude_config()
     assert not global_config.exists()
 
 
@@ -700,27 +686,6 @@ def test_get_user_claude_config_dir_falls_back_to_claude_config_dir(
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
     result = get_user_claude_config_dir()
     assert result == custom_dir
-
-
-# Tests for get_claude_config_path (CLAUDE_CONFIG_DIR-aware)
-
-
-def test_get_claude_config_path_respects_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """With CLAUDE_CONFIG_DIR set, returns $CLAUDE_CONFIG_DIR/.claude.json."""
-    custom_dir = tmp_path / "custom-claude"
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
-    result = get_claude_config_path()
-    assert result == custom_dir / ".claude.json"
-
-
-def test_get_claude_config_backup_path_derives_from_config_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Backup path should follow the config path location."""
-    custom_dir = tmp_path / "custom-claude"
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom_dir))
-    result = get_claude_config_backup_path()
-    assert result == custom_dir / ".claude.json.bak"
 
 
 # Tests for find_user_claude_config

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -72,9 +72,9 @@ from imbue.mngr_claude.claude_config import complete_onboarding
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
+from imbue.mngr_claude.claude_config import find_user_claude_config
 from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
-from imbue.mngr_claude.claude_config import get_user_claude_config_path
 from imbue.mngr_claude.claude_config import is_effort_callout_dismissed
 from imbue.mngr_claude.claude_config import is_onboarding_completed
 from imbue.mngr_claude.claude_config import is_source_directory_trusted
@@ -368,7 +368,7 @@ def _build_claude_json(
     before serializing.
     """
     if sync_local:
-        local_config = read_claude_config(get_user_claude_config_path())
+        local_config = read_claude_config(find_user_claude_config())
         data: dict[str, Any] = (
             local_config if local_config else _generate_claude_json(version, current_time=current_time)
         )
@@ -569,7 +569,7 @@ def _prompt_user_for_onboarding_completion() -> bool:
 
 def _claude_json_has_primary_api_key() -> bool:
     """Check if ~/.claude.json contains a non-empty primaryApiKey."""
-    claude_json_path = get_user_claude_config_path()
+    claude_json_path = find_user_claude_config()
     if not claude_json_path.exists():
         return False
     try:
@@ -1330,7 +1330,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
                 trust_path = source_path if source_path is not None else self.work_dir
             else:
                 trust_path = self.work_dir
-            check_claude_dialogs_dismissed(get_user_claude_config_path(), trust_path)
+            check_claude_dialogs_dismissed(find_user_claude_config(), trust_path)
         if not config.check_installation:
             logger.debug("Skipped claude installation check (check_installation=False)")
             return
@@ -1434,7 +1434,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         source_path is the trusted source directory (for git-worktree/git-mirror modes).
         When None (rsync/none mode), trust is prompted for work_dir instead.
         """
-        global_config_path = get_user_claude_config_path()
+        global_config_path = find_user_claude_config()
         trust_path = source_path if source_path is not None else self.work_dir
 
         if mngr_ctx.is_auto_approve:
@@ -1601,7 +1601,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
 
                 if config.auto_dismiss_dialogs:
                     # Auto-approve all dialogs for agents that opt into dismissal
-                    auto_dismiss_claude_dialogs(get_user_claude_config_path(), self.work_dir)
+                    auto_dismiss_claude_dialogs(find_user_claude_config(), self.work_dir)
                 else:
                     # Check/prompt for all blocking dialogs
                     # source_path=None (clone/no-git) means trust is prompted for work_dir
@@ -1658,7 +1658,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
                     logger.info("Claude installed successfully")
 
             # no matter what, *always* dismiss the cost popup, it's pointless
-            acknowledge_cost_threshold(get_user_claude_config_path())
+            acknowledge_cost_threshold(find_user_claude_config())
 
             # Transfer plugin data from source agent before config setup (if cloning via --from-agent).
             # This copies sessions, memory, transcript offsets, etc. The subsequent config setup
@@ -1767,7 +1767,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
                 logger.debug("Removed per-agent OAuth credentials keychain entry")
         elif not per_agent_config_exists:
             # Legacy agent without per-agent config dir -- clean up global file
-            removed = remove_claude_trust_for_path(get_user_claude_config_path(), self.work_dir)
+            removed = remove_claude_trust_for_path(find_user_claude_config(), self.work_dir)
             if removed:
                 logger.debug("Removed Claude trust entry for {} from global config", self.work_dir)
         else:
@@ -2009,7 +2009,7 @@ def modify_env_vars_for_deploy(
 
 def approve_api_key_for_claude(data: dict[str, Any]):
     """Approve the API key so that the agent doesn't get blocked by the custom API key dialog."""
-    user_config = read_claude_config(get_user_claude_config_path())
+    user_config = read_claude_config(find_user_claude_config())
     conf_key = user_config.get("primaryApiKey", "")
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if api_key or conf_key:


### PR DESCRIPTION
## Summary
- Renames `get_user_claude_config_path()` to `find_user_claude_config()` -- the function now searches disk for the config file rather than constructing a single path
- When `ORIGINAL_CLAUDE_CONFIG_DIR` is set (e.g. `~/.claude`), searches candidate paths in priority order: inside-dir (`~/.claude/.claude.json`), beside-dir (`~/.claude.json`), then `~/.claude.json` as default. Returns the first that exists, or the first candidate if none exist.
- This fixes trust checks failing when a mngr agent launches a nested agent, because the old code always returned `~/.claude/.claude.json` which doesn't exist in the default Claude Code layout (trust entries live in `~/.claude.json`)
- Removes unused `get_claude_config_path()` and `get_claude_config_backup_path()` (were only used in tests, never in production)

## Test plan
- [x] Unit tests for candidate-list search (inside-dir, beside-dir, default, preference order)
- [x] Existing trust/dialog plugin tests pass (197 passed)
- [x] Ratchet tests pass
- [ ] CI (integration shard 3 timed out at 152s/150s limit -- flake, not related)

Generated with [Claude Code](https://claude.com/claude-code)