### PR TITLE
fix release script unpublished package detection

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -26,6 +26,7 @@ from typing import Any
 from typing import Final
 from typing import cast
 
+import httpx
 import semver
 import tomlkit
 from utils import PACKAGES
@@ -68,8 +69,6 @@ def _find_last_release_tag() -> str:
 
 def _get_pypi_version() -> str | None:
     """Query PyPI for the latest published version of mngr. Returns None if the query fails."""
-    import httpx
-
     try:
         response = httpx.get("https://pypi.org/pypi/imbue-mngr/json", timeout=10)
         response.raise_for_status()
@@ -95,8 +94,6 @@ def _detect_changed_packages(since_tag: str) -> set[str]:
 
 def _is_published_on_pypi(pypi_name: str) -> bool:
     """Check whether a package has ever been published on PyPI."""
-    import httpx
-
     try:
         response = httpx.head(f"https://pypi.org/pypi/{pypi_name}/json", timeout=10)
         return response.status_code == 200


### PR DESCRIPTION
## Summary
- `_detect_new_packages` only checked whether a package's pyproject.toml existed at the last git tag. Packages that existed in the repo but were never published to PyPI (e.g. mngr-notifications, mngr-file, mngr-pi-coding, mngr-recursive, mngr-ttyd, mngr-wait) were incorrectly treated as "changed" and bumped (0.1.0 -> 0.1.1) instead of being offered as first-time publications at 0.1.0.
- Now also queries PyPI with a HEAD request to detect packages that exist in the repo but have never been published. Falls back to assuming "published" if PyPI is unreachable to avoid false positives.

## Test plan
- [x] Verified with `uv run scripts/release.py patch --dry-run` -- the 6 unpublished packages now appear under "New packages (first publication)" instead of "Packages to bump"