### PR TITLE
add skill for messaging another mngr agent

### DIFF
--- a/.claude/skills/find-agent/SKILL.md
+++ b/.claude/skills/find-agent/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: find-agent
+argument-hint: <agent_name_or_description>
+description: Resolve an agent name or description to an exact mngr agent name. Used by other skills that target agents.
+allowed-tools: Bash(uv run mngr list *)
+---
+
+The user's input is an agent name or description. Resolve it to an exact agent name.
+
+## Normalization
+
+The user may paste a git branch name like `mngr/some-agent` instead of the bare agent name. In that case, strip the `mngr/` prefix to get the actual agent name (e.g. `mngr/better-tabcomplete` -> `better-tabcomplete`).
+
+## Resolution
+
+Verify the target agent exists by running:
+
+```
+uv run mngr list --format '{name}'
+```
+
+If the extracted name doesn't match any agent exactly, check if the user's input was a description (e.g. "the agent working on X") rather than a name, and try to match against the listed agents and their git branches. If there's an unambiguous match, use it. Otherwise, use AskUserQuestion to ask the user which agent they meant, presenting the plausible candidates.
+
+Report the resolved agent name back to the caller.

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -33,13 +33,13 @@ To reply, use the /message-agent skill.
 
 ## Sending the Message
 
-Write the composed message to a temporary file using the Write tool, then send it with `--message-file`:
+Write the composed message to a temporary file using the Write tool, then send it with `--message-file`. Name the temp file `/tmp/mngr-message-from-YOUR_NAME-to-AGENT_NAME.txt` (using your agent name and the resolved target name):
 
 ```bash
-uv run mngr message AGENT_NAME --message-file /tmp/mngr-message-AGENT_NAME.txt
+uv run mngr message AGENT_NAME --message-file /tmp/mngr-message-from-YOUR_NAME-to-AGENT_NAME.txt
 ```
 
-Replace `AGENT_NAME` with the resolved target agent name. Use `--message-file` for all messages -- it avoids shell quoting issues and preserves formatting.
+Use `--message-file` for all messages -- it avoids shell quoting issues and preserves formatting.
 
 ## After Sending
 

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(uv run mngr message *), Bash(cat /tmp/mngr-message-*), Write(*), Skill(find-agent)
+allowed-tools: Bash(echo *), Bash(uv run mngr message *), Write(*), Skill(find-agent)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.
@@ -11,11 +11,21 @@ The user's message contains a target agent name (the first word) and a descripti
 
 Use the `/find-agent` skill with the first word of the user's input to resolve it to an exact agent name.
 
+## Your Agent Name
+
+Your own agent name is available in the `MNGR_AGENT_NAME` environment variable. Read it:
+
+```bash
+echo "$MNGR_AGENT_NAME"
+```
+
+You will use this to identify yourself in the message.
+
 ## Composing the Message
 
 Based on the user's description, compose the full message. Every message you send MUST:
 
-1. **Start with a sender tag**: `[from: $MNGR_AGENT_NAME]` -- the shell will expand this automatically.
+1. **Start with a sender tag**: `[from: <your agent name>]` (using the value from the echo above).
 2. **Contain the actual content**: Write the message based on what the user described. Be clear and direct.
 3. **End with a reply instruction**: Close with a line like: `To reply, use the /message-agent skill.`
 
@@ -31,23 +41,14 @@ To reply, use the /message-agent skill.
 
 ## Sending the Message
 
-Always write the message body to a temporary file and use `--message-file`. This avoids shell quoting issues and preserves formatting. Use `$MNGR_AGENT_NAME` in the heredoc so the shell expands it:
+Write the composed message to a temporary file using the Write tool, then send it with `--message-file`:
 
 ```bash
-cat > /tmp/mngr-message-AGENT_NAME.txt <<EOF
-[from: $MNGR_AGENT_NAME]
-
-<message body here>
-
-To reply, use the /message-agent skill.
-EOF
 uv run mngr message AGENT_NAME --message-file /tmp/mngr-message-AGENT_NAME.txt
 ```
 
