### PR TITLE
Add all the commands/generic and concept docs as help topics

### DIFF
--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -207,11 +207,6 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Agent Limits
-
-See [Limit Options](../secondary/limit.md)
-
-
 ## Provider Build/Start Arguments
 
 Provider: docker
@@ -278,6 +273,7 @@ Provider: vultr
 - [mngr connect](./connect.md) - Connect to an existing agent
 - [mngr list](./list.md) - List existing agents
 - [mngr destroy](./destroy.md) - Destroy agents
+- [mngr limit](../secondary/limit.md) - Configure agent resource limits
 
 ## Examples
 

--- a/libs/mngr/docs/commands/primary/destroy.md
+++ b/libs/mngr/docs/commands/primary/destroy.md
@@ -72,16 +72,13 @@ mngr destroy [OPTIONS] [AGENTS]...
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Related Documentation
-
-- [Resource Cleanup Options](../generic/resource_cleanup.md) - Control which associated resources are destroyed
-- [Multi-target Options](../generic/multi_target.md) - Behavior when targeting multiple agents
-
 ## See Also
 
 - [mngr create](./create.md) - Create a new agent
 - [mngr list](./list.md) - List existing agents
 - [mngr gc](../secondary/gc.md) - Garbage collect orphaned resources
+- [mngr help resource_cleanup](../generic/resource_cleanup.md) - Control which associated resources are destroyed
+- [mngr help multi_target](../generic/multi_target.md) - Behavior when targeting multiple agents
 
 ## Examples
 

--- a/libs/mngr/docs/commands/primary/exec.md
+++ b/libs/mngr/docs/commands/primary/exec.md
@@ -80,15 +80,12 @@ mngr exec [OPTIONS] [AGENTS]... COMMAND
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Related Documentation
-
-- [Multi-target Options](../generic/multi_target.md) - Behavior when targeting multiple agents
-
 ## See Also
 
 - [mngr connect](./connect.md) - Connect to an agent interactively
 - [mngr message](../secondary/message.md) - Send a message to an agent
 - [mngr list](./list.md) - List available agents
+- [mngr help multi_target](../generic/multi_target.md) - Behavior when targeting multiple agents
 
 ## Examples
 

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -175,17 +175,13 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - You can use Python-style list slicing for list fields (e.g., `host.snapshots[0]` for the first snapshot, `host.snapshots[:3]` for the first 3)
 
 
-
-## Related Documentation
-
-- [Multi-target Options](../generic/multi_target.md) - Behavior when some agents cannot be accessed
-- [Common Options](../generic/common.md) - Common CLI options for output format, logging, etc.
-
 ## See Also
 
 - [mngr create](./create.md) - Create a new agent
 - [mngr connect](./connect.md) - Connect to an existing agent
 - [mngr destroy](./destroy.md) - Destroy agents
+- [mngr help multi_target](../generic/multi_target.md) - Behavior when some agents cannot be accessed
+- [mngr help common](../generic/common.md) - Common CLI options for output format, logging, etc.
 
 ## Examples
 

--- a/libs/mngr/docs/commands/primary/pull.md
+++ b/libs/mngr/docs/commands/primary/pull.md
@@ -118,16 +118,13 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Multi-target Behavior
-
-See [multi_target](../generic/multi_target.md) for options controlling behavior when some agents cannot be processed.
-
 ## See Also
 
 - [mngr create](./create.md) - Create a new agent
 - [mngr list](./list.md) - List agents to find one to pull from
 - [mngr connect](./connect.md) - Connect to an agent interactively
 - [mngr push](./push.md) - Push files or git commits to an agent
+- [mngr help multi_target](../generic/multi_target.md) - Behavior when some agents cannot be processed
 
 ## Examples
 

--- a/libs/mngr/docs/commands/secondary/help.md
+++ b/libs/mngr/docs/commands/secondary/help.md
@@ -41,22 +41,22 @@ mngr help [OPTIONS] [TOPIC]...
 
 ## Available Topics
 
