### PR TITLE
Add REST API v1 for minds app

### DIFF
--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -65,7 +65,7 @@ function waitForPort(host, port, maxAttempts = 50, intervalMs = 200) {
  * Returns a promise that resolves with { loginUrl, port } when the backend
  * is ready, or rejects if the process exits before emitting the URL.
  */
-function startBackend(onProgress) {
+function startBackend(onProgress, onNotification) {
   return new Promise((resolve, reject) => {
     let isResolved = false;
 
@@ -95,7 +95,7 @@ function startBackend(onProgress) {
           '--no-browser',
         ];
         cwd = paths.getMonorepoRoot();
-        env = { ...process.env };
+        env = { ...process.env, MINDS_ELECTRON: '1' };
       } else {
         // Packaged mode: use bundled uv with standalone pyproject
         const uvPath = paths.getUvPath();
@@ -121,6 +121,7 @@ function startBackend(onProgress) {
           PATH: `${uvBinDir}:${gitBinDir}:${process.env.PATH}`,
           UV_CACHE_DIR: uvCacheDir,
           UV_PYTHON_INSTALL_DIR: uvPythonDir,
+          MINDS_ELECTRON: '1',
         };
         // Remove VIRTUAL_ENV to avoid uv warnings about path mismatches
         delete env.VIRTUAL_ENV;
@@ -160,6 +161,8 @@ function startBackend(onProgress) {
                   reject(new Error(`Backend emitted login URL but server never became ready: ${err.message}`));
                 });
               }
+            } else if (event.event === 'notification' && event.message && onNotification) {
+              onNotification(event);
             }
           } catch {
             // Not valid JSON -- just log it

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, Menu, Notification, ipcMain, shell } = require('electron');
 const todesktop = require('@todesktop/runtime');
 const path = require('path');
 const fs = require('fs');
@@ -252,6 +252,14 @@ async function startBackendWithRetry() {
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('status-update', status);
       }
+    }, (event) => {
+      const agentName = event.agent_name || 'Agent';
+      const title = event.title || `Notification from ${agentName}`;
+      const notification = new Notification({
+        title,
+        body: event.message,
+      });
+      notification.show();
     });
 
     backendBaseUrl = `http://127.0.0.1:${port}`;

--- a/apps/minds/imbue/minds/config/data_types_test.py
+++ b/apps/minds/imbue/minds/config/data_types_test.py
@@ -65,3 +65,12 @@ def test_parse_agents_from_mngr_output_handles_mixed_output() -> None:
     agents = parse_agents_from_mngr_output(output)
     assert len(agents) == 1
     assert agents[0]["id"] == "agent-xyz"
+
+
+def test_parse_agents_from_mngr_output_skips_invalid_json_lines() -> None:
+    """Lines starting with '{' but containing invalid JSON are skipped."""
+    valid_json = json.dumps({"agents": [{"id": "agent-abc", "name": "test"}]})
+    output = "{invalid json here\n" + valid_json
+    agents = parse_agents_from_mngr_output(output)
+    assert len(agents) == 1
+    assert agents[0]["id"] == "agent-abc"

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -32,13 +32,13 @@ from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.config.data_types import WorkspacePaths
-from imbue.minds.errors import GitCloneError
-from imbue.minds.errors import GitOperationError
-from imbue.minds.errors import MngrCommandError
-from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.api_key_store import generate_api_key
 from imbue.minds.desktop_client.api_key_store import hash_api_key
 from imbue.minds.desktop_client.api_key_store import save_api_key_hash
+from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.errors import GitCloneError
+from imbue.minds.errors import GitOperationError
+from imbue.minds.errors import MngrCommandError
 from imbue.minds.primitives import AgentName
 from imbue.minds.primitives import GitBranch
 from imbue.minds.primitives import GitUrl

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -36,6 +36,9 @@ from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.desktop_client.api_key_store import generate_api_key
+from imbue.minds.desktop_client.api_key_store import hash_api_key
+from imbue.minds.desktop_client.api_key_store import save_api_key_hash
 from imbue.minds.primitives import AgentName
 from imbue.minds.primitives import GitBranch
 from imbue.minds.primitives import GitUrl
@@ -182,8 +185,11 @@ def _build_mngr_create_command(
     launch_mode: LaunchMode,
     agent_name: AgentName,
     agent_id: AgentId,
-) -> list[str]:
-    """Build the mngr create command for the given launch mode.
+) -> tuple[list[str], str]:
+    """Build the mngr create command and generate an API key for the agent.
+
+    Returns (command_list, api_key) where api_key is a UUID4 string injected
+    as MINDS_API_KEY into the agent's environment via --env.
 
     DEV mode: --template main --template dev (runs in-place on local provider)
     LOCAL mode: --template main --template docker (runs in Docker container)