-Replace `AGENT_NAME` with the resolved target agent name and `<message body here>` with the actual content.
-
-Do NOT use a quoted heredoc delimiter (i.e. do NOT write `<<'EOF'`) -- the delimiter must be unquoted so that `$MNGR_AGENT_NAME` is expanded by the shell.
+Replace `AGENT_NAME` with the resolved target agent name. Use `--message-file` for all messages -- it avoids shell quoting issues and preserves formatting.
 
 ## After Sending
 
-Report to the user what you sent and to whom (you can `cat /tmp/mngr-message-AGENT_NAME.txt` to confirm the expanded content). If the send command fails, report the error.
+Report to the user what you sent and to whom. If the send command fails, report the error.

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(uv run mngr message *), Write(*), Skill(find-agent)
+allowed-tools: Bash(echo "$MNGR_AGENT_NAME"), Bash(uv run mngr message *), Write(*), Skill(find-agent)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(echo *), Bash(uv run mngr message *), Write(*), Skill(find-agent)
+allowed-tools: Bash(uv run mngr message *), Bash(cat /tmp/mngr-message-*), Write(*), Skill(find-agent)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.
@@ -11,25 +11,15 @@ The user's message contains a target agent name (the first word) and a descripti
 
 Use the `/find-agent` skill with the first word of the user's input to resolve it to an exact agent name.
 
-## Your Agent Name
-
-Your own agent name is available in the `MNGR_AGENT_NAME` environment variable. Read it:
-
-```bash
-echo "$MNGR_AGENT_NAME"
-```
-
-You will use this to identify yourself in the message.
-
 ## Composing the Message
 
 Based on the user's description, compose the full message. Every message you send MUST:
 
-1. **Start with a sender tag**: `[from: <your agent name>]` (using the value of `$MNGR_AGENT_NAME`).
+1. **Start with a sender tag**: `[from: $MNGR_AGENT_NAME]` -- the shell will expand this automatically.
 2. **Contain the actual content**: Write the message based on what the user described. Be clear and direct.
 3. **End with a reply instruction**: Close with a line like: `To reply, use the /message-agent skill.`
 
-Example message:
+Example message (for an agent named `refactor-auth`):
 
 ```
 [from: refactor-auth]
@@ -41,24 +31,23 @@ To reply, use the /message-agent skill.
 
 ## Sending the Message
 
-For **short, single-line messages**, use `--message` directly:
+Always write the message body to a temporary file and use `--message-file`. This avoids shell quoting issues and preserves formatting. Use `$MNGR_AGENT_NAME` in the heredoc so the shell expands it:
 
 ```bash