-address (addr)               Agent address syntax for targeting agents and hosts
-agent_types                  Agent Types
-agents                       Agents
-api                          mngr Plugin API
-common                       Common Options
-environment_variables        Environment Variables
-hosts                        Hosts
-idle_detection               Idle Detection
-multi_target                 Commands that target from multiple hosts/agents
-permissions                  Permissions
-plugins                      Plugins
-provider_backends            Provider Backends
-providers                    Provider Instances
-provisioning                 Provisioning
-resource_cleanup             Resource Cleanup
-snapshot                     Snapshots
+- address (addr) - Agent address syntax for targeting agents and hosts
+- agent_types - Agent Types
+- agents - Agents
+- api - mngr Plugin API
+- common - Common Options
+- environment_variables - Environment Variables
+- hosts - Hosts
+- idle_detection - Idle Detection
+- multi_target - Commands that target from multiple hosts/agents
+- permissions - Permissions
+- plugins - Plugins
+- provider_backends - Provider Backends
+- providers - Provider Instances
+- provisioning - Provisioning
+- resource_cleanup - Resource Cleanup
+- snapshot - Snapshots
 
 ## Examples
 

--- a/libs/mngr/docs/commands/secondary/help.md
+++ b/libs/mngr/docs/commands/secondary/help.md
@@ -41,9 +41,22 @@ mngr help [OPTIONS] [TOPIC]...
 
 ## Available Topics
 
-| Topic | Aliases | Description |
-| ----- | ------- | ----------- |
-| `address` | `addr` | Agent address syntax for targeting agents and hosts |
+address (addr)               Agent address syntax for targeting agents and hosts
+agent_types                  Agent Types
+agents                       Agents
+api                          mngr Plugin API
+common                       Common Options
+environment_variables        Environment Variables
+hosts                        Hosts
+idle_detection               Idle Detection
+multi_target                 Commands that target from multiple hosts/agents
+permissions                  Permissions
+plugins                      Plugins
+provider_backends            Provider Backends
+providers                    Provider Instances
+provisioning                 Provisioning
+resource_cleanup             Resource Cleanup
+snapshot                     Snapshots
 
 ## Examples
 

--- a/libs/mngr/docs/commands/secondary/limit.md
+++ b/libs/mngr/docs/commands/secondary/limit.md
@@ -91,15 +91,12 @@ mngr limit [OPTIONS] [AGENTS]...
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Idle Modes
-
-See [Idle Detection](../../concepts/idle_detection.md) for details on idle modes and activity sources.
-
 ## See Also
 
 - [mngr create](../primary/create.md) - Create a new agent
 - [mngr list](../primary/list.md) - List existing agents
 - [mngr stop](../primary/stop.md) - Stop running agents
+- [mngr help idle_detection](../../concepts/idle_detection.md) - Idle detection modes and activity sources
 
 ## Examples
 

