### PR TITLE
fix: set JUnit XML name at collection time for skipped tests

### DIFF
--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -556,9 +556,8 @@ def _print_test_durations_for_ci(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def _set_junit_test_id(request: pytest.FixtureRequest, record_xml_attribute) -> None:
-    """Set JUnit XML name to the full test ID for exact matching with offload.
+def _compute_test_id(nodeid: str, fspath: str) -> str:
+    """Compute the full test ID for a test item.
 
     Uses OFFLOAD_ROOT env var if set (for consistent paths in offload runs),
     otherwise falls back to pytest's nodeid directly.
@@ -566,15 +565,38 @@ def _set_junit_test_id(request: pytest.FixtureRequest, record_xml_attribute) -> 
     offload_root = os.environ.get("OFFLOAD_ROOT")
 
     if offload_root:
-        # Build full test ID: relative_path::class::method or relative_path::method
-        fspath = str(request.node.fspath)
         rel_path = os.path.relpath(fspath, offload_root)
-        nodeid_parts = request.node.nodeid.split("::")
-        # nodeid_parts[0] is the file path (possibly different due to rootdir), [1:] is class/method
-        test_id = "::".join([rel_path] + nodeid_parts[1:])
-    else:
-        test_id = request.node.nodeid
+        nodeid_parts = nodeid.split("::")
+        return "::".join([rel_path] + nodeid_parts[1:])
+    return nodeid
 
+
+def _pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Set JUnit XML name to the full test ID at collection time.
+
+    Unlike the record_xml_attribute fixture, this hook runs at collection time
+    before any test execution. This ensures the JUnit name attribute is set
+    even for skipped tests, where fixtures do not execute.
+    """
+    from _pytest.junitxml import xml_key
+
+    xml = config.stash.get(xml_key, None)
+    if xml is None:
+        return
+    for item in items:
+        test_id = _compute_test_id(item.nodeid, str(item.fspath))
+        node_reporter = xml.node_reporter(item.nodeid)
+        node_reporter.add_attribute("name", test_id)
+
+
+@pytest.fixture(autouse=True)
+def _set_junit_test_id(request: pytest.FixtureRequest, record_xml_attribute) -> None:
+    """Set JUnit XML name to the full test ID for exact matching with offload.
+
+    This fixture handles non-skipped tests. Skipped tests are handled by
+    _pytest_collection_modifyitems which runs at collection time.
+    """
+    test_id = _compute_test_id(request.node.nodeid, str(request.node.fspath))
     record_xml_attribute("name", test_id)
 
 
@@ -602,6 +624,7 @@ def register_conftest_hooks(namespace: dict) -> None:
     namespace["pytest_sessionfinish"] = _pytest_sessionfinish
     namespace["pytest_addoption"] = _pytest_addoption
     namespace["pytest_configure"] = _pytest_configure
+    namespace["pytest_collection_modifyitems"] = _pytest_collection_modifyitems
     namespace["pytest_collection_finish"] = _pytest_collection_finish
     namespace["pytest_terminal_summary"] = _pytest_terminal_summary
     # Register the JUnit test ID fixture (with public name for pytest discovery)

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -577,16 +577,20 @@ def _pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Ite
     Unlike the record_xml_attribute fixture, this hook runs at collection time
     before any test execution. This ensures the JUnit name attribute is set
     even for skipped tests, where fixtures do not execute.
-    """
-    from _pytest.junitxml import xml_key
 
-    xml = config.stash.get(xml_key, None)
+    Finds the JUnit XML plugin via duck typing (checking for ``node_reporter``
+    attribute) to avoid importing from pytest's private ``_pytest`` package.
+    """
+    xml = None
+    for plugin in config.pluginmanager.get_plugins():
+        if hasattr(plugin, "node_reporter"):
+            xml = plugin
+            break
     if xml is None:
         return
     for item in items:
         test_id = _compute_test_id(item.nodeid, str(item.fspath))
-        node_reporter = xml.node_reporter(item.nodeid)
-        node_reporter.add_attribute("name", test_id)
+        xml.node_reporter(item.nodeid).add_attribute("name", test_id)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- Add `pytest_collection_modifyitems` hook to pre-set JUnit XML `name` attribute via the `LogXML` node_reporter at collection time
- Fixes bare function names in JUnit XML for skipped tests (e.g. `@pytest.mark.skipif(os.geteuid() == 0, ...)`)
- The existing `_set_junit_test_id` fixture is kept for non-skipped tests; the collection hook handles all tests including skipped ones
- Extracts shared `_compute_test_id` helper to deduplicate the OFFLOAD_ROOT-aware ID logic

## Context
Offload's new test ID mismatch detection (imbue-ai/offload#148) was erroring on `test_atomic_write_raises_on_unwritable_directory` because that test is skipped in root sandboxes and `record_xml_attribute` doesn't execute for skipped tests.

## Test plan
- [x] Verified locally: skipped test now has full nodeid in JUnit XML `name` attribute
- [x] Normal tests still get full nodeid as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)