### PR TITLE
fix atomic_write breaking symlinks

### DIFF
--- a/libs/mngr/imbue/mngr/utils/file_utils.py
+++ b/libs/mngr/imbue/mngr/utils/file_utils.py
@@ -11,23 +11,32 @@ def atomic_write(path: Path, content: str) -> None:
     fsync, then atomically replaces the target file. This ensures readers
     never see a partially-written file, even after power loss.
 
+    If the target path is a symlink, the write goes through to the symlink's
+    target so the link is preserved.
+
     If the target file already exists, its permissions are preserved on the
     new file. Otherwise the file is created with default permissions (0600).
 
     The caller is responsible for catching OSError if the write fails.
     """
+    # Ensure the parent of the original path exists (for new non-symlink files).
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Resolve symlinks so os.replace overwrites the target file rather than
+    # replacing the symlink itself with a regular file.
+    resolved = path.resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
 
     # Capture existing permissions before overwriting
     existing_mode: int | None = None
     try:
-        existing_mode = path.stat().st_mode
+        existing_mode = resolved.stat().st_mode
     except OSError:
         pass
 
     with tempfile.NamedTemporaryFile(
         mode="w",
-        dir=path.parent,
+        dir=resolved.parent,
         suffix=".tmp",
         delete=False,
     ) as tmp_file:
@@ -39,7 +48,7 @@ def atomic_write(path: Path, content: str) -> None:
     try:
         if existing_mode is not None:
             os.chmod(tmp_path, stat.S_IMODE(existing_mode))
-        os.replace(tmp_path, path)
+        os.replace(tmp_path, resolved)
     except OSError:
         try:
             os.unlink(tmp_path)

--- a/libs/mngr/imbue/mngr/utils/file_utils_test.py
+++ b/libs/mngr/imbue/mngr/utils/file_utils_test.py
@@ -108,3 +108,37 @@ def test_atomic_write_to_new_nested_directory(tmp_path: Path) -> None:
     assert target.exists()
     assert target.read_text() == "deep content"
     assert target.parent.is_dir()
+
+
+def test_atomic_write_preserves_symlink(tmp_path: Path) -> None:
+    """atomic_write should write through a symlink, not replace it."""
+    real_file = tmp_path / "real" / "settings.toml"
+    real_file.parent.mkdir()
+    real_file.write_text("original")
+
+    link = tmp_path / "link" / "settings.toml"
+    link.parent.mkdir()
+    link.symlink_to(real_file)
+
+    atomic_write(link, "updated")
+
+    assert link.is_symlink(), "symlink was replaced with a regular file"
+    assert link.resolve() == real_file.resolve()
+    assert real_file.read_text() == "updated"
+    assert link.read_text() == "updated"
+
+
+def test_atomic_write_preserves_symlink_permissions(tmp_path: Path) -> None:
+    """atomic_write through a symlink should preserve the target's permissions."""
+    real_file = tmp_path / "real.toml"
+    real_file.write_text("original")
+    os.chmod(real_file, 0o644)
+
+    link = tmp_path / "link.toml"
+    link.symlink_to(real_file)
+
+    atomic_write(link, "updated")
+
+    assert link.is_symlink()
+    actual_mode = stat.S_IMODE(real_file.stat().st_mode)
+    assert actual_mode == 0o644


### PR DESCRIPTION
## Summary
- `atomic_write` used `os.replace(tmp_path, path)` which replaces a symlink with a regular file, breaking symlinked `settings.toml` files (e.g. symlinked from dotfiles)
- Now resolves the path via `path.resolve()` before the replace, so the write goes through to the symlink target and the link is preserved
- Temp file is also created in the resolved parent directory to ensure the rename is atomic (same filesystem)

## Test plan
- [x] Added `test_atomic_write_preserves_symlink` -- verifies symlink is still a symlink after write, content is correct at both link and target
- [x] Added `test_atomic_write_preserves_symlink_permissions` -- verifies target file permissions are preserved when writing through a symlink
- [x] All 3518 existing tests pass, 82.88% coverage