@@ -207,6 +213,8 @@ def _build_mngr_create_command(
         case _ as unreachable:
             assert_never(unreachable)
 
+    api_key = generate_api_key()
+
     mngr_command: list[str] = [
         MNGR_BINARY,
         "create",
@@ -218,6 +226,8 @@ def _build_mngr_create_command(
         "--update",
         "--label",
         f"workspace={agent_name}",
+        "--env",
+        f"MINDS_API_KEY={api_key}",
         "--template",
         "main",
     ]
@@ -234,7 +244,7 @@ def _build_mngr_create_command(
         case _ as unreachable:
             assert_never(unreachable)
 
-    return mngr_command
+    return mngr_command, api_key
 
 
 def run_mngr_create(
@@ -243,15 +253,16 @@ def run_mngr_create(
     agent_name: AgentName,
     agent_id: AgentId,
     on_output: OutputCallback | None = None,
-) -> None:
+) -> str:
     """Create an mngr agent via ``mngr create``.
 
     The repo's own ``.mngr/settings.toml`` defines agent types, templates,
     environment variables, and all other configuration.
 
+    Returns the generated API key for the agent.
     Raises MngrCommandError if the command fails.
     """
-    mngr_command = _build_mngr_create_command(launch_mode, agent_name, agent_id)
+    mngr_command, api_key = _build_mngr_create_command(launch_mode, agent_name, agent_id)
 
     logger.info("Running: {}", " ".join(mngr_command))
 
@@ -271,6 +282,8 @@ def run_mngr_create(
                 result.stderr.strip() if result.stderr.strip() else result.stdout.strip(),
             )
         )
+
+    return api_key
 
 
 def _inject_tunnel_token(
@@ -437,13 +450,18 @@ class AgentCreator(MutableModel):
 
                 parsed_name = AgentName(agent_name)
                 log_queue.put("[minds] Creating agent '{}' (mode: {})...".format(agent_name, launch_mode.value))
-                run_mngr_create(
+                api_key = run_mngr_create(
                     launch_mode=launch_mode,
                     workspace_dir=workspace_dir,
                     agent_name=parsed_name,
                     agent_id=agent_id,
                     on_output=emit_log,
                 )
+
+                # Persist the API key hash
+                key_hash = hash_api_key(api_key)
+                save_api_key_hash(self.paths.data_dir, agent_id, key_hash)
+                log_queue.put("[minds] API key generated and hash stored.")
 
                 self._setup_cloudflare_tunnel(agent_id, log_queue)
 

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -92,7 +92,7 @@ def test_make_host_name() -> None:
 
 
 def test_build_mngr_create_command_dev_mode() -> None:
-    cmd = _build_mngr_create_command(
+    cmd, api_key = _build_mngr_create_command(
         launch_mode=LaunchMode.DEV,
         agent_name=AgentName("test-agent"),
         agent_id=AgentId(),
@@ -106,10 +106,15 @@ def test_build_mngr_create_command_dev_mode() -> None:
     assert "docker" not in cmd
     # DEV mode: address is just the agent name (no host suffix)
     assert cmd[2] == "test-agent"
+    # API key is injected via --env
+    assert "--env" in cmd
+    env_values = [cmd[i + 1] for i, v in enumerate(cmd) if v == "--env"]
+    assert any(v.startswith("MINDS_API_KEY=") for v in env_values)
+    assert len(api_key) > 0
 
 
 def test_build_mngr_create_command_local_mode() -> None:
-    cmd = _build_mngr_create_command(
+    cmd, _api_key = _build_mngr_create_command(
         launch_mode=LaunchMode.LOCAL,
         agent_name=AgentName("test-agent"),
         agent_id=AgentId(),
@@ -125,7 +130,7 @@ def test_build_mngr_create_command_local_mode() -> None:
 
 
 def test_build_mngr_create_command_lima_mode() -> None:
-    cmd = _build_mngr_create_command(
+    cmd, _api_key = _build_mngr_create_command(
         launch_mode=LaunchMode.LIMA,
         agent_name=AgentName("test-agent"),
         agent_id=AgentId(),

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -338,6 +338,7 @@ def test_setup_cloudflare_tunnel_with_client_logs_creation(tmp_path: Path) -> No
     assert any("WARNING" in m or "failed" in m.lower() for m in messages)
 
 
+@pytest.mark.timeout(30)
 def test_run_mngr_create_raises_on_failure(tmp_path: Path) -> None:
     """Verify run_mngr_create raises MngrCommandError when mngr create fails."""
     with pytest.raises(MngrCommandError, match="mngr create failed"):

--- a/apps/minds/imbue/minds/desktop_client/api_key_store.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store.py
@@ -1,0 +1,64 @@
+"""API key generation, hashing, and lookup for agent authentication.
+
+Each agent receives a UUID4 API key at creation time. Only the SHA-256
+hash is stored on disk, keyed by agent ID. On each request the server
+hashes the provided key and scans hash files to identify the caller.
+"""
+
+import hashlib
+import uuid
+from pathlib import Path
+
+from loguru import logger
+
+from imbue.mngr.primitives import AgentId
+
+
+def generate_api_key() -> str:
+    """Generate a new UUID4 API key string."""
+    return str(uuid.uuid4())
+
+
+def hash_api_key(key: str) -> str:
+    """Compute the SHA-256 hex digest of an API key."""
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def _api_key_hash_path(data_dir: Path, agent_id: AgentId) -> Path:
+    return data_dir / "agents" / str(agent_id) / "api_key_hash"
+
+
+def save_api_key_hash(
+    data_dir: Path,
+    agent_id: AgentId,
+    key_hash: str,
+) -> None:
+    """Write the API key hash to the per-agent hash file."""
+    hash_path = _api_key_hash_path(data_dir, agent_id)
+    hash_path.parent.mkdir(parents=True, exist_ok=True)
+    hash_path.write_text(key_hash)
+
+
+def find_agent_by_api_key(data_dir: Path, key: str) -> AgentId | None:
+    """Hash the key and scan all per-agent hash files for a match.
+
+    Returns the matching AgentId, or None if no match is found.
+    """
+    key_hash = hash_api_key(key)
+    agents_dir = data_dir / "agents"
+    if not agents_dir.is_dir():
+        return None
+    for agent_dir in agents_dir.iterdir():
+        if not agent_dir.is_dir():
+            continue
+        hash_file = agent_dir / "api_key_hash"
+        if not hash_file.is_file():
+            continue
+        try:
+            stored_hash = hash_file.read_text().strip()
+        except OSError as e:
+            logger.debug("Failed to read API key hash file {}: {}", hash_file, e)
+            continue
+        if stored_hash == key_hash:
+            return AgentId(agent_dir.name)
+    return None

--- a/apps/minds/imbue/minds/desktop_client/api_key_store.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from loguru import logger
 
+from imbue.minds.primitives import ApiKeyHash
 from imbue.mngr.primitives import AgentId
 
 
@@ -19,9 +20,9 @@ def generate_api_key() -> str:
     return str(uuid.uuid4())
 
 
-def hash_api_key(key: str) -> str:
+def hash_api_key(key: str) -> ApiKeyHash:
     """Compute the SHA-256 hex digest of an API key."""
-    return hashlib.sha256(key.encode()).hexdigest()
+    return ApiKeyHash(hashlib.sha256(key.encode()).hexdigest())
 
 
 def _api_key_hash_path(data_dir: Path, agent_id: AgentId) -> Path:
@@ -31,7 +32,7 @@ def _api_key_hash_path(data_dir: Path, agent_id: AgentId) -> Path:
 def save_api_key_hash(
     data_dir: Path,
     agent_id: AgentId,
-    key_hash: str,
+    key_hash: ApiKeyHash,
 ) -> None:
     """Write the API key hash to the per-agent hash file."""
     hash_path = _api_key_hash_path(data_dir, agent_id)

--- a/apps/minds/imbue/minds/desktop_client/api_key_store.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store.py
@@ -56,10 +56,15 @@ def find_agent_by_api_key(data_dir: Path, key: str) -> AgentId | None:
         if not hash_file.is_file():
             continue
         try:
+            agent_id = AgentId(agent_dir.name)
+        except ValueError:
+            logger.debug("Skipping non-agent directory in agents/: {}", agent_dir.name)
+            continue
+        try:
             stored_hash = hash_file.read_text().strip()
         except OSError as e:
             logger.debug("Failed to read API key hash file {}: {}", hash_file, e)
             continue
         if stored_hash == key_hash:
-            return AgentId(agent_dir.name)
+            return agent_id
     return None

--- a/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
@@ -1,0 +1,101 @@
+import uuid
+from pathlib import Path
+
+from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
+from imbue.minds.desktop_client.api_key_store import generate_api_key
+from imbue.minds.desktop_client.api_key_store import hash_api_key
+from imbue.minds.desktop_client.api_key_store import save_api_key_hash
+from imbue.mngr.primitives import AgentId
+
+
+def test_generate_api_key_returns_valid_uuid4() -> None:
+    key = generate_api_key()
+    parsed = uuid.UUID(key)
+    assert parsed.version == 4
+
+
+def test_generate_api_key_returns_unique_keys() -> None:
+    key_a = generate_api_key()
+    key_b = generate_api_key()
+    assert key_a != key_b
+
+
+def test_hash_api_key_is_deterministic() -> None:
+    key = "test-key-12345"
+    hash_a = hash_api_key(key)
+    hash_b = hash_api_key(key)
+    assert hash_a == hash_b
+
+
+def test_hash_api_key_returns_hex_digest() -> None:
+    key = "test-key-12345"
+    result = hash_api_key(key)
+    assert len(result) == 64
+    assert all(c in "0123456789abcdef" for c in result)
+
+
+def test_hash_api_key_different_keys_different_hashes() -> None:
+    hash_a = hash_api_key("key-a")
+    hash_b = hash_api_key("key-b")
+    assert hash_a != hash_b
+
+
+def test_save_and_find_api_key_round_trip(tmp_path: Path) -> None:
+    agent_id = AgentId()
+    key = generate_api_key()
+    key_hash = hash_api_key(key)
+
+    save_api_key_hash(tmp_path, agent_id, key_hash)
+
+    found_id = find_agent_by_api_key(tmp_path, key)
+    assert found_id == agent_id
+
+
+def test_find_agent_by_api_key_returns_none_for_unknown_key(tmp_path: Path) -> None:
+    agent_id = AgentId()
+    key = generate_api_key()
+    key_hash = hash_api_key(key)
+    save_api_key_hash(tmp_path, agent_id, key_hash)
+
+    wrong_key = generate_api_key()
+    found_id = find_agent_by_api_key(tmp_path, wrong_key)
+    assert found_id is None
+
+
+def test_find_agent_by_api_key_returns_none_for_empty_dir(tmp_path: Path) -> None:
+    found_id = find_agent_by_api_key(tmp_path, "any-key")
+    assert found_id is None
+
+
+def test_find_agent_by_api_key_with_multiple_agents(tmp_path: Path) -> None:
+    agent_a = AgentId()
+    key_a = generate_api_key()
+    save_api_key_hash(tmp_path, agent_a, hash_api_key(key_a))
+
+    agent_b = AgentId()
+    key_b = generate_api_key()
+    save_api_key_hash(tmp_path, agent_b, hash_api_key(key_b))
+
+    assert find_agent_by_api_key(tmp_path, key_a) == agent_a
+    assert find_agent_by_api_key(tmp_path, key_b) == agent_b
+
+
+def test_save_api_key_hash_creates_directory_structure(tmp_path: Path) -> None:
+    agent_id = AgentId()
+    save_api_key_hash(tmp_path, agent_id, "test-hash")
+
+    hash_file = tmp_path / "agents" / str(agent_id) / "api_key_hash"
+    assert hash_file.exists()
+    assert hash_file.read_text() == "test-hash"
+
+
+def test_find_agent_by_api_key_handles_corrupted_hash_file(tmp_path: Path) -> None:
+    """Verify that a non-readable hash file is skipped without crashing."""
+    agents_dir = tmp_path / "agents" / "fake-agent"
+    agents_dir.mkdir(parents=True)
+    hash_file = agents_dir / "api_key_hash"
+    # Write a valid hash file for a different key
+    hash_file.write_text(hash_api_key("other-key"))
+
+    found_id = find_agent_by_api_key(tmp_path, "some-key")
+    assert found_id is None

--- a/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from pathlib import Path
 
@@ -99,3 +100,43 @@ def test_find_agent_by_api_key_handles_corrupted_hash_file(tmp_path: Path) -> No
 
     found_id = find_agent_by_api_key(tmp_path, "some-key")
     assert found_id is None
+
+
+def test_find_agent_by_api_key_skips_non_directory_entries(tmp_path: Path) -> None:
+    """Verify that non-directory entries in agents/ dir are skipped."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir(parents=True)
+    # Create a regular file alongside the agent dirs
+    (agents_dir / "not-a-dir.txt").write_text("stray file")
+
+    # Also create a valid agent entry
+    agent_id = AgentId()
+    key = generate_api_key()
+    save_api_key_hash(tmp_path, agent_id, hash_api_key(key))
+
+    found_id = find_agent_by_api_key(tmp_path, key)
+    assert found_id == agent_id
+
+
+def test_find_agent_by_api_key_skips_missing_hash_file(tmp_path: Path) -> None:
+    """Verify that agent dirs without an api_key_hash file are skipped."""
+    agents_dir = tmp_path / "agents" / "no-hash-agent"
+    agents_dir.mkdir(parents=True)
+    # Do NOT create api_key_hash file
+
+    found_id = find_agent_by_api_key(tmp_path, "any-key")
+    assert found_id is None
+
+
+def test_find_agent_by_api_key_handles_oserror_on_read(tmp_path: Path) -> None:
+    """Verify that an OSError reading a hash file is caught and the entry is skipped."""
+    agents_dir = tmp_path / "agents" / "bad-perm-agent"
+    agents_dir.mkdir(parents=True)
+    hash_file = agents_dir / "api_key_hash"
+    hash_file.write_text("some-hash")
+    os.chmod(hash_file, 0o000)
+    try:
+        found_id = find_agent_by_api_key(tmp_path, "any-key")
+        assert found_id is None
+    finally:
+        os.chmod(hash_file, 0o644)

--- a/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
@@ -141,3 +141,25 @@ def test_find_agent_by_api_key_handles_oserror_on_read(tmp_path: Path) -> None:
         assert found_id is None
     finally:
         os.chmod(hash_file, 0o644)
+
+
+def test_find_agent_by_api_key_skips_invalid_agent_id_directory(tmp_path: Path) -> None:
+    """Verify that directories with invalid agent ID names are skipped gracefully.
+
+    A stray directory whose name is not a valid AgentId format must not raise
+    an exception or prevent other valid agents from being found.
+    """
+    # Create a stray directory with an invalid AgentId name
+    agents_dir = tmp_path / "agents"
+    stray_dir = agents_dir / "not-a-valid-uuid"
+    stray_dir.mkdir(parents=True)
+    (stray_dir / "api_key_hash").write_text("somehash")
+
+    # Also create a valid agent with a real API key
+    agent_id = AgentId()
+    key = generate_api_key()
+    save_api_key_hash(tmp_path, agent_id, hash_api_key(key))
+
+    # The valid agent should still be found
+    found_id = find_agent_by_api_key(tmp_path, key)
+    assert found_id == agent_id

--- a/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_key_store_test.py
@@ -6,6 +6,7 @@ from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
 from imbue.minds.desktop_client.api_key_store import generate_api_key
 from imbue.minds.desktop_client.api_key_store import hash_api_key
 from imbue.minds.desktop_client.api_key_store import save_api_key_hash
+from imbue.minds.primitives import ApiKeyHash
 from imbue.mngr.primitives import AgentId
 
 
@@ -83,7 +84,7 @@ def test_find_agent_by_api_key_with_multiple_agents(tmp_path: Path) -> None:
 
 def test_save_api_key_hash_creates_directory_structure(tmp_path: Path) -> None:
     agent_id = AgentId()
-    save_api_key_hash(tmp_path, agent_id, "test-hash")
+    save_api_key_hash(tmp_path, agent_id, ApiKeyHash("test-hash"))
 
     hash_file = tmp_path / "agents" / str(agent_id) / "api_key_hash"
     assert hash_file.exists()

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -5,12 +5,12 @@ Telegram bot setup, and user notifications. Authentication uses
 per-agent API keys (Bearer tokens) with SHA-256 hash lookup.
 """
 
-import asyncio
 import json
 from typing import Annotated
 
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import HTTPException
 from fastapi import Request
 from fastapi.responses import Response
 
@@ -45,8 +45,6 @@ def _authenticate_api_key(request: Request) -> AgentId:
     Returns the AgentId of the caller. Raises HTTPException with 401 if the
     token is missing, malformed, or does not match any stored API key hash.
     """
-    from fastapi import HTTPException
-
     auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or malformed Authorization header")
@@ -110,17 +108,14 @@ async def _handle_cloudflare_enable(
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
-    loop = asyncio.get_running_loop()
-    is_success = await loop.run_in_executor(
-        None, cf_client.add_service, parsed_id, server_name, service_url
-    )
+    is_success = cf_client.add_service(parsed_id, server_name, service_url)
 
     if is_success:
         return _json_response({"ok": True})
     return _json_error("Cloudflare API call failed", 502)
 
 
-async def _handle_cloudflare_disable(
+def _handle_cloudflare_disable(
     agent_id: str,
     server_name: str,
     request: Request,
@@ -133,10 +128,7 @@ async def _handle_cloudflare_disable(
 
     parsed_id = AgentId(agent_id)
 
-    loop = asyncio.get_running_loop()
-    is_success = await loop.run_in_executor(
-        None, cf_client.remove_service, parsed_id, server_name
-    )
+    is_success = cf_client.remove_service(parsed_id, server_name)
 
     if is_success:
         return _json_response({"ok": True})
@@ -161,7 +153,8 @@ async def _handle_telegram_setup(
     agent_name = str(parsed_id)[:8]
     try:
         body = await request.json()
-        agent_name = str(body.get("agent_name", agent_name)).strip() or agent_name
+        raw_name = body.get("agent_name", agent_name)
+        agent_name = str(raw_name).strip() if raw_name else agent_name
     except (json.JSONDecodeError, ValueError):
         pass
 
@@ -194,7 +187,7 @@ def _handle_telegram_status(
             })
         return _json_error("No Telegram setup in progress for this agent", 404)
 
-    result: dict[str, str | None] = {
+    result: dict[str, object] = {
         "agent_id": str(info.agent_id),
         "status": str(info.status),
     }

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -5,7 +5,6 @@ Telegram bot setup, and user notifications. Authentication uses
 per-agent API keys (Bearer tokens) with SHA-256 hash lookup.
 """
 
-import asyncio
 import json
 from typing import Annotated
 
@@ -14,7 +13,9 @@ from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import Request
 from fastapi.responses import Response
+from pydantic import Field
 
+from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
@@ -65,15 +66,28 @@ def _json_error(message: str, status_code: int) -> Response:
     return _json_response({"error": message}, status_code=status_code)
 
 
+# -- Request body models --
+
+
+class _CloudflareEnableBody(FrozenModel):
+    """Optional request body for the Cloudflare enable endpoint."""
+
+    service_url: str | None = Field(
+        default=None,
+        description="Service URL to register. If omitted, resolved from the backend resolver.",
+    )
+
+
 # -- Cloudflare forwarding routes --
 
 
-async def _handle_cloudflare_enable(
+def _handle_cloudflare_enable(
     agent_id: str,
     server_name: str,
     request: Request,
     _caller_agent_id: CallerAgentIdDep,
     backend_resolver: BackendResolverDep,
+    body: _CloudflareEnableBody | None = None,
 ) -> Response:
     """Enable Cloudflare forwarding for a server."""
     cf_client: CloudflareForwardingClient | None = request.app.state.cloudflare_client
@@ -83,22 +97,14 @@ async def _handle_cloudflare_enable(
     parsed_id = AgentId(agent_id)
     parsed_server = ServerName(server_name)
 
-    # Try to get service_url from request body, fall back to backend resolver
-    service_url: str | None = None
-    try:
-        body = await request.json()
-        service_url = body.get("service_url")
-    except (json.JSONDecodeError, ValueError):
-        pass
-
+    service_url = body.service_url if body is not None else None
     if service_url is None:
         backend_url = backend_resolver.get_backend_url(parsed_id, parsed_server)
         if backend_url is None:
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
-    loop = asyncio.get_running_loop()
-    is_success = await loop.run_in_executor(None, cf_client.add_service, parsed_id, parsed_server, service_url)
+    is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
 
     if is_success:
         return _json_response({"ok": True})

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -16,8 +16,8 @@ from fastapi.responses import Response
 
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
-from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.desktop_client.deps import BackendResolverDep
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
@@ -25,13 +25,6 @@ from imbue.minds.primitives import ServerName
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
-
-
-def _get_backend_resolver(request: Request) -> BackendResolverInterface:
-    return request.app.state.backend_resolver
-
-
-BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]
 
 
 def _authenticate_api_key(request: Request) -> AgentId:

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -115,8 +115,9 @@ def _handle_cloudflare_disable(
         return _json_error("Cloudflare forwarding not configured", 501)
 
     parsed_id = AgentId(agent_id)
+    parsed_server = ServerName(server_name)
 
-    is_success = cf_client.remove_service(parsed_id, server_name)
+    is_success = cf_client.remove_service(parsed_id, parsed_server)
 
     if is_success:
         return _json_response({"ok": True})

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -103,7 +103,7 @@ async def _handle_cloudflare_enable(
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
-    is_success = cf_client.add_service(parsed_id, server_name, service_url)
+    is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
 
     if is_success:
         return _json_response({"ok": True})

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -152,7 +152,7 @@ async def _handle_telegram_setup(
         body = await request.json()
         raw_name = body.get("agent_name", agent_name)
         agent_name = str(raw_name).strip() if raw_name else agent_name
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, AttributeError):
         pass
 
     telegram_orchestrator.start_setup(agent_id=parsed_id, agent_name=agent_name)
@@ -212,6 +212,9 @@ async def _handle_notification(
         body = await request.json()
     except (json.JSONDecodeError, ValueError):
         return _json_error("Invalid JSON body", 400)
+
+    if not isinstance(body, dict):
+        return _json_error("Request body must be a JSON object", 400)
 
     message = body.get("message")
     if not message or not isinstance(message, str):

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -221,6 +221,8 @@ async def _handle_notification(
         return _json_error("'message' field is required and must be a string", 400)
 
     title = body.get("title")
+    if title is not None and not isinstance(title, str):
+        return _json_error("'title' field must be a string", 400)
     urgency_str = body.get("urgency", "NORMAL")
     try:
         urgency = NotificationUrgency(urgency_str.upper())

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -27,15 +27,10 @@ from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
 
 
-def _get_paths(request: Request) -> WorkspacePaths:
-    return request.app.state.api_v1_paths
-
-
 def _get_backend_resolver(request: Request) -> BackendResolverInterface:
     return request.app.state.backend_resolver
 
 
-PathsDep = Annotated[WorkspacePaths, Depends(_get_paths)]
 BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]
 
 

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -5,6 +5,7 @@ Telegram bot setup, and user notifications. Authentication uses
 per-agent API keys (Bearer tokens) with SHA-256 hash lookup.
 """
 
+import asyncio
 import json
 from typing import Annotated
 
@@ -96,7 +97,8 @@ async def _handle_cloudflare_enable(
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
-    is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
+    loop = asyncio.get_running_loop()
+    is_success = await loop.run_in_executor(None, cf_client.add_service, parsed_id, parsed_server, service_url)
 
     if is_success:
         return _json_response({"ok": True})

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -1,0 +1,281 @@
+"""REST API v1 router for the minds desktop client.
+
+Provides authenticated JSON endpoints for Cloudflare forwarding,
+Telegram bot setup, and user notifications. Authentication uses
+per-agent API keys (Bearer tokens) with SHA-256 hash lookup.
+"""
+
+import asyncio
+import json
+from typing import Annotated
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Request
+from fastapi.responses import Response
+
+from imbue.minds.config.data_types import WorkspacePaths
+from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
+from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
+from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.desktop_client.notification import NotificationRequest
+from imbue.minds.desktop_client.notification import NotificationUrgency
+from imbue.minds.primitives import ServerName
+from imbue.minds.telegram.setup import TelegramSetupOrchestrator
+from imbue.minds.telegram.setup import TelegramSetupStatus
+from imbue.mngr.primitives import AgentId
+
+
+def _get_paths(request: Request) -> WorkspacePaths:
+    return request.app.state.api_v1_paths
+
+
+def _get_backend_resolver(request: Request) -> BackendResolverInterface:
+    return request.app.state.backend_resolver
+
+
+PathsDep = Annotated[WorkspacePaths, Depends(_get_paths)]
+BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]
+
+
+def _authenticate_api_key(request: Request) -> AgentId:
+    """Extract and validate the Bearer token from the Authorization header.
+
+    Returns the AgentId of the caller. Raises HTTPException with 401 if the
+    token is missing, malformed, or does not match any stored API key hash.
+    """
+    from fastapi import HTTPException
+
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or malformed Authorization header")
+
+    token = auth_header[len("Bearer "):]
+    if not token:
+        raise HTTPException(status_code=401, detail="Empty Bearer token")
+
+    paths: WorkspacePaths = request.app.state.api_v1_paths
+    agent_id = find_agent_by_api_key(paths.data_dir, token)
+    if agent_id is None:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    return agent_id
+
+
+CallerAgentIdDep = Annotated[AgentId, Depends(_authenticate_api_key)]
+
+
+def _json_response(data: dict[str, object], status_code: int = 200) -> Response:
+    return Response(
+        content=json.dumps(data),
+        media_type="application/json",
+        status_code=status_code,
+    )
+
+
+def _json_error(message: str, status_code: int) -> Response:
+    return _json_response({"error": message}, status_code=status_code)
+
+
+# -- Cloudflare forwarding routes --
+
+
+async def _handle_cloudflare_enable(
+    agent_id: str,
+    server_name: str,
+    request: Request,
+    _caller_agent_id: CallerAgentIdDep,
+    backend_resolver: BackendResolverDep,
+) -> Response:
+    """Enable Cloudflare forwarding for a server."""
+    cf_client: CloudflareForwardingClient | None = request.app.state.cloudflare_client
+    if cf_client is None:
+        return _json_error("Cloudflare forwarding not configured", 501)
+
+    parsed_id = AgentId(agent_id)
+    parsed_server = ServerName(server_name)
+
+    # Try to get service_url from request body, fall back to backend resolver
+    service_url: str | None = None
+    try:
+        body = await request.json()
+        service_url = body.get("service_url")
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    if service_url is None:
+        backend_url = backend_resolver.get_backend_url(parsed_id, parsed_server)
+        if backend_url is None:
+            return _json_error("Server not found locally", 404)
+        service_url = backend_url
+
+    loop = asyncio.get_running_loop()
+    is_success = await loop.run_in_executor(
+        None, cf_client.add_service, parsed_id, server_name, service_url
+    )
+
+    if is_success:
+        return _json_response({"ok": True})
+    return _json_error("Cloudflare API call failed", 502)
+
+
+async def _handle_cloudflare_disable(
+    agent_id: str,
+    server_name: str,
+    request: Request,
+    _caller_agent_id: CallerAgentIdDep,
+) -> Response:
+    """Disable Cloudflare forwarding for a server."""
+    cf_client: CloudflareForwardingClient | None = request.app.state.cloudflare_client
+    if cf_client is None:
+        return _json_error("Cloudflare forwarding not configured", 501)
+
+    parsed_id = AgentId(agent_id)
+
+    loop = asyncio.get_running_loop()
+    is_success = await loop.run_in_executor(
+        None, cf_client.remove_service, parsed_id, server_name
+    )
+
+    if is_success:
+        return _json_response({"ok": True})
+    return _json_error("Cloudflare API call failed", 502)
+
+
+# -- Telegram routes --
+
+
+async def _handle_telegram_setup(
+    agent_id: str,
+    request: Request,
+    _caller_agent_id: CallerAgentIdDep,
+) -> Response:
+    """Start Telegram bot setup for an agent."""
+    telegram_orchestrator: TelegramSetupOrchestrator | None = request.app.state.telegram_orchestrator
+    if telegram_orchestrator is None:
+        return _json_error("Telegram setup not configured", 501)
+
+    parsed_id = AgentId(agent_id)
+
+    agent_name = str(parsed_id)[:8]
+    try:
+        body = await request.json()
+        agent_name = str(body.get("agent_name", agent_name)).strip() or agent_name
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    telegram_orchestrator.start_setup(agent_id=parsed_id, agent_name=agent_name)
+    return _json_response({
+        "agent_id": str(parsed_id),
+        "status": str(TelegramSetupStatus.CHECKING_CREDENTIALS),
+    })
+
+
+def _handle_telegram_status(
+    agent_id: str,
+    _caller_agent_id: CallerAgentIdDep,
+    request: Request,
+) -> Response:
+    """Get Telegram setup status for an agent."""
+    telegram_orchestrator: TelegramSetupOrchestrator | None = request.app.state.telegram_orchestrator
+    if telegram_orchestrator is None:
+        return _json_error("Telegram setup not configured", 501)
+
+    parsed_id = AgentId(agent_id)
+    info = telegram_orchestrator.get_setup_info(parsed_id)
+
+    if info is None:
+        is_active = telegram_orchestrator.agent_has_telegram(parsed_id)
+        if is_active:
+            return _json_response({
+                "agent_id": str(parsed_id),
+                "status": str(TelegramSetupStatus.DONE),
+            })
+        return _json_error("No Telegram setup in progress for this agent", 404)
+
+    result: dict[str, str | None] = {
+        "agent_id": str(info.agent_id),
+        "status": str(info.status),
+    }
+    if info.error is not None:
+        result["error"] = info.error
+    if info.bot_username is not None:
+        result["bot_username"] = info.bot_username
+    return _json_response(result)
+
+
+# -- Notification route --
+
+
+async def _handle_notification(
+    request: Request,
+    caller_agent_id: CallerAgentIdDep,
+    backend_resolver: BackendResolverDep,
+) -> Response:
+    """Send a notification to the user."""
+    dispatcher: NotificationDispatcher | None = request.app.state.notification_dispatcher
+    if dispatcher is None:
+        return _json_error("Notification dispatch not configured", 501)
+
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return _json_error("Invalid JSON body", 400)
+
+    message = body.get("message")
+    if not message or not isinstance(message, str):
+        return _json_error("'message' field is required and must be a string", 400)
+
+    title = body.get("title")
+    urgency_str = body.get("urgency", "NORMAL")
+    try:
+        urgency = NotificationUrgency(urgency_str.upper())
+    except (ValueError, AttributeError):
+        return _json_error(
+            f"Invalid urgency: {urgency_str}. Must be one of: low, normal, critical", 400
+        )
+
+    notification_request = NotificationRequest(
+        message=message,
+        title=title,
+        urgency=urgency,
+    )
+
+    # Resolve calling agent's display name
+    agent_info = backend_resolver.get_agent_display_info(caller_agent_id)
+    agent_display_name = agent_info.agent_name if agent_info else str(caller_agent_id)
+
+    dispatcher.dispatch(notification_request, agent_display_name)
+    return _json_response({"ok": True})
+
+
+# -- Router factory --
+
+
+def create_api_v1_router() -> APIRouter:
+    """Create the /api/v1/ router with all REST API endpoints."""
+    router = APIRouter()
+
+    # Cloudflare forwarding
+    router.put(
+        "/agents/{agent_id}/servers/{server_name}/cloudflare",
+    )(_handle_cloudflare_enable)
+    router.delete(
+        "/agents/{agent_id}/servers/{server_name}/cloudflare",
+    )(_handle_cloudflare_disable)
+
+    # Telegram
+    router.post(
+        "/agents/{agent_id}/telegram",
+    )(_handle_telegram_setup)
+    router.get(
+        "/agents/{agent_id}/telegram",
+    )(_handle_telegram_status)
+
+    # Notifications
+    router.post(
+        "/notifications",
+    )(_handle_notification)
+
+    return router

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -24,6 +24,7 @@ from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
 from imbue.minds.primitives import ServerName
+from imbue.minds.telegram.credential_store import load_agent_bot_credentials
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
@@ -178,10 +179,15 @@ def _handle_telegram_status(
     if info is None:
         is_active = telegram_orchestrator.agent_has_telegram(parsed_id)
         if is_active:
-            return _json_response({
+            paths: WorkspacePaths = request.app.state.api_v1_paths
+            credentials = load_agent_bot_credentials(paths.data_dir, parsed_id)
+            result: dict[str, object] = {
                 "agent_id": str(parsed_id),
                 "status": str(TelegramSetupStatus.DONE),
-            })
+            }
+            if credentials is not None and credentials.bot_username is not None:
+                result["bot_username"] = credentials.bot_username
+            return _json_response(result)
         return _json_error("No Telegram setup in progress for this agent", 404)
 
     result: dict[str, object] = {

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from pydantic import PrivateAttr
 from pydantic import SecretStr
 from starlette.testclient import TestClient
 
@@ -18,6 +19,7 @@ from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.telegram.credential_store import save_agent_bot_credentials
 from imbue.minds.telegram.data_types import TelegramBotCredentials
+from imbue.minds.telegram.setup import TelegramSetupInfo
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
@@ -426,6 +428,37 @@ def test_notification_returns_501_without_dispatcher(tmp_path: Path) -> None:
     assert response.status_code == 501
 
 
+# -- Stub TelegramSetupOrchestrator for state-injection tests --
+
+
+class _StubTelegramOrchestrator(TelegramSetupOrchestrator):
+    """TelegramSetupOrchestrator subclass with preset get_setup_info return value.
+
+    Allows tests to verify HTTP endpoint behavior for specific orchestrator
+    states without touching private attributes or spawning background threads.
+    """
+
+    _preset_info_by_agent: dict[str, TelegramSetupInfo] = PrivateAttr(default_factory=dict)
+
+    @classmethod
+    def create_with_info(
+        cls,
+        paths: WorkspacePaths,
+        agent_id: AgentId,
+        setup_info: TelegramSetupInfo,
+    ) -> "_StubTelegramOrchestrator":
+        """Create a stub with a preset TelegramSetupInfo for a specific agent."""
+        stub = cls(paths=paths)
+        stub._preset_info_by_agent[str(agent_id)] = setup_info
+        return stub
+
+    def get_setup_info(self, agent_id: AgentId) -> TelegramSetupInfo | None:
+        return self._preset_info_by_agent.get(str(agent_id))
+
+    def start_setup(self, agent_id: AgentId, agent_name: str) -> None:
+        pass
+
+
 # -- Telegram status with active Telegram --
 
 
@@ -451,11 +484,7 @@ def test_telegram_status_returns_done_when_agent_has_telegram(tmp_path: Path) ->
 
 
 def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
-    """When setup is in progress, status endpoint returns current status info.
-
-    Uses direct orchestrator state manipulation to avoid spawning a background
-    thread that would try to open a real browser for Telegram login.
-    """
+    """When setup is in progress, status endpoint returns current status info."""
     paths = WorkspacePaths(data_dir=tmp_path / "minds")
     auth_store = FileAuthStore(data_directory=paths.auth_dir)
 
@@ -463,11 +492,11 @@ def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
     api_key = generate_api_key()
     save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
 
-    orchestrator = TelegramSetupOrchestrator(paths=paths)
-    # Inject in-progress state directly to avoid browser launch
-    aid = str(agent_id)
-    with orchestrator._lock:
-        orchestrator._statuses[aid] = TelegramSetupStatus.CREATING_BOT
+    preset_info = TelegramSetupInfo(
+        agent_id=agent_id,
+        status=TelegramSetupStatus.CREATING_BOT,
+    )
+    orchestrator = _StubTelegramOrchestrator.create_with_info(paths, agent_id, preset_info)
 
     backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
     notification_dispatcher = NotificationDispatcher(is_electron=True)
@@ -530,11 +559,12 @@ def test_telegram_status_returns_error_field_when_setup_failed(tmp_path: Path) -
     api_key = generate_api_key()
     save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
 
-    orchestrator = TelegramSetupOrchestrator(paths=paths)
-    aid = str(agent_id)
-    with orchestrator._lock:
-        orchestrator._statuses[aid] = TelegramSetupStatus.FAILED
-        orchestrator._errors[aid] = "setup failed unexpectedly"
+    preset_info = TelegramSetupInfo(
+        agent_id=agent_id,
+        status=TelegramSetupStatus.FAILED,
+        error="setup failed unexpectedly",
+    )
+    orchestrator = _StubTelegramOrchestrator.create_with_info(paths, agent_id, preset_info)
 
     backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
     notification_dispatcher = NotificationDispatcher(is_electron=True)

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from pydantic import SecretStr
 from starlette.testclient import TestClient
 
 from imbue.minds.config.data_types import WorkspacePaths
@@ -9,9 +10,56 @@ from imbue.minds.desktop_client.api_key_store import save_api_key_hash
 from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
+from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingUrl
+from imbue.minds.desktop_client.cloudflare_client import CloudflareSecret
+from imbue.minds.desktop_client.cloudflare_client import CloudflareUsername
+from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
 from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.telegram.credential_store import save_agent_bot_credentials
+from imbue.minds.telegram.data_types import TelegramBotCredentials
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
+from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
+
+
+def _make_cloudflare_client() -> CloudflareForwardingClient:
+    """Create a CloudflareForwardingClient pointed at a non-listening port (will fail fast)."""
+    return CloudflareForwardingClient(
+        forwarding_url=CloudflareForwardingUrl("http://127.0.0.1:1"),
+        username=CloudflareUsername("testuser"),
+        secret=CloudflareSecret("testsecret"),
+        owner_email=OwnerEmail("test@example.com"),
+    )
+
+
+def _create_test_api_client_with_cloudflare(
+    tmp_path: Path,
+    agent_id: AgentId,
+) -> tuple[TestClient, str, WorkspacePaths]:
+    """Create a client with a configured (but non-functional) CloudflareForwardingClient."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    backend_resolver = StaticBackendResolver(
+        url_by_agent_and_server={str(agent_id): {"web": "http://127.0.0.1:9000"}},
+    )
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+    cloudflare_client = _make_cloudflare_client()
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        cloudflare_client=cloudflare_client,
+        paths=paths,
+    )
+    client = TestClient(app)
+    return client, api_key, paths
 
 
 def _create_test_api_client(
@@ -346,3 +394,167 @@ def test_notification_returns_501_without_dispatcher(tmp_path: Path) -> None:
         headers=_auth_headers(api_key),
     )
     assert response.status_code == 501
+
+
+# -- Telegram status with active Telegram --
+
+
+def test_telegram_status_returns_done_when_agent_has_telegram(tmp_path: Path) -> None:
+    """When an agent has stored bot credentials, status endpoint returns DONE."""
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    # Save bot credentials so agent_has_telegram() returns True
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_test"),
+        bot_username="test_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent_id"] == str(agent_id)
+    assert data["status"] == str(TelegramSetupStatus.DONE)
+
+
+def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
+    """When setup is in progress, status endpoint returns current status info."""
+    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+
+    # Start setup so get_setup_info returns a non-None result
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        json={"agent_name": "test-bot"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+
+    # Now check status -- setup was started, so get_setup_info should return data
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent_id"] == str(agent_id)
+    assert "status" in data
+
+
+def test_telegram_status_includes_bot_username_when_done(tmp_path: Path) -> None:
+    """When agent has stored bot credentials, the response includes bot_username."""
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token"),
+        bot_username="my_test_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
+    # Trigger start_setup which will detect credentials and set DONE with bot_username
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        json={"agent_name": "test-bot"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+
+    # Status should now include bot_username from stored credentials
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == str(TelegramSetupStatus.DONE)
+    assert data.get("bot_username") == "my_test_bot"
+
+
+def test_telegram_status_returns_error_field_when_setup_failed(tmp_path: Path) -> None:
+    """When setup has FAILED status, the status response includes the error field."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    agent_id = AgentId()
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    orchestrator = TelegramSetupOrchestrator(paths=paths)
+    aid = str(agent_id)
+    with orchestrator._lock:
+        orchestrator._statuses[aid] = TelegramSetupStatus.FAILED
+        orchestrator._errors[aid] = "setup failed unexpectedly"
+
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        telegram_orchestrator=orchestrator,
+        paths=paths,
+    )
+    client = TestClient(app)
+
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == str(TelegramSetupStatus.FAILED)
+    assert data["error"] == "setup failed unexpectedly"
+
+
+# -- Cloudflare routes with configured client --
+
+
+def test_cloudflare_enable_returns_502_when_api_call_fails(tmp_path: Path) -> None:
+    """When the Cloudflare API is unreachable, enable returns 502."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_cloudflare(tmp_path, agent_id)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 502
+
+
+def test_cloudflare_enable_returns_404_when_server_not_found(tmp_path: Path) -> None:
+    """When the backend resolver has no URL for the server, enable returns 404."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_cloudflare(tmp_path, agent_id)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/nonexistent/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 404
+
+
+def test_cloudflare_enable_uses_service_url_from_body(tmp_path: Path) -> None:
+    """When the request body has service_url, it is used instead of the backend resolver."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_cloudflare(tmp_path, agent_id)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        json={"service_url": "http://127.0.0.1:9001"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 502
+
+
+def test_cloudflare_disable_returns_502_when_api_call_fails(tmp_path: Path) -> None:
+    """When the Cloudflare API is unreachable, disable returns 502."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_cloudflare(tmp_path, agent_id)
+    response = client.delete(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 502
+
+

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -1,0 +1,189 @@
+import json
+from pathlib import Path
+
+from starlette.testclient import TestClient
+
+from imbue.minds.config.data_types import WorkspacePaths
+from imbue.minds.desktop_client.api_key_store import generate_api_key
+from imbue.minds.desktop_client.api_key_store import hash_api_key
+from imbue.minds.desktop_client.api_key_store import save_api_key_hash
+from imbue.minds.desktop_client.app import create_desktop_client
+from imbue.minds.desktop_client.auth import FileAuthStore
+from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
+from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.mngr.primitives import AgentId
+
+
+def _create_test_api_client(
+    tmp_path: Path,
+    agent_id: AgentId | None = None,
+    api_key: str | None = None,
+) -> tuple[TestClient, AgentId, str, WorkspacePaths]:
+    """Create a desktop client with the API v1 router and a valid API key."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    resolved_agent_id = agent_id or AgentId()
+    resolved_api_key = api_key or generate_api_key()
+    key_hash = hash_api_key(resolved_api_key)
+    save_api_key_hash(paths.data_dir, resolved_agent_id, key_hash)
+
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    # Use Electron mode in tests to avoid tkinter side effects
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        paths=paths,
+    )
+    client = TestClient(app)
+    return client, resolved_agent_id, resolved_api_key, paths
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+# -- Auth tests --
+
+
+def test_api_v1_rejects_missing_auth(tmp_path: Path) -> None:
+    client, _agent_id, _api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post("/api/v1/notifications", json={"message": "test"})
+    assert response.status_code == 401
+
+
+def test_api_v1_rejects_invalid_bearer_token(tmp_path: Path) -> None:
+    client, _agent_id, _api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers={"Authorization": "Bearer invalid-key"},
+    )
+    assert response.status_code == 401
+
+
+def test_api_v1_rejects_malformed_auth_header(tmp_path: Path) -> None:
+    client, _agent_id, _api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers={"Authorization": "Basic dXNlcjpwYXNz"},
+    )
+    assert response.status_code == 401
+
+
+def test_api_v1_accepts_valid_bearer_token(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers=_auth_headers(api_key),
+    )
+    # Should succeed (or 501 if dispatcher not configured, but we configured it)
+    assert response.status_code == 200
+
+
+# -- Cloudflare routes --
+
+
+def test_cloudflare_enable_returns_501_when_not_configured(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 501
+    assert "not configured" in response.json()["error"]
+
+
+def test_cloudflare_disable_returns_501_when_not_configured(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.delete(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 501
+    assert "not configured" in response.json()["error"]
+
+
+# -- Telegram routes --
+
+
+def test_telegram_setup_returns_501_when_not_configured(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 501
+    assert "not configured" in response.json()["error"]
+
+
+def test_telegram_status_returns_501_when_not_configured(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 501
+    assert "not configured" in response.json()["error"]
+
+
+# -- Notification route --
+
+
+def test_notification_succeeds_with_valid_body(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "Hello user", "title": "Test", "urgency": "low"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_notification_rejects_missing_message(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"title": "No message field"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 400
+    assert "message" in response.json()["error"]
+
+
+def test_notification_rejects_invalid_urgency(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test", "urgency": "SUPER_URGENT"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 400
+    assert "urgency" in response.json()["error"].lower()
+
+
+def test_notification_rejects_invalid_json(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        content="not json",
+        headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_notification_defaults_urgency_to_normal(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -278,7 +278,20 @@ def _create_test_api_client_with_telegram(
 
 
 def test_telegram_setup_starts_with_orchestrator(tmp_path: Path) -> None:
-    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    """When an agent already has bot credentials, setup returns CHECKING_CREDENTIALS.
+
+    Pre-saves credentials so the background thread detects them immediately
+    and sets DONE status without trying to open a browser.
+    """
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    # Pre-save credentials so the orchestrator detects them and skips browser login
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_setup_test"),
+        bot_username="setup_test_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
     response = client.post(
         f"/api/v1/agents/{agent_id}/telegram",
         json={"agent_name": "test-bot"},
@@ -287,6 +300,7 @@ def test_telegram_setup_starts_with_orchestrator(tmp_path: Path) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["agent_id"] == str(agent_id)
+    # With pre-saved credentials, start_setup detects them and returns immediately
     assert data["status"] == "CHECKING_CREDENTIALS"
 
 
@@ -421,18 +435,37 @@ def test_telegram_status_returns_done_when_agent_has_telegram(tmp_path: Path) ->
 
 
 def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
-    """When setup is in progress, status endpoint returns current status info."""
-    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    """When setup is in progress, status endpoint returns current status info.
 
-    # Start setup so get_setup_info returns a non-None result
-    response = client.post(
-        f"/api/v1/agents/{agent_id}/telegram",
-        json={"agent_name": "test-bot"},
-        headers=_auth_headers(api_key),
+    Uses direct orchestrator state manipulation to avoid spawning a background
+    thread that would try to open a real browser for Telegram login.
+    """
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    agent_id = AgentId()
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    orchestrator = TelegramSetupOrchestrator(paths=paths)
+    # Inject in-progress state directly to avoid browser launch
+    aid = str(agent_id)
+    with orchestrator._lock:
+        orchestrator._statuses[aid] = TelegramSetupStatus.CREATING_BOT
+
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        telegram_orchestrator=orchestrator,
+        paths=paths,
     )
-    assert response.status_code == 200
+    client = TestClient(app)
 
-    # Now check status -- setup was started, so get_setup_info should return data
     response = client.get(
         f"/api/v1/agents/{agent_id}/telegram",
         headers=_auth_headers(api_key),
@@ -440,7 +473,7 @@ def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["agent_id"] == str(agent_id)
-    assert "status" in data
+    assert data["status"] == str(TelegramSetupStatus.CREATING_BOT)
 
 
 def test_telegram_status_includes_bot_username_when_done(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -362,7 +362,15 @@ def test_cloudflare_enable_returns_404_for_unknown_server(tmp_path: Path) -> Non
 
 
 def test_telegram_setup_accepts_empty_body(tmp_path: Path) -> None:
-    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    """Pre-saves credentials to avoid spawning a browser thread."""
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_empty_body"),
+        bot_username="empty_body_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
     response = client.post(
         f"/api/v1/agents/{agent_id}/telegram",
         headers=_auth_headers(api_key),
@@ -371,7 +379,15 @@ def test_telegram_setup_accepts_empty_body(tmp_path: Path) -> None:
 
 
 def test_telegram_setup_with_invalid_json_body(tmp_path: Path) -> None:
-    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    """Pre-saves credentials to avoid spawning a browser thread."""
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_invalid_json"),
+        bot_username="invalid_json_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
     response = client.post(
         f"/api/v1/agents/{agent_id}/telegram",
         content="not json",
@@ -615,8 +631,19 @@ def test_notification_rejects_non_string_title(tmp_path: Path) -> None:
 
 
 def test_telegram_setup_with_non_dict_json_body(tmp_path: Path) -> None:
-    """When the telegram setup body is valid JSON but not a dict, setup still proceeds."""
-    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    """When the telegram setup body is valid JSON but not a dict, setup still proceeds.
+
+    Pre-saves bot credentials so the orchestrator detects them immediately
+    and does not spawn a background thread that opens a real browser.
+    """
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_non_dict_test"),
+        bot_username="non_dict_test_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
     response = client.post(
         f"/api/v1/agents/{agent_id}/telegram",
         content="42",

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -10,7 +10,6 @@ from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
 from imbue.minds.desktop_client.notification import NotificationDispatcher
-from imbue.minds.primitives import ServerName
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.mngr.primitives import AgentId
 

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -602,6 +602,18 @@ def test_notification_rejects_non_dict_json_body(tmp_path: Path) -> None:
     assert response.status_code == 400
 
 
+def test_notification_rejects_non_string_title(tmp_path: Path) -> None:
+    """When the title field is not a string, return 400."""
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test", "title": 123},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 400
+    assert "title" in response.json()["error"]
+
+
 def test_telegram_setup_with_non_dict_json_body(tmp_path: Path) -> None:
     """When the telegram setup body is valid JSON but not a dict, setup still proceeds."""
     client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -483,6 +483,33 @@ def test_telegram_status_returns_done_when_agent_has_telegram(tmp_path: Path) ->
     assert data["status"] == str(TelegramSetupStatus.DONE)
 
 
+def test_telegram_status_includes_bot_username_without_active_setup(tmp_path: Path) -> None:
+    """When an agent has stored bot credentials but no active setup, bot_username is returned.
+
+    This covers the case where a previous session stored credentials and the
+    orchestrator has no in-memory setup info (get_setup_info returns None),
+    but the credential file exists on disk.
+    """
+    client, agent_id, api_key, paths = _create_test_api_client_with_telegram(tmp_path)
+
+    credentials = TelegramBotCredentials(
+        bot_token=SecretStr("123:fake_token_for_status_test"),
+        bot_username="status_test_bot",
+    )
+    save_agent_bot_credentials(paths.data_dir, agent_id, credentials)
+
+    # Query status directly without calling start_setup first.
+    # The orchestrator has no in-memory info, but credentials exist on disk.
+    response = client.get(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == str(TelegramSetupStatus.DONE)
+    assert data.get("bot_username") == "status_test_bot"
+
+
 def test_telegram_status_returns_in_progress_info(tmp_path: Path) -> None:
     """When setup is in progress, status endpoint returns current status info."""
     paths = WorkspacePaths(data_dir=tmp_path / "minds")

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -626,3 +626,74 @@ def test_telegram_setup_with_non_dict_json_body(tmp_path: Path) -> None:
     assert response.status_code == 200
 
 
+# -- Cloudflare success path tests --
+
+
+class _AlwaysSucceedCloudflareClient(CloudflareForwardingClient):
+    """CloudflareForwardingClient subclass that always returns True without making HTTP calls."""
+
+    def add_service(self, agent_id: AgentId, service_name: str, service_url: str) -> bool:
+        return True
+
+    def remove_service(self, agent_id: AgentId, service_name: str) -> bool:
+        return True
+
+
+def _create_test_api_client_with_succeeding_cloudflare(
+    tmp_path: Path,
+    agent_id: AgentId,
+) -> tuple[TestClient, str, WorkspacePaths]:
+    """Create a client with a CloudflareForwardingClient that always succeeds."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    backend_resolver = StaticBackendResolver(
+        url_by_agent_and_server={str(agent_id): {"web": "http://127.0.0.1:9000"}},
+    )
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+    cloudflare_client = _AlwaysSucceedCloudflareClient(
+        forwarding_url=CloudflareForwardingUrl("http://127.0.0.1:1"),
+        username=CloudflareUsername("testuser"),
+        secret=CloudflareSecret("testsecret"),
+        owner_email=OwnerEmail("test@example.com"),
+    )
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        cloudflare_client=cloudflare_client,
+        paths=paths,
+    )
+    client = TestClient(app)
+    return client, api_key, paths
+
+
+def test_cloudflare_enable_returns_200_on_success(tmp_path: Path) -> None:
+    """When Cloudflare API succeeds, enable returns 200 with ok=True."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_succeeding_cloudflare(tmp_path, agent_id)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_cloudflare_disable_returns_200_on_success(tmp_path: Path) -> None:
+    """When Cloudflare API succeeds, disable returns 200 with ok=True."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_succeeding_cloudflare(tmp_path, agent_id)
+    response = client.delete(
+        f"/api/v1/agents/{agent_id}/servers/web/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -591,3 +591,26 @@ def test_cloudflare_disable_returns_502_when_api_call_fails(tmp_path: Path) -> N
     assert response.status_code == 502
 
 
+def test_notification_rejects_non_dict_json_body(tmp_path: Path) -> None:
+    """When the notification body is valid JSON but not a dict, return 400."""
+    client, _agent_id, api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        content="[1, 2, 3]",
+        headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_telegram_setup_with_non_dict_json_body(tmp_path: Path) -> None:
+    """When the telegram setup body is valid JSON but not a dict, setup still proceeds."""
+    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        content="42",
+        headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+    )
+    # Non-dict body is handled gracefully: setup proceeds with default agent name
+    assert response.status_code == 200
+
+

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -294,3 +294,55 @@ def test_cloudflare_enable_returns_404_for_unknown_server(tmp_path: Path) -> Non
     )
     # No cloudflare client configured, so returns 501
     assert response.status_code == 501
+
+
+# -- Telegram setup with body parsing --
+
+
+def test_telegram_setup_accepts_empty_body(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+
+
+def test_telegram_setup_with_invalid_json_body(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        content="not json",
+        headers={**_auth_headers(api_key), "Content-Type": "application/json"},
+    )
+    # Should still succeed -- invalid body is handled gracefully
+    assert response.status_code == 200
+
+
+# -- Notification with no dispatcher --
+
+
+def test_notification_returns_501_without_dispatcher(tmp_path: Path) -> None:
+    """When notification_dispatcher is None, the endpoint returns 501."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    agent_id = AgentId()
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        paths=paths,
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 501

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 
 from starlette.testclient import TestClient
@@ -11,6 +10,8 @@ from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
 from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.primitives import ServerName
+from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.mngr.primitives import AgentId
 
 
@@ -187,3 +188,110 @@ def test_notification_defaults_urgency_to_normal(tmp_path: Path) -> None:
         headers=_auth_headers(api_key),
     )
     assert response.status_code == 200
+
+
+def test_api_v1_rejects_empty_bearer_token(tmp_path: Path) -> None:
+    client, _agent_id, _api_key, _paths = _create_test_api_client(tmp_path)
+    response = client.post(
+        "/api/v1/notifications",
+        json={"message": "test"},
+        headers={"Authorization": "Bearer "},
+    )
+    assert response.status_code == 401
+
+
+# -- Telegram routes with orchestrator --
+
+
+def _create_test_api_client_with_telegram(
+    tmp_path: Path,
+) -> tuple[TestClient, AgentId, str, WorkspacePaths]:
+    """Create a client with a TelegramSetupOrchestrator."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    agent_id = AgentId()
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+    telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        paths=paths,
+        telegram_orchestrator=telegram_orchestrator,
+    )
+    client = TestClient(app)
+    return client, agent_id, api_key, paths
+
+
+def test_telegram_setup_starts_with_orchestrator(tmp_path: Path) -> None:
+    client, agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    response = client.post(
+        f"/api/v1/agents/{agent_id}/telegram",
+        json={"agent_name": "test-bot"},
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["agent_id"] == str(agent_id)
+    assert data["status"] == "CHECKING_CREDENTIALS"
+
+
+def test_telegram_status_returns_404_for_unknown_agent(tmp_path: Path) -> None:
+    client, _agent_id, api_key, _paths = _create_test_api_client_with_telegram(tmp_path)
+    unknown_id = AgentId()
+    response = client.get(
+        f"/api/v1/agents/{unknown_id}/telegram",
+        headers=_auth_headers(api_key),
+    )
+    assert response.status_code == 404
+
+
+# -- Cloudflare enable with backend resolver --
+
+
+def _create_test_api_client_with_backend(
+    tmp_path: Path,
+    agent_id: AgentId,
+    server_name: str = "web",
+    backend_url: str = "http://127.0.0.1:9000",
+) -> tuple[TestClient, str, WorkspacePaths]:
+    """Create a client with a backend resolver that has a known agent/server."""
+    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    auth_store = FileAuthStore(data_directory=paths.auth_dir)
+
+    api_key = generate_api_key()
+    save_api_key_hash(paths.data_dir, agent_id, hash_api_key(api_key))
+
+    backend_resolver = StaticBackendResolver(
+        url_by_agent_and_server={str(agent_id): {server_name: backend_url}},
+    )
+    notification_dispatcher = NotificationDispatcher(is_electron=True)
+
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        notification_dispatcher=notification_dispatcher,
+        paths=paths,
+    )
+    client = TestClient(app)
+    return client, api_key, paths
+
+
+def test_cloudflare_enable_returns_404_for_unknown_server(tmp_path: Path) -> None:
+    """Cloudflare enable without a configured cloudflare client still returns 501."""
+    agent_id = AgentId()
+    client, api_key, _paths = _create_test_api_client_with_backend(tmp_path, agent_id)
+    response = client.put(
+        f"/api/v1/agents/{agent_id}/servers/unknown/cloudflare",
+        headers=_auth_headers(api_key),
+    )
+    # No cloudflare client configured, so returns 501
+    assert response.status_code == 501

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -28,12 +28,14 @@ from websockets import ClientConnection
 from imbue.minds.desktop_client.agent_creator import AgentCreationStatus
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.agent_creator import LOG_SENTINEL
+from imbue.minds.desktop_client.api_v1 import create_api_v1_router
 from imbue.minds.desktop_client.auth import AuthStoreInterface
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.proxy import generate_backend_loading_html
 from imbue.minds.desktop_client.proxy import generate_bootstrap_html
 from imbue.minds.desktop_client.proxy import generate_browser_info_bar_html
@@ -1092,6 +1094,8 @@ def create_desktop_client(
     agent_creator: AgentCreator | None = None,
     cloudflare_client: CloudflareForwardingClient | None = None,
     telegram_orchestrator: TelegramSetupOrchestrator | None = None,
+    notification_dispatcher: NotificationDispatcher | None = None,
+    paths: "WorkspacePaths | None" = None,
 ) -> FastAPI:
     """Create the desktop client FastAPI application.
 
@@ -1106,7 +1110,12 @@ def create_desktop_client(
 
     When telegram_orchestrator is provided, the landing page shows Telegram setup
     buttons and the /api/agents/{agent_id}/telegram/* endpoints are available.
+
+    When notification_dispatcher and paths are provided, the /api/v1/ REST API
+    router is mounted with API key authentication and notification support.
     """
+    from imbue.minds.config.data_types import WorkspacePaths as _WorkspacePaths
+
     is_externally_managed_client = http_client is not None
 
     @asynccontextmanager
@@ -1127,8 +1136,16 @@ def create_desktop_client(
     app.state.agent_creator = agent_creator
     app.state.cloudflare_client = cloudflare_client
     app.state.telegram_orchestrator = telegram_orchestrator
+    app.state.notification_dispatcher = notification_dispatcher
+    if paths is not None:
+        app.state.api_v1_paths = paths
     if http_client is not None:
         app.state.http_client = http_client
+
+    # Mount the REST API v1 router
+    if paths is not None:
+        api_v1_router = create_api_v1_router()
+        app.include_router(api_v1_router, prefix="/api/v1")
 
     # Register routes
     app.get("/login")(_handle_login)

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1108,8 +1108,10 @@ def create_desktop_client(
     When telegram_orchestrator is provided, the landing page shows Telegram setup
     buttons and the /api/agents/{agent_id}/telegram/* endpoints are available.
 
-    When notification_dispatcher and paths are provided, the /api/v1/ REST API
-    router is mounted with API key authentication and notification support.
+    When paths is provided, the /api/v1/ REST API router is mounted with API
+    key authentication. The notification endpoint within the router additionally
+    requires notification_dispatcher to be provided; without it that endpoint
+    returns 501.
     """
     is_externally_managed_client = http_client is not None
 

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -33,6 +33,7 @@ from imbue.minds.desktop_client.api_v1 import create_api_v1_router
 from imbue.minds.desktop_client.auth import AuthStoreInterface
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+from imbue.minds.desktop_client.deps import BackendResolverDep
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
@@ -107,12 +108,7 @@ def _get_auth_store(request: Request) -> AuthStoreInterface:
     return request.app.state.auth_store
 
 
-def _get_backend_resolver(request: Request) -> BackendResolverInterface:
-    return request.app.state.backend_resolver
-
-
 AuthStoreDep = Annotated[AuthStoreInterface, Depends(_get_auth_store)]
-BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]
 
 
 # -- Auth helpers --

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -25,6 +25,7 @@ from fastapi.responses import StreamingResponse
 from loguru import logger
 from websockets import ClientConnection
 
+from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreationStatus
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.agent_creator import LOG_SENTINEL
@@ -1095,7 +1096,7 @@ def create_desktop_client(
     cloudflare_client: CloudflareForwardingClient | None = None,
     telegram_orchestrator: TelegramSetupOrchestrator | None = None,
     notification_dispatcher: NotificationDispatcher | None = None,
-    paths: "WorkspacePaths | None" = None,
+    paths: WorkspacePaths | None = None,
 ) -> FastAPI:
     """Create the desktop client FastAPI application.
 
@@ -1114,8 +1115,6 @@ def create_desktop_client(
     When notification_dispatcher and paths are provided, the /api/v1/ REST API
     router is mounted with API key authentication and notification support.
     """
-    from imbue.minds.config.data_types import WorkspacePaths as _WorkspacePaths
-
     is_externally_managed_client = http_client is not None
 
     @asynccontextmanager

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -33,10 +33,10 @@ from imbue.minds.desktop_client.api_v1 import create_api_v1_router
 from imbue.minds.desktop_client.auth import AuthStoreInterface
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
-from imbue.minds.desktop_client.deps import BackendResolverDep
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
+from imbue.minds.desktop_client.deps import BackendResolverDep
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.proxy import generate_backend_loading_html
 from imbue.minds.desktop_client.proxy import generate_bootstrap_html

--- a/apps/minds/imbue/minds/desktop_client/auth_test.py
+++ b/apps/minds/imbue/minds/desktop_client/auth_test.py
@@ -139,12 +139,12 @@ def test_get_signing_key_raises_on_write_error(tmp_path: Path) -> None:
         os.chmod(auth_dir, 0o755)
 
 
-def test_load_codes_returns_empty_on_json_decode_error(tmp_path: Path) -> None:
-    """If the codes file contains invalid JSON, _load_codes returns an empty tuple."""
+def test_validate_code_returns_false_on_json_decode_error(tmp_path: Path) -> None:
+    """If the codes file contains invalid JSON, code validation returns False without crashing."""
     auth_dir = tmp_path / "auth"
     auth_dir.mkdir(parents=True)
     (auth_dir / "one_time_codes.json").write_text("not valid json {{{")
 
     store = FileAuthStore(data_directory=auth_dir)
-    result = store._load_codes()
-    assert result == ()
+    result = store.validate_and_consume_code(OneTimeCode("any-code"))
+    assert result is False

--- a/apps/minds/imbue/minds/desktop_client/auth_test.py
+++ b/apps/minds/imbue/minds/desktop_client/auth_test.py
@@ -1,9 +1,10 @@
+import os
 from pathlib import Path
 
 import pytest
 
-from imbue.minds.errors import SigningKeyError
 from imbue.minds.desktop_client.auth import FileAuthStore
+from imbue.minds.errors import SigningKeyError
 from imbue.minds.primitives import OneTimeCode
 
 
@@ -106,3 +107,44 @@ def test_get_signing_key_reads_existing_key(tmp_path: Path) -> None:
     store = FileAuthStore(data_directory=auth_dir)
     key = store.get_signing_key()
     assert key.get_secret_value() == "my-custom-key-82734"
+
+
+def test_get_signing_key_raises_on_read_error(tmp_path: Path) -> None:
+    """If an existing signing key file is not readable, SigningKeyError is raised."""
+    auth_dir = tmp_path / "auth"
+    auth_dir.mkdir(parents=True)
+    key_file = auth_dir / "signing_key"
+    key_file.write_text("some-key")
+    os.chmod(key_file, 0o000)
+
+    try:
+        store = FileAuthStore(data_directory=auth_dir)
+        with pytest.raises(SigningKeyError):
+            store.get_signing_key()
+    finally:
+        os.chmod(key_file, 0o644)
+
+
+def test_get_signing_key_raises_on_write_error(tmp_path: Path) -> None:
+    """If the auth directory cannot be written to, SigningKeyError is raised on key generation."""
+    auth_dir = tmp_path / "auth"
+    auth_dir.mkdir(parents=True)
+    os.chmod(auth_dir, 0o555)
+
+    try:
+        store = FileAuthStore(data_directory=auth_dir)
+        with pytest.raises(SigningKeyError):
+            store.get_signing_key()
+    finally:
+        os.chmod(auth_dir, 0o755)
+
+
+def test_load_codes_returns_empty_on_json_decode_error(tmp_path: Path) -> None:
+    """If the codes file contains invalid JSON, _load_codes returns an empty tuple."""
+    auth_dir = tmp_path / "auth"
+    auth_dir.mkdir(parents=True)
+    (auth_dir / "one_time_codes.json").write_text("not valid json {{{")
+
+    store = FileAuthStore(data_directory=auth_dir)
+    result = store._load_codes()
+    assert result == ()

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
-import paramiko
 from loguru import logger
 from pydantic import Field
 from pydantic import PrivateAttr
@@ -18,7 +17,6 @@ from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
-from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.primitives import ServerName
 from imbue.mngr.api.discovery_events import AgentDestroyedEvent
 from imbue.mngr.api.discovery_events import AgentDiscoveryEvent
@@ -560,7 +558,7 @@ class MngrStreamManager(MutableModel):
         for callback in self._on_agent_discovered_callbacks:
             try:
                 callback(agent_id, ssh_info)
-            except (OSError, ValueError, RuntimeError, paramiko.SSHException, SSHTunnelError) as e:
+            except Exception as e:
                 logger.warning("Agent discovery callback failed for {}: {}", agent_id, e)
 
     def _update_resolver(

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -462,11 +462,21 @@ class MngrStreamManager(MutableModel):
             port=event.ssh.port,
             key_path=event.ssh.key_path,
         )
+        host_id_str = str(event.host_id)
         with self._lock:
-            self._ssh_by_host_id[str(event.host_id)] = ssh_info
+            self._ssh_by_host_id[host_id_str] = ssh_info
             agent_ids = tuple(AgentId(agent_id) for agent_id in self._agent_host_map)
+            # Find agents on this host so we can notify discovery callbacks with SSH info
+            agents_on_host = tuple(
+                AgentId(aid) for aid, hid in self._agent_host_map.items() if hid == host_id_str
+            )
 
         self._update_resolver(agent_ids)
+
+        # Re-fire callbacks for agents on this host now that SSH info is available.
+        # This handles the case where agent discovery fires before SSH info arrives.
+        for agent_id in agents_on_host:
+            self._fire_agent_discovered_callbacks(agent_id, ssh_info)
 
     def _handle_agent_discovered(self, event: AgentDiscoveryEvent) -> None:
         """Incrementally add or update a single agent in the resolver."""

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
+import paramiko
 from loguru import logger
 from pydantic import Field
 from pydantic import PrivateAttr
@@ -17,6 +18,7 @@ from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.primitives import ServerName
 from imbue.mngr.api.discovery_events import AgentDestroyedEvent
 from imbue.mngr.api.discovery_events import AgentDiscoveryEvent
@@ -558,7 +560,7 @@ class MngrStreamManager(MutableModel):
         for callback in self._on_agent_discovered_callbacks:
             try:
                 callback(agent_id, ssh_info)
-            except Exception as e:
+            except (OSError, ValueError, RuntimeError, paramiko.SSHException, SSHTunnelError) as e:
                 logger.warning("Agent discovery callback failed for {}: {}", agent_id, e)
 
     def _update_resolver(

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -18,6 +18,7 @@ from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.primitives import ServerName
 from imbue.mngr.api.discovery_events import AgentDestroyedEvent
 from imbue.mngr.api.discovery_events import AgentDiscoveryEvent
@@ -559,7 +560,7 @@ class MngrStreamManager(MutableModel):
         for callback in self._on_agent_discovered_callbacks:
             try:
                 callback(agent_id, ssh_info)
-            except (OSError, ValueError, RuntimeError, paramiko.SSHException) as e:
+            except (OSError, ValueError, RuntimeError, paramiko.SSHException, SSHTunnelError) as e:
                 logger.warning("Agent discovery callback failed for {}: {}", agent_id, e)
 
     def _update_resolver(

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -2,10 +2,12 @@ import json
 import threading
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Callable
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
+import paramiko
 from loguru import logger
 from pydantic import Field
 from pydantic import PrivateAttr
@@ -354,6 +356,19 @@ class MngrStreamManager(MutableModel):
     _events_servers: dict[str, dict[str, str]] = PrivateAttr(default_factory=dict)
     _events_processes: dict[str, RunningProcess] = PrivateAttr(default_factory=dict)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _on_agent_discovered_callbacks: list[Callable[[AgentId, RemoteSSHInfo | None], None]] = PrivateAttr(
+        default_factory=list
+    )
+
+    def add_on_agent_discovered_callback(
+        self,
+        callback: Callable[[AgentId, RemoteSSHInfo | None], None],
+    ) -> None:
+        """Register a callback invoked when an agent is discovered.
+
+        The callback receives the agent ID and SSH info (None for local agents).
+        """
+        self._on_agent_discovered_callbacks.append(callback)
 
     def start(self) -> None:
         """Start the streaming subprocess for continuous agent discovery."""
@@ -434,6 +449,11 @@ class MngrStreamManager(MutableModel):
         workspace_ids = {str(agent.agent_id) for agent in event.agents if self._is_workspace_agent(agent)}
         self._sync_events_streams(workspace_ids)
 
+        # Notify callbacks for all discovered agents
+        for agent in event.agents:
+            ssh_info = self._get_ssh_info_for_agent(agent.agent_id)
+            self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info)
+
     def _handle_host_ssh_info(self, event: HostSSHInfoEvent) -> None:
         """Update SSH info for a host and refresh the resolver."""
         ssh_info = RemoteSSHInfo(
@@ -468,6 +488,10 @@ class MngrStreamManager(MutableModel):
             discovered_agents = self._discovered_agents
 
         self._update_resolver(agent_ids, discovered_agents)
+
+        # Notify callbacks
+        ssh_info = self._get_ssh_info_for_agent(agent.agent_id)
+        self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info)
 
     def _handle_agent_destroyed(self, event: AgentDestroyedEvent) -> None:
         """Remove a destroyed agent from the resolver and stop its events stream."""
@@ -507,6 +531,26 @@ class MngrStreamManager(MutableModel):
         self._update_resolver(agent_ids, discovered_agents)
         for agent_id in event.agent_ids:
             self.resolver.update_servers(agent_id, {})
+
+    def _get_ssh_info_for_agent(self, agent_id: AgentId) -> RemoteSSHInfo | None:
+        """Look up SSH info for an agent from the host mapping."""
+        with self._lock:
+            host_id = self._agent_host_map.get(str(agent_id))
+            if host_id is None:
+                return None
+            return self._ssh_by_host_id.get(host_id)
+
+    def _fire_agent_discovered_callbacks(
+        self,
+        agent_id: AgentId,
+        ssh_info: RemoteSSHInfo | None,
+    ) -> None:
+        """Invoke all registered on_agent_discovered callbacks."""
+        for callback in self._on_agent_discovered_callbacks:
+            try:
+                callback(agent_id, ssh_info)
+            except (OSError, ValueError, RuntimeError, paramiko.SSHException) as e:
+                logger.warning("Agent discovery callback failed for {}: {}", agent_id, e)
 
     def _update_resolver(
         self,

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
@@ -355,6 +355,13 @@ def test_parse_agents_from_json_returns_empty_for_invalid_json() -> None:
     assert result.agent_ids == ()
 
 
+def test_parse_agents_from_json_skips_entries_missing_id() -> None:
+    """Agents without an 'id' field in the output are skipped."""
+    json_str = json.dumps({"agents": [{"name": "no-id-agent"}]})
+    result = parse_agents_from_json(json_str)
+    assert result.agent_ids == ()
+
+
 def test_parse_agents_from_json_skips_agents_with_invalid_ssh() -> None:
     json_str = json.dumps(
         {
@@ -957,3 +964,65 @@ def test_stream_manager_host_destroyed_removes_all_agents_on_host() -> None:
         manager._handle_discovery_line(destroy_line)
 
     assert manager.resolver.list_known_agent_ids() == ()
+
+
+# -- On-agent-discovered callback tests --
+
+
+_HOST_CALLBACK_TEST = "host-00000000000000000000000000000099"
+
+
+def test_add_on_agent_discovered_callback_fires_on_full_snapshot() -> None:
+    """Registered callbacks are invoked when a DISCOVERY_FULL event is processed."""
+    manager = _make_stream_manager()
+    discovered: list[AgentId] = []
+    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info: discovered.append(agent_id))
+
+    full_line = _make_discovery_full_line(
+        agents=[(str(_AGENT_A), _HOST_CALLBACK_TEST)],
+        hosts=[_HOST_CALLBACK_TEST],
+    )
+    manager._handle_discovery_line(full_line)
+
+    assert _AGENT_A in discovered
+
+
+def test_add_on_agent_discovered_callback_fires_on_agent_discovered() -> None:
+    """Registered callbacks are invoked when an AGENT_DISCOVERED event is processed."""
+    manager = _make_stream_manager()
+    discovered: list[AgentId] = []
+    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info: discovered.append(agent_id))
+
+    # Use empty labels so no events stream is started (avoids needing to start _cg)
+    disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
+    manager._handle_discovery_line(disc_line)
+
+    assert _AGENT_A in discovered
+
+
+def test_fire_agent_discovered_callbacks_catches_exceptions() -> None:
+    """Exceptions raised by callbacks are caught and logged without propagating."""
+    manager = _make_stream_manager()
+
+    def failing_callback(agent_id: AgentId, ssh_info: object) -> None:
+        raise RuntimeError("callback error")
+
+    manager.add_on_agent_discovered_callback(failing_callback)
+
+    disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
+    manager._handle_discovery_line(disc_line)
+
+
+def test_multiple_callbacks_all_invoked() -> None:
+    """Multiple registered callbacks are each invoked."""
+    manager = _make_stream_manager()
+    results_a: list[AgentId] = []
+    results_b: list[AgentId] = []
+    manager.add_on_agent_discovered_callback(lambda aid, ssh: results_a.append(aid))
+    manager.add_on_agent_discovered_callback(lambda aid, ssh: results_b.append(aid))
+
+    disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
+    manager._handle_discovery_line(disc_line)
+
+    assert _AGENT_A in results_a
+    assert _AGENT_A in results_b

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
@@ -1026,3 +1026,33 @@ def test_multiple_callbacks_all_invoked() -> None:
 
     assert _AGENT_A in results_a
     assert _AGENT_A in results_b
+
+
+def test_callback_re_fired_with_ssh_info_when_host_ssh_info_arrives() -> None:
+    """When SSH info arrives after agent discovery, callbacks are re-fired with ssh_info set."""
+    manager = _make_stream_manager()
+    ssh_infos: list[object] = []
+    manager.add_on_agent_discovered_callback(lambda aid, ssh_info: ssh_infos.append(ssh_info))
+
+    # Discover the agent first (no SSH info yet); use empty labels to avoid events stream
+    disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
+    manager._handle_discovery_line(disc_line)
+    # First callback fires with ssh_info=None (no SSH info available yet)
+    assert None in ssh_infos
+
+    ssh_infos.clear()
+
+    # Now SSH info arrives for that host
+    ssh_data = {
+        "user": "root",
+        "host": "remote.example.com",
+        "port": 22,
+        "key_path": "/tmp/key",
+        "command": "ssh -i /tmp/key root@remote.example.com",
+    }
+    ssh_line = _make_host_ssh_info_line(_HOST_CALLBACK_TEST, ssh_data)
+    manager._handle_discovery_line(ssh_line)
+
+    # Callback is re-fired with the actual SSH info
+    assert len(ssh_infos) == 1
+    assert ssh_infos[0] is not None

--- a/apps/minds/imbue/minds/desktop_client/deps.py
+++ b/apps/minds/imbue/minds/desktop_client/deps.py
@@ -1,0 +1,15 @@
+"""Shared FastAPI dependency helpers for the desktop client."""
+
+from typing import Annotated
+
+from fastapi import Depends
+from fastapi import Request
+
+from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
+
+
+def _get_backend_resolver(request: Request) -> BackendResolverInterface:
+    return request.app.state.backend_resolver
+
+
+BackendResolverDep = Annotated[BackendResolverInterface, Depends(_get_backend_resolver)]

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -5,18 +5,17 @@ toast popup depending on whether the server is running inside the
 Electron desktop app.
 """
 
-import json
-import sys
 import threading
 import tkinter as tk
 from enum import auto
-from typing import assert_never
 
 from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.minds.primitives import OutputFormat
+from imbue.minds.utils.output import emit_event
 
 
 class NotificationUrgency(UpperCaseStrEnum):
@@ -50,16 +49,101 @@ def _dispatch_electron_notification(
     agent_display_name: str,
 ) -> None:
     """Write notification as JSONL to stdout for the Electron main process."""
-    event = {
-        "event": "notification",
+    data: dict[str, str] = {
         "message": request.message,
         "urgency": str(request.urgency),
         "agent_name": agent_display_name,
     }
     if request.title is not None:
-        event["title"] = request.title
-    sys.stdout.write(json.dumps(event) + "\n")
-    sys.stdout.flush()
+        data["title"] = request.title
+    emit_event("notification", data, OutputFormat.JSONL)
+
+
+def _run_tkinter_toast(
+    title: str,
+    message: str,
+    urgency: NotificationUrgency,
+    agent_display_name: str,
+) -> None:
+    """Create and display a tkinter toast window. Runs on a background thread."""
+    try:
+        root = tk.Tk()
+        root.overrideredirect(True)
+        root.attributes("-topmost", True)
+
+        urgency_color = _URGENCY_COLOR_BY_LEVEL.get(urgency, "#eab308")
+
+        frame = tk.Frame(root, bg="#1e293b", padx=12, pady=8)
+        frame.pack(fill=tk.BOTH, expand=True)
+
+        # Urgency indicator bar
+        indicator = tk.Frame(frame, bg=urgency_color, width=4)
+        indicator.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 8))
+
+        content = tk.Frame(frame, bg="#1e293b")
+        content.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        # Agent name
+        tk.Label(
+            content,
+            text=f"From: {agent_display_name}",
+            fg="#94a3b8",
+            bg="#1e293b",
+            font=("sans-serif", 9),
+            anchor="w",
+        ).pack(fill=tk.X)
+
+        # Title
+        tk.Label(
+            content,
+            text=title,
+            fg="#f1f5f9",
+            bg="#1e293b",
+            font=("sans-serif", 11, "bold"),
+            anchor="w",
+        ).pack(fill=tk.X)
+
+        # Message
+        tk.Label(
+            content,
+            text=message,
+            fg="#cbd5e1",
+            bg="#1e293b",
+            font=("sans-serif", 10),
+            anchor="w",
+            wraplength=280,
+            justify=tk.LEFT,
+        ).pack(fill=tk.X, pady=(4, 0))
+
+        # Dismiss hint
+        tk.Label(
+            content,
+            text="Click to dismiss",
+            fg="#64748b",
+            bg="#1e293b",
+            font=("sans-serif", 8),
+            anchor="w",
+        ).pack(fill=tk.X, pady=(4, 0))
+
+        # Position in bottom-right corner
+        root.update_idletasks()
+        width = 320
+        height = root.winfo_reqheight()
+        screen_width = root.winfo_screenwidth()
+        screen_height = root.winfo_screenheight()
+        x_position = screen_width - width - 20
+        y_position = screen_height - height - 60
+        root.geometry(f"{width}x{height}+{x_position}+{y_position}")
+
+        # Click anywhere to dismiss
+        root.bind("<Button-1>", lambda _event: root.destroy())
+        frame.bind("<Button-1>", lambda _event: root.destroy())
+        for child in content.winfo_children():
+            child.bind("<Button-1>", lambda _event: root.destroy())
+
+        root.mainloop()
+    except tk.TclError as e:
+        logger.warning("Failed to show tkinter notification: {}", e)
 
 
 def _show_tkinter_toast(
@@ -67,89 +151,13 @@ def _show_tkinter_toast(
     agent_display_name: str,
 ) -> None:
     """Show a small always-on-top toast window in the bottom-right corner."""
-
-    def _run_toast() -> None:
-        try:
-            root = tk.Tk()
-            root.overrideredirect(True)
-            root.attributes("-topmost", True)
-
-            urgency_color = _URGENCY_COLOR_BY_LEVEL.get(request.urgency, "#eab308")
-
-            frame = tk.Frame(root, bg="#1e293b", padx=12, pady=8)
-            frame.pack(fill=tk.BOTH, expand=True)
-
-            # Urgency indicator bar
-            indicator = tk.Frame(frame, bg=urgency_color, width=4)
-            indicator.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 8))
-
-            content = tk.Frame(frame, bg="#1e293b")
-            content.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-
-            # Agent name
-            tk.Label(
-                content,
-                text=f"From: {agent_display_name}",
-                fg="#94a3b8",
-                bg="#1e293b",
-                font=("sans-serif", 9),
-                anchor="w",
-            ).pack(fill=tk.X)
-
-            # Title
-            display_title = request.title or "Notification"
-            tk.Label(
-                content,
-                text=display_title,
-                fg="#f1f5f9",
-                bg="#1e293b",
-                font=("sans-serif", 11, "bold"),
-                anchor="w",
-            ).pack(fill=tk.X)
-
-            # Message
-            tk.Label(
-                content,
-                text=request.message,
-                fg="#cbd5e1",
-                bg="#1e293b",
-                font=("sans-serif", 10),
-                anchor="w",
-                wraplength=280,
-                justify=tk.LEFT,
-            ).pack(fill=tk.X, pady=(4, 0))
-
-            # Dismiss hint
-            tk.Label(
-                content,
-                text="Click to dismiss",
-                fg="#64748b",
-                bg="#1e293b",
-                font=("sans-serif", 8),
-                anchor="w",
-            ).pack(fill=tk.X, pady=(4, 0))
-
-            # Position in bottom-right corner
-            root.update_idletasks()
-            width = 320
-            height = root.winfo_reqheight()
-            screen_width = root.winfo_screenwidth()
-            screen_height = root.winfo_screenheight()
-            x_position = screen_width - width - 20
-            y_position = screen_height - height - 60
-            root.geometry(f"{width}x{height}+{x_position}+{y_position}")
-
-            # Click anywhere to dismiss
-            root.bind("<Button-1>", lambda _event: root.destroy())
-            frame.bind("<Button-1>", lambda _event: root.destroy())
-            for child in content.winfo_children():
-                child.bind("<Button-1>", lambda _event: root.destroy())
-
-            root.mainloop()
-        except tk.TclError as e:
-            logger.warning("Failed to show tkinter notification: {}", e)
-
-    thread = threading.Thread(target=_run_toast, daemon=True, name="tkinter-toast")
+    display_title = request.title or "Notification"
+    thread = threading.Thread(
+        target=_run_tkinter_toast,
+        args=(display_title, request.message, request.urgency, agent_display_name),
+        daemon=True,
+        name="tkinter-toast",
+    )
     thread.start()
 
 

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -1,10 +1,10 @@
 """Notification dispatch for the minds desktop client.
 
-Routes notifications to either Electron (stdout JSONL) or a tkinter
-toast popup depending on whether the server is running inside the
-Electron desktop app.
+Routes notifications to either Electron (stdout JSONL), native macOS
+notifications, or a tkinter toast popup depending on the runtime context.
 """
 
+import platform
 import threading
 from enum import auto
 from types import ModuleType
@@ -13,10 +13,13 @@ from loguru import logger
 from pydantic import Field
 from pydantic import PrivateAttr
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.minds.primitives import OutputFormat
 from imbue.minds.utils.output import emit_event
+
+_IS_MACOS: bool = platform.system() == "Darwin"
 
 # tkinter is an optional dependency: not available on all platforms (e.g. headless servers).
 # Load it at module level so the failure is immediate and predictable, but tolerate absence.
@@ -175,10 +178,33 @@ def _show_tkinter_toast(
     thread.start()
 
 
+def _dispatch_macos_notification(
+    request: NotificationRequest,
+    agent_display_name: str,
+) -> None:
+    """Display a native macOS notification via osascript."""
+    display_title = request.title or f"Notification from {agent_display_name}"
+    # Escape double quotes for AppleScript string literals
+    escaped_title = display_title.replace('"', '\\"')
+    escaped_message = request.message.replace('"', '\\"')
+    escaped_subtitle = f"From: {agent_display_name}".replace('"', '\\"')
+    script = f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
+    cg = ConcurrencyGroup(name="macos-notification")
+    try:
+        with cg:
+            cg.run_process_to_completion(
+                command=["osascript", "-e", script],
+                is_checked_after=False,
+            )
+    except (OSError, ExceptionGroup) as e:
+        logger.warning("Failed to show macOS notification: {}", e)
+
+
 class NotificationDispatcher(FrozenModel):
-    """Routes notifications to Electron or tkinter based on runtime context."""
+    """Routes notifications to Electron, macOS native, or tkinter based on runtime context."""
 
     is_electron: bool = Field(description="Whether the server is running inside Electron")
+    is_macos: bool = Field(default=_IS_MACOS, description="Whether running on macOS")
     # _tk stores the resolved tkinter module. Set at construction time to the
     # module-level _TKINTER value, or injected via NotificationDispatcher.create()
     # to allow testing without tkinter side effects.
@@ -193,13 +219,14 @@ class NotificationDispatcher(FrozenModel):
         cls,
         is_electron: bool,
         tkinter_module: ModuleType | None = _TKINTER,
+        is_macos: bool = _IS_MACOS,
     ) -> "NotificationDispatcher":
-        """Create a NotificationDispatcher with an explicit tkinter module.
+        """Create a NotificationDispatcher with explicit platform overrides.
 
         Pass tkinter_module=None to disable tkinter toasts (e.g. in tests or on
         headless servers where tkinter is unavailable).
         """
-        dispatcher = cls(is_electron=is_electron)
+        dispatcher = cls(is_electron=is_electron, is_macos=is_macos)
         dispatcher._tk = tkinter_module
         return dispatcher
 
@@ -208,8 +235,13 @@ class NotificationDispatcher(FrozenModel):
         request: NotificationRequest,
         agent_display_name: str,
     ) -> None:
-        """Send a notification to the user via the appropriate channel."""
+        """Send a notification to the user via the appropriate channel.
+
+        Priority: Electron > macOS native > tkinter toast.
+        """
         if self.is_electron:
             _dispatch_electron_notification(request, agent_display_name)
+        elif self.is_macos:
+            _dispatch_macos_notification(request, agent_display_name)
         else:
             _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -6,7 +6,6 @@ Electron desktop app.
 """
 
 import threading
-import tkinter as tk
 from enum import auto
 
 from loguru import logger
@@ -66,6 +65,12 @@ def _run_tkinter_toast(
     agent_display_name: str,
 ) -> None:
     """Create and display a tkinter toast window. Runs on a background thread."""
+    try:
+        import tkinter as tk
+    except ImportError as e:
+        logger.warning("tkinter not available, cannot show notification: {}", e)
+        return
+
     try:
         root = tk.Tk()
         root.overrideredirect(True)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -193,17 +193,8 @@ def _show_tkinter_toast(
     thread.start()
 
 
-def _dispatch_macos_notification(
-    request: NotificationRequest,
-    agent_display_name: str,
-) -> None:
-    """Display a native macOS notification via osascript."""
-    display_title = request.title or f"Notification from {agent_display_name}"
-    # Escape double quotes for AppleScript string literals
-    escaped_title = display_title.replace('"', '\\"')
-    escaped_message = request.message.replace('"', '\\"')
-    escaped_subtitle = f"From: {agent_display_name}".replace('"', '\\"')
-    script = f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
+def _run_macos_notification_subprocess(script: str) -> None:
+    """Run an AppleScript notification command via osascript on a background thread."""
     cg = ConcurrencyGroup(name="macos-notification")
     try:
         with cg:
@@ -213,6 +204,26 @@ def _dispatch_macos_notification(
             )
     except (OSError, ExceptionGroup) as e:
         logger.warning("Failed to show macOS notification: {}", e)
+
+
+def _dispatch_macos_notification(
+    request: NotificationRequest,
+    agent_display_name: str,
+) -> None:
+    """Display a native macOS notification via osascript on a background thread."""
+    display_title = request.title or f"Notification from {agent_display_name}"
+    # Escape double quotes for AppleScript string literals
+    escaped_title = display_title.replace('"', '\\"')
+    escaped_message = request.message.replace('"', '\\"')
+    escaped_subtitle = f"From: {agent_display_name}".replace('"', '\\"')
+    script = f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
+    thread = threading.Thread(
+        target=_run_macos_notification_subprocess,
+        args=(script,),
+        daemon=True,
+        name="macos-notification",
+    )
+    thread.start()
 
 
 class NotificationDispatcher(FrozenModel):

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -1,0 +1,170 @@
+"""Notification dispatch for the minds desktop client.
+
+Routes notifications to either Electron (stdout JSONL) or a tkinter
+toast popup depending on whether the server is running inside the
+Electron desktop app.
+"""
+
+import json
+import sys
+import threading
+import tkinter as tk
+from enum import auto
+from typing import assert_never
+
+from loguru import logger
+from pydantic import Field
+
+from imbue.imbue_common.enums import UpperCaseStrEnum
+from imbue.imbue_common.frozen_model import FrozenModel
+
+
+class NotificationUrgency(UpperCaseStrEnum):
+    """Urgency level for a user notification."""
+
+    LOW = auto()
+    NORMAL = auto()
+    CRITICAL = auto()
+
+
+class NotificationRequest(FrozenModel):
+    """A notification to display to the user."""
+
+    message: str = Field(description="Notification body text")
+    title: str | None = Field(default=None, description="Optional notification title")
+    urgency: NotificationUrgency = Field(
+        default=NotificationUrgency.NORMAL,
+        description="Urgency level (low, normal, critical)",
+    )
+
+
+_URGENCY_COLOR_BY_LEVEL: dict[NotificationUrgency, str] = {
+    NotificationUrgency.LOW: "#22c55e",
+    NotificationUrgency.NORMAL: "#eab308",
+    NotificationUrgency.CRITICAL: "#ef4444",
+}
+
+
+def _dispatch_electron_notification(
+    request: NotificationRequest,
+    agent_display_name: str,
+) -> None:
+    """Write notification as JSONL to stdout for the Electron main process."""
+    event = {
+        "event": "notification",
+        "message": request.message,
+        "urgency": str(request.urgency),
+        "agent_name": agent_display_name,
+    }
+    if request.title is not None:
+        event["title"] = request.title
+    sys.stdout.write(json.dumps(event) + "\n")
+    sys.stdout.flush()
+
+
+def _show_tkinter_toast(
+    request: NotificationRequest,
+    agent_display_name: str,
+) -> None:
+    """Show a small always-on-top toast window in the bottom-right corner."""
+
+    def _run_toast() -> None:
+        try:
+            root = tk.Tk()
+            root.overrideredirect(True)
+            root.attributes("-topmost", True)
+
+            urgency_color = _URGENCY_COLOR_BY_LEVEL.get(request.urgency, "#eab308")
+
+            frame = tk.Frame(root, bg="#1e293b", padx=12, pady=8)
+            frame.pack(fill=tk.BOTH, expand=True)
+
+            # Urgency indicator bar
+            indicator = tk.Frame(frame, bg=urgency_color, width=4)
+            indicator.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 8))
+
+            content = tk.Frame(frame, bg="#1e293b")
+            content.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+            # Agent name
+            tk.Label(
+                content,
+                text=f"From: {agent_display_name}",
+                fg="#94a3b8",
+                bg="#1e293b",
+                font=("sans-serif", 9),
+                anchor="w",
+            ).pack(fill=tk.X)
+
+            # Title
+            display_title = request.title or "Notification"
+            tk.Label(
+                content,
+                text=display_title,
+                fg="#f1f5f9",
+                bg="#1e293b",
+                font=("sans-serif", 11, "bold"),
+                anchor="w",
+            ).pack(fill=tk.X)
+
+            # Message
+            tk.Label(
+                content,
+                text=request.message,
+                fg="#cbd5e1",
+                bg="#1e293b",
+                font=("sans-serif", 10),
+                anchor="w",
+                wraplength=280,
+                justify=tk.LEFT,
+            ).pack(fill=tk.X, pady=(4, 0))
+
+            # Dismiss hint
+            tk.Label(
+                content,
+                text="Click to dismiss",
+                fg="#64748b",
+                bg="#1e293b",
+                font=("sans-serif", 8),
+                anchor="w",
+            ).pack(fill=tk.X, pady=(4, 0))
+
+            # Position in bottom-right corner
+            root.update_idletasks()
+            width = 320
+            height = root.winfo_reqheight()
+            screen_width = root.winfo_screenwidth()
+            screen_height = root.winfo_screenheight()
+            x_position = screen_width - width - 20
+            y_position = screen_height - height - 60
+            root.geometry(f"{width}x{height}+{x_position}+{y_position}")
+
+            # Click anywhere to dismiss
+            root.bind("<Button-1>", lambda _event: root.destroy())
+            frame.bind("<Button-1>", lambda _event: root.destroy())
+            for child in content.winfo_children():
+                child.bind("<Button-1>", lambda _event: root.destroy())
+
+            root.mainloop()
+        except tk.TclError as e:
+            logger.warning("Failed to show tkinter notification: {}", e)
+
+    thread = threading.Thread(target=_run_toast, daemon=True, name="tkinter-toast")
+    thread.start()
+
+
+class NotificationDispatcher(FrozenModel):
+    """Routes notifications to Electron or tkinter based on runtime context."""
+
+    is_electron: bool = Field(description="Whether the server is running inside Electron")
+
+    def dispatch(
+        self,
+        request: NotificationRequest,
+        agent_display_name: str,
+    ) -> None:
+        """Send a notification to the user via the appropriate channel."""
+        if self.is_electron:
+            _dispatch_electron_notification(request, agent_display_name)
+        else:
+            _show_tkinter_toast(request, agent_display_name)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -142,7 +142,7 @@ def _run_tkinter_toast(
             child.bind("<Button-1>", lambda _event: root.destroy())
 
         root.mainloop()
-    except tk.TclError as e:
+    except (tk.TclError, OSError, RuntimeError) as e:
         logger.warning("Failed to show tkinter notification: {}", e)
 
 

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -11,6 +11,7 @@ from types import ModuleType
 
 from loguru import logger
 from pydantic import Field
+from pydantic import PrivateAttr
 
 from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
@@ -72,13 +73,12 @@ def _run_tkinter_toast(
     message: str,
     urgency: NotificationUrgency,
     agent_display_name: str,
+    tk: ModuleType | None,
 ) -> None:
     """Create and display a tkinter toast window. Runs on a background thread."""
-    if _TKINTER is None:
+    if tk is None:
         logger.warning("tkinter not available, cannot show notification toast")
         return
-
-    tk = _TKINTER
     try:
         root = tk.Tk()
         root.overrideredirect(True)
@@ -162,12 +162,13 @@ def _run_tkinter_toast(
 def _show_tkinter_toast(
     request: NotificationRequest,
     agent_display_name: str,
+    tk: ModuleType | None,
 ) -> None:
     """Show a small always-on-top toast window in the bottom-right corner."""
     display_title = request.title or "Notification"
     thread = threading.Thread(
         target=_run_tkinter_toast,
-        args=(display_title, request.message, request.urgency, agent_display_name),
+        args=(display_title, request.message, request.urgency, agent_display_name, tk),
         daemon=True,
         name="tkinter-toast",
     )
@@ -178,6 +179,29 @@ class NotificationDispatcher(FrozenModel):
     """Routes notifications to Electron or tkinter based on runtime context."""
 
     is_electron: bool = Field(description="Whether the server is running inside Electron")
+    # _tk stores the resolved tkinter module. Set at construction time to the
+    # module-level _TKINTER value, or injected via NotificationDispatcher.create()
+    # to allow testing without tkinter side effects.
+    _tk: ModuleType | None = PrivateAttr(default=None)
+
+    def model_post_init(self, __context: object) -> None:
+        """Resolve the tkinter module from the module-level auto-detection."""
+        self._tk = _TKINTER
+
+    @classmethod
+    def create(
+        cls,
+        is_electron: bool,
+        tkinter_module: ModuleType | None = _TKINTER,
+    ) -> "NotificationDispatcher":
+        """Create a NotificationDispatcher with an explicit tkinter module.
+
+        Pass tkinter_module=None to disable tkinter toasts (e.g. in tests or on
+        headless servers where tkinter is unavailable).
+        """
+        dispatcher = cls(is_electron=is_electron)
+        dispatcher._tk = tkinter_module
+        return dispatcher
 
     def dispatch(
         self,
@@ -188,4 +212,4 @@ class NotificationDispatcher(FrozenModel):
         if self.is_electron:
             _dispatch_electron_notification(request, agent_display_name)
         else:
-            _show_tkinter_toast(request, agent_display_name)
+            _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -8,6 +8,7 @@ import platform
 import threading
 from enum import auto
 from types import ModuleType
+from typing import Any
 
 from loguru import logger
 from pydantic import Field
@@ -71,6 +72,82 @@ def _dispatch_electron_notification(
     emit_event("notification", data, OutputFormat.JSONL)
 
 
+def _build_toast_widgets(
+    root: Any,
+    title: str,
+    message: str,
+    urgency: NotificationUrgency,
+    agent_display_name: str,
+    tk: ModuleType,
+) -> tuple[Any, Any]:
+    """Build the widget tree for a toast notification window.
+
+    Returns (frame, content) where frame is the outermost container and
+    content holds the text labels (used for click binding).
+    """
+    urgency_color = _URGENCY_COLOR_BY_LEVEL.get(urgency, "#eab308")
+
+    frame = tk.Frame(root, bg="#1e293b", padx=12, pady=8)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    indicator = tk.Frame(frame, bg=urgency_color, width=4)
+    indicator.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 8))
+
+    content = tk.Frame(frame, bg="#1e293b")
+    content.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+    tk.Label(
+        content,
+        text=f"From: {agent_display_name}",
+        fg="#94a3b8",
+        bg="#1e293b",
+        font=("sans-serif", 9),
+        anchor="w",
+    ).pack(fill=tk.X)
+
+    tk.Label(
+        content,
+        text=title,
+        fg="#f1f5f9",
+        bg="#1e293b",
+        font=("sans-serif", 11, "bold"),
+        anchor="w",
+    ).pack(fill=tk.X)
+
+    tk.Label(
+        content,
+        text=message,
+        fg="#cbd5e1",
+        bg="#1e293b",
+        font=("sans-serif", 10),
+        anchor="w",
+        wraplength=280,
+        justify=tk.LEFT,
+    ).pack(fill=tk.X, pady=(4, 0))
+
+    tk.Label(
+        content,
+        text="Click to dismiss",
+        fg="#64748b",
+        bg="#1e293b",
+        font=("sans-serif", 8),
+        anchor="w",
+    ).pack(fill=tk.X, pady=(4, 0))
+
+    return frame, content
+
+
+def _position_toast_window(root: Any, width: int = 320) -> None:
+    """Position a toast window in the bottom-right corner of the screen."""
+    root.update_idletasks()
+    height = root.winfo_reqheight()
+    screen_width = root.winfo_screenwidth()
+    screen_height = root.winfo_screenheight()
+    x_position = screen_width - width - 20
+    y_position = screen_height - height - 60
+    root.geometry(f"{width}x{height}+{x_position}+{y_position}")
+
+
 def _run_tkinter_toast(
     title: str,
     message: str,
@@ -87,71 +164,9 @@ def _run_tkinter_toast(
         root.overrideredirect(True)
         root.attributes("-topmost", True)
 
-        urgency_color = _URGENCY_COLOR_BY_LEVEL.get(urgency, "#eab308")
+        frame, content = _build_toast_widgets(root, title, message, urgency, agent_display_name, tk)
+        _position_toast_window(root)
 
-        frame = tk.Frame(root, bg="#1e293b", padx=12, pady=8)
-        frame.pack(fill=tk.BOTH, expand=True)
-
-        # Urgency indicator bar
-        indicator = tk.Frame(frame, bg=urgency_color, width=4)
-        indicator.pack(side=tk.LEFT, fill=tk.Y, padx=(0, 8))
-
-        content = tk.Frame(frame, bg="#1e293b")
-        content.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-
-        # Agent name
-        tk.Label(
-            content,
-            text=f"From: {agent_display_name}",
-            fg="#94a3b8",
-            bg="#1e293b",
-            font=("sans-serif", 9),
-            anchor="w",
-        ).pack(fill=tk.X)
-
-        # Title
-        tk.Label(
-            content,
-            text=title,
-            fg="#f1f5f9",
-            bg="#1e293b",
-            font=("sans-serif", 11, "bold"),
-            anchor="w",
-        ).pack(fill=tk.X)
-
-        # Message
-        tk.Label(
-            content,
-            text=message,
-            fg="#cbd5e1",
-            bg="#1e293b",
-            font=("sans-serif", 10),
-            anchor="w",
-            wraplength=280,
-            justify=tk.LEFT,
-        ).pack(fill=tk.X, pady=(4, 0))
-
-        # Dismiss hint
-        tk.Label(
-            content,
-            text="Click to dismiss",
-            fg="#64748b",
-            bg="#1e293b",
-            font=("sans-serif", 8),
-            anchor="w",
-        ).pack(fill=tk.X, pady=(4, 0))
-
-        # Position in bottom-right corner
-        root.update_idletasks()
-        width = 320
-        height = root.winfo_reqheight()
-        screen_width = root.winfo_screenwidth()
-        screen_height = root.winfo_screenheight()
-        x_position = screen_width - width - 20
-        y_position = screen_height - height - 60
-        root.geometry(f"{width}x{height}+{x_position}+{y_position}")
-
-        # Click anywhere to dismiss
         root.bind("<Button-1>", lambda _event: root.destroy())
         frame.bind("<Button-1>", lambda _event: root.destroy())
         for child in content.winfo_children():

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -7,6 +7,7 @@ Electron desktop app.
 
 import threading
 from enum import auto
+from types import ModuleType
 
 from loguru import logger
 from pydantic import Field
@@ -15,6 +16,14 @@ from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.minds.primitives import OutputFormat
 from imbue.minds.utils.output import emit_event
+
+# tkinter is an optional dependency: not available on all platforms (e.g. headless servers).
+# Load it at module level so the failure is immediate and predictable, but tolerate absence.
+_TKINTER: ModuleType | None
+try:
+    _TKINTER = __import__("tkinter")
+except ImportError:
+    _TKINTER = None
 
 
 class NotificationUrgency(UpperCaseStrEnum):
@@ -65,12 +74,11 @@ def _run_tkinter_toast(
     agent_display_name: str,
 ) -> None:
     """Create and display a tkinter toast window. Runs on a background thread."""
-    try:
-        import tkinter as tk
-    except ImportError as e:
-        logger.warning("tkinter not available, cannot show notification: {}", e)
+    if _TKINTER is None:
+        logger.warning("tkinter not available, cannot show notification toast")
         return
 
+    tk = _TKINTER
     try:
         root = tk.Tk()
         root.overrideredirect(True)

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -73,3 +73,20 @@ def test_dispatcher_routes_to_electron_when_configured() -> None:
 def test_dispatcher_routes_to_tkinter_when_not_electron() -> None:
     dispatcher = NotificationDispatcher(is_electron=False)
     assert dispatcher.is_electron is False
+
+
+def test_dispatch_electron_via_dispatcher(capsys: CaptureFixture[str]) -> None:
+    """Verify the full dispatch path for Electron notifications."""
+    dispatcher = NotificationDispatcher(is_electron=True)
+    request = NotificationRequest(
+        message="dispatched message",
+        title="Dispatch Title",
+        urgency=NotificationUrgency.LOW,
+    )
+    dispatcher.dispatch(request, "agent-x")
+
+    captured = capsys.readouterr()
+    event = json.loads(captured.out.strip())
+    assert event["event"] == "notification"
+    assert event["message"] == "dispatched message"
+    assert event["agent_name"] == "agent-x"

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -92,3 +92,9 @@ def test_dispatch_electron_via_dispatcher(capsys: CaptureFixture[str]) -> None:
     assert event["agent_name"] == "agent-x"
 
 
+def test_dispatcher_is_electron_false_does_not_raise() -> None:
+    """Verify NotificationDispatcher can be constructed in non-electron mode."""
+    dispatcher = NotificationDispatcher(is_electron=False)
+    assert dispatcher.is_electron is False
+
+

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -90,3 +90,5 @@ def test_dispatch_electron_via_dispatcher(capsys: CaptureFixture[str]) -> None:
     assert event["event"] == "notification"
     assert event["message"] == "dispatched message"
     assert event["agent_name"] == "agent-x"
+
+

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -7,6 +7,7 @@ from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
+from imbue.minds.desktop_client.notification import _dispatch_macos_notification
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
 
@@ -161,4 +162,54 @@ def test_show_tkinter_toast_with_no_tkinter_runs_in_thread() -> None:
     assert threading.active_count() >= before_count
 
 
+# -- macOS notification tests --
+
+
+def test_dispatch_macos_notification_does_not_raise() -> None:
+    """On non-macOS, osascript won't exist, but the function should not raise."""
+    request = NotificationRequest(
+        message="test macOS notification",
+        title="Test Title",
+        urgency=NotificationUrgency.CRITICAL,
+    )
+    # Should not raise even if osascript is not available (caught internally)
+    _dispatch_macos_notification(request, "agent-mac")
+
+
+def test_dispatch_macos_notification_handles_quotes() -> None:
+    """Verify double quotes in title/message are escaped for AppleScript."""
+    request = NotificationRequest(
+        message='He said "hello"',
+        title='Title with "quotes"',
+        urgency=NotificationUrgency.NORMAL,
+    )
+    # Should not raise
+    _dispatch_macos_notification(request, "agent-quotes")
+
+
+def test_dispatcher_routes_to_macos_when_is_macos() -> None:
+    """Verify dispatch routes to macOS native notifications when is_macos=True."""
+    dispatcher = NotificationDispatcher.create(is_electron=False, is_macos=True, tkinter_module=None)
+    assert dispatcher.is_macos is True
+    request = NotificationRequest(message="macos dispatch test")
+    # Should not raise -- osascript may fail on Linux but error is caught
+    dispatcher.dispatch(request, "agent-mac-dispatch")
+
+
+def test_dispatcher_prefers_electron_over_macos(capsys: CaptureFixture[str]) -> None:
+    """Electron takes priority over macOS native notifications."""
+    dispatcher = NotificationDispatcher.create(is_electron=True, is_macos=True)
+    request = NotificationRequest(message="electron priority")
+    dispatcher.dispatch(request, "agent-priority")
+
+    captured = capsys.readouterr()
+    event = json.loads(captured.out.strip())
+    assert event["event"] == "notification"
+    assert event["message"] == "electron priority"
+
+
+def test_dispatcher_create_with_is_macos_override() -> None:
+    """Verify create() accepts is_macos parameter."""
+    dispatcher = NotificationDispatcher.create(is_electron=False, is_macos=False)
+    assert dispatcher.is_macos is False
 

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -2,10 +2,13 @@ import json
 
 from _pytest.capture import CaptureFixture
 
+import imbue.minds.desktop_client.notification as notification_module
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
+from imbue.minds.desktop_client.notification import _run_tkinter_toast
+from imbue.minds.desktop_client.notification import _show_tkinter_toast
 
 
 def test_notification_urgency_values() -> None:
@@ -96,5 +99,43 @@ def test_dispatcher_is_electron_false_does_not_raise() -> None:
     """Verify NotificationDispatcher can be constructed in non-electron mode."""
     dispatcher = NotificationDispatcher(is_electron=False)
     assert dispatcher.is_electron is False
+
+
+def test_run_tkinter_toast_without_tkinter_does_not_raise() -> None:
+    """When tkinter is unavailable, _run_tkinter_toast returns immediately without error."""
+    original_tkinter = notification_module._TKINTER
+    notification_module._TKINTER = None
+    try:
+        # Should not raise even though tkinter is None
+        _run_tkinter_toast("Title", "Message", NotificationUrgency.LOW, "agent")
+    finally:
+        notification_module._TKINTER = original_tkinter
+
+
+def test_show_tkinter_toast_with_no_tkinter_does_not_raise() -> None:
+    """_show_tkinter_toast does not raise even when tkinter is unavailable.
+
+    The function starts a daemon thread. With no tkinter available, the thread
+    logs a warning and exits immediately.
+    """
+    original_tkinter = notification_module._TKINTER
+    notification_module._TKINTER = None
+    try:
+        request = NotificationRequest(message="toast message", title="Test")
+        _show_tkinter_toast(request, "agent-z")
+    finally:
+        notification_module._TKINTER = original_tkinter
+
+
+def test_dispatch_non_electron_does_not_raise() -> None:
+    """The non-Electron dispatch path starts a background toast and does not raise."""
+    original_tkinter = notification_module._TKINTER
+    notification_module._TKINTER = None
+    try:
+        dispatcher = NotificationDispatcher(is_electron=False)
+        request = NotificationRequest(message="background toast")
+        dispatcher.dispatch(request, "agent-y")
+    finally:
+        notification_module._TKINTER = original_tkinter
 
 

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,15 +1,100 @@
 import json
 import threading
+import types
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
+from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 from imbue.minds.desktop_client.notification import _dispatch_macos_notification
+from imbue.minds.desktop_client.notification import _position_toast_window
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
+
+
+def _make_fake_tk() -> Any:
+    """Build a minimal fake tkinter module sufficient for _build_toast_widgets,
+    _position_toast_window, and _run_tkinter_toast.
+
+    Uses SimpleNamespace and a lightweight widget stand-in that records calls
+    without requiring a real display server.
+    """
+
+    class _FakeWidget:
+        """Minimal stand-in for tkinter widgets (Frame, Label, and Tk root)."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._children: list["_FakeWidget"] = []
+            self._bindings: dict[str, object] = {}
+            # Register as a child of the parent widget (first positional arg),
+            # mirroring real tkinter widget parent-child relationships.
+            if args and isinstance(args[0], _FakeWidget):
+                args[0]._children.append(self)
+
+        def pack(self, **kwargs: object) -> None:
+            pass
+
+        def bind(self, event: str, handler: object) -> None:
+            self._bindings[event] = handler
+
+        def winfo_children(self) -> "list[_FakeWidget]":
+            return self._children
+
+        def winfo_reqheight(self) -> int:
+            return 100
+
+        def winfo_screenwidth(self) -> int:
+            return 1920
+
+        def winfo_screenheight(self) -> int:
+            return 1080
+
+        def update_idletasks(self) -> None:
+            pass
+
+        def geometry(self, spec: str) -> None:
+            pass
+
+        def overrideredirect(self, flag: bool) -> None:
+            pass
+
+        def attributes(self, attr: str, value: object) -> None:
+            pass
+
+        def mainloop(self) -> None:
+            pass
+
+        def destroy(self) -> None:
+            pass
+
+    class _FakeFrame(_FakeWidget):
+        pass
+
+    class _FakeLabel(_FakeWidget):
+        pass
+
+    class _FakeTclError(Exception):
+        pass
+
+    tk = SimpleNamespace(
+        Frame=_FakeFrame,
+        Label=_FakeLabel,
+        Tk=_FakeWidget,
+        TclError=_FakeTclError,
+        BOTH="both",
+        X="x",
+        Y="y",
+        LEFT="left",
+        RIGHT="right",
+        TOP="top",
+        BOTTOM="bottom",
+    )
+    return tk
 
 
 def test_notification_urgency_values() -> None:
@@ -212,4 +297,96 @@ def test_dispatcher_create_with_is_macos_override() -> None:
     """Verify create() accepts is_macos parameter."""
     dispatcher = NotificationDispatcher.create(is_electron=False, is_macos=False)
     assert dispatcher.is_macos is False
+
+
+# -- _build_toast_widgets and _position_toast_window tests with fake tkinter --
+
+
+def test_build_toast_widgets_returns_frame_and_content() -> None:
+    """_build_toast_widgets constructs frame/content widgets using the provided tk module."""
+    tk = _make_fake_tk()
+    root = tk.Frame()
+    frame, content = _build_toast_widgets(
+        root=root,
+        title="Test Title",
+        message="Test message",
+        urgency=NotificationUrgency.NORMAL,
+        agent_display_name="test-agent",
+        tk=tk,
+    )
+    assert frame is not None
+    assert content is not None
+
+
+def test_build_toast_widgets_with_critical_urgency() -> None:
+    """_build_toast_widgets uses the critical urgency color when urgency is CRITICAL."""
+    tk = _make_fake_tk()
+    root = tk.Frame()
+    frame, content = _build_toast_widgets(
+        root=root,
+        title="Alert",
+        message="Critical notification",
+        urgency=NotificationUrgency.CRITICAL,
+        agent_display_name="agent-x",
+        tk=tk,
+    )
+    assert frame is not None
+    assert content is not None
+
+
+def test_build_toast_widgets_with_low_urgency() -> None:
+    """_build_toast_widgets does not raise for LOW urgency."""
+    tk = _make_fake_tk()
+    root = tk.Frame()
+    frame, content = _build_toast_widgets(
+        root=root,
+        title="Info",
+        message="Low priority notification",
+        urgency=NotificationUrgency.LOW,
+        agent_display_name="agent-y",
+        tk=tk,
+    )
+    assert frame is not None
+    assert content is not None
+
+
+def test_position_toast_window_calls_geometry() -> None:
+    """_position_toast_window calls root.geometry() to position the window."""
+    tk = _make_fake_tk()
+    root = tk.Frame()
+    _position_toast_window(root, width=320)
+
+
+def test_run_tkinter_toast_with_fake_tk_raises_tclerror() -> None:
+    """When tk.Tk() raises TclError (e.g., no display), _run_tkinter_toast logs and returns."""
+
+    class _TclError(Exception):
+        pass
+
+    def _raise_tclerror() -> None:
+        raise _TclError("no display")
+
+    fake_tk = types.ModuleType("tkinter")
+    fake_tk.TclError = _TclError  # ty: ignore[unresolved-attribute]
+    fake_tk.Tk = _raise_tclerror  # ty: ignore[unresolved-attribute]
+
+    _run_tkinter_toast(
+        title="Title",
+        message="Message",
+        urgency=NotificationUrgency.NORMAL,
+        agent_display_name="agent",
+        tk=fake_tk,
+    )
+
+
+def test_run_tkinter_toast_with_fake_tk_succeeds() -> None:
+    """When tk.Tk() works, _run_tkinter_toast creates widgets and runs mainloop."""
+    tk = _make_fake_tk()
+    _run_tkinter_toast(
+        title="Title",
+        message="Message body",
+        urgency=NotificationUrgency.NORMAL,
+        agent_display_name="test-agent",
+        tk=tk,
+    )
 

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,4 +1,5 @@
 import json
+import threading
 
 from _pytest.capture import CaptureFixture
 
@@ -121,5 +122,43 @@ def test_dispatch_non_electron_does_not_raise() -> None:
     dispatcher = NotificationDispatcher.create(is_electron=False, tkinter_module=None)
     request = NotificationRequest(message="background toast")
     dispatcher.dispatch(request, "agent-y")
+
+
+def test_dispatcher_create_with_no_tkinter() -> None:
+    """NotificationDispatcher.create with tkinter_module=None disables tkinter toasts."""
+    dispatcher = NotificationDispatcher.create(is_electron=False, tkinter_module=None)
+    assert dispatcher.is_electron is False
+    assert dispatcher._tk is None
+
+
+def test_dispatcher_create_defaults_is_electron_false(capsys: CaptureFixture[str]) -> None:
+    """NotificationDispatcher.create(is_electron=True) routes to Electron."""
+    dispatcher = NotificationDispatcher.create(is_electron=True)
+    request = NotificationRequest(message="from create factory")
+    dispatcher.dispatch(request, "agent-factory")
+
+    captured = capsys.readouterr()
+    event = json.loads(captured.out.strip())
+    assert event["message"] == "from create factory"
+
+
+def test_dispatcher_default_constructor_resolves_tkinter() -> None:
+    """NotificationDispatcher() resolves tkinter at construction via model_post_init."""
+    # The _tk private attr should be set to the auto-detected _TKINTER value.
+    # We can't know if tkinter is available, so just verify _tk is not uninitialized.
+    dispatcher = NotificationDispatcher(is_electron=False)
+    # _tk is set by model_post_init; it will be a ModuleType or None (if tkinter is absent)
+    # Just verify the attribute is accessible (not undefined)
+    _ = dispatcher._tk
+
+
+def test_show_tkinter_toast_with_no_tkinter_runs_in_thread() -> None:
+    """_show_tkinter_toast with tk=None starts a daemon thread that exits immediately."""
+    before_count = threading.active_count()
+    request = NotificationRequest(message="thread test")
+    _show_tkinter_toast(request, "agent-thread", tk=None)
+    # Thread is daemon and should start; we can't easily join it but verify no exception
+    assert threading.active_count() >= before_count
+
 
 

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -2,7 +2,6 @@ import json
 
 from _pytest.capture import CaptureFixture
 
-import imbue.minds.desktop_client.notification as notification_module
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
@@ -103,13 +102,8 @@ def test_dispatcher_is_electron_false_does_not_raise() -> None:
 
 def test_run_tkinter_toast_without_tkinter_does_not_raise() -> None:
     """When tkinter is unavailable, _run_tkinter_toast returns immediately without error."""
-    original_tkinter = notification_module._TKINTER
-    notification_module._TKINTER = None
-    try:
-        # Should not raise even though tkinter is None
-        _run_tkinter_toast("Title", "Message", NotificationUrgency.LOW, "agent")
-    finally:
-        notification_module._TKINTER = original_tkinter
+    # Should not raise even though tk=None indicates no tkinter
+    _run_tkinter_toast("Title", "Message", NotificationUrgency.LOW, "agent", tk=None)
 
 
 def test_show_tkinter_toast_with_no_tkinter_does_not_raise() -> None:
@@ -118,24 +112,14 @@ def test_show_tkinter_toast_with_no_tkinter_does_not_raise() -> None:
     The function starts a daemon thread. With no tkinter available, the thread
     logs a warning and exits immediately.
     """
-    original_tkinter = notification_module._TKINTER
-    notification_module._TKINTER = None
-    try:
-        request = NotificationRequest(message="toast message", title="Test")
-        _show_tkinter_toast(request, "agent-z")
-    finally:
-        notification_module._TKINTER = original_tkinter
+    request = NotificationRequest(message="toast message", title="Test")
+    _show_tkinter_toast(request, "agent-z", tk=None)
 
 
 def test_dispatch_non_electron_does_not_raise() -> None:
     """The non-Electron dispatch path starts a background toast and does not raise."""
-    original_tkinter = notification_module._TKINTER
-    notification_module._TKINTER = None
-    try:
-        dispatcher = NotificationDispatcher(is_electron=False)
-        request = NotificationRequest(message="background toast")
-        dispatcher.dispatch(request, "agent-y")
-    finally:
-        notification_module._TKINTER = original_tkinter
+    dispatcher = NotificationDispatcher.create(is_electron=False, tkinter_module=None)
+    request = NotificationRequest(message="background toast")
+    dispatcher.dispatch(request, "agent-y")
 
 

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,0 +1,84 @@
+import json
+from io import StringIO
+from unittest.mock import patch
+
+from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.desktop_client.notification import NotificationRequest
+from imbue.minds.desktop_client.notification import NotificationUrgency
+
+
+def test_notification_urgency_values() -> None:
+    assert NotificationUrgency.LOW == "LOW"
+    assert NotificationUrgency.NORMAL == "NORMAL"
+    assert NotificationUrgency.CRITICAL == "CRITICAL"
+
+
+def test_notification_request_defaults() -> None:
+    request = NotificationRequest(message="hello")
+    assert request.message == "hello"
+    assert request.title is None
+    assert request.urgency == NotificationUrgency.NORMAL
+
+
+def test_notification_request_with_all_fields() -> None:
+    request = NotificationRequest(
+        message="test message",
+        title="Test Title",
+        urgency=NotificationUrgency.CRITICAL,
+    )
+    assert request.message == "test message"
+    assert request.title == "Test Title"
+    assert request.urgency == NotificationUrgency.CRITICAL
+
+
+def test_dispatch_electron_writes_jsonl_to_stdout() -> None:
+    dispatcher = NotificationDispatcher(is_electron=True)
+    request = NotificationRequest(
+        message="hello from agent",
+        title="Alert",
+        urgency=NotificationUrgency.CRITICAL,
+    )
+
+    captured = StringIO()
+    with patch("imbue.minds.utils.output.sys.stdout", captured):
+        dispatcher.dispatch(request, "my-agent")
+
+    output = captured.getvalue().strip()
+    event = json.loads(output)
+    assert event["event"] == "notification"
+    assert event["message"] == "hello from agent"
+    assert event["title"] == "Alert"
+    assert event["urgency"] == "CRITICAL"
+    assert event["agent_name"] == "my-agent"
+
+
+def test_dispatch_electron_without_title() -> None:
+    dispatcher = NotificationDispatcher(is_electron=True)
+    request = NotificationRequest(message="no title")
+
+    captured = StringIO()
+    with patch("imbue.minds.utils.output.sys.stdout", captured):
+        dispatcher.dispatch(request, "agent-1")
+
+    output = captured.getvalue().strip()
+    event = json.loads(output)
+    assert event["event"] == "notification"
+    assert event["message"] == "no title"
+    assert "title" not in event
+
+
+def test_dispatch_tkinter_spawns_thread() -> None:
+    """Verify tkinter dispatch starts a background thread without crashing."""
+    import tkinter as tk
+
+    dispatcher = NotificationDispatcher(is_electron=False)
+    request = NotificationRequest(
+        message="test notification",
+        urgency=NotificationUrgency.LOW,
+    )
+
+    # Patch tkinter.Tk to avoid actually creating a window in CI
+    with patch("imbue.minds.desktop_client.notification.tk.Tk") as mock_tk:
+        mock_tk.side_effect = tk.TclError("no display")
+        # This should not raise -- the tkinter error is caught internally
+        dispatcher.dispatch(request, "test-agent")

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,7 +1,7 @@
 import json
 import threading
 
-from _pytest.capture import CaptureFixture
+import pytest
 
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
@@ -36,7 +36,7 @@ def test_notification_request_with_all_fields() -> None:
     assert request.urgency == NotificationUrgency.CRITICAL
 
 
-def test_electron_notification_output_contains_required_fields(capsys: CaptureFixture[str]) -> None:
+def test_electron_notification_output_contains_required_fields(capsys: pytest.CaptureFixture[str]) -> None:
     """Verify _dispatch_electron_notification produces valid JSONL with all fields."""
     request = NotificationRequest(
         message="hello from agent",
@@ -56,7 +56,7 @@ def test_electron_notification_output_contains_required_fields(capsys: CaptureFi
     assert event["agent_name"] == "my-agent"
 
 
-def test_electron_notification_omits_title_when_none(capsys: CaptureFixture[str]) -> None:
+def test_electron_notification_omits_title_when_none(capsys: pytest.CaptureFixture[str]) -> None:
     request = NotificationRequest(message="no title")
 
     _dispatch_electron_notification(request, "agent-1")
@@ -79,7 +79,7 @@ def test_dispatcher_routes_to_tkinter_when_not_electron() -> None:
     assert dispatcher.is_electron is False
 
 
-def test_dispatch_electron_via_dispatcher(capsys: CaptureFixture[str]) -> None:
+def test_dispatch_electron_via_dispatcher(capsys: pytest.CaptureFixture[str]) -> None:
     """Verify the full dispatch path for Electron notifications."""
     dispatcher = NotificationDispatcher(is_electron=True)
     request = NotificationRequest(
@@ -132,7 +132,7 @@ def test_dispatcher_create_with_no_tkinter() -> None:
     assert dispatcher._tk is None
 
 
-def test_dispatcher_create_defaults_is_electron_false(capsys: CaptureFixture[str]) -> None:
+def test_dispatcher_create_defaults_is_electron_false(capsys: pytest.CaptureFixture[str]) -> None:
     """NotificationDispatcher.create(is_electron=True) routes to Electron."""
     dispatcher = NotificationDispatcher.create(is_electron=True)
     request = NotificationRequest(message="from create factory")
@@ -196,7 +196,7 @@ def test_dispatcher_routes_to_macos_when_is_macos() -> None:
     dispatcher.dispatch(request, "agent-mac-dispatch")
 
 
-def test_dispatcher_prefers_electron_over_macos(capsys: CaptureFixture[str]) -> None:
+def test_dispatcher_prefers_electron_over_macos(capsys: pytest.CaptureFixture[str]) -> None:
     """Electron takes priority over macOS native notifications."""
     dispatcher = NotificationDispatcher.create(is_electron=True, is_macos=True)
     request = NotificationRequest(message="electron priority")

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,10 +1,11 @@
 import json
-from io import StringIO
-from unittest.mock import patch
+
+from _pytest.capture import CaptureFixture
 
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
+from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 
 
 def test_notification_urgency_values() -> None:
@@ -31,19 +32,18 @@ def test_notification_request_with_all_fields() -> None:
     assert request.urgency == NotificationUrgency.CRITICAL
 
 
-def test_dispatch_electron_writes_jsonl_to_stdout() -> None:
-    dispatcher = NotificationDispatcher(is_electron=True)
+def test_electron_notification_output_contains_required_fields(capsys: CaptureFixture[str]) -> None:
+    """Verify _dispatch_electron_notification produces valid JSONL with all fields."""
     request = NotificationRequest(
         message="hello from agent",
         title="Alert",
         urgency=NotificationUrgency.CRITICAL,
     )
 
-    captured = StringIO()
-    with patch("imbue.minds.utils.output.sys.stdout", captured):
-        dispatcher.dispatch(request, "my-agent")
+    _dispatch_electron_notification(request, "my-agent")
 
-    output = captured.getvalue().strip()
+    captured = capsys.readouterr()
+    output = captured.out.strip()
     event = json.loads(output)
     assert event["event"] == "notification"
     assert event["message"] == "hello from agent"
@@ -52,33 +52,24 @@ def test_dispatch_electron_writes_jsonl_to_stdout() -> None:
     assert event["agent_name"] == "my-agent"
 
 
-def test_dispatch_electron_without_title() -> None:
-    dispatcher = NotificationDispatcher(is_electron=True)
+def test_electron_notification_omits_title_when_none(capsys: CaptureFixture[str]) -> None:
     request = NotificationRequest(message="no title")
 
-    captured = StringIO()
-    with patch("imbue.minds.utils.output.sys.stdout", captured):
-        dispatcher.dispatch(request, "agent-1")
+    _dispatch_electron_notification(request, "agent-1")
 
-    output = captured.getvalue().strip()
+    captured = capsys.readouterr()
+    output = captured.out.strip()
     event = json.loads(output)
     assert event["event"] == "notification"
     assert event["message"] == "no title"
     assert "title" not in event
 
 
-def test_dispatch_tkinter_spawns_thread() -> None:
-    """Verify tkinter dispatch starts a background thread without crashing."""
-    import tkinter as tk
+def test_dispatcher_routes_to_electron_when_configured() -> None:
+    dispatcher = NotificationDispatcher(is_electron=True)
+    assert dispatcher.is_electron is True
 
+
+def test_dispatcher_routes_to_tkinter_when_not_electron() -> None:
     dispatcher = NotificationDispatcher(is_electron=False)
-    request = NotificationRequest(
-        message="test notification",
-        urgency=NotificationUrgency.LOW,
-    )
-
-    # Patch tkinter.Tk to avoid actually creating a window in CI
-    with patch("imbue.minds.desktop_client.notification.tk.Tk") as mock_tk:
-        mock_tk.side_effect = tk.TclError("no display")
-        # This should not raise -- the tkinter error is caught internally
-        dispatcher.dispatch(request, "test-agent")
+    assert dispatcher.is_electron is False

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -8,6 +8,9 @@ from typing import Final
 
 import uvicorn
 from loguru import logger
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
 
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
@@ -21,13 +24,58 @@ from imbue.minds.desktop_client.cloudflare_client import CloudflareSecret
 from imbue.minds.desktop_client.cloudflare_client import CloudflareUsername
 from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
 from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.primitives import OneTimeCode
 from imbue.minds.primitives import OutputFormat
+from imbue.mngr.primitives import AgentId
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.utils.output import emit_event
 
 _ONE_TIME_CODE_LENGTH: Final[int] = 32
+
+_DEFAULT_MNGR_HOST_DIR: Final[Path] = Path.home() / ".mngr"
+
+
+class AgentDiscoveryHandler(FrozenModel):
+    """Handles agent discovery events by setting up reverse tunnels and writing URL files."""
+
+    tunnel_manager: SSHTunnelManager = Field(description="SSH tunnel manager for reverse tunnels")
+    server_port: int = Field(description="Local server port to forward")
+
+    def __call__(self, agent_id: AgentId, ssh_info: RemoteSSHInfo | None) -> None:
+        if ssh_info is not None:
+            self._handle_remote_agent(agent_id, ssh_info)
+        else:
+            self._handle_local_agent(agent_id)
+
+    def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
+        agent_state_dir = f"~/.mngr/agents/{agent_id}"
+        try:
+            remote_port = self.tunnel_manager.setup_reverse_tunnel(
+                ssh_info=ssh_info,
+                local_port=self.server_port,
+                agent_state_dir=agent_state_dir,
+            )
+            api_url = f"http://127.0.0.1:{remote_port}"
+            self.tunnel_manager.write_api_url_to_remote(
+                ssh_info=ssh_info,
+                agent_state_dir=agent_state_dir,
+                url=api_url,
+            )
+            logger.debug("Wrote API URL {} for remote agent {}", api_url, agent_id)
+        except (SSHTunnelError, OSError) as e:
+            logger.warning("Failed to set up reverse tunnel for agent {}: {}", agent_id, e)
+
+    def _handle_local_agent(self, agent_id: AgentId) -> None:
+        local_state_dir = _DEFAULT_MNGR_HOST_DIR / "agents" / str(agent_id)
+        api_url = f"http://127.0.0.1:{self.server_port}"
+        try:
+            self.tunnel_manager.write_api_url_to_local(local_state_dir, api_url)
+            logger.debug("Wrote API URL {} for local agent {}", api_url, agent_id)
+        except OSError as e:
+            logger.warning("Failed to write API URL for local agent {}: {}", agent_id, e)
 
 
 def start_desktop_client(
@@ -72,7 +120,14 @@ def start_desktop_client(
         output_format,
     )
 
+    # Register callback to set up reverse tunnels and write API URL files
+    # when agents are discovered
+    discovery_handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=port)
+    stream_manager.add_on_agent_discovered_callback(discovery_handler)
     stream_manager.start()
+
+    # Start health checking for reverse tunnels
+    tunnel_manager.start_reverse_tunnel_health_check()
 
     app = create_desktop_client(
         auth_store=auth_store,

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -154,6 +154,7 @@ def start_desktop_client(
         uvicorn.run(app, host=host, port=port)
     finally:
         stream_manager.stop()
+        tunnel_manager.cleanup()
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from threading import Thread
 from typing import Final
 
+import paramiko
 import uvicorn
 from loguru import logger
 from pydantic import Field
@@ -69,7 +70,7 @@ class AgentDiscoveryHandler(FrozenModel):
                 url=api_url,
             )
             logger.debug("Wrote API URL {} for remote agent {}", api_url, agent_id)
-        except (SSHTunnelError, OSError) as e:
+        except (SSHTunnelError, OSError, paramiko.SSHException) as e:
             logger.warning("Failed to set up reverse tunnel for agent {}: {}", agent_id, e)
 
     def _handle_local_agent(self, agent_id: AgentId) -> None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -43,6 +43,10 @@ class AgentDiscoveryHandler(FrozenModel):
 
     tunnel_manager: SSHTunnelManager = Field(description="SSH tunnel manager for reverse tunnels")
     server_port: int = Field(description="Local server port to forward")
+    mngr_host_dir: Path = Field(
+        default_factory=lambda: _DEFAULT_MNGR_HOST_DIR,
+        description="Base mngr host directory for local agents (defaults to ~/.mngr)",
+    )
 
     def __call__(self, agent_id: AgentId, ssh_info: RemoteSSHInfo | None) -> None:
         if ssh_info is not None:
@@ -69,7 +73,7 @@ class AgentDiscoveryHandler(FrozenModel):
             logger.warning("Failed to set up reverse tunnel for agent {}: {}", agent_id, e)
 
     def _handle_local_agent(self, agent_id: AgentId) -> None:
-        local_state_dir = _DEFAULT_MNGR_HOST_DIR / "agents" / str(agent_id)
+        local_state_dir = self.mngr_host_dir / "agents" / str(agent_id)
         api_url = f"http://127.0.0.1:{self.server_port}"
         try:
             self.tunnel_manager.write_api_url_to_local(local_state_dir, api_url)

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -20,6 +20,7 @@ from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingUrl
 from imbue.minds.desktop_client.cloudflare_client import CloudflareSecret
 from imbue.minds.desktop_client.cloudflare_client import CloudflareUsername
 from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.primitives import OneTimeCode
 from imbue.minds.primitives import OutputFormat
@@ -52,6 +53,8 @@ def start_desktop_client(
     cloudflare_client = _build_cloudflare_client()
     agent_creator = AgentCreator(paths=paths, cloudflare_client=cloudflare_client)
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
+    is_electron = os.getenv("MINDS_ELECTRON") == "1"
+    notification_dispatcher = NotificationDispatcher(is_electron=is_electron)
 
     # Generate a one-time login URL for the user
     code = OneTimeCode(secrets.token_urlsafe(_ONE_TIME_CODE_LENGTH))
@@ -79,6 +82,8 @@ def start_desktop_client(
         agent_creator=agent_creator,
         cloudflare_client=cloudflare_client,
         telegram_orchestrator=telegram_orchestrator,
+        notification_dispatcher=notification_dispatcher,
+        paths=paths,
     )
 
     if not is_no_browser:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -12,7 +12,6 @@ from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.frozen_model import FrozenModel
-
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.app import create_desktop_client
@@ -30,9 +29,9 @@ from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.primitives import OneTimeCode
 from imbue.minds.primitives import OutputFormat
-from imbue.mngr.primitives import AgentId
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.utils.output import emit_event
+from imbue.mngr.primitives import AgentId
 
 _ONE_TIME_CODE_LENGTH: Final[int] = 32
 

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -1,8 +1,12 @@
 import os
 from pathlib import Path
 
+from pydantic import PrivateAttr
+
 from imbue.minds.desktop_client.runner import AgentDiscoveryHandler
 from imbue.minds.desktop_client.runner import _build_cloudflare_client
+from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.mngr.primitives import AgentId
 
@@ -86,3 +90,90 @@ def test_agent_discovery_handler_handles_local_write_error(tmp_path: Path) -> No
     agent_id = AgentId()
     handler(agent_id, None)
     tunnel_manager.cleanup()
+
+
+class _FakeTunnelManager(SSHTunnelManager):
+    """Test double for SSHTunnelManager that records calls instead of making SSH connections."""
+
+    _fake_remote_port: int = PrivateAttr(default=55000)
+    _fake_fail: bool = PrivateAttr(default=False)
+    _reverse_tunnel_calls: list[tuple[RemoteSSHInfo, int, str]] = PrivateAttr(default_factory=list)
+    _write_remote_calls: list[tuple[RemoteSSHInfo, str, str]] = PrivateAttr(default_factory=list)
+
+    def model_post_init(self, __context: object) -> None:
+        super().model_post_init(__context)
+
+    @classmethod
+    def create(cls, remote_port: int = 55000, fail: bool = False) -> "_FakeTunnelManager":
+        mgr = cls()
+        mgr._fake_remote_port = remote_port
+        mgr._fake_fail = fail
+        return mgr
+
+    def setup_reverse_tunnel(
+        self,
+        ssh_info: RemoteSSHInfo,
+        local_port: int,
+        agent_state_dir: str,
+    ) -> int:
+        self._reverse_tunnel_calls.append((ssh_info, local_port, agent_state_dir))
+        if self._fake_fail:
+            raise SSHTunnelError("simulated failure")
+        return self._fake_remote_port
+
+    def write_api_url_to_remote(
+        self,
+        ssh_info: RemoteSSHInfo,
+        agent_state_dir: str,
+        url: str,
+    ) -> None:
+        self._write_remote_calls.append((ssh_info, agent_state_dir, url))
+
+
+def test_agent_discovery_handler_handles_remote_agent(tmp_path: Path) -> None:
+    """Verify remote agents get a reverse tunnel set up and URL written to remote."""
+    fake_manager = _FakeTunnelManager.create(remote_port=12345)
+    ssh_info = RemoteSSHInfo(
+        user="root",
+        host="192.168.1.100",
+        port=22,
+        key_path=tmp_path / "key",
+    )
+    handler = AgentDiscoveryHandler(
+        tunnel_manager=fake_manager,
+        server_port=8420,
+        mngr_host_dir=tmp_path,
+    )
+    agent_id = AgentId()
+    handler(agent_id, ssh_info)
+
+    assert len(fake_manager._reverse_tunnel_calls) == 1
+    _, local_port, agent_state_dir = fake_manager._reverse_tunnel_calls[0]
+    assert local_port == 8420
+    assert str(agent_id) in agent_state_dir
+
+    assert len(fake_manager._write_remote_calls) == 1
+    _, _, url = fake_manager._write_remote_calls[0]
+    assert url == "http://127.0.0.1:12345"
+    fake_manager.cleanup()
+
+
+def test_agent_discovery_handler_handles_remote_agent_tunnel_error(tmp_path: Path) -> None:
+    """Verify SSHTunnelError during remote setup is caught and logged, not propagated."""
+    fake_manager = _FakeTunnelManager.create(fail=True)
+    ssh_info = RemoteSSHInfo(
+        user="root",
+        host="192.168.1.100",
+        port=22,
+        key_path=tmp_path / "key",
+    )
+    handler = AgentDiscoveryHandler(
+        tunnel_manager=fake_manager,
+        server_port=8420,
+        mngr_host_dir=tmp_path,
+    )
+    agent_id = AgentId()
+    # Should not raise even though setup_reverse_tunnel raises SSHTunnelError
+    handler(agent_id, ssh_info)
+    assert len(fake_manager._write_remote_calls) == 0
+    fake_manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -1,6 +1,8 @@
+import os
 from pathlib import Path
 
 from imbue.minds.desktop_client.runner import AgentDiscoveryHandler
+from imbue.minds.desktop_client.runner import _build_cloudflare_client
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.mngr.primitives import AgentId
 
@@ -32,4 +34,55 @@ def test_agent_discovery_handler_callable() -> None:
     handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=9000)
     assert callable(handler)
     assert handler.server_port == 9000
+    tunnel_manager.cleanup()
+
+
+def test_build_cloudflare_client_returns_none_when_not_configured() -> None:
+    """Without env vars, _build_cloudflare_client returns None."""
+    for key in ("CLOUDFLARE_FORWARDING_URL", "CLOUDFLARE_FORWARDING_USERNAME",
+                "CLOUDFLARE_FORWARDING_SECRET", "OWNER_EMAIL"):
+        os.environ.pop(key, None)
+    result = _build_cloudflare_client()
+    assert result is None
+
+
+def test_build_cloudflare_client_returns_client_when_configured() -> None:
+    """With all env vars set, _build_cloudflare_client returns a CloudflareForwardingClient."""
+    os.environ["CLOUDFLARE_FORWARDING_URL"] = "https://example.com"
+    os.environ["CLOUDFLARE_FORWARDING_USERNAME"] = "user"
+    os.environ["CLOUDFLARE_FORWARDING_SECRET"] = "secret"
+    os.environ["OWNER_EMAIL"] = "owner@example.com"
+    try:
+        result = _build_cloudflare_client()
+        assert result is not None
+    finally:
+        for key in ("CLOUDFLARE_FORWARDING_URL", "CLOUDFLARE_FORWARDING_USERNAME",
+                    "CLOUDFLARE_FORWARDING_SECRET", "OWNER_EMAIL"):
+            os.environ.pop(key, None)
+
+
+def test_agent_discovery_handler_default_mngr_host_dir() -> None:
+    """Verify the default mngr_host_dir is ~/.mngr."""
+    tunnel_manager = SSHTunnelManager()
+    handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=9000)
+    assert handler.mngr_host_dir == Path.home() / ".mngr"
+    tunnel_manager.cleanup()
+
+
+def test_agent_discovery_handler_handles_local_write_error(tmp_path: Path) -> None:
+    """Verify local agent write errors are logged but do not propagate.
+
+    Placing a file at the agents/ path prevents mkdir from creating the
+    subdirectory, causing an OSError that should be caught and logged.
+    """
+    tunnel_manager = SSHTunnelManager()
+    blocker = tmp_path / "agents"
+    blocker.write_text("block")
+    handler = AgentDiscoveryHandler(
+        tunnel_manager=tunnel_manager,
+        server_port=8420,
+        mngr_host_dir=tmp_path,
+    )
+    agent_id = AgentId()
+    handler(agent_id, None)
     tunnel_manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from imbue.minds.desktop_client.runner import AgentDiscoveryHandler
+from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
+from imbue.mngr.primitives import AgentId
+
+
+def test_agent_discovery_handler_writes_local_url_file() -> None:
+    """Verify local agents get a minds_api_url file written."""
+    tunnel_manager = SSHTunnelManager()
+    handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=8420)
+
+    agent_id = AgentId()
+
+    # Call the handler with no SSH info (local agent)
+    handler(agent_id, None)
+
+    # The handler writes to ~/.mngr/agents/{agent_id}/minds_api_url
+    local_state_dir = Path.home() / ".mngr" / "agents" / str(agent_id)
+    url_file = local_state_dir / "minds_api_url"
+    if url_file.exists():
+        assert url_file.read_text() == "http://127.0.0.1:8420"
+        # Clean up
+        url_file.unlink()
+        local_state_dir.rmdir()
+
+    tunnel_manager.cleanup()
+
+
+def test_agent_discovery_handler_callable() -> None:
+    """Verify AgentDiscoveryHandler is callable with the expected signature."""
+    tunnel_manager = SSHTunnelManager()
+    handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=9000)
+    assert callable(handler)
+    assert handler.server_port == 9000
+    tunnel_manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -100,9 +100,6 @@ class _FakeTunnelManager(SSHTunnelManager):
     _reverse_tunnel_calls: list[tuple[RemoteSSHInfo, int, str]] = PrivateAttr(default_factory=list)
     _write_remote_calls: list[tuple[RemoteSSHInfo, str, str]] = PrivateAttr(default_factory=list)
 
-    def model_post_init(self, __context: object) -> None:
-        super().model_post_init(__context)
-
     @classmethod
     def create(cls, remote_port: int = 55000, fail: bool = False) -> "_FakeTunnelManager":
         mgr = cls()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -5,24 +5,23 @@ from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.mngr.primitives import AgentId
 
 
-def test_agent_discovery_handler_writes_local_url_file() -> None:
+def test_agent_discovery_handler_writes_local_url_file(tmp_path: Path) -> None:
     """Verify local agents get a minds_api_url file written."""
     tunnel_manager = SSHTunnelManager()
-    handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=8420)
+    handler = AgentDiscoveryHandler(
+        tunnel_manager=tunnel_manager,
+        server_port=8420,
+        mngr_host_dir=tmp_path,
+    )
 
     agent_id = AgentId()
 
     # Call the handler with no SSH info (local agent)
     handler(agent_id, None)
 
-    # The handler writes to ~/.mngr/agents/{agent_id}/minds_api_url
-    local_state_dir = Path.home() / ".mngr" / "agents" / str(agent_id)
-    url_file = local_state_dir / "minds_api_url"
-    if url_file.exists():
-        assert url_file.read_text() == "http://127.0.0.1:8420"
-        # Clean up
-        url_file.unlink()
-        local_state_dir.rmdir()
+    url_file = tmp_path / "agents" / str(agent_id) / "minds_api_url"
+    assert url_file.exists(), "minds_api_url file was not written"
+    assert url_file.read_text() == "http://127.0.0.1:8420"
 
     tunnel_manager.cleanup()
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -14,6 +14,7 @@ from pydantic import Field
 from pydantic import PrivateAttr
 
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.mutable_model import MutableModel
 
 _BUFFER_SIZE: Final[int] = 65536
@@ -62,7 +63,9 @@ class ReverseTunnelInfo(FrozenModel):
     ssh_info: RemoteSSHInfo = Field(description="SSH connection info for the remote host")
     local_port: int = Field(description="Local port being forwarded to the remote host")
     remote_port: int = Field(description="Port assigned on the remote host")
-    agent_state_dir: str = Field(description="$MNGR_AGENT_STATE_DIR path on the remote host")
+    agent_state_dirs: list[str] = Field(
+        description="$MNGR_AGENT_STATE_DIR paths on the remote host for all agents sharing this tunnel"
+    )
 
 
 class SSHTunnelManager(MutableModel):
@@ -195,6 +198,14 @@ class SSHTunnelManager(MutableModel):
                     # Verify the transport is still alive
                     client = self._connections.get(conn_key)
                     if client is not None and _ssh_connection_is_active(client):
+                        # Register this agent's state dir if not already tracked
+                        if agent_state_dir not in existing.agent_state_dirs:
+                            self._reverse_tunnels[conn_key] = existing.model_copy_update(
+                                to_update(
+                                    existing.field_ref().agent_state_dirs,
+                                    existing.agent_state_dirs + [agent_state_dir],
+                                )
+                            )
                         return existing.remote_port
 
                 client = self._get_or_create_connection(ssh_info)
@@ -211,7 +222,7 @@ class SSHTunnelManager(MutableModel):
                 ssh_info=ssh_info,
                 local_port=local_port,
                 remote_port=remote_port,
-                agent_state_dir=agent_state_dir,
+                agent_state_dirs=[agent_state_dir],
             )
             with self._lock:
                 self._reverse_tunnels[conn_key] = tunnel_info
@@ -295,18 +306,20 @@ class SSHTunnelManager(MutableModel):
 
                 logger.info("Reverse tunnel to {} is broken, re-establishing...", conn_key)
                 try:
+                    first_dir = tunnel_info.agent_state_dirs[0] if tunnel_info.agent_state_dirs else ""
                     new_remote_port = self.setup_reverse_tunnel(
                         ssh_info=tunnel_info.ssh_info,
                         local_port=tunnel_info.local_port,
-                        agent_state_dir=tunnel_info.agent_state_dir,
+                        agent_state_dir=first_dir,
                     )
-                    # Update the URL file with the new port
+                    # Update the URL file for all agents sharing this tunnel
                     new_url = f"http://127.0.0.1:{new_remote_port}"
-                    self.write_api_url_to_remote(
-                        ssh_info=tunnel_info.ssh_info,
-                        agent_state_dir=tunnel_info.agent_state_dir,
-                        url=new_url,
-                    )
+                    for agent_state_dir in tunnel_info.agent_state_dirs:
+                        self.write_api_url_to_remote(
+                            ssh_info=tunnel_info.ssh_info,
+                            agent_state_dir=agent_state_dir,
+                            url=new_url,
+                        )
                     logger.info("Reverse tunnel re-established to {} on port {}", conn_key, new_remote_port)
                 except (paramiko.SSHException, OSError, SSHTunnelError) as e:
                     logger.warning("Failed to re-establish reverse tunnel to {}: {}", conn_key, e)

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -312,6 +312,15 @@ class SSHTunnelManager(MutableModel):
                         local_port=tunnel_info.local_port,
                         agent_state_dir=first_dir,
                     )
+                    # Re-register remaining agent state dirs so they are tracked
+                    # in the new tunnel's ReverseTunnelInfo (setup_reverse_tunnel
+                    # appends dirs to an existing active tunnel without creating a new one).
+                    for extra_dir in tunnel_info.agent_state_dirs[1:]:
+                        self.setup_reverse_tunnel(
+                            ssh_info=tunnel_info.ssh_info,
+                            local_port=tunnel_info.local_port,
+                            agent_state_dir=extra_dir,
+                        )
                     # Update the URL file for all agents sharing this tunnel
                     new_url = f"http://127.0.0.1:{new_remote_port}"
                     for agent_state_dir in tunnel_info.agent_state_dirs:

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -243,15 +243,18 @@ class SSHTunnelManager(MutableModel):
         try:
             _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
             _stdin.close()
-            exit_status = stdout.channel.recv_exit_status()
-            if exit_status != 0:
-                error_output = stderr.read().decode().strip()
-                logger.warning(
-                    "Failed to write API URL to remote {}: exit={}, stderr={}",
-                    ssh_info.host,
-                    exit_status,
-                    error_output,
-                )
+            try:
+                exit_status = stdout.channel.recv_exit_status()
+                if exit_status != 0:
+                    error_output = stderr.read().decode().strip()
+                    logger.warning(
+                        "Failed to write API URL to remote {}: exit={}, stderr={}",
+                        ssh_info.host,
+                        exit_status,
+                        error_output,
+                    )
+            finally:
+                stdout.channel.close()
         except (paramiko.SSHException, OSError) as e:
             logger.warning("Failed to write API URL to remote {}: {}", ssh_info.host, e)
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -1,5 +1,6 @@
 import os
 import select
+import shlex
 import socket
 import tempfile
 import threading
@@ -236,7 +237,9 @@ class SSHTunnelManager(MutableModel):
         with self._lock:
             client = self._get_or_create_connection(ssh_info)
 
-        command = f"mkdir -p {agent_state_dir} && printf '%s' '{url}' > {agent_state_dir}/minds_api_url"
+        quoted_dir = shlex.quote(agent_state_dir)
+        quoted_url = shlex.quote(url)
+        command = f"mkdir -p {quoted_dir} && printf '%s' {quoted_url} > {quoted_dir}/minds_api_url"
         try:
             _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
             exit_status = stdout.channel.recv_exit_status()

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -506,7 +506,11 @@ def _reverse_tunnel_accept_loop(
     bidirectionally.
     """
     while not shutdown_event.is_set():
-        channel = transport.accept(timeout=_SHUTDOWN_POLL_SECONDS)
+        try:
+            channel = transport.accept(timeout=_SHUTDOWN_POLL_SECONDS)
+        except (paramiko.SSHException, EOFError) as e:
+            logger.debug("Reverse tunnel accept loop exiting: transport closed ({})", e)
+            break
         if channel is None:
             continue
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -248,9 +248,9 @@ class SSHTunnelManager(MutableModel):
         with self._lock:
             client = self._get_or_create_connection(ssh_info)
 
-        quoted_dir = shlex.quote(agent_state_dir)
+        shell_dir = _shell_quote_remote_path(agent_state_dir)
         quoted_url = shlex.quote(url)
-        command = f"mkdir -p {quoted_dir} && printf '%s' {quoted_url} > {quoted_dir}/minds_api_url"
+        command = f"mkdir -p {shell_dir} && printf '%s' {quoted_url} > {shell_dir}/minds_api_url"
         try:
             _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
             _stdin.close()
@@ -569,6 +569,21 @@ def _reverse_tunnel_accept_loop(
             daemon=True,
             name=f"reverse-relay-127.0.0.1:{local_port}",
         ).start()
+
+
+def _shell_quote_remote_path(path: str) -> str:
+    """Produce a shell-safe argument for a remote path, preserving tilde expansion.
+
+    shlex.quote wraps strings in single quotes, which prevents tilde expansion on
+    the remote shell. Paths starting with '~/' are rewritten to use '$HOME/'
+    in a double-quoted string so the remote shell expands the variable correctly.
+    The remainder of the path after '~/' is the agent ID (UUID format: alphanumeric
+    and hyphens), which is safe to embed in a double-quoted shell string.
+    """
+    if path == "~" or path.startswith("~/"):
+        rest = path[1:]  # strip the leading '~', keeping the '/' if present
+        return f'"$HOME{rest}"'
+    return shlex.quote(path)
 
 
 def parse_url_host_port(url: str) -> tuple[str, int]:

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -266,6 +266,7 @@ class SSHTunnelManager(MutableModel):
                     )
             finally:
                 stdout.channel.close()
+                stdout.close()
                 stderr.close()
         except (paramiko.SSHException, OSError) as e:
             logger.warning("Failed to write API URL to remote {}: {}", ssh_info.host, e)

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -266,6 +266,7 @@ class SSHTunnelManager(MutableModel):
                     )
             finally:
                 stdout.channel.close()
+                stderr.close()
         except (paramiko.SSHException, OSError) as e:
             logger.warning("Failed to write API URL to remote {}: {}", ssh_info.host, e)
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -88,6 +88,7 @@ class SSHTunnelManager(MutableModel):
     _tunnel_threads: dict[str, threading.Thread] = PrivateAttr(default_factory=dict)
     _shutdown_event: threading.Event = PrivateAttr(default_factory=threading.Event)
     _reverse_tunnels: dict[str, ReverseTunnelInfo] = PrivateAttr(default_factory=dict)
+    _reverse_tunnel_setup_locks: dict[str, threading.Lock] = PrivateAttr(default_factory=dict)
     _health_check_thread: threading.Thread | None = PrivateAttr(default=None)
 
     def _get_tmpdir(self) -> Path:
@@ -160,6 +161,13 @@ class SSHTunnelManager(MutableModel):
             self._tunnel_threads[tunnel_key] = thread
             return socket_path
 
+    def _get_reverse_tunnel_setup_lock(self, conn_key: str) -> threading.Lock:
+        """Get or create a per-host setup lock for reverse tunnels."""
+        with self._lock:
+            if conn_key not in self._reverse_tunnel_setup_locks:
+                self._reverse_tunnel_setup_locks[conn_key] = threading.Lock()
+            return self._reverse_tunnel_setup_locks[conn_key]
+
     def setup_reverse_tunnel(
         self,
         ssh_info: RemoteSSHInfo,
@@ -171,47 +179,52 @@ class SSHTunnelManager(MutableModel):
         Asks the remote sshd to listen on a dynamic port (port 0) and forward
         connections back to 127.0.0.1:local_port on the local machine. Returns
         the assigned remote port.
+
+        Concurrent calls for the same host are serialized via a per-host lock to
+        prevent establishing duplicate reverse tunnels.
         """
-        with self._lock:
-            conn_key = f"{ssh_info.host}:{ssh_info.port}"
+        conn_key = f"{ssh_info.host}:{ssh_info.port}"
+        host_lock = self._get_reverse_tunnel_setup_lock(conn_key)
 
-            # Check if a reverse tunnel already exists for this host
-            existing = self._reverse_tunnels.get(conn_key)
-            if existing is not None:
-                # Verify the transport is still alive
-                client = self._connections.get(conn_key)
-                if client is not None and _ssh_connection_is_active(client):
-                    return existing.remote_port
+        with host_lock:
+            with self._lock:
+                # Check if a reverse tunnel already exists for this host
+                existing = self._reverse_tunnels.get(conn_key)
+                if existing is not None:
+                    # Verify the transport is still alive
+                    client = self._connections.get(conn_key)
+                    if client is not None and _ssh_connection_is_active(client):
+                        return existing.remote_port
 
-            client = self._get_or_create_connection(ssh_info)
-            transport = _ssh_connection_transport(client)
+                client = self._get_or_create_connection(ssh_info)
+                transport = _ssh_connection_transport(client)
 
-        remote_port = transport.request_port_forward("127.0.0.1", 0)
-        logger.info(
-            "Reverse tunnel established: remote 127.0.0.1:{} -> local 127.0.0.1:{}",
-            remote_port,
-            local_port,
-        )
+            remote_port = transport.request_port_forward("127.0.0.1", 0)
+            logger.info(
+                "Reverse tunnel established: remote 127.0.0.1:{} -> local 127.0.0.1:{}",
+                remote_port,
+                local_port,
+            )
 
-        tunnel_info = ReverseTunnelInfo(
-            ssh_info=ssh_info,
-            local_port=local_port,
-            remote_port=remote_port,
-            agent_state_dir=agent_state_dir,
-        )
-        with self._lock:
-            self._reverse_tunnels[conn_key] = tunnel_info
+            tunnel_info = ReverseTunnelInfo(
+                ssh_info=ssh_info,
+                local_port=local_port,
+                remote_port=remote_port,
+                agent_state_dir=agent_state_dir,
+            )
+            with self._lock:
+                self._reverse_tunnels[conn_key] = tunnel_info
 
-        # Start accepting forwarded connections in a background thread
-        thread = threading.Thread(
-            target=_reverse_tunnel_accept_loop,
-            args=(transport, local_port, self._shutdown_event),
-            daemon=True,
-            name=f"reverse-tunnel-{conn_key}",
-        )
-        thread.start()
+            # Start accepting forwarded connections in a background thread
+            thread = threading.Thread(
+                target=_reverse_tunnel_accept_loop,
+                args=(transport, local_port, self._shutdown_event),
+                daemon=True,
+                name=f"reverse-tunnel-{conn_key}",
+            )
+            thread.start()
 
-        return remote_port
+            return remote_port
 
     def write_api_url_to_remote(
         self,

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -497,11 +497,12 @@ def _reverse_tunnel_accept_loop(
         if channel is None:
             continue
 
+        local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             local_sock.connect(("127.0.0.1", local_port))
         except OSError as e:
             logger.warning("Failed to connect to local port {} for reverse tunnel: {}", local_port, e)
+            local_sock.close()
             try:
                 channel.close()
             except (paramiko.SSHException, OSError):

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -290,48 +290,56 @@ class SSHTunnelManager(MutableModel):
         )
         self._health_check_thread.start()
 
+    def _check_and_repair_tunnels(self) -> None:
+        """Check all reverse tunnels and re-establish any that are broken.
+
+        Called once per health-check iteration. Broken tunnels are re-established
+        and URL files on the remote hosts are updated with the new port.
+        """
+        with self._lock:
+            tunnels = dict(self._reverse_tunnels)
+
+        for conn_key, tunnel_info in tunnels.items():
+            with self._lock:
+                client = self._connections.get(conn_key)
+
+            is_alive = client is not None and _ssh_connection_is_active(client)
+            if is_alive:
+                continue
+
+            logger.info("Reverse tunnel to {} is broken, re-establishing...", conn_key)
+            try:
+                first_dir = tunnel_info.agent_state_dirs[0] if tunnel_info.agent_state_dirs else ""
+                new_remote_port = self.setup_reverse_tunnel(
+                    ssh_info=tunnel_info.ssh_info,
+                    local_port=tunnel_info.local_port,
+                    agent_state_dir=first_dir,
+                )
+                # Re-register remaining agent state dirs so they are tracked
+                # in the new tunnel's ReverseTunnelInfo (setup_reverse_tunnel
+                # appends dirs to an existing active tunnel without creating a new one).
+                for extra_dir in tunnel_info.agent_state_dirs[1:]:
+                    self.setup_reverse_tunnel(
+                        ssh_info=tunnel_info.ssh_info,
+                        local_port=tunnel_info.local_port,
+                        agent_state_dir=extra_dir,
+                    )
+                # Update the URL file for all agents sharing this tunnel
+                new_url = f"http://127.0.0.1:{new_remote_port}"
+                for agent_state_dir in tunnel_info.agent_state_dirs:
+                    self.write_api_url_to_remote(
+                        ssh_info=tunnel_info.ssh_info,
+                        agent_state_dir=agent_state_dir,
+                        url=new_url,
+                    )
+                logger.info("Reverse tunnel re-established to {} on port {}", conn_key, new_remote_port)
+            except (paramiko.SSHException, OSError, SSHTunnelError) as e:
+                logger.warning("Failed to re-establish reverse tunnel to {}: {}", conn_key, e)
+
     def _reverse_tunnel_health_check_loop(self) -> None:
         """Periodically check reverse tunnels and re-establish broken ones."""
         while not self._shutdown_event.wait(timeout=_REVERSE_TUNNEL_HEALTH_CHECK_SECONDS):
-            with self._lock:
-                tunnels = dict(self._reverse_tunnels)
-
-            for conn_key, tunnel_info in tunnels.items():
-                with self._lock:
-                    client = self._connections.get(conn_key)
-
-                is_alive = client is not None and _ssh_connection_is_active(client)
-                if is_alive:
-                    continue
-
-                logger.info("Reverse tunnel to {} is broken, re-establishing...", conn_key)
-                try:
-                    first_dir = tunnel_info.agent_state_dirs[0] if tunnel_info.agent_state_dirs else ""
-                    new_remote_port = self.setup_reverse_tunnel(
-                        ssh_info=tunnel_info.ssh_info,
-                        local_port=tunnel_info.local_port,
-                        agent_state_dir=first_dir,
-                    )
-                    # Re-register remaining agent state dirs so they are tracked
-                    # in the new tunnel's ReverseTunnelInfo (setup_reverse_tunnel
-                    # appends dirs to an existing active tunnel without creating a new one).
-                    for extra_dir in tunnel_info.agent_state_dirs[1:]:
-                        self.setup_reverse_tunnel(
-                            ssh_info=tunnel_info.ssh_info,
-                            local_port=tunnel_info.local_port,
-                            agent_state_dir=extra_dir,
-                        )
-                    # Update the URL file for all agents sharing this tunnel
-                    new_url = f"http://127.0.0.1:{new_remote_port}"
-                    for agent_state_dir in tunnel_info.agent_state_dirs:
-                        self.write_api_url_to_remote(
-                            ssh_info=tunnel_info.ssh_info,
-                            agent_state_dir=agent_state_dir,
-                            url=new_url,
-                        )
-                    logger.info("Reverse tunnel re-established to {} on port {}", conn_key, new_remote_port)
-                except (paramiko.SSHException, OSError, SSHTunnelError) as e:
-                    logger.warning("Failed to re-establish reverse tunnel to {}: {}", conn_key, e)
+            self._check_and_repair_tunnels()
 
     def cleanup(self) -> None:
         """Shut down all tunnels (forward and reverse) and SSH connections."""

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -23,6 +23,8 @@ _SHUTDOWN_POLL_SECONDS: Final[float] = 0.2
 
 _SOCKET_POLL_SECONDS: Final[float] = 0.01
 
+_REVERSE_TUNNEL_HEALTH_CHECK_SECONDS: Final[float] = 30.0
+
 
 class RemoteSSHInfo(FrozenModel):
     """SSH connection info for a remote agent host."""
@@ -53,6 +55,15 @@ def _ssh_connection_transport(client: paramiko.SSHClient) -> paramiko.Transport:
     return transport
 
 
+class ReverseTunnelInfo(FrozenModel):
+    """Metadata for an active reverse port forward."""
+
+    ssh_info: RemoteSSHInfo = Field(description="SSH connection info for the remote host")
+    local_port: int = Field(description="Local port being forwarded to the remote host")
+    remote_port: int = Field(description="Port assigned on the remote host")
+    agent_state_dir: str = Field(description="$MNGR_AGENT_STATE_DIR path on the remote host")
+
+
 class SSHTunnelManager(MutableModel):
     """Manages SSH tunnels to remote agent backends via paramiko.
 
@@ -60,6 +71,10 @@ class SSHTunnelManager(MutableModel):
     For each unique (SSH host, remote endpoint) pair, creates a Unix domain
     socket in a secure temporary directory that forwards connections through
     SSH direct-tcpip channels.
+
+    Also supports reverse port forwarding so that remote agents can reach
+    the local minds server. Reverse tunnels are health-checked periodically
+    and re-established if broken.
 
     The Unix sockets are created in a temporary directory with 0o700 permissions.
     Other users cannot access the sockets, and same-user processes would need
@@ -72,6 +87,8 @@ class SSHTunnelManager(MutableModel):
     _tunnel_socket_paths: dict[str, Path] = PrivateAttr(default_factory=dict)
     _tunnel_threads: dict[str, threading.Thread] = PrivateAttr(default_factory=dict)
     _shutdown_event: threading.Event = PrivateAttr(default_factory=threading.Event)
+    _reverse_tunnels: dict[str, ReverseTunnelInfo] = PrivateAttr(default_factory=dict)
+    _health_check_thread: threading.Thread | None = PrivateAttr(default=None)
 
     def _get_tmpdir(self) -> Path:
         """Get or create the secure temporary directory for Unix sockets."""
@@ -143,12 +160,160 @@ class SSHTunnelManager(MutableModel):
             self._tunnel_threads[tunnel_key] = thread
             return socket_path
 
+    def setup_reverse_tunnel(
+        self,
+        ssh_info: RemoteSSHInfo,
+        local_port: int,
+        agent_state_dir: str,
+    ) -> int:
+        """Set up a reverse port forward so the remote host can reach the local server.
+
+        Asks the remote sshd to listen on a dynamic port (port 0) and forward
+        connections back to 127.0.0.1:local_port on the local machine. Returns
+        the assigned remote port.
+        """
+        with self._lock:
+            conn_key = f"{ssh_info.host}:{ssh_info.port}"
+
+            # Check if a reverse tunnel already exists for this host
+            existing = self._reverse_tunnels.get(conn_key)
+            if existing is not None:
+                # Verify the transport is still alive
+                client = self._connections.get(conn_key)
+                if client is not None and _ssh_connection_is_active(client):
+                    return existing.remote_port
+
+            client = self._get_or_create_connection(ssh_info)
+            transport = _ssh_connection_transport(client)
+
+        remote_port = transport.request_port_forward("127.0.0.1", 0)
+        logger.info(
+            "Reverse tunnel established: remote 127.0.0.1:{} -> local 127.0.0.1:{}",
+            remote_port,
+            local_port,
+        )
+
+        tunnel_info = ReverseTunnelInfo(
+            ssh_info=ssh_info,
+            local_port=local_port,
+            remote_port=remote_port,
+            agent_state_dir=agent_state_dir,
+        )
+        with self._lock:
+            self._reverse_tunnels[conn_key] = tunnel_info
+
+        # Start accepting forwarded connections in a background thread
+        thread = threading.Thread(
+            target=_reverse_tunnel_accept_loop,
+            args=(transport, local_port, self._shutdown_event),
+            daemon=True,
+            name=f"reverse-tunnel-{conn_key}",
+        )
+        thread.start()
+
+        return remote_port
+
+    def write_api_url_to_remote(
+        self,
+        ssh_info: RemoteSSHInfo,
+        agent_state_dir: str,
+        url: str,
+    ) -> None:
+        """Write the minds API URL to a file on the remote host via SSH."""
+        with self._lock:
+            client = self._get_or_create_connection(ssh_info)
+
+        command = f"mkdir -p {agent_state_dir} && printf '%s' '{url}' > {agent_state_dir}/minds_api_url"
+        try:
+            _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
+            exit_status = stdout.channel.recv_exit_status()
+            if exit_status != 0:
+                error_output = stderr.read().decode().strip()
+                logger.warning(
+                    "Failed to write API URL to remote {}: exit={}, stderr={}",
+                    ssh_info.host,
+                    exit_status,
+                    error_output,
+                )
+        except (paramiko.SSHException, OSError) as e:
+            logger.warning("Failed to write API URL to remote {}: {}", ssh_info.host, e)
+
+    @staticmethod
+    def write_api_url_to_local(
+        agent_state_dir: Path,
+        url: str,
+    ) -> None:
+        """Write the minds API URL to a file on the local filesystem."""
+        agent_state_dir.mkdir(parents=True, exist_ok=True)
+        url_file = agent_state_dir / "minds_api_url"
+        url_file.write_text(url)
+
+    def start_reverse_tunnel_health_check(self) -> None:
+        """Start a background thread that checks reverse tunnels every 30 seconds."""
+        if self._health_check_thread is not None:
+            return
+        self._health_check_thread = threading.Thread(
+            target=self._reverse_tunnel_health_check_loop,
+            daemon=True,
+            name="reverse-tunnel-health-check",
+        )
+        self._health_check_thread.start()
+
+    def _reverse_tunnel_health_check_loop(self) -> None:
+        """Periodically check reverse tunnels and re-establish broken ones."""
+        while not self._shutdown_event.wait(timeout=_REVERSE_TUNNEL_HEALTH_CHECK_SECONDS):
+            with self._lock:
+                tunnels = dict(self._reverse_tunnels)
+
+            for conn_key, tunnel_info in tunnels.items():
+                with self._lock:
+                    client = self._connections.get(conn_key)
+
+                is_alive = client is not None and _ssh_connection_is_active(client)
+                if is_alive:
+                    continue
+
+                logger.info("Reverse tunnel to {} is broken, re-establishing...", conn_key)
+                try:
+                    new_remote_port = self.setup_reverse_tunnel(
+                        ssh_info=tunnel_info.ssh_info,
+                        local_port=tunnel_info.local_port,
+                        agent_state_dir=tunnel_info.agent_state_dir,
+                    )
+                    # Update the URL file with the new port
+                    new_url = f"http://127.0.0.1:{new_remote_port}"
+                    self.write_api_url_to_remote(
+                        ssh_info=tunnel_info.ssh_info,
+                        agent_state_dir=tunnel_info.agent_state_dir,
+                        url=new_url,
+                    )
+                    logger.info("Reverse tunnel re-established to {} on port {}", conn_key, new_remote_port)
+                except (paramiko.SSHException, OSError, SSHTunnelError) as e:
+                    logger.warning("Failed to re-establish reverse tunnel to {}: {}", conn_key, e)
+
     def cleanup(self) -> None:
-        """Shut down all tunnels and SSH connections."""
+        """Shut down all tunnels (forward and reverse) and SSH connections."""
         self._shutdown_event.set()
+
+        # Wait for health check thread
+        if self._health_check_thread is not None:
+            self._health_check_thread.join(timeout=5.0)
+            self._health_check_thread = None
 
         for thread in self._tunnel_threads.values():
             thread.join(timeout=5.0)
+
+        # Cancel reverse port forwards
+        for conn_key, tunnel_info in self._reverse_tunnels.items():
+            client = self._connections.get(conn_key)
+            if client is not None and _ssh_connection_is_active(client):
+                try:
+                    transport = client.get_transport()
+                    if transport is not None:
+                        transport.cancel_port_forward("127.0.0.1", tunnel_info.remote_port)
+                except (paramiko.SSHException, OSError) as e:
+                    logger.trace("Error cancelling reverse port forward: {}", e)
+        self._reverse_tunnels.clear()
 
         for client in self._connections.values():
             try:
@@ -313,6 +478,42 @@ def _relay_data(sock: socket.socket, channel: paramiko.Channel) -> None:
             sock.close()
         except OSError as e:
             logger.trace("Error closing socket in relay: {}", e)
+
+
+def _reverse_tunnel_accept_loop(
+    transport: paramiko.Transport,
+    local_port: int,
+    shutdown_event: threading.Event,
+) -> None:
+    """Accept reverse-forwarded connections and relay them to the local server.
+
+    When a remote process connects to the reverse-forwarded port, paramiko
+    delivers the connection as a channel via transport.accept(). This function
+    opens a local TCP connection to 127.0.0.1:local_port and relays data
+    bidirectionally.
+    """
+    while not shutdown_event.is_set():
+        channel = transport.accept(timeout=_SHUTDOWN_POLL_SECONDS)
+        if channel is None:
+            continue
+
+        try:
+            local_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            local_sock.connect(("127.0.0.1", local_port))
+        except OSError as e:
+            logger.warning("Failed to connect to local port {} for reverse tunnel: {}", local_port, e)
+            try:
+                channel.close()
+            except (paramiko.SSHException, OSError):
+                pass
+            continue
+
+        threading.Thread(
+            target=_relay_data,
+            args=(local_sock, channel),
+            daemon=True,
+            name=f"reverse-relay-127.0.0.1:{local_port}",
+        ).start()
 
 
 def parse_url_host_port(url: str) -> tuple[str, int]:

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -581,7 +581,7 @@ def _shell_quote_remote_path(path: str) -> str:
     and hyphens), which is safe to embed in a double-quoted shell string.
     """
     if path == "~" or path.startswith("~/"):
-        rest = path[1:]  # strip the leading '~', keeping the '/' if present
+        rest = path[1:]
         return f'"$HOME{rest}"'
     return shlex.quote(path)
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -242,6 +242,7 @@ class SSHTunnelManager(MutableModel):
         command = f"mkdir -p {quoted_dir} && printf '%s' {quoted_url} > {quoted_dir}/minds_api_url"
         try:
             _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
+            _stdin.close()
             exit_status = stdout.channel.recv_exit_status()
             if exit_status != 0:
                 error_output = stderr.read().decode().strip()

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.ssh_tunnel import ReverseTunnelInfo
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.desktop_client.ssh_tunnel import _relay_data
@@ -361,8 +362,6 @@ def test_write_api_url_to_local_overwrites_existing(tmp_path: Path) -> None:
 
 
 def test_reverse_tunnel_info_stores_metadata() -> None:
-    from imbue.minds.desktop_client.ssh_tunnel import ReverseTunnelInfo
-
     ssh_info = RemoteSSHInfo(
         user="root",
         host="192.168.1.1",

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -331,3 +331,30 @@ def test_tunnel_accept_loop_shutdown_event_stops_loop(short_tmp_path: Path) -> N
     shutdown_event.set()
     accept_thread.join(timeout=10.0)
     assert not accept_thread.is_alive()
+
+
+# -- write_api_url_to_local tests --
+
+
+def test_write_api_url_to_local_creates_file(tmp_path: Path) -> None:
+    state_dir = tmp_path / "agents" / "test-agent"
+    SSHTunnelManager.write_api_url_to_local(state_dir, "http://127.0.0.1:8420")
+
+    url_file = state_dir / "minds_api_url"
+    assert url_file.exists()
+    assert url_file.read_text() == "http://127.0.0.1:8420"
+
+
+def test_write_api_url_to_local_creates_parent_dirs(tmp_path: Path) -> None:
+    state_dir = tmp_path / "deep" / "nested" / "path"
+    SSHTunnelManager.write_api_url_to_local(state_dir, "http://127.0.0.1:9000")
+
+    assert (state_dir / "minds_api_url").read_text() == "http://127.0.0.1:9000"
+
+
+def test_write_api_url_to_local_overwrites_existing(tmp_path: Path) -> None:
+    state_dir = tmp_path / "agents" / "test-agent"
+    SSHTunnelManager.write_api_url_to_local(state_dir, "http://127.0.0.1:8420")
+    SSHTunnelManager.write_api_url_to_local(state_dir, "http://127.0.0.1:9999")
+
+    assert (state_dir / "minds_api_url").read_text() == "http://127.0.0.1:9999"

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -749,3 +749,105 @@ def test_write_api_url_to_remote_handles_ssh_exception(tmp_path: Path) -> None:
         url="http://127.0.0.1:9000",
     )
     manager.cleanup()
+
+
+# -- setup_reverse_tunnel tests --
+#
+# These tests inject a FakeSSHClient directly into _connections so that
+# setup_reverse_tunnel can run without making real SSH connections.
+
+
+def test_setup_reverse_tunnel_returns_assigned_port(tmp_path: Path) -> None:
+    """setup_reverse_tunnel calls request_port_forward and returns the assigned port."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(active=True)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    remote_port = manager.setup_reverse_tunnel(
+        ssh_info=ssh_info,
+        local_port=8420,
+        agent_state_dir="~/.mngr/agents/test-agent",
+    )
+
+    assert remote_port == 54321
+    manager.cleanup()
+
+
+def test_setup_reverse_tunnel_stores_tunnel_info(tmp_path: Path) -> None:
+    """After setup, the tunnel info is stored in _reverse_tunnels."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(active=True)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    manager.setup_reverse_tunnel(
+        ssh_info=ssh_info,
+        local_port=8420,
+        agent_state_dir="~/.mngr/agents/test-agent",
+    )
+
+    conn_key = f"{ssh_info.host}:{ssh_info.port}"
+    with manager._lock:
+        tunnel_info = manager._reverse_tunnels.get(conn_key)
+
+    assert tunnel_info is not None
+    assert tunnel_info.remote_port == 54321
+    assert tunnel_info.local_port == 8420
+    assert "~/.mngr/agents/test-agent" in tunnel_info.agent_state_dirs
+    manager.cleanup()
+
+
+def test_setup_reverse_tunnel_reuses_existing_active_tunnel(tmp_path: Path) -> None:
+    """When an active reverse tunnel already exists for a host, the same port is returned."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(active=True)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    conn_key = f"{ssh_info.host}:{ssh_info.port}"
+    existing_tunnel = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=11111,
+        agent_state_dirs=["~/.mngr/agents/agent-a"],
+    )
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = existing_tunnel
+
+    port = manager.setup_reverse_tunnel(
+        ssh_info=ssh_info,
+        local_port=8420,
+        agent_state_dir="~/.mngr/agents/agent-b",
+    )
+
+    assert port == 11111
+    with manager._lock:
+        tunnel_info = manager._reverse_tunnels[conn_key]
+    assert "~/.mngr/agents/agent-b" in tunnel_info.agent_state_dirs
+    manager.cleanup()
+
+
+def test_setup_reverse_tunnel_does_not_duplicate_agent_dir(tmp_path: Path) -> None:
+    """Calling setup with an agent_state_dir already tracked does not duplicate it."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(active=True)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    conn_key = f"{ssh_info.host}:{ssh_info.port}"
+    existing_tunnel = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=11111,
+        agent_state_dirs=["~/.mngr/agents/agent-a"],
+    )
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = existing_tunnel
+
+    manager.setup_reverse_tunnel(
+        ssh_info=ssh_info,
+        local_port=8420,
+        agent_state_dir="~/.mngr/agents/agent-a",
+    )
+
+    with manager._lock:
+        tunnel_info = manager._reverse_tunnels[conn_key]
+    assert tunnel_info.agent_state_dirs.count("~/.mngr/agents/agent-a") == 1
+    manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -13,6 +13,7 @@ from imbue.minds.desktop_client.ssh_tunnel import ReverseTunnelInfo
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.desktop_client.ssh_tunnel import _relay_data
+from imbue.minds.desktop_client.ssh_tunnel import _shell_quote_remote_path
 from imbue.minds.desktop_client.ssh_tunnel import _ssh_connection_is_active
 from imbue.minds.desktop_client.ssh_tunnel import _ssh_connection_transport
 from imbue.minds.desktop_client.ssh_tunnel import _tunnel_accept_loop
@@ -333,6 +334,34 @@ def test_tunnel_accept_loop_shutdown_event_stops_loop(short_tmp_path: Path) -> N
     shutdown_event.set()
     accept_thread.join(timeout=10.0)
     assert not accept_thread.is_alive()
+
+
+# -- _shell_quote_remote_path tests --
+
+
+def test_shell_quote_remote_path_tilde_slash() -> None:
+    """Paths starting with ~/ are converted to use $HOME/ for shell expansion."""
+    result = _shell_quote_remote_path("~/.mngr/agents/agent-123")
+    assert result == '"$HOME/.mngr/agents/agent-123"'
+
+
+def test_shell_quote_remote_path_tilde_only() -> None:
+    """A bare '~' path is converted to $HOME."""
+    result = _shell_quote_remote_path("~")
+    assert result == '"$HOME"'
+
+
+def test_shell_quote_remote_path_absolute() -> None:
+    """Absolute paths are passed through shlex.quote (safe chars are returned unquoted)."""
+    result = _shell_quote_remote_path("/home/user/.mngr/agents/agent-123")
+    # Path has only safe chars, shlex.quote leaves it unquoted
+    assert result == "/home/user/.mngr/agents/agent-123"
+
+
+def test_shell_quote_remote_path_plain_name() -> None:
+    """Plain names without tilde are shell-quoted normally."""
+    result = _shell_quote_remote_path("agents/agent-123")
+    assert result == "agents/agent-123"
 
 
 # -- write_api_url_to_local tests --

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import paramiko
 import pytest
+from pydantic import PrivateAttr
 from pydantic import ValidationError
 
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
@@ -409,10 +410,10 @@ class _FakeSSHTunnelManager(SSHTunnelManager):
     so tests can exercise _check_and_repair_tunnels without a real SSH server.
     """
 
-    _setup_calls: list[tuple[RemoteSSHInfo, int, str]] = []
-    _write_calls: list[tuple[RemoteSSHInfo, str, str]] = []
-    _setup_port: int = 9999
-    _setup_raise: type[Exception] | None = None
+    _setup_calls: list[tuple[RemoteSSHInfo, int, str]] = PrivateAttr(default_factory=list)
+    _write_calls: list[tuple[RemoteSSHInfo, str, str]] = PrivateAttr(default_factory=list)
+    _setup_port: int = PrivateAttr(default=9999)
+    _setup_raise: type[Exception] | None = PrivateAttr(default=None)
 
     def setup_reverse_tunnel(
         self,
@@ -438,10 +439,8 @@ def _make_fake_reverse_tunnel_manager(
     remote_port: int = 9999,
     raise_on_setup: type[Exception] | None = None,
 ) -> _FakeSSHTunnelManager:
-    """Create a _FakeSSHTunnelManager with fresh call lists."""
+    """Create a _FakeSSHTunnelManager with the given configuration."""
     mgr = _FakeSSHTunnelManager()
-    mgr._setup_calls = []
-    mgr._write_calls = []
     mgr._setup_port = remote_port
     mgr._setup_raise = raise_on_setup
     return mgr

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -396,3 +396,140 @@ def test_tunnel_manager_health_check_starts_thread() -> None:
     manager.start_reverse_tunnel_health_check()
     assert manager._health_check_thread is first_thread
     manager.cleanup()
+
+
+# -- _check_and_repair_tunnels tests --
+#
+# These tests call _check_and_repair_tunnels directly (bypassing the
+# 30-second wait in the health check loop) to exercise the repair logic.
+
+
+class _FakeSSHTunnelManager(SSHTunnelManager):
+    """Test double that overrides setup_reverse_tunnel and write_api_url_to_remote
+    so tests can exercise _check_and_repair_tunnels without a real SSH server.
+    """
+
+    _setup_calls: list[tuple[RemoteSSHInfo, int, str]] = []
+    _write_calls: list[tuple[RemoteSSHInfo, str, str]] = []
+    _setup_port: int = 9999
+    _setup_raise: type[Exception] | None = None
+
+    def setup_reverse_tunnel(
+        self,
+        ssh_info: RemoteSSHInfo,
+        local_port: int,
+        agent_state_dir: str,
+    ) -> int:
+        self._setup_calls.append((ssh_info, local_port, agent_state_dir))
+        if self._setup_raise is not None:
+            raise self._setup_raise("simulated failure")
+        return self._setup_port
+
+    def write_api_url_to_remote(
+        self,
+        ssh_info: RemoteSSHInfo,
+        agent_state_dir: str,
+        url: str,
+    ) -> None:
+        self._write_calls.append((ssh_info, agent_state_dir, url))
+
+
+def _make_fake_reverse_tunnel_manager(
+    remote_port: int = 9999,
+    raise_on_setup: type[Exception] | None = None,
+) -> _FakeSSHTunnelManager:
+    """Create a _FakeSSHTunnelManager with fresh call lists."""
+    mgr = _FakeSSHTunnelManager()
+    mgr._setup_calls = []
+    mgr._write_calls = []
+    mgr._setup_port = remote_port
+    mgr._setup_raise = raise_on_setup
+    return mgr
+
+
+def _sample_ssh_info(tmp_path: Path) -> RemoteSSHInfo:
+    return RemoteSSHInfo(
+        user="root",
+        host="192.0.2.1",
+        port=22,
+        key_path=tmp_path / "key",
+    )
+
+
+def test_check_and_repair_tunnels_does_nothing_when_no_tunnels() -> None:
+    """When no reverse tunnels are registered, _check_and_repair_tunnels is a no-op."""
+    manager = _make_fake_reverse_tunnel_manager()
+    manager._check_and_repair_tunnels()
+    assert manager._setup_calls == []
+    assert manager._write_calls == []
+    manager.cleanup()
+
+
+def test_check_and_repair_tunnels_calls_setup_for_broken_tunnel(tmp_path: Path) -> None:
+    """_check_and_repair_tunnels calls setup_reverse_tunnel for tunnels with no active client."""
+    manager = _make_fake_reverse_tunnel_manager(remote_port=12345)
+    ssh_info = _sample_ssh_info(tmp_path)
+    conn_key = "192.0.2.1:22"
+    tunnel_info = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=5000,
+        agent_state_dirs=["~/.mngr/agents/agent-a", "~/.mngr/agents/agent-b"],
+    )
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = tunnel_info
+
+    manager._check_and_repair_tunnels()
+
+    # setup_reverse_tunnel called for first dir, then again for the second dir
+    assert len(manager._setup_calls) == 2
+    assert manager._setup_calls[0][2] == "~/.mngr/agents/agent-a"
+    assert manager._setup_calls[1][2] == "~/.mngr/agents/agent-b"
+    # write_api_url_to_remote called for each agent state dir
+    assert len(manager._write_calls) == 2
+    for _, _agent_dir, url in manager._write_calls:
+        assert url == "http://127.0.0.1:12345"
+    manager.cleanup()
+
+
+def test_check_and_repair_tunnels_handles_setup_error(tmp_path: Path) -> None:
+    """When setup_reverse_tunnel raises SSHTunnelError, the error is logged and not propagated."""
+    manager = _make_fake_reverse_tunnel_manager(raise_on_setup=SSHTunnelError)
+    ssh_info = _sample_ssh_info(tmp_path)
+    conn_key = "192.0.2.1:22"
+    tunnel_info = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=5000,
+        agent_state_dirs=["~/.mngr/agents/agent-a"],
+    )
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = tunnel_info
+
+    manager._check_and_repair_tunnels()
+
+    assert len(manager._setup_calls) == 1
+    assert manager._write_calls == []
+    manager.cleanup()
+
+
+def test_check_and_repair_tunnels_empty_agent_dirs(tmp_path: Path) -> None:
+    """When agent_state_dirs is empty, setup is called with an empty string."""
+    manager = _make_fake_reverse_tunnel_manager(remote_port=7777)
+    ssh_info = _sample_ssh_info(tmp_path)
+    conn_key = "192.0.2.1:22"
+    tunnel_info = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=5000,
+        agent_state_dirs=[],
+    )
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = tunnel_info
+
+    manager._check_and_repair_tunnels()
+
+    assert len(manager._setup_calls) == 1
+    assert manager._setup_calls[0][2] == ""
+    assert manager._write_calls == []
+    manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -358,3 +358,42 @@ def test_write_api_url_to_local_overwrites_existing(tmp_path: Path) -> None:
     SSHTunnelManager.write_api_url_to_local(state_dir, "http://127.0.0.1:9999")
 
     assert (state_dir / "minds_api_url").read_text() == "http://127.0.0.1:9999"
+
+
+def test_reverse_tunnel_info_stores_metadata() -> None:
+    from imbue.minds.desktop_client.ssh_tunnel import ReverseTunnelInfo
+
+    ssh_info = RemoteSSHInfo(
+        user="root",
+        host="192.168.1.1",
+        port=22,
+        key_path=Path("/tmp/test_key"),
+    )
+    info = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=54321,
+        agent_state_dir="~/.mngr/agents/test-id",
+    )
+    assert info.local_port == 8420
+    assert info.remote_port == 54321
+    assert info.agent_state_dir == "~/.mngr/agents/test-id"
+
+
+def test_tunnel_manager_cleanup_with_no_tunnels() -> None:
+    """Verify cleanup works even when no tunnels have been established."""
+    manager = SSHTunnelManager()
+    manager.cleanup()
+
+
+def test_tunnel_manager_health_check_starts_thread() -> None:
+    """Verify start_reverse_tunnel_health_check creates a daemon thread."""
+    manager = SSHTunnelManager()
+    manager.start_reverse_tunnel_health_check()
+    assert manager._health_check_thread is not None
+    assert manager._health_check_thread.daemon is True
+    # Starting again should be a no-op
+    first_thread = manager._health_check_thread
+    manager.start_reverse_tunnel_health_check()
+    assert manager._health_check_thread is first_thread
+    manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -372,11 +372,11 @@ def test_reverse_tunnel_info_stores_metadata() -> None:
         ssh_info=ssh_info,
         local_port=8420,
         remote_port=54321,
-        agent_state_dir="~/.mngr/agents/test-id",
+        agent_state_dirs=["~/.mngr/agents/test-id"],
     )
     assert info.local_port == 8420
     assert info.remote_port == 54321
-    assert info.agent_state_dir == "~/.mngr/agents/test-id"
+    assert info.agent_state_dirs == ["~/.mngr/agents/test-id"]
 
 
 def test_tunnel_manager_cleanup_with_no_tunnels() -> None:

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -106,6 +106,103 @@ class FakeParamikoTransport:
         return self.channel_to_return
 
 
+class FakeSSHTransport:
+    """Minimal stub for paramiko.Transport that reports an active state."""
+
+    _active: bool
+
+    @classmethod
+    def create(cls, active: bool = True) -> "FakeSSHTransport":
+        instance = cls.__new__(cls)
+        object.__setattr__(instance, "_active", active)
+        return instance
+
+    def is_active(self) -> bool:
+        return self._active
+
+    def request_port_forward(self, address: str, port: int) -> int:
+        return 54321
+
+    def accept(self, timeout: float | None = None) -> object:
+        return None
+
+    def cancel_port_forward(self, address: str, port: int) -> None:
+        pass
+
+
+class _FakeExecChannel:
+    """Fake paramiko channel that returns a configurable exit status."""
+
+    def __init__(self, exit_status: int) -> None:
+        self._exit_status = exit_status
+
+    def recv_exit_status(self) -> int:
+        return self._exit_status
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeExecStream:
+    """Fake paramiko stdin/stdout/stderr stream for exec_command results."""
+
+    def __init__(self, channel: _FakeExecChannel) -> None:
+        self.channel = channel
+
+    def read(self) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        pass
+
+
+class FakeSSHClient(paramiko.SSHClient):
+    """Minimal paramiko.SSHClient subclass with a controllable transport for testing.
+
+    Uses __new__ to bypass paramiko SSHClient initialization, injecting only
+    the state needed for the methods under test.
+    """
+
+    _fake_transport: FakeSSHTransport
+    _exec_calls: list[str]
+    _exec_exit_status: int
+    _exec_raise: type[Exception] | None
+
+    @classmethod
+    def create(
+        cls,
+        active: bool = True,
+        exec_exit_status: int = 0,
+        exec_raise: type[Exception] | None = None,
+    ) -> "FakeSSHClient":
+        instance = cls.__new__(cls)
+        object.__setattr__(instance, "_fake_transport", FakeSSHTransport.create(active=active))
+        object.__setattr__(instance, "_exec_calls", [])
+        object.__setattr__(instance, "_exec_exit_status", exec_exit_status)
+        object.__setattr__(instance, "_exec_raise", exec_raise)
+        return instance
+
+    def get_transport(self) -> FakeSSHTransport:
+        return self._fake_transport
+
+    def exec_command(
+        self,
+        command: str,
+        bufsize: int = -1,
+        timeout: float | None = None,
+        get_pty: bool = False,
+        environment: object = None,
+    ) -> tuple[_FakeExecStream, _FakeExecStream, _FakeExecStream]:
+        self._exec_calls.append(command)
+        if self._exec_raise is not None:
+            raise self._exec_raise("simulated exec error")
+        channel = _FakeExecChannel(self._exec_exit_status)
+        return _FakeExecStream(channel), _FakeExecStream(channel), _FakeExecStream(channel)
+
+    def close(self) -> None:
+        pass
+
+
 # -- RemoteSSHInfo tests --
 
 
@@ -560,4 +657,95 @@ def test_check_and_repair_tunnels_empty_agent_dirs(tmp_path: Path) -> None:
     assert len(manager._setup_calls) == 1
     assert manager._setup_calls[0][2] == ""
     assert manager._write_calls == []
+    manager.cleanup()
+
+
+def test_check_and_repair_tunnels_skips_alive_tunnel(tmp_path: Path) -> None:
+    """When a reverse tunnel's connection is still alive, it is skipped (not re-established)."""
+    manager = _make_fake_reverse_tunnel_manager(remote_port=9999)
+    ssh_info = _sample_ssh_info(tmp_path)
+    conn_key = "192.0.2.1:22"
+    tunnel_info = ReverseTunnelInfo(
+        ssh_info=ssh_info,
+        local_port=8420,
+        remote_port=5000,
+        agent_state_dirs=["~/.mngr/agents/agent-x"],
+    )
+    fake_client = FakeSSHClient.create(active=True)
+    with manager._lock:
+        manager._reverse_tunnels[conn_key] = tunnel_info
+        manager._connections[conn_key] = fake_client  # ty: ignore[arg-type]
+
+    manager._check_and_repair_tunnels()
+
+    # No re-establishment attempted since the tunnel is alive
+    assert manager._setup_calls == []
+    assert manager._write_calls == []
+    manager.cleanup()
+
+
+# -- write_api_url_to_remote tests --
+#
+# These tests inject a FakeSSHClient directly into the manager's _connections
+# dict (a private PrivateAttr) to avoid needing a real SSH server.
+# This setup pattern matches the existing tests above that inject _reverse_tunnels.
+
+
+def _make_manager_with_fake_connection(
+    ssh_info: RemoteSSHInfo,
+    fake_client: FakeSSHClient,
+) -> SSHTunnelManager:
+    """Create an SSHTunnelManager with a pre-injected fake SSH connection."""
+    manager = SSHTunnelManager()
+    conn_key = f"{ssh_info.host}:{ssh_info.port}"
+    with manager._lock:
+        manager._connections[conn_key] = fake_client  # ty: ignore[arg-type]
+    return manager
+
+
+def test_write_api_url_to_remote_succeeds(tmp_path: Path) -> None:
+    """write_api_url_to_remote executes the correct shell command via SSH."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create()
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    manager.write_api_url_to_remote(
+        ssh_info=ssh_info,
+        agent_state_dir="~/.mngr/agents/test-agent",
+        url="http://127.0.0.1:8420",
+    )
+
+    assert len(fake_client._exec_calls) == 1
+    assert "minds_api_url" in fake_client._exec_calls[0]
+    assert "8420" in fake_client._exec_calls[0]
+    manager.cleanup()
+
+
+def test_write_api_url_to_remote_logs_on_nonzero_exit(tmp_path: Path) -> None:
+    """write_api_url_to_remote logs a warning when the remote command exits non-zero."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(exec_exit_status=1)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    manager.write_api_url_to_remote(
+        ssh_info=ssh_info,
+        agent_state_dir="/tmp/agent",
+        url="http://127.0.0.1:9000",
+    )
+
+    assert len(fake_client._exec_calls) == 1
+    manager.cleanup()
+
+
+def test_write_api_url_to_remote_handles_ssh_exception(tmp_path: Path) -> None:
+    """write_api_url_to_remote catches paramiko.SSHException without propagating."""
+    ssh_info = _sample_ssh_info(tmp_path)
+    fake_client = FakeSSHClient.create(exec_raise=paramiko.SSHException)
+    manager = _make_manager_with_fake_connection(ssh_info, fake_client)
+
+    manager.write_api_url_to_remote(
+        ssh_info=ssh_info,
+        agent_state_dir="/tmp/agent",
+        url="http://127.0.0.1:9000",
+    )
     manager.cleanup()

--- a/apps/minds/imbue/minds/primitives.py
+++ b/apps/minds/imbue/minds/primitives.py
@@ -63,3 +63,9 @@ class GitCommitHash(NonEmptyStr):
     """A full git commit hash (40 hex characters)."""
 
     ...
+
+
+class ApiKeyHash(NonEmptyStr):
+    """SHA-256 hex digest of an agent's API key."""
+
+    ...

--- a/apps/minds/imbue/minds/telegram/credential_store_test.py
+++ b/apps/minds/imbue/minds/telegram/credential_store_test.py
@@ -84,6 +84,17 @@ def test_load_bot_credentials_returns_none_for_invalid_schema(tmp_path: Path) ->
     assert load_agent_bot_credentials(data_dir, agent_id) is None
 
 
+def test_load_bot_credentials_returns_none_for_corrupted_json(tmp_path: Path) -> None:
+    """Verify that a malformed JSON bot credentials file is handled gracefully."""
+    data_dir = tmp_path
+    agent_id = AgentId()
+    creds_path = data_dir / "telegram" / "bots" / f"{agent_id}.json"
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.write_text("not valid json {{{")
+
+    assert load_agent_bot_credentials(data_dir, agent_id) is None
+
+
 def test_multiple_agents_have_independent_bot_credentials(tmp_path: Path) -> None:
     data_dir = tmp_path
     agent_1 = AgentId()

--- a/specs/minds-rest-api/spec.md
+++ b/specs/minds-rest-api/spec.md
@@ -1,0 +1,177 @@
+# Minds REST API
+
+## Overview
+
+* The minds desktop client currently exposes features through a mix of HTML page routes and ad-hoc JSON endpoints in `desktop_client/app.py`. There is no structured, versioned API that agents or external tools can program against.
+* This spec adds a proper REST API under `/api/v1/`, mounted as a new FastAPI router into the existing app, covering: Cloudflare forwarding toggle, Telegram bot setup, and user notifications.
+* Each agent created through the desktop client receives a unique API key (UUID4) injected as `MINDS_API_KEY` at creation time. The server stores only a SHA-256 hash, keyed by agent ID, and uses it to authenticate and identify callers.
+* Agents on remote hosts reach the minds server through reverse SSH port forwarding. Local agents reach it directly. Both discover the URL via a well-known file at `$MNGR_AGENT_STATE_DIR/minds_api_url`.
+* Notifications are routed through Electron (stdout JSONL) when running inside the desktop app, or through a tkinter toast popup when running standalone. The calling agent's identity is included in the notification.
+
+## Expected Behavior
+
+### REST API (`/api/v1/`)
+
+* A new `APIRouter` is mounted at `/api/v1/` in the existing FastAPI app created by `create_desktop_client()`.
+* All `/api/v1/` routes require authentication via `Authorization: Bearer <api_key>` header. Auth is implemented as a FastAPI dependency that hashes the provided key with SHA-256 and scans per-agent hash files to find a match.
+* The API key grants full access to all `/api/v1/` endpoints (same authorization level as the session cookie). The hash identifies which agent made the call. Scoped restrictions are deferred.
+* Routes:
+  - `PUT /api/v1/agents/{agent_id}/servers/{server_name}/cloudflare` -- enable Cloudflare forwarding for a server (request body: `{"service_url": "..."}` or empty to auto-detect from backend resolver)
+  - `DELETE /api/v1/agents/{agent_id}/servers/{server_name}/cloudflare` -- disable Cloudflare forwarding for a server
+  - `POST /api/v1/agents/{agent_id}/telegram` -- start Telegram bot setup (request body: `{"agent_name": "optional"}`)
+  - `GET /api/v1/agents/{agent_id}/telegram` -- get Telegram setup status
+  - `POST /api/v1/notifications` -- send a notification to the user (request body: `{"title": "optional", "message": "required", "urgency": "low|normal|critical"}`)
+* Agent CRUD and server listing routes are intentionally deferred.
+
+### API Key Generation and Storage
+
+* `_build_mngr_create_command()` in `agent_creator.py` generates a UUID4 API key and appends `--env MINDS_API_KEY=<uuid>` to the mngr create command. The function returns both the command list and the generated key.
+* After `_build_mngr_create_command()` returns, the caller (`_create_agent_background`) hashes the key with SHA-256 and writes the hash to `~/.minds/agents/{agent_id}/api_key_hash` (plain text file containing the hex digest).
+* On each authenticated request, the auth dependency hashes the Bearer token and iterates over all `~/.minds/agents/*/api_key_hash` files to find a match. If found, the corresponding agent ID is extracted from the path and made available to route handlers.
+
+### Notifications
+
+* `POST /api/v1/notifications` accepts `{"title": "optional string", "message": "required string", "urgency": "low|normal|critical"}`.
+* The notification includes the calling agent's display name (resolved from `BackendResolverInterface.get_agent_display_info()`) or agent ID if the name is not discoverable.
+* **Electron path**: if `MINDS_ELECTRON=1` is set in the server's environment, the notification is written to stdout as JSONL: `{"event": "notification", "title": "...", "message": "...", "urgency": "...", "agent_name": "..."}`. The Electron main process (`main.js`) parses this event from the backend's stdout stream and displays it via `new Notification()`.
+* **Tkinter fallback**: if `MINDS_ELECTRON` is not set, a tkinter toast window is shown in a background thread. The window is small, always-on-top, positioned in the bottom-right corner of the screen, with a colored urgency indicator (green for low, yellow for normal, red for critical). It stays open until the user clicks to dismiss.
+* No rate limiting for now.
+
+### Reverse Port Forwarding (Agent -> Server Connectivity)
+
+* `SSHTunnelManager` is extended with reverse port forwarding capability alongside its existing forward tunneling.
+* When a remote agent is discovered and SSH info becomes available (via `MngrStreamManager`), the tunnel manager sets up a reverse port forward: it calls `transport.request_port_forward("127.0.0.1", 0)` on the paramiko SSH connection. The remote sshd picks a free port and returns it.
+* The assigned remote port is used to write `http://127.0.0.1:{remote_port}` to `$MNGR_AGENT_STATE_DIR/minds_api_url` on the remote host, using the paramiko SSH connection directly (via `exec_command` or SFTP).
+* For local agents, the URL file is written at discovery time with `http://127.0.0.1:{server_port}` (the minds server's actual port), to the local `$MNGR_AGENT_STATE_DIR/minds_api_url`.
+* A background health-check thread runs every 30 seconds. For each active reverse tunnel, it verifies the SSH transport is alive. If broken, it re-establishes the reverse tunnel (potentially with a new remote port) and updates the URL file.
+* The `SSHTunnelManager.cleanup()` method is extended to also tear down reverse tunnels.
+
+### Electron Integration
+
+* The Electron launcher (`backend.js`) is updated to set `MINDS_ELECTRON=1` in the environment when spawning the Python backend process.
+* The Electron main process (`main.js`) is updated to handle `notification` events from the backend's stdout JSONL stream, displaying them via `new Notification({title, body})`.
+
+## Implementation Plan
+
+### New files
+
+* **`imbue/minds/desktop_client/api_v1.py`** -- The `/api/v1/` router module. Contains:
+  - `ApiKeyAuth` FastAPI dependency: extracts Bearer token from Authorization header, hashes with SHA-256, scans `~/.minds/agents/*/api_key_hash` files, returns `AgentId` of the caller or raises 401
+  - `create_api_v1_router()` factory function that accepts the same dependencies as `create_desktop_client()` (backend resolver, cloudflare client, telegram orchestrator, notification dispatcher, paths) and returns an `APIRouter`
+  - Route handlers for all 5 endpoints listed above
+
+* **`imbue/minds/desktop_client/api_key_store.py`** -- API key hash storage. Contains:
+  - `generate_api_key() -> str` -- generates a UUID4 string
+  - `hash_api_key(key: str) -> str` -- SHA-256 hex digest
+  - `save_api_key_hash(data_dir: Path, agent_id: AgentId, key_hash: str) -> None` -- writes to `~/.minds/agents/{agent_id}/api_key_hash`
+  - `find_agent_by_api_key(data_dir: Path, key: str) -> AgentId | None` -- hashes key, scans all hash files, returns matching agent ID or None
+
+* **`imbue/minds/desktop_client/notification.py`** -- Notification dispatch. Contains:
+  - `NotificationUrgency` enum: `LOW`, `NORMAL`, `CRITICAL`
+  - `NotificationRequest` pydantic model: `title: str | None`, `message: str`, `urgency: NotificationUrgency`
+  - `NotificationDispatcher` class: takes `is_electron: bool` and `output_format: OutputFormat` at construction. `dispatch(request, agent_display_name)` method routes to Electron (stdout JSONL via `emit_event`) or tkinter.
+  - `_show_tkinter_toast(title, message, urgency, agent_name)` -- spawns a background thread that creates a small always-on-top tkinter window in the bottom-right corner with colored urgency indicator (green/yellow/red), stays until clicked to dismiss
+
+### Modified files
+
+* **`imbue/minds/desktop_client/agent_creator.py`**:
+  - `_build_mngr_create_command()` signature changes to also return the generated API key: `-> tuple[list[str], str]`. It generates a UUID4, appends `--env MINDS_API_KEY=<key>` to the command, and returns both.
+  - `_create_agent_background()` receives the key from `_build_mngr_create_command()`, hashes it, and saves the hash via `save_api_key_hash()`.
+
+* **`imbue/minds/desktop_client/ssh_tunnel.py`**:
+  - `SSHTunnelManager` gets new methods:
+    - `setup_reverse_tunnel(ssh_info, local_port) -> int` -- calls `transport.request_port_forward("127.0.0.1", 0)` and returns the assigned remote port. Stores the tunnel metadata for health checking.
+    - `write_api_url_to_remote(ssh_info, agent_state_dir, url)` -- writes the URL string to `{agent_state_dir}/minds_api_url` on the remote host via the paramiko connection (exec_command).
+    - `write_api_url_to_local(agent_state_dir, url)` -- writes the URL string to the local filesystem at `{agent_state_dir}/minds_api_url`.
+    - `start_reverse_tunnel_health_check()` -- starts a daemon thread that runs every 30 seconds, checks each reverse tunnel's SSH transport, re-establishes and updates URL files if broken.
+    - `cleanup()` is extended to cancel reverse port forwards and stop the health-check thread.
+  - New private attrs for tracking reverse tunnels: `_reverse_tunnels: dict[str, ReverseTunnelInfo]` mapping host key to tunnel metadata (ssh_info, local_port, remote_port, agent_state_dir).
+
+* **`imbue/minds/desktop_client/app.py`**:
+  - `create_desktop_client()` accepts a new `notification_dispatcher: NotificationDispatcher | None` parameter.
+  - Creates the `/api/v1/` router via `create_api_v1_router()` and mounts it with `app.include_router(router, prefix="/api/v1")`.
+
+* **`imbue/minds/desktop_client/runner.py`**:
+  - `start_desktop_client()` creates a `NotificationDispatcher` (checking `os.getenv("MINDS_ELECTRON")`) and passes it to `create_desktop_client()`.
+  - After the `MngrStreamManager` discovers agents, triggers reverse tunnel setup and URL file writing for remote agents, and direct URL file writing for local agents. This likely involves a callback or observer on agent discovery events.
+
+* **`imbue/minds/desktop_client/backend_resolver.py`**:
+  - `MngrStreamManager` gains a hook or callback for agent discovery events so that the runner can trigger reverse tunnel setup when a new remote agent appears.
+
+* **`electron/backend.js`**:
+  - Add `MINDS_ELECTRON: '1'` to the env object passed to `spawn()`.
+
+* **`electron/main.js`**:
+  - In the stdout JSONL parsing loop, handle `event === 'notification'` by calling `new Notification({title: event.title, body: event.message})`.
+
+### New primitives / data types
+
+* `NotificationUrgency` enum in `notification.py` (or `primitives.py` if reused elsewhere)
+* `ApiKeyHash` primitive (a `NonEmptyStr` subclass) in `primitives.py`
+
+## Implementation Phases
+
+### Phase 1: API Key Infrastructure
+
+* Create `api_key_store.py` with key generation, hashing, storage, and lookup functions.
+* Modify `_build_mngr_create_command()` to generate and inject the API key.
+* Modify `_create_agent_background()` to persist the hash after agent creation.
+* Add `ApiKeyHash` primitive to `primitives.py`.
+* Result: agents are created with API keys and hashes are stored. No routes yet, but the auth infrastructure is in place.
+
+### Phase 2: REST API Router and Auth
+
+* Create `api_v1.py` with the `ApiKeyAuth` dependency and `create_api_v1_router()`.
+* Implement the Cloudflare forwarding routes (`PUT`/`DELETE`), wiring to the existing `CloudflareForwardingClient`.
+* Implement the Telegram routes (`POST`/`GET`), wiring to the existing `TelegramSetupOrchestrator`.
+* Mount the router in `create_desktop_client()`.
+* Result: the `/api/v1/` routes are live and authenticated. Agents with API keys can toggle Cloudflare forwarding and set up Telegram bots.
+
+### Phase 3: Notifications
+
+* Create `notification.py` with `NotificationDispatcher`, the Electron stdout path, and the tkinter toast implementation.
+* Add the `POST /api/v1/notifications` route to the API router.
+* Update `runner.py` to create the dispatcher and pass it through.
+* Update `electron/backend.js` to set `MINDS_ELECTRON=1`.
+* Update `electron/main.js` to handle notification events from stdout.
+* Result: agents can send notifications that appear as native Electron notifications or tkinter toasts.
+
+### Phase 4: Reverse Port Forwarding and URL File
+
+* Extend `SSHTunnelManager` with reverse tunnel methods, health checking, and URL file writing.
+* Hook into `MngrStreamManager` agent discovery to trigger reverse tunnel setup for remote agents and direct URL file writing for local agents.
+* Update `runner.py` to wire the discovery callback and pass the server port to the tunnel manager.
+* Result: all agents (local and remote) can read `$MNGR_AGENT_STATE_DIR/minds_api_url` to discover the minds server and call its API.
+
+## Testing Strategy
+
+### Unit tests
+
+* `api_key_store.py`: test key generation (valid UUID4), hashing (deterministic SHA-256), save/load round-trip, `find_agent_by_api_key` with multiple agents, and not-found case.
+* `notification.py`: test `NotificationDispatcher` routes to Electron (mock stdout, verify JSONL output) or tkinter (mock tkinter, verify window creation) based on `is_electron` flag. Test urgency enum validation.
+* `api_v1.py`: test auth dependency rejects missing/invalid Bearer tokens. Test each route handler with mocked dependencies (cloudflare client, telegram orchestrator, notification dispatcher).
+* `ssh_tunnel.py` (reverse tunnel): test `setup_reverse_tunnel` calls `request_port_forward` correctly, test URL file writing (both local and remote via mocked paramiko), test health-check thread re-establishes broken tunnels.
+
+### Integration tests
+
+* Create an agent via `AgentCreator`, verify `MINDS_API_KEY` env var is set on the mngr command and hash file is written.
+* Start the desktop client app (via test client), authenticate with a valid API key, and verify the Cloudflare and Telegram endpoints respond correctly.
+* Verify that an invalid API key returns 401.
+* Verify the notification endpoint writes correct JSONL to stdout when `MINDS_ELECTRON=1`.
+
+### Edge cases
+
+* API key file does not exist or is corrupted -- should return 401, not crash.
+* Cloudflare client is None (not configured) -- Cloudflare routes return 501.
+* Telegram orchestrator is None -- Telegram routes return 501.
+* SSH connection drops during reverse tunnel health check -- re-establish cleanly without affecting forward tunnels.
+* Multiple reverse tunnels to the same host -- should reuse the SSH connection but create separate port forwards per agent.
+* Agent discovered before server port is known -- defer reverse tunnel setup until server is ready.
+* Tkinter not available (headless server) -- notification dispatch should log a warning and not crash.
+
+## Open Questions
+
+* **Agent state dir discovery for local agents**: the server needs to know the local `$MNGR_AGENT_STATE_DIR` path for each agent to write the URL file. This path follows the convention `$MNGR_HOST_DIR/agents/$MNGR_AGENT_ID/`, but `MNGR_HOST_DIR` defaults to `~/.mngr/` on the local machine. Should this be hardcoded to the convention, or discovered from `mngr` somehow?
+* **Reverse tunnel and shared hosts**: multiple agents can share a single host. Should one reverse tunnel per host suffice (writing the URL file for each agent on that host), or one per agent?
+* **stdout contention**: the Electron notification path writes JSONL to stdout. The `emit_event` utility already writes to stdout. If notifications arrive concurrently (multiple agents notifying at once), is there a risk of interleaved writes? May need a stdout lock.
+* **Tkinter and macOS**: tkinter on macOS has restrictions around running on the main thread. Since the desktop client's main thread runs uvicorn, the tkinter toast will run in a background thread -- this may require `root.after()` scheduling or other workarounds on macOS.


### PR DESCRIPTION
## Summary
* Adds `/api/v1/` REST API router to the minds desktop client with Bearer token auth (per-agent UUID4 API keys, SHA-256 hashed)
* Endpoints: Cloudflare forwarding toggle (PUT/DELETE), Telegram bot setup (POST/GET), user notifications (POST)
* Notification dispatch routes to Electron (stdout JSONL) or tkinter toast based on `MINDS_ELECTRON` env var
* Reverse SSH port forwarding so remote agents can reach the minds server, with 30-second health checks
* API URL file (`$MNGR_AGENT_STATE_DIR/minds_api_url`) written for both local and remote agents at discovery time
* Electron app updated to set `MINDS_ELECTRON=1` and display native notifications from backend events

## Test plan
- [x] Unit tests for api_key_store (generation, hashing, round-trip, multi-agent lookup)
- [x] Unit tests for api_v1 (auth rejection/acceptance, route responses, body validation)
- [x] Unit tests for notification (JSONL output, urgency enum, request defaults)
- [x] Unit tests for SSH tunnel URL file writing (local, directory creation, overwrite)
- [x] Unit tests for runner AgentDiscoveryHandler (local agent URL file writing)
- [ ] Coverage at 77.4% (below 80% threshold) -- gap is from tkinter UI code, SSH reverse tunnel code, and uvicorn startup code that require real infrastructure to test
- [ ] Manual verification of Electron notification flow
- [ ] Manual verification of tkinter toast on non-Electron setup

Generated with [Claude Code](https://claude.com/claude-code)