### PR TITLE
kanpan: add config option for section order

### DIFF
--- a/libs/mngr_kanpan/README.md
+++ b/libs/mngr_kanpan/README.md
@@ -87,6 +87,17 @@ column_order = ["name", "state", "custom_blocked", "git", "pr", "ci"]
 
 Built-in column names are: `name`, `state`, `git`, `pr`, `ci`. Custom columns use `custom_<key>` (e.g. `custom_blocked` for a column defined under `[plugins.kanpan.columns.blocked]`). Columns not listed in `column_order` are omitted.
 
+## Section order
+
+By default, sections are displayed in this order: Done (PR merged), Cancelled (PR closed), In review (PR pending), In progress (no PR), In progress (PRs not loaded), Muted. To customize:
+
+```toml
+[plugins.kanpan]
+section_order = ["STILL_COOKING", "PR_BEING_REVIEWED", "PR_MERGED", "PR_CLOSED", "MUTED"]
+```
+
+Valid section names are: `PR_MERGED`, `PR_CLOSED`, `PR_BEING_REVIEWED`, `STILL_COOKING`, `PRS_FAILED`, `MUTED`. Sections not listed in `section_order` are omitted.
+
 The PR column displays clickable hyperlinks (OSC 8) in terminals that support them. When an agent has a PR, the column shows `#<number>` linked to the PR URL. When no PR exists but the branch is pushable, it shows `+PR` linked to the create-PR URL.
 
 When no label or plugin data is present for an agent, the column shows an empty cell.

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
@@ -161,6 +161,13 @@ class KanpanPluginConfig(PluginConfig):
         "Built-in names: name, state, git, pr, ci. "
         "If None, defaults to: name, state, git, pr, [custom in config order], ci.",
     )