--- a/libs/mngr/docs/commands/secondary/message.md
+++ b/libs/mngr/docs/commands/secondary/message.md
@@ -72,14 +72,11 @@ mngr message [OPTIONS] [AGENTS]...
 | `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
 | `-h`, `--help` | boolean | Show this message and exit. | `False` |
 
-## Related Documentation
-
-- [Multi-target Options](../generic/multi_target.md) - Behavior when some agents fail to receive the message
-
 ## See Also
 
 - [mngr connect](../primary/connect.md) - Connect to an agent interactively
 - [mngr list](../primary/list.md) - List available agents
+- [mngr help multi_target](../generic/multi_target.md) - Behavior when some agents fail to receive the message
 
 ## Examples
 

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -1723,6 +1723,7 @@ via git push --mirror. Use --transfer to override the default.""",
         ("connect", "Connect to an existing agent"),
         ("list", "List existing agents"),
         ("destroy", "Destroy agents"),
+        ("limit", "Configure agent resource limits"),
     ),
     group_intros=(
         (
@@ -1736,12 +1737,6 @@ via git push --mirror. Use --transfer to override the default.""",
         (
             "Host Options",
             "By default, `mngr create` uses the local host. Use the agent address to specify a different host.",
-        ),
-    ),
-    additional_sections=(
-        (
-            "Agent Limits",
-            "See [Limit Options](../secondary/limit.md)",
         ),
     ),
 )

--- a/libs/mngr/imbue/mngr/cli/destroy.py
+++ b/libs/mngr/imbue/mngr/cli/destroy.py
@@ -644,13 +644,8 @@ Supports custom format templates via --format. Available fields: name.""",
         ("create", "Create a new agent"),
         ("list", "List existing agents"),
         ("gc", "Garbage collect orphaned resources"),
-    ),
-    additional_sections=(
-        (
-            "Related Documentation",
-            """- [Resource Cleanup Options](../generic/resource_cleanup.md) - Control which associated resources are destroyed
-- [Multi-target Options](../generic/multi_target.md) - Behavior when targeting multiple agents""",
-        ),
+        ("resource_cleanup", "Control which associated resources are destroyed"),
+        ("multi_target", "Behavior when targeting multiple agents"),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/exec.py
+++ b/libs/mngr/imbue/mngr/cli/exec.py
@@ -293,12 +293,7 @@ Supports custom format templates via --format. Available fields: agent, stdout, 
         ("connect", "Connect to an agent interactively"),
         ("message", "Send a message to an agent"),
         ("list", "List available agents"),
-    ),
-    additional_sections=(
-        (
-            "Related Documentation",
-            """- [Multi-target Options](../generic/multi_target.md) - Behavior when targeting multiple agents""",
-        ),
+        ("multi_target", "Behavior when targeting multiple agents"),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -431,7 +431,11 @@ EXAMPLES
 
 
 def _build_available_topics_section() -> str:
-    """Build the Available Topics section content from the topic registry."""
+    """Build the Available Topics section content from the topic registry.
+
+    Uses a bullet-list format that renders well in both terminal (indented
+    by the help formatter) and markdown (in generated docs).
+    """
     all_topics = get_all_topics()
     if not all_topics:
         return ""
@@ -440,7 +444,7 @@ def _build_available_topics_section() -> str:
         name_str = key
         if topic.aliases:
             name_str += f" ({', '.join(topic.aliases)})"
-        lines.append(f"{name_str:<28} {topic.one_line_description}")
+        lines.append(f"- {name_str} - {topic.one_line_description}")
     return "\n".join(lines)
 
 

--- a/libs/mngr/imbue/mngr/cli/help.py
+++ b/libs/mngr/imbue/mngr/cli/help.py
@@ -8,8 +8,10 @@ Both commands and topics support aliases (e.g., ``mngr help c`` for create,
 ``mngr help addr`` for address).
 """
 
+import re
 import sys
 from io import StringIO
+from pathlib import Path
 
 import click
 from pydantic import Field
@@ -43,6 +45,11 @@ class TopicHelpPage(FrozenModel):
     see_also: tuple[tuple[str, str], ...] = Field(
         default=(), description="See Also references as (name, description) tuples"
     )
+    docs_path: str | None = Field(
+        default=None,
+        description="Path to the source doc file relative to the docs root (e.g., 'concepts/idle_detection.md'). "
+        "Used by the doc generator to create correct relative links.",
+    )
 
     def register(self) -> None:
         """Register this topic page in the global topic registry."""
@@ -64,6 +71,75 @@ def get_topic(name: str) -> TopicHelpPage | None:
 def get_all_topics() -> dict[str, TopicHelpPage]:
     """Return a copy of the topic registry."""
     return dict(_topic_registry)
+
+
+# =============================================================================
+# Doc-based topic registration
+# =============================================================================
+
+# Docs root relative to this file:
+# this file: libs/mngr/imbue/mngr/cli/help.py
+# docs root: libs/mngr/docs/
+_DOCS_ROOT = Path(__file__).resolve().parents[3] / "docs"
+
+# Directories containing topic documentation, mapped to their path prefix
+# relative to the docs root.
+_TOPIC_DOC_DIRECTORIES: tuple[tuple[str, Path], ...] = (
+    ("commands/generic", _DOCS_ROOT / "commands" / "generic"),
+    ("concepts", _DOCS_ROOT / "concepts"),
+)
+
+
+def _extract_first_heading(content: str) -> str:
+    """Extract the text of the first markdown heading from content."""
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            title = stripped.lstrip("#").strip()
+            # Remove [future] tags
+            title = re.sub(r"\s*\[future\]", "", title)
+            return title
+    return ""
+
+
+def _strip_first_heading(content: str) -> str:
+    """Strip the first markdown heading and any trailing blank lines after it."""
+    lines = content.split("\n")
+    for i, line in enumerate(lines):
+        if line.strip().startswith("#"):
+            remaining = lines[i + 1 :]
+            while remaining and not remaining[0].strip():
+                remaining.pop(0)
+            return "\n".join(remaining)
+    return content
+
+
+def _register_docs_topics() -> None:
+    """Register topic pages from markdown documentation files.
+
+    Scans the generic/ and concepts/ doc directories, and creates a
+    TopicHelpPage for each .md file found. The topic key is the filename
+    stem (e.g., ``multi_target`` from ``multi_target.md``).
+    """
+    for path_prefix, directory in _TOPIC_DOC_DIRECTORIES:
+        if not directory.exists():
+            continue
+        for md_file in sorted(directory.glob("*.md")):
+            key = md_file.stem
+            if key in _topic_registry:
+                continue
+            raw_content = md_file.read_text()
+            title = _extract_first_heading(raw_content)
+            body = _strip_first_heading(raw_content)
+            TopicHelpPage(
+                key=key,
+                one_line_description=title,
+                content=body,
+                docs_path=f"{path_prefix}/{md_file.name}",
+            ).register()
+
+
+_register_docs_topics()
 
 
 # =============================================================================
@@ -270,42 +346,6 @@ def help_command(ctx: click.Context, topic: tuple[str, ...]) -> None:
     ctx.exit(1)
 
 
-# === Help metadata for the help command itself ===
-
-CommandHelpMetadata(
-    key="help",
-    one_line_description="Show help for a command or topic",
-    synopsis="mngr help [<command> | <topic>]",
-    description="""Show help for a mngr command or topic. Without arguments, lists all
-available commands and help topics.
-
-For commands, 'mngr help <command>' is equivalent to 'mngr <command> --help'.
-Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
-
-For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
-
-Help topics provide documentation on concepts that span multiple commands,
-such as agent address format.""",
-    additional_sections=(
-        (
-            "Available Topics",
-            "| Topic | Aliases | Description |\n"
-            "| ----- | ------- | ----------- |\n"
-            "| `address` | `addr` | Agent address syntax for targeting agents and hosts |",
-        ),
-    ),
-    examples=(
-        ("Show help for the create command", "mngr help create"),
-        ("Show help using a command alias", "mngr help c"),
-        ("Show help for a subcommand", "mngr help snapshot create"),
-        ("Show the address format topic", "mngr help address"),
-        ("List all commands and topics", "mngr help"),
-    ),
-).register()
-
-add_pager_help_option(help_command)
-
-
 # =============================================================================
 # Topic page definitions
 # =============================================================================
@@ -383,3 +423,49 @@ EXAMPLES
         ("connect", "Connect to an existing agent"),
     ),
 ).register()
+
+
+# =============================================================================
+# Help metadata for the help command itself
+# =============================================================================
+
+
+def _build_available_topics_section() -> str:
+    """Build the Available Topics section content from the topic registry."""
+    all_topics = get_all_topics()
+    if not all_topics:
+        return ""
+    lines: list[str] = []
+    for key, topic in sorted(all_topics.items()):
+        name_str = key
+        if topic.aliases:
+            name_str += f" ({', '.join(topic.aliases)})"
+        lines.append(f"{name_str:<28} {topic.one_line_description}")
+    return "\n".join(lines)
+
+
+CommandHelpMetadata(
+    key="help",
+    one_line_description="Show help for a command or topic",
+    synopsis="mngr help [<command> | <topic>]",
+    description="""Show help for a mngr command or topic. Without arguments, lists all
+available commands and help topics.
+
+For commands, 'mngr help <command>' is equivalent to 'mngr <command> --help'.
+Command aliases are supported (e.g., 'mngr help c' shows help for 'create').
+
+For subcommands, specify the full command path (e.g., 'mngr help snapshot create').
+
+Help topics provide documentation on concepts that span multiple commands,
+such as agent address format.""",
+    additional_sections=(("Available Topics", _build_available_topics_section()),),
+    examples=(
+        ("Show help for the create command", "mngr help create"),
+        ("Show help using a command alias", "mngr help c"),
+        ("Show help for a subcommand", "mngr help snapshot create"),
+        ("Show the address format topic", "mngr help address"),
+        ("List all commands and topics", "mngr help"),
+    ),
+).register()
+
+add_pager_help_option(help_command)

--- a/libs/mngr/imbue/mngr/cli/help_formatter.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter.py
@@ -298,8 +298,8 @@ def _write_git_style_help(
     # SEE ALSO section (if provided)
     if metadata.see_also:
         output.write(f"{_format_section_title('See Also')}\n")
-        for command_name, description in metadata.see_also:
-            output.write(f"       mngr {command_name} --help - {description}\n")
+        for ref_name, description in metadata.see_also:
+            output.write(f"       mngr help {ref_name} - {description}\n")
         output.write("\n")
 
     # EXAMPLES section (if provided)

--- a/libs/mngr/imbue/mngr/cli/help_formatter.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter.py
@@ -49,8 +49,8 @@ class CommandHelpMetadata(FrozenModel):
     )
     see_also: tuple[tuple[str, str], ...] = Field(
         default=(),
-        description="See Also references as (command_name, description) tuples. "
-        "Command name is just the subcommand (e.g., 'create' not 'mngr create').",
+        description="See Also references as (name, description) tuples. "
+        "Name can be a command (e.g., 'create') or a topic (e.g., 'multi_target').",
     )
 
     @property

--- a/libs/mngr/imbue/mngr/cli/help_test.py
+++ b/libs/mngr/imbue/mngr/cli/help_test.py
@@ -39,6 +39,36 @@ def test_get_all_topics_contains_registered_topics() -> None:
     assert "address" in topics
 
 
+def test_doc_based_topics_are_registered() -> None:
+    """Topics from generic/ and concepts/ docs directories are auto-registered."""
+    topics = get_all_topics()
+    # generic/ topics
+    assert "multi_target" in topics
+    assert "resource_cleanup" in topics
+    assert "common" in topics
+    # concepts/ topics
+    assert "idle_detection" in topics
+    assert "agents" in topics
+    assert "hosts" in topics
+    assert "providers" in topics
+
+
+def test_doc_based_topic_has_content() -> None:
+    """Doc-based topics have content loaded from the markdown file."""
+    topic = get_topic("idle_detection")
+    assert topic is not None
+    assert "idle" in topic.content.lower()
+    assert topic.docs_path is not None
+    assert topic.docs_path.endswith(".md")
+
+
+def test_doc_based_topic_has_description_from_heading() -> None:
+    """Doc-based topics extract their one-line description from the first heading."""
+    topic = get_topic("idle_detection")
+    assert topic is not None
+    assert topic.one_line_description == "Idle Detection"
+
+
 # =============================================================================
 # Topic formatting tests
 # =============================================================================
@@ -184,6 +214,28 @@ def test_help_topic_alias(
     assert "[NAME][@[HOST][.PROVIDER]]" in result.output
 
 
+def test_help_doc_based_topic(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help multi_target' shows a doc-based topic page."""
+    result = cli_runner.invoke(cli, ["help", "multi_target"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "multi_target" in result.output
+    assert "DESCRIPTION" in result.output
+
+
+def test_help_concepts_topic(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help idle_detection' shows a concepts topic page."""
+    result = cli_runner.invoke(cli, ["help", "idle_detection"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "idle_detection" in result.output
+    assert "idle" in result.output.lower()
+
+
 def test_help_nonexistent_topic(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
@@ -203,6 +255,34 @@ def test_help_help_shows_self(
     assert result.exit_code == 0
     assert "mngr help" in result.output
     assert "command or topic" in result.output.lower()
+
+
+def test_help_help_lists_topics_dynamically(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """'mngr help help' shows auto-generated Available Topics including doc-based topics."""
+    result = cli_runner.invoke(cli, ["help", "help"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "AVAILABLE TOPICS" in result.output
+    assert "address" in result.output
+    assert "multi_target" in result.output
+    assert "idle_detection" in result.output
+
+
+def test_command_see_also_renders_help_format(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """Command see_also entries render as 'mngr help <name>' for both commands and topics."""
+    result = cli_runner.invoke(cli, ["help", "destroy"], obj=plugin_manager, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "SEE ALSO" in result.output
+    # Command references
+    assert "mngr help create" in result.output
+    # Topic references
+    assert "mngr help resource_cleanup" in result.output
+    assert "mngr help multi_target" in result.output
 
 
 def test_help_list_alias(

--- a/libs/mngr/imbue/mngr/cli/limit.py
+++ b/libs/mngr/imbue/mngr/cli/limit.py
@@ -562,12 +562,7 @@ Use '-' in place of agent names to read them from stdin, one per line.""",
         ("create", "Create a new agent"),
         ("list", "List existing agents"),
         ("stop", "Stop running agents"),
-    ),
-    additional_sections=(
-        (
-            "Idle Modes",
-            "See [Idle Detection](../../concepts/idle_detection.md) for details on idle modes and activity sources.",
-        ),
+        ("idle_detection", "Idle detection modes and activity sources"),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1232,16 +1232,13 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - You can use Python-style list slicing for list fields (e.g., `host.snapshots[0]` for the first snapshot, `host.snapshots[:3]` for the first 3)
 """,
         ),
-        (
-            "Related Documentation",
-            """- [Multi-target Options](../generic/multi_target.md) - Behavior when some agents cannot be accessed
-- [Common Options](../generic/common.md) - Common CLI options for output format, logging, etc.""",
-        ),
     ),
     see_also=(
         ("create", "Create a new agent"),
         ("connect", "Connect to an existing agent"),
         ("destroy", "Destroy agents"),
+        ("multi_target", "Behavior when some agents cannot be accessed"),
+        ("common", "Common CLI options for output format, logging, etc."),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/message.py
+++ b/libs/mngr/imbue/mngr/cli/message.py
@@ -306,12 +306,7 @@ Use '-' in place of agent names to read them from stdin, one per line.""",
     see_also=(
         ("connect", "Connect to an agent interactively"),
         ("list", "List available agents"),
-    ),
-    additional_sections=(
-        (
-            "Related Documentation",
-            """- [Multi-target Options](../generic/multi_target.md) - Behavior when some agents fail to receive the message""",
-        ),
+        ("multi_target", "Behavior when some agents fail to receive the message"),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -341,18 +341,12 @@ If no source is specified, shows an interactive selector to choose an agent.""",
         ("Preview what would be transferred", "mngr pull my-agent --dry-run"),
         ("Pull git commits", "mngr pull my-agent --sync-mode=git"),
     ),
-    additional_sections=(
-        (
-            "Multi-target Behavior",
-            "See [multi_target](../generic/multi_target.md) for options controlling behavior "
-            "when some agents cannot be processed.",
-        ),
-    ),
     see_also=(
         ("create", "Create a new agent"),
         ("list", "List agents to find one to pull from"),
         ("connect", "Connect to an agent interactively"),
         ("push", "Push files or git commits to an agent"),
+        ("multi_target", "Behavior when some agents cannot be processed"),
     ),
 ).register()
 

--- a/scripts/make_cli_docs.py
+++ b/scripts/make_cli_docs.py
@@ -29,6 +29,7 @@ import click
 from click_option_group import GroupedOption
 
 from imbue.mngr.cli.common_opts import COMMON_OPTIONS_GROUP_NAME
+from imbue.mngr.cli.help import get_topic
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import get_help_metadata
 from imbue.mngr.main import BUILTIN_COMMANDS
@@ -381,18 +382,25 @@ def get_command_category(command_name: str) -> str | None:
     return None
 
 
-def get_relative_link(from_command: str, to_command: str) -> str:
-    """Get the relative markdown link path from one command's doc to another."""
+def get_relative_link(from_command: str, to_name: str) -> str:
+    """Get the relative markdown link path from one command's doc to another command or topic."""
     from_category = get_command_category(from_command)
-    to_category = get_command_category(to_command)
 
-    if to_category is None:
-        return f"mngr {to_command}"
+    # Check if the target is a command
+    to_category = get_command_category(to_name)
+    if to_category is not None:
+        if from_category == to_category:
+            return f"./{to_name}.md"
+        else:
+            return f"../{to_category}/{to_name}.md"
 
-    if from_category == to_category:
-        return f"./{to_command}.md"
-    else:
-        return f"../{to_category}/{to_command}.md"
+    # Check if the target is a topic with a docs path
+    topic = get_topic(to_name)
+    if topic is not None and topic.docs_path is not None:
+        from_dir = f"commands/{from_category}" if from_category else "commands"
+        return os.path.relpath(topic.docs_path, from_dir)
+
+    return f"mngr help {to_name}"
 
 
 def format_see_also_section(command_name: str, metadata: CommandHelpMetadata) -> str:
@@ -401,9 +409,14 @@ def format_see_also_section(command_name: str, metadata: CommandHelpMetadata) ->
         return ""
 
     lines = ["", "## See Also", ""]
-    for ref_command, description in metadata.see_also:
-        link = get_relative_link(command_name, ref_command)
-        lines.append(f"- [mngr {ref_command}]({link}) - {description}")
+    for ref_name, description in metadata.see_also:
+        link = get_relative_link(command_name, ref_name)
+        # Use "mngr <name>" for commands, "mngr help <name>" for topics
+        if get_command_category(ref_name) is not None:
+            link_text = f"mngr {ref_name}"
+        else:
+            link_text = f"mngr help {ref_name}"
+        lines.append(f"- [{link_text}]({link}) - {description}")
 
     lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Commands like `destroy`, `exec`, `limit`, etc. had `additional_sections` containing markdown links (e.g., `[Multi-target Options](../generic/multi_target.md)`) that displayed as raw markdown in `--help` terminal output. These are now `see_also` entries that render cleanly in both terminal and markdown docs.
- All markdown pages in `docs/commands/generic/` and `docs/concepts/` are now automatically registered as help topics, accessible via `mngr help <topic_name>` (e.g., `mngr help multi_target`, `mngr help idle_detection`).
- The `see_also` section now renders as `mngr help <name>` which works uniformly for both command and topic references.
- The "Available Topics" list in `mngr help help` is now auto-generated from the topic registry instead of being hardcoded.

## Manual testing

- [ ] `mngr help destroy` -- SEE ALSO should show `mngr help resource_cleanup` and `mngr help multi_target` (not raw markdown links)
- [ ] `mngr help create` -- SEE ALSO should include `mngr help limit`; no "AGENT LIMITS" additional section
- [ ] `mngr help multi_target` -- should display the multi-target docs as a topic page
- [ ] `mngr help idle_detection` -- should display the idle detection docs as a topic page
- [ ] `mngr help resource_cleanup` -- should display the resource cleanup docs
- [ ] `mngr help` (no args) -- TOPICS section should list all registered topics including doc-based ones
- [ ] `mngr help help` -- AVAILABLE TOPICS section should list all topics dynamically
- [ ] `mngr list --help` -- should still show CEL Filter Examples and Available Fields as additional_sections, with multi_target and common in SEE ALSO