-uv run mngr message AGENT_NAME --message '[from: my-name] Short message here. To reply, use the /message-agent skill.'
-```
+cat > /tmp/mngr-message-AGENT_NAME.txt <<EOF
+[from: $MNGR_AGENT_NAME]
 
-For **multiline messages** (which is most messages), write the composed message to a temporary file and use `--message-file`:
+<message body here>
 
-```bash
-# Write the message to a temp file
-# (use the Write tool to create /tmp/mngr-message-AGENT_NAME.txt with the full message content)
-
-# Then send it
+To reply, use the /message-agent skill.
+EOF
 uv run mngr message AGENT_NAME --message-file /tmp/mngr-message-AGENT_NAME.txt
 ```
 
-Prefer `--message-file` for anything longer than a single sentence. It avoids shell quoting issues and preserves formatting.
+Replace `AGENT_NAME` with the resolved target agent name and `<message body here>` with the actual content.
+
+Do NOT use a quoted heredoc delimiter (i.e. do NOT write `<<'EOF'`) -- the delimiter must be unquoted so that `$MNGR_AGENT_NAME` is expanded by the shell.
 
 ## After Sending
 
-Report to the user what you sent and to whom. If the send command fails, report the error.
+Report to the user what you sent and to whom (you can `cat /tmp/mngr-message-AGENT_NAME.txt` to confirm the expanded content). If the send command fails, report the error.

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,22 +2,14 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(echo *), Bash(uv run mngr message *), Bash(uv run mngr list *), Write(*)
+allowed-tools: Bash(echo *), Bash(uv run mngr message *), Write(*), Skill(find-agent)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.
 
-Note: the user may paste a git branch name like `mngr/some-agent` instead of the bare agent name. In that case, strip the `mngr/` prefix to get the actual agent name (e.g. `mngr/better-tabcomplete` -> `better-tabcomplete`).
-
 ## Agent Name Resolution
 
-First, verify the target agent exists by running:
-
-```
-uv run mngr list --format '{name}'
-```
-
-If the extracted name doesn't match any agent exactly, check if the user's input was a description (e.g. "the agent working on X") rather than a name, and try to match against the listed agents and their git branches. If there's an unambiguous match, use it. Otherwise, use AskUserQuestion to ask the user which agent they meant, presenting the plausible candidates.
+Use the `/find-agent` skill with the first word of the user's input to resolve it to an exact agent name.
 
 ## Your Agent Name
 

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,30 +2,22 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(echo *), Bash(uv run mngr message *), Write(*), Skill(find-agent)
+allowed-tools: Bash(uv run mngr message *), Write(*), Skill(find-agent)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.
+
+Your agent name is: !`echo "$MNGR_AGENT_NAME"`
 
 ## Agent Name Resolution
 
 Use the `/find-agent` skill with the first word of the user's input to resolve it to an exact agent name.
 
-## Your Agent Name
-
-Your own agent name is available in the `MNGR_AGENT_NAME` environment variable. Read it:
-
-```bash
-echo "$MNGR_AGENT_NAME"
-```
-
-You will use this to identify yourself in the message.
-
 ## Composing the Message
 
 Based on the user's description, compose the full message. Every message you send MUST:
 
-1. **Start with a sender tag**: `[from: <your agent name>]` (using the value from the echo above).
+1. **Start with a sender tag**: `[from: !`echo "$MNGR_AGENT_NAME"`]`.
 2. **Contain the actual content**: Write the message based on what the user described. Be clear and direct.
 3. **End with a reply instruction**: Close with a line like: `To reply, use the /message-agent skill.`
 

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: message-agent
+argument-hint: <agent_name> <description of what to say>
+description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
+allowed-tools: Bash(uv run mngr message *), Bash(uv run mngr list *), Write(*)
+---
+
+The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.
+
+Note: the user may paste a git branch name like `mngr/some-agent` instead of the bare agent name. In that case, strip the `mngr/` prefix to get the actual agent name (e.g. `mngr/better-tabcomplete` -> `better-tabcomplete`).
+
+## Agent Name Resolution
+
+First, verify the target agent exists by running:
+
+```
+uv run mngr list --format '{name}'
+```
+
+If the extracted name doesn't match any agent exactly, check if the user's input was a description (e.g. "the agent working on X") rather than a name, and try to match against the listed agents and their git branches. If there's an unambiguous match, use it. Otherwise, use AskUserQuestion to ask the user which agent they meant, presenting the plausible candidates.
+
+## Your Agent Name
+
+Your own agent name is available in the `MNGR_AGENT_NAME` environment variable. Read it:
+
+```bash
+echo "$MNGR_AGENT_NAME"
+```
+
+You will use this to identify yourself in the message.
+
+## Composing the Message
+
+Based on the user's description, compose the full message. Every message you send MUST:
+
+1. **Start with a sender tag**: `[from: <your agent name>]` (using the value of `$MNGR_AGENT_NAME`).
+2. **Contain the actual content**: Write the message based on what the user described. Be clear and direct.
+3. **End with a reply instruction**: Close with a line like: `To reply, use the /message-agent skill.`
+
+Example message:
+
+```
+[from: refactor-auth]
+
+Hey -- I just finished refactoring the auth middleware on my branch. You'll want to rebase before merging since I changed the SessionStore interface. The new method is `get_session_by_token()` instead of `lookup()`.
+
+To reply, use the /message-agent skill.
+```
+
+## Sending the Message
+
+For **short, single-line messages**, use `--message` directly:
+
+```bash
+uv run mngr message AGENT_NAME --message '[from: my-name] Short message here. To reply, use the /message-agent skill.'
+```
+
+For **multiline messages** (which is most messages), write the composed message to a temporary file and use `--message-file`:
+
+```bash
+# Write the message to a temp file
+# (use the Write tool to create /tmp/mngr-message-AGENT_NAME.txt with the full message content)
+
+# Then send it
+uv run mngr message AGENT_NAME --message-file /tmp/mngr-message-AGENT_NAME.txt
+```
+
+Prefer `--message-file` for anything longer than a single sentence. It avoids shell quoting issues and preserves formatting.
+
+## After Sending
+
+Report to the user what you sent and to whom. If the send command fails, report the error.

--- a/.claude/skills/message-agent/SKILL.md
+++ b/.claude/skills/message-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: message-agent
 argument-hint: <agent_name> <description of what to say>
 description: Send a message to another mngr agent. Use when you need to communicate with a peer agent.
-allowed-tools: Bash(uv run mngr message *), Bash(uv run mngr list *), Write(*)
+allowed-tools: Bash(echo *), Bash(uv run mngr message *), Bash(uv run mngr list *), Write(*)
 ---
 
 The user's message contains a target agent name (the first word) and a description of what to communicate. Extract the agent name and treat everything after it as the intent/content of the message.

--- a/.claude/skills/wait-for-agent/SKILL.md
+++ b/.claude/skills/wait-for-agent/SKILL.md
@@ -2,22 +2,14 @@
 name: wait-for-agent
 argument-hint: [agent_name] [instructions...]
 description: Wait for another agent to enter WAITING state, then execute follow-up instructions
-allowed-tools: Bash(uv run mngr list *), Bash(while true; do*)
+allowed-tools: Bash(uv run mngr list *), Bash(while true; do*), Skill(find-agent)
 ---
 
 The user's message contains an agent name and optional follow-up instructions. Extract the agent name (the first word) and treat everything after it as follow-up instructions.
 
-Note: the user may paste a git branch name like `mngr/some-agent` instead of the bare agent name. In that case, strip the `mngr/` prefix to get the actual agent name (e.g. `mngr/better-tabcomplete` -> `better-tabcomplete`).
-
 ## Agent Name Resolution
 
-First, verify the target agent exists by running:
-
-```
-uv run mngr list --format '{name}'
-```
-
-If the extracted name doesn't match any agent exactly, check if the user's input was a description (e.g. "the agent working on X") rather than a name, and try to match against the listed agents and their git branches. If there's an unambiguous match, use it. Otherwise, use AskUserQuestion to ask the user which agent they meant, presenting the plausible candidates.
+Use the `/find-agent` skill with the first word of the user's input to resolve it to an exact agent name.
 
 ## Polling
 


### PR DESCRIPTION
## Summary

- Adds a new `/message-agent` Claude skill that teaches agents how to send messages to other mngr agents
- Messages are prefixed with `[from: <agent name>]` (read from `$MNGR_AGENT_NAME`) and end with a reply instruction pointing recipients to the same skill
- Advises using `--message-file` for multiline messages to avoid shell quoting issues
- Includes agent name resolution (with fuzzy matching against `mngr list`) following the same pattern as `wait-for-agent`

## Test plan

- [ ] Verify the skill appears in the Claude skill list (confirmed locally)
- [ ] Test invoking `/message-agent some-agent tell them to rebase` and verify the composed message format
- [ ] Verify `$MNGR_AGENT_NAME` is read correctly in an agent session

Generated with [Claude Code](https://claude.com/claude-code)