### PR TITLE
Skip libs without pyproject.toml during editable mngr installation

### DIFF
--- a/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
@@ -317,7 +317,7 @@ def _install_mngr_editable_remote(
             lib_names = ls_result.stdout.strip().split()
             install_parts = [f"{_UV_PATH_PREFIX}{uv_env}cd {remote_repo_dir} && uv tool install -e libs/mngr"]
             for lib_name in lib_names:
-                if lib_name != "imbue-mngr":
+                if lib_name != "imbue-mngr" and lib_name.startswith("mngr_"):
                     install_parts.append(f"--with-editable libs/{lib_name}")
 
             install_cmd = " ".join(install_parts)

--- a/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/provisioning.py
@@ -248,9 +248,13 @@ def _install_mngr_editable_local(
     """Install mngr in editable mode on a local host by pointing directly at the source tree."""
     quoted_root = shlex.quote(str(repo_root))
 
-    # Discover which mngr plugin libs exist in the repo
+    # Discover which mngr plugin libs exist in the repo (must have pyproject.toml)
     libs_dir = repo_root / "libs"
-    lib_names = [d.name for d in libs_dir.iterdir() if d.is_dir()] if libs_dir.is_dir() else []
+    lib_names = [
+        d.name
+        for d in libs_dir.iterdir()
+        if d.is_dir() and (d / "pyproject.toml").exists()
+    ] if libs_dir.is_dir() else []
 
     install_parts = [f"{_UV_PATH_PREFIX}{uv_env}cd {quoted_root} && uv tool install -e libs/mngr"]
     for lib_name in lib_names:
@@ -302,15 +306,18 @@ def _install_mngr_editable_remote(
                 raise MngrError(f"Failed to extract mngr tarball: {result.stderr.strip()}")
 
             # Build the install command with editable installs for all workspace packages
-            # First, discover which libs exist in the tarball
-            ls_result = host.execute_idempotent_command(f"ls {remote_repo_dir}/libs/")
+            # First, discover which libs exist in the tarball (must have pyproject.toml)
+            ls_result = host.execute_idempotent_command(
+                f"for d in {remote_repo_dir}/libs/mngr_*/; do "
+                f'[ -f "$d/pyproject.toml" ] && basename "$d"; done'
+            )
             if not ls_result.success:
                 raise MngrError(f"Failed to list mngr libs: {ls_result.stderr.strip()}")
 
             lib_names = ls_result.stdout.strip().split()
             install_parts = [f"{_UV_PATH_PREFIX}{uv_env}cd {remote_repo_dir} && uv tool install -e libs/mngr"]
             for lib_name in lib_names:
-                if lib_name != "imbue-mngr" and lib_name.startswith("mngr_"):
+                if lib_name != "imbue-mngr":
                     install_parts.append(f"--with-editable libs/{lib_name}")
 
             install_cmd = " ".join(install_parts)

--- a/libs/mngr_recursive/imbue/mngr_recursive/provisioning_test.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/provisioning_test.py
@@ -285,12 +285,14 @@ def test_agent_package_mode_builds_correct_command() -> None:
 
 def test_agent_editable_local_mode_builds_correct_command(tmp_path: Path) -> None:
     """Editable local mode should install from the source tree with per-agent UV_TOOL_DIR/UV_TOOL_BIN_DIR."""
-    # Set up a fake monorepo structure
+    # Set up a fake monorepo structure (libs need pyproject.toml to be discovered)
     repo_root = tmp_path / "monorepo"
     libs_dir = repo_root / "libs"
     (libs_dir / "mngr").mkdir(parents=True)
     (libs_dir / "mngr_recursive").mkdir(parents=True)
+    (libs_dir / "mngr_recursive" / "pyproject.toml").touch()
     (libs_dir / "mngr_pair").mkdir(parents=True)
+    (libs_dir / "mngr_pair" / "pyproject.toml").touch()
     (libs_dir / "imbue_common").mkdir(parents=True)
 
     host_dir = Path("/tmp/mngr-test/host")


### PR DESCRIPTION
## Summary
- The editable install logic in `mngr_recursive` discovers plugin libs by iterating `libs/mngr_*` directories, but did not verify each directory is a valid Python package
- Stray or incomplete directories (e.g. `mngr_*` with no `pyproject.toml`, leftover from previous versions / bad git state) caused `uv tool install --with-editable` to fail, preventing per-agent mngr installation during mind provisioning
- Filter out directories missing `pyproject.toml` in both local and remote editable install paths

## Test plan
- [x] All 131 mngr_recursive tests pass (85.47% coverage)
- [x] Updated `test_agent_editable_local_mode_builds_correct_command` to create `pyproject.toml` in mock lib dirs