+    section_order: list[BoardSection] | None = Field(
+        default=None,
+        description="Display order for board sections. "
+        "Valid names: PR_MERGED, PR_CLOSED, PR_BEING_REVIEWED, STILL_COOKING, PRS_FAILED, MUTED. "
+        "If None, defaults to: PR_MERGED, PR_CLOSED, PR_BEING_REVIEWED, STILL_COOKING, PRS_FAILED, MUTED. "
+        "Sections not listed are omitted.",
+    )
     refresh_interval_seconds: float = Field(
         default=600.0,
         description="Seconds between periodic full refreshes (default 10 minutes)",
@@ -186,6 +193,7 @@ class KanpanPluginConfig(PluginConfig):
         merged_commands = {**self.commands, **override.commands}
         merged_columns = {**self.columns, **override.columns}
         merged_column_order = override.column_order if override.column_order is not None else self.column_order
+        merged_section_order = override.section_order if override.section_order is not None else self.section_order
         merged_refresh_interval = (
             override.refresh_interval_seconds
             if override.refresh_interval_seconds is not None
@@ -203,6 +211,7 @@ class KanpanPluginConfig(PluginConfig):
             commands=merged_commands,
             columns=merged_columns,
             column_order=merged_column_order,
+            section_order=merged_section_order,
             refresh_interval_seconds=merged_refresh_interval,
             retry_cooldown_seconds=merged_auto_cooldown,
             on_before_refresh=merged_on_before_refresh,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types_test.py
@@ -183,6 +183,20 @@ def test_kanpan_plugin_config_merge_with_column_order_none_keeps_base() -> None:
     assert merged.column_order == ["name", "state", "ci"]
 
 
+def test_kanpan_plugin_config_merge_with_section_order() -> None:
+    base = KanpanPluginConfig(section_order=[BoardSection.PR_MERGED, BoardSection.MUTED])
+    override = KanpanPluginConfig(section_order=[BoardSection.STILL_COOKING, BoardSection.PR_MERGED])
+    merged = base.merge_with(override)
+    assert merged.section_order == [BoardSection.STILL_COOKING, BoardSection.PR_MERGED]
+
+
+def test_kanpan_plugin_config_merge_with_section_order_none_keeps_base() -> None:
+    base = KanpanPluginConfig(section_order=[BoardSection.PR_MERGED, BoardSection.MUTED])
+    override = KanpanPluginConfig()
+    merged = base.merge_with(override)
+    assert merged.section_order == [BoardSection.PR_MERGED, BoardSection.MUTED]
+
+
 def test_kanpan_plugin_config_merge_with_column_override_replaces() -> None:
     base = KanpanPluginConfig(
         columns={"blocked": CustomColumnConfig(header="OLD")},

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
@@ -1301,6 +1301,16 @@ def _assemble_column_defs(
 
 
 @pure
+def _resolve_section_order(
+    config_order: list[BoardSection] | None,
+) -> tuple[BoardSection, ...]:
+    """Resolve the configured section order, falling back to the default."""
+    if config_order is None:
+        return BOARD_SECTION_ORDER
+    return tuple(config_order)
+
+
+@pure
 def _build_column_palette(
     columns_config: dict[str, CustomColumnConfig],
 ) -> tuple[list[tuple[str, str, str]], tuple[str, ...]]:
@@ -1660,9 +1670,7 @@ def run_kanpan(
     on_before_refresh = _load_refresh_hooks(plugin_config.on_before_refresh)
     on_after_refresh = _load_refresh_hooks(plugin_config.on_after_refresh)
 
-    section_order = (
-        tuple(plugin_config.section_order) if plugin_config.section_order is not None else BOARD_SECTION_ORDER
-    )
+    section_order = _resolve_section_order(plugin_config.section_order)
 
     state = _KanpanState(
         mngr_ctx=mngr_ctx,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
@@ -318,6 +318,8 @@ class _KanpanState(MutableModel):
     mark_attr_names: tuple[str, ...] = ()
     # Column definitions (builtins + any custom columns from config)
     column_defs: list["_ColumnDef"] = []  # populated from _BOARD_COLUMN_DEFS at startup
+    # Board section display order (from config or default BOARD_SECTION_ORDER)
+    section_order: tuple[BoardSection, ...] = BOARD_SECTION_ORDER
     # Palette attr names for custom column colors
     col_attr_names: tuple[str, ...] = ()
     # Refresh hooks loaded from plugin config
@@ -1426,6 +1428,7 @@ def _build_board_widgets(
     marks: dict[AgentName, str] | None = None,
     mark_attr_names: tuple[str, ...] = (),
     col_attr_names: tuple[str, ...] = (),
+    section_order: tuple[BoardSection, ...] = BOARD_SECTION_ORDER,
 ) -> tuple[SimpleFocusListWalker[AttrMap | Text | Divider | Columns], dict[int, AgentBoardEntry]]:
     """Build the urwid widget list from a BoardSnapshot, grouped by PR state.
 
@@ -1450,7 +1453,7 @@ def _build_board_widgets(
 
     has_content = False
 
-    for section in BOARD_SECTION_ORDER:
+    for section in section_order:
         entries = by_section.get(section)
         if not entries:
             continue
@@ -1504,6 +1507,7 @@ def _refresh_display(state: _KanpanState) -> None:
         state.marks or None,
         state.mark_attr_names,
         state.col_attr_names,
+        state.section_order,
     )
     state.list_walker = walker
     state.frame.body = ListBox(walker)
@@ -1656,6 +1660,10 @@ def run_kanpan(
     on_before_refresh = _load_refresh_hooks(plugin_config.on_before_refresh)
     on_after_refresh = _load_refresh_hooks(plugin_config.on_after_refresh)
 
+    section_order = (
+        tuple(plugin_config.section_order) if plugin_config.section_order is not None else BOARD_SECTION_ORDER
+    )
+
     state = _KanpanState(
         mngr_ctx=mngr_ctx,
         frame=frame,
@@ -1672,6 +1680,7 @@ def run_kanpan(
         col_attr_names=col_attr_names,
         include_filters=include_filters,
         exclude_filters=exclude_filters,
+        section_order=section_order,
     )
 
     input_handler = _KanpanInputHandler(state=state)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -1967,3 +1967,71 @@ def test_finish_refresh_prunes_orphaned_marks() -> None:
 
     assert AgentName("agent-a") in state.marks
     assert AgentName("agent-b") not in state.marks
+
+
+# =============================================================================
+# Tests for _build_board_widgets section_order parameter
+# =============================================================================
+
+
+def _extract_section_headings(walker: Any) -> list[str]:
+    """Extract plain-text section heading strings from a walker."""
+    headings: list[str] = []
+    for widget in walker:
+        if isinstance(widget, Text):
+            text = widget.get_text()[0]
+            if " (" in text and (
+                "Done" in text
+                or "In progress" in text
+                or "In review" in text
+                or "Muted" in text
+                or "Cancelled" in text
+            ):
+                headings.append(text)
+    return headings
+
+
+def test_build_board_widgets_default_section_order() -> None:
+    entries = (
+        _make_entry(name="cooking"),
+        _make_entry(name="merged", pr=_make_pr(state=PrState.MERGED)),
+    )
+    walker, _ = _build_board_widgets(_make_snapshot(entries=entries), _BOARD_COLUMN_DEFS)
+    headings = _extract_section_headings(walker)
+    assert len(headings) == 2
+    assert "Done" in headings[0]
+    assert "In progress" in headings[1]
+
+
+def test_build_board_widgets_custom_section_order_reverses() -> None:
+    entries = (
+        _make_entry(name="cooking"),
+        _make_entry(name="merged", pr=_make_pr(state=PrState.MERGED)),
+    )
+    reversed_order = (BoardSection.STILL_COOKING, BoardSection.PR_MERGED)
+    walker, _ = _build_board_widgets(
+        _make_snapshot(entries=entries),
+        _BOARD_COLUMN_DEFS,
+        section_order=reversed_order,
+    )
+    headings = _extract_section_headings(walker)
+    assert len(headings) == 2
+    assert "In progress" in headings[0]
+    assert "Done" in headings[1]
+
+
+def test_build_board_widgets_section_order_omits_unlisted() -> None:
+    entries = (
+        _make_entry(name="cooking"),
+        _make_entry(name="merged", pr=_make_pr(state=PrState.MERGED)),
+    )
+    only_merged = (BoardSection.PR_MERGED,)
+    walker, index_to_entry = _build_board_widgets(
+        _make_snapshot(entries=entries),
+        _BOARD_COLUMN_DEFS,
+        section_order=only_merged,
+    )
+    headings = _extract_section_headings(walker)
+    assert len(headings) == 1
+    assert "Done" in headings[0]
+    assert len(index_to_entry) == 1

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -31,6 +31,7 @@ from imbue.mngr_kanpan.data_types import PrInfo
 from imbue.mngr_kanpan.data_types import PrState
 from imbue.mngr_kanpan.data_types import RefreshHook
 from imbue.mngr_kanpan.testing import make_pr_info
+from imbue.mngr_kanpan.tui import BOARD_SECTION_ORDER
 from imbue.mngr_kanpan.tui import DEFAULT_REFRESH_INTERVAL_SECONDS
 from imbue.mngr_kanpan.tui import _BOARD_COLUMN_DEFS
 from imbue.mngr_kanpan.tui import _BatchWorkItem
@@ -68,6 +69,7 @@ from imbue.mngr_kanpan.tui import _on_spinner_tick
 from imbue.mngr_kanpan.tui import _prune_orphaned_marks
 from imbue.mngr_kanpan.tui import _refresh_display
 from imbue.mngr_kanpan.tui import _request_refresh
+from imbue.mngr_kanpan.tui import _resolve_section_order
 from imbue.mngr_kanpan.tui import _restore_footer
 from imbue.mngr_kanpan.tui import _run_shell_command
 from imbue.mngr_kanpan.tui import _schedule_next_refresh
@@ -2035,3 +2037,18 @@ def test_build_board_widgets_section_order_omits_unlisted() -> None:
     assert len(headings) == 1
     assert "Done" in headings[0]
     assert len(index_to_entry) == 1
+
+
+# =============================================================================
+# Tests for _resolve_section_order
+# =============================================================================
+
+
+def test_resolve_section_order_none_returns_default() -> None:
+    assert _resolve_section_order(None) == BOARD_SECTION_ORDER
+
+
+def test_resolve_section_order_custom_list() -> None:
+    custom = [BoardSection.STILL_COOKING, BoardSection.MUTED]
+    result = _resolve_section_order(custom)
+    assert result == (BoardSection.STILL_COOKING, BoardSection.MUTED)


### PR DESCRIPTION
## Summary
- Adds a `section_order` config option to `KanpanPluginConfig`, mirroring the existing `column_order` pattern
- Users can now control which board sections (Done, In review, In progress, etc.) appear and in what order via `[plugins.kanpan] section_order` in settings
- Sections not listed in `section_order` are omitted from the board

## Test plan
- [x] Unit tests for config merge behavior (override replaces, None keeps base)
- [x] Unit tests for `_build_board_widgets` with default, reversed, and partial section orders
- [x] Full kanpan test suite passes (311 tests, 87.42% coverage)

Generated with [Claude Code](https://claude.com/claude-code)