### PR TITLE
Remove dead --interactive flag from create command

### DIFF
--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -173,7 +173,6 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--reconnect`, `--no-reconnect` | boolean | Automatically reconnect if dropped | `True` |
-| `--interactive`, `--no-interactive` | boolean | Enable interactive mode [default: yes if TTY] | None |
 | `--message` | text | Initial message to send after the agent starts | None |
 | `--message-file` | path | File containing initial message to send | None |
 | `--edit-message` | boolean | Open an editor to compose the initial message (uses $EDITOR). Editor runs in parallel with agent creation. If --message or --message-file is provided, their content is used as initial editor content. | `False` |

--- a/libs/mngr/imbue/mngr/api/data_types.py
+++ b/libs/mngr/imbue/mngr/api/data_types.py
@@ -70,10 +70,6 @@ class ConnectionOptions(FrozenModel):
         default=True,
         description="Automatically reconnect if connection is dropped",
     )
-    is_interactive: bool | None = Field(
-        default=None,
-        description="Enable interactive mode (None means auto-detect TTY)",
-    )
     message: str | None = Field(
         default=None,
         description="Message to send after connecting to agent",

--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -101,7 +101,6 @@ def default_create_cli_opts() -> CreateCliOptions:
         build_arg=(),
         start_arg=(),
         reconnect=True,
-        interactive=None,
         message=None,
         message_file=None,
         edit_message=False,

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -396,12 +396,6 @@ class _CreateCommand(click.Command):
 @optgroup.option(
     "--reconnect/--no-reconnect", default=True, show_default=True, help="Automatically reconnect if dropped"
 )
-@optgroup.option(
-    "--interactive/--no-interactive",
-    "interactive",
-    default=None,
-    help="Enable interactive mode [default: yes if TTY]",
-)
 @optgroup.option("--message", help="Initial message to send after the agent starts")
 @optgroup.option("--message-file", type=click.Path(exists=True), help="File containing initial message to send")
 @optgroup.option(
@@ -642,7 +636,6 @@ def _create_agent(
     # parse the connection options
     connection_opts = ConnectionOptions(
         is_reconnect=opts.reconnect,
-        is_interactive=opts.interactive,
         message=None,
         retry_count=opts.retry,
         retry_delay=opts.retry_delay,

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -820,7 +820,6 @@ class CreateCliOptions(CommonCliOptions):
     build_arg: tuple[str, ...]
     start_arg: tuple[str, ...]
     reconnect: bool
-    interactive: bool | None
     message: str | None
     message_file: str | None
     edit_message: bool


### PR DESCRIPTION
## Summary
- The `--interactive/--no-interactive` flag on `mngr create` was stored in `ConnectionOptions.is_interactive` but never read by any consumer
- Interactive mode is actually controlled by `--headless`, `config.headless`, and TTY auto-detection in `setup_command_context`
- Removed the flag, the `ConnectionOptions.is_interactive` field, the `CreateCliOptions.interactive` field, and the docs reference

## Test plan
- [x] All 3518 tests pass with coverage (83.99%)
- [x] Type checker passes (was catching the dead field reference in conftest)

Generated with [Claude Code](https://claude.com/claude-code)