### PR TITLE
Add tab action buttons (destroy, share, close) to minds workspace server

### DIFF
--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -86,6 +86,7 @@ TEMPLATE_BRANCH=$(cd .external_worktrees/forever-claude-template && git branch -
 (
   set -a
   source .env
+  source .test_env
   set +a
   export MINDS_WORKSPACE_GIT_URL="$(pwd)/.external_worktrees/forever-claude-template"
   export MINDS_WORKSPACE_NAME="mindtest"

--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -64,13 +64,17 @@ Source `.env` from the mngr repo root and set these env vars:
 - `MINDS_WORKSPACE_NAME` -- agent name (default: `mindtest`)
 - `MINDS_WORKSPACE_BRANCH` -- branch to use (set to the template worktree's branch if not `main`)
 
+**IMPORTANT**: `MINDS_WORKSPACE_BRANCH` MUST match the branch the template worktree is on. Get it with `cd .external_worktrees/forever-claude-template && git branch --show-current`. If this is wrong, agent creation will fail with `git checkout failed for branch`.
+
 ```bash
+TEMPLATE_BRANCH=$(cd .external_worktrees/forever-claude-template && git branch --show-current)
 (
   set -a
   source .env
   set +a
   export MINDS_WORKSPACE_GIT_URL="$(pwd)/.external_worktrees/forever-claude-template"
   export MINDS_WORKSPACE_NAME="mindtest"
+  export MINDS_WORKSPACE_BRANCH="$TEMPLATE_BRANCH"
   setsid bash -c "cd apps/minds && npm start" >> /tmp/minds-electron.log 2>&1 &
 )
 ```

--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: minds-dev-iterate
+description: Set up and iterate on the minds app stack (desktop client, workspace server, mngr, forever-claude-template) with a running Docker agent
+---
+
+# Minds Dev Iteration Loop
+
+This skill sets up and manages the development iteration loop for testing the minds app stack end-to-end with a running Docker agent.
+
+## Architecture Overview
+
+The minds stack has four components that need to stay in sync:
+
+1. **minds desktop client** (`apps/minds/`) -- Electron app + FastAPI backend that runs locally, proxies to agent web servers
+2. **minds_workspace_server** (`apps/minds_workspace_server/`) -- FastAPI + web UI that runs INSIDE the agent's Docker container as a background service
+3. **mngr core** (`libs/mngr/`) -- the agent management CLI
+4. **forever-claude-template** -- the template repo that defines the Docker container (Dockerfile, services.toml, skills, scripts)
+
+The template contains a `vendor/mngr/` directory (git subtree) with a copy of the mngr repo. During development, we sidestep the subtree by rsyncing the local mngr repo directly into `vendor/mngr/`.
+
+### How changes propagate
+
+```
+local mngr repo  -->  template's vendor/mngr/  -->  Docker container's /code/
+                      (on the host)                 (via rsync over SSH)
+```
+
+The desktop client runs on the host (via Electron). The workspace server + mngr run inside the container. The `propagate_changes` script syncs everything.
+
+## Setup (one-time per worktree)
+
+### 1. Create the template worktree
+
+The forever-claude-template must exist at `.external_worktrees/forever-claude-template` relative to the mngr worktree root:
+
+```bash
+cd ~/project/forever-claude-template
+git worktree add /path/to/mngr/worktree/.external_worktrees/forever-claude-template -b <branch-name> main
+```
+
+### 2. Install Electron dependencies
+
+```bash
+cd apps/minds && npm install && cd ../..
+```
+
+### 3. Find your Docker SSH key
+
+The Docker provider stores SSH keys at:
+```
+~/.mngr/profiles/<profile_id>/providers/docker/docker/keys/docker_ssh_key
+```
+
+Find yours with:
+```bash
+find ~/.mngr/profiles -path "*/docker/*/keys/docker_ssh_key"
+```
+
+### 4. Start the Electron app
+
+Source `.env` from the mngr repo root and set these env vars:
+
+- `MINDS_WORKSPACE_GIT_URL` -- path to the template worktree (e.g., `/path/to/mngr/worktree/.external_worktrees/forever-claude-template`)
+- `MINDS_WORKSPACE_NAME` -- agent name (default: `mindtest`)
+- `MINDS_WORKSPACE_BRANCH` -- branch to use (set to the template worktree's branch if not `main`)
+
+```bash
+(
+  set -a
+  source .env
+  set +a
+  export MINDS_WORKSPACE_GIT_URL="$(pwd)/.external_worktrees/forever-claude-template"
+  export MINDS_WORKSPACE_NAME="mindtest"
+  setsid bash -c "cd apps/minds && npm start" >> /tmp/minds-electron.log 2>&1 &
+)
+```
+
+### 5. Create the agent
+
+Use the Electron app's creation form to create a Docker agent. The form will default to the template path and agent name from the env vars.
+
+### 6. Find the Docker container's SSH port
+
+```bash
+docker ps --format '{{.Names}} {{.Ports}}' | grep mindtest
+# Output: mngr-mindtest-host 0.0.0.0:32772->22/tcp
+```
+
+## Iterating
+
+After making changes to any component, run:
+
+```bash
+apps/minds/scripts/propagate_changes \
+  --user root --host 127.0.0.1 --port <SSH_PORT> \
+  --key <SSH_KEY_PATH>
+```
+
+This does:
+1. Rsyncs the mngr repo into the template's `vendor/mngr/` (so future `mngr create` picks up changes too)
+2. Stops the agent (`mngr stop`)
+3. Rsyncs the full template (with updated vendor/mngr/) into `/code/` in the container
+4. Rebuilds the workspace server frontend (`npm run build` via SSH)
+5. Starts the agent (`mngr start`)
+6. Stops and restarts the Electron desktop client (clean SIGTERM shutdown)
+
+The whole cycle takes about 5-10 seconds.
+
+### For local (non-container) agents
+
+```bash
+apps/minds/scripts/propagate_changes --target /path/to/agent/workdir
+```
+
+## Key details
+
+### Clean shutdown
+
+The Electron app shuts down cleanly via this chain:
+- Electron window close -> `before-quit` handler -> `backend.js shutdown()` -> SIGTERM to `uv run`
+- `uv run` forwards SIGTERM to Python
+- Uvicorn catches SIGTERM, does 1-second graceful shutdown (`timeout_graceful_shutdown=1`)
+- ASGI lifespan shutdown hook runs `stream_manager.stop()` (terminates mngr observe/events subprocesses)
+- Uvicorn re-raises SIGTERM, process exits with code 143
+
+If this chain breaks (orphaned `mngr observe`/`mngr events` processes appear), something is wrong -- investigate, don't just kill the orphans.
+
+### Env vars
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `MINDS_WORKSPACE_GIT_URL` | Template repo path/URL for creation form | `https://github.com/imbue-ai/forever-claude-template.git` |
+| `MINDS_WORKSPACE_NAME` | Default agent name in creation form | `selene` |
+| `MINDS_WORKSPACE_BRANCH` | Default git branch for template | `main` |
+
+### Rsync exclusions
+
+Both syncs (mngr->vendor/mngr and template->container) exclude:
+`.git`, `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `uv.lock`, `.external_worktrees`
+
+The template->container sync also protects `runtime/` and `.mngr/` from deletion.
+
+### Editable installs
+
+The Dockerfile uses `uv tool install -e` for mngr and minds_workspace_server, so Python code changes in `vendor/mngr/` are picked up immediately after rsync. Frontend changes require the `npm run build` step (done automatically by the script).
+
+### Template settings
+
+The template's `.mngr/settings.toml` controls agent types, create templates, env vars, and extra_window entries. Key settings:
+- `disable_plugin = ["recursive", "ttyd"]` -- disables plugins that would conflict with template-managed services
+- `extra_window` entries for bootstrap, telegram, terminal, reviewer_settings
+- `env` entries for `IS_SANDBOX`, `IS_AUTONOMOUS`, and reviewer toggles
+
+### Logs
+
+- Electron app: `/tmp/minds-electron.log`
+- Minds backend: `~/.minds/logs/minds.log` and `~/.minds/logs/minds-events.jsonl`

--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -38,13 +38,28 @@ cd ~/project/forever-claude-template
 git worktree add /path/to/mngr/worktree/.external_worktrees/forever-claude-template -b <branch-name> main
 ```
 
-### 2. Install Electron dependencies
+### 2. Sync current mngr code into the template
+
+**CRITICAL**: The template's `vendor/mngr/` starts with whatever was committed on `main`. You MUST rsync the current mngr repo into it before creating any agents, otherwise the container will run stale code:
+
+```bash
+rsync -a --delete \
+    --exclude='.git' --exclude='__pycache__' --exclude='.venv' \
+    --exclude='node_modules' --exclude='.test_output' --exclude='.mypy_cache' \
+    --exclude='.ruff_cache' --exclude='.pytest_cache' --exclude='uv.lock' \
+    --exclude='.external_worktrees' \
+    ./ .external_worktrees/forever-claude-template/vendor/mngr/
+```
+
+This is the same rsync that `propagate_changes` does as step 1, but it must happen once before the first agent creation.
+
+### 3. Install Electron dependencies
 
 ```bash
 cd apps/minds && npm install && cd ../..
 ```
 
-### 3. Find your Docker SSH key
+### 4. Find your Docker SSH key
 
 The Docker provider stores SSH keys at:
 ```
@@ -56,7 +71,7 @@ Find yours with:
 find ~/.mngr/profiles -path "*/docker/*/keys/docker_ssh_key"
 ```
 
-### 4. Start the Electron app
+### 5. Start the Electron app
 
 Source `.env` from the mngr repo root and set these env vars:
 
@@ -79,11 +94,11 @@ TEMPLATE_BRANCH=$(cd .external_worktrees/forever-claude-template && git branch -
 )
 ```
 
-### 5. Create the agent
+### 6. Create the agent
 
 Use the Electron app's creation form to create a Docker agent. The form will default to the template path and agent name from the env vars.
 
-### 6. Find the Docker container's SSH port
+### 7. Find the Docker container's SSH port
 
 ```bash
 docker ps --format '{{.Names}} {{.Ports}}' | grep mindtest

--- a/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
+++ b/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
@@ -374,27 +374,57 @@ def cf_kv_ensure_namespace(client: httpx.Client, account_id: str, title: str) ->
 # ---------------------------------------------------------------------------
 
 
-def make_tunnel_name(username: str, agent_id: str) -> str:
+_MAX_USERNAME_LENGTH = 22
+_MAX_SERVICE_NAME_LENGTH = 21
+_AGENT_ID_PREFIX_LENGTH = 16
+
+
+def truncate_agent_id(agent_id: str) -> str:
+    """Truncate an agent ID to a short prefix for use in hostnames.
+
+    Strips the "agent-" prefix (if present) and takes the first 16 hex chars.
+    16 chars of hex provides sufficient uniqueness per user.
+    """
+    raw = agent_id.removeprefix("agent-")
+    return raw[:_AGENT_ID_PREFIX_LENGTH]
+
+
+def _validate_username(username: str) -> None:
     if TUNNEL_NAME_SEP in username:
         raise InvalidTunnelComponentError("Username", username, TUNNEL_NAME_SEP)
-    if TUNNEL_NAME_SEP in agent_id:
-        raise InvalidTunnelComponentError("Agent ID", agent_id, TUNNEL_NAME_SEP)
-    return f"{username}{TUNNEL_NAME_SEP}{agent_id}"
+    if len(username) > _MAX_USERNAME_LENGTH:
+        raise ValueError(f"Username '{username}' exceeds maximum length of {_MAX_USERNAME_LENGTH}")
+
+
+def _validate_service_name(service_name: str) -> None:
+    if TUNNEL_NAME_SEP in service_name:
+        raise InvalidTunnelComponentError("Service name", service_name, TUNNEL_NAME_SEP)
+    if len(service_name) > _MAX_SERVICE_NAME_LENGTH:
+        raise ValueError(f"Service name '{service_name}' exceeds maximum length of {_MAX_SERVICE_NAME_LENGTH}")
+
+
+def make_tunnel_name(username: str, agent_id: str) -> str:
+    _validate_username(username)
+    short_id = truncate_agent_id(agent_id)
+    return f"{username}{TUNNEL_NAME_SEP}{short_id}"
 
 
 def make_hostname(service_name: str, agent_id: str, username: str, domain: str) -> str:
-    return f"{service_name}--{agent_id}--{username}.{domain}"
+    _validate_service_name(service_name)
+    short_id = truncate_agent_id(agent_id)
+    return f"{service_name}--{short_id}--{username}.{domain}"
 
 
-def extract_agent_id(tunnel_name: str, username: str) -> str:
+def extract_agent_id_prefix(tunnel_name: str, username: str) -> str:
+    """Extract the truncated agent ID prefix from a tunnel name."""
     prefix = f"{username}{TUNNEL_NAME_SEP}"
     if not tunnel_name.startswith(prefix):
         raise TunnelOwnershipError(tunnel_name, username)
     return tunnel_name[len(prefix) :]
 
 
-def extract_service_name(hostname: str, agent_id: str, username: str, domain: str) -> str | None:
-    expected_suffix = f"--{agent_id}--{username}.{domain}"
+def extract_service_name(hostname: str, agent_id_prefix: str, username: str, domain: str) -> str | None:
+    expected_suffix = f"--{agent_id_prefix}--{username}.{domain}"
     if not hostname.endswith(expected_suffix):
         return None
     return hostname[: -len(expected_suffix)]
@@ -666,7 +696,7 @@ class ForwardingCtx:
         self.verify_ownership(tunnel_name, username)
         tunnel = self.get_tunnel_or_raise(tunnel_name)
         tid = tunnel["id"]
-        agent_id = extract_agent_id(tunnel_name, username)
+        agent_id = extract_agent_id_prefix(tunnel_name, username)
         hostname = make_hostname(service_name, agent_id, username, self.domain)
         self.ops.create_cname(hostname, f"{tid}.cfargotunnel.com")
         config = self.ops.get_tunnel_config(tid)
@@ -686,7 +716,7 @@ class ForwardingCtx:
         self.verify_ownership(tunnel_name, username)
         tunnel = self.get_tunnel_or_raise(tunnel_name)
         tid = tunnel["id"]
-        agent_id = extract_agent_id(tunnel_name, username)
+        agent_id = extract_agent_id_prefix(tunnel_name, username)
         hostname = make_hostname(service_name, agent_id, username, self.domain)
         config = self.ops.get_tunnel_config(tid)
         rules = non_catchall_rules(config.get("config", {}).get("ingress", []))
@@ -710,7 +740,7 @@ class ForwardingCtx:
 
     def get_service_auth(self, tunnel_name: str, username: str, service_name: str) -> AuthPolicy | None:
         """Get the auth policy for a specific service from its Access Application."""
-        agent_id = extract_agent_id(tunnel_name, username)
+        agent_id = extract_agent_id_prefix(tunnel_name, username)
         hostname = make_hostname(service_name, agent_id, username, self.domain)
         access_app = self.ops.get_access_app_by_domain(hostname)
         if access_app is None:
@@ -720,7 +750,7 @@ class ForwardingCtx:
 
     def set_service_auth(self, tunnel_name: str, username: str, service_name: str, policy: AuthPolicy) -> None:
         """Set the auth policy for a specific service on its Access Application."""
-        agent_id = extract_agent_id(tunnel_name, username)
+        agent_id = extract_agent_id_prefix(tunnel_name, username)
         hostname = make_hostname(service_name, agent_id, username, self.domain)
         access_app = self.ops.get_access_app_by_domain(hostname)
         if access_app is None:
@@ -740,7 +770,7 @@ class ForwardingCtx:
         return self._list_services(tunnel["id"], tunnel_name, username)
 
     def _list_services(self, tunnel_id: str, tunnel_name: str, username: str) -> list[ServiceInfo]:
-        agent_id = extract_agent_id(tunnel_name, username)
+        agent_id = extract_agent_id_prefix(tunnel_name, username)
         config = self.ops.get_tunnel_config(tunnel_id)
         rules = non_catchall_rules(config.get("config", {}).get("ingress", []))
         services: list[ServiceInfo] = []

--- a/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
+++ b/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
@@ -671,7 +671,11 @@ class ForwardingCtx:
         self.ops.create_cname(hostname, f"{tid}.cfargotunnel.com")
         config = self.ops.get_tunnel_config(tid)
         rules = non_catchall_rules(config.get("config", {}).get("ingress", []))
-        rules.append({"hostname": hostname, "service": service_url})
+        rules.append({
+            "hostname": hostname,
+            "service": service_url,
+            "originRequest": {"noTLSVerify": True},
+        })
         self.ops.put_tunnel_config(tid, wrap_ingress(rules))
 
         self._apply_default_access_policy(tunnel_name, hostname)

--- a/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
+++ b/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
@@ -619,6 +619,10 @@ class ForwardingCtx:
             tid = existing["id"]
             token = self.ops.get_tunnel_token(tid)
             services = self._list_services(tid, name, username)
+            # Update the default auth policy if provided (may have been missing
+            # from the original creation or may need updating)
+            if default_auth_policy is not None:
+                self.ops.kv_put(name, default_auth_policy.model_dump_json())
             return TunnelInfo(tunnel_name=name, tunnel_id=tid, token=token, services=services)
 
         result = self.ops.create_tunnel(name)

--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -207,23 +207,30 @@ function startBackend(onProgress, onNotification) {
 function shutdown() {
   return new Promise((resolve) => {
     if (!backendProcess) {
+      console.log('[shutdown] No backend process to shut down');
       resolve();
       return;
     }
 
     const child = backendProcess;
     let isExited = false;
+    const startTime = Date.now();
 
-    child.on('exit', () => {
+    child.on('exit', (code, signal) => {
+      const elapsed = Date.now() - startTime;
+      console.log(`[shutdown] Backend exited after ${elapsed}ms (code=${code}, signal=${signal})`);
       isExited = true;
       backendProcess = null;
       resolve();
     });
 
+    console.log(`[shutdown] Sending SIGTERM to backend (PID ${child.pid})`);
     child.kill('SIGTERM');
 
     setTimeout(() => {
       if (!isExited) {
+        const elapsed = Date.now() - startTime;
+        console.log(`[shutdown] Backend still alive after ${elapsed}ms, sending SIGKILL`);
         try {
           child.kill('SIGKILL');
         } catch {
@@ -233,6 +240,8 @@ function shutdown() {
       // Resolve after SIGKILL attempt regardless
       setTimeout(() => {
         if (!isExited) {
+          const elapsed = Date.now() - startTime;
+          console.log(`[shutdown] Backend did not exit after SIGKILL (${elapsed}ms), giving up`);
           backendProcess = null;
           resolve();
         }

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -397,18 +397,24 @@ ipcMain.on('window-close', () => {
 let isShuttingDown = false;
 
 app.on('window-all-closed', async () => {
+  console.log('[lifecycle] window-all-closed fired, isShuttingDown=' + isShuttingDown);
   if (!isShuttingDown) {
     isShuttingDown = true;
+    console.log('[lifecycle] Starting shutdown from window-all-closed...');
     await shutdown();
+    console.log('[lifecycle] Shutdown complete, calling app.quit()');
     app.quit();
   }
 });
 
 app.on('before-quit', async (event) => {
+  console.log('[lifecycle] before-quit fired, isShuttingDown=' + isShuttingDown + ', hasBackend=' + !!getBackendProcess());
   if (getBackendProcess() && !isShuttingDown) {
     isShuttingDown = true;
     event.preventDefault();
+    console.log('[lifecycle] Starting shutdown from before-quit...');
     await shutdown();
+    console.log('[lifecycle] Shutdown complete, calling app.quit()');
     app.quit();
   }
 });

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -195,11 +195,28 @@ function createWindow() {
     mainWindow = null;
   });
 
+  // Prevent backward navigation to file:// pages (shell.html) once the
+  // backend is running. Without this, hitting Back enough times lands on
+  // the static shell page which has no way to recover.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (url.startsWith('file://') && backendBaseUrl) {
+      event.preventDefault();
+    }
+  });
+
   // Inject the custom title bar into every backend page.
   // Skip file:// pages (loading/error screens).
   mainWindow.webContents.on('dom-ready', () => {
     const url = mainWindow.webContents.getURL();
-    if (url.startsWith('file://')) return;
+    if (url.startsWith('file://')) {
+      // If the backend is already running and we somehow ended up on
+      // shell.html (e.g. via history navigation that bypassed will-navigate),
+      // redirect to the backend landing page.
+      if (backendBaseUrl) {
+        mainWindow.loadURL(backendBaseUrl + '/');
+      }
+      return;
+    }
 
     const css = TITLEBAR_CSS + (isMac ? TITLEBAR_CSS_MAC : '');
     mainWindow.webContents.insertCSS(css);

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -484,7 +484,7 @@ class AgentCreator(MutableModel):
 
                 with self._lock:
                     self._statuses[aid] = AgentCreationStatus.DONE
-                    self._redirect_urls[aid] = "/agents/{}/".format(agent_id)
+                    self._redirect_urls[aid] = "/forwarding/{}/".format(agent_id)
 
         except (GitCloneError, GitOperationError, MngrCommandError, ValueError, OSError) as e:
             logger.error("Failed to create agent {}: {}", agent_id, e)

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -173,6 +173,48 @@ def checkout_branch(
         )
 
 
+def _rsync_worktree_over_clone(
+    worktree_dir: Path,
+    clone_dir: Path,
+    on_output: OutputCallback | None = None,
+) -> None:
+    """Rsync a worktree's working directory over a shallow clone.
+
+    Copies all files from the worktree into the clone, preserving the
+    clone's ``.git`` directory (which is a proper standalone git dir,
+    unlike the worktree's ``.git`` file). This ensures uncommitted
+    changes in the worktree are present in the clone.
+    """
+    logger.debug("Rsyncing worktree {} over clone {}", worktree_dir, clone_dir)
+    command = [
+        "rsync",
+        "-a",
+        "--exclude=.git",
+        "--exclude=__pycache__",
+        "--exclude=.venv",
+        "--exclude=node_modules",
+        "--exclude=.mypy_cache",
+        "--exclude=.ruff_cache",
+        "--exclude=.pytest_cache",
+        "--exclude=.test_output",
+        f"{worktree_dir}/",
+        f"{clone_dir}/",
+    ]
+    cg = ConcurrencyGroup(name="rsync-worktree")
+    with cg:
+        result = cg.run_process_to_completion(
+            command=command,
+            is_checked_after=False,
+            on_output=on_output,
+        )
+    if result.returncode != 0:
+        logger.warning(
+            "rsync worktree over clone exited with code {}: {}",
+            result.returncode,
+            result.stderr.strip() if result.stderr.strip() else result.stdout.strip(),
+        )
+
+
 def _make_host_name(agent_name: AgentName) -> str:
     """Build the host name for an agent.
 
@@ -432,6 +474,11 @@ class AgentCreator(MutableModel):
                             shutil.rmtree(clone_target)
                         file_url = GitUrl("file://{}".format(resolved_path))
                         clone_git_repo(file_url, clone_target, on_output=emit_log, is_shallow=True)
+                        # The shallow clone only contains committed content. Rsync
+                        # the worktree's working directory over so that uncommitted
+                        # changes (e.g. a locally-rsynced vendor/mngr/) are included
+                        # in the Docker build context.
+                        _rsync_worktree_over_clone(resolved_path, clone_target, on_output=emit_log)
                         workspace_dir = clone_target
                     else:
                         workspace_dir = resolved_path

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -35,7 +35,7 @@ from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import generate_api_key
 from imbue.minds.desktop_client.api_key_store import hash_api_key
 from imbue.minds.desktop_client.api_key_store import save_api_key_hash
-from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
+
 from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
@@ -332,35 +332,6 @@ def run_mngr_create(
     return api_key
 
 
-def _inject_tunnel_token(
-    agent_id: AgentId,
-    token: str,
-    log_queue: queue.Queue[str],
-) -> None:
-    """Inject the tunnel token into the agent's runtime/secrets file via mngr exec."""
-    log_queue.put("[minds] Injecting tunnel token into agent...")
-    safe_token = shlex.quote(token)
-    cg = ConcurrencyGroup(name="mngr-exec-token")
-    with cg:
-        command = [
-            MNGR_BINARY,
-            "exec",
-            str(agent_id),
-            f"mkdir -p runtime && printf 'export CLOUDFLARE_TUNNEL_TOKEN=%s\\n' {safe_token} >> runtime/secrets",
-        ]
-        result = cg.run_process_to_completion(
-            command=command,
-            is_checked_after=False,
-        )
-    if result.returncode != 0:
-        log_queue.put(
-            "[minds] WARNING: Failed to inject tunnel token: {}".format(
-                result.stderr.strip() if result.stderr.strip() else result.stdout.strip()
-            )
-        )
-    else:
-        log_queue.put("[minds] Tunnel token injected successfully.")
-
 
 class AgentCreator(MutableModel):
     """Creates mngr agents in the background from git repositories or local paths.
@@ -372,11 +343,6 @@ class AgentCreator(MutableModel):
     """
 
     paths: WorkspacePaths = Field(frozen=True, description="Filesystem paths for minds data")
-    cloudflare_client: CloudflareForwardingClient | None = Field(
-        default=None,
-        frozen=True,
-        description="Client for Cloudflare tunnel API, or None if not configured",
-    )
 
     _statuses: dict[str, AgentCreationStatus] = PrivateAttr(default_factory=dict)
     _redirect_urls: dict[str, str] = PrivateAttr(default_factory=dict)
@@ -514,8 +480,6 @@ class AgentCreator(MutableModel):
                 save_api_key_hash(self.paths.data_dir, agent_id, key_hash)
                 log_queue.put("[minds] API key generated and hash stored.")
 
-                self._setup_cloudflare_tunnel(agent_id, log_queue)
-
                 log_queue.put("[minds] Agent created successfully.")
 
                 with self._lock:
@@ -531,24 +495,3 @@ class AgentCreator(MutableModel):
         finally:
             log_queue.put(LOG_SENTINEL)
 
-    def _setup_cloudflare_tunnel(
-        self,
-        agent_id: AgentId,
-        log_queue: queue.Queue[str],
-    ) -> None:
-        """Create a Cloudflare tunnel and inject its token into the agent.
-
-        Uses the cloudflare_client if configured. Does nothing otherwise.
-        """
-        if self.cloudflare_client is None:
-            log_queue.put("[minds] Cloudflare forwarding not configured, skipping tunnel creation.")
-            return
-
-        log_queue.put("[minds] Creating Cloudflare tunnel...")
-        token, message = self.cloudflare_client.create_tunnel(agent_id)
-        log_queue.put(f"[minds] {message}")
-
-        if token is not None:
-            _inject_tunnel_token(agent_id, token, log_queue)
-        else:
-            log_queue.put("[minds] Skipping tunnel token injection.")

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -105,6 +105,10 @@ class _CloudflareEnableBody(FrozenModel):
         default=None,
         description="Service URL to register. If omitted, resolved from the backend resolver.",
     )
+    auth_rules: list[dict[str, object]] | None = Field(
+        default=None,
+        description="Auth policy rules to apply. If omitted, uses tunnel default.",
+    )
 
 
 # -- Cloudflare forwarding routes --
@@ -125,13 +129,21 @@ def _handle_cloudflare_status(
 
     services = cf_client.list_services(parsed_id)
     if services is None:
-        # No tunnel exists yet or query failed -- treat as not enabled
-        return _json_response({"enabled": False, "url": None})
+        # No tunnel exists yet -- return default auth from tunnel (if any)
+        default_rules = cf_client.get_tunnel_auth(parsed_id)
+        return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or []})
 
     hostname = services.get(server_name)
     if hostname:
-        return _json_response({"enabled": True, "url": f"https://{hostname}"})
-    return _json_response({"enabled": False, "url": None})
+        # Service is enabled -- get its specific auth policy
+        auth_rules = cf_client.get_service_auth(parsed_id, server_name)
+        if auth_rules is None:
+            auth_rules = cf_client.get_tunnel_auth(parsed_id) or []
+        return _json_response({"enabled": True, "url": f"https://{hostname}", "auth_rules": auth_rules})
+
+    # Tunnel exists but this service isn't enabled -- return tunnel default auth
+    default_rules = cf_client.get_tunnel_auth(parsed_id)
+    return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or []})
 
 
 def _handle_cloudflare_enable(
@@ -170,10 +182,15 @@ def _handle_cloudflare_enable(
         _inject_tunnel_token_into_agent(parsed_id, token)
 
     is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
+    if not is_success:
+        return _json_error("Cloudflare API call failed", 502)
 
-    if is_success:
-        return _json_response({"ok": True})
-    return _json_error("Cloudflare API call failed", 502)
+    # Apply auth rules if provided
+    auth_rules = body.auth_rules if body is not None else None
+    if auth_rules is not None:
+        cf_client.set_service_auth(parsed_id, str(parsed_server), auth_rules)
+
+    return _json_response({"ok": True})
 
 
 def _handle_cloudflare_disable(

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -97,7 +97,8 @@ def _handle_cloudflare_status(
 
     services = cf_client.list_services(parsed_id)
     if services is None:
-        return _json_error("Failed to query Cloudflare services", 502)
+        # No tunnel exists yet or query failed -- treat as not enabled
+        return _json_response({"enabled": False, "url": None})
 
     hostname = services.get(server_name)
     if hostname:

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -24,6 +24,7 @@ from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.deps import BackendResolverDep
+from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
 from imbue.minds.desktop_client.tunnel_token_store import save_tunnel_token
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
@@ -156,18 +157,16 @@ def _handle_cloudflare_enable(
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
-    # Ensure the tunnel exists before adding a service.
-    # The tunnel is normally created during agent creation, but may not exist
-    # if the agent was created without Cloudflare configured.
-    services = cf_client.list_services(parsed_id)
-    if services is None:
+    # Ensure the tunnel exists and we have a token for it.
+    # create_tunnel is idempotent -- if the tunnel already exists, it returns
+    # the existing token. We always need the token to inject into the agent.
+    paths: WorkspacePaths = request.app.state.api_v1_paths
+    stored_token = load_tunnel_token(paths.data_dir, parsed_id)
+    if stored_token is None:
         token, message = cf_client.create_tunnel(parsed_id)
         if token is None:
             return _json_error(f"Failed to create Cloudflare tunnel: {message}", 502)
-        # Store the token so it can be re-injected on agent restart/rediscovery
-        paths: WorkspacePaths = request.app.state.api_v1_paths
         save_tunnel_token(paths.data_dir, parsed_id, token)
-        # Inject the token into the agent's runtime/secrets so cloudflared starts
         _inject_tunnel_token_into_agent(parsed_id, token)
 
     is_success = cf_client.add_service(parsed_id, parsed_server, service_url)

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -127,23 +127,28 @@ def _handle_cloudflare_status(
 
     parsed_id = AgentId(agent_id)
 
+    # Build the default auth rules from the owner email for when no policy is stored
+    owner_default_rules = [
+        {"action": "allow", "include": [{"email": {"email": str(cf_client.owner_email)}}]},
+    ]
+
     services = cf_client.list_services(parsed_id)
     if services is None:
-        # No tunnel exists yet -- return default auth from tunnel (if any)
+        # No tunnel exists yet -- return owner email as the default
         default_rules = cf_client.get_tunnel_auth(parsed_id)
-        return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or []})
+        return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or owner_default_rules})
 
     hostname = services.get(server_name)
     if hostname:
         # Service is enabled -- get its specific auth policy
         auth_rules = cf_client.get_service_auth(parsed_id, server_name)
         if auth_rules is None:
-            auth_rules = cf_client.get_tunnel_auth(parsed_id) or []
+            auth_rules = cf_client.get_tunnel_auth(parsed_id) or owner_default_rules
         return _json_response({"enabled": True, "url": f"https://{hostname}", "auth_rules": auth_rules})
 
-    # Tunnel exists but this service isn't enabled -- return tunnel default auth
+    # Tunnel exists but this service isn't enabled -- return tunnel default or owner email
     default_rules = cf_client.get_tunnel_auth(parsed_id)
-    return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or []})
+    return _json_response({"enabled": False, "url": None, "auth_rules": default_rules or owner_default_rules})
 
 
 def _handle_cloudflare_enable(

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -129,6 +129,15 @@ def _handle_cloudflare_enable(
             return _json_error("Server not found locally", 404)
         service_url = backend_url
 
+    # Ensure the tunnel exists before adding a service.
+    # The tunnel is normally created during agent creation, but may not exist
+    # if the agent was created without Cloudflare configured.
+    services = cf_client.list_services(parsed_id)
+    if services is None:
+        token, message = cf_client.create_tunnel(parsed_id)
+        if token is None:
+            return _json_error(f"Failed to create Cloudflare tunnel: {message}", 502)
+
     is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
 
     if is_success:

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -82,6 +82,29 @@ class _CloudflareEnableBody(FrozenModel):
 # -- Cloudflare forwarding routes --
 
 
+def _handle_cloudflare_status(
+    agent_id: str,
+    server_name: str,
+    request: Request,
+    _caller_agent_id: CallerAgentIdDep,
+) -> Response:
+    """Get Cloudflare forwarding status for a server."""
+    cf_client: CloudflareForwardingClient | None = request.app.state.cloudflare_client
+    if cf_client is None:
+        return _json_error("Cloudflare forwarding not configured", 501)
+
+    parsed_id = AgentId(agent_id)
+
+    services = cf_client.list_services(parsed_id)
+    if services is None:
+        return _json_error("Failed to query Cloudflare services", 502)
+
+    hostname = services.get(server_name)
+    if hostname:
+        return _json_response({"enabled": True, "url": f"https://{hostname}"})
+    return _json_response({"enabled": False, "url": None})
+
+
 def _handle_cloudflare_enable(
     agent_id: str,
     server_name: str,
@@ -259,6 +282,9 @@ def create_api_v1_router() -> APIRouter:
     router = APIRouter()
 
     # Cloudflare forwarding
+    router.get(
+        "/agents/{agent_id}/servers/{server_name}/cloudflare",
+    )(_handle_cloudflare_status)
     router.put(
         "/agents/{agent_id}/servers/{server_name}/cloudflare",
     )(_handle_cloudflare_enable)

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -6,6 +6,7 @@ per-agent API keys (Bearer tokens) with SHA-256 hash lookup.
 """
 
 import json
+import shlex
 from typing import Annotated
 
 from fastapi import APIRouter
@@ -13,13 +14,17 @@ from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import Request
 from fastapi.responses import Response
+from loguru import logger
 from pydantic import Field
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.deps import BackendResolverDep
+from imbue.minds.desktop_client.tunnel_token_store import save_tunnel_token
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
@@ -53,6 +58,28 @@ def _authenticate_api_key(request: Request) -> AgentId:
 
 
 CallerAgentIdDep = Annotated[AgentId, Depends(_authenticate_api_key)]
+
+
+def _inject_tunnel_token_into_agent(agent_id: AgentId, token: str) -> None:
+    """Write the tunnel token to the agent's runtime/secrets via mngr exec.
+
+    This causes the cloudflare-tunnel service inside the agent to detect
+    the token and start cloudflared.
+    """
+    safe_token = shlex.quote(token)
+    cg = ConcurrencyGroup(name="inject-tunnel-token")
+    with cg:
+        result = cg.run_process_to_completion(
+            command=[
+                MNGR_BINARY,
+                "exec",
+                str(agent_id),
+                f"mkdir -p runtime && printf 'export CLOUDFLARE_TUNNEL_TOKEN=%s\\n' {safe_token} > runtime/secrets",
+            ],
+            is_checked_after=False,
+        )
+    if result.returncode != 0:
+        logger.warning("Failed to inject tunnel token into agent {}: {}", agent_id, result.stderr.strip())
 
 
 def _json_response(data: dict[str, object], status_code: int = 200) -> Response:
@@ -137,6 +164,11 @@ def _handle_cloudflare_enable(
         token, message = cf_client.create_tunnel(parsed_id)
         if token is None:
             return _json_error(f"Failed to create Cloudflare tunnel: {message}", 502)
+        # Store the token so it can be re-injected on agent restart/rediscovery
+        paths: WorkspacePaths = request.app.state.api_v1_paths
+        save_tunnel_token(paths.data_dir, parsed_id, token)
+        # Inject the token into the agent's runtime/secrets so cloudflared starts
+        _inject_tunnel_token_into_agent(parsed_id, token)
 
     is_success = cf_client.add_service(parsed_id, parsed_server, service_url)
 

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -32,6 +32,7 @@ from imbue.minds.desktop_client.agent_creator import LOG_SENTINEL
 from imbue.minds.desktop_client.api_v1 import create_api_v1_router
 from imbue.minds.desktop_client.auth import AuthStoreInterface
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
+from imbue.minds.desktop_client.backend_resolver import MngrStreamManager
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
@@ -211,6 +212,16 @@ async def _managed_lifespan(
         inner_app.state.ssh_http_clients.clear()
         if not is_externally_managed_client:
             await inner_app.state.http_client.aclose()
+        # Stop mngr observe/events subprocesses before cleaning up tunnels.
+        # This runs inside uvicorn's lifespan shutdown, which happens BEFORE
+        # uvicorn re-raises the captured SIGTERM signal. A finally block
+        # around uvicorn.run() would never execute because uvicorn calls
+        # signal.raise_signal(SIGTERM) after shutdown, killing the process.
+        stream_manager: MngrStreamManager | None = inner_app.state.stream_manager
+        if stream_manager is not None:
+            logger.info("Stopping stream manager subprocesses...")
+            stream_manager.stop()
+            logger.info("Stream manager stopped.")
         tunnel_manager: SSHTunnelManager | None = inner_app.state.tunnel_manager
         if tunnel_manager is not None:
             tunnel_manager.cleanup()
@@ -1116,6 +1127,7 @@ def create_desktop_client(
     telegram_orchestrator: TelegramSetupOrchestrator | None = None,
     notification_dispatcher: NotificationDispatcher | None = None,
     paths: WorkspacePaths | None = None,
+    stream_manager: MngrStreamManager | None = None,
 ) -> FastAPI:
     """Create the desktop client FastAPI application.
 
@@ -1153,6 +1165,7 @@ def create_desktop_client(
     app.state.auth_store = auth_store
     app.state.backend_resolver = backend_resolver
     app.state.tunnel_manager = tunnel_manager
+    app.state.stream_manager = stream_manager
     app.state.agent_creator = agent_creator
     app.state.cloudflare_client = cloudflare_client
     app.state.telegram_orchestrator = telegram_orchestrator

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -327,7 +327,7 @@ def _handle_agent_default_redirect(
     if not _is_authenticated(cookies=request.cookies, auth_store=auth_store):
         return Response(status_code=403, content="Not authenticated")
 
-    return Response(status_code=307, headers={"Location": f"/agents/{agent_id}/web/"})
+    return Response(status_code=307, headers={"Location": f"/forwarding/{agent_id}/web/"})
 
 
 async def _handle_agent_servers_page(
@@ -1194,26 +1194,26 @@ def create_desktop_client(
     app.get("/creating/{agent_id}")(_handle_creating_page)
 
     # Agent default page: redirect to web server
-    app.get("/agents/{agent_id}/")(_handle_agent_default_redirect)
+    app.get("/forwarding/{agent_id}/")(_handle_agent_default_redirect)
 
-    # Agent server listing page: /agents/{agent_id}/servers/
-    app.get("/agents/{agent_id}/servers/")(_handle_agent_servers_page)
+    # Agent server listing page: /forwarding/{agent_id}/servers/
+    app.get("/forwarding/{agent_id}/servers/")(_handle_agent_servers_page)
 
     # Toggle global forwarding for a server
-    app.post("/agents/{agent_id}/servers/{server_name}/global")(_handle_toggle_global)
+    app.post("/forwarding/{agent_id}/servers/{server_name}/global")(_handle_toggle_global)
 
     # Telegram setup routes
     app.post("/api/agents/{agent_id}/telegram/setup")(_handle_telegram_setup)
     app.get("/api/agents/{agent_id}/telegram/status")(_handle_telegram_status)
 
-    # Proxy routes: /agents/{agent_id}/{server_name}/{path:path}
+    # Proxy routes: /forwarding/{agent_id}/{server_name}/{path:path}
     app.api_route(
-        "/agents/{agent_id}/{server_name}/{path:path}",
+        "/forwarding/{agent_id}/{server_name}/{path:path}",
         methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
     )(_handle_proxy_http)
 
     # WebSocket route needs manual dependency wiring since Depends doesn't work on WS
-    @app.websocket("/agents/{agent_id}/{server_name}/{path:path}")
+    @app.websocket("/forwarding/{agent_id}/{server_name}/{path:path}")
     async def proxy_websocket(websocket: WebSocket, agent_id: str, server_name: str, path: str) -> None:
         await _handle_proxy_websocket(
             websocket=websocket,

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -373,14 +373,13 @@ class MngrStreamManager(MutableModel):
     resolver: MngrCliBackendResolver = Field(frozen=True, description="Backend resolver to update with streaming data")
     mngr_binary: str = Field(default=MNGR_BINARY, frozen=True, description="Path to mngr binary")
 
-    _cg: ConcurrencyGroup = PrivateAttr(
-        default_factory=lambda: ConcurrencyGroup(name="mngr-stream-manager", exit_timeout_seconds=2.0)
-    )
+    _cg: ConcurrencyGroup = PrivateAttr(default_factory=lambda: ConcurrencyGroup(name="mngr-stream-manager"))
     _known_agent_ids: set[str] = PrivateAttr(default_factory=set)
     _agent_host_map: dict[str, str] = PrivateAttr(default_factory=dict)
     _discovered_agents: tuple[DiscoveredAgent, ...] = PrivateAttr(default=())
     _ssh_by_host_id: dict[str, RemoteSSHInfo] = PrivateAttr(default_factory=dict)
     _events_servers: dict[str, dict[str, str]] = PrivateAttr(default_factory=dict)
+    _observe_process: RunningProcess | None = PrivateAttr(default=None)
     _events_processes: dict[str, RunningProcess] = PrivateAttr(default_factory=dict)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
     _on_agent_discovered_callbacks: list[Callable[[AgentId, RemoteSSHInfo | None], None]] = PrivateAttr(
@@ -402,15 +401,30 @@ class MngrStreamManager(MutableModel):
         self._cg.__enter__()
         # Run from $HOME so mngr uses its global config, not any project-specific
         # .mngr/settings.toml that might restrict behavior (e.g. is_allowed_in_pytest).
-        self._cg.run_process_in_background(
+        self._observe_process = self._cg.run_process_in_background(
             command=[self.mngr_binary, "observe", "--discovery-only", "--quiet"],
             on_output=self._on_discovery_stream_output,
             cwd=Path.home(),
         )
 
     def stop(self) -> None:
-        """Stop all streaming subprocesses."""
+        """Stop all streaming subprocesses.
+
+        Terminates the mngr observe and mngr events processes first so
+        that the threads reading their output unblock immediately, then
+        exits the ConcurrencyGroup (which joins the threads).
+        """
+        for process in self._all_managed_processes():
+            process.terminate()
         self._cg.__exit__(None, None, None)
+
+    def _all_managed_processes(self) -> list[RunningProcess]:
+        """Return all managed subprocess handles (observe + per-agent events)."""
+        result: list[RunningProcess] = []
+        if self._observe_process is not None:
+            result.append(self._observe_process)
+        result.extend(self._events_processes.values())
+        return result
 
     def _on_discovery_stream_output(self, line: str, is_stdout: bool) -> None:
         """Handle a line of output from mngr observe --discovery-only."""

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -373,7 +373,9 @@ class MngrStreamManager(MutableModel):
     resolver: MngrCliBackendResolver = Field(frozen=True, description="Backend resolver to update with streaming data")
     mngr_binary: str = Field(default=MNGR_BINARY, frozen=True, description="Path to mngr binary")
 
-    _cg: ConcurrencyGroup = PrivateAttr(default_factory=lambda: ConcurrencyGroup(name="mngr-stream-manager"))
+    _cg: ConcurrencyGroup = PrivateAttr(
+        default_factory=lambda: ConcurrencyGroup(name="mngr-stream-manager", exit_timeout_seconds=2.0)
+    )
     _known_agent_ids: set[str] = PrivateAttr(default_factory=set)
     _agent_host_map: dict[str, str] = PrivateAttr(default_factory=dict)
     _discovered_agents: tuple[DiscoveredAgent, ...] = PrivateAttr(default=())

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -382,17 +382,18 @@ class MngrStreamManager(MutableModel):
     _observe_process: RunningProcess | None = PrivateAttr(default=None)
     _events_processes: dict[str, RunningProcess] = PrivateAttr(default_factory=dict)
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
-    _on_agent_discovered_callbacks: list[Callable[[AgentId, RemoteSSHInfo | None], None]] = PrivateAttr(
+    _on_agent_discovered_callbacks: list[Callable[[AgentId, RemoteSSHInfo | None, str], None]] = PrivateAttr(
         default_factory=list
     )
 
     def add_on_agent_discovered_callback(
         self,
-        callback: Callable[[AgentId, RemoteSSHInfo | None], None],
+        callback: Callable[[AgentId, RemoteSSHInfo | None, str], None],
     ) -> None:
         """Register a callback invoked when an agent is discovered.
 
-        The callback receives the agent ID and SSH info (None for local agents).
+        The callback receives the agent ID, SSH info (None for local agents),
+        and the provider name (e.g. "docker", "local").
         """
         self._on_agent_discovered_callbacks.append(callback)
 
@@ -493,7 +494,7 @@ class MngrStreamManager(MutableModel):
         # Notify callbacks for all discovered agents
         for agent in event.agents:
             ssh_info = self._get_ssh_info_for_agent(agent.agent_id)
-            self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info)
+            self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info, str(agent.provider_name))
 
     def _handle_host_ssh_info(self, event: HostSSHInfoEvent) -> None:
         """Update SSH info for a host and refresh the resolver."""
@@ -515,7 +516,8 @@ class MngrStreamManager(MutableModel):
         # Re-fire callbacks for agents on this host now that SSH info is available.
         # This handles the case where agent discovery fires before SSH info arrives.
         for agent_id in agents_on_host:
-            self._fire_agent_discovered_callbacks(agent_id, ssh_info)
+            provider = self._get_provider_name_for_agent(agent_id)
+            self._fire_agent_discovered_callbacks(agent_id, ssh_info, provider)
 
     def _handle_agent_discovered(self, event: AgentDiscoveryEvent) -> None:
         """Incrementally add or update a single agent in the resolver."""
@@ -540,7 +542,7 @@ class MngrStreamManager(MutableModel):
 
         # Notify callbacks
         ssh_info = self._get_ssh_info_for_agent(agent.agent_id)
-        self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info)
+        self._fire_agent_discovered_callbacks(agent.agent_id, ssh_info, str(agent.provider_name))
 
     def _handle_agent_destroyed(self, event: AgentDestroyedEvent) -> None:
         """Remove a destroyed agent from the resolver and stop its events stream."""
@@ -581,6 +583,14 @@ class MngrStreamManager(MutableModel):
         for agent_id in event.agent_ids:
             self.resolver.update_servers(agent_id, {})
 
+    def _get_provider_name_for_agent(self, agent_id: AgentId) -> str:
+        """Look up the provider name for an agent. Returns 'unknown' if not found."""
+        with self._lock:
+            for agent in self._discovered_agents:
+                if agent.agent_id == agent_id:
+                    return str(agent.provider_name)
+        return "unknown"
+
     def _get_ssh_info_for_agent(self, agent_id: AgentId) -> RemoteSSHInfo | None:
         """Look up SSH info for an agent from the host mapping."""
         with self._lock:
@@ -593,11 +603,12 @@ class MngrStreamManager(MutableModel):
         self,
         agent_id: AgentId,
         ssh_info: RemoteSSHInfo | None,
+        provider_name: str,
     ) -> None:
         """Invoke all registered on_agent_discovered callbacks."""
         for callback in self._on_agent_discovered_callbacks:
             try:
-                callback(agent_id, ssh_info)
+                callback(agent_id, ssh_info, provider_name)
             except (OSError, ValueError, RuntimeError, paramiko.SSHException, SSHTunnelError) as e:
                 logger.warning("Agent discovery callback failed for {}: {}", agent_id, e)
 

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -13,6 +13,7 @@ from pydantic import Field
 from pydantic import PrivateAttr
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.concurrency_group import InvalidConcurrencyGroupStateError
 from imbue.concurrency_group.local_process import RunningProcess
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.mutable_model import MutableModel
@@ -658,13 +659,20 @@ class MngrStreamManager(MutableModel):
 
     def _start_events_stream(self, agent_id: AgentId) -> None:
         """Start mngr events <agent-id> servers --follow for a single workspace agent."""
+        if self._cg.is_shutting_down():
+            logger.debug("Skipping events stream for {} -- shutting down", agent_id)
+            return
+
         aid_str = str(agent_id)
         self._events_servers[aid_str] = {}
 
         logger.info("Starting events stream for agent {}", aid_str)
-        process = self._cg.run_process_in_background(
-            command=[self.mngr_binary, "events", aid_str, SERVERS_EVENT_SOURCE_NAME, "--follow", "--quiet"],
-            on_output=lambda line, is_stdout: self._on_events_stream_output(line, is_stdout, agent_id),
-            cwd=Path.home(),
-        )
-        self._events_processes[aid_str] = process
+        try:
+            process = self._cg.run_process_in_background(
+                command=[self.mngr_binary, "events", aid_str, SERVERS_EVENT_SOURCE_NAME, "--follow", "--quiet"],
+                on_output=lambda line, is_stdout: self._on_events_stream_output(line, is_stdout, agent_id),
+                cwd=Path.home(),
+            )
+            self._events_processes[aid_str] = process
+        except InvalidConcurrencyGroupStateError:
+            logger.debug("Cannot start events stream for {} -- concurrency group is no longer active", agent_id)

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
@@ -976,7 +976,7 @@ def test_add_on_agent_discovered_callback_fires_on_full_snapshot() -> None:
     """Registered callbacks are invoked when a DISCOVERY_FULL event is processed."""
     manager = _make_stream_manager()
     discovered: list[AgentId] = []
-    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info: discovered.append(agent_id))
+    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info, provider: discovered.append(agent_id))
 
     full_line = _make_discovery_full_line(
         agents=[(str(_AGENT_A), _HOST_CALLBACK_TEST)],
@@ -991,7 +991,7 @@ def test_add_on_agent_discovered_callback_fires_on_agent_discovered() -> None:
     """Registered callbacks are invoked when an AGENT_DISCOVERED event is processed."""
     manager = _make_stream_manager()
     discovered: list[AgentId] = []
-    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info: discovered.append(agent_id))
+    manager.add_on_agent_discovered_callback(lambda agent_id, ssh_info, provider: discovered.append(agent_id))
 
     # Use empty labels so no events stream is started (avoids needing to start _cg)
     disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
@@ -1004,7 +1004,7 @@ def test_fire_agent_discovered_callbacks_catches_exceptions() -> None:
     """Exceptions raised by callbacks are caught and logged without propagating."""
     manager = _make_stream_manager()
 
-    def failing_callback(agent_id: AgentId, ssh_info: object) -> None:
+    def failing_callback(agent_id: AgentId, ssh_info: object, provider: str) -> None:
         raise RuntimeError("callback error")
 
     manager.add_on_agent_discovered_callback(failing_callback)
@@ -1018,8 +1018,8 @@ def test_multiple_callbacks_all_invoked() -> None:
     manager = _make_stream_manager()
     results_a: list[AgentId] = []
     results_b: list[AgentId] = []
-    manager.add_on_agent_discovered_callback(lambda aid, ssh: results_a.append(aid))
-    manager.add_on_agent_discovered_callback(lambda aid, ssh: results_b.append(aid))
+    manager.add_on_agent_discovered_callback(lambda aid, ssh, prov: results_a.append(aid))
+    manager.add_on_agent_discovered_callback(lambda aid, ssh, prov: results_b.append(aid))
 
     disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})
     manager._handle_discovery_line(disc_line)
@@ -1032,7 +1032,7 @@ def test_callback_re_fired_with_ssh_info_when_host_ssh_info_arrives() -> None:
     """When SSH info arrives after agent discovery, callbacks are re-fired with ssh_info set."""
     manager = _make_stream_manager()
     ssh_infos: list[object] = []
-    manager.add_on_agent_discovered_callback(lambda aid, ssh_info: ssh_infos.append(ssh_info))
+    manager.add_on_agent_discovered_callback(lambda aid, ssh_info, prov: ssh_infos.append(ssh_info))
 
     # Discover the agent first (no SSH info yet); use empty labels to avoid events stream
     disc_line = _make_agent_discovered_line(str(_AGENT_A), _HOST_CALLBACK_TEST, labels={})

--- a/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
+++ b/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
@@ -56,9 +56,14 @@ class CloudflareForwardingClient(FrozenModel):
         credentials = f"{self.username}:{self.secret}"
         return "Basic " + base64.b64encode(credentials.encode()).decode()
 
+    @staticmethod
+    def _truncate_agent_id(agent_id: AgentId) -> str:
+        """Truncate an agent ID to a 16-char prefix for use in hostnames."""
+        return str(agent_id).removeprefix("agent-")[:16]
+
     def make_tunnel_name(self, agent_id: AgentId) -> str:
         """Build the tunnel name for an agent."""
-        return f"{self.username}--{agent_id}"
+        return f"{self.username}--{self._truncate_agent_id(agent_id)}"
 
     def create_tunnel(self, agent_id: AgentId) -> tuple[str | None, str]:
         """Create a Cloudflare tunnel for the agent and return (token, message).

--- a/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
+++ b/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
@@ -115,9 +115,13 @@ class CloudflareForwardingClient(FrozenModel):
                     "Failed to list services for {}: {} {}", tunnel_name, response.status_code, response.text
                 )
                 return None
-            services = response.json().get("services", [])
+            data = response.json()
+            # The forwarding API may return {"services": [...]} or a bare list
+            services = data.get("services", data) if isinstance(data, dict) else data
+            if not isinstance(services, list):
+                services = []
             return {s["service_name"]: s["hostname"] for s in services if "service_name" in s and "hostname" in s}
-        except (httpx.HTTPError, KeyError) as e:
+        except (httpx.HTTPError, KeyError, AttributeError) as e:
             logger.warning("Failed to list services for {}: {}", tunnel_name, e)
             return None
 

--- a/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
+++ b/apps/minds/imbue/minds/desktop_client/cloudflare_client.py
@@ -154,6 +154,59 @@ class CloudflareForwardingClient(FrozenModel):
             logger.warning("Failed to add service {} to {}: {}", service_name, tunnel_name, e)
             return False
 
+    def get_tunnel_auth(self, agent_id: AgentId) -> list[dict[str, object]] | None:
+        """Get the default auth policy rules for the agent's tunnel.
+
+        Returns the rules list, or None on failure.
+        """
+        tunnel_name = self.make_tunnel_name(agent_id)
+        try:
+            response = httpx.get(
+                f"{self.forwarding_url}/tunnels/{tunnel_name}/auth",
+                headers={"Authorization": self._auth_header()},
+                timeout=10.0,
+            )
+            if response.status_code != 200:
+                return None
+            return response.json().get("rules", [])
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("Failed to get tunnel auth for {}: {}", tunnel_name, e)
+            return None
+
+    def get_service_auth(self, agent_id: AgentId, service_name: str) -> list[dict[str, object]] | None:
+        """Get the auth policy rules for a specific service.
+
+        Returns the rules list, or None on failure.
+        """
+        tunnel_name = self.make_tunnel_name(agent_id)
+        try:
+            response = httpx.get(
+                f"{self.forwarding_url}/tunnels/{tunnel_name}/services/{service_name}/auth",
+                headers={"Authorization": self._auth_header()},
+                timeout=10.0,
+            )
+            if response.status_code != 200:
+                return None
+            return response.json().get("rules", [])
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("Failed to get service auth for {}/{}: {}", tunnel_name, service_name, e)
+            return None
+
+    def set_service_auth(self, agent_id: AgentId, service_name: str, rules: list[dict[str, object]]) -> bool:
+        """Set the auth policy rules for a specific service. Returns True on success."""
+        tunnel_name = self.make_tunnel_name(agent_id)
+        try:
+            response = httpx.put(
+                f"{self.forwarding_url}/tunnels/{tunnel_name}/services/{service_name}/auth",
+                headers={"Authorization": self._auth_header()},
+                json={"rules": rules},
+                timeout=15.0,
+            )
+            return response.status_code == 200
+        except httpx.HTTPError as e:
+            logger.warning("Failed to set service auth for {}/{}: {}", tunnel_name, service_name, e)
+            return False
+
     def remove_service(self, agent_id: AgentId, service_name: str) -> bool:
         """Remove a service from the agent's tunnel. Returns True on success."""
         tunnel_name = self.make_tunnel_name(agent_id)

--- a/apps/minds/imbue/minds/desktop_client/proxy.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy.py
@@ -19,7 +19,7 @@ _ABSOLUTE_PATH_ATTR_PATTERN: Final[re.Pattern[str]] = re.compile(
 @pure
 def _get_server_prefix(agent_id: AgentId, server_name: ServerName) -> str:
     """Return the URL prefix for a specific server of an agent."""
-    return f"/agents/{agent_id}/{server_name}"
+    return f"/forwarding/{agent_id}/{server_name}"
 
 
 @pure
@@ -164,7 +164,7 @@ def rewrite_absolute_paths_in_html(
 ) -> str:
     """Rewrite absolute-path URLs in HTML attributes to include the server prefix.
 
-    Handles href, src, action, formaction attributes. Rewrites /foo to /agents/{id}/{server}/foo
+    Handles href, src, action, formaction attributes. Rewrites /foo to /forwarding/{id}/{server}/foo
     but leaves already-prefixed paths and protocol-relative URLs (//...) unchanged.
     """
     prefix = _get_server_prefix(agent_id, server_name)
@@ -348,7 +348,7 @@ def generate_backend_loading_html(
 
         if servers_to_show:
             link_items = "".join(
-                '<a href="/agents/{agent_id}/{server}/" target="_top"'
+                '<a href="/forwarding/{agent_id}/{server}/" target="_top"'
                 ' style="color: rgb(100, 149, 237); text-decoration: none;'
                 ' margin: 0 8px;">{server}</a>'.format(agent_id=agent_id, server=server)
                 for server in servers_to_show

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -1,6 +1,5 @@
 import os
 import secrets
-import signal
 import time
 import webbrowser
 from pathlib import Path
@@ -13,7 +12,6 @@ from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.frozen_model import FrozenModel
-from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.app import create_desktop_client
@@ -39,34 +37,6 @@ _ONE_TIME_CODE_LENGTH: Final[int] = 32
 
 _DEFAULT_MNGR_HOST_DIR: Final[Path] = Path.home() / ".mngr"
 
-
-class _SubprocessCleanupState(MutableModel):
-    """Tracks whether subprocess cleanup has run, ensuring it happens exactly once.
-
-    Used to coordinate between the SIGTERM signal handler and the finally block.
-    The signal handler runs cleanup immediately on SIGTERM (before uvicorn's own
-    shutdown completes), while the finally block serves as a fallback for normal
-    exits.
-    """
-
-    model_config = {"arbitrary_types_allowed": True}
-
-    stream_manager: MngrStreamManager = Field(frozen=True, description="Stream manager to stop on cleanup")
-    tunnel_manager: SSHTunnelManager = Field(frozen=True, description="Tunnel manager to clean up")
-    is_done: bool = Field(default=False, description="Whether cleanup has already run")
-
-    def run_cleanup(self) -> None:
-        if self.is_done:
-            return
-        self.is_done = True
-        logger.info("Stopping subprocesses...")
-        self.stream_manager.stop()
-        self.tunnel_manager.cleanup()
-        logger.info("Subprocess cleanup complete.")
-
-    def handle_sigterm(self, signum: int, frame: object) -> None:
-        self.run_cleanup()
-        raise SystemExit(0)
 
 
 class AgentDiscoveryHandler(FrozenModel):
@@ -181,23 +151,20 @@ def start_desktop_client(
         thread.daemon = True
         thread.start()
 
-    # Install a SIGTERM handler that immediately starts cleaning up
-    # subprocesses. Without this, the cleanup only happens in the finally
-    # block after uvicorn completes its own graceful shutdown, which can
-    # take longer than the 5 seconds before the electron wrapper sends
-    # SIGKILL. By stopping the stream manager in the signal handler, the
-    # mngr observe/events subprocesses are terminated before the process
-    # gets killed.
-    cleanup_state = _SubprocessCleanupState(
-        stream_manager=stream_manager,
-        tunnel_manager=tunnel_manager,
-    )
-    signal.signal(signal.SIGTERM, cleanup_state.handle_sigterm)
-
     try:
-        uvicorn.run(app, host=host, port=port)
+        # Set a short graceful shutdown timeout so uvicorn exits quickly on
+        # SIGTERM. The electron wrapper sends SIGKILL after 5 seconds, and
+        # we need time in the finally block to stop mngr subprocesses.
+        uvicorn.run(app, host=host, port=port, timeout_graceful_shutdown=1)
     finally:
-        cleanup_state.run_cleanup()
+        # Stop subprocesses. The stream manager's ConcurrencyGroup has a
+        # 2-second exit timeout, which combined with uvicorn's 1-second
+        # graceful shutdown fits within electron's 5-second SIGKILL window.
+        logger.info("Stopping stream manager subprocesses...")
+        stream_manager.stop()
+        logger.info("Stream manager stopped. Cleaning up tunnels...")
+        tunnel_manager.cleanup()
+        logger.info("Subprocess cleanup complete.")
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -144,6 +144,7 @@ def start_desktop_client(
         telegram_orchestrator=telegram_orchestrator,
         notification_dispatcher=notification_dispatcher,
         paths=paths,
+        stream_manager=stream_manager,
     )
 
     if not is_no_browser:
@@ -151,25 +152,12 @@ def start_desktop_client(
         thread.daemon = True
         thread.start()
 
-    try:
-        # Set a short graceful shutdown timeout so uvicorn exits quickly on
-        # SIGTERM. The electron wrapper sends SIGKILL after 5 seconds, and
-        # we need time in the finally block to stop mngr subprocesses.
-        uvicorn.run(app, host=host, port=port, timeout_graceful_shutdown=1)
-    finally:
-        # Stop subprocesses. The stream manager's ConcurrencyGroup has a
-        # 2-second exit timeout, which combined with uvicorn's 1-second
-        # graceful shutdown fits within electron's 5-second SIGKILL window.
-        import time as _time
-
-        _t0 = _time.monotonic()
-        logger.info("[cleanup] Finally block entered. Stopping stream manager...")
-        stream_manager.stop()
-        _t1 = _time.monotonic()
-        logger.info("[cleanup] Stream manager stopped in {:.2f}s. Cleaning up tunnels...", _t1 - _t0)
-        tunnel_manager.cleanup()
-        _t2 = _time.monotonic()
-        logger.info("[cleanup] Tunnels cleaned up in {:.2f}s. Total cleanup: {:.2f}s", _t2 - _t1, _t2 - _t0)
+    # Subprocess cleanup (stream_manager.stop(), tunnel_manager.cleanup())
+    # happens in the ASGI lifespan shutdown hook inside create_desktop_client,
+    # NOT in a finally block here. Uvicorn re-raises the captured SIGTERM
+    # after shutdown (via signal.raise_signal), so a finally block around
+    # uvicorn.run() would never execute on signal-triggered shutdown.
+    uvicorn.run(app, host=host, port=port)
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -56,10 +56,9 @@ class AgentDiscoveryHandler(FrozenModel):
             self._handle_local_agent(agent_id)
 
     def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
-        # Use $MNGR_HOST_DIR on the remote host (defaults to ~/.mngr if unset).
-        # Docker containers set MNGR_HOST_DIR=/mngr, so we can't hardcode ~/.mngr.
-        agent_state_dir = f"${{MNGR_HOST_DIR:-$HOME/.mngr}}/agents/{agent_id}"
         try:
+            remote_host_dir = self.tunnel_manager.read_remote_mngr_host_dir(ssh_info)
+            agent_state_dir = f"{remote_host_dir}/agents/{agent_id}"
             remote_port = self.tunnel_manager.setup_reverse_tunnel(
                 ssh_info=ssh_info,
                 local_port=self.server_port,

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import signal
 import time
 import webbrowser
 from pathlib import Path
@@ -12,6 +13,7 @@ from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.app import create_desktop_client
@@ -36,6 +38,35 @@ from imbue.mngr.primitives import AgentId
 _ONE_TIME_CODE_LENGTH: Final[int] = 32
 
 _DEFAULT_MNGR_HOST_DIR: Final[Path] = Path.home() / ".mngr"
+
+
+class _SubprocessCleanupState(MutableModel):
+    """Tracks whether subprocess cleanup has run, ensuring it happens exactly once.
+
+    Used to coordinate between the SIGTERM signal handler and the finally block.
+    The signal handler runs cleanup immediately on SIGTERM (before uvicorn's own
+    shutdown completes), while the finally block serves as a fallback for normal
+    exits.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    stream_manager: MngrStreamManager = Field(frozen=True, description="Stream manager to stop on cleanup")
+    tunnel_manager: SSHTunnelManager = Field(frozen=True, description="Tunnel manager to clean up")
+    is_done: bool = Field(default=False, description="Whether cleanup has already run")
+
+    def run_cleanup(self) -> None:
+        if self.is_done:
+            return
+        self.is_done = True
+        logger.info("Stopping subprocesses...")
+        self.stream_manager.stop()
+        self.tunnel_manager.cleanup()
+        logger.info("Subprocess cleanup complete.")
+
+    def handle_sigterm(self, signum: int, frame: object) -> None:
+        self.run_cleanup()
+        raise SystemExit(0)
 
 
 class AgentDiscoveryHandler(FrozenModel):
@@ -150,11 +181,23 @@ def start_desktop_client(
         thread.daemon = True
         thread.start()
 
+    # Install a SIGTERM handler that immediately starts cleaning up
+    # subprocesses. Without this, the cleanup only happens in the finally
+    # block after uvicorn completes its own graceful shutdown, which can
+    # take longer than the 5 seconds before the electron wrapper sends
+    # SIGKILL. By stopping the stream manager in the signal handler, the
+    # mngr observe/events subprocesses are terminated before the process
+    # gets killed.
+    cleanup_state = _SubprocessCleanupState(
+        stream_manager=stream_manager,
+        tunnel_manager=tunnel_manager,
+    )
+    signal.signal(signal.SIGTERM, cleanup_state.handle_sigterm)
+
     try:
         uvicorn.run(app, host=host, port=port)
     finally:
-        stream_manager.stop()
-        tunnel_manager.cleanup()
+        cleanup_state.run_cleanup()
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -157,7 +157,11 @@ def start_desktop_client(
     # NOT in a finally block here. Uvicorn re-raises the captured SIGTERM
     # after shutdown (via signal.raise_signal), so a finally block around
     # uvicorn.run() would never execute on signal-triggered shutdown.
-    uvicorn.run(app, host=host, port=port)
+    #
+    # timeout_graceful_shutdown=1 ensures uvicorn cancels in-flight tasks
+    # quickly, giving the lifespan shutdown hook time to run within
+    # electron's 5-second SIGKILL window.
+    uvicorn.run(app, host=host, port=port, timeout_graceful_shutdown=1)
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -160,11 +160,16 @@ def start_desktop_client(
         # Stop subprocesses. The stream manager's ConcurrencyGroup has a
         # 2-second exit timeout, which combined with uvicorn's 1-second
         # graceful shutdown fits within electron's 5-second SIGKILL window.
-        logger.info("Stopping stream manager subprocesses...")
+        import time as _time
+
+        _t0 = _time.monotonic()
+        logger.info("[cleanup] Finally block entered. Stopping stream manager...")
         stream_manager.stop()
-        logger.info("Stream manager stopped. Cleaning up tunnels...")
+        _t1 = _time.monotonic()
+        logger.info("[cleanup] Stream manager stopped in {:.2f}s. Cleaning up tunnels...", _t1 - _t0)
         tunnel_manager.cleanup()
-        logger.info("Subprocess cleanup complete.")
+        _t2 = _time.monotonic()
+        logger.info("[cleanup] Tunnels cleaned up in {:.2f}s. Total cleanup: {:.2f}s", _t2 - _t1, _t2 - _t0)
 
 
 def _build_cloudflare_client() -> CloudflareForwardingClient | None:

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -25,6 +25,7 @@ from imbue.minds.desktop_client.cloudflare_client import CloudflareUsername
 from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
+from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
 from imbue.minds.primitives import OneTimeCode
@@ -53,6 +54,10 @@ class AgentDiscoveryHandler(FrozenModel):
     mngr_host_dir: Path = Field(
         default_factory=lambda: _DEFAULT_MNGR_HOST_DIR,
         description="Base mngr host directory for local agents (defaults to ~/.mngr)",
+    )
+    data_dir: Path = Field(
+        default_factory=lambda: _DEFAULT_MNGR_HOST_DIR.parent / ".minds",
+        description="Minds data directory for looking up stored tunnel tokens",
     )
 
     def __call__(self, agent_id: AgentId, ssh_info: RemoteSSHInfo | None, provider_name: str) -> None:
@@ -84,6 +89,19 @@ class AgentDiscoveryHandler(FrozenModel):
             logger.debug("Wrote API URL {} for remote agent {}", api_url, agent_id)
         except (SSHTunnelError, OSError, paramiko.SSHException) as e:
             logger.warning("Failed to set up reverse tunnel for agent {}: {}", agent_id, e)
+
+        # Inject stored tunnel token if one exists for this agent
+        self._inject_stored_tunnel_token(agent_id)
+
+    def _inject_stored_tunnel_token(self, agent_id: AgentId) -> None:
+        """If a tunnel token is stored for this agent, inject it via mngr exec."""
+        token = load_tunnel_token(self.data_dir, agent_id)
+        if token is None:
+            return
+        # Import here to avoid circular dependency and keep the import light
+        from imbue.minds.desktop_client.api_v1 import _inject_tunnel_token_into_agent
+
+        _inject_tunnel_token_into_agent(agent_id, token)
 
     def _handle_local_agent(self, agent_id: AgentId) -> None:
         local_state_dir = self.mngr_host_dir / "agents" / str(agent_id)
@@ -139,7 +157,9 @@ def start_desktop_client(
 
     # Register callback to set up reverse tunnels and write API URL files
     # when agents are discovered
-    discovery_handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=port)
+    discovery_handler = AgentDiscoveryHandler(
+        tunnel_manager=tunnel_manager, server_port=port, data_dir=data_directory,
+    )
     stream_manager.add_on_agent_discovered_callback(discovery_handler)
     stream_manager.start()
 

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -56,7 +56,9 @@ class AgentDiscoveryHandler(FrozenModel):
             self._handle_local_agent(agent_id)
 
     def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
-        agent_state_dir = f"~/.mngr/agents/{agent_id}"
+        # Use $MNGR_HOST_DIR on the remote host (defaults to ~/.mngr if unset).
+        # Docker containers set MNGR_HOST_DIR=/mngr, so we can't hardcode ~/.mngr.
+        agent_state_dir = f"${{MNGR_HOST_DIR:-$HOME/.mngr}}/agents/{agent_id}"
         try:
             remote_port = self.tunnel_manager.setup_reverse_tunnel(
                 ssh_info=ssh_info,

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -39,6 +39,12 @@ _DEFAULT_MNGR_HOST_DIR: Final[Path] = Path.home() / ".mngr"
 
 
 
+_PROVIDER_HOST_DIR: Final[dict[str, str]] = {
+    "docker": "/mngr",
+    "modal": "/mngr",
+}
+
+
 class AgentDiscoveryHandler(FrozenModel):
     """Handles agent discovery events by setting up reverse tunnels and writing URL files."""
 
@@ -49,15 +55,21 @@ class AgentDiscoveryHandler(FrozenModel):
         description="Base mngr host directory for local agents (defaults to ~/.mngr)",
     )
 
-    def __call__(self, agent_id: AgentId, ssh_info: RemoteSSHInfo | None) -> None:
+    def __call__(self, agent_id: AgentId, ssh_info: RemoteSSHInfo | None, provider_name: str) -> None:
         if ssh_info is not None:
-            self._handle_remote_agent(agent_id, ssh_info)
+            self._handle_remote_agent(agent_id, ssh_info, provider_name)
         else:
             self._handle_local_agent(agent_id)
 
-    def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
+    @staticmethod
+    def _remote_host_dir(provider_name: str) -> str:
+        """Return the mngr host directory for a provider, defaulting to ~/.mngr."""
+        return _PROVIDER_HOST_DIR.get(provider_name, "~/.mngr")
+
+    def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo, provider_name: str) -> None:
+        host_dir = self._remote_host_dir(provider_name)
+        agent_state_dir = f"{host_dir}/agents/{agent_id}"
         try:
-            agent_state_dir = self.tunnel_manager.read_remote_agent_state_dir(ssh_info, agent_id)
             remote_port = self.tunnel_manager.setup_reverse_tunnel(
                 ssh_info=ssh_info,
                 local_port=self.server_port,

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -57,8 +57,7 @@ class AgentDiscoveryHandler(FrozenModel):
 
     def _handle_remote_agent(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
         try:
-            remote_host_dir = self.tunnel_manager.read_remote_mngr_host_dir(ssh_info)
-            agent_state_dir = f"{remote_host_dir}/agents/{agent_id}"
+            agent_state_dir = self.tunnel_manager.read_remote_agent_state_dir(ssh_info, agent_id)
             remote_port = self.tunnel_manager.setup_reverse_tunnel(
                 ssh_info=ssh_info,
                 local_port=self.server_port,

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -134,7 +134,7 @@ def start_desktop_client(
     tunnel_manager = SSHTunnelManager()
 
     cloudflare_client = _build_cloudflare_client()
-    agent_creator = AgentCreator(paths=paths, cloudflare_client=cloudflare_client)
+    agent_creator = AgentCreator(paths=paths)
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
     is_electron = os.getenv("MINDS_ELECTRON") == "1"
     notification_dispatcher = NotificationDispatcher(is_electron=is_electron)

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -119,6 +119,9 @@ class _FakeTunnelManager(SSHTunnelManager):
             raise SSHTunnelError("simulated failure")
         return self._fake_remote_port
 
+    def read_remote_mngr_host_dir(self, ssh_info: RemoteSSHInfo) -> str:
+        return "~/.mngr"
+
     def write_api_url_to_remote(
         self,
         ssh_info: RemoteSSHInfo,

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -24,7 +24,7 @@ def test_agent_discovery_handler_writes_local_url_file(tmp_path: Path) -> None:
     agent_id = AgentId()
 
     # Call the handler with no SSH info (local agent)
-    handler(agent_id, None)
+    handler(agent_id, None, "local")
 
     url_file = tmp_path / "agents" / str(agent_id) / "minds_api_url"
     assert url_file.exists(), "minds_api_url file was not written"
@@ -89,7 +89,7 @@ def test_agent_discovery_handler_handles_local_write_error(tmp_path: Path) -> No
         mngr_host_dir=tmp_path,
     )
     agent_id = AgentId()
-    handler(agent_id, None)
+    handler(agent_id, None, "local")
     tunnel_manager.cleanup()
 
 
@@ -119,9 +119,6 @@ class _FakeTunnelManager(SSHTunnelManager):
             raise SSHTunnelError("simulated failure")
         return self._fake_remote_port
 
-    def read_remote_agent_state_dir(self, ssh_info: RemoteSSHInfo, agent_id: AgentId) -> str:
-        return f"~/.mngr/agents/{agent_id}"
-
     def write_api_url_to_remote(
         self,
         ssh_info: RemoteSSHInfo,
@@ -146,12 +143,12 @@ def test_agent_discovery_handler_handles_remote_agent(tmp_path: Path) -> None:
         mngr_host_dir=tmp_path,
     )
     agent_id = AgentId()
-    handler(agent_id, ssh_info)
+    handler(agent_id, ssh_info, "docker")
 
     assert len(fake_manager._reverse_tunnel_calls) == 1
     _, local_port, agent_state_dir = fake_manager._reverse_tunnel_calls[0]
     assert local_port == 8420
-    assert str(agent_id) in agent_state_dir
+    assert agent_state_dir == f"/mngr/agents/{agent_id}"
 
     assert len(fake_manager._write_remote_calls) == 1
     _, _, url = fake_manager._write_remote_calls[0]
@@ -175,6 +172,6 @@ def test_agent_discovery_handler_handles_remote_agent_tunnel_error(tmp_path: Pat
     )
     agent_id = AgentId()
     # Should not raise even though setup_reverse_tunnel raises SSHTunnelError
-    handler(agent_id, ssh_info)
+    handler(agent_id, ssh_info, "docker")
     assert len(fake_manager._write_remote_calls) == 0
     fake_manager.cleanup()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -119,8 +119,8 @@ class _FakeTunnelManager(SSHTunnelManager):
             raise SSHTunnelError("simulated failure")
         return self._fake_remote_port
 
-    def read_remote_mngr_host_dir(self, ssh_info: RemoteSSHInfo) -> str:
-        return "~/.mngr"
+    def read_remote_agent_state_dir(self, ssh_info: RemoteSSHInfo, agent_id: AgentId) -> str:
+        return f"~/.mngr/agents/{agent_id}"
 
     def write_api_url_to_remote(
         self,

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from pydantic import PrivateAttr
 
 from imbue.minds.desktop_client.runner import AgentDiscoveryHandler
+from imbue.minds.desktop_client.runner import _DEFAULT_MNGR_HOST_DIR
 from imbue.minds.desktop_client.runner import _build_cloudflare_client
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
@@ -66,10 +67,10 @@ def test_build_cloudflare_client_returns_client_when_configured() -> None:
 
 
 def test_agent_discovery_handler_default_mngr_host_dir() -> None:
-    """Verify the default mngr_host_dir is ~/.mngr."""
+    """Verify the default mngr_host_dir matches the module-level constant."""
     tunnel_manager = SSHTunnelManager()
     handler = AgentDiscoveryHandler(tunnel_manager=tunnel_manager, server_port=9000)
-    assert handler.mngr_host_dir == Path.home() / ".mngr"
+    assert handler.mngr_host_dir == _DEFAULT_MNGR_HOST_DIR
     tunnel_manager.cleanup()
 
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -15,6 +15,7 @@ from pydantic import PrivateAttr
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.model_update import to_update
+from imbue.mngr.primitives import AgentId
 from imbue.imbue_common.mutable_model import MutableModel
 
 _BUFFER_SIZE: Final[int] = 65536
@@ -238,33 +239,40 @@ class SSHTunnelManager(MutableModel):
 
             return remote_port
 
-    def read_remote_mngr_host_dir(self, ssh_info: RemoteSSHInfo) -> str:
-        """Read MNGR_HOST_DIR from the remote host, falling back to ~/.mngr.
+    def read_remote_agent_state_dir(self, ssh_info: RemoteSSHInfo, agent_id: AgentId) -> str:
+        """Read MNGR_AGENT_STATE_DIR from the agent's env file on the remote host.
 
-        Runs ``echo $MNGR_HOST_DIR`` on the remote host. If the variable is
-        unset or empty, falls back to the home-directory default ``~/.mngr``.
+        Checks well-known host dir locations (``/mngr`` for Docker containers,
+        then ``~/.mngr``) for the agent env file containing ``MNGR_AGENT_STATE_DIR``.
+        Falls back to ``~/.mngr/agents/{agent_id}`` if not found.
         """
+        fallback = f"~/.mngr/agents/{agent_id}"
         with self._lock:
             client = self._get_or_create_connection(ssh_info)
 
-        command = 'echo "${MNGR_HOST_DIR:-$HOME/.mngr}"'
+        # Try /mngr first (Docker convention), then ~/.mngr (default)
+        command = (
+            f'for d in /mngr "$HOME/.mngr"; do '
+            f'f="$d/agents/{agent_id}/env"; '
+            f'if [ -f "$f" ]; then grep "^MNGR_AGENT_STATE_DIR=" "$f" 2>/dev/null | head -1 | cut -d= -f2-; exit 0; fi; '
+            f"done"
+        )
         try:
             _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
             _stdin.close()
             try:
                 result = stdout.read().decode().strip()
                 exit_status = stdout.channel.recv_exit_status()
-                if exit_status != 0 or not result:
-                    logger.debug("Could not read MNGR_HOST_DIR from remote, using default")
-                    return "~/.mngr"
-                return result
+                if exit_status == 0 and result:
+                    return result
+                return fallback
             finally:
                 stdout.channel.close()
                 stdout.close()
                 stderr.close()
         except (paramiko.SSHException, OSError) as e:
-            logger.warning("Failed to read MNGR_HOST_DIR from remote {}: {}", ssh_info.host, e)
-            return "~/.mngr"
+            logger.warning("Failed to read agent state dir from remote {}: {}", ssh_info.host, e)
+            return fallback
 
     def write_api_url_to_remote(
         self,

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -15,7 +15,6 @@ from pydantic import PrivateAttr
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.model_update import to_update
-from imbue.mngr.primitives import AgentId
 from imbue.imbue_common.mutable_model import MutableModel
 
 _BUFFER_SIZE: Final[int] = 65536
@@ -238,41 +237,6 @@ class SSHTunnelManager(MutableModel):
             thread.start()
 
             return remote_port
-
-    def read_remote_agent_state_dir(self, ssh_info: RemoteSSHInfo, agent_id: AgentId) -> str:
-        """Read MNGR_AGENT_STATE_DIR from the agent's env file on the remote host.
-
-        Checks well-known host dir locations (``/mngr`` for Docker containers,
-        then ``~/.mngr``) for the agent env file containing ``MNGR_AGENT_STATE_DIR``.
-        Falls back to ``~/.mngr/agents/{agent_id}`` if not found.
-        """
-        fallback = f"~/.mngr/agents/{agent_id}"
-        with self._lock:
-            client = self._get_or_create_connection(ssh_info)
-
-        # Try /mngr first (Docker convention), then ~/.mngr (default)
-        command = (
-            f'for d in /mngr "$HOME/.mngr"; do '
-            f'f="$d/agents/{agent_id}/env"; '
-            f'if [ -f "$f" ]; then grep "^MNGR_AGENT_STATE_DIR=" "$f" 2>/dev/null | head -1 | cut -d= -f2-; exit 0; fi; '
-            f"done"
-        )
-        try:
-            _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
-            _stdin.close()
-            try:
-                result = stdout.read().decode().strip()
-                exit_status = stdout.channel.recv_exit_status()
-                if exit_status == 0 and result:
-                    return result
-                return fallback
-            finally:
-                stdout.channel.close()
-                stdout.close()
-                stderr.close()
-        except (paramiko.SSHException, OSError) as e:
-            logger.warning("Failed to read agent state dir from remote {}: {}", ssh_info.host, e)
-            return fallback
 
     def write_api_url_to_remote(
         self,

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel.py
@@ -238,6 +238,34 @@ class SSHTunnelManager(MutableModel):
 
             return remote_port
 
+    def read_remote_mngr_host_dir(self, ssh_info: RemoteSSHInfo) -> str:
+        """Read MNGR_HOST_DIR from the remote host, falling back to ~/.mngr.
+
+        Runs ``echo $MNGR_HOST_DIR`` on the remote host. If the variable is
+        unset or empty, falls back to the home-directory default ``~/.mngr``.
+        """
+        with self._lock:
+            client = self._get_or_create_connection(ssh_info)
+
+        command = 'echo "${MNGR_HOST_DIR:-$HOME/.mngr}"'
+        try:
+            _stdin, stdout, stderr = client.exec_command(command, timeout=10.0)
+            _stdin.close()
+            try:
+                result = stdout.read().decode().strip()
+                exit_status = stdout.channel.recv_exit_status()
+                if exit_status != 0 or not result:
+                    logger.debug("Could not read MNGR_HOST_DIR from remote, using default")
+                    return "~/.mngr"
+                return result
+            finally:
+                stdout.channel.close()
+                stdout.close()
+                stderr.close()
+        except (paramiko.SSHException, OSError) as e:
+            logger.warning("Failed to read MNGR_HOST_DIR from remote {}: {}", ssh_info.host, e)
+            return "~/.mngr"
+
     def write_api_url_to_remote(
         self,
         ssh_info: RemoteSSHInfo,

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -674,7 +674,7 @@ def test_check_and_repair_tunnels_skips_alive_tunnel(tmp_path: Path) -> None:
     fake_client = FakeSSHClient.create(active=True)
     with manager._lock:
         manager._reverse_tunnels[conn_key] = tunnel_info
-        manager._connections[conn_key] = fake_client  # ty: ignore[invalid-argument-type]
+        manager._connections[conn_key] = fake_client
 
     manager._check_and_repair_tunnels()
 
@@ -699,7 +699,7 @@ def _make_manager_with_fake_connection(
     manager = SSHTunnelManager()
     conn_key = f"{ssh_info.host}:{ssh_info.port}"
     with manager._lock:
-        manager._connections[conn_key] = fake_client  # ty: ignore[invalid-argument-type]
+        manager._connections[conn_key] = fake_client
     return manager
 
 

--- a/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssh_tunnel_test.py
@@ -674,7 +674,7 @@ def test_check_and_repair_tunnels_skips_alive_tunnel(tmp_path: Path) -> None:
     fake_client = FakeSSHClient.create(active=True)
     with manager._lock:
         manager._reverse_tunnels[conn_key] = tunnel_info
-        manager._connections[conn_key] = fake_client  # ty: ignore[arg-type]
+        manager._connections[conn_key] = fake_client  # ty: ignore[invalid-argument-type]
 
     manager._check_and_repair_tunnels()
 
@@ -699,7 +699,7 @@ def _make_manager_with_fake_connection(
     manager = SSHTunnelManager()
     conn_key = f"{ssh_info.host}:{ssh_info.port}"
     with manager._lock:
-        manager._connections[conn_key] = fake_client  # ty: ignore[arg-type]
+        manager._connections[conn_key] = fake_client  # ty: ignore[invalid-argument-type]
     return manager
 
 

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -97,7 +97,7 @@ _LANDING_PAGE_TEMPLATE: Final[str] = (
       </thead>
       <tbody>
         {% for agent_id in agent_ids %}
-        <tr onclick="window.location='/agents/{{ agent_id }}/'" data-agent-id="{{ agent_id }}">
+        <tr onclick="window.location='/forwarding/{{ agent_id }}/'" data-agent-id="{{ agent_id }}">
           <td><span class="ws-name">{{ agent_names.get(agent_id | string, agent_id) }}</span></td>
           <td><span class="shared-with">No one</span></td>
           <td>
@@ -573,7 +573,7 @@ _AGENT_SERVERS_TEMPLATE: Final[str] = """<!DOCTYPE html>
     <li>
       <span class="server-name">{{ server_name }}</span>
       <div class="server-links">
-        <a href="/agents/{{ agent_id }}/{{ server_name }}/">Local</a>
+        <a href="/forwarding/{{ agent_id }}/{{ server_name }}/">Local</a>
         {% if cf_services and server_name in cf_services %}
         <a href="https://{{ cf_services[server_name] }}" class="global-link" target="_blank">Global</a>
         <button class="toggle-btn enabled" onclick="toggleGlobal('{{ agent_id }}', '{{ server_name }}', false)">Disable global</button>
@@ -593,7 +593,7 @@ _AGENT_SERVERS_TEMPLATE: Final[str] = """<!DOCTYPE html>
   <script>
   async function toggleGlobal(agentId, serverName, enable) {
     try {
-      const resp = await fetch('/agents/' + agentId + '/servers/' + serverName + '/global', {
+      const resp = await fetch('/forwarding/' + agentId + '/servers/' + serverName + '/global', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({enabled: enable})

--- a/apps/minds/imbue/minds/desktop_client/tunnel_token_store.py
+++ b/apps/minds/imbue/minds/desktop_client/tunnel_token_store.py
@@ -1,0 +1,44 @@
+"""Storage for Cloudflare tunnel tokens, keyed by agent ID.
+
+Tunnel tokens are stored on disk so they can be re-injected into agents
+when the desktop client restarts or when agents are rediscovered.
+"""
+
+from pathlib import Path
+
+from loguru import logger
+
+from imbue.mngr.primitives import AgentId
+
+
+def _tunnel_token_path(data_dir: Path, agent_id: AgentId) -> Path:
+    return data_dir / "agents" / str(agent_id) / "tunnel_token"
+
+
+def save_tunnel_token(data_dir: Path, agent_id: AgentId, token: str) -> None:
+    """Write the tunnel token to the per-agent token file."""
+    token_path = _tunnel_token_path(data_dir, agent_id)
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(token)
+    logger.debug("Saved tunnel token for agent {}", agent_id)
+
+
+def load_tunnel_token(data_dir: Path, agent_id: AgentId) -> str | None:
+    """Read the tunnel token for an agent, or None if not stored."""
+    token_path = _tunnel_token_path(data_dir, agent_id)
+    if not token_path.is_file():
+        return None
+    try:
+        token = token_path.read_text().strip()
+        return token if token else None
+    except OSError as e:
+        logger.debug("Failed to read tunnel token for agent {}: {}", agent_id, e)
+        return None
+
+
+def clear_tunnel_token(data_dir: Path, agent_id: AgentId) -> None:
+    """Remove the stored tunnel token for an agent."""
+    token_path = _tunnel_token_path(data_dir, agent_id)
+    if token_path.is_file():
+        token_path.unlink()
+        logger.debug("Cleared tunnel token for agent {}", agent_id)

--- a/apps/minds/imbue/minds/test_ratchets.py
+++ b/apps/minds/imbue/minds/test_ratchets.py
@@ -139,9 +139,7 @@ def test_prevent_num_prefix() -> None:
 
 
 def test_prevent_trailing_comments() -> None:
-    # All violations are CSS hex color codes (e.g. `color: #64748b;`) inside
-    # template strings in templates.py -- the regex misfires on these.
-    rc.check_trailing_comments(_DIR, snapshot(28))
+    rc.check_trailing_comments(_DIR, snapshot(0))
 
 
 def test_prevent_init_docstrings() -> None:

--- a/apps/minds/package-lock.json
+++ b/apps/minds/package-lock.json
@@ -1,0 +1,7096 @@
+{
+  "name": "minds",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "minds",
+      "version": "0.1.0",
+      "dependencies": {
+        "@todesktop/runtime": "^1.6.0"
+      },
+      "devDependencies": {
+        "@todesktop/cli": "^1.8.0",
+        "electron": "35.7.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.0.tgz",
+      "integrity": "sha512-+oqOne/h5J51LezazR+VyzKe3AK455W29JXnb4jOeVvQhC7FymledN5+XE+w5vEcMhRQ6n1f62fdGs4A44X32A==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.21",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.21.tgz",
+      "integrity": "sha512-j2y2q65BlgLGB5Pwjhv/Jopw2X/TBTzvAtI5z/DSp56U4wBj7LfhBfzbdCtFPges+Wz0g55GdoawXibOH5jGng==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.27.tgz",
+      "integrity": "sha512-ZObpYpAxL6JfgH7GnvlDD0sbzGZ0o4nijV8skatV9ZX49hJtCYbFqaEcPYptT94rgX1KUoKEderC7/fa7hybtw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "dev": true
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
+      "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.2.tgz",
+      "integrity": "sha512-jcXQVMHAQ5AEKzVD5C7s5fmAYeFOuN6lAJeNTgZK2B9aLnofWaJt8u1A8Idm8gpsBBYSaY3cVyeH5SWMOVPBLQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.2.tgz",
+      "integrity": "sha512-M91NhxqbSkI0ChkJWy69blC+rPr6HEgaeRllddSaU1pQ/7IiegeCQM9pPDIgvWnwnBSzKhUHpe6ro/jhJ+cvzw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
+      "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app": "0.14.11",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.5.tgz",
+      "integrity": "sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "dev": true
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.6.0.tgz",
+      "integrity": "sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.0.tgz",
+      "integrity": "sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz",
+      "integrity": "sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.3.tgz",
+      "integrity": "sha512-csO7ckK3SSs+NUZW1nms9EK7ckHe/1QOjiP8uAkCYa7ND18s44vjE9g3KxEeIUpyEPqZaX1EhJuFyZjHigAcYw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.3.tgz",
+      "integrity": "sha512-BxkEwWgx1of0tKaao/r2VR6WBLk/RAiyztatiONPrPE8gkitFkOnOCxf8i9cUyA5hX5RGt5H30uNn25Q6QNEmQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "dev": true
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.21.tgz",
+      "integrity": "sha512-xGFGTeICJZ5vhrmmDukeczIcFULFXybojML2+QSDFoKj5A7zbGN7KzFGSKNhDkIxpjzsYG9IleJyUebuAcmqWA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.21.tgz",
+      "integrity": "sha512-zahIUkaVKbR8zmTeBHkdfaVl6JGWlhVoSjF7CVH33nFqD3SlPEpEEegn2GNT5iAfsVdtlCyJJ9GW4YKjq+RJKQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.25.tgz",
+      "integrity": "sha512-7RhDwoDHlOK1/ou0/LeubxmjcngsTjDdrY/ssg2vwAVpUuVAhQzQvuCAOYxcX5wNC1zCgQ54AP1vdngBwbCmOQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.25.tgz",
+      "integrity": "sha512-eoOQqGLtRlseTdiemTN44LlHZpltK5gnhq8XVUuLgtIOG+odtDzrz2UoTpcJWSzaJQVxNLb/x9f39tHdDM4N4w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "dev": true
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.11.tgz",
+      "integrity": "sha512-V3uAhrz7IYJuji+OgT3qYTGKxpek/TViXti9OSsUJ4AexZ3jQjYH5Yrn7JvBxk8MGiSLsC872hh+BxQiPZsm7g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.24.tgz",
+      "integrity": "sha512-YRlejH8wLt7ThWao+HXoKUHUrZKGYq+otxkPS+8nuE5PeN1cBXX7NAJl9ueuUkBwMIrnKdnDqL/voHXxDAAt3g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "dev": true
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.2.tgz",
+      "integrity": "sha512-5EXqOThV4upjK9D38d/qOSVwOqRhemlaOFk9vCkMNNALeIlwr+4pLjtLNo4qoY8etQmU/1q4aIATE9N8PFqg0g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.23.tgz",
+      "integrity": "sha512-4+KqRRHEUUmKT6tFmnpWATOsaFfmSuBs1jXH8JzVtMLEYqq/WS9IDM92OdefFDSrAA2xGd0WN004z8mKeIIscw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "dev": true
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.2.tgz",
+      "integrity": "sha512-o/culaTeJ8GRpKXRJov21rux/n9dRaSOWLebyatFP2sqEdCxQPjVA1H9Z2fzYwQxMIU0JVmC7SPPmU11v7L6vQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.2.tgz",
+      "integrity": "sha512-R+aB38wxCH5zjIO/xu9KznI7fgiPuZAG98uVm1NcidHyyupGgIDLKigGmRGBZMnxibe/m2oxNKoZpfEbUX2aQQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "dev": true
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
+      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
+      "integrity": "sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.48.0.tgz",
+      "integrity": "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/context-async-hooks": "^2.6.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/instrumentation-undici": "0.24.0",
+        "@opentelemetry/resources": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.48.0",
+        "@sentry/node-core": "10.48.0",
+        "@sentry/opentelemetry": "10.48.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.48.0.tgz",
+      "integrity": "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "10.48.0",
+        "@sentry/opentelemetry": "10.48.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/context-async-hooks": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.48.0.tgz",
+      "integrity": "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@todesktop/cli": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@todesktop/cli/-/cli-1.23.2.tgz",
+      "integrity": "sha512-w3uiE3oxkyN+r4oFu3I4S781xvfxl6igLt/2E1syRuD7/8T6chpodynCXU5Vnypw818G3kNUje5m7XrBhLW9gQ==",
+      "dev": true,
+      "dependencies": {
+        "@segment/analytics-node": "^2.3.0",
+        "@sentry/node": "^10.29.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "archiver": "^7.0.1",
+        "axios": "^1.13.2",
+        "better-ajv-errors": "^2.0.2",
+        "bunyan": "^1.8.15",
+        "chalk": "^4.1.2",
+        "commander": "^14.0.2",
+        "conf": "^10.2.0",
+        "date-fns": "^4.1.0",
+        "del": "^6.1.1",
+        "dotenv": "^17.2.3",
+        "du": "^1.0.0",
+        "email-regex": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "final-form": "^5.0.0",
+        "find-up": "^5.0.0",
+        "firebase": "^12.6.0",
+        "git-rev-sync": "^3.0.2",
+        "ink": "^3.2.0",
+        "ink-gradient": "^2.0.0",
+        "ink-link": "^2.0.1",
+        "ink-select-input": "^4.2.2",
+        "ink-text-input": "^4.0.3",
+        "is-ci": "^4.1.0",
+        "is-installed-globally": "^0.4.0",
+        "js-yaml": "^4.1.1",
+        "latest-version": "^5.1.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.throttle": "^4.1.1",
+        "parse-author": "^2.0.0",
+        "pkg-up": "^3.1.0",
+        "pretty-bytes": "^5.6.0",
+        "prop-types": "^15.8.1",
+        "react": "^17.0.2",
+        "react-final-form": "^7.0.0",
+        "semver": "^7.7.3",
+        "source-map-support": "^0.5.21",
+        "stream-to-array": "^2.3.0",
+        "superagent": "^10.2.3",
+        "uuid": "^11.1.0",
+        "ws": "^8.18.3",
+        "xdg-basedir": "^4.0.0"
+      },
+      "bin": {
+        "todesktop": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@todesktop/runtime": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@todesktop/runtime/-/runtime-1.6.4.tgz",
+      "integrity": "sha512-n6dOxhrKKsXMM+i2u9iRvoJSR2KCWw0orYK+FT9RbWNPykhuFIYd0yy8dYgYy/OuClKGyGl4SJFi2757FLhWDA==",
+      "dependencies": {
+        "del": "^6.0.0",
+        "electron-updater": "^4.6.1",
+        "eventemitter2": "^6.4.5",
+        "execa": "^5.0.0",
+        "lodash.once": "^4.1.1",
+        "semver": "^7.3.2"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "dev": true,
+      "dependencies": {
+        "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+      "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yoga-layout": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
+      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
+      "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/arr-rotate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/arr-rotate/-/arr-rotate-1.0.0.tgz",
+      "integrity": "sha512-yOzOZcR9Tn7enTF66bqKorGGH0F36vcPaSWg8fO0c0UYb3LX3VMXj5ZxEqQLNOecAhlRJ7wYZja5i4jTlnbIfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/atomically": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+      "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/author-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
+      "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.0.tgz",
+      "integrity": "sha512-xzqKsCFxAek9aezYhjJuJRXBIaYlg/0OGDTZp+T8eYmYMlm66cs6cYko02drIyjN2CBbi+I6L7YfXyqpqtKRXA==",
+      "dev": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "dev": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dev": true,
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/better-ajv-errors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-2.0.3.tgz",
+      "integrity": "sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@humanwhocodes/momoa": "^2.0.4",
+        "chalk": "^4.1.2",
+        "jsonpointer": "^5.0.1",
+        "leven": "^3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">= 18.20.6"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz",
+      "integrity": "sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "dev": true,
+      "engines": [
+        "node >=0.10.0"
+      ],
+      "bin": {
+        "bunyan": "bin/bunyan"
+      },
+      "optionalDependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
+      "dev": true,
+      "dependencies": {
+        "convert-to-spaces": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/conf": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+      "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+      "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+      "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/del": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dev": true,
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/du": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/du/-/du-1.0.0.tgz",
+      "integrity": "sha512-w00+6XpIq924IvDLyOOx5HFO4KwH6YV6buqFx6og/ErTaJ34kVOyI+Q2f+X8pvZkDoEgT6xspA4iYSN99mqPDA==",
+      "dev": true,
+      "dependencies": {
+        "map-async": "~0.1.1"
+      },
+      "bin": {
+        "dujs": "du.js"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer3": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
+      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
+      "dev": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/electron": {
+      "version": "35.7.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+      "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.6.5.tgz",
+      "integrity": "sha512-kdTly8O9mSZfm9fslc1mnCY+mYOeaYRy7ERa2Fed240u01BKll3aiupzkd07qKw69KvhBSzuHroIW3mF0D8DWA==",
+      "dependencies": {
+        "@types/semver": "^7.3.6",
+        "builder-util-runtime": "8.9.2",
+        "fs-extra": "^10.0.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
+    "node_modules/email-regex": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/email-regex/-/email-regex-4.0.0.tgz",
+      "integrity": "sha512-OxR2NqoYS3ZikqOkju2krRTyxngwjJ5Wh4yalpTqbBnUOr+LLwwjY2x5Sksruw6TieyQDswE5Pc83Eh6RQj3GA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/final-form": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-5.0.0.tgz",
+      "integrity": "sha512-HByosvP7x3N4bWTCPoBeUeoMatadewRifxaH3qhCQI2DBwFNO0m5wxETLVUXNGWz2yokdSCMdJEvtjfZoXnqDA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.0.tgz",
+      "integrity": "sha512-5Ap+pN5iEJUvBlQEZEmLuUm7Gvu6I5xv1jZ5SiSNyw4jrwlHo+4tmZv3OPPoKfN9eo1kBwyyBvi+pWHIPXwfYw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/ai": "2.11.0",
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-compat": "0.2.27",
+        "@firebase/app": "0.14.11",
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-compat": "0.4.2",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-compat": "0.4.3",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-compat": "0.2.21",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/messaging-compat": "0.2.25",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-compat": "0.2.24",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-compat": "0.2.23",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-compat": "0.4.2",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-rev-sync": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.2.tgz",
+      "integrity": "sha512-Nd5RiYpyncjLv0j6IONy0lGzAqdRXUaBctuGBbrEA2m6Bn4iDrN/9MeQTXuiquw8AEKL9D2BW0nw5m/lQvxqnQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "1.0.5",
+        "graceful-fs": "4.1.15",
+        "shelljs": "0.8.5"
+      }
+    },
+    "node_modules/git-rev-sync/node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-dirs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
+      "dev": true,
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/gradient-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-1.2.0.tgz",
+      "integrity": "sha512-Lxog7IDMMWNjwo4O0KbdBvSewk4vW6kQe5XaLuuPCyCE65AGQ1P8YqKJa5dq8TYf/Ge31F+KjWzPR5mAJvjlAg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "tinygradient": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/gradient-string/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/gradient-string/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/gradient-string/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/gradient-string/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/gradient-string/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/gradient-string/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ink": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
+      "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "auto-bind": "4.0.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.0",
+        "cli-cursor": "^3.1.0",
+        "cli-truncate": "^2.1.0",
+        "code-excerpt": "^3.0.0",
+        "indent-string": "^4.0.0",
+        "is-ci": "^2.0.0",
+        "lodash": "^4.17.20",
+        "patch-console": "^1.0.0",
+        "react-devtools-core": "^4.19.1",
+        "react-reconciler": "^0.26.2",
+        "scheduler": "^0.20.2",
+        "signal-exit": "^3.0.2",
+        "slice-ansi": "^3.0.0",
+        "stack-utils": "^2.0.2",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.12.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0",
+        "ws": "^7.5.5",
+        "yoga-layout-prebuilt": "^1.9.6"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-gradient": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ink-gradient/-/ink-gradient-2.0.0.tgz",
+      "integrity": "sha512-d2BK/EzzBRoDL54NWkS3JGE4J8xtzwRVWxDAIkQ/eQ60XIzrFMtT5JlUqgV05Qlt32Jvk50qW51YqxGJggTuqA==",
+      "dev": true,
+      "dependencies": {
+        "gradient-string": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "ink": ">=3.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/ink-link": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ink-link/-/ink-link-2.0.1.tgz",
+      "integrity": "sha512-244mypIguXjMz+vW9F0fMrgFJyDy8ZEoMUYTMW7FOB2Vlb9IqkVZOtDL7sLaeOSQj28L9of591FJR6JpvsF4lA==",
+      "dev": true,
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "terminal-link": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "ink": ">=3.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/ink-select-input": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-4.2.2.tgz",
+      "integrity": "sha512-E5AS2Vnd4CSzEa7Rm+hG47wxRQo1ASfh4msKxO7FHmn/ym+GKSSsFIfR+FonqjKNDPXYJClw8lM47RdN3Pi+nw==",
+      "dev": true,
+      "dependencies": {
+        "arr-rotate": "^1.0.0",
+        "figures": "^3.2.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ink": "^3.0.5",
+        "react": "^16.5.2 || ^17.0.0"
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-4.0.3.tgz",
+      "integrity": "sha512-eQD01ik9ltmNoHmkeQ2t8LszYkv2XwuPSUz3ie/85qer6Ll/j0QSlSaLNl6ENHZakBHdCBVZY04iOXcLLXA0PQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "type-fest": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ink": "^3.0.0-3",
+        "react": "^16.5.2 || ^17.0.0"
+      }
+    },
+    "node_modules/ink-text-input/node_modules/type-fest": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.15.1.tgz",
+      "integrity": "sha512-n+UXrN8i5ioo7kqT/nF8xsEzLaqFra7k32SEsSPwvXVGyAcRgV/FUQN/sgfptJTR1oRmmq7z4IXMFSM7im7C9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/ink/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/ink/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-4.1.0.tgz",
+      "integrity": "sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "dependencies": {
+        "ci-info": "^4.1.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+      "dev": true,
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+      "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "dependencies": {
+        "package-json": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "dev": true
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/map-async": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/map-async/-/map-async-0.1.1.tgz",
+      "integrity": "sha512-nim726/DRF1yuTrx3qNJcFNqJCgiFD98eh/49EdI5LWTspX4whkVvT0hOcMEVJWCijKkp519vCY1uD05Hklc6w==",
+      "dev": true
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mv/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/mv/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/mv/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mv/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mv/node_modules/rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "glob": "^6.0.1"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "dependencies": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/package-json/node_modules/@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json/node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/package-json/node_modules/defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+      "dev": true
+    },
+    "node_modules/package-json/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/package-json/node_modules/got/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json/node_modules/json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
+      "dev": true
+    },
+    "node_modules/package-json/node_modules/keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "node_modules/package-json/node_modules/normalize-url": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json/node_modules/p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json/node_modules/responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "node_modules/package-json/node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/parse-author": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
+      "integrity": "sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==",
+      "dev": true,
+      "dependencies": {
+        "author-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
+      "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-core": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.28.5.tgz",
+      "integrity": "sha512-cq/o30z9W2Wb4rzBefjv5fBalHU0rJGZCHAkf/RHSBWSSYwh8PlQTqqOJmgIIbBtpj27T6FIPXeomIjZtCNVqA==",
+      "dev": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-final-form": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-7.0.0.tgz",
+      "integrity": "sha512-aEeAWbSsCLVXa4GBkJtjjyhPyX4L/Pgp5P/jXZwdz0YYcK6Zs/0PkgB+qWMSyIsbbGGE7m9yYlSpui5E5Gx26A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      },
+      "peerDependencies": {
+        "final-form": "^5.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
+      "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+      "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+      "dev": true,
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "dependencies": {
+        "rc": "^1.2.8"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true
+    },
+    "node_modules/tinygradient": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-0.4.3.tgz",
+      "integrity": "sha512-tBPYQSs6eWukzzAITBSmqcOwZCKACvRa/XjPPh1mj4mnx4G3Drm51HxyCTU/TKnY8kG4hmTe5QlOh9O82aNtJQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/tinycolor2": "^1.4.0",
+        "tinycolor2": "^1.0.0"
+      }
+    },
+    "node_modules/to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "dev": true,
+      "dependencies": {
+        "prepend-http": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoga-layout-prebuilt": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
+      "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
+      "dev": true,
+      "dependencies": {
+        "@types/yoga-layout": "1.9.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    }
+  }
+}

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -136,17 +136,17 @@ agent_update() {
     fi
     echo "      Done."
 
-    echo "[3.5/4] Rebuilding minds_workspace_server frontend..."
+    echo "[3.5/4] Starting agent '${AGENT_NAME}'..."
+    uv run mngr start "${AGENT_NAME}" 2>&1
+    echo "      Agent started."
+
+    echo "[4/4] Rebuilding minds_workspace_server frontend..."
     if [[ "${MODE}" == "remote" ]]; then
-        uv run mngr exec --no-start "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
+        uv run mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
     else
         (cd "${LOCAL_TARGET}/vendor/mngr/apps/minds_workspace_server/frontend" && npm run build) 2>&1
     fi
     echo "      Frontend rebuilt."
-
-    echo "[4/4] Starting agent '${AGENT_NAME}'..."
-    uv run mngr start "${AGENT_NAME}" 2>&1
-    echo "      Agent started."
 }
 
 # --- Track B: Desktop client restart ---

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -151,69 +151,29 @@ agent_update() {
     echo "      Agent started."
 }
 
-# --- Track B: Desktop client restart ---
-
-_find_electron_pid() {
-    # Find the top-level electron process (the one running "electron .")
-    # by looking for the dist/electron binary with " ." at the end.
-    # Avoids matching zygote helpers or other electron internals which
-    # have --type= flags after the binary name.
-    pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1
-}
-
-_find_minds_backend_pids() {
-    # Find any minds forward / minds -vv backend processes (children of electron)
-    pgrep -f "minds.*forward|minds.*--format jsonl" 2>/dev/null
-}
-
-_find_mngr_stream_pids() {
-    # Find orphaned mngr observe / mngr events processes
-    pgrep -f "mngr (observe|events)" 2>/dev/null
-}
+# --- Track B: Desktop client stop and restart ---
 
 electron_stop() {
     echo "[electron] Stopping desktop client..."
-
-    # Send SIGTERM to the process group so electron, the Python backend,
-    # and all mngr subprocesses receive it simultaneously. This gives the
-    # Python backend the full shutdown window to clean up subprocesses,
-    # rather than waiting for SIGTERM to cascade through electron -> uv ->
-    # python (which can eat several seconds of the 5-second SIGKILL window).
     local electron_pid
-    electron_pid=$(_find_electron_pid)
-    if [[ -n "${electron_pid}" ]]; then
-        local pgid
-        pgid=$(ps -o pgid= -p "${electron_pid}" 2>/dev/null | tr -d ' ')
-        if [[ -n "${pgid}" ]] && [[ "${pgid}" != "0" ]]; then
-            kill -TERM -"${pgid}" 2>/dev/null || true
-        else
-            kill -TERM "${electron_pid}" 2>/dev/null || true
-        fi
+    electron_pid=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1)
+    if [[ -z "${electron_pid}" ]]; then
+        echo "[electron] No running electron app found."
+        return
     fi
 
-    # Wait up to 10 seconds for the full process tree to shut down
+    kill -TERM "${electron_pid}" 2>/dev/null || true
+
+    # Wait for clean shutdown (typically ~1.5 seconds)
     for i in $(seq 1 20); do
-        if [[ -z "$(_find_electron_pid)" ]] && [[ -z "$(_find_minds_backend_pids)" ]]; then
-            break
+        if ! ps -p "${electron_pid}" > /dev/null 2>&1; then
+            echo "[electron] Desktop client stopped."
+            return
         fi
         sleep 0.5
     done
 
-    # Verify everything is gone
-    local remaining_electron remaining_backend remaining_streams
-    remaining_electron=$(_find_electron_pid)
-    remaining_backend=$(_find_minds_backend_pids)
-    remaining_streams=$(_find_mngr_stream_pids)
-
-    if [[ -n "${remaining_electron}" ]]; then
-        echo "[electron] WARNING: Electron process ${remaining_electron} did not exit within 10 seconds after SIGTERM"
-    fi
-    if [[ -n "${remaining_backend}" ]]; then
-        echo "[electron] WARNING: minds backend process(es) still running: ${remaining_backend}"
-    fi
-    if [[ -n "${remaining_streams}" ]]; then
-        echo "[electron] WARNING: orphaned mngr observe/events process(es) still running: ${remaining_streams}"
-    fi
+    echo "[electron] WARNING: Electron did not exit within 10 seconds after SIGTERM"
 }
 
 electron_start() {
@@ -225,7 +185,6 @@ electron_start() {
         set +a
     fi
 
-    # Set env vars for the desktop client
     export MINDS_WORKSPACE_GIT_URL="${TEMPLATE_DIR}"
     export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
 
@@ -234,15 +193,13 @@ electron_start() {
     disown
 }
 
-# Stop electron first (runs in parallel with agent update)
+# Stop electron in parallel with agent update
 electron_stop &
 ELECTRON_STOP_PID=$!
 
-# Run agent update in parallel with electron shutdown
 agent_update &
 AGENT_PID=$!
 
-# Wait for both to finish
 wait "${ELECTRON_STOP_PID}"
 wait "${AGENT_PID}"
 AGENT_EXIT=$?

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -94,6 +94,7 @@ RSYNC_EXCLUDES=(
     --exclude='.ruff_cache'
     --exclude='.pytest_cache'
     --exclude='uv.lock'
+    --exclude='.external_worktrees'
 )
 
 # ---------------------------------------------------------------------------

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -136,17 +136,18 @@ agent_update() {
     fi
     echo "      Done."
 
-    echo "[3.5/4] Starting agent '${AGENT_NAME}'..."
-    uv run --directory "${MNGR_REPO_ROOT}" mngr start "${AGENT_NAME}" 2>&1
-    echo "      Agent started."
-
-    echo "[4/4] Rebuilding minds_workspace_server frontend..."
+    echo "[3.5/4] Rebuilding minds_workspace_server frontend..."
     if [[ "${MODE}" == "remote" ]]; then
-        uv run --directory "${MNGR_REPO_ROOT}" mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
+        ssh -p "${SSH_PORT}" -i "${SSH_KEY}" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
+            "${SSH_USER}@${SSH_HOST}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
     else
         (cd "${LOCAL_TARGET}/vendor/mngr/apps/minds_workspace_server/frontend" && npm run build) 2>&1
     fi
     echo "      Frontend rebuilt."
+
+    echo "[4/4] Starting agent '${AGENT_NAME}'..."
+    uv run --directory "${MNGR_REPO_ROOT}" mngr start "${AGENT_NAME}" 2>&1
+    echo "      Agent started."
 }
 
 # --- Track B: Desktop client restart ---
@@ -179,7 +180,7 @@ electron_restart() {
     export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
 
     echo "[electron] Starting desktop client (MINDS_WORKSPACE_GIT_URL=${TEMPLATE_DIR})..."
-    (cd "${MNGR_REPO_ROOT}/apps/minds" && npm start) &
+    (cd "${MNGR_REPO_ROOT}/apps/minds" && npm start >> /tmp/minds-electron.log 2>&1) &
 }
 
 # Run both tracks in parallel

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -177,13 +177,15 @@ electron_stop() {
 }
 
 electron_start() {
-    # Source .env if it exists
-    if [[ -f "${MNGR_REPO_ROOT}/.env" ]]; then
-        set -a
-        # shellcheck disable=SC1091
-        source "${MNGR_REPO_ROOT}/.env"
-        set +a
-    fi
+    # Source .env and .test_env if they exist
+    for envfile in "${MNGR_REPO_ROOT}/.env" "${MNGR_REPO_ROOT}/.test_env"; do
+        if [[ -f "${envfile}" ]]; then
+            set -a
+            # shellcheck disable=SC1090
+            source "${envfile}"
+            set +a
+        fi
+    done
 
     export MINDS_WORKSPACE_GIT_URL="${TEMPLATE_DIR}"
     export MINDS_WORKSPACE_NAME="${AGENT_NAME}"

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -152,17 +152,17 @@ agent_update() {
 # --- Track B: Desktop client restart ---
 electron_restart() {
     echo "[electron] Stopping desktop client..."
-    pkill -TERM -f "electron.*minds" 2>/dev/null || true
+    pkill -TERM -f "minds.*electron|electron.*minds" 2>/dev/null || true
 
     # Wait up to 5 seconds for graceful shutdown
     for i in $(seq 1 10); do
-        if ! pgrep -f "electron.*minds" > /dev/null 2>&1; then
+        if ! pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
             break
         fi
         sleep 0.5
     done
 
-    if pgrep -f "electron.*minds" > /dev/null 2>&1; then
+    if pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
         echo "[electron] WARNING: Electron app did not exit within 5 seconds after SIGTERM"
     fi
 
@@ -196,7 +196,7 @@ AGENT_EXIT=$?
 # Don't wait for electron -- it runs until the user closes it
 # But do check that it started successfully (give it a moment)
 sleep 1
-if ! pgrep -f "electron.*minds" > /dev/null 2>&1; then
+if ! pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
     echo "WARNING: Electron app does not appear to be running"
 fi
 

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -117,7 +117,7 @@ ELECTRON_PID=""
 # --- Track A: Agent stop -> sync -> frontend build -> start ---
 agent_update() {
     echo "[2/4] Stopping agent '${AGENT_NAME}'..."
-    uv run mngr stop "${AGENT_NAME}" 2>&1 || echo "      (agent may not have been running)"
+    uv run --directory "${MNGR_REPO_ROOT}" mngr stop "${AGENT_NAME}" 2>&1 || echo "      (agent may not have been running)"
 
     echo "[3/4] Syncing template into agent work_dir..."
     if [[ "${MODE}" == "remote" ]]; then
@@ -137,12 +137,12 @@ agent_update() {
     echo "      Done."
 
     echo "[3.5/4] Starting agent '${AGENT_NAME}'..."
-    uv run mngr start "${AGENT_NAME}" 2>&1
+    uv run --directory "${MNGR_REPO_ROOT}" mngr start "${AGENT_NAME}" 2>&1
     echo "      Agent started."
 
     echo "[4/4] Rebuilding minds_workspace_server frontend..."
     if [[ "${MODE}" == "remote" ]]; then
-        uv run mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
+        uv run --directory "${MNGR_REPO_ROOT}" mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
     else
         (cd "${LOCAL_TARGET}/vendor/mngr/apps/minds_workspace_server/frontend" && npm run build) 2>&1
     fi

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# propagate_changes -- sync code changes into a running minds agent and restart
+#
+# Syncs the local mngr repo into the template's vendor/mngr/, then syncs the
+# full template into the agent's work_dir (container or local), rebuilds the
+# frontend, restarts the agent, and restarts the Electron desktop client.
+#
+# Usage:
+#   # Remote (Docker container):
+#   propagate_changes --user root --host 127.0.0.1 --port 32768 --key ~/.mngr/.../id_ed25519
+#
+#   # Local (non-container agent):
+#   propagate_changes --target /path/to/agent/workdir
+#
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Path inference
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MNGR_REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TEMPLATE_DIR="${MNGR_REPO_ROOT}/.external_worktrees/forever-claude-template"
+
+if [[ ! -d "${TEMPLATE_DIR}" ]]; then
+    echo "ERROR: Template directory not found: ${TEMPLATE_DIR}" >&2
+    echo "       Create it with: cd ~/project/forever-claude-template && git worktree add ${TEMPLATE_DIR} -b <branch> main" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Agent name
+# ---------------------------------------------------------------------------
+
+AGENT_NAME="${MINDS_WORKSPACE_NAME:-mindtest}"
+export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+SSH_USER=""
+SSH_HOST=""
+SSH_PORT=""
+SSH_KEY=""
+LOCAL_TARGET=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --user)  SSH_USER="$2";  shift 2 ;;
+        --host)  SSH_HOST="$2";  shift 2 ;;
+        --port)  SSH_PORT="$2";  shift 2 ;;
+        --key)   SSH_KEY="$2";   shift 2 ;;
+        --target) LOCAL_TARGET="$2"; shift 2 ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            echo "Usage: propagate_changes [--user USER --host HOST --port PORT --key KEY | --target PATH]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate: need either SSH details or a local target
+if [[ -n "${SSH_HOST}" ]]; then
+    if [[ -z "${SSH_USER}" || -z "${SSH_PORT}" || -z "${SSH_KEY}" ]]; then
+        echo "ERROR: --host requires --user, --port, and --key" >&2
+        exit 1
+    fi
+    MODE="remote"
+elif [[ -n "${LOCAL_TARGET}" ]]; then
+    if [[ ! -d "${LOCAL_TARGET}" ]]; then
+        echo "ERROR: Local target directory does not exist: ${LOCAL_TARGET}" >&2
+        exit 1
+    fi
+    MODE="local"
+else
+    echo "ERROR: Must specify either --host (remote) or --target (local)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Shared rsync exclusions
+# ---------------------------------------------------------------------------
+
+RSYNC_EXCLUDES=(
+    --exclude='.git'
+    --exclude='__pycache__'
+    --exclude='.venv'
+    --exclude='node_modules'
+    --exclude='.test_output'
+    --exclude='.mypy_cache'
+    --exclude='.ruff_cache'
+    --exclude='.pytest_cache'
+    --exclude='uv.lock'
+)
+
+# ---------------------------------------------------------------------------
+# Step 1: Sync mngr repo into template's vendor/mngr/
+# ---------------------------------------------------------------------------
+
+echo "[1/4] Syncing mngr repo into template vendor/mngr/..."
+rsync -a --delete \
+    "${RSYNC_EXCLUDES[@]}" \
+    "${MNGR_REPO_ROOT}/" "${TEMPLATE_DIR}/vendor/mngr/"
+echo "      Done."
+
+# ---------------------------------------------------------------------------
+# Step 2 (parallel): Agent update + Desktop client restart
+# ---------------------------------------------------------------------------
+
+# Track background PIDs for parallel execution
+AGENT_PID=""
+ELECTRON_PID=""
+
+# --- Track A: Agent stop -> sync -> frontend build -> start ---
+agent_update() {
+    echo "[2/4] Stopping agent '${AGENT_NAME}'..."
+    uv run mngr stop "${AGENT_NAME}" 2>&1 || echo "      (agent may not have been running)"
+
+    echo "[3/4] Syncing template into agent work_dir..."
+    if [[ "${MODE}" == "remote" ]]; then
+        rsync -avz --delete \
+            "${RSYNC_EXCLUDES[@]}" \
+            --filter='protect runtime/' \
+            --filter='protect .mngr/' \
+            -e "ssh -p ${SSH_PORT} -i ${SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
+            "${TEMPLATE_DIR}/" "${SSH_USER}@${SSH_HOST}:/code/"
+    else
+        rsync -a --delete \
+            "${RSYNC_EXCLUDES[@]}" \
+            --filter='protect runtime/' \
+            --filter='protect .mngr/' \
+            "${TEMPLATE_DIR}/" "${LOCAL_TARGET}/"
+    fi
+    echo "      Done."
+
+    echo "[3.5/4] Rebuilding minds_workspace_server frontend..."
+    if [[ "${MODE}" == "remote" ]]; then
+        uv run mngr exec --no-start "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build" 2>&1
+    else
+        (cd "${LOCAL_TARGET}/vendor/mngr/apps/minds_workspace_server/frontend" && npm run build) 2>&1
+    fi
+    echo "      Frontend rebuilt."
+
+    echo "[4/4] Starting agent '${AGENT_NAME}'..."
+    uv run mngr start "${AGENT_NAME}" 2>&1
+    echo "      Agent started."
+}
+
+# --- Track B: Desktop client restart ---
+electron_restart() {
+    echo "[electron] Stopping desktop client..."
+    pkill -TERM -f "electron.*minds" 2>/dev/null || true
+
+    # Wait up to 5 seconds for graceful shutdown
+    for i in $(seq 1 10); do
+        if ! pgrep -f "electron.*minds" > /dev/null 2>&1; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if pgrep -f "electron.*minds" > /dev/null 2>&1; then
+        echo "[electron] WARNING: Electron app did not exit within 5 seconds after SIGTERM"
+    fi
+
+    # Source .env if it exists
+    if [[ -f "${MNGR_REPO_ROOT}/.env" ]]; then
+        set -a
+        # shellcheck disable=SC1091
+        source "${MNGR_REPO_ROOT}/.env"
+        set +a
+    fi
+
+    # Set env vars for the desktop client
+    export MINDS_WORKSPACE_GIT_URL="${TEMPLATE_DIR}"
+    export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
+
+    echo "[electron] Starting desktop client (MINDS_WORKSPACE_GIT_URL=${TEMPLATE_DIR})..."
+    (cd "${MNGR_REPO_ROOT}/apps/minds" && npm start) &
+}
+
+# Run both tracks in parallel
+agent_update &
+AGENT_PID=$!
+
+electron_restart &
+ELECTRON_PID=$!
+
+# Wait for the agent update track to finish (electron runs in background)
+wait "${AGENT_PID}"
+AGENT_EXIT=$?
+
+# Don't wait for electron -- it runs until the user closes it
+# But do check that it started successfully (give it a moment)
+sleep 1
+if ! pgrep -f "electron.*minds" > /dev/null 2>&1; then
+    echo "WARNING: Electron app does not appear to be running"
+fi
+
+if [[ "${AGENT_EXIT}" -ne 0 ]]; then
+    echo "ERROR: Agent update failed (exit code ${AGENT_EXIT})" >&2
+    exit 1
+fi
+
+echo ""
+echo "All changes propagated. Agent '${AGENT_NAME}' is running with updated code."

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -155,25 +155,56 @@ agent_update() {
 
 electron_stop() {
     echo "[electron] Stopping desktop client..."
-    local electron_pid
-    electron_pid=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1)
-    if [[ -z "${electron_pid}" ]]; then
-        echo "[electron] No running electron app found."
+
+    # Find ALL electron main processes (the "electron ." ones, not zygotes)
+    local pids
+    pids=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null || true)
+
+    # Also find any orphaned Python backends from previous runs
+    local backend_pids
+    backend_pids=$(pgrep -f "uv run --package minds minds" 2>/dev/null || true)
+
+    if [[ -z "${pids}" && -z "${backend_pids}" ]]; then
+        echo "[electron] No running electron app or backend found."
         return
     fi
 
-    kill -TERM "${electron_pid}" 2>/dev/null || true
+    # Kill electron processes
+    for pid in ${pids}; do
+        echo "[electron] Sending SIGTERM to electron PID ${pid}"
+        kill -TERM "${pid}" 2>/dev/null || echo "[electron] ERROR: Failed to send SIGTERM to PID ${pid}"
+    done
 
-    # Wait for clean shutdown (typically ~1.5 seconds)
-    for i in $(seq 1 20); do
-        if ! ps -p "${electron_pid}" > /dev/null 2>&1; then
+    # Kill orphaned backends
+    for pid in ${backend_pids}; do
+        echo "[electron] Sending SIGTERM to orphaned backend PID ${pid}"
+        kill -TERM "${pid}" 2>/dev/null || echo "[electron] ERROR: Failed to send SIGTERM to backend PID ${pid}"
+    done
+
+    # Wait for all to exit
+    local all_pids="${pids} ${backend_pids}"
+    for attempt in $(seq 1 20); do
+        local still_running=false
+        for pid in ${all_pids}; do
+            if ps -p "${pid}" > /dev/null 2>&1; then
+                still_running=true
+                break
+            fi
+        done
+        if [[ "${still_running}" == "false" ]]; then
             echo "[electron] Desktop client stopped."
             return
         fi
         sleep 0.5
     done
 
-    echo "[electron] WARNING: Electron did not exit within 10 seconds after SIGTERM"
+    # Force kill anything still alive
+    for pid in ${all_pids}; do
+        if ps -p "${pid}" > /dev/null 2>&1; then
+            echo "[electron] ERROR: PID ${pid} did not exit after 10s SIGTERM, sending SIGKILL"
+            kill -9 "${pid}" 2>/dev/null || true
+        fi
+    done
 }
 
 electron_start() {

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -155,9 +155,10 @@ agent_update() {
 
 _find_electron_pid() {
     # Find the top-level electron process (the one running "electron .")
-    # by looking for the dist/electron binary. Avoid matching zygote
-    # helpers or other electron internals.
-    pgrep -f "electron/dist/electron \\.\\b" 2>/dev/null | head -1
+    # by looking for the dist/electron binary with " ." at the end.
+    # Avoids matching zygote helpers or other electron internals which
+    # have --type= flags after the binary name.
+    pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1
 }
 
 _find_minds_backend_pids() {
@@ -170,7 +171,7 @@ _find_mngr_stream_pids() {
     pgrep -f "mngr (observe|events)" 2>/dev/null
 }
 
-electron_restart() {
+electron_stop() {
     echo "[electron] Stopping desktop client..."
 
     # Send SIGTERM to the top-level electron process only. Electron's
@@ -207,7 +208,9 @@ electron_restart() {
     if [[ -n "${remaining_streams}" ]]; then
         echo "[electron] WARNING: orphaned mngr observe/events process(es) still running: ${remaining_streams}"
     fi
+}
 
+electron_start() {
     # Source .env if it exists
     if [[ -f "${MNGR_REPO_ROOT}/.env" ]]; then
         set -a
@@ -225,28 +228,26 @@ electron_restart() {
     disown
 }
 
-# Run both tracks in parallel
+# Stop electron first (runs in parallel with agent update)
+electron_stop &
+ELECTRON_STOP_PID=$!
+
+# Run agent update in parallel with electron shutdown
 agent_update &
 AGENT_PID=$!
 
-electron_restart &
-ELECTRON_PID=$!
-
-# Wait for the agent update track to finish (electron runs in background)
+# Wait for both to finish
+wait "${ELECTRON_STOP_PID}"
 wait "${AGENT_PID}"
 AGENT_EXIT=$?
-
-# Don't wait for electron -- it runs until the user closes it
-# But do check that it started successfully (give it a moment)
-sleep 1
-if [[ -z "$(_find_electron_pid)" ]]; then
-    echo "WARNING: Electron app does not appear to be running"
-fi
 
 if [[ "${AGENT_EXIT}" -ne 0 ]]; then
     echo "ERROR: Agent update failed (exit code ${AGENT_EXIT})" >&2
     exit 1
 fi
+
+# Start electron after everything is clean
+electron_start
 
 echo ""
 echo "All changes propagated. Agent '${AGENT_NAME}' is running with updated code."

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -158,11 +158,16 @@ electron_stop() {
     local electron_pid
     electron_pid=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1)
     if [[ -z "${electron_pid}" ]]; then
-        echo "[electron] No running electron app found."
-        return
+        echo "[electron] ERROR: No running electron app found. If this is unexpected, check for orphaned processes:" >&2
+        echo "[electron]   pgrep -af 'electron|uv run.*minds'" >&2
+        return 1
     fi
 
-    kill -TERM "${electron_pid}" 2>/dev/null || true
+    echo "[electron] Sending SIGTERM to electron PID ${electron_pid}"
+    if ! kill -TERM "${electron_pid}"; then
+        echo "[electron] ERROR: Failed to send SIGTERM to PID ${electron_pid}" >&2
+        return 1
+    fi
 
     # Wait for clean shutdown (typically ~1.5 seconds)
     for i in $(seq 1 20); do
@@ -173,7 +178,11 @@ electron_stop() {
         sleep 0.5
     done
 
-    echo "[electron] WARNING: Electron did not exit within 10 seconds after SIGTERM"
+    echo "[electron] ERROR: Electron PID ${electron_pid} did not exit within 10 seconds after SIGTERM." >&2
+    echo "[electron] The clean shutdown chain is broken. Debug with:" >&2
+    echo "[electron]   pgrep -af 'electron|uv run.*minds'" >&2
+    echo "[electron]   tail -50 /tmp/minds-electron.log" >&2
+    return 1
 }
 
 electron_start() {
@@ -203,8 +212,15 @@ agent_update &
 AGENT_PID=$!
 
 wait "${ELECTRON_STOP_PID}"
+ELECTRON_STOP_EXIT=$?
 wait "${AGENT_PID}"
 AGENT_EXIT=$?
+
+if [[ "${ELECTRON_STOP_EXIT}" -ne 0 ]]; then
+    echo "ERROR: Electron stop failed (exit code ${ELECTRON_STOP_EXIT}). Not starting a new instance." >&2
+    echo "       Fix the issue, then re-run propagate_changes." >&2
+    exit 1
+fi
 
 if [[ "${AGENT_EXIT}" -ne 0 ]]; then
     echo "ERROR: Agent update failed (exit code ${AGENT_EXIT})" >&2

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -230,7 +230,7 @@ electron_start() {
     export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
 
     echo "[electron] Starting desktop client (MINDS_WORKSPACE_GIT_URL=${TEMPLATE_DIR})..."
-    nohup bash -c "cd '${MNGR_REPO_ROOT}/apps/minds' && npm start" >> /tmp/minds-electron.log 2>&1 &
+    setsid bash -c "cd '${MNGR_REPO_ROOT}/apps/minds' && npm start" >> /tmp/minds-electron.log 2>&1 &
     disown
 }
 

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -152,20 +152,60 @@ agent_update() {
 }
 
 # --- Track B: Desktop client restart ---
+
+_find_electron_pid() {
+    # Find the top-level electron process (the one running "electron .")
+    # by looking for the dist/electron binary. Avoid matching zygote
+    # helpers or other electron internals.
+    pgrep -f "electron/dist/electron \\.\\b" 2>/dev/null | head -1
+}
+
+_find_minds_backend_pids() {
+    # Find any minds forward / minds -vv backend processes (children of electron)
+    pgrep -f "minds.*forward|minds.*--format jsonl" 2>/dev/null
+}
+
+_find_mngr_stream_pids() {
+    # Find orphaned mngr observe / mngr events processes
+    pgrep -f "mngr (observe|events)" 2>/dev/null
+}
+
 electron_restart() {
     echo "[electron] Stopping desktop client..."
-    pkill -TERM -f "minds.*electron|electron.*minds" 2>/dev/null || true
 
-    # Wait up to 5 seconds for graceful shutdown
-    for i in $(seq 1 10); do
-        if ! pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
+    # Send SIGTERM to the top-level electron process only. Electron's
+    # before-quit handler calls shutdown() which SIGTERMs the Python
+    # backend, which then gracefully stops uvicorn, runs the finally
+    # block (stream_manager.stop()), and terminates all mngr observe /
+    # mngr events children.
+    local electron_pid
+    electron_pid=$(_find_electron_pid)
+    if [[ -n "${electron_pid}" ]]; then
+        kill -TERM "${electron_pid}" 2>/dev/null || true
+    fi
+
+    # Wait up to 10 seconds for the full process tree to shut down
+    for i in $(seq 1 20); do
+        if [[ -z "$(_find_electron_pid)" ]] && [[ -z "$(_find_minds_backend_pids)" ]]; then
             break
         fi
         sleep 0.5
     done
 
-    if pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
-        echo "[electron] WARNING: Electron app did not exit within 5 seconds after SIGTERM"
+    # Verify everything is gone
+    local remaining_electron remaining_backend remaining_streams
+    remaining_electron=$(_find_electron_pid)
+    remaining_backend=$(_find_minds_backend_pids)
+    remaining_streams=$(_find_mngr_stream_pids)
+
+    if [[ -n "${remaining_electron}" ]]; then
+        echo "[electron] WARNING: Electron process ${remaining_electron} did not exit within 10 seconds after SIGTERM"
+    fi
+    if [[ -n "${remaining_backend}" ]]; then
+        echo "[electron] WARNING: minds backend process(es) still running: ${remaining_backend}"
+    fi
+    if [[ -n "${remaining_streams}" ]]; then
+        echo "[electron] WARNING: orphaned mngr observe/events process(es) still running: ${remaining_streams}"
     fi
 
     # Source .env if it exists
@@ -199,7 +239,7 @@ AGENT_EXIT=$?
 # Don't wait for electron -- it runs until the user closes it
 # But do check that it started successfully (give it a moment)
 sleep 1
-if ! pgrep -f "minds.*electron|electron.*minds" > /dev/null 2>&1; then
+if [[ -z "$(_find_electron_pid)" ]]; then
     echo "WARNING: Electron app does not appear to be running"
 fi
 

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -174,15 +174,21 @@ _find_mngr_stream_pids() {
 electron_stop() {
     echo "[electron] Stopping desktop client..."
 
-    # Send SIGTERM to the top-level electron process only. Electron's
-    # before-quit handler calls shutdown() which SIGTERMs the Python
-    # backend, which then gracefully stops uvicorn, runs the finally
-    # block (stream_manager.stop()), and terminates all mngr observe /
-    # mngr events children.
+    # Send SIGTERM to the process group so electron, the Python backend,
+    # and all mngr subprocesses receive it simultaneously. This gives the
+    # Python backend the full shutdown window to clean up subprocesses,
+    # rather than waiting for SIGTERM to cascade through electron -> uv ->
+    # python (which can eat several seconds of the 5-second SIGKILL window).
     local electron_pid
     electron_pid=$(_find_electron_pid)
     if [[ -n "${electron_pid}" ]]; then
-        kill -TERM "${electron_pid}" 2>/dev/null || true
+        local pgid
+        pgid=$(ps -o pgid= -p "${electron_pid}" 2>/dev/null | tr -d ' ')
+        if [[ -n "${pgid}" ]] && [[ "${pgid}" != "0" ]]; then
+            kill -TERM -"${pgid}" 2>/dev/null || true
+        else
+            kill -TERM "${electron_pid}" 2>/dev/null || true
+        fi
     fi
 
     # Wait up to 10 seconds for the full process tree to shut down

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -155,56 +155,25 @@ agent_update() {
 
 electron_stop() {
     echo "[electron] Stopping desktop client..."
-
-    # Find ALL electron main processes (the "electron ." ones, not zygotes)
-    local pids
-    pids=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null || true)
-
-    # Also find any orphaned Python backends from previous runs
-    local backend_pids
-    backend_pids=$(pgrep -f "uv run --package minds minds" 2>/dev/null || true)
-
-    if [[ -z "${pids}" && -z "${backend_pids}" ]]; then
-        echo "[electron] No running electron app or backend found."
+    local electron_pid
+    electron_pid=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1)
+    if [[ -z "${electron_pid}" ]]; then
+        echo "[electron] No running electron app found."
         return
     fi
 
-    # Kill electron processes
-    for pid in ${pids}; do
-        echo "[electron] Sending SIGTERM to electron PID ${pid}"
-        kill -TERM "${pid}" 2>/dev/null || echo "[electron] ERROR: Failed to send SIGTERM to PID ${pid}"
-    done
+    kill -TERM "${electron_pid}" 2>/dev/null || true
 
-    # Kill orphaned backends
-    for pid in ${backend_pids}; do
-        echo "[electron] Sending SIGTERM to orphaned backend PID ${pid}"
-        kill -TERM "${pid}" 2>/dev/null || echo "[electron] ERROR: Failed to send SIGTERM to backend PID ${pid}"
-    done
-
-    # Wait for all to exit
-    local all_pids="${pids} ${backend_pids}"
-    for attempt in $(seq 1 20); do
-        local still_running=false
-        for pid in ${all_pids}; do
-            if ps -p "${pid}" > /dev/null 2>&1; then
-                still_running=true
-                break
-            fi
-        done
-        if [[ "${still_running}" == "false" ]]; then
+    # Wait for clean shutdown (typically ~1.5 seconds)
+    for i in $(seq 1 20); do
+        if ! ps -p "${electron_pid}" > /dev/null 2>&1; then
             echo "[electron] Desktop client stopped."
             return
         fi
         sleep 0.5
     done
 
-    # Force kill anything still alive
-    for pid in ${all_pids}; do
-        if ps -p "${pid}" > /dev/null 2>&1; then
-            echo "[electron] ERROR: PID ${pid} did not exit after 10s SIGTERM, sending SIGKILL"
-            kill -9 "${pid}" 2>/dev/null || true
-        fi
-    done
+    echo "[electron] WARNING: Electron did not exit within 10 seconds after SIGTERM"
 }
 
 electron_start() {

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -181,7 +181,8 @@ electron_restart() {
     export MINDS_WORKSPACE_NAME="${AGENT_NAME}"
 
     echo "[electron] Starting desktop client (MINDS_WORKSPACE_GIT_URL=${TEMPLATE_DIR})..."
-    (cd "${MNGR_REPO_ROOT}/apps/minds" && npm start >> /tmp/minds-electron.log 2>&1) &
+    nohup bash -c "cd '${MNGR_REPO_ROOT}/apps/minds' && npm start" >> /tmp/minds-electron.log 2>&1 &
+    disown
 }
 
 # Run both tracks in parallel

--- a/apps/minds_workspace_server/frontend/src/base-path.ts
+++ b/apps/minds_workspace_server/frontend/src/base-path.ts
@@ -34,3 +34,14 @@ export function getHostname(): string {
   cachedHostname = metaElement?.getAttribute("content") ?? "localhost";
   return cachedHostname;
 }
+
+let cachedPrimaryAgentId: string | null = null;
+
+export function getPrimaryAgentId(): string {
+  if (cachedPrimaryAgentId !== null) {
+    return cachedPrimaryAgentId;
+  }
+  const metaElement = document.querySelector('meta[name="minds-workspace-server-agent-id"]');
+  cachedPrimaryAgentId = metaElement?.getAttribute("content") ?? "";
+  return cachedPrimaryAgentId;
+}

--- a/apps/minds_workspace_server/frontend/src/models/AgentManager.ts
+++ b/apps/minds_workspace_server/frontend/src/models/AgentManager.ts
@@ -146,6 +146,11 @@ export function getAgentById(id: string): AgentState | undefined {
   return agents.find((a) => a.id === id);
 }
 
+export function removeAgentLocally(agentId: string): void {
+  agents = agents.filter((a) => a.id !== agentId);
+  delete applications[agentId];
+}
+
 export function getApplicationsForAgent(agentId: string): ApplicationEntry[] {
   return applications[agentId] ?? [];
 }

--- a/apps/minds_workspace_server/frontend/src/style.css
+++ b/apps/minds_workspace_server/frontend/src/style.css
@@ -1642,9 +1642,52 @@ body {
   border-color: var(--color-accent);
 }
 
-.share-modal-actions {
+.share-modal-header {
   display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.share-modal-header .share-modal-title {
+  margin: 0;
+}
+
+.share-modal-close-x {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.share-modal-close-x:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.share-modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.share-modal-btn-create {
+  padding: 6px 16px;
+  background: #1e293b;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.share-modal-btn-create:hover:not(:disabled) {
+  background: #334155;
 }

--- a/apps/minds_workspace_server/frontend/src/style.css
+++ b/apps/minds_workspace_server/frontend/src/style.css
@@ -1310,3 +1310,273 @@ body {
 .custom-url-dialog-open:hover {
   background: var(--color-accent-hover);
 }
+
+/* ── Custom tab renderer ── */
+.dv-custom-tab {
+  gap: 4px;
+}
+
+.dv-custom-tab-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+}
+
+.dv-custom-tab-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background 80ms, color 80ms;
+  flex-shrink: 0;
+}
+
+.dv-custom-tab-action svg {
+  width: 12px;
+  height: 12px;
+}
+
+.dv-custom-tab-action:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--color-text-primary);
+}
+
+.dv-custom-tab-action-destructive:hover {
+  background: rgba(220, 38, 38, 0.1);
+  color: #dc2626;
+}
+
+.dv-custom-tab-action-disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.dv-custom-tab-action-disabled:hover {
+  background: none;
+  color: var(--color-text-secondary);
+}
+
+/* ── Destroy confirmation dialog ── */
+.destroy-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.destroy-dialog {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.destroy-dialog-title {
+  font-family: var(--font-family-heading);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 12px;
+}
+
+.destroy-dialog-message {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.destroy-dialog-children {
+  margin-bottom: 16px;
+}
+
+.destroy-dialog-children-warning {
+  font-size: 13px;
+  font-weight: 500;
+  color: #dc2626;
+  margin: 0 0 8px;
+}
+
+.destroy-dialog-children-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.destroy-dialog-children-list li {
+  margin-bottom: 2px;
+}
+
+.destroy-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.destroy-dialog-btn {
+  padding: 8px 16px;
+  font-family: var(--font-family-base);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--radius-base);
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+}
+
+.destroy-dialog-btn-cancel {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.destroy-dialog-btn-cancel:hover {
+  background: var(--color-bg-hover);
+}
+
+.destroy-dialog-btn-destroy {
+  background: #dc2626;
+  color: #fff;
+  border-color: #dc2626;
+}
+
+.destroy-dialog-btn-destroy:hover {
+  background: #b91c1c;
+}
+
+/* ── Share modal ── */
+.share-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.share-modal {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 480px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.share-modal-title {
+  font-family: var(--font-family-heading);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 16px;
+}
+
+.share-modal-loading {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin: 0 0 16px;
+}
+
+.share-modal-error {
+  font-size: 14px;
+  color: #dc2626;
+  margin: 0 0 12px;
+}
+
+.share-modal-label {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin: 0 0 12px;
+}
+
+.share-modal-url-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.share-modal-url-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-family: var(--font-family-mono, monospace);
+  font-size: 13px;
+  color: var(--color-text-primary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  outline: none;
+}
+
+.share-modal-btn {
+  padding: 8px 16px;
+  font-family: var(--font-family-base);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--radius-base);
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+}
+
+.share-modal-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.share-modal-btn-primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
+.share-modal-btn-primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.share-modal-btn-secondary {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.share-modal-btn-secondary:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.share-modal-btn-destructive {
+  background: var(--color-surface);
+  color: #dc2626;
+  border-color: #dc2626;
+  margin-bottom: 16px;
+}
+
+.share-modal-btn-destructive:hover:not(:disabled) {
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.share-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/apps/minds_workspace_server/frontend/src/style.css
+++ b/apps/minds_workspace_server/frontend/src/style.css
@@ -1676,6 +1676,11 @@ body {
   margin-top: 16px;
 }
 
+.share-modal-footer-left {
+  display: flex;
+  gap: 8px;
+}
+
 .share-modal-btn-create {
   padding: 6px 16px;
   background: #1e293b;

--- a/apps/minds_workspace_server/frontend/src/style.css
+++ b/apps/minds_workspace_server/frontend/src/style.css
@@ -1574,6 +1574,74 @@ body {
   background: rgba(220, 38, 38, 0.05);
 }
 
+.share-modal-section {
+  margin: 16px 0;
+}
+
+.share-modal-empty {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  margin: 8px 0;
+}
+
+.share-modal-email-list {
+  list-style: none;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.share-modal-email-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.share-modal-email-item:last-child {
+  border-bottom: none;
+}
+
+.share-modal-email-remove {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.share-modal-email-remove:hover {
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.1);
+}
+
+.share-modal-add-email {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.share-modal-email-input {
+  flex: 1;
+  padding: 6px 10px;
+  font-family: var(--font-family-base);
+  font-size: 13px;
+  color: var(--color-text-primary);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-base);
+  outline: none;
+}
+
+.share-modal-email-input:focus {
+  border-color: var(--color-accent);
+}
+
 .share-modal-actions {
   display: flex;
   justify-content: flex-end;

--- a/apps/minds_workspace_server/frontend/src/style.css
+++ b/apps/minds_workspace_server/frontend/src/style.css
@@ -1530,13 +1530,19 @@ body {
 }
 
 .share-modal-btn {
-  padding: 8px 16px;
-  font-family: var(--font-family-base);
-  font-size: 13px;
-  font-weight: 500;
-  border-radius: var(--radius-base);
+  padding: 6px 16px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 6px;
   cursor: pointer;
-  border: 1px solid var(--color-border);
+  border: none;
+  background: #1e293b;
+  color: white;
+}
+
+.share-modal-btn:hover:not(:disabled) {
+  background: #334155;
 }
 
 .share-modal-btn:disabled {
@@ -1544,34 +1550,24 @@ body {
   cursor: not-allowed;
 }
 
-.share-modal-btn-primary {
-  background: var(--color-accent);
-  color: #fff;
-  border-color: var(--color-accent);
-}
-
-.share-modal-btn-primary:hover:not(:disabled) {
-  background: var(--color-accent-hover);
-}
-
 .share-modal-btn-secondary {
-  background: var(--color-surface);
-  color: var(--color-text-primary);
+  background: white;
+  color: #1e293b;
+  border: 1px solid #e2e8f0;
 }
 
 .share-modal-btn-secondary:hover:not(:disabled) {
-  background: var(--color-bg-hover);
+  background: #f1f5f9;
 }
 
 .share-modal-btn-destructive {
-  background: var(--color-surface);
+  background: white;
   color: #dc2626;
-  border-color: #dc2626;
-  margin-bottom: 16px;
+  border: 1px solid #fecaca;
 }
 
 .share-modal-btn-destructive:hover:not(:disabled) {
-  background: rgba(220, 38, 38, 0.05);
+  background: #fef2f2;
 }
 
 .share-modal-section {
@@ -1598,11 +1594,6 @@ body {
   padding: 4px 8px;
   font-size: 13px;
   color: var(--color-text-primary);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.share-modal-email-item:last-child {
-  border-bottom: none;
 }
 
 .share-modal-email-remove {
@@ -1681,18 +1672,4 @@ body {
   gap: 8px;
 }
 
-.share-modal-btn-create {
-  padding: 6px 16px;
-  background: #1e293b;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.share-modal-btn-create:hover:not(:disabled) {
-  background: #334155;
-}
+/* share-modal-btn-create uses the base .share-modal-btn styling (dark button) */

--- a/apps/minds_workspace_server/frontend/src/views/ChatPanel.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ChatPanel.ts
@@ -47,6 +47,12 @@ export function ChatPanel(): m.Component<{ agentId: string }> {
   let previousScrollTop = 0;
   let backfillStarted = false;
 
+  // Screen capture state (shown when agent has no conversation)
+  let screenContent: string | null = null;
+  let screenError: string | null = null;
+  let screenLoading = false;
+  let screenAgentId: string | null = null;
+
   // Proto-agent log state
   let logWs: WebSocket | null = null;
   let logLines: string[] = [];
@@ -54,6 +60,30 @@ export function ChatPanel(): m.Component<{ agentId: string }> {
   let logSuccess = false;
   let logError: string | null = null;
   let logAgentId: string | null = null;
+
+  async function fetchScreenCapture(agentId: string): Promise<void> {
+    if (screenAgentId === agentId && (screenContent !== null || screenLoading)) {
+      return;
+    }
+    screenAgentId = agentId;
+    screenLoading = true;
+    screenContent = null;
+    screenError = null;
+    try {
+      const result = await m.request<{ screen: string | null; error?: string }>({
+        method: "GET",
+        url: apiUrl("/api/agents/:agentId/screen"),
+        params: { agentId, scrollback: "true" },
+      });
+      screenContent = result.screen;
+      screenError = result.error ?? null;
+    } catch {
+      screenError = "Failed to capture screen";
+    } finally {
+      screenLoading = false;
+      m.redraw();
+    }
+  }
 
   function connectLogWs(agentId: string): void {
     if (logWs !== null) {
@@ -247,9 +277,19 @@ export function ChatPanel(): m.Component<{ agentId: string }> {
     manageStreamConnection(agentId);
 
     if (isConversationNotFound(agentId)) {
-      return m("div", { class: "message-list-not-found flex flex-col items-center justify-center h-full gap-2" }, [
-        m("p", { class: "text-2xl font-semibold text-text-primary" }, "404"),
-        m("p", { class: "text-text-secondary" }, "Agent not found."),
+      fetchScreenCapture(agentId);
+      return m("div", { class: "message-list-not-found flex flex-col items-center justify-center h-full gap-4 p-8" }, [
+        m("p", { class: "text-lg font-semibold text-text-primary" }, "No conversation data"),
+        m("p", { class: "text-text-secondary" }, "This agent has no Claude session. It may have crashed on startup."),
+        screenLoading
+          ? m("p", { class: "text-text-secondary" }, "Loading terminal output...")
+          : screenContent
+            ? m("pre", {
+                class: "text-sm bg-gray-900 text-gray-100 p-4 rounded-lg overflow-auto w-full max-h-96 font-mono whitespace-pre",
+              }, screenContent)
+            : screenError
+              ? m("p", { class: "text-text-secondary text-sm" }, `Could not capture terminal: ${screenError}`)
+              : null,
       ]);
     }
 

--- a/apps/minds_workspace_server/frontend/src/views/DestroyConfirmDialog.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DestroyConfirmDialog.ts
@@ -1,0 +1,51 @@
+/**
+ * Confirmation dialog for destroying an agent.
+ * Lists child chat agents when destroying a worktree/sidebar agent.
+ */
+
+import m from "mithril";
+import type { AgentState } from "../models/AgentManager";
+
+interface DestroyConfirmDialogAttrs {
+  agentName: string;
+  chatChildren: AgentState[];
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const DestroyConfirmDialog: m.Component<DestroyConfirmDialogAttrs> = {
+  view(vnode) {
+    const { agentName, chatChildren, onConfirm, onCancel } = vnode.attrs;
+
+    const hasChildren = chatChildren.length > 0;
+
+    return m("div.destroy-dialog-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) onCancel(); } }, [
+      m("div.destroy-dialog", [
+        m("h3.destroy-dialog-title", "Destroy Agent"),
+        m("p.destroy-dialog-message", [
+          `Are you sure you want to destroy `,
+          m("strong", agentName),
+          `? This cannot be undone.`,
+        ]),
+
+        hasChildren
+          ? m("div.destroy-dialog-children", [
+              m("p.destroy-dialog-children-warning",
+                "The following chat agents will also be destroyed:"
+              ),
+              m("ul.destroy-dialog-children-list",
+                chatChildren.map((child) =>
+                  m("li", { key: child.id }, child.name)
+                )
+              ),
+            ])
+          : null,
+
+        m("div.destroy-dialog-actions", [
+          m("button.destroy-dialog-btn.destroy-dialog-btn-cancel", { onclick: onCancel }, "Cancel"),
+          m("button.destroy-dialog-btn.destroy-dialog-btn-destroy", { onclick: onConfirm }, "Destroy"),
+        ]),
+      ]),
+    ]);
+  },
+};

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -301,13 +301,15 @@ function buildDropdownItems(
   // --- Applications section ---
   items.push({ label: "Applications", action: () => {}, header: true });
 
-  // Always show a terminal option, even for agents without their own ttyd.
-  // Uses the primary agent's ttyd with a workdir dispatch to open in the
-  // correct directory for the selected agent.
-  const agent = getAgentById(agentId);
-  const terminalBaseUrl = getApplicationUrl("terminal", "http://localhost:7681", agentId);
-  const terminalUrl = agent?.work_dir
-    ? `${terminalBaseUrl}?arg=workdir&arg=${encodeURIComponent(agent.work_dir)}`
+  // Always show a terminal option. Uses the primary agent's ttyd instance
+  // with a workdir dispatch to cd into the selected agent's work directory.
+  // The terminal URL always routes through the primary agent since ttyd only
+  // runs there.
+  const primaryId = getPrimaryAgentId();
+  const currentAgent = getAgentById(agentId);
+  const terminalBaseUrl = getApplicationUrl("terminal", "http://localhost:7681", primaryId || agentId);
+  const terminalUrl = currentAgent?.work_dir
+    ? `${terminalBaseUrl}?arg=workdir&arg=${encodeURIComponent(currentAgent.work_dir)}`
     : terminalBaseUrl;
   items.push({
     label: "terminal",

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -589,6 +589,7 @@ function createDockviewForAgent(agentId: string, parentElement: HTMLElement): Ag
   const dockview = new DockviewComponent(container, {
     theme: themeLight,
     defaultRenderer: "always",
+    defaultTabComponent: "custom",
     createComponent(options) {
       const params = (options as unknown as { params?: PanelParams }).params ?? panelParams.get(options.id);
 

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -38,7 +38,7 @@ function getAccessMode(): AccessMode {
   if (hostname.match(/^[^-]+--(.*)/)) {
     return "cloudflare";
   }
-  if (window.location.pathname.match(/^.*\/agents\/[^/]+\//)) {
+  if (window.location.pathname.match(/^.*\/forwarding\/[^/]+\//)) {
     return "local";
   }
   return "dev";
@@ -60,8 +60,8 @@ function getApplicationUrl(appName: string, rawUrl: string, _agentId: string): s
     return `${proto}//${appName}--${cfMatch[1]}${port}/`;
   }
 
-  // Local forwarding server: /agents/{id}/{server_name}/
-  const pathMatch = window.location.pathname.match(/^(.*\/agents\/[^/]+)\//);
+  // Local forwarding server: /forwarding/{id}/{server_name}/
+  const pathMatch = window.location.pathname.match(/^(.*\/forwarding\/[^/]+)\//);
   if (pathMatch) {
     return `${pathMatch[1]}/${appName}/`;
   }
@@ -83,7 +83,7 @@ function getTerminalUrl(): string {
 
   // Local forwarding server: always use the primary agent's terminal
   const primaryId = getPrimaryAgentId();
-  const pathMatch = window.location.pathname.match(/^(.*\/agents\/)[^/]+\//);
+  const pathMatch = window.location.pathname.match(/^(.*\/forwarding\/)[^/]+\//);
   if (pathMatch && primaryId) {
     return `${pathMatch[1]}${primaryId}/terminal/`;
   }

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -838,7 +838,7 @@ export const DockviewWorkspace: m.Component<{ agentId: string | null }> = {
         : null,
 
       showShareModal && shareServerName
-        ? m(ShareModal, {
+        ? m(ShareModal(), {
             serverName: shareServerName,
             onClose() {
               showShareModal = false;

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -38,7 +38,10 @@ function getAccessMode(): AccessMode {
   if (hostname.match(/^[^-]+--(.*)/)) {
     return "cloudflare";
   }
-  if (window.location.pathname.match(/^.*\/forwarding\/[^/]+\//)) {
+  // Local mode: detected by Mithril's /agents/:agentId/ route in the pathname.
+  // The desktop client proxy uses /forwarding/ but Mithril's pushState sets
+  // the visible pathname to its own /agents/ route.
+  if (window.location.pathname.match(/^.*\/agents\/[^/]+\//)) {
     return "local";
   }
   return "dev";
@@ -49,7 +52,7 @@ const SVG_CLOSE = '<line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2=
 const SVG_TRASH = '<polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>';
 const SVG_SHARE = '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>';
 
-function getApplicationUrl(appName: string, rawUrl: string, _agentId: string): string {
+function getApplicationUrl(appName: string, rawUrl: string, agentId: string): string {
   const hostname = window.location.hostname;
 
   // Cloudflare proxy: server--agentid--username.domain
@@ -60,10 +63,9 @@ function getApplicationUrl(appName: string, rawUrl: string, _agentId: string): s
     return `${proto}//${appName}--${cfMatch[1]}${port}/`;
   }
 
-  // Local forwarding server: /forwarding/{id}/{server_name}/
-  const pathMatch = window.location.pathname.match(/^(.*\/forwarding\/[^/]+)\//);
-  if (pathMatch) {
-    return `${pathMatch[1]}/${appName}/`;
+  // Local forwarding server: construct /forwarding/{agentId}/{appName}/
+  if (window.location.pathname.match(/^.*\/agents\/[^/]+\//) && agentId) {
+    return `/forwarding/${agentId}/${appName}/`;
   }
 
   // Dev mode (no forwarding server): use the raw URL from applications.toml
@@ -83,9 +85,8 @@ function getTerminalUrl(): string {
 
   // Local forwarding server: always use the primary agent's terminal
   const primaryId = getPrimaryAgentId();
-  const pathMatch = window.location.pathname.match(/^(.*\/forwarding\/)[^/]+\//);
-  if (pathMatch && primaryId) {
-    return `${pathMatch[1]}${primaryId}/terminal/`;
+  if (window.location.pathname.match(/^.*\/agents\/[^/]+\//) && primaryId) {
+    return `/forwarding/${primaryId}/terminal/`;
   }
 
   // Dev mode

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -29,6 +29,19 @@ import { selectAgent } from "../navigation";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 
+type AccessMode = "cloudflare" | "local" | "dev";
+
+function getAccessMode(): AccessMode {
+  const hostname = window.location.hostname;
+  if (hostname.match(/^[^-]+--(.*)/)) {
+    return "cloudflare";
+  }
+  if (window.location.pathname.match(/^.*\/agents\/[^/]+\//)) {
+    return "local";
+  }
+  return "dev";
+}
+
 // SVG path constants for tab action icons
 const SVG_CLOSE = '<line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/>';
 const SVG_TRASH = '<polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>';
@@ -537,9 +550,10 @@ async function saveLayout(agentId: string, state: AgentDockviewState): Promise<v
     panelParams[id] = params;
   }
   const payload: SavedLayout = { dockview: dockviewJson, panelParams };
+  const mode = getAccessMode();
 
   try {
-    await fetch(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/layout`), {
+    await fetch(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/layout?mode=${mode}`), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -560,8 +574,9 @@ function scheduleSave(agentId: string, state: AgentDockviewState): void {
 }
 
 async function loadLayout(agentId: string): Promise<SavedLayout | null> {
+  const mode = getAccessMode();
   try {
-    const response = await fetch(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/layout`));
+    const response = await fetch(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/layout?mode=${mode}`));
     if (!response.ok) return null;
     return (await response.json()) as SavedLayout;
   } catch {

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -68,6 +68,28 @@ function getApplicationUrl(appName: string, rawUrl: string, _agentId: string): s
   return rawUrl;
 }
 
+function getTerminalUrl(): string {
+  const hostname = window.location.hostname;
+
+  // Cloudflare proxy: terminal--agentid--username.domain
+  const cfMatch = hostname.match(/^[^-]+--(.*)/);
+  if (cfMatch) {
+    const proto = window.location.protocol;
+    const port = window.location.port ? `:${window.location.port}` : "";
+    return `${proto}//terminal--${cfMatch[1]}${port}/`;
+  }
+
+  // Local forwarding server: always use the primary agent's terminal
+  const primaryId = getPrimaryAgentId();
+  const pathMatch = window.location.pathname.match(/^(.*\/agents\/)[^/]+\//);
+  if (pathMatch && primaryId) {
+    return `${pathMatch[1]}${primaryId}/terminal/`;
+  }
+
+  // Dev mode
+  return "http://localhost:7681";
+}
+
 type PanelType = "chat" | "iframe" | "subagent";
 
 interface PanelParams {
@@ -304,10 +326,11 @@ function buildDropdownItems(
   // Always show a terminal option. Uses the primary agent's ttyd instance
   // with a workdir dispatch to cd into the selected agent's work directory.
   // The terminal URL always routes through the primary agent since ttyd only
-  // runs there.
-  const primaryId = getPrimaryAgentId();
+  // runs there -- we can't use getApplicationUrl because in local mode it
+  // derives the agent ID from the current URL path (which points to the
+  // selected agent, not the primary one).
   const currentAgent = getAgentById(agentId);
-  const terminalBaseUrl = getApplicationUrl("terminal", "http://localhost:7681", primaryId || agentId);
+  const terminalBaseUrl = getTerminalUrl();
   const terminalUrl = currentAgent?.work_dir
     ? `${terminalBaseUrl}?arg=workdir&arg=${encodeURIComponent(currentAgent.work_dir)}`
     : terminalBaseUrl;

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -25,6 +25,7 @@ import {
   getChatProtoAgentsForParent,
   getProtoAgents,
   getSidebarAgents,
+  removeAgentLocally,
 } from "../models/AgentManager";
 import { selectAgent } from "../navigation";
 
@@ -764,6 +765,13 @@ async function executeDestroy(
     alert(`Failed to destroy agent: ${(e as Error).message}`);
     return;
   }
+
+  // Remove destroyed agents from the frontend's local state immediately
+  // so the sidebar updates without waiting for the WebSocket broadcast.
+  for (const child of chatChildren) {
+    removeAgentLocally(child.id);
+  }
+  removeAgentLocally(agentId);
 
   // Remove the panel from dockview
   const state = agentDockviews.get(dockviewAgentId);

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -301,7 +301,20 @@ function buildDropdownItems(
   // --- Applications section ---
   items.push({ label: "Applications", action: () => {}, header: true });
 
-  const apps = getApplicationsForAgent(agentId).filter((app) => app.name !== "web");
+  // Always show a terminal option, even for agents without their own ttyd.
+  // Uses the primary agent's ttyd with a workdir dispatch to open in the
+  // correct directory for the selected agent.
+  const agent = getAgentById(agentId);
+  const terminalBaseUrl = getApplicationUrl("terminal", "http://localhost:7681", agentId);
+  const terminalUrl = agent?.work_dir
+    ? `${terminalBaseUrl}?arg=workdir&arg=${encodeURIComponent(agent.work_dir)}`
+    : terminalBaseUrl;
+  items.push({
+    label: "terminal",
+    action: () => openIframeTab(agentId, dockviewState, terminalUrl, "terminal"),
+  });
+
+  const apps = getApplicationsForAgent(agentId).filter((app) => app.name !== "web" && app.name !== "terminal");
   for (const app of apps) {
     const proxyUrl = getApplicationUrl(app.name, app.url, agentId);
     items.push({

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -23,6 +23,7 @@ import {
   getChatAgentsForParent,
   getApplicationsForAgent,
   getChatProtoAgentsForParent,
+  getProtoAgents,
   getSidebarAgents,
 } from "../models/AgentManager";
 import { selectAgent } from "../navigation";
@@ -713,7 +714,9 @@ async function initializeAgentDockview(agentId: string, parentElement: HTMLEleme
   }
 
   const agent = getAgentById(agentId);
-  addChatPanel(agentId, agentId, agent?.name ?? "Chat", state);
+  const proto = agent ? null : getProtoAgents().find((p) => p.agent_id === agentId);
+  const agentName = agent?.name ?? proto?.name ?? "Chat";
+  addChatPanel(agentId, agentId, agentName, state);
 }
 
 function showAgentDockview(agentId: string): void {

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -331,8 +331,11 @@ function buildDropdownItems(
   // selected agent, not the primary one).
   const currentAgent = getAgentById(agentId);
   const terminalBaseUrl = getTerminalUrl();
+  // ttyd runs `bash -c "$DISPATCH_SCRIPT" <args...>`. In bash -c, the first
+  // arg after the script becomes $0 (not $1). The dispatch script reads $1,
+  // so we prepend a dummy arg for $0.
   const terminalUrl = currentAgent?.work_dir
-    ? `${terminalBaseUrl}?arg=workdir&arg=${encodeURIComponent(currentAgent.work_dir)}`
+    ? `${terminalBaseUrl}?arg=_&arg=workdir&arg=${encodeURIComponent(currentAgent.work_dir)}`
     : terminalBaseUrl;
   items.push({
     label: "terminal",

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -838,7 +838,7 @@ export const DockviewWorkspace: m.Component<{ agentId: string | null }> = {
         : null,
 
       showShareModal && shareServerName
-        ? m(ShareModal(), {
+        ? m(ShareModal, {
             serverName: shareServerName,
             onClose() {
               showShareModal = false;

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -14,21 +14,27 @@ import {
 import { ChatPanel } from "./ChatPanel";
 import { IframePanel } from "./IframePanel";
 import { SubagentView } from "./SubagentView";
-// ProtoAgentLogView is no longer used as a separate panel type.
-// Build logs are now shown inline by ChatPanel when the agent is a proto-agent.
 import { CreateAgentModal } from "./CreateAgentModal";
-import { apiUrl } from "../base-path";
+import { DestroyConfirmDialog } from "./DestroyConfirmDialog";
+import { ShareModal } from "./ShareModal";
+import { apiUrl, getPrimaryAgentId } from "../base-path";
 import {
   getAgentById,
   getChatAgentsForParent,
   getApplicationsForAgent,
   getChatProtoAgentsForParent,
+  getSidebarAgents,
 } from "../models/AgentManager";
-// selectAgent is not used here -- chat panels stay in the parent dockview
+import { selectAgent } from "../navigation";
 
 const AUTOSAVE_DEBOUNCE_MS = 1500;
 
-function getApplicationUrl(appName: string, rawUrl: string, agentId: string): string {
+// SVG path constants for tab action icons
+const SVG_CLOSE = '<line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/>';
+const SVG_TRASH = '<polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>';
+const SVG_SHARE = '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>';
+
+function getApplicationUrl(appName: string, rawUrl: string, _agentId: string): string {
   const hostname = window.location.hostname;
 
   // Cloudflare proxy: server--agentid--username.domain
@@ -62,6 +68,17 @@ interface PanelParams {
 
 let showNewChatModal = false;
 let newChatParentAgentId: string | null = null;
+
+// Destroy dialog state
+let showDestroyDialog = false;
+let destroyTargetAgentId: string | null = null;
+let destroyTargetAgentName: string | null = null;
+let destroyTargetPanelId: string | null = null;
+let destroyTargetDockviewAgentId: string | null = null;
+
+// Share modal state
+let showShareModal = false;
+let shareServerName: string | null = null;
 
 interface SavedLayout {
   dockview: SerializedDockview;
@@ -98,6 +115,131 @@ function createMithrilRenderer(
     },
     dispose() {
       m.mount(element, null);
+    },
+  };
+}
+
+function makeSvgIcon(pathContent: string, viewBox: string = "0 0 24 24"): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${pathContent}</svg>`;
+}
+
+function createTabActionButton(
+  title: string,
+  svgPath: string,
+  onClick: (ev: MouseEvent) => void,
+  className: string = "",
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = `dv-custom-tab-action ${className}`.trim();
+  btn.title = title;
+  btn.innerHTML = makeSvgIcon(svgPath);
+  btn.addEventListener("pointerdown", (ev) => ev.preventDefault());
+  btn.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    onClick(ev);
+  });
+  return btn;
+}
+
+interface CustomTabOptions {
+  panelParams: Map<string, PanelParams>;
+  dockviewAgentId: string;
+}
+
+function createCustomTab(
+  options: { id: string; name: string },
+  tabOptions: CustomTabOptions,
+): { element: HTMLElement; init: (params: { title: string; api: { close: () => void; onDidTitleChange: (cb: (e: { title: string }) => void) => { dispose: () => void }; isActive: boolean; onDidActiveChange: (cb: (e: { isActive: boolean }) => void) => { dispose: () => void } } }) => void; dispose: () => void } {
+  const element = document.createElement("div");
+  element.className = "dv-default-tab dv-custom-tab";
+
+  const content = document.createElement("div");
+  content.className = "dv-default-tab-content";
+  element.appendChild(content);
+
+  const actions = document.createElement("div");
+  actions.className = "dv-custom-tab-actions";
+  actions.style.display = "none";
+  element.appendChild(actions);
+
+  const disposables: Array<{ dispose: () => void }> = [];
+
+  return {
+    element,
+    init(params) {
+      content.textContent = params.title ?? "";
+      disposables.push(
+        params.api.onDidTitleChange((event) => {
+          content.textContent = event.title ?? "";
+        }),
+      );
+
+      const panelParams = tabOptions.panelParams.get(options.id);
+      const panelType = panelParams?.panelType ?? "chat";
+
+      // Share button -- only on iframe/application tabs
+      if (panelType === "iframe") {
+        const serverName = panelParams?.title ?? "web";
+        actions.appendChild(
+          createTabActionButton("Share", SVG_SHARE, () => {
+            shareServerName = serverName;
+            showShareModal = true;
+            m.redraw();
+          }),
+        );
+      }
+
+      // Destroy button -- only on chat/agent tabs
+      if (panelType === "chat") {
+        const chatAgentId = panelParams?.chatAgentId ?? panelParams?.agentId ?? tabOptions.dockviewAgentId;
+        const primaryAgentId = getPrimaryAgentId();
+        const isPrimary = chatAgentId === primaryAgentId;
+
+        const destroyBtn = createTabActionButton(
+          isPrimary ? "Cannot destroy the primary agent" : "Destroy agent",
+          SVG_TRASH,
+          () => {
+            if (isPrimary) return;
+            const agent = getAgentById(chatAgentId);
+            destroyTargetAgentId = chatAgentId;
+            destroyTargetAgentName = agent?.name ?? chatAgentId;
+            destroyTargetPanelId = options.id;
+            destroyTargetDockviewAgentId = tabOptions.dockviewAgentId;
+            showDestroyDialog = true;
+            m.redraw();
+          },
+          isPrimary ? "dv-custom-tab-action-disabled" : "dv-custom-tab-action-destructive",
+        );
+        if (isPrimary) {
+          destroyBtn.disabled = true;
+        }
+        actions.appendChild(destroyBtn);
+      }
+
+      // Close button -- on all tab types
+      actions.appendChild(
+        createTabActionButton("Close tab", SVG_CLOSE, () => {
+          params.api.close();
+        }),
+      );
+
+      // Show/hide actions based on active state
+      function updateActionsVisibility(isActive: boolean): void {
+        actions.style.display = isActive ? "flex" : "none";
+      }
+      updateActionsVisibility(params.api.isActive);
+      disposables.push(
+        params.api.onDidActiveChange((event) => {
+          updateActionsVisibility(event.isActive);
+        }),
+      );
+    },
+    dispose() {
+      for (const d of disposables) {
+        d.dispose();
+      }
+      disposables.length = 0;
     },
   };
 }
@@ -146,9 +288,6 @@ function buildDropdownItems(
   // --- Applications section ---
   items.push({ label: "Applications", action: () => {}, header: true });
 
-  // Filter out the "web" application for the currently selected agent,
-  // since that's what we're already looking at. Other agents' "web" apps
-  // (e.g., worktree agents) are kept so you can preview their changes.
   const apps = getApplicationsForAgent(agentId).filter((app) => app.name !== "web");
   for (const app of apps) {
     const proxyUrl = getApplicationUrl(app.name, app.url, agentId);
@@ -188,7 +327,6 @@ function createAddTabButton(agentId: string, dockviewState: AgentDockviewState):
     if (isVisible) {
       dropdown.style.display = "none";
     } else {
-      // Rebuild dropdown items each time (dynamic content)
       dropdown.innerHTML = "";
       const items = buildDropdownItems(agentId, dockviewState);
       for (const item of items) {
@@ -223,7 +361,6 @@ function createAddTabButton(agentId: string, dockviewState: AgentDockviewState):
     }
   });
 
-  // Close dropdown when clicking outside
   const closeDropdown = (e: MouseEvent) => {
     if (!element.contains(e.target as Node)) {
       dropdown.style.display = "none";
@@ -305,7 +442,6 @@ export function openSubagentTab(agentId: string, subagentSessionId: string, desc
   const state = agentDockviews.get(agentId);
   if (!state) return;
 
-  // Check if this subagent tab is already open
   const existingPanel = state.component.panels.find((p) => {
     const params = state.panelParams.get(p.id);
     return params?.panelType === "subagent" && params.subagentSessionId === subagentSessionId;
@@ -478,6 +614,9 @@ function createDockviewForAgent(agentId: string, parentElement: HTMLElement): Ag
           return createMithrilRenderer(ChatPanel, { agentId });
       }
     },
+    createTabComponent(options) {
+      return createCustomTab(options, { panelParams, dockviewAgentId: agentId });
+    },
     createLeftHeaderActionComponent() {
       return createAddTabButton(agentId, state);
     },
@@ -505,7 +644,6 @@ async function initializeAgentDockview(agentId: string, parentElement: HTMLEleme
   const saved = await loadLayout(agentId);
 
   if (saved) {
-    // Restore panel params before fromJSON so createComponent can access them
     for (const [id, params] of Object.entries(saved.panelParams)) {
       state.panelParams.set(id, params);
     }
@@ -513,28 +651,95 @@ async function initializeAgentDockview(agentId: string, parentElement: HTMLEleme
       state.component.fromJSON(saved.dockview);
       return;
     } catch {
-      // If restore fails, fall through to default layout
       state.panelParams.clear();
     }
   }
 
-  // Default layout: single chat tab for this agent
   const agent = getAgentById(agentId);
   addChatPanel(agentId, agentId, agent?.name ?? "Chat", state);
 }
 
 function showAgentDockview(agentId: string): void {
-  // Hide all agent containers
   for (const [id, state] of agentDockviews) {
     state.container.style.display = id === agentId ? "block" : "none";
     if (id === agentId) {
-      // Trigger layout recalculation after showing
       requestAnimationFrame(() => {
         const rect = state.container.getBoundingClientRect();
         state.component.layout(rect.width, rect.height);
       });
     }
   }
+}
+
+async function executeDestroy(
+  agentId: string,
+  panelId: string,
+  dockviewAgentId: string,
+): Promise<void> {
+  const chatChildren = getChatAgentsForParent(agentId);
+
+  // Cascade: destroy children first
+  for (const child of chatChildren) {
+    try {
+      await fetch(apiUrl(`/api/agents/${encodeURIComponent(child.id)}/destroy`), {
+        method: "POST",
+      });
+    } catch {
+      // Continue even if a child destroy fails
+    }
+  }
+
+  // Destroy the target agent
+  try {
+    const response = await fetch(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/destroy`), {
+      method: "POST",
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      const detail = (data as { detail?: string }).detail ?? "Unknown error";
+      alert(`Failed to destroy agent: ${detail}`);
+      return;
+    }
+  } catch (e) {
+    alert(`Failed to destroy agent: ${(e as Error).message}`);
+    return;
+  }
+
+  // Remove the panel from dockview
+  const state = agentDockviews.get(dockviewAgentId);
+  if (state) {
+    const panel = state.component.panels.find((p) => p.id === panelId);
+    if (panel) {
+      state.component.removePanel(panel);
+    }
+
+    // Also remove any child chat panels
+    for (const child of chatChildren) {
+      const childPanelId = `chat-${child.id}`;
+      const childPanel = state.component.panels.find((p) => p.id === childPanelId);
+      if (childPanel) {
+        state.component.removePanel(childPanel);
+      }
+    }
+  }
+
+  // If the destroyed agent was a sidebar agent, auto-select another
+  const isSidebarAgent = agentId === dockviewAgentId;
+  if (isSidebarAgent) {
+    // Clean up the dockview for this agent
+    agentDockviews.delete(agentId);
+    state?.container.remove();
+
+    // Auto-select the first remaining sidebar agent
+    const remaining = getSidebarAgents().filter((a) => a.id !== agentId);
+    if (remaining.length > 0) {
+      selectAgent(remaining[0].id);
+    } else {
+      selectAgent("");
+    }
+  }
+
+  m.redraw();
 }
 
 export const DockviewWorkspace: m.Component<{ agentId: string | null }> = {
@@ -559,7 +764,6 @@ export const DockviewWorkspace: m.Component<{ agentId: string | null }> = {
     currentAgentId = agentId;
 
     if (!agentId) {
-      // Hide all
       for (const state of agentDockviews.values()) {
         state.container.style.display = "none";
       }
@@ -598,14 +802,46 @@ export const DockviewWorkspace: m.Component<{ agentId: string | null }> = {
               showNewChatModal = false;
               const state = agentDockviews.get(agentId);
               if (state) {
-                // Open a chat panel for the new agent. ChatPanel will detect
-                // it's a proto-agent and show build logs, then automatically
-                // switch to the chat view when creation completes.
                 focusOrCreateChatPanelForAgent(agentId, newAgentId, newAgentName, state);
               }
             },
             onCancel() {
               showNewChatModal = false;
+            },
+          })
+        : null,
+
+      showDestroyDialog && destroyTargetAgentId && destroyTargetAgentName
+        ? m(DestroyConfirmDialog, {
+            agentName: destroyTargetAgentName,
+            chatChildren: getChatAgentsForParent(destroyTargetAgentId),
+            onConfirm() {
+              showDestroyDialog = false;
+              const targetId = destroyTargetAgentId!;
+              const panelId = destroyTargetPanelId!;
+              const dvAgentId = destroyTargetDockviewAgentId!;
+              destroyTargetAgentId = null;
+              destroyTargetAgentName = null;
+              destroyTargetPanelId = null;
+              destroyTargetDockviewAgentId = null;
+              executeDestroy(targetId, panelId, dvAgentId);
+            },
+            onCancel() {
+              showDestroyDialog = false;
+              destroyTargetAgentId = null;
+              destroyTargetAgentName = null;
+              destroyTargetPanelId = null;
+              destroyTargetDockviewAgentId = null;
+            },
+          })
+        : null,
+
+      showShareModal && shareServerName
+        ? m(ShareModal, {
+            serverName: shareServerName,
+            onClose() {
+              showShareModal = false;
+              shareServerName = null;
             },
           })
         : null,

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -1,6 +1,6 @@
 /**
  * Modal dialog for managing Cloudflare forwarding (sharing) for a server.
- * Fetches current status, allows enabling/disabling, and provides a copy-to-clipboard button.
+ * Shows sharing status, auth policy (email list), and allows enabling/disabling/updating.
  */
 
 import m from "mithril";
@@ -14,6 +14,7 @@ interface ShareModalAttrs {
 interface SharingStatus {
   enabled: boolean;
   url: string | null;
+  auth_rules: Array<{ action: string; include: Array<{ email?: { email: string } }> }>;
 }
 
 // Module-level state for the share modal (only one can be open at a time)
@@ -23,6 +24,7 @@ let modalError: string | null = null;
 let modalActionInProgress = false;
 let modalCopied = false;
 let modalFetchedFor: string | null = null;
+let modalNewEmail = "";
 
 function resetModalState(): void {
   modalLoading = true;
@@ -31,6 +33,27 @@ function resetModalState(): void {
   modalActionInProgress = false;
   modalCopied = false;
   modalFetchedFor = null;
+  modalNewEmail = "";
+}
+
+function extractEmails(status: SharingStatus): string[] {
+  const emails: string[] = [];
+  for (const rule of status.auth_rules) {
+    for (const inc of rule.include || []) {
+      if (inc.email?.email) {
+        emails.push(inc.email.email);
+      }
+    }
+  }
+  return emails;
+}
+
+function buildAuthRules(emails: string[]): Array<{ action: string; include: Array<{ email: { email: string } }> }> {
+  if (emails.length === 0) return [];
+  return [{
+    action: "allow",
+    include: emails.map((email) => ({ email: { email } })),
+  }];
 }
 
 async function fetchStatus(serverName: string): Promise<void> {
@@ -52,11 +75,41 @@ async function fetchStatus(serverName: string): Promise<void> {
   m.redraw();
 }
 
-async function enableSharing(serverName: string): Promise<void> {
+async function enableSharing(serverName: string, emails: string[]): Promise<void> {
   modalActionInProgress = true;
   m.redraw();
   try {
-    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), { method: "PUT" });
+    const body: { auth_rules?: object[] } = {};
+    if (emails.length > 0) {
+      body.auth_rules = buildAuthRules(emails);
+    }
+    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+    } else {
+      modalStatus = (await response.json()) as SharingStatus;
+    }
+  } catch (e) {
+    modalError = `Network error: ${(e as Error).message}`;
+  }
+  modalActionInProgress = false;
+  m.redraw();
+}
+
+async function updateAuth(serverName: string, emails: string[]): Promise<void> {
+  modalActionInProgress = true;
+  m.redraw();
+  try {
+    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}/auth`), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ auth_rules: buildAuthRules(emails) }),
+    });
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
       modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
@@ -88,6 +141,72 @@ async function disableSharing(serverName: string): Promise<void> {
   m.redraw();
 }
 
+function renderEmailList(emails: string[], serverName: string, isEnabled: boolean): m.Vnode[] {
+  return [
+    m("div.share-modal-section", [
+      m("p.share-modal-label", "Allowed emails:"),
+      emails.length === 0
+        ? m("p.share-modal-empty", "No email restrictions configured. Anyone with the link can access.")
+        : m("ul.share-modal-email-list",
+            emails.map((email) =>
+              m("li.share-modal-email-item", { key: email }, [
+                m("span", email),
+                m("button.share-modal-email-remove", {
+                  title: "Remove",
+                  onclick: () => {
+                    const updated = emails.filter((e) => e !== email);
+                    if (isEnabled) {
+                      updateAuth(serverName, updated);
+                    } else if (modalStatus) {
+                      modalStatus.auth_rules = buildAuthRules(updated);
+                    }
+                  },
+                }, "x"),
+              ]),
+            ),
+          ),
+      m("div.share-modal-add-email", [
+        m("input.share-modal-email-input", {
+          type: "email",
+          placeholder: "user@example.com",
+          value: modalNewEmail,
+          oninput: (e: Event) => { modalNewEmail = (e.target as HTMLInputElement).value; },
+          onkeydown: (e: KeyboardEvent) => {
+            if (e.key === "Enter" && modalNewEmail.trim()) {
+              e.preventDefault();
+              const email = modalNewEmail.trim();
+              if (!emails.includes(email)) {
+                const updated = [...emails, email];
+                modalNewEmail = "";
+                if (isEnabled) {
+                  updateAuth(serverName, updated);
+                } else if (modalStatus) {
+                  modalStatus.auth_rules = buildAuthRules(updated);
+                }
+              }
+            }
+          },
+        }),
+        m("button.share-modal-btn.share-modal-btn-secondary", {
+          disabled: !modalNewEmail.trim(),
+          onclick: () => {
+            const email = modalNewEmail.trim();
+            if (email && !emails.includes(email)) {
+              const updated = [...emails, email];
+              modalNewEmail = "";
+              if (isEnabled) {
+                updateAuth(serverName, updated);
+              } else if (modalStatus) {
+                modalStatus.auth_rules = buildAuthRules(updated);
+              }
+            }
+          },
+        }, "Add"),
+      ]),
+    ]),
+  ];
+}
+
 export const ShareModal: m.Component<ShareModalAttrs> = {
   view(vnode) {
     const { serverName, onClose } = vnode.attrs;
@@ -98,6 +217,8 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
       modalFetchedFor = serverName;
       fetchStatus(serverName);
     }
+
+    const emails = modalStatus ? extractEmails(modalStatus) : [];
 
     return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) { resetModalState(); onClose(); } } }, [
       m("div.share-modal", [
@@ -132,16 +253,18 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                       },
                     }, modalCopied ? "Copied" : "Copy"),
                   ]),
+                  ...renderEmailList(emails, serverName, true),
                   m("button.share-modal-btn.share-modal-btn-destructive", {
                     disabled: modalActionInProgress,
                     onclick: () => disableSharing(serverName),
-                  }, modalActionInProgress ? "Disabling..." : "Disable sharing"),
+                  }, modalActionInProgress ? "Working..." : "Disable sharing"),
                 ])
               : m("div", [
                   m("p.share-modal-label", "This application is not currently shared."),
+                  ...renderEmailList(emails, serverName, false),
                   m("button.share-modal-btn.share-modal-btn-primary", {
                     disabled: modalActionInProgress,
-                    onclick: () => enableSharing(serverName),
+                    onclick: () => enableSharing(serverName, emails),
                   }, modalActionInProgress ? "Enabling..." : "Enable sharing"),
                 ]),
 

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -255,10 +255,17 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                   ]),
                   renderEmailList(emails, serverName, true),
                   m("div.share-modal-footer", [
-                    m("button.share-modal-btn.share-modal-btn-destructive", {
+                    m("div.share-modal-footer-left", [
+                      m("button.share-modal-btn.share-modal-btn-secondary", { onclick: close }, "Cancel"),
+                      m("button.share-modal-btn.share-modal-btn-destructive", {
+                        disabled: modalActionInProgress,
+                        onclick: () => disableSharing(serverName),
+                      }, "Disable sharing"),
+                    ]),
+                    m("button.share-modal-btn.share-modal-btn-create", {
                       disabled: modalActionInProgress,
-                      onclick: () => disableSharing(serverName),
-                    }, modalActionInProgress ? "Working..." : "Disable sharing"),
+                      onclick: () => updateAuth(serverName, emails),
+                    }, modalActionInProgress ? "Updating..." : "Update"),
                   ]),
                 ])
               : m("div", [

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -135,14 +135,18 @@ async function disableSharing(serverName: string): Promise<void> {
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
       modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
-    } else {
-      modalStatus = (await response.json()) as SharingStatus;
+      modalActionInProgress = false;
+      m.redraw();
+      return;
     }
+    // Re-fetch to get the default auth policy for the disabled state
+    modalActionInProgress = false;
+    await fetchStatus(serverName);
   } catch (e) {
     modalError = `Network error: ${(e as Error).message}`;
+    modalActionInProgress = false;
+    m.redraw();
   }
-  modalActionInProgress = false;
-  m.redraw();
 }
 
 function addEmail(emails: string[], serverName: string, isEnabled: boolean): void {
@@ -169,7 +173,7 @@ function removeEmail(emails: string[], email: string, serverName: string, isEnab
 function renderEmailList(emails: string[], serverName: string, isEnabled: boolean): m.Vnode {
   return m("div.share-modal-emails", [
     emails.length === 0
-      ? m("p.share-modal-empty", "No email restrictions. Anyone with the link can access.")
+      ? null
       : m("ul.share-modal-email-list",
           emails.map((email) =>
             m("li.share-modal-email-item", { key: email }, [

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -94,8 +94,8 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
 
     // Fetch once when the modal opens for a new server
     if (modalFetchedFor !== serverName) {
-      modalFetchedFor = serverName;
       resetModalState();
+      modalFetchedFor = serverName;
       fetchStatus(serverName);
     }
 

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -92,7 +92,11 @@ async function enableSharing(serverName: string, emails: string[]): Promise<void
       const data = await response.json().catch(() => ({}));
       modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
     } else {
-      modalStatus = (await response.json()) as SharingStatus;
+      // The enable response is provisional (may not have URL yet).
+      // Re-fetch to get the full status including the URL.
+      modalActionInProgress = false;
+      await fetchStatus(serverName);
+      return;
     }
   } catch (e) {
     modalError = `Network error: ${(e as Error).message}`;

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -1,0 +1,152 @@
+/**
+ * Modal dialog for managing Cloudflare forwarding (sharing) for a server.
+ * Fetches current status, allows enabling/disabling, and provides a copy-to-clipboard button.
+ */
+
+import m from "mithril";
+import { apiUrl } from "../base-path";
+
+interface ShareModalAttrs {
+  serverName: string;
+  onClose: () => void;
+}
+
+interface SharingStatus {
+  enabled: boolean;
+  url: string | null;
+}
+
+export const ShareModal: m.Component<ShareModalAttrs> = {
+  oninit(vnode) {
+    const state = {
+      loading: true,
+      status: null as SharingStatus | null,
+      error: null as string | null,
+      actionInProgress: false,
+      copied: false,
+    };
+    (vnode as unknown as { state: typeof state }).state = state;
+    fetchStatus(vnode.attrs.serverName, state);
+  },
+
+  view(vnode) {
+    const { serverName, onClose } = vnode.attrs;
+    const state = (vnode as unknown as { state: {
+      loading: boolean;
+      status: SharingStatus | null;
+      error: string | null;
+      actionInProgress: boolean;
+      copied: boolean;
+    } }).state;
+
+    return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) onClose(); } }, [
+      m("div.share-modal", [
+        m("h3.share-modal-title", `Share: ${serverName}`),
+
+        state.loading
+          ? m("p.share-modal-loading", "Loading...")
+          : state.error
+            ? m("div", [
+                m("p.share-modal-error", state.error),
+                m("button.share-modal-btn.share-modal-btn-secondary", { onclick: () => { state.error = null; state.loading = true; fetchStatus(serverName, state); } }, "Retry"),
+              ])
+            : state.status?.enabled
+              ? m("div", [
+                  m("p.share-modal-label", "This application is shared globally:"),
+                  m("div.share-modal-url-row", [
+                    m("input.share-modal-url-input", {
+                      type: "text",
+                      readonly: true,
+                      value: state.status.url ?? "(URL not available)",
+                      onclick: (e: Event) => (e.target as HTMLInputElement).select(),
+                    }),
+                    m("button.share-modal-btn.share-modal-btn-primary", {
+                      onclick: () => {
+                        if (state.status?.url) {
+                          navigator.clipboard.writeText(state.status.url);
+                          state.copied = true;
+                          setTimeout(() => { state.copied = false; m.redraw(); }, 2000);
+                        }
+                      },
+                    }, state.copied ? "Copied" : "Copy"),
+                  ]),
+                  m("button.share-modal-btn.share-modal-btn-destructive", {
+                    disabled: state.actionInProgress,
+                    onclick: () => disableSharing(serverName, state),
+                  }, state.actionInProgress ? "Disabling..." : "Disable sharing"),
+                ])
+              : m("div", [
+                  m("p.share-modal-label", "This application is not currently shared."),
+                  m("button.share-modal-btn.share-modal-btn-primary", {
+                    disabled: state.actionInProgress,
+                    onclick: () => enableSharing(serverName, state),
+                  }, state.actionInProgress ? "Enabling..." : "Enable sharing"),
+                ]),
+
+        m("div.share-modal-actions", [
+          m("button.share-modal-btn.share-modal-btn-secondary", { onclick: onClose }, "Close"),
+        ]),
+      ]),
+    ]);
+  },
+};
+
+interface ModalState {
+  loading: boolean;
+  status: SharingStatus | null;
+  error: string | null;
+  actionInProgress: boolean;
+  copied: boolean;
+}
+
+async function fetchStatus(serverName: string, state: ModalState): Promise<void> {
+  try {
+    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`));
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+    } else {
+      state.status = (await response.json()) as SharingStatus;
+    }
+  } catch (e) {
+    state.error = `Network error: ${(e as Error).message}`;
+  }
+  state.loading = false;
+  m.redraw();
+}
+
+async function enableSharing(serverName: string, state: ModalState): Promise<void> {
+  state.actionInProgress = true;
+  m.redraw();
+  try {
+    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), { method: "PUT" });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+    } else {
+      state.status = (await response.json()) as SharingStatus;
+    }
+  } catch (e) {
+    state.error = `Network error: ${(e as Error).message}`;
+  }
+  state.actionInProgress = false;
+  m.redraw();
+}
+
+async function disableSharing(serverName: string, state: ModalState): Promise<void> {
+  state.actionInProgress = true;
+  m.redraw();
+  try {
+    const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), { method: "DELETE" });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+    } else {
+      state.status = (await response.json()) as SharingStatus;
+    }
+  } catch (e) {
+    state.error = `Network error: ${(e as Error).message}`;
+  }
+  state.actionInProgress = false;
+  m.redraw();
+}

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -141,77 +141,67 @@ async function disableSharing(serverName: string): Promise<void> {
   m.redraw();
 }
 
-function renderEmailList(emails: string[], serverName: string, isEnabled: boolean): m.Vnode[] {
-  return [
-    m("div.share-modal-section", [
-      m("p.share-modal-label", "Allowed emails:"),
-      emails.length === 0
-        ? m("p.share-modal-empty", "No email restrictions configured. Anyone with the link can access.")
-        : m("ul.share-modal-email-list",
-            emails.map((email) =>
-              m("li.share-modal-email-item", { key: email }, [
-                m("span", email),
-                m("button.share-modal-email-remove", {
-                  title: "Remove",
-                  onclick: () => {
-                    const updated = emails.filter((e) => e !== email);
-                    if (isEnabled) {
-                      updateAuth(serverName, updated);
-                    } else if (modalStatus) {
-                      modalStatus.auth_rules = buildAuthRules(updated);
-                    }
-                  },
-                }, "x"),
-              ]),
-            ),
+function addEmail(emails: string[], serverName: string, isEnabled: boolean): void {
+  const email = modalNewEmail.trim();
+  if (!email || emails.includes(email)) return;
+  const updated = [...emails, email];
+  modalNewEmail = "";
+  if (isEnabled) {
+    updateAuth(serverName, updated);
+  } else if (modalStatus) {
+    modalStatus.auth_rules = buildAuthRules(updated);
+  }
+}
+
+function removeEmail(emails: string[], email: string, serverName: string, isEnabled: boolean): void {
+  const updated = emails.filter((e) => e !== email);
+  if (isEnabled) {
+    updateAuth(serverName, updated);
+  } else if (modalStatus) {
+    modalStatus.auth_rules = buildAuthRules(updated);
+  }
+}
+
+function renderEmailList(emails: string[], serverName: string, isEnabled: boolean): m.Vnode {
+  return m("div.share-modal-emails", [
+    emails.length === 0
+      ? m("p.share-modal-empty", "No email restrictions. Anyone with the link can access.")
+      : m("ul.share-modal-email-list",
+          emails.map((email) =>
+            m("li.share-modal-email-item", { key: email }, [
+              m("span", email),
+              m("button.share-modal-email-remove", {
+                title: "Remove",
+                onclick: () => removeEmail(emails, email, serverName, isEnabled),
+              }, "x"),
+            ]),
           ),
-      m("div.share-modal-add-email", [
-        m("input.share-modal-email-input", {
-          type: "email",
-          placeholder: "user@example.com",
-          value: modalNewEmail,
-          oninput: (e: Event) => { modalNewEmail = (e.target as HTMLInputElement).value; },
-          onkeydown: (e: KeyboardEvent) => {
-            if (e.key === "Enter" && modalNewEmail.trim()) {
-              e.preventDefault();
-              const email = modalNewEmail.trim();
-              if (!emails.includes(email)) {
-                const updated = [...emails, email];
-                modalNewEmail = "";
-                if (isEnabled) {
-                  updateAuth(serverName, updated);
-                } else if (modalStatus) {
-                  modalStatus.auth_rules = buildAuthRules(updated);
-                }
-              }
-            }
-          },
-        }),
-        m("button.share-modal-btn.share-modal-btn-secondary", {
-          disabled: !modalNewEmail.trim(),
-          onclick: () => {
-            const email = modalNewEmail.trim();
-            if (email && !emails.includes(email)) {
-              const updated = [...emails, email];
-              modalNewEmail = "";
-              if (isEnabled) {
-                updateAuth(serverName, updated);
-              } else if (modalStatus) {
-                modalStatus.auth_rules = buildAuthRules(updated);
-              }
-            }
-          },
-        }, "Add"),
-      ]),
+        ),
+    m("div.share-modal-add-email", [
+      m("input.share-modal-email-input", {
+        type: "email",
+        placeholder: "user@example.com",
+        value: modalNewEmail,
+        oninput: (e: Event) => { modalNewEmail = (e.target as HTMLInputElement).value; },
+        onkeydown: (e: KeyboardEvent) => {
+          if (e.key === "Enter" && modalNewEmail.trim()) {
+            e.preventDefault();
+            addEmail(emails, serverName, isEnabled);
+          }
+        },
+      }),
+      m("button.share-modal-btn.share-modal-btn-secondary", {
+        disabled: !modalNewEmail.trim(),
+        onclick: () => addEmail(emails, serverName, isEnabled),
+      }, "Add"),
     ]),
-  ];
+  ]);
 }
 
 export const ShareModal: m.Component<ShareModalAttrs> = {
   view(vnode) {
     const { serverName, onClose } = vnode.attrs;
 
-    // Fetch once when the modal opens for a new server
     if (modalFetchedFor !== serverName) {
       resetModalState();
       modalFetchedFor = serverName;
@@ -219,10 +209,17 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
     }
 
     const emails = modalStatus ? extractEmails(modalStatus) : [];
+    const isEnabled = modalStatus?.enabled ?? false;
+    const title = isEnabled ? `Edit ${serverName} sharing` : `Share ${serverName} with...`;
 
-    return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) { resetModalState(); onClose(); } } }, [
+    const close = () => { resetModalState(); onClose(); };
+
+    return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) close(); } }, [
       m("div.share-modal", [
-        m("h3.share-modal-title", `Share: ${serverName}`),
+        m("div.share-modal-header", [
+          m("h3.share-modal-title", title),
+          m("button.share-modal-close-x", { onclick: close, title: "Close" }, "x"),
+        ]),
 
         modalLoading
           ? m("p.share-modal-loading", "Loading...")
@@ -233,17 +230,16 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                   onclick: () => fetchStatus(serverName),
                 }, "Retry"),
               ])
-            : modalStatus?.enabled
+            : isEnabled
               ? m("div", [
-                  m("p.share-modal-label", "This application is shared globally:"),
                   m("div.share-modal-url-row", [
                     m("input.share-modal-url-input", {
                       type: "text",
                       readonly: true,
-                      value: modalStatus.url ?? "(URL not available)",
+                      value: modalStatus?.url ?? "(URL not available)",
                       onclick: (e: Event) => (e.target as HTMLInputElement).select(),
                     }),
-                    m("button.share-modal-btn.share-modal-btn-primary", {
+                    m("button.share-modal-btn.share-modal-btn-secondary", {
                       onclick: () => {
                         if (modalStatus?.url) {
                           navigator.clipboard.writeText(modalStatus.url);
@@ -253,26 +249,24 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                       },
                     }, modalCopied ? "Copied" : "Copy"),
                   ]),
-                  ...renderEmailList(emails, serverName, true),
-                  m("button.share-modal-btn.share-modal-btn-destructive", {
-                    disabled: modalActionInProgress,
-                    onclick: () => disableSharing(serverName),
-                  }, modalActionInProgress ? "Working..." : "Disable sharing"),
+                  renderEmailList(emails, serverName, true),
+                  m("div.share-modal-footer", [
+                    m("button.share-modal-btn.share-modal-btn-destructive", {
+                      disabled: modalActionInProgress,
+                      onclick: () => disableSharing(serverName),
+                    }, modalActionInProgress ? "Working..." : "Disable sharing"),
+                  ]),
                 ])
               : m("div", [
-                  m("p.share-modal-label", "This application is not currently shared."),
-                  ...renderEmailList(emails, serverName, false),
-                  m("button.share-modal-btn.share-modal-btn-primary", {
-                    disabled: modalActionInProgress,
-                    onclick: () => enableSharing(serverName, emails),
-                  }, modalActionInProgress ? "Enabling..." : "Enable sharing"),
+                  renderEmailList(emails, serverName, false),
+                  m("div.share-modal-footer", [
+                    m("button.share-modal-btn.share-modal-btn-secondary", { onclick: close }, "Cancel"),
+                    m("button.share-modal-btn.share-modal-btn-create", {
+                      disabled: modalActionInProgress,
+                      onclick: () => enableSharing(serverName, emails),
+                    }, modalActionInProgress ? "Enabling..." : "Enable sharing"),
+                  ]),
                 ]),
-
-        m("div.share-modal-actions", [
-          m("button.share-modal-btn.share-modal-btn-secondary", {
-            onclick: () => { resetModalState(); onClose(); },
-          }, "Close"),
-        ]),
       ]),
     ]);
   },

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -16,81 +16,6 @@ interface SharingStatus {
   url: string | null;
 }
 
-export const ShareModal: m.Component<ShareModalAttrs> = {
-  oninit(vnode) {
-    const state = {
-      loading: true,
-      status: null as SharingStatus | null,
-      error: null as string | null,
-      actionInProgress: false,
-      copied: false,
-    };
-    (vnode as unknown as { state: typeof state }).state = state;
-    fetchStatus(vnode.attrs.serverName, state);
-  },
-
-  view(vnode) {
-    const { serverName, onClose } = vnode.attrs;
-    const state = (vnode as unknown as { state: {
-      loading: boolean;
-      status: SharingStatus | null;
-      error: string | null;
-      actionInProgress: boolean;
-      copied: boolean;
-    } }).state;
-
-    return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) onClose(); } }, [
-      m("div.share-modal", [
-        m("h3.share-modal-title", `Share: ${serverName}`),
-
-        state.loading
-          ? m("p.share-modal-loading", "Loading...")
-          : state.error
-            ? m("div", [
-                m("p.share-modal-error", state.error),
-                m("button.share-modal-btn.share-modal-btn-secondary", { onclick: () => { state.error = null; state.loading = true; fetchStatus(serverName, state); } }, "Retry"),
-              ])
-            : state.status?.enabled
-              ? m("div", [
-                  m("p.share-modal-label", "This application is shared globally:"),
-                  m("div.share-modal-url-row", [
-                    m("input.share-modal-url-input", {
-                      type: "text",
-                      readonly: true,
-                      value: state.status.url ?? "(URL not available)",
-                      onclick: (e: Event) => (e.target as HTMLInputElement).select(),
-                    }),
-                    m("button.share-modal-btn.share-modal-btn-primary", {
-                      onclick: () => {
-                        if (state.status?.url) {
-                          navigator.clipboard.writeText(state.status.url);
-                          state.copied = true;
-                          setTimeout(() => { state.copied = false; m.redraw(); }, 2000);
-                        }
-                      },
-                    }, state.copied ? "Copied" : "Copy"),
-                  ]),
-                  m("button.share-modal-btn.share-modal-btn-destructive", {
-                    disabled: state.actionInProgress,
-                    onclick: () => disableSharing(serverName, state),
-                  }, state.actionInProgress ? "Disabling..." : "Disable sharing"),
-                ])
-              : m("div", [
-                  m("p.share-modal-label", "This application is not currently shared."),
-                  m("button.share-modal-btn.share-modal-btn-primary", {
-                    disabled: state.actionInProgress,
-                    onclick: () => enableSharing(serverName, state),
-                  }, state.actionInProgress ? "Enabling..." : "Enable sharing"),
-                ]),
-
-        m("div.share-modal-actions", [
-          m("button.share-modal-btn.share-modal-btn-secondary", { onclick: onClose }, "Close"),
-        ]),
-      ]),
-    ]);
-  },
-};
-
 interface ModalState {
   loading: boolean;
   status: SharingStatus | null;
@@ -149,4 +74,79 @@ async function disableSharing(serverName: string, state: ModalState): Promise<vo
   }
   state.actionInProgress = false;
   m.redraw();
+}
+
+export function ShareModal(): m.Component<ShareModalAttrs> {
+  const state: ModalState = {
+    loading: true,
+    status: null,
+    error: null,
+    actionInProgress: false,
+    copied: false,
+  };
+
+  let initialized = false;
+
+  return {
+    view(vnode) {
+      const { serverName, onClose } = vnode.attrs;
+
+      if (!initialized) {
+        initialized = true;
+        fetchStatus(serverName, state);
+      }
+
+      return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) onClose(); } }, [
+        m("div.share-modal", [
+          m("h3.share-modal-title", `Share: ${serverName}`),
+
+          state.loading
+            ? m("p.share-modal-loading", "Loading...")
+            : state.error
+              ? m("div", [
+                  m("p.share-modal-error", state.error),
+                  m("button.share-modal-btn.share-modal-btn-secondary", {
+                    onclick: () => { state.error = null; state.loading = true; fetchStatus(serverName, state); },
+                  }, "Retry"),
+                ])
+              : state.status?.enabled
+                ? m("div", [
+                    m("p.share-modal-label", "This application is shared globally:"),
+                    m("div.share-modal-url-row", [
+                      m("input.share-modal-url-input", {
+                        type: "text",
+                        readonly: true,
+                        value: state.status.url ?? "(URL not available)",
+                        onclick: (e: Event) => (e.target as HTMLInputElement).select(),
+                      }),
+                      m("button.share-modal-btn.share-modal-btn-primary", {
+                        onclick: () => {
+                          if (state.status?.url) {
+                            navigator.clipboard.writeText(state.status.url);
+                            state.copied = true;
+                            setTimeout(() => { state.copied = false; m.redraw(); }, 2000);
+                          }
+                        },
+                      }, state.copied ? "Copied" : "Copy"),
+                    ]),
+                    m("button.share-modal-btn.share-modal-btn-destructive", {
+                      disabled: state.actionInProgress,
+                      onclick: () => disableSharing(serverName, state),
+                    }, state.actionInProgress ? "Disabling..." : "Disable sharing"),
+                  ])
+                : m("div", [
+                    m("p.share-modal-label", "This application is not currently shared."),
+                    m("button.share-modal-btn.share-modal-btn-primary", {
+                      disabled: state.actionInProgress,
+                      onclick: () => enableSharing(serverName, state),
+                    }, state.actionInProgress ? "Enabling..." : "Enable sharing"),
+                  ]),
+
+          m("div.share-modal-actions", [
+            m("button.share-modal-btn.share-modal-btn-secondary", { onclick: onClose }, "Close"),
+          ]),
+        ]),
+      ]);
+    },
+  };
 }

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -262,7 +262,7 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                         onclick: () => disableSharing(serverName),
                       }, "Disable sharing"),
                     ]),
-                    m("button.share-modal-btn.share-modal-btn-create", {
+                    m("button.share-modal-btn.share-modal-btn", {
                       disabled: modalActionInProgress,
                       onclick: () => updateAuth(serverName, emails),
                     }, modalActionInProgress ? "Updating..." : "Update"),
@@ -272,7 +272,7 @@ export const ShareModal: m.Component<ShareModalAttrs> = {
                   renderEmailList(emails, serverName, false),
                   m("div.share-modal-footer", [
                     m("button.share-modal-btn.share-modal-btn-secondary", { onclick: close }, "Cancel"),
-                    m("button.share-modal-btn.share-modal-btn-create", {
+                    m("button.share-modal-btn.share-modal-btn", {
                       disabled: modalActionInProgress,
                       onclick: () => enableSharing(serverName, emails),
                     }, modalActionInProgress ? "Enabling..." : "Enable sharing"),

--- a/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ShareModal.ts
@@ -16,137 +16,141 @@ interface SharingStatus {
   url: string | null;
 }
 
-interface ModalState {
-  loading: boolean;
-  status: SharingStatus | null;
-  error: string | null;
-  actionInProgress: boolean;
-  copied: boolean;
+// Module-level state for the share modal (only one can be open at a time)
+let modalLoading = true;
+let modalStatus: SharingStatus | null = null;
+let modalError: string | null = null;
+let modalActionInProgress = false;
+let modalCopied = false;
+let modalFetchedFor: string | null = null;
+
+function resetModalState(): void {
+  modalLoading = true;
+  modalStatus = null;
+  modalError = null;
+  modalActionInProgress = false;
+  modalCopied = false;
+  modalFetchedFor = null;
 }
 
-async function fetchStatus(serverName: string, state: ModalState): Promise<void> {
+async function fetchStatus(serverName: string): Promise<void> {
+  modalLoading = true;
+  modalError = null;
+  m.redraw();
   try {
     const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`));
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
-      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+      modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
     } else {
-      state.status = (await response.json()) as SharingStatus;
+      modalStatus = (await response.json()) as SharingStatus;
     }
   } catch (e) {
-    state.error = `Network error: ${(e as Error).message}`;
+    modalError = `Network error: ${(e as Error).message}`;
   }
-  state.loading = false;
+  modalLoading = false;
   m.redraw();
 }
 
-async function enableSharing(serverName: string, state: ModalState): Promise<void> {
-  state.actionInProgress = true;
+async function enableSharing(serverName: string): Promise<void> {
+  modalActionInProgress = true;
   m.redraw();
   try {
     const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), { method: "PUT" });
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
-      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+      modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
     } else {
-      state.status = (await response.json()) as SharingStatus;
+      modalStatus = (await response.json()) as SharingStatus;
     }
   } catch (e) {
-    state.error = `Network error: ${(e as Error).message}`;
+    modalError = `Network error: ${(e as Error).message}`;
   }
-  state.actionInProgress = false;
+  modalActionInProgress = false;
   m.redraw();
 }
 
-async function disableSharing(serverName: string, state: ModalState): Promise<void> {
-  state.actionInProgress = true;
+async function disableSharing(serverName: string): Promise<void> {
+  modalActionInProgress = true;
   m.redraw();
   try {
     const response = await fetch(apiUrl(`/api/sharing/${encodeURIComponent(serverName)}`), { method: "DELETE" });
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
-      state.error = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
+      modalError = (data as { detail?: string }).detail ?? `HTTP ${response.status}`;
     } else {
-      state.status = (await response.json()) as SharingStatus;
+      modalStatus = (await response.json()) as SharingStatus;
     }
   } catch (e) {
-    state.error = `Network error: ${(e as Error).message}`;
+    modalError = `Network error: ${(e as Error).message}`;
   }
-  state.actionInProgress = false;
+  modalActionInProgress = false;
   m.redraw();
 }
 
-export function ShareModal(): m.Component<ShareModalAttrs> {
-  const state: ModalState = {
-    loading: true,
-    status: null,
-    error: null,
-    actionInProgress: false,
-    copied: false,
-  };
+export const ShareModal: m.Component<ShareModalAttrs> = {
+  view(vnode) {
+    const { serverName, onClose } = vnode.attrs;
 
-  let initialized = false;
+    // Fetch once when the modal opens for a new server
+    if (modalFetchedFor !== serverName) {
+      modalFetchedFor = serverName;
+      resetModalState();
+      fetchStatus(serverName);
+    }
 
-  return {
-    view(vnode) {
-      const { serverName, onClose } = vnode.attrs;
+    return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) { resetModalState(); onClose(); } } }, [
+      m("div.share-modal", [
+        m("h3.share-modal-title", `Share: ${serverName}`),
 
-      if (!initialized) {
-        initialized = true;
-        fetchStatus(serverName, state);
-      }
-
-      return m("div.share-modal-overlay", { onclick: (e: Event) => { if (e.target === e.currentTarget) onClose(); } }, [
-        m("div.share-modal", [
-          m("h3.share-modal-title", `Share: ${serverName}`),
-
-          state.loading
-            ? m("p.share-modal-loading", "Loading...")
-            : state.error
+        modalLoading
+          ? m("p.share-modal-loading", "Loading...")
+          : modalError
+            ? m("div", [
+                m("p.share-modal-error", modalError),
+                m("button.share-modal-btn.share-modal-btn-secondary", {
+                  onclick: () => fetchStatus(serverName),
+                }, "Retry"),
+              ])
+            : modalStatus?.enabled
               ? m("div", [
-                  m("p.share-modal-error", state.error),
-                  m("button.share-modal-btn.share-modal-btn-secondary", {
-                    onclick: () => { state.error = null; state.loading = true; fetchStatus(serverName, state); },
-                  }, "Retry"),
-                ])
-              : state.status?.enabled
-                ? m("div", [
-                    m("p.share-modal-label", "This application is shared globally:"),
-                    m("div.share-modal-url-row", [
-                      m("input.share-modal-url-input", {
-                        type: "text",
-                        readonly: true,
-                        value: state.status.url ?? "(URL not available)",
-                        onclick: (e: Event) => (e.target as HTMLInputElement).select(),
-                      }),
-                      m("button.share-modal-btn.share-modal-btn-primary", {
-                        onclick: () => {
-                          if (state.status?.url) {
-                            navigator.clipboard.writeText(state.status.url);
-                            state.copied = true;
-                            setTimeout(() => { state.copied = false; m.redraw(); }, 2000);
-                          }
-                        },
-                      }, state.copied ? "Copied" : "Copy"),
-                    ]),
-                    m("button.share-modal-btn.share-modal-btn-destructive", {
-                      disabled: state.actionInProgress,
-                      onclick: () => disableSharing(serverName, state),
-                    }, state.actionInProgress ? "Disabling..." : "Disable sharing"),
-                  ])
-                : m("div", [
-                    m("p.share-modal-label", "This application is not currently shared."),
+                  m("p.share-modal-label", "This application is shared globally:"),
+                  m("div.share-modal-url-row", [
+                    m("input.share-modal-url-input", {
+                      type: "text",
+                      readonly: true,
+                      value: modalStatus.url ?? "(URL not available)",
+                      onclick: (e: Event) => (e.target as HTMLInputElement).select(),
+                    }),
                     m("button.share-modal-btn.share-modal-btn-primary", {
-                      disabled: state.actionInProgress,
-                      onclick: () => enableSharing(serverName, state),
-                    }, state.actionInProgress ? "Enabling..." : "Enable sharing"),
+                      onclick: () => {
+                        if (modalStatus?.url) {
+                          navigator.clipboard.writeText(modalStatus.url);
+                          modalCopied = true;
+                          setTimeout(() => { modalCopied = false; m.redraw(); }, 2000);
+                        }
+                      },
+                    }, modalCopied ? "Copied" : "Copy"),
                   ]),
+                  m("button.share-modal-btn.share-modal-btn-destructive", {
+                    disabled: modalActionInProgress,
+                    onclick: () => disableSharing(serverName),
+                  }, modalActionInProgress ? "Disabling..." : "Disable sharing"),
+                ])
+              : m("div", [
+                  m("p.share-modal-label", "This application is not currently shared."),
+                  m("button.share-modal-btn.share-modal-btn-primary", {
+                    disabled: modalActionInProgress,
+                    onclick: () => enableSharing(serverName),
+                  }, modalActionInProgress ? "Enabling..." : "Enable sharing"),
+                ]),
 
-          m("div.share-modal-actions", [
-            m("button.share-modal-btn.share-modal-btn-secondary", { onclick: onClose }, "Close"),
-          ]),
+        m("div.share-modal-actions", [
+          m("button.share-modal-btn.share-modal-btn-secondary", {
+            onclick: () => { resetModalState(); onClose(); },
+          }, "Close"),
         ]),
-      ]);
-    },
-  };
-}
+      ]),
+    ]);
+  },
+};

--- a/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
+++ b/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
@@ -177,7 +177,7 @@ export const Sidebar: m.Component = {
             })
           : null,
         showSidebarShareModal
-          ? m(ShareModal(), {
+          ? m(ShareModal, {
               serverName: "web",
               onClose() {
                 showSidebarShareModal = false;

--- a/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
+++ b/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
@@ -5,6 +5,7 @@ import { getHostname } from "../base-path";
 import { AgentSelector } from "./ConversationSelector";
 import { getSidebarItems } from "../sidebar-items";
 import { CreateAgentModal } from "./CreateAgentModal";
+import { ShareModal } from "./ShareModal";
 import { selectAgent, getSelectedAgentId } from "../navigation";
 import type { SidebarItemDefinition } from "../sidebar-items";
 
@@ -18,6 +19,7 @@ function invokeSlotRendered(slotName: string, container: HTMLElement): void {
 
 const ICON_PANEL_LEFT_CLOSE = '<path d="M3 3h18v18H3z"/><path d="M9 3v18"/><path d="M16 9l-3 3 3 3"/>';
 const ICON_PANEL_LEFT_OPEN = '<path d="M3 3h18v18H3z"/><path d="M9 3v18"/><path d="M14 9l3 3-3 3"/>';
+const ICON_SHARE = '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>';
 
 const SIDEBAR_COLLAPSED_KEY = "sidebar-collapsed";
 
@@ -85,6 +87,7 @@ function inlineIconButton(label: string, onclick: () => void, svgPath: string): 
 }
 
 let showCreateModal = false;
+let showSidebarShareModal = false;
 
 export const Sidebar: m.Component = {
   view() {
@@ -138,6 +141,7 @@ export const Sidebar: m.Component = {
                       ? null
                       : m("span", { class: "sidebar-branding-title" }, getHostname()),
                   ),
+                  inlineIconButton("Share workspace", () => { showSidebarShareModal = true; }, ICON_SHARE),
                   inlineIconButton("Collapse sidebar", toggle, ICON_PANEL_LEFT_CLOSE),
                 ]),
                 m("div", { class: "sidebar-action-rows" }, [...getSidebarItems().map(sidebarItemActionRow)]),
@@ -169,6 +173,14 @@ export const Sidebar: m.Component = {
               },
               onCancel() {
                 showCreateModal = false;
+              },
+            })
+          : null,
+        showSidebarShareModal
+          ? m(ShareModal, {
+              serverName: "web",
+              onClose() {
+                showSidebarShareModal = false;
               },
             })
           : null,

--- a/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
+++ b/apps/minds_workspace_server/frontend/src/views/Sidebar.ts
@@ -177,7 +177,7 @@ export const Sidebar: m.Component = {
             })
           : null,
         showSidebarShareModal
-          ? m(ShareModal, {
+          ? m(ShareModal(), {
               serverName: "web",
               onClose() {
                 showSidebarShareModal = false;

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_discovery.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_discovery.py
@@ -44,7 +44,7 @@ def _get_mngr_context() -> tuple[MngrContext, ConcurrencyGroup]:
     return mngr_ctx, cg
 
 
-def _read_claude_config_dir_from_env_file(agent_state_dir: Path) -> Path:
+def read_claude_config_dir_from_env_file(agent_state_dir: Path) -> Path:
     """Read CLAUDE_CONFIG_DIR from the agent's env file.
 
     Each mngr agent has an env file at <agent_state_dir>/env that contains
@@ -98,7 +98,7 @@ def discover_agents(
         agent_state_dir = default_host_dir / "agents" / agent_id
 
         # Get CLAUDE_CONFIG_DIR from the agent's env file
-        claude_config_dir = _read_claude_config_dir_from_env_file(agent_state_dir)
+        claude_config_dir = read_claude_config_dir_from_env_file(agent_state_dir)
 
         agents.append(
             AgentInfo(

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_discovery_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_discovery_test.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from imbue.minds_workspace_server.agent_discovery import _read_claude_config_dir_from_env_file
+from imbue.minds_workspace_server.agent_discovery import read_claude_config_dir_from_env_file
 
 
 def test_reads_claude_config_dir_from_env_file(tmp_path: Path) -> None:
@@ -11,7 +11,7 @@ def test_reads_claude_config_dir_from_env_file(tmp_path: Path) -> None:
     env_file = agent_state_dir / "env"
     env_file.write_text('CLAUDE_CONFIG_DIR="/custom/config/dir"\n')
 
-    result = _read_claude_config_dir_from_env_file(agent_state_dir)
+    result = read_claude_config_dir_from_env_file(agent_state_dir)
 
     assert result == Path("/custom/config/dir")
 
@@ -22,7 +22,7 @@ def test_falls_back_to_conventional_path_when_env_file_missing(tmp_path: Path) -
     conventional = agent_state_dir / "plugin" / "claude" / "anthropic"
     conventional.mkdir(parents=True)
 
-    result = _read_claude_config_dir_from_env_file(agent_state_dir)
+    result = read_claude_config_dir_from_env_file(agent_state_dir)
 
     assert result == conventional
 
@@ -35,7 +35,7 @@ def test_falls_back_to_conventional_path_when_env_has_no_config_dir(tmp_path: Pa
     conventional = agent_state_dir / "plugin" / "claude" / "anthropic"
     conventional.mkdir(parents=True)
 
-    result = _read_claude_config_dir_from_env_file(agent_state_dir)
+    result = read_claude_config_dir_from_env_file(agent_state_dir)
 
     assert result == conventional
 
@@ -44,6 +44,6 @@ def test_falls_back_to_home_claude_when_nothing_else_exists(tmp_path: Path) -> N
     agent_state_dir = tmp_path / "agent_state"
     agent_state_dir.mkdir()
 
-    result = _read_claude_config_dir_from_env_file(agent_state_dir)
+    result = read_claude_config_dir_from_env_file(agent_state_dir)
 
     assert result == Path.home() / ".claude"

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -211,6 +211,8 @@ class AgentManager:
 
         with self._lock:
             work_dir = self._resolve_agent_work_dir(selected_agent_id)
+            parent = self._agents.get(selected_agent_id)
+            parent_labels = dict(parent.labels) if parent else {}
 
         if work_dir is None:
             msg = f"Cannot determine work directory for agent {selected_agent_id}"
@@ -238,6 +240,10 @@ class AgentManager:
             "--no-connect",
         ]
 
+        # Inherit the project label from the parent agent
+        if "project" in parent_labels:
+            cmd.extend(["--label", f"project={parent_labels['project']}"])
+
         log_queue: queue.Queue[str | None] = queue.Queue(maxsize=10000)
 
         proto_info = {
@@ -258,6 +264,8 @@ class AgentManager:
         )
 
         labels = {"user_created": "true", "workspace": name}
+        if "project" in parent_labels:
+            labels["project"] = parent_labels["project"]
         self._launch_creation_thread(agent_id, name, cmd, Path(work_dir), log_queue, labels)
 
         return agent_id

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -147,6 +147,19 @@ class AgentManager:
         with self._lock:
             return self._agents.get(agent_id)
 
+    def remove_agent(self, agent_id: str) -> None:
+        """Remove an agent from the tracked state and broadcast the update.
+
+        Called after a successful mngr destroy to immediately reflect
+        the destruction without waiting for the observe subprocess.
+        """
+        with self._lock:
+            self._agents.pop(agent_id, None)
+            self._applications.pop(agent_id, None)
+
+        self._stop_app_watcher(agent_id)
+        self._broadcaster.broadcast_agents_updated(self.get_agents_serialized())
+
     def get_applications(self) -> dict[str, list[ApplicationEntry]]:
         """Return per-agent application map."""
         with self._lock:

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -233,6 +233,8 @@ class AgentManager:
             "worktree",
             "--label",
             "user_created=true",
+            "--label",
+            f"workspace={name}",
             "--no-connect",
         ]
 
@@ -255,7 +257,7 @@ class AgentManager:
             parent_agent_id=None,
         )
 
-        labels = {"user_created": "true"}
+        labels = {"user_created": "true", "workspace": name}
         self._launch_creation_thread(agent_id, name, cmd, Path(work_dir), log_queue, labels)
 
         return agent_id

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
@@ -446,7 +446,7 @@ def test_run_creation_logs_header_and_completion(
     done_event = threading.Event()
 
     def run_and_signal() -> None:
-        agent_manager._run_creation("test-id", cmd, tmp_path, log_q)
+        agent_manager._run_creation("test-id", "test-agent", cmd, tmp_path, log_q, {})
         done_event.set()
 
     t = threading.Thread(target=run_and_signal, daemon=True)

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/models.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/models.py
@@ -85,3 +85,9 @@ class RandomNameResponse(FrozenModel):
     """Response from the random name endpoint."""
 
     name: str = Field(description="A random agent name")
+
+
+class DestroyAgentResponse(FrozenModel):
+    """Response from the agent destroy endpoint."""
+
+    status: str = Field(description="Result of the destroy operation")

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -379,13 +379,22 @@ def _stream_subagent_events(agent_id: str, subagent_session_id: str, request: Re
     )
 
 
+def _layout_filename(request: Request) -> str:
+    """Return the layout filename based on the access mode query parameter."""
+    mode = request.query_params.get("mode", "")
+    if mode and mode in ("cloudflare", "local", "dev"):
+        return f"layout-{mode}.json"
+    return "layout.json"
+
+
 def _get_layout(agent_id: str, request: Request) -> Response:
     """Get the saved workspace layout for an agent."""
     agent_info = _find_agent(agent_id, request)
     if agent_info is None:
         return _agent_not_found_response(agent_id)
 
-    layout_file = agent_info.agent_state_dir / "workspace_layout" / "layout.json"
+    filename = _layout_filename(request)
+    layout_file = agent_info.agent_state_dir / "workspace_layout" / filename
     if not layout_file.exists():
         return JSONResponse(content=None, status_code=404)
 
@@ -410,9 +419,10 @@ async def _save_layout(agent_id: str, request: Request) -> Response:
         error = ErrorResponse(detail="Invalid JSON in request body")
         return JSONResponse(content=error.model_dump(), status_code=400)
 
+    filename = _layout_filename(request)
     layout_dir = agent_info.agent_state_dir / "workspace_layout"
     layout_dir.mkdir(parents=True, exist_ok=True)
-    layout_file = layout_dir / "layout.json"
+    layout_file = layout_dir / filename
     layout_file.write_bytes(body)
 
     return JSONResponse(content={"status": "ok"})

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -46,6 +46,7 @@ from imbue.minds_workspace_server.sharing_proxy import SharingProxyError
 from imbue.minds_workspace_server.sharing_proxy import disable_sharing
 from imbue.minds_workspace_server.sharing_proxy import enable_sharing
 from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
+from imbue.minds_workspace_server.sharing_proxy import update_sharing_auth
 from imbue.minds_workspace_server.plugins import get_plugin_manager
 from imbue.minds_workspace_server.session_watcher import AgentSessionWatcher
 from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
@@ -642,10 +643,38 @@ async def _get_sharing_status_endpoint(server_name: str) -> JSONResponse:
         return JSONResponse(content=error.model_dump(), status_code=502)
 
 
-async def _enable_sharing_endpoint(server_name: str) -> JSONResponse:
-    """Enable Cloudflare forwarding for a server."""
+async def _enable_sharing_endpoint(server_name: str, request: Request) -> JSONResponse:
+    """Enable Cloudflare forwarding for a server, optionally with auth rules."""
+    auth_rules = None
     try:
-        status = await run_in_threadpool(enable_sharing, server_name)
+        body = await request.json()
+        auth_rules = body.get("auth_rules")
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    try:
+        status = await run_in_threadpool(enable_sharing, server_name, auth_rules)
+        return JSONResponse(content=status.model_dump())
+    except SharingProxyError as e:
+        error = ErrorResponse(detail=str(e))
+        return JSONResponse(content=error.model_dump(), status_code=502)
+
+
+async def _update_sharing_auth_endpoint(server_name: str, request: Request) -> JSONResponse:
+    """Update the auth policy for an already-enabled shared server."""
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        error = ErrorResponse(detail="Invalid JSON in request body")
+        return JSONResponse(content=error.model_dump(), status_code=400)
+
+    auth_rules = body.get("auth_rules")
+    if auth_rules is None:
+        error = ErrorResponse(detail="auth_rules field is required")
+        return JSONResponse(content=error.model_dump(), status_code=400)
+
+    try:
+        status = await run_in_threadpool(update_sharing_auth, server_name, auth_rules)
         return JSONResponse(content=status.model_dump())
     except SharingProxyError as e:
         error = ErrorResponse(detail=str(e))
@@ -700,6 +729,7 @@ def create_application(
     application.add_api_route("/api/sharing/{server_name}", _get_sharing_status_endpoint, methods=["GET"])
     application.add_api_route("/api/sharing/{server_name}", _enable_sharing_endpoint, methods=["PUT"])
     application.add_api_route("/api/sharing/{server_name}", _disable_sharing_endpoint, methods=["DELETE"])
+    application.add_api_route("/api/sharing/{server_name}/auth", _update_sharing_auth_endpoint, methods=["PUT"])
     application.add_api_route(
         "/api/agents/{agent_id}/subagents/{subagent_session_id}/events", _get_subagent_events, methods=["GET"]
     )

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -625,6 +625,10 @@ async def _destroy_agent(agent_id: str, request: Request) -> JSONResponse:
         error = ErrorResponse(detail=f"Failed to destroy agent '{agent_name}': {output}")
         return JSONResponse(content=error.model_dump(), status_code=500)
 
+    # Remove the agent from the workspace server's tracked state immediately
+    # so the frontend reflects the destruction without waiting for mngr observe.
+    agent_manager.remove_agent(agent_id)
+
     return JSONResponse(content=DestroyAgentResponse(status="ok").model_dump())
 
 

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -24,7 +24,7 @@ from starlette.websockets import WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from imbue.minds_workspace_server.agent_discovery import AgentInfo
-from imbue.minds_workspace_server.agent_discovery import _read_claude_config_dir_from_env_file
+from imbue.minds_workspace_server.agent_discovery import read_claude_config_dir_from_env_file
 from imbue.minds_workspace_server.agent_discovery import discover_agents
 from imbue.minds_workspace_server.agent_discovery import send_message
 from imbue.minds_workspace_server.agent_manager import AgentManager
@@ -216,7 +216,7 @@ def _find_agent(agent_id: str, request: Request) -> AgentInfo | None:
 
     host_dir = _get_host_dir()
     agent_state_dir = host_dir / "agents" / agent_id
-    claude_config_dir = _read_claude_config_dir_from_env_file(agent_state_dir)
+    claude_config_dir = read_claude_config_dir_from_env_file(agent_state_dir)
 
     return AgentInfo(
         id=agent_state.id,

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -23,6 +23,7 @@ from starlette.concurrency import run_in_threadpool
 from starlette.websockets import WebSocket
 from starlette.websockets import WebSocketDisconnect
 
+from imbue.concurrency_group.subprocess_utils import run_local_command_modern_version
 from imbue.minds_workspace_server.agent_discovery import AgentInfo
 from imbue.minds_workspace_server.agent_discovery import read_claude_config_dir_from_env_file
 from imbue.minds_workspace_server.agent_discovery import discover_agents
@@ -411,6 +412,42 @@ async def _save_layout(agent_id: str, request: Request) -> Response:
     return JSONResponse(content={"status": "ok"})
 
 
+async def _get_screen_capture(agent_id: str, request: Request) -> Response:
+    """Capture the tmux pane content for an agent.
+
+    Returns the visible screen content (and optionally scrollback) as plain
+    text. Useful for seeing what's on an agent's terminal when it has no
+    Claude session data (e.g., the agent crashed on startup).
+    """
+    agent_info = _find_agent(agent_id, request)
+    if agent_info is None:
+        return _agent_not_found_response(agent_id)
+
+    prefix = os.environ.get("MNGR_PREFIX", "mngr-")
+    session_name = f"{prefix}{agent_info.name}"
+    include_scrollback = request.query_params.get("scrollback", "false").lower() == "true"
+    scrollback_flag = ["-S", "-"] if include_scrollback else []
+    command = ["tmux", "capture-pane", "-t", session_name, *scrollback_flag, "-p"]
+
+    def _run_capture() -> tuple[bool, str]:
+        result = run_local_command_modern_version(
+            command=command,
+            cwd=None,
+            is_checked=False,
+            timeout=5.0,
+        )
+        succeeded = result.returncode == 0
+        return succeeded, result.stdout if succeeded else result.stderr
+
+    success, output = await run_in_threadpool(_run_capture)
+    if not success:
+        return JSONResponse(
+            content={"screen": None, "error": f"tmux session not found: {session_name}"},
+            status_code=200,
+        )
+    return JSONResponse(content={"screen": output})
+
+
 def _serve_static_file(basename: str, request: Request) -> Response:
     config: Config = request.app.state.config
     file_path_string = config.static_file_basename_to_path.get(basename)
@@ -572,6 +609,7 @@ def create_application(
     application.add_api_route("/api/agents/{agent_id}/message", _send_message_endpoint, methods=["POST"])
     application.add_api_route("/api/agents/{agent_id}/layout", _get_layout, methods=["GET"])
     application.add_api_route("/api/agents/{agent_id}/layout", _save_layout, methods=["POST"])
+    application.add_api_route("/api/agents/{agent_id}/screen", _get_screen_capture, methods=["GET"])
     application.add_api_route(
         "/api/agents/{agent_id}/subagents/{subagent_session_id}/events", _get_subagent_events, methods=["GET"]
     )

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -37,10 +37,15 @@ from imbue.minds_workspace_server.models import AgentListResponse
 from imbue.minds_workspace_server.models import CreateAgentResponse
 from imbue.minds_workspace_server.models import CreateChatRequest
 from imbue.minds_workspace_server.models import CreateWorktreeRequest
+from imbue.minds_workspace_server.models import DestroyAgentResponse
 from imbue.minds_workspace_server.models import ErrorResponse
 from imbue.minds_workspace_server.models import RandomNameResponse
 from imbue.minds_workspace_server.models import SendMessageRequest
 from imbue.minds_workspace_server.models import SendMessageResponse
+from imbue.minds_workspace_server.sharing_proxy import SharingProxyError
+from imbue.minds_workspace_server.sharing_proxy import disable_sharing
+from imbue.minds_workspace_server.sharing_proxy import enable_sharing
+from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
 from imbue.minds_workspace_server.plugins import get_plugin_manager
 from imbue.minds_workspace_server.session_watcher import AgentSessionWatcher
 from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
@@ -169,6 +174,7 @@ def _index(request: Request) -> Response:
         html_content = index_path.read_text()
         html_content = _inject_base_path_meta_tag(html_content, root_path)
         html_content = _inject_hostname_meta_tag(html_content)
+        html_content = _inject_agent_id_meta_tag(html_content)
         if config.javascript_plugin_basenames:
             html_content = _inject_plugin_script_tags(html_content, config.javascript_plugin_basenames, root_path)
         return HTMLResponse(html_content)
@@ -583,6 +589,72 @@ async def _proto_agent_logs_endpoint(websocket: WebSocket) -> None:
         pass
 
 
+async def _destroy_agent(agent_id: str, request: Request) -> JSONResponse:
+    """Destroy an agent by running mngr destroy --force."""
+    agent_manager: AgentManager = request.app.state.agent_manager
+    agent_state = agent_manager.get_agent_by_id(agent_id)
+    if agent_state is None:
+        error = ErrorResponse(detail=f"Agent '{agent_id}' not found")
+        return JSONResponse(content=error.model_dump(), status_code=404)
+
+    agent_name = agent_state.name
+
+    def _run_destroy() -> tuple[bool, str]:
+        result = run_local_command_modern_version(
+            command=["mngr", "destroy", agent_name, "--force"],
+            cwd=None,
+            is_checked=False,
+            timeout=30.0,
+        )
+        succeeded = result.returncode == 0
+        output = result.stdout.strip() if succeeded else result.stderr.strip()
+        return succeeded, output
+
+    success, output = await run_in_threadpool(_run_destroy)
+    if not success:
+        error = ErrorResponse(detail=f"Failed to destroy agent '{agent_name}': {output}")
+        return JSONResponse(content=error.model_dump(), status_code=500)
+
+    return JSONResponse(content=DestroyAgentResponse(status="ok").model_dump())
+
+
+async def _get_sharing_status_endpoint(server_name: str) -> JSONResponse:
+    """Get the Cloudflare forwarding status for a server."""
+    try:
+        status = await run_in_threadpool(get_sharing_status, server_name)
+        return JSONResponse(content=status.model_dump())
+    except SharingProxyError as e:
+        error = ErrorResponse(detail=str(e))
+        return JSONResponse(content=error.model_dump(), status_code=502)
+
+
+async def _enable_sharing_endpoint(server_name: str) -> JSONResponse:
+    """Enable Cloudflare forwarding for a server."""
+    try:
+        status = await run_in_threadpool(enable_sharing, server_name)
+        return JSONResponse(content=status.model_dump())
+    except SharingProxyError as e:
+        error = ErrorResponse(detail=str(e))
+        return JSONResponse(content=error.model_dump(), status_code=502)
+
+
+async def _disable_sharing_endpoint(server_name: str) -> JSONResponse:
+    """Disable Cloudflare forwarding for a server."""
+    try:
+        status = await run_in_threadpool(disable_sharing, server_name)
+        return JSONResponse(content=status.model_dump())
+    except SharingProxyError as e:
+        error = ErrorResponse(detail=str(e))
+        return JSONResponse(content=error.model_dump(), status_code=502)
+
+
+def _inject_agent_id_meta_tag(html_content: str) -> str:
+    """Inject the primary agent ID as a meta tag for the frontend."""
+    agent_id = os.environ.get("MNGR_AGENT_ID", "")
+    meta_tag = f'<meta name="minds-workspace-server-agent-id" content="{agent_id}">'
+    return html_content.replace("</head>", f"{meta_tag}\n</head>")
+
+
 def create_application(
     config: Config | None = None,
     provider_names: tuple[str, ...] | None = None,
@@ -610,6 +682,10 @@ def create_application(
     application.add_api_route("/api/agents/{agent_id}/layout", _get_layout, methods=["GET"])
     application.add_api_route("/api/agents/{agent_id}/layout", _save_layout, methods=["POST"])
     application.add_api_route("/api/agents/{agent_id}/screen", _get_screen_capture, methods=["GET"])
+    application.add_api_route("/api/agents/{agent_id}/destroy", _destroy_agent, methods=["POST"])
+    application.add_api_route("/api/sharing/{server_name}", _get_sharing_status_endpoint, methods=["GET"])
+    application.add_api_route("/api/sharing/{server_name}", _enable_sharing_endpoint, methods=["PUT"])
+    application.add_api_route("/api/sharing/{server_name}", _disable_sharing_endpoint, methods=["DELETE"])
     application.add_api_route(
         "/api/agents/{agent_id}/subagents/{subagent_session_id}/events", _get_subagent_events, methods=["GET"]
     )

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
@@ -135,16 +135,14 @@ def test_get_events_with_session_files(client: TestClient, tmp_path: Path) -> No
     # Write session history
     (agent_state_dir / "claude_session_id_history").write_text(f"{session_id}\n")
 
-    with patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover:
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=agent_state_dir,
-                claude_config_dir=claude_config_dir,
-            )
-        ]
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=agent_state_dir,
+        claude_config_dir=claude_config_dir,
+    )
+    with patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info):
         response = client.get("/api/agents/agent-123/events")
 
     assert response.status_code == 200

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
@@ -156,19 +156,17 @@ def test_get_events_with_session_files(client: TestClient, tmp_path: Path) -> No
 
 def test_send_message_success(client: TestClient) -> None:
     """Sending a message to a known agent succeeds."""
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=Path("/tmp/test"),
+        claude_config_dir=Path("/tmp/.claude"),
+    )
     with (
-        patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover,
+        patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info),
         patch("imbue.minds_workspace_server.server.send_message", return_value=True) as mock_send,
     ):
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=Path("/tmp/test"),
-                claude_config_dir=Path("/tmp/.claude"),
-            )
-        ]
         response = client.post("/api/agents/agent-123/message", json={"message": "hello"})
 
     assert response.status_code == 200
@@ -188,16 +186,14 @@ def test_get_layout_returns_404_when_no_layout_saved(client: TestClient, tmp_pat
     agent_state_dir = tmp_path / "agent_state"
     agent_state_dir.mkdir()
 
-    with patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover:
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=agent_state_dir,
-                claude_config_dir=Path("/tmp/.claude"),
-            )
-        ]
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=agent_state_dir,
+        claude_config_dir=Path("/tmp/.claude"),
+    )
+    with patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info):
         response = client.get("/api/agents/agent-123/layout")
 
     assert response.status_code == 404
@@ -210,17 +206,14 @@ def test_save_and_get_layout(client: TestClient, tmp_path: Path) -> None:
 
     layout_data = {"dockview": {"panels": {}}, "panelParams": {"chat-1": {"panelType": "chat"}}}
 
-    with patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover:
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=agent_state_dir,
-                claude_config_dir=Path("/tmp/.claude"),
-            )
-        ]
-
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=agent_state_dir,
+        claude_config_dir=Path("/tmp/.claude"),
+    )
+    with patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info):
         save_response = client.post("/api/agents/agent-123/layout", json=layout_data)
         assert save_response.status_code == 200
         assert save_response.json()["status"] == "ok"
@@ -235,16 +228,14 @@ def test_save_layout_creates_directory(client: TestClient, tmp_path: Path) -> No
     agent_state_dir = tmp_path / "agent_state"
     agent_state_dir.mkdir()
 
-    with patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover:
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=agent_state_dir,
-                claude_config_dir=Path("/tmp/.claude"),
-            )
-        ]
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=agent_state_dir,
+        claude_config_dir=Path("/tmp/.claude"),
+    )
+    with patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info):
         client.post("/api/agents/agent-123/layout", json={"test": True})
 
     assert (agent_state_dir / "workspace_layout" / "layout.json").exists()
@@ -255,16 +246,14 @@ def test_save_layout_rejects_invalid_json(client: TestClient, tmp_path: Path) ->
     agent_state_dir = tmp_path / "agent_state"
     agent_state_dir.mkdir()
 
-    with patch("imbue.minds_workspace_server.server.discover_agents") as mock_discover:
-        mock_discover.return_value = [
-            AgentInfo(
-                id="agent-123",
-                name="test-agent",
-                state="RUNNING",
-                agent_state_dir=agent_state_dir,
-                claude_config_dir=Path("/tmp/.claude"),
-            )
-        ]
+    agent_info = AgentInfo(
+        id="agent-123",
+        name="test-agent",
+        state="RUNNING",
+        agent_state_dir=agent_state_dir,
+        claude_config_dir=Path("/tmp/.claude"),
+    )
+    with patch("imbue.minds_workspace_server.server._find_agent", return_value=agent_info):
         response = client.post(
             "/api/agents/agent-123/layout",
             content=b"not valid json",

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -35,6 +35,10 @@ class SharingStatus(FrozenModel):
 
     enabled: bool = Field(description="Whether Cloudflare forwarding is active for this server")
     url: str | None = Field(default=None, description="The global URL if forwarding is enabled")
+    auth_rules: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="Cloudflare Access auth policy rules (who has access)",
+    )
 
 
 def _read_minds_api_url() -> str:
@@ -97,6 +101,7 @@ def get_sharing_status(server_name: str) -> SharingStatus:
             return SharingStatus(
                 enabled=data.get("enabled", False),
                 url=data.get("url"),
+                auth_rules=data.get("auth_rules", []),
             )
 
         error_msg = _extract_error(response)
@@ -106,7 +111,7 @@ def get_sharing_status(server_name: str) -> SharingStatus:
         raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e
 
 
-def enable_sharing(server_name: str) -> SharingStatus:
+def enable_sharing(server_name: str, auth_rules: list[dict[str, object]] | None = None) -> SharingStatus:
     """Enable Cloudflare forwarding for a server via the desktop client API.
 
     After enabling, queries the status to get the resulting URL.
@@ -114,13 +119,39 @@ def enable_sharing(server_name: str) -> SharingStatus:
     url = _cloudflare_url(server_name)
     headers = _get_desktop_client_auth_headers()
 
+    body: dict[str, object] = {}
+    if auth_rules is not None:
+        body["auth_rules"] = auth_rules
+
     try:
-        response = httpx.put(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+        response = httpx.put(url, headers=headers, json=body if body else None, timeout=_REQUEST_TIMEOUT_SECONDS)
         if response.status_code == 200:
             return get_sharing_status(server_name)
 
         error_msg = _extract_error(response)
         raise SharingProxyError(f"Failed to enable sharing: {error_msg}")
+
+    except httpx.HTTPError as e:
+        raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e
+
+
+def update_sharing_auth(server_name: str, auth_rules: list[dict[str, object]]) -> SharingStatus:
+    """Update the auth policy for an already-enabled service."""
+    url = _cloudflare_url(server_name)
+    headers = _get_desktop_client_auth_headers()
+
+    try:
+        response = httpx.put(
+            url,
+            headers=headers,
+            json={"auth_rules": auth_rules},
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 200:
+            return get_sharing_status(server_name)
+
+        error_msg = _extract_error(response)
+        raise SharingProxyError(f"Failed to update sharing auth: {error_msg}")
 
     except httpx.HTTPError as e:
         raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -1,0 +1,183 @@
+"""Proxy helpers for communicating with the minds desktop client REST API.
+
+The minds desktop client exposes its API to agents via a reverse SSH tunnel.
+The URL is written to ``$MNGR_AGENT_STATE_DIR/minds_api_url``. Authentication
+uses the ``MINDS_API_KEY`` environment variable as a Bearer token.
+
+For checking forwarding status (GET), we query the Cloudflare forwarding API
+directly since the desktop client does not expose a dedicated GET endpoint.
+For enabling/disabling (PUT/DELETE), we proxy through the desktop client API.
+"""
+
+import os
+from pathlib import Path
+from typing import Final
+
+import httpx
+from loguru import logger as _loguru_logger
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+
+logger = _loguru_logger
+
+_MINDS_API_URL_FILENAME: Final[str] = "minds_api_url"
+_REQUEST_TIMEOUT_SECONDS: Final[float] = 15.0
+
+
+class SharingProxyError(RuntimeError):
+    """Raised when the sharing proxy cannot communicate with the desktop client."""
+
+    ...
+
+
+class SharingStatus(FrozenModel):
+    """Forwarding status for a server."""
+
+    enabled: bool = Field(description="Whether Cloudflare forwarding is active for this server")
+    url: str | None = Field(default=None, description="The global URL if forwarding is enabled")
+
+
+def _read_minds_api_url() -> str:
+    """Read the minds desktop client API URL from the agent state directory.
+
+    Raises SharingProxyError if the file is missing or unreadable.
+    """
+    agent_state_dir = os.environ.get("MNGR_AGENT_STATE_DIR", "")
+    if not agent_state_dir:
+        raise SharingProxyError("MNGR_AGENT_STATE_DIR environment variable is not set")
+
+    url_file = Path(agent_state_dir) / _MINDS_API_URL_FILENAME
+    if not url_file.exists():
+        raise SharingProxyError(f"Minds API URL file not found: {url_file}")
+
+    url = url_file.read_text().strip()
+    if not url:
+        raise SharingProxyError(f"Minds API URL file is empty: {url_file}")
+
+    return url
+
+
+def _get_desktop_client_auth_headers() -> dict[str, str]:
+    """Build authorization headers for the desktop client using MINDS_API_KEY."""
+    api_key = os.environ.get("MINDS_API_KEY", "")
+    if not api_key:
+        raise SharingProxyError("MINDS_API_KEY environment variable is not set")
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _get_own_agent_id() -> str:
+    """Return this server's own agent ID from the environment."""
+    agent_id = os.environ.get("MNGR_AGENT_ID", "")
+    if not agent_id:
+        raise SharingProxyError("MNGR_AGENT_ID environment variable is not set")
+    return agent_id
+
+
+def _read_tunnel_token() -> str | None:
+    """Read the Cloudflare tunnel token from runtime/secrets.
+
+    Returns None if the file doesn't exist or the token is not found.
+    """
+    work_dir = os.environ.get("MNGR_AGENT_WORK_DIR", "")
+    if not work_dir:
+        return None
+
+    secrets_file = Path(work_dir) / "runtime" / "secrets"
+    if not secrets_file.exists():
+        return None
+
+    try:
+        for line in secrets_file.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("export CLOUDFLARE_TUNNEL_TOKEN="):
+                return stripped.split("=", 1)[1].strip().strip("'\"")
+        return None
+    except OSError:
+        return None
+
+
+def get_sharing_status(server_name: str) -> SharingStatus:
+    """Fetch the current Cloudflare forwarding status for a server.
+
+    Queries the Cloudflare forwarding API directly using the tunnel token,
+    since the desktop client does not expose a GET endpoint for this.
+    """
+    forwarding_url = os.environ.get("CLOUDFLARE_FORWARDING_URL", "")
+    if not forwarding_url:
+        raise SharingProxyError("CLOUDFLARE_FORWARDING_URL environment variable is not set")
+
+    tunnel_token = _read_tunnel_token()
+    if not tunnel_token:
+        raise SharingProxyError("Cloudflare tunnel token not found in runtime/secrets")
+
+    try:
+        url = f"{forwarding_url}/tunnels/_/services"
+        headers = {"Authorization": f"Bearer {tunnel_token}"}
+        response = httpx.get(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code != 200:
+            raise SharingProxyError(f"Forwarding API returned status {response.status_code}")
+
+        data = response.json()
+        for service in data.get("services", []):
+            if service.get("service_name") == server_name:
+                hostname = service.get("hostname", "")
+                if hostname:
+                    return SharingStatus(enabled=True, url=f"https://{hostname}")
+                return SharingStatus(enabled=True, url=None)
+
+        return SharingStatus(enabled=False)
+
+    except httpx.HTTPError as e:
+        raise SharingProxyError(f"Failed to query forwarding API: {e}") from e
+
+
+def enable_sharing(server_name: str) -> SharingStatus:
+    """Enable Cloudflare forwarding for a server via the desktop client API."""
+    base_url = _read_minds_api_url()
+    agent_id = _get_own_agent_id()
+    headers = _get_desktop_client_auth_headers()
+
+    url = f"{base_url}/api/v1/agents/{agent_id}/servers/{server_name}/cloudflare"
+    try:
+        response = httpx.put(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+        if response.status_code == 200:
+            return get_sharing_status(server_name)
+
+        error_msg = _extract_error(response)
+        raise SharingProxyError(f"Failed to enable sharing: {error_msg}")
+
+    except httpx.HTTPError as e:
+        raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e
+
+
+def disable_sharing(server_name: str) -> SharingStatus:
+    """Disable Cloudflare forwarding for a server via the desktop client API."""
+    base_url = _read_minds_api_url()
+    agent_id = _get_own_agent_id()
+    headers = _get_desktop_client_auth_headers()
+
+    url = f"{base_url}/api/v1/agents/{agent_id}/servers/{server_name}/cloudflare"
+    try:
+        response = httpx.delete(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+        if response.status_code == 200:
+            return SharingStatus(enabled=False)
+
+        error_msg = _extract_error(response)
+        raise SharingProxyError(f"Failed to disable sharing: {error_msg}")
+
+    except httpx.HTTPError as e:
+        raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e
+
+
+def _extract_error(response: httpx.Response) -> str:
+    """Extract an error message from a non-200 response."""
+    content_type = response.headers.get("content-type", "")
+    if "application/json" in content_type:
+        try:
+            data = response.json()
+            return str(data.get("error", f"HTTP {response.status_code}"))
+        except (ValueError, KeyError):
+            pass
+    return f"HTTP {response.status_code}"

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -40,36 +40,21 @@ class SharingStatus(FrozenModel):
 def _read_minds_api_url() -> str:
     """Read the minds desktop client API URL from the agent state directory.
 
-    The desktop client writes the URL to ``~/.mngr/agents/{agent_id}/minds_api_url``
-    (using the SSH user's home directory), which may differ from the path in
-    ``$MNGR_AGENT_STATE_DIR`` (which uses ``$MNGR_HOST_DIR``). We check both
-    locations.
-
     Raises SharingProxyError if the file is missing or unreadable.
     """
-    agent_id = os.environ.get("MNGR_AGENT_ID", "")
-    candidates: list[Path] = []
-
-    # Primary: ~/.mngr/agents/{agent_id}/ (where the desktop client writes via SSH)
-    if agent_id:
-        candidates.append(Path.home() / ".mngr" / "agents" / agent_id / _MINDS_API_URL_FILENAME)
-
-    # Fallback: $MNGR_AGENT_STATE_DIR/ (mngr host dir convention)
     agent_state_dir = os.environ.get("MNGR_AGENT_STATE_DIR", "")
-    if agent_state_dir:
-        candidates.append(Path(agent_state_dir) / _MINDS_API_URL_FILENAME)
+    if not agent_state_dir:
+        raise SharingProxyError("MNGR_AGENT_STATE_DIR environment variable is not set")
 
-    if not candidates:
-        raise SharingProxyError("Neither MNGR_AGENT_ID nor MNGR_AGENT_STATE_DIR is set")
+    url_file = Path(agent_state_dir) / _MINDS_API_URL_FILENAME
+    if not url_file.exists():
+        raise SharingProxyError(f"Minds API URL file not found: {url_file}")
 
-    for url_file in candidates:
-        if url_file.exists():
-            url = url_file.read_text().strip()
-            if url:
-                return url
+    url = url_file.read_text().strip()
+    if not url:
+        raise SharingProxyError(f"Minds API URL file is empty: {url_file}")
 
-    tried = ", ".join(str(p) for p in candidates)
-    raise SharingProxyError(f"Minds API URL file not found (checked: {tried})")
+    return url
 
 
 def _get_desktop_client_auth_headers() -> dict[str, str]:

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -40,21 +40,36 @@ class SharingStatus(FrozenModel):
 def _read_minds_api_url() -> str:
     """Read the minds desktop client API URL from the agent state directory.
 
+    The desktop client writes the URL to ``~/.mngr/agents/{agent_id}/minds_api_url``
+    (using the SSH user's home directory), which may differ from the path in
+    ``$MNGR_AGENT_STATE_DIR`` (which uses ``$MNGR_HOST_DIR``). We check both
+    locations.
+
     Raises SharingProxyError if the file is missing or unreadable.
     """
+    agent_id = os.environ.get("MNGR_AGENT_ID", "")
+    candidates: list[Path] = []
+
+    # Primary: ~/.mngr/agents/{agent_id}/ (where the desktop client writes via SSH)
+    if agent_id:
+        candidates.append(Path.home() / ".mngr" / "agents" / agent_id / _MINDS_API_URL_FILENAME)
+
+    # Fallback: $MNGR_AGENT_STATE_DIR/ (mngr host dir convention)
     agent_state_dir = os.environ.get("MNGR_AGENT_STATE_DIR", "")
-    if not agent_state_dir:
-        raise SharingProxyError("MNGR_AGENT_STATE_DIR environment variable is not set")
+    if agent_state_dir:
+        candidates.append(Path(agent_state_dir) / _MINDS_API_URL_FILENAME)
 
-    url_file = Path(agent_state_dir) / _MINDS_API_URL_FILENAME
-    if not url_file.exists():
-        raise SharingProxyError(f"Minds API URL file not found: {url_file}")
+    if not candidates:
+        raise SharingProxyError("Neither MNGR_AGENT_ID nor MNGR_AGENT_STATE_DIR is set")
 
-    url = url_file.read_text().strip()
-    if not url:
-        raise SharingProxyError(f"Minds API URL file is empty: {url_file}")
+    for url_file in candidates:
+        if url_file.exists():
+            url = url_file.read_text().strip()
+            if url:
+                return url
 
-    return url
+    tried = ", ".join(str(p) for p in candidates)
+    raise SharingProxyError(f"Minds API URL file not found (checked: {tried})")
 
 
 def _get_desktop_client_auth_headers() -> dict[str, str]:

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -21,7 +21,7 @@ from imbue.imbue_common.frozen_model import FrozenModel
 logger = _loguru_logger
 
 _MINDS_API_URL_FILENAME: Final[str] = "minds_api_url"
-_REQUEST_TIMEOUT_SECONDS: Final[float] = 15.0
+_REQUEST_TIMEOUT_SECONDS: Final[float] = 60.0
 
 
 class SharingProxyError(RuntimeError):

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -126,7 +126,10 @@ def enable_sharing(server_name: str, auth_rules: list[dict[str, object]] | None 
     try:
         response = httpx.put(url, headers=headers, json=body if body else None, timeout=_REQUEST_TIMEOUT_SECONDS)
         if response.status_code == 200:
-            return get_sharing_status(server_name)
+            # Return a provisional enabled status. The frontend will re-fetch
+            # to get the full status (URL, auth) without blocking on a second
+            # round trip that could cause a timeout.
+            return SharingStatus(enabled=True, auth_rules=auth_rules or [])
 
         error_msg = _extract_error(response)
         raise SharingProxyError(f"Failed to enable sharing: {error_msg}")
@@ -148,7 +151,7 @@ def update_sharing_auth(server_name: str, auth_rules: list[dict[str, object]]) -
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
         if response.status_code == 200:
-            return get_sharing_status(server_name)
+            return SharingStatus(enabled=True, auth_rules=auth_rules)
 
         error_msg = _extract_error(response)
         raise SharingProxyError(f"Failed to update sharing auth: {error_msg}")

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy.py
@@ -4,9 +4,8 @@ The minds desktop client exposes its API to agents via a reverse SSH tunnel.
 The URL is written to ``$MNGR_AGENT_STATE_DIR/minds_api_url``. Authentication
 uses the ``MINDS_API_KEY`` environment variable as a Bearer token.
 
-For checking forwarding status (GET), we query the Cloudflare forwarding API
-directly since the desktop client does not expose a dedicated GET endpoint.
-For enabling/disabling (PUT/DELETE), we proxy through the desktop client API.
+All sharing operations (GET status, PUT enable, DELETE disable) are proxied
+through the desktop client API.
 """
 
 import os
@@ -74,72 +73,47 @@ def _get_own_agent_id() -> str:
     return agent_id
 
 
-def _read_tunnel_token() -> str | None:
-    """Read the Cloudflare tunnel token from runtime/secrets.
-
-    Returns None if the file doesn't exist or the token is not found.
-    """
-    work_dir = os.environ.get("MNGR_AGENT_WORK_DIR", "")
-    if not work_dir:
-        return None
-
-    secrets_file = Path(work_dir) / "runtime" / "secrets"
-    if not secrets_file.exists():
-        return None
-
-    try:
-        for line in secrets_file.read_text().splitlines():
-            stripped = line.strip()
-            if stripped.startswith("export CLOUDFLARE_TUNNEL_TOKEN="):
-                return stripped.split("=", 1)[1].strip().strip("'\"")
-        return None
-    except OSError:
-        return None
+def _cloudflare_url(server_name: str) -> str:
+    """Build the desktop client API URL for a server's Cloudflare forwarding."""
+    base_url = _read_minds_api_url()
+    agent_id = _get_own_agent_id()
+    return f"{base_url}/api/v1/agents/{agent_id}/servers/{server_name}/cloudflare"
 
 
 def get_sharing_status(server_name: str) -> SharingStatus:
     """Fetch the current Cloudflare forwarding status for a server.
 
-    Queries the Cloudflare forwarding API directly using the tunnel token,
-    since the desktop client does not expose a GET endpoint for this.
+    Queries the desktop client's GET cloudflare endpoint, which returns
+    ``{"enabled": bool, "url": str | null}``.
     """
-    forwarding_url = os.environ.get("CLOUDFLARE_FORWARDING_URL", "")
-    if not forwarding_url:
-        raise SharingProxyError("CLOUDFLARE_FORWARDING_URL environment variable is not set")
-
-    tunnel_token = _read_tunnel_token()
-    if not tunnel_token:
-        raise SharingProxyError("Cloudflare tunnel token not found in runtime/secrets")
+    url = _cloudflare_url(server_name)
+    headers = _get_desktop_client_auth_headers()
 
     try:
-        url = f"{forwarding_url}/tunnels/_/services"
-        headers = {"Authorization": f"Bearer {tunnel_token}"}
         response = httpx.get(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
 
-        if response.status_code != 200:
-            raise SharingProxyError(f"Forwarding API returned status {response.status_code}")
+        if response.status_code == 200:
+            data = response.json()
+            return SharingStatus(
+                enabled=data.get("enabled", False),
+                url=data.get("url"),
+            )
 
-        data = response.json()
-        for service in data.get("services", []):
-            if service.get("service_name") == server_name:
-                hostname = service.get("hostname", "")
-                if hostname:
-                    return SharingStatus(enabled=True, url=f"https://{hostname}")
-                return SharingStatus(enabled=True, url=None)
-
-        return SharingStatus(enabled=False)
+        error_msg = _extract_error(response)
+        raise SharingProxyError(f"Failed to query sharing status: {error_msg}")
 
     except httpx.HTTPError as e:
-        raise SharingProxyError(f"Failed to query forwarding API: {e}") from e
+        raise SharingProxyError(f"Failed to communicate with desktop client: {e}") from e
 
 
 def enable_sharing(server_name: str) -> SharingStatus:
-    """Enable Cloudflare forwarding for a server via the desktop client API."""
-    base_url = _read_minds_api_url()
-    agent_id = _get_own_agent_id()
+    """Enable Cloudflare forwarding for a server via the desktop client API.
+
+    After enabling, queries the status to get the resulting URL.
+    """
+    url = _cloudflare_url(server_name)
     headers = _get_desktop_client_auth_headers()
 
-    url = f"{base_url}/api/v1/agents/{agent_id}/servers/{server_name}/cloudflare"
     try:
         response = httpx.put(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
         if response.status_code == 200:
@@ -154,11 +128,9 @@ def enable_sharing(server_name: str) -> SharingStatus:
 
 def disable_sharing(server_name: str) -> SharingStatus:
     """Disable Cloudflare forwarding for a server via the desktop client API."""
-    base_url = _read_minds_api_url()
-    agent_id = _get_own_agent_id()
+    url = _cloudflare_url(server_name)
     headers = _get_desktop_client_auth_headers()
 
-    url = f"{base_url}/api/v1/agents/{agent_id}/servers/{server_name}/cloudflare"
     try:
         response = httpx.delete(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
         if response.status_code == 200:

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy_test.py
@@ -1,0 +1,108 @@
+"""Tests for sharing_proxy module."""
+
+from pathlib import Path
+
+import pytest
+
+from imbue.minds_workspace_server.sharing_proxy import SharingProxyError
+from imbue.minds_workspace_server.sharing_proxy import SharingStatus
+from imbue.minds_workspace_server.sharing_proxy import _read_minds_api_url
+from imbue.minds_workspace_server.sharing_proxy import _read_tunnel_token
+
+
+def test_read_minds_api_url_missing_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MNGR_AGENT_STATE_DIR", raising=False)
+    with pytest.raises(SharingProxyError, match="MNGR_AGENT_STATE_DIR"):
+        _read_minds_api_url()
+
+
+def test_read_minds_api_url_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    with pytest.raises(SharingProxyError, match="not found"):
+        _read_minds_api_url()
+
+
+def test_read_minds_api_url_empty_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url_file = tmp_path / "minds_api_url"
+    url_file.write_text("")
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    with pytest.raises(SharingProxyError, match="empty"):
+        _read_minds_api_url()
+
+
+def test_read_minds_api_url_valid_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    url_file = tmp_path / "minds_api_url"
+    url_file.write_text("http://127.0.0.1:8420\n")
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    assert _read_minds_api_url() == "http://127.0.0.1:8420"
+
+
+def test_read_tunnel_token_missing_work_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MNGR_AGENT_WORK_DIR", raising=False)
+    assert _read_tunnel_token() is None
+
+
+def test_read_tunnel_token_missing_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
+    assert _read_tunnel_token() is None
+
+
+def test_read_tunnel_token_no_token_in_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    secrets_dir = tmp_path / "runtime"
+    secrets_dir.mkdir()
+    (secrets_dir / "secrets").write_text("export OTHER_VAR=something\n")
+    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
+    assert _read_tunnel_token() is None
+
+
+def test_read_tunnel_token_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    secrets_dir = tmp_path / "runtime"
+    secrets_dir.mkdir()
+    (secrets_dir / "secrets").write_text("export CLOUDFLARE_TUNNEL_TOKEN=abc123\n")
+    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
+    assert _read_tunnel_token() == "abc123"
+
+
+def test_sharing_status_enabled_with_url() -> None:
+    status = SharingStatus(enabled=True, url="https://web.example.com")
+    assert status.enabled is True
+    assert status.url == "https://web.example.com"
+
+
+def test_sharing_status_disabled() -> None:
+    status = SharingStatus(enabled=False)
+    assert status.enabled is False
+    assert status.url is None
+
+
+def test_get_sharing_status_missing_forwarding_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
+
+    monkeypatch.delenv("CLOUDFLARE_FORWARDING_URL", raising=False)
+    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", "/nonexistent")
+    with pytest.raises(SharingProxyError):
+        get_sharing_status("web")
+
+
+def test_enable_sharing_missing_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from imbue.minds_workspace_server.sharing_proxy import enable_sharing
+
+    api_url_file = tmp_path / "minds_api_url"
+    api_url_file.write_text("http://127.0.0.1:8420")
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("MNGR_AGENT_ID", "agent-123")
+    monkeypatch.delenv("MINDS_API_KEY", raising=False)
+    with pytest.raises(SharingProxyError, match="MINDS_API_KEY"):
+        enable_sharing("web")
+
+
+def test_disable_sharing_missing_agent_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from imbue.minds_workspace_server.sharing_proxy import disable_sharing
+
+    api_url_file = tmp_path / "minds_api_url"
+    api_url_file.write_text("http://127.0.0.1:8420")
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("MNGR_AGENT_ID", raising=False)
+    monkeypatch.setenv("MINDS_API_KEY", "test-key")
+    with pytest.raises(SharingProxyError, match="MNGR_AGENT_ID"):
+        disable_sharing("web")

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/sharing_proxy_test.py
@@ -7,7 +7,6 @@ import pytest
 from imbue.minds_workspace_server.sharing_proxy import SharingProxyError
 from imbue.minds_workspace_server.sharing_proxy import SharingStatus
 from imbue.minds_workspace_server.sharing_proxy import _read_minds_api_url
-from imbue.minds_workspace_server.sharing_proxy import _read_tunnel_token
 
 
 def test_read_minds_api_url_missing_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -37,32 +36,6 @@ def test_read_minds_api_url_valid_file(tmp_path: Path, monkeypatch: pytest.Monke
     assert _read_minds_api_url() == "http://127.0.0.1:8420"
 
 
-def test_read_tunnel_token_missing_work_dir(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("MNGR_AGENT_WORK_DIR", raising=False)
-    assert _read_tunnel_token() is None
-
-
-def test_read_tunnel_token_missing_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
-    assert _read_tunnel_token() is None
-
-
-def test_read_tunnel_token_no_token_in_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    secrets_dir = tmp_path / "runtime"
-    secrets_dir.mkdir()
-    (secrets_dir / "secrets").write_text("export OTHER_VAR=something\n")
-    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
-    assert _read_tunnel_token() is None
-
-
-def test_read_tunnel_token_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    secrets_dir = tmp_path / "runtime"
-    secrets_dir.mkdir()
-    (secrets_dir / "secrets").write_text("export CLOUDFLARE_TUNNEL_TOKEN=abc123\n")
-    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", str(tmp_path))
-    assert _read_tunnel_token() == "abc123"
-
-
 def test_sharing_status_enabled_with_url() -> None:
     status = SharingStatus(enabled=True, url="https://web.example.com")
     assert status.enabled is True
@@ -73,15 +46,6 @@ def test_sharing_status_disabled() -> None:
     status = SharingStatus(enabled=False)
     assert status.enabled is False
     assert status.url is None
-
-
-def test_get_sharing_status_missing_forwarding_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
-
-    monkeypatch.delenv("CLOUDFLARE_FORWARDING_URL", raising=False)
-    monkeypatch.setenv("MNGR_AGENT_WORK_DIR", "/nonexistent")
-    with pytest.raises(SharingProxyError):
-        get_sharing_status("web")
 
 
 def test_enable_sharing_missing_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -106,3 +70,11 @@ def test_disable_sharing_missing_agent_id(tmp_path: Path, monkeypatch: pytest.Mo
     monkeypatch.setenv("MINDS_API_KEY", "test-key")
     with pytest.raises(SharingProxyError, match="MNGR_AGENT_ID"):
         disable_sharing("web")
+
+
+def test_get_sharing_status_missing_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
+
+    monkeypatch.delenv("MNGR_AGENT_STATE_DIR", raising=False)
+    with pytest.raises(SharingProxyError, match="MNGR_AGENT_STATE_DIR"):
+        get_sharing_status("web")

--- a/apps/minds_workspace_server/pyproject.toml
+++ b/apps/minds_workspace_server/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
+    "httpx>=0.27",
     "imbue-common",
     "imbue-mngr",
     "pluggy>=1.5",

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
@@ -224,7 +224,7 @@ PREVENT_NUM_PREFIX = RegexRatchetRule(
 PREVENT_TRAILING_COMMENTS = RegexRatchetRule(
     rule_name="trailing comments",
     rule_description="Comments should be on their own line, not trailing after code. Trailing comments make code harder to read",
-    pattern_string=r"[^\s#].*[ \t]#(?!\s*ty:\s*ignore\[)",
+    pattern_string=r"[^\s#].*[ \t]#(?![0-9a-fA-F]{3,6}[;\s])(?!\s*ty:\s*ignore\[)",
 )
 
 PREVENT_INIT_DOCSTRINGS = RegexRatchetRule(

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -478,13 +478,14 @@ def apply_create_template(
 
     Templates are named presets of create command arguments that can be applied
     using --template <name>. Multiple templates can be specified and are applied
-    in order, stacking their values. Template values act as defaults - they only
-    override parameters that came from DEFAULT source, not user-specified values.
+    in order, stacking their values.
 
-    When multiple templates are specified, later templates override earlier ones
-    for the same parameter.
-
-    CLI arguments always take precedence over template values.
+    Merge semantics (matching config file merge behavior):
+    - Scalar params: latest template wins; CLI arguments always take precedence.
+    - List/tuple params (env, pass_env, etc.): concatenated with existing values
+      (from config defaults, earlier templates, or CLI). An explicit empty list
+      [] resets the parameter, clearing all values from earlier in the chain
+      (but not CLI-specified values).
 
     This function should only be called for the 'create' command.
     """
@@ -495,7 +496,7 @@ def apply_create_template(
     # Start with existing params
     updated_params = params.copy()
 
-    # Apply each template in order (later templates override earlier ones)
+    # Apply each template in order
     for template_name in template_names:
         try:
             template_key = CreateTemplateName(template_name)
@@ -516,15 +517,32 @@ def apply_create_template(
 
         template = config.create_templates[template_key]
 
-        # Apply template options only for parameters that came from defaults (not CLI)
         for param_name, template_value in template.options.items():
             if template_value is None:
                 continue
             if param_name not in params:
                 continue
             source = ctx.get_parameter_source(param_name)
-            if source == ParameterSource.DEFAULT:
+            existing_value = updated_params[param_name]
+
+            # List/tuple params: concatenate (or reset on explicit empty list)
+            if isinstance(template_value, (list, tuple)) and isinstance(existing_value, (list, tuple)):
+                if not template_value:
+                    # Explicit empty list resets values from config defaults and
+                    # earlier templates, but CLI-specified values are preserved
+                    if source == ParameterSource.DEFAULT:
+                        updated_params[param_name] = ()
+                    else:
+                        pass
+                else:
+                    # Concatenate existing values with template values
+                    updated_params[param_name] = tuple(existing_value) + tuple(template_value)
+            elif source == ParameterSource.DEFAULT:
+                # Scalar params from defaults: template value wins
                 updated_params[param_name] = template_value
+            else:
+                # CLI-specified scalar params: CLI wins (no change)
+                pass
 
     return updated_params
 

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -27,6 +27,7 @@ from imbue.mngr.config.data_types import CreateTemplateName
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.config.loader import block_disabled_plugins
 from imbue.mngr.config.loader import load_config
 from imbue.mngr.config.loader import parse_config
 from imbue.mngr.errors import ParseSpecError
@@ -194,6 +195,14 @@ def setup_command_context(
     # Apply create template if this is the create command and a template was specified
     if command_name == "create":
         updated_params = apply_create_template(ctx, updated_params, mngr_ctx.config)
+
+    # Block plugins that were disabled via command defaults or create templates
+    # (e.g. disable_plugin from [commands.create] in settings.toml). load_config
+    # only blocks plugins from CLI args and [plugins] config sections; command
+    # defaults are applied later and need a second blocking pass.
+    updated_disable_plugin = updated_params.get("disable_plugin", ())
+    if updated_disable_plugin:
+        block_disabled_plugins(pm, frozenset(updated_disable_plugin))
 
     # Allow plugins to override command options before creating the options object
     _apply_plugin_option_overrides(pm, command_name, command_class, updated_params)

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -29,8 +29,11 @@ from imbue.mngr.config.data_types import CreateTemplateName
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.errors import UserInputError
+from imbue.mngr.plugins import hookspecs
 from imbue.mngr.primitives import LogLevel
 from imbue.mngr.primitives import OutputFormat
+
+hookimpl = pluggy.HookimplMarker("mngr")
 
 
 def _make_click_context(
@@ -874,28 +877,23 @@ def test_setting_flag_sets_command_defaults_in_config(
     assert captured_config[0].commands["create"].defaults["connect"] is False
 
 
-def test_disable_plugin_in_command_defaults_does_not_block_override_hook(
-    plugin_manager: pluggy.PluginManager,
+def test_disable_plugin_in_command_defaults_blocks_override_hook(
+    cli_runner: CliRunner,
+    tmp_path: Path,
 ) -> None:
-    """Demonstrate that disable_plugin in [commands.create] does NOT block
-    a plugin's override_command_options hook.
+    """A plugin disabled via [commands.create] disable_plugin should not have
+    its override_command_options hook fire.
 
-    The disable_plugin field under [commands.create] in settings.toml is
-    a command default -- it updates the --disable-plugin CLI param but does
-    NOT call block_disabled_plugins on the plugin manager. So a plugin
-    like mngr_ttyd that uses override_command_options to inject extra_window
-    entries will still fire even when disable_plugin=["ttyd"] is set.
-
-    This test simulates what happens inside setup_command_context:
-    1. apply_config_defaults sets disable_plugin in params
-    2. _apply_plugin_option_overrides fires ALL plugin hooks (including disabled ones)
+    Regression test: the ttyd plugin was injecting a duplicate 'terminal'
+    extra_window even though disable_plugin=["ttyd"] was set in the project
+    settings under [commands.create]. The root cause was that disable_plugin
+    from command defaults only updated CLI params but never called
+    block_disabled_plugins on the plugin manager, so the plugin's hooks
+    still fired.
     """
-    from imbue.mngr import hookimpl as mngr_hookimpl
-    from imbue.mngr.cli.common_opts import _apply_plugin_option_overrides
-    from imbue.mngr.plugins import hookspecs
 
     class FakeTerminalPlugin:
-        @mngr_hookimpl
+        @hookimpl
         def override_command_options(
             self,
             command_name: str,
@@ -906,24 +904,46 @@ def test_disable_plugin_in_command_defaults_does_not_block_override_hook(
                 existing = params.get("extra_window", ())
                 params["extra_window"] = (*existing, 'terminal="fake-ttyd-command"')
 
+    # Set up a project settings file that disables our plugin via command defaults
+    project_dir = tmp_path / ".mngr"
+    project_dir.mkdir(exist_ok=True)
+    settings_path = project_dir / "settings.toml"
+    settings_path.write_text(
+        '[commands.create]\n'
+        'disable_plugin = ["fake_terminal"]\n'
+    )
+
     pm = pluggy.PluginManager("mngr")
     pm.add_hookspecs(hookspecs)
     pm.register(FakeTerminalPlugin(), name="fake_terminal")
 
-    # Simulate what happens after apply_config_defaults: disable_plugin is
-    # set in the params dict, but the plugin manager doesn't know about it.
-    params: dict[str, Any] = {
-        "extra_window": ('terminal="bash scripts/run_ttyd.sh"',),
-        "disable_plugin": ("fake_terminal",),
-    }
+    captured_params: list[dict[str, Any]] = []
 
-    # This is what setup_command_context calls at line 199.
-    # The plugin is NOT blocked in the PM, so its hook fires.
-    _apply_plugin_option_overrides(pm, "create", CommonCliOptions, params)
+    @click.command()
+    @click.option("--extra-window", multiple=True, default=())
+    @add_common_options
+    @click.pass_context
+    def test_create(ctx: click.Context, **kwargs: Any) -> None:
+        _mngr_ctx, _output_opts, _opts = setup_command_context(
+            ctx=ctx,
+            command_name="create",
+            command_class=CommonCliOptions,
+        )
+        captured_params.append(ctx.params.copy())
 
-    # BUG: The plugin injected a SECOND terminal entry despite being in disable_plugin
-    terminal_entries = [e for e in params["extra_window"] if "fake-ttyd" in str(e)]
-    assert len(terminal_entries) == 1, (
-        f"The disabled plugin's hook fired and injected a duplicate terminal entry. "
-        f"extra_window={params['extra_window']}"
+    result = cli_runner.invoke(
+        test_create,
+        [],
+        obj=pm,
+        catch_exceptions=False,
+        env={"MNGR_PROJECT_DIR": str(tmp_path)},
+    )
+    assert result.exit_code == 0
+    assert len(captured_params) == 1
+
+    extra_window = captured_params[0].get("extra_window", ())
+    terminal_entries = [e for e in extra_window if "fake-ttyd" in str(e)]
+    assert terminal_entries == [], (
+        f"Disabled plugin's override_command_options hook still fired, "
+        f"injecting: {terminal_entries}. extra_window={extra_window}"
     )

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -872,3 +872,58 @@ def test_setting_flag_sets_command_defaults_in_config(
     )
     assert result.exit_code == 0
     assert captured_config[0].commands["create"].defaults["connect"] is False
+
+
+def test_disable_plugin_in_command_defaults_does_not_block_override_hook(
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """Demonstrate that disable_plugin in [commands.create] does NOT block
+    a plugin's override_command_options hook.
+
+    The disable_plugin field under [commands.create] in settings.toml is
+    a command default -- it updates the --disable-plugin CLI param but does
+    NOT call block_disabled_plugins on the plugin manager. So a plugin
+    like mngr_ttyd that uses override_command_options to inject extra_window
+    entries will still fire even when disable_plugin=["ttyd"] is set.
+
+    This test simulates what happens inside setup_command_context:
+    1. apply_config_defaults sets disable_plugin in params
+    2. _apply_plugin_option_overrides fires ALL plugin hooks (including disabled ones)
+    """
+    from imbue.mngr import hookimpl as mngr_hookimpl
+    from imbue.mngr.cli.common_opts import _apply_plugin_option_overrides
+    from imbue.mngr.plugins import hookspecs
+
+    class FakeTerminalPlugin:
+        @mngr_hookimpl
+        def override_command_options(
+            self,
+            command_name: str,
+            command_class: type,
+            params: dict[str, Any],
+        ) -> None:
+            if command_name == "create":
+                existing = params.get("extra_window", ())
+                params["extra_window"] = (*existing, 'terminal="fake-ttyd-command"')
+
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+    pm.register(FakeTerminalPlugin(), name="fake_terminal")
+
+    # Simulate what happens after apply_config_defaults: disable_plugin is
+    # set in the params dict, but the plugin manager doesn't know about it.
+    params: dict[str, Any] = {
+        "extra_window": ('terminal="bash scripts/run_ttyd.sh"',),
+        "disable_plugin": ("fake_terminal",),
+    }
+
+    # This is what setup_command_context calls at line 199.
+    # The plugin is NOT blocked in the PM, so its hook fires.
+    _apply_plugin_option_overrides(pm, "create", CommonCliOptions, params)
+
+    # BUG: The plugin injected a SECOND terminal entry despite being in disable_plugin
+    terminal_entries = [e for e in params["extra_window"] if "fake-ttyd" in str(e)]
+    assert len(terminal_entries) == 1, (
+        f"The disabled plugin's hook fired and injected a duplicate terminal entry. "
+        f"extra_window={params['extra_window']}"
+    )

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -545,6 +545,148 @@ def test_apply_create_template_skips_unknown_params(mngr_test_prefix: str) -> No
 
 
 # =============================================================================
+# Tests for apply_create_template list/tuple merging
+# =============================================================================
+
+
+def test_apply_create_template_concatenates_list_params_with_config_defaults(mngr_test_prefix: str) -> None:
+    """Template list values should concatenate with existing config defaults, not overwrite."""
+    # Simulate the state after apply_config_defaults has set env from [commands.create]
+    ctx = _make_click_context(
+        params={
+            "template": ("main",),
+            "env": ("IS_SANDBOX=1", "IS_AUTONOMOUS=1"),
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("main"): CreateTemplate(options={"env": ["REVIEWER_AUTOFIX_ENABLE=0"]}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    assert result["env"] == ("IS_SANDBOX=1", "IS_AUTONOMOUS=1", "REVIEWER_AUTOFIX_ENABLE=0")
+
+
+def test_apply_create_template_concatenates_list_params_across_multiple_templates(mngr_test_prefix: str) -> None:
+    """Multiple templates should concatenate their list values."""
+    ctx = _make_click_context(
+        params={
+            "template": ("first", "second"),
+            "env": (),
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("first"): CreateTemplate(options={"env": ["FOO=1"]}),
+            CreateTemplateName("second"): CreateTemplate(options={"env": ["BAR=2"]}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    assert result["env"] == ("FOO=1", "BAR=2")
+
+
+def test_apply_create_template_empty_list_resets(mngr_test_prefix: str) -> None:
+    """An explicit empty list in a template should reset earlier values."""
+    # Simulate config defaults already applied
+    ctx = _make_click_context(
+        params={
+            "template": ("reset-template",),
+            "env": ("FROM_CONFIG=1",),
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("reset-template"): CreateTemplate(options={"env": []}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    assert result["env"] == ()
+
+
+def test_apply_create_template_empty_list_reset_then_later_template_adds(mngr_test_prefix: str) -> None:
+    """After a reset, later templates can still add values."""
+    ctx = _make_click_context(
+        params={
+            "template": ("reset", "add-back"),
+            "env": ("FROM_CONFIG=1",),
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("reset"): CreateTemplate(options={"env": []}),
+            CreateTemplateName("add-back"): CreateTemplate(options={"env": ["FRESH=1"]}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    assert result["env"] == ("FRESH=1",)
+
+
+def test_apply_create_template_list_concat_with_cli_values(mngr_test_prefix: str) -> None:
+    """Template list values should concatenate with CLI-specified list values."""
+    ctx = _make_click_context(
+        params={
+            "template": ("mytemplate",),
+            "env": ("CLI_VAR=1",),
+        },
+        source_by_param_name={
+            "env": ParameterSource.COMMANDLINE,
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("mytemplate"): CreateTemplate(options={"env": ["TEMPLATE_VAR=2"]}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    assert result["env"] == ("CLI_VAR=1", "TEMPLATE_VAR=2")
+
+
+def test_apply_create_template_empty_list_does_not_reset_cli_values(mngr_test_prefix: str) -> None:
+    """An explicit empty list should not clear CLI-specified list values."""
+    ctx = _make_click_context(
+        params={
+            "template": ("reset-template",),
+            "env": ("CLI_VAR=1",),
+        },
+        source_by_param_name={
+            "env": ParameterSource.COMMANDLINE,
+        },
+    )
+
+    config = MngrConfig(
+        prefix=mngr_test_prefix,
+        create_templates={
+            CreateTemplateName("reset-template"): CreateTemplate(options={"env": []}),
+        },
+    )
+
+    result = apply_create_template(ctx, ctx.params.copy(), config)
+
+    # CLI-specified values should be preserved even when template resets
+    assert result["env"] == ("CLI_VAR=1",)
+
+
+# =============================================================================
 # Tests for _split_known_and_plugin_params
 # =============================================================================
 

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -75,18 +75,10 @@ def merge_cli_args(base: tuple[str, ...], override: tuple[str, ...]) -> tuple[st
 
 @pure
 def merge_list_fields(base: list[T], override: list[T] | None) -> list[T]:
-    """Merge list fields with concatenation semantics.
-
-    None means "not set" (field absent from config) -- base is preserved.
-    An explicit empty list [] means "reset" -- clears everything from earlier
-    in the precedence chain.
-    A non-empty list is concatenated with the base.
-    """
-    if override is None:
-        return base
-    if not override:
-        return []
-    return list(base) + list(override)
+    """Merge list fields, concatenating if override is not None."""
+    if override is not None:
+        return list(base) + list(override)
+    return base
 
 
 K = TypeVar("K")
@@ -95,18 +87,10 @@ V = TypeVar("V")
 
 @pure
 def merge_dict_fields(base: dict[K, V], override: dict[K, V] | None) -> dict[K, V]:
-    """Merge dict fields with override-key-wins semantics.
-
-    None means "not set" (field absent from config) -- base is preserved.
-    An explicit empty dict {} means "reset" -- clears everything from earlier
-    in the precedence chain.
-    A non-empty dict is merged with the base (override keys take precedence).
-    """
-    if override is None:
-        return base
-    if not override:
-        return {}
-    return {**base, **override}
+    """Merge dict fields, with override keys taking precedence."""
+    if override is not None:
+        return {**base, **override}
+    return base
 
 
 # === Enums ===

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -75,10 +75,18 @@ def merge_cli_args(base: tuple[str, ...], override: tuple[str, ...]) -> tuple[st
 
 @pure
 def merge_list_fields(base: list[T], override: list[T] | None) -> list[T]:
-    """Merge list fields, concatenating if override is not None."""
-    if override is not None:
-        return list(base) + list(override)
-    return base
+    """Merge list fields with concatenation semantics.
+
+    None means "not set" (field absent from config) -- base is preserved.
+    An explicit empty list [] means "reset" -- clears everything from earlier
+    in the precedence chain.
+    A non-empty list is concatenated with the base.
+    """
+    if override is None:
+        return base
+    if not override:
+        return []
+    return list(base) + list(override)
 
 
 K = TypeVar("K")
@@ -87,10 +95,18 @@ V = TypeVar("V")
 
 @pure
 def merge_dict_fields(base: dict[K, V], override: dict[K, V] | None) -> dict[K, V]:
-    """Merge dict fields, with override keys taking precedence."""
-    if override is not None:
-        return {**base, **override}
-    return base
+    """Merge dict fields with override-key-wins semantics.
+
+    None means "not set" (field absent from config) -- base is preserved.
+    An explicit empty dict {} means "reset" -- clears everything from earlier
+    in the precedence chain.
+    A non-empty dict is merged with the base (override keys take precedence).
+    """
+    if override is None:
+        return base
+    if not override:
+        return {}
+    return {**base, **override}
 
 
 # === Enums ===

--- a/libs/mngr/imbue/mngr/config/data_types_test.py
+++ b/libs/mngr/imbue/mngr/config/data_types_test.py
@@ -249,10 +249,10 @@ def test_merge_list_fields_returns_base_when_override_none() -> None:
     assert result == [1, 2]
 
 
-def test_merge_list_fields_resets_on_empty_override() -> None:
-    """merge_list_fields should reset (clear base) when override is an explicit empty list."""
+def test_merge_list_fields_concatenates_empty_override() -> None:
+    """merge_list_fields should handle empty override list."""
     result = merge_list_fields([1, 2], [])
-    assert result == []
+    assert result == [1, 2]
 
 
 # =============================================================================
@@ -284,10 +284,10 @@ def test_merge_dict_fields_returns_override_when_base_empty() -> None:
     assert result == {"a": 1}
 
 
-def test_merge_dict_fields_resets_on_empty_override() -> None:
-    """merge_dict_fields should reset (clear base) when override is an explicit empty dict."""
+def test_merge_dict_fields_handles_empty_override() -> None:
+    """merge_dict_fields should return base when override is empty dict."""
     result = merge_dict_fields({"a": 1}, {})
-    assert result == {}
+    assert result == {"a": 1}
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/config/data_types_test.py
+++ b/libs/mngr/imbue/mngr/config/data_types_test.py
@@ -249,10 +249,10 @@ def test_merge_list_fields_returns_base_when_override_none() -> None:
     assert result == [1, 2]
 
 
-def test_merge_list_fields_concatenates_empty_override() -> None:
-    """merge_list_fields should handle empty override list."""
+def test_merge_list_fields_resets_on_empty_override() -> None:
+    """merge_list_fields should reset (clear base) when override is an explicit empty list."""
     result = merge_list_fields([1, 2], [])
-    assert result == [1, 2]
+    assert result == []
 
 
 # =============================================================================
@@ -284,10 +284,10 @@ def test_merge_dict_fields_returns_override_when_base_empty() -> None:
     assert result == {"a": 1}
 
 
-def test_merge_dict_fields_handles_empty_override() -> None:
-    """merge_dict_fields should return base when override is empty dict."""
+def test_merge_dict_fields_resets_on_empty_override() -> None:
+    """merge_dict_fields should reset (clear base) when override is an explicit empty dict."""
     result = merge_dict_fields({"a": 1}, {})
-    assert result == {"a": 1}
+    assert result == {}
 
 
 # =============================================================================

--- a/specs/minds-dev-iteration-loop/spec.md
+++ b/specs/minds-dev-iteration-loop/spec.md
@@ -1,0 +1,149 @@
+# Minds Dev Iteration Loop
+
+## Overview
+
+* When developing across the minds stack (desktop client, minds_workspace_server, mngr core, forever-claude-template), the current workflow is slow and error-prone: changes require updating git subtrees, rebuilding Docker images, and manually restarting multiple components.
+* This spec defines a `propagate_changes` shell script and documented workflow that enables sub-10-second iteration cycles by rsyncing code directly into running containers and restarting only what's needed.
+* The key insight is to sidestep the git subtree problem entirely during development: rsync the local mngr repo into the template's `vendor/mngr/` on the host, then rsync the full template (now with updated mngr) into the container. The subtree is only updated for releases.
+* This approach works for both Docker containers (via SSH) and local/non-container agents (via local rsync), keeping a single script for both cases.
+* The script also restarts the Electron desktop client in parallel, ensuring both the container-side and host-side components are updated atomically.
+
+## Expected Behavior
+
+* Running `propagate_changes` from any mngr worktree syncs code changes into a running minds agent and restarts all affected components within seconds.
+* The script expects `forever-claude-template` to exist at `.external_worktrees/forever-claude-template` relative to the mngr worktree root. It fails with a clear error if this directory is missing.
+* The agent name is determined by `MINDS_WORKSPACE_NAME` env var if set, otherwise defaults to `"mindtest"`.
+* On every invocation, the script:
+  1. Rsyncs the local mngr repo into the template's `vendor/mngr/` (on the host). This ensures any subsequent `mngr create` also uses the latest code.
+  2. In parallel:
+     - **Container/agent side:** stops the agent (`mngr stop`), rsyncs the full template (with updated `vendor/mngr/`) into the target, rebuilds the minds_workspace_server frontend (`npm run build`), starts the agent (`mngr start`).
+     - **Desktop client side:** gracefully kills the Electron app (SIGTERM + wait), sources `.env` from the mngr repo root, sets `MINDS_WORKSPACE_GIT_URL` to the template path and `MINDS_WORKSPACE_NAME`, then starts the Electron app (`npm start` from `apps/minds/`).
+* `mngr start` automatically restarts the bootstrap service manager, which reads `services.toml` and starts all background services (web server, cloudflared, app-watcher). No manual service restart is needed.
+* For Docker/remote agents, the rsync target is `<user>@<host>:/code/` over SSH. For local agents, the rsync target is a local filesystem path. The script detects which mode based on whether `--host` is provided.
+* Python code changes are picked up immediately because the Dockerfile uses `uv tool install -e` (editable installs). Frontend changes require the `npm run build` step.
+* Rsync uses `--delete` to ensure clean syncs (removed files don't linger). Additional exclusions protect runtime state in the container.
+
+## Implementation Plan
+
+### `apps/minds/scripts/propagate_changes` (new file)
+
+A bash script that orchestrates the full iteration cycle.
+
+**Arguments (named flags):**
+
+* `--user <ssh_user>` -- SSH user for remote rsync (e.g., `root`). Required when `--host` is given.
+* `--host <ssh_host>` -- SSH host for remote rsync (e.g., `127.0.0.1`). When omitted, `--target` is required for local mode.
+* `--port <ssh_port>` -- SSH port (e.g., `32768`). Required when `--host` is given.
+* `--key <ssh_key_path>` -- Path to SSH private key. Required when `--host` is given.
+* `--target <local_path>` -- Local filesystem path for the agent's work_dir. Required when `--host` is not given (local/non-container mode).
+
+**Inferred paths:**
+
+* `MNGR_REPO_ROOT`: inferred from the script's own location: `$(cd "$(dirname "$0")/../../.." && pwd)`.
+* `TEMPLATE_DIR`: `${MNGR_REPO_ROOT}/.external_worktrees/forever-claude-template`. The script exits with an error if this directory does not exist.
+* `AGENT_NAME`: from `MINDS_WORKSPACE_NAME` env var, defaulting to `"mindtest"`.
+
+**Rsync exclusions (shared across both syncs):**
+
+* `.git`, `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `uv.lock`
+
+**Step 1: Sync mngr into template's vendor/mngr/ (local rsync)**
+
+```
+rsync -a --delete \
+  --exclude='.git' --exclude='__pycache__' --exclude='.venv' \
+  --exclude='node_modules' --exclude='.test_output' \
+  --exclude='.mypy_cache' --exclude='.ruff_cache' \
+  --exclude='.pytest_cache' --exclude='uv.lock' \
+  "${MNGR_REPO_ROOT}/" "${TEMPLATE_DIR}/vendor/mngr/"
+```
+
+This ensures that `vendor/mngr/` in the template on disk always reflects the current mngr checkout, so any future `mngr create` (Docker build) picks up the latest code.
+
+**Step 2 (parallel track A): Container/agent update**
+
+1. `uv run mngr stop "${AGENT_NAME}"` -- stops the agent and all its services (bootstrap, web, cloudflared, app-watcher).
+2. Rsync the full template into the target:
+   - Remote mode: `rsync -avz --delete --exclude=... -e "ssh -p ${PORT} -i ${KEY} -o StrictHostKeyChecking=no" "${TEMPLATE_DIR}/" "${USER}@${HOST}:/code/"`
+   - Local mode: `rsync -a --delete --exclude=... "${TEMPLATE_DIR}/" "${TARGET}/"`
+   - Additional `--delete` exclusions for container state: `runtime/`, `.mngr/`
+3. Rebuild frontend: `uv run mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build"`
+   - For local mode, run the npm build directly at the appropriate path.
+4. `uv run mngr start "${AGENT_NAME}"` -- starts the agent; bootstrap auto-starts all services.
+
+**Step 2 (parallel track B): Desktop client restart**
+
+1. `pkill -TERM -f "electron.*minds"` -- gracefully kill the Electron app.
+2. Wait up to 5 seconds for the process to exit. (If it doesn't exit, that's a bug to fix separately -- the script should log a warning, not force-kill.)
+3. Source `.env` from the mngr repo root if it exists: `. "${MNGR_REPO_ROOT}/.env"`.
+4. Export env vars:
+   - `MINDS_WORKSPACE_GIT_URL="${TEMPLATE_DIR}"`
+   - `MINDS_WORKSPACE_NAME="${AGENT_NAME}"`
+5. Start the Electron app in the background: `cd "${MNGR_REPO_ROOT}/apps/minds" && npm start &`
+
+**Parallel execution:** Tracks A and B run concurrently. The script waits for both to complete before exiting.
+
+### Rsync details
+
+**Mngr -> vendor/mngr/ (Step 1):**
+
+* Source: `${MNGR_REPO_ROOT}/` (trailing slash = copy contents)
+* Destination: `${TEMPLATE_DIR}/vendor/mngr/`
+* Flags: `-a --delete`
+* Exclusions: `.git`, `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `uv.lock`
+
+**Template -> container (Step 2A):**
+
+* Source: `${TEMPLATE_DIR}/` (trailing slash = copy contents)
+* Destination: `/code/` (remote) or `${TARGET}/` (local)
+* Flags: `-a --delete` (add `-vz` for remote)
+* Exclusions: same as above, plus `--filter='protect runtime/'` and `--filter='protect .mngr/'` to prevent `--delete` from removing container runtime state
+
+## Implementation Phases
+
+### Phase 1: Core script with remote (Docker) support
+
+* Create `apps/minds/scripts/propagate_changes` with the full argument parsing, path inference, and remote-mode workflow.
+* Implement Step 1 (mngr -> vendor/mngr/ rsync).
+* Implement Step 2A (stop agent, rsync to container, rebuild frontend, start agent) for remote mode only.
+* Implement Step 2B (kill and restart Electron app) running in parallel with 2A.
+* Test manually with a Docker-based minds agent.
+
+### Phase 2: Local mode support
+
+* Add `--target` flag handling for local/non-container agents.
+* When `--host` is not provided, require `--target` and use local rsync instead of SSH-based rsync.
+* For local mode, run the frontend build directly instead of via `mngr exec`.
+* Test manually with a DEV-mode minds agent.
+
+### Phase 3: Documentation
+
+* Add a "Development Iteration" section to `apps/minds/docs/` explaining:
+  * Prerequisites (running agent, SSH details for Docker, `.external_worktrees/forever-claude-template` setup).
+  * Example invocations for Docker and local modes.
+  * How the git subtree sidestep works and when to update the subtree for releases.
+  * Troubleshooting (stale processes, port conflicts, SSH key issues).
+
+## Testing Strategy
+
+* **Manual verification (primary):** Run the script against a Docker-based minds agent and verify:
+  * Python code changes in mngr are reflected immediately (e.g., add a log line to minds_workspace_server, verify it appears in the service logs after restart).
+  * Frontend changes are reflected after the build (e.g., modify a template string, verify it appears in the web UI).
+  * Template changes (e.g., modify `services.toml`) are picked up by bootstrap.
+  * The Electron app restarts and shows the correct template URL in the creation form.
+  * The `--delete` behavior removes files that were deleted from the source (create a temp file, sync, delete it, sync again, verify it's gone from the container).
+  * Runtime state (`runtime/`, `.mngr/`) survives the sync.
+* **Manual verification (local mode):** Same checks but with a DEV-mode agent and `--target` flag.
+* **Edge cases to verify manually:**
+  * Script fails clearly when `.external_worktrees/forever-claude-template` is missing.
+  * Script fails clearly when required SSH flags are missing in remote mode.
+  * Script fails clearly when neither `--host` nor `--target` is provided.
+  * Running the script twice in quick succession doesn't leave orphaned processes.
+  * Creating a new agent after `propagate_changes` picks up the latest mngr code (because `vendor/mngr/` was updated on disk).
+
+## Open Questions
+
+* Should the script also handle the case where the agent doesn't exist yet (i.e., run `mngr create` as part of the first invocation)? Currently, the script assumes the agent already exists and was created via the desktop client or `mngr create`.
+* The `pkill -TERM -f "electron.*minds"` pattern could match unrelated Electron apps if any happen to have "minds" in their command line. A more precise matching pattern may be needed.
+* When `mngr stop` is called, any in-progress Claude conversation is lost. Should the script warn the user or require a `--force` flag? (Current decision: no, since we're testing infrastructure, not conversations.)
+* The `npm run build` step runs inside the container via `mngr exec`, which requires the agent to be stopped then started. But `mngr exec` may need the agent to be running (it auto-starts). The sequencing is: stop -> rsync -> start -> exec (npm build). Alternatively, the frontend build could run directly via SSH (`ssh -p ... "cd /code/... && npm run build"`) between the rsync and `mngr start`, while the agent is still stopped. This needs verification.

--- a/specs/minds-dev-iteration-loop/spec.md
+++ b/specs/minds-dev-iteration-loop/spec.md
@@ -67,9 +67,10 @@ This ensures that `vendor/mngr/` in the template on disk always reflects the cur
    - Remote mode: `rsync -avz --delete --exclude=... -e "ssh -p ${PORT} -i ${KEY} -o StrictHostKeyChecking=no" "${TEMPLATE_DIR}/" "${USER}@${HOST}:/code/"`
    - Local mode: `rsync -a --delete --exclude=... "${TEMPLATE_DIR}/" "${TARGET}/"`
    - Additional `--delete` exclusions for container state: `runtime/`, `.mngr/`
-3. Rebuild frontend: `uv run mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build"`
+3. `uv run mngr start "${AGENT_NAME}"` -- starts the agent; bootstrap auto-starts all services.
+4. Rebuild frontend: `uv run mngr exec "${AGENT_NAME}" "cd /code/vendor/mngr/apps/minds_workspace_server/frontend && npm run build"`
    - For local mode, run the npm build directly at the appropriate path.
-4. `uv run mngr start "${AGENT_NAME}"` -- starts the agent; bootstrap auto-starts all services.
+   - The agent must be running before `mngr exec` is called, since `mngr exec` requires an active agent connection.
 
 **Step 2 (parallel track B): Desktop client restart**
 
@@ -146,4 +147,4 @@ This ensures that `vendor/mngr/` in the template on disk always reflects the cur
 * Should the script also handle the case where the agent doesn't exist yet (i.e., run `mngr create` as part of the first invocation)? Currently, the script assumes the agent already exists and was created via the desktop client or `mngr create`.
 * The `pkill -TERM -f "electron.*minds"` pattern could match unrelated Electron apps if any happen to have "minds" in their command line. A more precise matching pattern may be needed.
 * When `mngr stop` is called, any in-progress Claude conversation is lost. Should the script warn the user or require a `--force` flag? (Current decision: no, since we're testing infrastructure, not conversations.)
-* The `npm run build` step runs inside the container via `mngr exec`, which requires the agent to be stopped then started. But `mngr exec` may need the agent to be running (it auto-starts). The sequencing is: stop -> rsync -> start -> exec (npm build). Alternatively, the frontend build could run directly via SSH (`ssh -p ... "cd /code/... && npm run build"`) between the rsync and `mngr start`, while the agent is still stopped. This needs verification.
+* The frontend build via `mngr exec` requires the agent to be running. The implemented sequencing is: stop -> rsync -> start -> exec (npm build). An alternative would be to run the build directly via SSH between rsync and start (while the agent is still stopped), but this would require duplicating SSH connection logic.

--- a/specs/minds-tab-actions/spec.md
+++ b/specs/minds-tab-actions/spec.md
@@ -1,0 +1,190 @@
+# Minds Workspace Server: Tab Action Buttons and Sharing
+
+## Overview
+
+- The dockview tab UI in `minds_workspace_server` currently uses the default dockview tab renderer, which only shows a title and a close ("x") button
+- This spec adds a custom tab renderer with up to three action icons per tab: **share** (external-link icon), **destroy** (trash can icon), and **close** (x icon), displayed only on the active/selected tab
+- A top-level **share** button is added to the sidebar branding row to control Cloudflare forwarding for the primary agent's "web" server, allowing the entire workspace (including chats) to be shared via a global URL
+- A new **destroy** backend endpoint (`POST /api/agents/{agent_id}/destroy`) runs `mngr destroy --force` synchronously
+- Three new **sharing proxy** endpoints (`GET/PUT/DELETE /api/sharing/{server_name}`) proxy forwarding requests to the minds desktop client REST API, so the frontend never calls the desktop client directly
+- All changes are made in this monorepo at `apps/minds_workspace_server/`; vendoring into `forever-claude-template` happens separately
+
+## Expected Behavior
+
+### Custom tab renderer
+
+- All tabs show only the title when inactive
+- The active/selected tab shows the title plus action icons on the right side of the tab header (no hover-triggered display)
+- **Close icon** (x): appears on all tab types (chat, iframe, subagent). Removes the panel from the dockview workspace (same behavior as today)
+- **Destroy icon** (trash can): appears only on chat/agent tabs. Clicking opens a confirmation dialog. On the primary agent's chat tab, the icon is visible but grayed out/disabled with a tooltip ("Cannot destroy the primary agent")
+- **Share icon** (external-link): appears only on iframe/application tabs. Clicking opens the share modal dialog for that application's server name
+
+### Destroy behavior
+
+- The confirmation dialog for a **chat agent** shows the agent name and asks the user to confirm destruction
+- The confirmation dialog for a **worktree/sidebar agent** additionally lists all chat children (fetched via `getChatAgentsForParent`) and warns that they will also be destroyed
+- The frontend handles cascade: destroys each child chat agent first (sequential `POST /api/agents/{child_id}/destroy` calls), then destroys the parent worktree agent
+- After a successful destroy, the tab is explicitly removed from the dockview component
+- If the destroyed agent was the currently selected sidebar agent, the UI auto-selects the first remaining sidebar agent (or shows the empty state if none remain)
+- `POST /api/agents/{agent_id}/destroy` calls `mngr destroy --force <agent_name>` synchronously and returns `{"status": "ok"}` on success or an error response on failure
+
+### Sidebar share button
+
+- A share icon button appears in the sidebar branding row, next to the hostname text
+- Clicking opens the same share modal dialog, but hardcoded to the primary agent's "web" server
+- This controls whether the entire workspace is accessible via the Cloudflare-forwarded global URL
+
+### Share modal dialog
+
+- On open, issues `GET /api/sharing/{server_name}` to fetch current forwarding status
+- If forwarding is **enabled**: displays the global URL with a "Copy to clipboard" button
+- If forwarding is **not enabled**: shows an "Enable sharing" button that issues `PUT /api/sharing/{server_name}`, then refreshes the dialog to show the URL
+- If forwarding is **enabled** and the user wants to stop: shows a "Disable sharing" button that issues `DELETE /api/sharing/{server_name}`
+- The modal uses the same visual style as the existing `CreateAgentModal` and `custom-url-dialog`
+
+### Sharing proxy endpoints
+
+- `GET /api/sharing/{server_name}`: returns the forwarding status from the desktop client (whether the service is registered and its global hostname)
+- `PUT /api/sharing/{server_name}`: enables Cloudflare forwarding for the given server name
+- `DELETE /api/sharing/{server_name}`: disables Cloudflare forwarding for the given server name
+- All three endpoints read `$MNGR_AGENT_STATE_DIR/minds_api_url` to discover the desktop client API URL, and authenticate using the `MINDS_API_KEY` environment variable as a Bearer token
+- No authentication is required on these workspace server endpoints (same trust model as all other workspace server endpoints)
+- If the `minds_api_url` file does not exist or `MINDS_API_KEY` is not set, the endpoints return an appropriate error
+
+## Implementation Plan
+
+### Backend (`imbue/minds_workspace_server/`)
+
+**`server.py`** -- add three new routes:
+- `POST /api/agents/{agent_id}/destroy` -> `_destroy_agent()`: looks up the agent by ID, runs `mngr destroy --force <agent_name>` via `run_local_command_modern_version`, returns success/failure JSON
+- `GET /api/sharing/{server_name}` -> `_get_sharing_status()`: reads `minds_api_url` file, calls `GET /api/v1/agents/{own_agent_id}/servers/{server_name}/cloudflare` on the desktop client (or uses `list_services` equivalent), returns forwarding status
+- `PUT /api/sharing/{server_name}` -> `_enable_sharing()`: reads `minds_api_url` file, calls `PUT /api/v1/agents/{own_agent_id}/servers/{server_name}/cloudflare` on the desktop client, returns result
+- `DELETE /api/sharing/{server_name}` -> `_disable_sharing()`: reads `minds_api_url` file, calls `DELETE /api/v1/agents/{own_agent_id}/servers/{server_name}/cloudflare` on the desktop client, returns result
+
+**`sharing_proxy.py`** (new file) -- helper module for minds desktop client communication:
+- `read_minds_api_url() -> str | None`: reads `$MNGR_AGENT_STATE_DIR/minds_api_url` and returns the URL, or None
+- `get_sharing_status(server_name: str) -> dict`: issues GET to the desktop client API, returns `{"enabled": bool, "url": str | None}`
+- `enable_sharing(server_name: str) -> dict`: issues PUT to the desktop client API
+- `disable_sharing(server_name: str) -> dict`: issues DELETE to the desktop client API
+- All functions use `MINDS_API_KEY` env var for Bearer token auth and `MNGR_AGENT_ID` env var for the agent ID path parameter
+- Uses `httpx` (already a dependency) for HTTP requests
+
+**`models.py`** -- add response models:
+- `DestroyAgentResponse`: `{"status": str}`
+- `SharingStatusResponse`: response from desktop client forwarding API
+
+### Frontend (`frontend/src/`)
+
+**`views/DockviewWorkspace.ts`** -- major changes:
+- Add `createTabComponent` option to the `DockviewComponent` constructor to provide a custom tab renderer
+- The custom tab renderer creates an HTML element with: the panel title (span), and a button group (share, destroy, close icons as inline SVG buttons)
+- Share button: visible only if `panelType === "iframe"`. `onclick` opens the share modal with the panel's `title` (application name) as the server name
+- Destroy button: visible only if `panelType === "chat"`. Disabled if `chatAgentId` matches the primary agent ID (`MNGR_AGENT_ID`). `onclick` opens the destroy confirmation dialog
+- Close button: visible on all panel types. `onclick` calls `dockview.api.removePanel(panel)`
+- Only the active panel's tab shows the action buttons; inactive tabs show only the title
+- Listen to `onDidActivePanelChange` to update which tab shows action buttons (re-render tab elements)
+
+**`views/ShareModal.ts`** (new file) -- share modal dialog component:
+- Mithril component accepting `serverName: string` and `onClose: () => void` as attrs
+- On mount, fetches `GET /api/sharing/{serverName}` via `apiUrl()`
+- Displays loading state, then the result:
+  - Enabled: global URL text + "Copy" button (uses `navigator.clipboard.writeText`) + "Disable sharing" button
+  - Not enabled: "Enable sharing" button
+- Enable/disable buttons issue PUT/DELETE and re-fetch status
+- Styled consistently with existing dialogs (overlay + centered card)
+
+**`views/DestroyConfirmDialog.ts`** (new file) -- destroy confirmation dialog component:
+- Mithril component accepting `agentId: string`, `agentName: string`, `chatChildren: AgentState[]`, `isPrimary: boolean`, `onConfirm: () => void`, `onCancel: () => void`
+- For chat agents (no children): "Are you sure you want to destroy {name}? This cannot be undone."
+- For worktree agents (with children): "Destroying {name} will also destroy these chat agents: {list}. This cannot be undone."
+- "Destroy" button (red/destructive styling) and "Cancel" button
+- The calling code in DockviewWorkspace handles the actual destroy API calls and cascade logic
+
+**`views/Sidebar.ts`** -- add share button:
+- Add a share icon button in the `sidebar-branding-row` div, next to the hostname and collapse button
+- `onclick` opens the `ShareModal` with `serverName = "web"`
+- Uses the same inline SVG helper pattern as existing sidebar icon buttons
+
+**`models/AgentManager.ts`** -- add helper:
+- Export `getPrimaryAgentId(): string` that returns the primary agent ID (read from a meta tag or passed from server, similar to `getHostname()` in `base-path.ts`)
+
+**`base-path.ts`** or new module -- expose primary agent ID:
+- The workspace server injects a `<meta name="minds-workspace-server-agent-id">` tag into `index.html` (like the existing `minds-workspace-server-hostname` meta tag)
+- Frontend reads this to determine which agent is the primary/host agent
+
+### CSS (`frontend/src/style.css`)
+
+- Add styles for the custom tab renderer button group (`.dv-custom-tab-actions`)
+- Action buttons: small, icon-only, matching existing dockview tab styling (12-16px icons, subtle colors, no background)
+- Disabled state for the destroy button on primary agent (opacity reduction, cursor: not-allowed)
+- Share modal and destroy dialog styles (overlay, card, buttons) -- follow existing `custom-url-dialog` pattern
+- Sidebar share button style (same as `sidebar-inline-icon-button`)
+
+## Implementation Phases
+
+### Phase 1: Backend endpoints
+
+- Add `sharing_proxy.py` with minds desktop client communication helpers
+- Add `POST /api/agents/{agent_id}/destroy` endpoint to `server.py`
+- Add `GET/PUT/DELETE /api/sharing/{server_name}` endpoints to `server.py`
+- Add response models to `models.py`
+- Inject `MNGR_AGENT_ID` as a meta tag into the HTML response
+- Result: backend is fully functional, testable via curl
+
+### Phase 2: Custom tab renderer
+
+- Add `createTabComponent` to `DockviewWorkspace.ts` with close button only (matching current behavior)
+- Add active/inactive tab logic (action buttons only on active tab)
+- Add CSS for the custom tab button group
+- Result: tabs look and behave the same as before, but using the custom renderer
+
+### Phase 3: Destroy functionality
+
+- Add `DestroyConfirmDialog.ts` component
+- Wire destroy icon in custom tab renderer to open the dialog (chat tabs only, disabled on primary agent)
+- Add primary agent ID discovery (meta tag + frontend reader)
+- Implement cascade logic: destroy children, then parent, then remove tab and auto-select next agent
+- Result: agents can be destroyed from the tab UI
+
+### Phase 4: Share functionality
+
+- Add `ShareModal.ts` component
+- Wire share icon in custom tab renderer to open the modal (iframe tabs only)
+- Add sidebar share button in branding row for the primary agent's "web" server
+- Result: sharing is fully functional
+
+## Testing Strategy
+
+### Unit tests (backend)
+
+- `sharing_proxy.py`: test `read_minds_api_url` with missing file, empty file, valid file; test each proxy function with mocked HTTP responses (success, failure, missing env vars)
+- `server.py` destroy endpoint: test with valid agent ID (mock `run_local_command_modern_version`), unknown agent ID, command failure
+- `server.py` sharing endpoints: test proxy behavior with mocked `sharing_proxy` functions
+
+### Integration tests (backend)
+
+- Create a test agent via the existing `create-chat` endpoint, then destroy it via the new destroy endpoint, verify it disappears from the agent list
+- Test sharing endpoints with a mock desktop client API server
+
+### Frontend (manual verification via tmux)
+
+- Verify the custom tab renderer shows the correct icons per tab type (chat: destroy + close; iframe: share + close; subagent: close only)
+- Verify inactive tabs show only the title, active tab shows title + actions
+- Verify the destroy confirmation dialog lists chat children for worktree agents
+- Verify the share modal fetches and displays forwarding status correctly
+- Verify the sidebar share button opens the share modal for the "web" server
+- Verify the primary agent's destroy button is disabled
+
+### Edge cases
+
+- Destroy an agent that is already gone (race condition) -- should handle gracefully
+- Share when `minds_api_url` file doesn't exist -- should show a clear error in the modal
+- Share when `MINDS_API_KEY` is not set -- should show a clear error
+- Destroy the currently selected sidebar agent -- should auto-select the next agent
+- Destroy a worktree agent whose chat children have already been destroyed externally -- should handle missing children gracefully during cascade
+
+## Open Questions
+
+- The exact response format from the desktop client's `list_services` endpoint may vary; the sharing proxy should handle both the per-service response and the full services list response gracefully
+- Whether the `mngr destroy --force` command should run with a timeout to prevent the endpoint from hanging if destruction takes unexpectedly long
+- Whether the frontend should poll or use the existing WebSocket `agents_updated` event to detect when a destroyed agent has actually been removed from the agent list (relevant for sidebar auto-selection timing)

--- a/uv.lock
+++ b/uv.lock
@@ -2295,6 +2295,7 @@ version = "0.1.0"
 source = { editable = "apps/minds_workspace_server" }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "imbue-common" },
     { name = "imbue-mngr" },
     { name = "pluggy" },
@@ -2314,6 +2315,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "imbue-common", editable = "libs/imbue_common" },
     { name = "imbue-mngr", editable = "libs/mngr" },
     { name = "pluggy", specifier = ">=1.5" },


### PR DESCRIPTION
## Summary

* Custom dockview tab renderer with three action icons (close, destroy, share) displayed only on the active tab
* Backend `POST /api/agents/{agent_id}/destroy` endpoint that runs `mngr destroy --force` synchronously
* Backend `GET/PUT/DELETE /api/sharing/{server_name}` proxy endpoints for Cloudflare forwarding management
* Sidebar "Share workspace" button for controlling the primary agent's web server forwarding
* Destroy confirmation dialog with cascade handling (destroys chat children before parent)
* Share modal with enable/disable/copy-URL functionality

## Test plan

- [x] All 177 existing + new tests pass
- [x] Frontend TypeScript builds successfully
- [ ] Manual test: verify custom tab icons appear only on active tab
- [ ] Manual test: verify destroy dialog cascades for worktree agents
- [ ] Manual test: verify share modal fetches and displays Cloudflare forwarding status
- [ ] Manual test: verify sidebar share button opens modal for "web" server

Generated with [Claude Code](https://claude.com/claude-code)