### PR TITLE
Move retry flags into settings, and actually implement connection retry

### DIFF
--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -47,8 +47,6 @@ mngr connect [OPTIONS] [AGENT]
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--reconnect`, `--no-reconnect` | boolean | Automatically reconnect if dropped [future] | `True` |
-| `--retry` | integer | Number of connection retries [future] | `3` |
-| `--retry-delay` | text | Delay between retries [future] | `5s` |
 | `--attach-command` | text | Command to run instead of attaching to main session [future] | None |
 | `--allow-unknown-host`, `--no-allow-unknown-host` | boolean | Allow connecting to hosts without a known_hosts file (disables SSH host key verification) | `False` |
 

--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -177,8 +177,6 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 | `--message` | text | Initial message to send after the agent starts | None |
 | `--message-file` | path | File containing initial message to send | None |
 | `--edit-message` | boolean | Open an editor to compose the initial message (uses $EDITOR). Editor runs in parallel with agent creation. If --message or --message-file is provided, their content is used as initial editor content. | `False` |
-| `--retry` | integer | Number of connection retries | `3` |
-| `--retry-delay` | text | Delay between retries (e.g., 5s, 1m) | `5s` |
 | `--attach-command` | text | Command to run instead of attaching to main session | None |
 | `--connect-command` | text | Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set. | None |
 

--- a/libs/mngr/imbue/mngr/api/connect.py
+++ b/libs/mngr/imbue/mngr/api/connect.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import time
 from pathlib import Path
 from typing import Final
 
@@ -14,7 +15,6 @@ from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.utils.duration import parse_duration_to_seconds
 from imbue.mngr.utils.interactive_subprocess import run_interactive_subprocess
-from imbue.mngr.utils.polling import poll_until
 
 # Exit codes used by the remote SSH wrapper script to signal post-disconnect actions.
 # These are checked by connect_to_agent after the SSH session ends to determine
@@ -274,7 +274,7 @@ def connect_to_agent(
                     attempt,
                     max_attempts,
                 )
-                poll_until(lambda: False, timeout=retry_delay_seconds, poll_interval=retry_delay_seconds)
+                time.sleep(retry_delay_seconds)
             else:
                 logger.debug(
                     "SSH session ended with exit code {} after {} attempt(s)",

--- a/libs/mngr/imbue/mngr/api/connect.py
+++ b/libs/mngr/imbue/mngr/api/connect.py
@@ -12,7 +12,9 @@ from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import NestedTmuxError
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.utils.duration import parse_duration_to_seconds
 from imbue.mngr.utils.interactive_subprocess import run_interactive_subprocess
+from imbue.mngr.utils.polling import poll_until
 
 # Exit codes used by the remote SSH wrapper script to signal post-disconnect actions.
 # These are checked by connect_to_agent after the SSH session ends to determine
@@ -239,15 +241,43 @@ def connect_to_agent(
         if fixed_env.get("TERM") == "xterm-kitty":
             fixed_env["TERM"] = "xterm-256color"
 
-        # Use run_interactive_subprocess instead of os.execvp so we can check the exit code
-        # and run post-disconnect actions (destroy/stop) triggered by tmux key bindings
-        completed = run_interactive_subprocess(ssh_args, env=fixed_env)
-        exit_code = completed.returncode
+        retry_delay_seconds = parse_duration_to_seconds(connection_opts.retry_delay)
+        max_attempts = 1 + connection_opts.retry_count
 
-        action = _determine_post_disconnect_action(exit_code, session_name)
-        if action is not None:
-            executable, argv = action
-            logger.info("Running post-disconnect action: {}", argv)
-            os.execvp(executable, argv)
-        else:
-            logger.debug("SSH session ended with exit code {} (no post-disconnect action)", exit_code)
+        for attempt in range(1, max_attempts + 1):
+            # Use run_interactive_subprocess instead of os.execvp so we can check the exit code
+            # and run post-disconnect actions (destroy/stop) triggered by tmux key bindings
+            completed = run_interactive_subprocess(ssh_args, env=fixed_env)
+            exit_code = completed.returncode
+
+            # Exit code 0 means normal disconnect -- no retry needed
+            if exit_code == 0:
+                logger.debug("SSH session ended normally")
+                return
+
+            # Check for post-disconnect actions (destroy/stop via tmux key bindings)
+            action = _determine_post_disconnect_action(exit_code, session_name)
+            if action is not None:
+                executable, argv = action
+                logger.info("Running post-disconnect action: {}", argv)
+                os.execvp(executable, argv)
+                # The exec call above replaces the process and never returns.
+                # This return is a safety net for tests that mock the exec call.
+                return
+
+            # Non-zero, non-signal exit code: SSH connection failed
+            if attempt < max_attempts:
+                logger.warning(
+                    "SSH connection failed (exit code {}). Retrying in {} ({}/{})...",
+                    exit_code,
+                    connection_opts.retry_delay,
+                    attempt,
+                    max_attempts,
+                )
+                poll_until(lambda: False, timeout=retry_delay_seconds, poll_interval=retry_delay_seconds)
+            else:
+                logger.debug(
+                    "SSH session ended with exit code {} after {} attempt(s)",
+                    exit_code,
+                    max_attempts,
+                )

--- a/libs/mngr/imbue/mngr/api/connect.py
+++ b/libs/mngr/imbue/mngr/api/connect.py
@@ -1,6 +1,5 @@
 import os
 import shlex
-import time
 from pathlib import Path
 from typing import Final
 
@@ -15,6 +14,7 @@ from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.utils.duration import parse_duration_to_seconds
 from imbue.mngr.utils.interactive_subprocess import run_interactive_subprocess
+from imbue.mngr.utils.polling import poll_until
 
 # Exit codes used by the remote SSH wrapper script to signal post-disconnect actions.
 # These are checked by connect_to_agent after the SSH session ends to determine
@@ -274,7 +274,7 @@ def connect_to_agent(
                     attempt,
                     max_attempts,
                 )
-                time.sleep(retry_delay_seconds)
+                poll_until(lambda: False, timeout=retry_delay_seconds, poll_interval=retry_delay_seconds)
             else:
                 logger.debug(
                     "SSH session ended with exit code {} after {} attempt(s)",

--- a/libs/mngr/imbue/mngr/api/connect_test.py
+++ b/libs/mngr/imbue/mngr/api/connect_test.py
@@ -446,6 +446,129 @@ def test_connect_to_agent_remote_unknown_exit_code_no_action(
     assert len(result.execvp_calls) == 0
 
 
+# =========================================================================
+# Tests for connect_to_agent retry behavior
+# =========================================================================
+
+
+def _run_connect_with_retries(
+    local_provider: LocalProviderInstance,
+    mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+    ssh_exit_codes: list[int],
+    retry_count: int = 2,
+) -> _ConnectTestResult:
+    """Set up and run connect_to_agent with a sequence of SSH exit codes.
+
+    Each successive call to run_interactive_subprocess returns the next exit code.
+    Also patches poll_until to avoid sleeping during retries.
+    """
+    host = _make_ssh_host(local_provider, mngr_ctx, ssh_known_hosts_file="/tmp/known_hosts")
+    agent = _make_remote_agent(host, mngr_ctx, agent_name="test-agent")
+    opts = ConnectionOptions(is_unknown_host_allowed=False, retry_count=retry_count, retry_delay="1s")
+
+    result = _ConnectTestResult()
+    call_index = 0
+
+    def fake_run_interactive(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        nonlocal call_index
+        exit_code = ssh_exit_codes[min(call_index, len(ssh_exit_codes) - 1)]
+        call_index += 1
+        result.subprocess_call_args.append(list(args))
+        return subprocess.CompletedProcess(args=args, returncode=exit_code)
+
+    monkeypatch.setattr(
+        "imbue.mngr.api.connect.run_interactive_subprocess",
+        fake_run_interactive,
+    )
+    monkeypatch.setattr(
+        "imbue.mngr.api.connect.os.execvp",
+        lambda cmd, args: result.execvp_calls.append((cmd, list(args))),
+    )
+    monkeypatch.setattr(
+        "imbue.mngr.api.connect.poll_until",
+        lambda condition, timeout, poll_interval: False,
+    )
+
+    connect_to_agent(agent, host, mngr_ctx, opts)
+
+    return result
+
+
+def test_connect_to_agent_retries_on_ssh_failure(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect_to_agent should retry up to retry_count times when SSH fails with a non-signal exit code."""
+    result = _run_connect_with_retries(
+        local_provider,
+        temp_mngr_ctx,
+        monkeypatch,
+        ssh_exit_codes=[255, 255, 255],
+        retry_count=2,
+    )
+
+    # 1 initial attempt + 2 retries = 3 total calls
+    assert len(result.subprocess_call_args) == 3
+    assert len(result.execvp_calls) == 0
+
+
+def test_connect_to_agent_no_retry_on_normal_exit(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect_to_agent should not retry when SSH exits normally (code 0)."""
+    result = _run_connect_with_retries(
+        local_provider,
+        temp_mngr_ctx,
+        monkeypatch,
+        ssh_exit_codes=[0],
+        retry_count=2,
+    )
+
+    assert len(result.subprocess_call_args) == 1
+    assert len(result.execvp_calls) == 0
+
+
+def test_connect_to_agent_no_retry_on_signal_exit(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect_to_agent should not retry on a post-disconnect signal exit code (destroy/stop)."""
+    result = _run_connect_with_retries(
+        local_provider,
+        temp_mngr_ctx,
+        monkeypatch,
+        ssh_exit_codes=[SIGNAL_EXIT_CODE_DESTROY],
+        retry_count=2,
+    )
+
+    assert len(result.subprocess_call_args) == 1
+    assert len(result.execvp_calls) == 1
+
+
+def test_connect_to_agent_retries_then_succeeds(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """connect_to_agent should stop retrying once SSH succeeds."""
+    result = _run_connect_with_retries(
+        local_provider,
+        temp_mngr_ctx,
+        monkeypatch,
+        ssh_exit_codes=[255, 0],
+        retry_count=2,
+    )
+
+    # First attempt fails, second succeeds -- no third attempt
+    assert len(result.subprocess_call_args) == 2
+    assert len(result.execvp_calls) == 0
+
+
 def test_connect_to_agent_remote_uses_correct_session_name(
     local_provider: LocalProviderInstance,
     temp_host_dir: Path,

--- a/libs/mngr/imbue/mngr/api/connect_test.py
+++ b/libs/mngr/imbue/mngr/api/connect_test.py
@@ -366,23 +366,32 @@ class _ConnectTestResult:
         self.subprocess_call_args: list[list[str]] = []
 
 
-def _run_connect_to_agent(
+def _run_connect_with_retries(
     local_provider: LocalProviderInstance,
     mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
-    ssh_exit_code: int,
+    ssh_exit_codes: list[int],
+    retry_count: int = 2,
     agent_name: str = "test-agent",
 ) -> _ConnectTestResult:
-    """Set up and run connect_to_agent with intercepted system calls."""
+    """Set up and run connect_to_agent with a sequence of SSH exit codes.
+
+    Each successive call to run_interactive_subprocess returns the next exit code
+    from the list. When the list is exhausted, the last exit code is repeated.
+    """
     host = _make_ssh_host(local_provider, mngr_ctx, ssh_known_hosts_file="/tmp/known_hosts")
     agent = _make_remote_agent(host, mngr_ctx, agent_name=agent_name)
-    opts = ConnectionOptions(is_unknown_host_allowed=False, retry_count=0)
+    opts = ConnectionOptions(is_unknown_host_allowed=False, retry_count=retry_count, retry_delay="1s")
 
     result = _ConnectTestResult()
+    call_index = 0
 
-    def fake_run_interactive(args, **kwargs):
+    def fake_run_interactive(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        nonlocal call_index
+        exit_code = ssh_exit_codes[min(call_index, len(ssh_exit_codes) - 1)]
+        call_index += 1
         result.subprocess_call_args.append(list(args))
-        return subprocess.CompletedProcess(args=args, returncode=ssh_exit_code)
+        return subprocess.CompletedProcess(args=args, returncode=exit_code)
 
     monkeypatch.setattr(
         "imbue.mngr.api.connect.run_interactive_subprocess",
@@ -396,6 +405,24 @@ def _run_connect_to_agent(
     connect_to_agent(agent, host, mngr_ctx, opts)
 
     return result
+
+
+def _run_connect_to_agent(
+    local_provider: LocalProviderInstance,
+    mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+    ssh_exit_code: int,
+    agent_name: str = "test-agent",
+) -> _ConnectTestResult:
+    """Set up and run connect_to_agent with intercepted system calls (no retries)."""
+    return _run_connect_with_retries(
+        local_provider,
+        mngr_ctx,
+        monkeypatch,
+        ssh_exit_codes=[ssh_exit_code],
+        retry_count=0,
+        agent_name=agent_name,
+    )
 
 
 def test_connect_to_agent_remote_destroy_signal(
@@ -449,50 +476,6 @@ def test_connect_to_agent_remote_unknown_exit_code_no_action(
 # =========================================================================
 # Tests for connect_to_agent retry behavior
 # =========================================================================
-
-
-def _run_connect_with_retries(
-    local_provider: LocalProviderInstance,
-    mngr_ctx: MngrContext,
-    monkeypatch: pytest.MonkeyPatch,
-    ssh_exit_codes: list[int],
-    retry_count: int = 2,
-) -> _ConnectTestResult:
-    """Set up and run connect_to_agent with a sequence of SSH exit codes.
-
-    Each successive call to run_interactive_subprocess returns the next exit code.
-    Also patches poll_until to avoid sleeping during retries.
-    """
-    host = _make_ssh_host(local_provider, mngr_ctx, ssh_known_hosts_file="/tmp/known_hosts")
-    agent = _make_remote_agent(host, mngr_ctx, agent_name="test-agent")
-    opts = ConnectionOptions(is_unknown_host_allowed=False, retry_count=retry_count, retry_delay="1s")
-
-    result = _ConnectTestResult()
-    call_index = 0
-
-    def fake_run_interactive(args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
-        nonlocal call_index
-        exit_code = ssh_exit_codes[min(call_index, len(ssh_exit_codes) - 1)]
-        call_index += 1
-        result.subprocess_call_args.append(list(args))
-        return subprocess.CompletedProcess(args=args, returncode=exit_code)
-
-    monkeypatch.setattr(
-        "imbue.mngr.api.connect.run_interactive_subprocess",
-        fake_run_interactive,
-    )
-    monkeypatch.setattr(
-        "imbue.mngr.api.connect.os.execvp",
-        lambda cmd, args: result.execvp_calls.append((cmd, list(args))),
-    )
-    monkeypatch.setattr(
-        "imbue.mngr.api.connect.poll_until",
-        lambda condition, timeout, poll_interval: False,
-    )
-
-    connect_to_agent(agent, host, mngr_ctx, opts)
-
-    return result
 
 
 def test_connect_to_agent_retries_on_ssh_failure(

--- a/libs/mngr/imbue/mngr/api/connect_test.py
+++ b/libs/mngr/imbue/mngr/api/connect_test.py
@@ -376,7 +376,7 @@ def _run_connect_to_agent(
     """Set up and run connect_to_agent with intercepted system calls."""
     host = _make_ssh_host(local_provider, mngr_ctx, ssh_known_hosts_file="/tmp/known_hosts")
     agent = _make_remote_agent(host, mngr_ctx, agent_name=agent_name)
-    opts = ConnectionOptions(is_unknown_host_allowed=False)
+    opts = ConnectionOptions(is_unknown_host_allowed=False, retry_count=0)
 
     result = _ConnectTestResult()
 

--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -105,8 +105,6 @@ def default_create_cli_opts() -> CreateCliOptions:
         message=None,
         message_file=None,
         edit_message=False,
-        retry=3,
-        retry_delay="5s",
         attach_command=None,
         connect_command=None,
         idle_timeout=None,
@@ -147,8 +145,6 @@ def default_connect_cli_opts() -> ConnectCliOptions:
         agent=None,
         start=True,
         reconnect=True,
-        retry=3,
-        retry_delay="5s",
         attach_command=None,
         allow_unknown_host=False,
     )

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -28,6 +28,7 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.urwid_utils import create_urwid_screen_preserving_terminal
 from imbue.mngr.config.data_types import CommonCliOptions
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.data_types import AgentDetails
@@ -44,8 +45,6 @@ class ConnectCliOptions(CommonCliOptions):
     agent: str | None
     start: bool
     reconnect: bool
-    retry: int
-    retry_delay: str
     attach_command: str | None
     allow_unknown_host: bool
 
@@ -317,12 +316,12 @@ def select_agent_interactively(agents: list[AgentDetails]) -> AgentDetails | Non
 
 
 @pure
-def _build_connection_options(opts: ConnectCliOptions) -> ConnectionOptions:
-    """Build ConnectionOptions from CLI options."""
+def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) -> ConnectionOptions:
+    """Build ConnectionOptions from CLI options and config."""
     return ConnectionOptions(
         is_reconnect=opts.reconnect,
-        retry_count=opts.retry,
-        retry_delay=opts.retry_delay,
+        retry_count=mngr_ctx.config.retry.connect_retry_times,
+        retry_delay=mngr_ctx.config.retry.connect_retry_delay,
         attach_command=opts.attach_command,
         is_unknown_host_allowed=opts.allow_unknown_host,
     )
@@ -345,8 +344,6 @@ def _build_connection_options(opts: ConnectCliOptions) -> ConnectionOptions:
     show_default=True,
     help="Automatically reconnect if dropped [future]",
 )
-@optgroup.option("--retry", type=int, default=3, show_default=True, help="Number of connection retries [future]")
-@optgroup.option("--retry-delay", default="5s", show_default=True, help="Delay between retries [future]")
 @optgroup.option("--attach-command", help="Command to run instead of attaching to main session [future]")
 @optgroup.option(
     "--allow-unknown-host/--no-allow-unknown-host",
@@ -363,14 +360,6 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
         command_name="connect",
         command_class=ConnectCliOptions,
     )
-
-    # Number of times to retry connection on failure before giving up
-    if opts.retry != 3:
-        raise NotImplementedError("--retry with non-default value is not implemented yet")
-
-    # Delay between connection retries (supports durations like "5s", "1m")
-    if opts.retry_delay != "5s":
-        raise NotImplementedError("--retry-delay with non-default value is not implemented yet")
 
     # Run this command instead of the default tmux attach
     # Useful for running a different shell or command in the agent's environment
@@ -428,7 +417,7 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
         )
 
     # Build connection options
-    connection_opts = _build_connection_options(opts)
+    connection_opts = _build_connection_options(opts, mngr_ctx)
 
     logger.info("Connecting to agent: {}", agent.name)
     connect_to_agent(agent, host, mngr_ctx, connection_opts)

--- a/libs/mngr/imbue/mngr/cli/connect_test.py
+++ b/libs/mngr/imbue/mngr/cli/connect_test.py
@@ -5,6 +5,7 @@ from imbue.mngr.cli.connect import _build_connection_options
 from imbue.mngr.cli.connect import build_status_text
 from imbue.mngr.cli.connect import filter_agents
 from imbue.mngr.cli.connect import handle_search_key
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.utils.testing import make_test_agent_details
@@ -18,8 +19,6 @@ def _make_connect_opts(
     agent: str | None = "my-agent",
     start: bool = True,
     reconnect: bool = True,
-    retry: int = 3,
-    retry_delay: str = "5s",
     attach_command: str | None = None,
     allow_unknown_host: bool = False,
     output_format: str = "human",
@@ -38,8 +37,6 @@ def _make_connect_opts(
         agent=agent,
         start=start,
         reconnect=reconnect,
-        retry=retry,
-        retry_delay=retry_delay,
         attach_command=attach_command,
         allow_unknown_host=allow_unknown_host,
         output_format=output_format,
@@ -66,7 +63,6 @@ def test_connect_cli_options_can_be_instantiated() -> None:
     assert opts.agent == "my-agent"
     assert opts.start is True
     assert opts.reconnect is True
-    assert opts.retry == 3
 
 
 # =============================================================================
@@ -207,30 +203,28 @@ def test_handle_search_key_printable_but_no_character() -> None:
 # =============================================================================
 
 
-def test_build_connection_options_default_values() -> None:
-    """_build_connection_options should create ConnectionOptions from CLI options."""
+def test_build_connection_options_default_values(temp_mngr_ctx: MngrContext) -> None:
+    """_build_connection_options should create ConnectionOptions from CLI options and config."""
     opts = _make_connect_opts()
-    conn_opts = _build_connection_options(opts)
+    conn_opts = _build_connection_options(opts, temp_mngr_ctx)
     assert conn_opts.is_reconnect is True
-    assert conn_opts.retry_count == 3
-    assert conn_opts.retry_delay == "5s"
+    assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
+    assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
     assert conn_opts.attach_command is None
     assert conn_opts.is_unknown_host_allowed is False
 
 
-def test_build_connection_options_custom_values() -> None:
+def test_build_connection_options_custom_values(temp_mngr_ctx: MngrContext) -> None:
     """_build_connection_options should map custom CLI values correctly."""
     opts = _make_connect_opts(
         reconnect=False,
-        retry=5,
-        retry_delay="10s",
         attach_command="ssh user@host",
         allow_unknown_host=True,
     )
-    conn_opts = _build_connection_options(opts)
+    conn_opts = _build_connection_options(opts, temp_mngr_ctx)
     assert conn_opts.is_reconnect is False
-    assert conn_opts.retry_count == 5
-    assert conn_opts.retry_delay == "10s"
+    assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
+    assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
     assert conn_opts.attach_command == "ssh user@host"
     assert conn_opts.is_unknown_host_allowed is True
 

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -409,8 +409,6 @@ class _CreateCommand(click.Command):
     is_flag=True,
     help="Open an editor to compose the initial message (uses $EDITOR). Editor runs in parallel with agent creation. If --message or --message-file is provided, their content is used as initial editor content.",
 )
-@optgroup.option("--retry", type=int, default=3, show_default=True, help="Number of connection retries")
-@optgroup.option("--retry-delay", default="5s", show_default=True, help="Delay between retries (e.g., 5s, 1m)")
 @optgroup.option("--attach-command", help="Command to run instead of attaching to main session")
 @optgroup.option(
     "--connect-command",
@@ -644,8 +642,8 @@ def _create_agent(
         is_reconnect=opts.reconnect,
         is_interactive=opts.interactive,
         message=None,
-        retry_count=opts.retry,
-        retry_delay=opts.retry_delay,
+        retry_count=mngr_ctx.config.retry.connect_retry_times,
+        retry_delay=mngr_ctx.config.retry.connect_retry_delay,
         attach_command=opts.attach_command,
     )
 

--- a/libs/mngr/imbue/mngr/cli/start.py
+++ b/libs/mngr/imbue/mngr/cli/start.py
@@ -219,8 +219,8 @@ def start(ctx: click.Context, **kwargs: Any) -> None:
         else:
             connection_opts = ConnectionOptions(
                 is_reconnect=True,
-                retry_count=3,
-                retry_delay="5s",
+                retry_count=mngr_ctx.config.retry.connect_retry_times,
+                retry_delay=mngr_ctx.config.retry.connect_retry_delay,
                 attach_command=None,
                 is_unknown_host_allowed=False,
             )

--- a/libs/mngr/imbue/mngr/cli/test_connect.py
+++ b/libs/mngr/imbue/mngr/cli/test_connect.py
@@ -26,6 +26,7 @@ from imbue.mngr.cli.connect import filter_agents
 from imbue.mngr.cli.connect import handle_search_key
 from imbue.mngr.cli.connect import select_agent_interactively
 from imbue.mngr.cli.create import create
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.main import cli
 from imbue.mngr.primitives import AgentLifecycleState
@@ -282,43 +283,44 @@ def test_connect_cli_non_interactive_selects_most_recent_agent(
 
 def test_build_connection_options_allow_unknown_host_true(
     default_connect_cli_opts: ConnectCliOptions,
+    temp_mngr_ctx: MngrContext,
 ) -> None:
     """Test that allow_unknown_host=True produces is_unknown_host_allowed=True."""
     opts = default_connect_cli_opts.model_copy_update(
         to_update(default_connect_cli_opts.field_ref().allow_unknown_host, True),
     )
 
-    connection_opts = _build_connection_options(opts)
+    connection_opts = _build_connection_options(opts, temp_mngr_ctx)
 
     assert connection_opts.is_unknown_host_allowed is True
 
 
 def test_build_connection_options_allow_unknown_host_default(
     default_connect_cli_opts: ConnectCliOptions,
+    temp_mngr_ctx: MngrContext,
 ) -> None:
     """Test that is_unknown_host_allowed defaults to False."""
-    connection_opts = _build_connection_options(default_connect_cli_opts)
+    connection_opts = _build_connection_options(default_connect_cli_opts, temp_mngr_ctx)
 
     assert connection_opts.is_unknown_host_allowed is False
 
 
 def test_build_connection_options_maps_all_fields(
     default_connect_cli_opts: ConnectCliOptions,
+    temp_mngr_ctx: MngrContext,
 ) -> None:
     """Test that all ConnectCliOptions fields are correctly mapped to ConnectionOptions."""
     opts = default_connect_cli_opts.model_copy_update(
         to_update(default_connect_cli_opts.field_ref().reconnect, False),
-        to_update(default_connect_cli_opts.field_ref().retry, 5),
-        to_update(default_connect_cli_opts.field_ref().retry_delay, "10s"),
         to_update(default_connect_cli_opts.field_ref().attach_command, "bash"),
         to_update(default_connect_cli_opts.field_ref().allow_unknown_host, True),
     )
 
-    connection_opts = _build_connection_options(opts)
+    connection_opts = _build_connection_options(opts, temp_mngr_ctx)
 
     assert connection_opts.is_reconnect is False
-    assert connection_opts.retry_count == 5
-    assert connection_opts.retry_delay == "10s"
+    assert connection_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
+    assert connection_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
     assert connection_opts.attach_command == "bash"
     assert connection_opts.is_unknown_host_allowed is True
 

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -375,6 +375,40 @@ class CreateTemplate(FrozenModel):
         return self.__class__(options=merged_options)
 
 
+class RetryConfig(FrozenModel):
+    """Configuration for connection retry behavior.
+
+    Controls how many times and how frequently mngr retries SSH connections
+    to remote agents when connecting (via both ``mngr create --connect`` and
+    ``mngr connect``).
+    """
+
+    connect_retry_times: int = Field(
+        default=3,
+        description="Number of times to retry a failed SSH connection before giving up",
+    )
+    connect_retry_delay: str = Field(
+        default="5s",
+        description="Delay between connection retries (e.g., '5s', '1m')",
+    )
+
+    def merge_with(self, override: "RetryConfig") -> "RetryConfig":
+        """Merge this config with an override config.
+
+        Important note: despite the type signatures, any of these fields may be None in the override--this means that they were NOT set in the toml (and thus should be ignored)
+
+        Scalar fields: override wins if not None
+        """
+        return RetryConfig(
+            connect_retry_times=override.connect_retry_times
+            if override.connect_retry_times is not None
+            else self.connect_retry_times,
+            connect_retry_delay=override.connect_retry_delay
+            if override.connect_retry_delay is not None
+            else self.connect_retry_delay,
+        )
+
+
 class MngrConfig(FrozenModel):
     """Root configuration model for mngr."""
 
@@ -432,6 +466,10 @@ class MngrConfig(FrozenModel):
     pre_command_scripts: dict[str, list[str]] = Field(
         default_factory=dict,
         description="Commands to run before CLI commands execute, keyed by command name (e.g., 'create': ['echo hello', 'validate.sh'])",
+    )
+    retry: RetryConfig = Field(
+        default_factory=RetryConfig,
+        description="Connection retry configuration",
     )
     logging: LoggingConfig = Field(
         default_factory=LoggingConfig,
@@ -611,6 +649,11 @@ class MngrConfig(FrozenModel):
         if override.default_destroyed_host_persisted_seconds is not None:
             default_destroyed_host_persisted_seconds = override.default_destroyed_host_persisted_seconds
 
+        # Merge retry (nested config - use merge_with if override.retry is not None)
+        merged_retry = self.retry
+        if override.retry is not None:
+            merged_retry = self.retry.merge_with(override.retry)
+
         # Merge logging (nested config - use merge_with if override.logging is not None)
         merged_logging = self.logging
         if override.logging is not None:
@@ -632,6 +675,7 @@ class MngrConfig(FrozenModel):
             pre_command_scripts=merged_pre_command_scripts,
             is_remote_agent_installation_allowed=is_remote_agent_installation_allowed,
             connect_command=merged_connect_command,
+            retry=merged_retry,
             logging=merged_logging,
             is_nested_tmux_allowed=merged_is_nested_tmux_allowed,
             headless=merged_headless,
@@ -824,8 +868,6 @@ class CreateCliOptions(CommonCliOptions):
     message: str | None
     message_file: str | None
     edit_message: bool
-    retry: int
-    retry_delay: str
     attach_command: str | None
     idle_timeout: str | None
     idle_mode: str | None

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -182,6 +182,10 @@ def load_config(
     # CLI-level --disable-plugin flags that weren't known at startup.
     block_disabled_plugins(pm, config_dict["disabled_plugins"], is_strict=True)
 
+    # Include retry if not None
+    if config.retry is not None:
+        config_dict["retry"] = config.retry
+
     # Include logging if not None
     if config.logging is not None:
         config_dict["logging"] = config.logging

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -24,6 +24,7 @@ from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import PluginConfig
 from imbue.mngr.config.data_types import ProviderInstanceConfig
+from imbue.mngr.config.data_types import RetryConfig
 from imbue.mngr.config.data_types import split_cli_args_string
 from imbue.mngr.config.host_dir import read_default_host_dir
 from imbue.mngr.config.plugin_registry import get_plugin_config_class
@@ -501,6 +502,15 @@ def block_disabled_plugins(pm: pluggy.PluginManager, disabled_names: frozenset[s
             pm.set_blocked(name)
 
 
+def _parse_retry_config(raw_retry: dict[str, Any], *, strict: bool = True) -> RetryConfig:
+    """Parse retry config.
+
+    Uses model_construct to bypass validation and explicitly set None for unset fields.
+    """
+    _check_unknown_fields(raw_retry, RetryConfig, "retry", strict=strict)
+    return RetryConfig.model_construct(**raw_retry)
+
+
 def _parse_logging_config(raw_logging: dict[str, Any], *, strict: bool = True) -> LoggingConfig:
     """Parse logging config.
 
@@ -601,6 +611,7 @@ def parse_config(
     kwargs["create_templates"] = (
         _parse_create_templates(raw.pop("create_templates", {})) if "create_templates" in raw else {}
     )
+    kwargs["retry"] = _parse_retry_config(raw.pop("retry", {}), strict=strict) if "retry" in raw else None
     kwargs["logging"] = _parse_logging_config(raw.pop("logging", {}), strict=strict) if "logging" in raw else None
     kwargs["is_nested_tmux_allowed"] = raw.pop("is_nested_tmux_allowed", None)
     kwargs["headless"] = raw.pop("headless", None)

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -749,6 +749,8 @@ def test_load_config_threads_every_field_from_toml(
     assert config.is_nested_tmux_allowed is True
     assert config.is_error_reporting_enabled is False
     assert config.default_destroyed_host_persisted_seconds == 12345.0
+    assert config.retry.connect_retry_times == 5
+    assert config.retry.connect_retry_delay == "10s"
     assert "TEST_VAR" in config.unset_vars
     assert ProviderBackendName("local") in config.enabled_backends
     assert ".venv" in config.work_dir_extra_paths

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -770,6 +770,7 @@ _SAMPLE_CONFIG_VALUES: dict[str, Any] = {
     "create_templates": {"modal": {"new_host": "modal"}},
     "pre_command_scripts": {"create": ["echo hello"]},
     "work_dir_extra_paths": {".venv": "SHARE", ".test_output": "COPY"},
+    "retry": {"connect_retry_times": 5, "connect_retry_delay": "10s"},
     "logging": {"file_level": "DEBUG"},
     "is_remote_agent_installation_allowed": False,
     "connect_command": "my-connect",
@@ -803,6 +804,10 @@ create = ["echo hello"]
 [work_dir_extra_paths]
 ".venv" = "SHARE"
 ".test_output" = "COPY"
+
+[retry]
+connect_retry_times = 5
+connect_retry_delay = "10s"
 
 [logging]
 file_level = "DEBUG"

--- a/libs/mngr/imbue/mngr/e2e/test_create_modal.py
+++ b/libs/mngr/imbue/mngr/e2e/test_create_modal.py
@@ -340,13 +340,15 @@ def test_create_modal_reuse(e2e: E2eSession) -> None:
 @pytest.mark.timeout(120)
 def test_create_modal_retry(e2e: E2eSession) -> None:
     e2e.write_tutorial_block("""
-    # you can control connection retries and timeouts:
-    mngr create my-task --provider modal --retry 5 --retry-delay 10s
+    # you can control connection retries and timeouts via settings.toml:
+    # [retry]
+    # connect_retry_times = 5
+    # connect_retry_delay = "10s"
     # (--reconnect / --no-reconnect controls auto-reconnect on disconnect)
     """)
     result = e2e.run(
-        "mngr create my-task --provider modal --retry 5 --retry-delay 10s --no-connect --no-ensure-clean",
-        comment="you can control connection retries and timeouts",
+        "mngr create my-task --provider modal --no-connect --no-ensure-clean",
+        comment="retry settings are configured via [retry] in settings.toml",
         timeout=_REMOTE_TIMEOUT,
     )
     expect(result).to_succeed()

--- a/libs/mngr/imbue/mngr/resources/mega_tutorial.sh
+++ b/libs/mngr/imbue/mngr/resources/mega_tutorial.sh
@@ -228,8 +228,10 @@ mngr create my-task --no-ensure-clean
 mngr create sisyphus --reuse --provider modal
 # if that agent already exists, it will be reused (and started) instead of creating a new one. If it doesn't exist, it will be created.
 
-# you can control connection retries and timeouts:
-mngr create my-task --provider modal --retry 5 --retry-delay 10s
+# you can control connection retries and timeouts via settings.toml:
+# [retry]
+# connect_retry_times = 5
+# connect_retry_delay = "10s"
 # (--reconnect / --no-reconnect controls auto-reconnect on disconnect)
 
 # you can use a custom connect command instead of the default (eg, useful for, say, connecting in a new iterm window instead of the current one)


### PR DESCRIPTION
## Summary

- **Removed** `--retry` and `--retry-delay` CLI flags from `mngr create`, `mngr connect`, and `mngr start`
- **Added** a `[retry]` config stanza in `settings.toml` with `connect_retry_times` and `connect_retry_delay`
- **Implemented** actual SSH connection retry logic -- previously these flags were accepted but never used

### Configuration

```toml
[retry]
connect_retry_times = 5    # default: 3
connect_retry_delay = "10s" # default: "5s"
```

Settings are read from the standard config precedence chain (user profile, project, local, `--setting` flag).

### Retry behavior

When an SSH connection to a remote agent fails with a non-zero, non-signal exit code, mngr now retries up to `connect_retry_times` times with `connect_retry_delay` between attempts. Signal exit codes (destroy/stop from tmux keybindings) and normal exits (code 0) are handled immediately without retry.

## Manual test plan

- [ ] `mngr connect <remote-agent>` connects normally (no retry on success)
- [ ] Kill the SSH connection mid-session and verify it retries (check log output for "Retrying in..." messages)
- [ ] Set `[retry] connect_retry_times = 0` in settings.toml and verify no retries occur on failure
- [ ] Set custom retry delay (e.g. `connect_retry_delay = "2s"`) and verify the delay between retries matches
- [ ] `mngr create --connect` to a remote host uses the configured retry settings
- [ ] `mngr start --connect` to a remote host uses the configured retry settings
- [ ] Verify `--retry` and `--retry-delay` flags are no longer accepted on create/connect/start
- [ ] Ctrl-q (destroy) and Ctrl-t (stop) during a remote session still trigger post-disconnect actions without retry