### PR TITLE
fix misc test docstrings, comments, and config

### DIFF
--- a/libs/mngr/imbue/mngr/conftest.py
+++ b/libs/mngr/imbue/mngr/conftest.py
@@ -150,9 +150,10 @@ def tmp_home_dir(tmp_path: Path) -> Generator[Path, None, None]:
 def setup_git_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Isolate git and provide user config for tests that run git commands.
 
-    Sets GIT_CONFIG_NOSYSTEM, GIT_TERMINAL_PROMPT, and GIT_CONFIG_GLOBAL
-    via the shared isolate_git() helper. Tests that need git should request
-    this fixture (or temp_git_repo, which depends on it).
+    Sets GIT_CONFIG_NOSYSTEM and GIT_TERMINAL_PROMPT, and writes a
+    .gitconfig to the fake HOME via the shared isolate_git() helper.
+    Tests that need git should request this fixture (or temp_git_repo,
+    which depends on it).
     """
     with isolate_git(monkeypatch):
         yield

--- a/libs/mngr/imbue/mngr/hosts/test_host.py
+++ b/libs/mngr/imbue/mngr/hosts/test_host.py
@@ -1719,8 +1719,8 @@ def _init_git_repo(path: Path, commit_message: str = "Initial commit") -> None:
     commits them.
     """
     # Inline GIT_CONFIG_NOSYSTEM to prevent reading /etc/gitconfig under
-    # parallel execution. We don't import run_git_command from testing.py
-    # because the type checker cannot resolve that module.
+    # parallel execution. This helper commits pre-existing files (unlike
+    # init_git_repo which creates a fresh repo), so we keep it local.
     env = {**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0"}
     subprocess.run(["git", "init"], cwd=path, capture_output=True, check=True, env=env)
     subprocess.run(["git", "add", "."], cwd=path, capture_output=True, check=True, env=env)

--- a/libs/mngr/imbue/mngr/utils/plugin_testing.py
+++ b/libs/mngr/imbue/mngr/utils/plugin_testing.py
@@ -111,9 +111,10 @@ def cg() -> Generator[ConcurrencyGroup, None, None]:
 def setup_git_config(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Isolate git and provide user config for tests that run git commands.
 
-    Sets GIT_CONFIG_NOSYSTEM, GIT_TERMINAL_PROMPT, and GIT_CONFIG_GLOBAL
-    via the shared isolate_git() helper. Tests that need git should request
-    this fixture (or temp_git_repo, which depends on it).
+    Sets GIT_CONFIG_NOSYSTEM and GIT_TERMINAL_PROMPT, and writes a
+    .gitconfig to the fake HOME via the shared isolate_git() helper.
+    Tests that need git should request this fixture (or temp_git_repo,
+    which depends on it).
     """
     with isolate_git(monkeypatch):
         yield

--- a/libs/mngr/imbue/mngr/utils/testing.py
+++ b/libs/mngr/imbue/mngr/utils/testing.py
@@ -221,7 +221,9 @@ def isolate_git(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
 
     gitconfig = Path.home() / ".gitconfig"
     if not gitconfig.exists():
-        gitconfig.write_text("[user]\n\tname = Test User\n\temail = test@test.com\n[init]\n\tdefaultBranch = main\n")
+        gitconfig.write_text(
+            "[user]\n\tname = Test User\n\temail = test@example.com\n[init]\n\tdefaultBranch = main\n"
+        )
 
     yield
 


### PR DESCRIPTION
an agent accidentally ran autofix against a dirty diff

---

## Summary
- Fix inaccurate docstrings in `setup_git_config` fixtures (conftest.py and plugin_testing.py)
- Fix incorrect comment about type checker in test_host.py
- Use consistent test email in `isolate_git` fixture

## Test plan
- [ ] Existing tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)