### PR TITLE
Fix SSH connection leak across all providers

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -243,7 +243,20 @@ class Host(BaseHost, OnlineHostInterface):
         if self.connector.host.connected:
             self.connector.host.disconnect()
             logger.trace("Disconnected pyinfra host {}", self.id)
+        self._explicitly_disconnected = True
 
+    def __del__(self) -> None:
+        """Best-effort cleanup of the paramiko SSH client on garbage collection.
+
+        Only acts if disconnect() was never called explicitly (i.e., the Host
+        was dropped without proper cleanup).
+        """
+        if getattr(self, "_explicitly_disconnected", False):
+            return
+        try:
+            self._close_paramiko_client()
+        except (OSError, SSHException, AttributeError, TypeError):
+            logger.debug("Failed to close paramiko client during Host.__del__ for {}", self.id)
 
     @contextmanager
     def _notify_on_connection_error(self) -> Iterator[None]:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -245,11 +245,23 @@ class Host(BaseHost, OnlineHostInterface):
             logger.trace("Disconnected pyinfra host {}", self.id)
         self._explicitly_disconnected = True
 
+    def model_copy_update(self, *updates: Any) -> "Host":
+        """Create a copy of this Host with updated fields.
+
+        The copy shares the same pyinfra connector (and thus the same SSH
+        client). Mark ourselves so __del__ does not close the shared client
+        when this original is garbage collected.
+        """
+        result = super().model_copy_update(*updates)
+        self._explicitly_disconnected = True
+        return result
+
     def __del__(self) -> None:
         """Best-effort cleanup of the paramiko SSH client on garbage collection.
 
-        Only acts if disconnect() was never called explicitly (i.e., the Host
-        was dropped without proper cleanup).
+        Only acts if disconnect() was never called explicitly and this Host
+        was never copied via model_copy_update (the copy shares the connector,
+        so closing the client here would kill the copy's connection).
         """
         if getattr(self, "_explicitly_disconnected", False):
             return

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -244,12 +244,6 @@ class Host(BaseHost, OnlineHostInterface):
             self.connector.host.disconnect()
             logger.trace("Disconnected pyinfra host {}", self.id)
 
-    def __del__(self) -> None:
-        """Best-effort cleanup of the paramiko SSH client on garbage collection."""
-        try:
-            self._close_paramiko_client()
-        except (OSError, SSHException, AttributeError, TypeError):
-            pass
 
     @contextmanager
     def _notify_on_connection_error(self) -> Iterator[None]:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -360,16 +360,16 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while running command: {}, retrying without disconnect", e)
             else:
                 logger.debug("SSH error while running command: {}, disconnecting for retry", e)
-                self.disconnect()
+                self.connector.host.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while running command: {}, disconnecting for retry", e)
-            self.disconnect()
+            self.connector.host.disconnect()
             raise
         except OSError as e:
             if "Socket is closed" in str(e):
                 logger.debug("Socket closed while running command, disconnecting for retry")
-                self.disconnect()
+                self.connector.host.disconnect()
             raise
 
         # Detect ghost failures: pyinfra silently returns (False, output) when
@@ -379,7 +379,7 @@ class Host(BaseHost, OnlineHostInterface):
         success, _output = result
         if not success and transport_before is not None and not transport_before.is_active():
             logger.debug("Command failed and SSH transport is dead, disconnecting for retry")
-            self.disconnect()
+            self.connector.host.disconnect()
             raise SSHException(
                 "Command returned failure with dead SSH transport "
                 "(likely channel closed during execution by concurrent disconnect)"
@@ -443,7 +443,7 @@ class Host(BaseHost, OnlineHostInterface):
                 raise FileNotFoundError(f"File not found: {remote_filename}") from e
             elif "Socket is closed" in error_msg:
                 logger.debug("Socket closed while reading {}, disconnecting for retry", remote_filename)
-                self.disconnect()
+                self.connector.host.disconnect()
                 raise
             else:
                 raise
@@ -461,11 +461,11 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while reading {}: {}, retrying without disconnect", remote_filename, e)
             else:
                 logger.debug("SSH error while reading {}: {}, disconnecting for retry", remote_filename, e)
-                self.disconnect()
+                self.connector.host.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while reading {}: {}, disconnecting for retry", remote_filename, e)
-            self.disconnect()
+            self.connector.host.disconnect()
             raise
 
     def _get_file_via_paramiko(
@@ -545,7 +545,7 @@ class Host(BaseHost, OnlineHostInterface):
         except OSError as e:
             if "Socket is closed" in str(e):
                 logger.debug("Socket closed while writing {}, disconnecting for retry", remote_filename)
-                self.disconnect()
+                self.connector.host.disconnect()
                 raise
             else:
                 raise
@@ -563,11 +563,11 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while writing {}: {}, retrying without disconnect", remote_filename, e)
             else:
                 logger.debug("SSH error while writing {}: {}, disconnecting for retry", remote_filename, e)
-                self.disconnect()
+                self.connector.host.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while writing {}: {}, disconnecting for retry", remote_filename, e)
-            self.disconnect()
+            self.connector.host.disconnect()
             raise
 
     def _get_paramiko_transport(self) -> object:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -244,6 +244,13 @@ class Host(BaseHost, OnlineHostInterface):
             self.connector.host.disconnect()
             logger.trace("Disconnected pyinfra host {}", self.id)
 
+    def __del__(self) -> None:
+        """Best-effort cleanup of the paramiko SSH client on garbage collection."""
+        try:
+            self._close_paramiko_client()
+        except (OSError, SSHException, AttributeError, TypeError):
+            pass
+
     @contextmanager
     def _notify_on_connection_error(self) -> Iterator[None]:
         """Context manager that calls on_connection_error when HostConnectionError is raised.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -209,13 +209,37 @@ class Host(BaseHost, OnlineHostInterface):
             else:
                 raise HostConnectionError(f"Failed to connect to host: {e}") from e
 
+    def _close_paramiko_client(self) -> None:
+        """Close the paramiko SSH client if one exists.
+
+        pyinfra's disconnect() only clears its SFTP cache and sets
+        connected=False. It does NOT close the underlying paramiko SSHClient.
+        When connect() is called again, pyinfra creates a new SSHClient
+        without closing the old one, leaking the TCP socket (and a
+        server-side sshd-session process). This method explicitly closes
+        the client to prevent that leak.
+
+        Safe to call on local connectors (no paramiko client) and on
+        already-closed clients.
+        """
+        try:
+            client = self.connector.host.connector.client  # ty: ignore[unresolved-attribute]
+        except AttributeError:
+            return
+        if client is not None:
+            try:
+                client.close()
+            except (OSError, SSHException):
+                pass
+
     def disconnect(self) -> None:
         """Disconnect the pyinfra host if connected.
 
-        This should be called before destroying or stopping a host to cleanly
-        close the SSH connection. Failure to disconnect can lead to stale
-        socket state causing "Socket is closed" errors in subsequent operations.
+        Closes the paramiko SSH client first (which pyinfra's disconnect
+        neglects to do), then calls pyinfra's disconnect to clear its
+        internal state.
         """
+        self._close_paramiko_client()
         if self.connector.host.connected:
             self.connector.host.disconnect()
             logger.trace("Disconnected pyinfra host {}", self.id)
@@ -329,16 +353,16 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while running command: {}, retrying without disconnect", e)
             else:
                 logger.debug("SSH error while running command: {}, disconnecting for retry", e)
-                self.connector.host.disconnect()
+                self.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while running command: {}, disconnecting for retry", e)
-            self.connector.host.disconnect()
+            self.disconnect()
             raise
         except OSError as e:
             if "Socket is closed" in str(e):
                 logger.debug("Socket closed while running command, disconnecting for retry")
-                self.connector.host.disconnect()
+                self.disconnect()
             raise
 
         # Detect ghost failures: pyinfra silently returns (False, output) when
@@ -348,7 +372,7 @@ class Host(BaseHost, OnlineHostInterface):
         success, _output = result
         if not success and transport_before is not None and not transport_before.is_active():
             logger.debug("Command failed and SSH transport is dead, disconnecting for retry")
-            self.connector.host.disconnect()
+            self.disconnect()
             raise SSHException(
                 "Command returned failure with dead SSH transport "
                 "(likely channel closed during execution by concurrent disconnect)"
@@ -412,7 +436,7 @@ class Host(BaseHost, OnlineHostInterface):
                 raise FileNotFoundError(f"File not found: {remote_filename}") from e
             elif "Socket is closed" in error_msg:
                 logger.debug("Socket closed while reading {}, disconnecting for retry", remote_filename)
-                self.connector.host.disconnect()
+                self.disconnect()
                 raise
             else:
                 raise
@@ -430,11 +454,11 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while reading {}: {}, retrying without disconnect", remote_filename, e)
             else:
                 logger.debug("SSH error while reading {}: {}, disconnecting for retry", remote_filename, e)
-                self.connector.host.disconnect()
+                self.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while reading {}: {}, disconnecting for retry", remote_filename, e)
-            self.connector.host.disconnect()
+            self.disconnect()
             raise
 
     def _get_file_via_paramiko(
@@ -514,7 +538,7 @@ class Host(BaseHost, OnlineHostInterface):
         except OSError as e:
             if "Socket is closed" in str(e):
                 logger.debug("Socket closed while writing {}, disconnecting for retry", remote_filename)
-                self.connector.host.disconnect()
+                self.disconnect()
                 raise
             else:
                 raise
@@ -532,11 +556,11 @@ class Host(BaseHost, OnlineHostInterface):
                 logger.debug("Channel closed while writing {}: {}, retrying without disconnect", remote_filename, e)
             else:
                 logger.debug("SSH error while writing {}: {}, disconnecting for retry", remote_filename, e)
-                self.connector.host.disconnect()
+                self.disconnect()
             raise
         except EOFError as e:
             logger.debug("SSH error while writing {}: {}, disconnecting for retry", remote_filename, e)
-            self.connector.host.disconnect()
+            self.disconnect()
             raise
 
     def _get_paramiko_transport(self) -> object:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -27,6 +27,7 @@ from paramiko import SFTPClient
 from paramiko import SSHException
 from paramiko import Transport
 from pydantic import Field
+from pydantic import PrivateAttr
 from pydantic import ValidationError
 from pyinfra.api.command import StringCommand
 from pyinfra.api.exceptions import ConnectError
@@ -179,6 +180,10 @@ class Host(BaseHost, OnlineHostInterface):
     )
     mngr_ctx: MngrContext = Field(frozen=True, repr=False, description="The mngr context")
 
+    # Set to True by disconnect() and model_copy_update() to prevent __del__
+    # from closing the paramiko client (which may be shared with a copy).
+    _explicitly_disconnected: bool = PrivateAttr(default=False)
+
     @property
     def is_local(self) -> bool:
         """Check if this host uses the local connector."""
@@ -263,7 +268,7 @@ class Host(BaseHost, OnlineHostInterface):
         was never copied via model_copy_update (the copy shares the connector,
         so closing the client here would kill the copy's connection).
         """
-        if getattr(self, "_explicitly_disconnected", False):
+        if self._explicitly_disconnected:
             return
         try:
             self._close_paramiko_client()

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -1028,9 +1028,13 @@ class _FakeSSHClient:
 
     def __init__(self, transport_return: object = None) -> None:
         self._transport = transport_return
+        self.close_call_count = 0
 
     def get_transport(self) -> object:
         return self._transport
+
+    def close(self) -> None:
+        self.close_call_count += 1
 
 
 class _FakeSSHConnector:

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -1688,6 +1688,51 @@ def test_run_shell_command_wraps_ssh_exception_in_host_connection_error(
 
 
 # =========================================================================
+# Tests for disconnect / _close_paramiko_client
+# =========================================================================
+
+
+def test_disconnect_closes_paramiko_client(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """Host.disconnect() must call close() on the underlying paramiko SSH client.
+
+    pyinfra's disconnect() only clears its SFTP cache and sets connected=False.
+    It does not close the paramiko SSHClient, which would leak the TCP socket.
+    """
+    ssh_client = _FakeSSHClient(transport_return=_FakeTransport())
+    fake = _FakeHostWithSSH(ssh_client=ssh_client)
+    connector = PyinfraConnector(cast(PyinfraHost, fake))
+    host = Host(
+        id=HostId.generate(),
+        connector=connector,
+        provider_instance=local_provider,
+        mngr_ctx=local_provider.mngr_ctx,
+    )
+
+    host.disconnect()
+
+    assert ssh_client.close_call_count == 1
+
+
+def test_disconnect_is_safe_without_paramiko_client(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """Host.disconnect() must not raise when the pyinfra host has no SSH client."""
+    fake = _FakeHostWithSSH(ssh_client=None)
+    connector = PyinfraConnector(cast(PyinfraHost, fake))
+    host = Host(
+        id=HostId.generate(),
+        connector=connector,
+        provider_instance=local_provider,
+        mngr_ctx=local_provider.mngr_ctx,
+    )
+
+    # Should not raise
+    host.disconnect()
+
+
+# =========================================================================
 # Tests for _format_env_file
 # =========================================================================
 

--- a/libs/mngr/imbue/mngr/providers/base_provider.py
+++ b/libs/mngr/imbue/mngr/providers/base_provider.py
@@ -1,6 +1,8 @@
 from typing import Mapping
 from typing import Sequence
 
+from pydantic import PrivateAttr
+
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.hosts.offline_host import OfflineHost
@@ -21,6 +23,21 @@ class BaseProviderInstance(ProviderInstanceInterface):
 
     Useful because it communicates that the concrete Host class (not HostInterface) is returned from these methods.
     """
+
+    _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
+
+    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
+        """Remove a Host from the cache, disconnecting it if it holds an SSH connection.
+
+        If replacement is provided and is a different instance than the cached one, the old
+        Host is disconnected before being evicted. If replacement is None, the entry is simply
+        removed (with disconnect if applicable).
+        """
+        old_host = self._host_by_id_cache.pop(host_id, None)
+        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
+            old_host.disconnect()
+        if replacement is not None:
+            self._host_by_id_cache[host_id] = replacement
 
     def reset_caches(self) -> None:
         pass

--- a/libs/mngr/imbue/mngr/providers/docker/instance.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance.py
@@ -231,6 +231,19 @@ class DockerProviderInstance(BaseProviderInstance):
     _container_cache_by_id: dict[HostId, docker.models.containers.Container] = PrivateAttr(default_factory=dict)
     _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
 
+    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
+        """Remove a Host from the cache, disconnecting it if it holds an SSH connection.
+
+        If replacement is provided and is a different instance than the cached one,
+        the old Host is disconnected before being evicted. If replacement is None,
+        the entry is simply removed (with disconnect).
+        """
+        old_host = self._host_by_id_cache.pop(host_id, None)
+        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
+            old_host.disconnect()
+        if replacement is not None:
+            self._host_by_id_cache[host_id] = replacement
+
     @property
     def supports_snapshots(self) -> bool:
         return True
@@ -758,6 +771,10 @@ kill -TERM 1
         """Create a Host object from a running Docker container.
 
         Returns None if the host record doesn't exist.
+
+        If a cached Host already exists for this host_id and the SSH
+        connection details (host, port, key) have not changed, the cached
+        Host is returned as-is to preserve the existing SSH connection.
         """
         labels = container.labels or {}
         host_id, name, provider_name, user_tags = parse_container_labels(labels)
@@ -770,6 +787,18 @@ kill -TERM 1
         if host_record.ssh_host is None or host_record.ssh_port is None or host_record.ssh_host_public_key is None:
             logger.warning("Skipped container {}: missing SSH info (likely failed host)", container.short_id)
             return None
+
+        # Reuse the cached Host if the SSH details have not changed.
+        # This avoids creating a new pyinfra connector (and eventually a
+        # new SSH connection) on every discovery poll when the underlying
+        # container is the same.
+        cached = self._host_by_id_cache.get(host_id)
+        if isinstance(cached, Host):
+            cached_name = cached.connector.name
+            expected_name = host_record.ssh_host
+            cached_port = cached.connector.host.data.get("ssh_port")
+            if cached_name == expected_name and cached_port == host_record.ssh_port:
+                return cached
 
         add_host_to_known_hosts(
             self._known_hosts_path,
@@ -976,11 +1005,11 @@ kill -TERM 1
         host_id = host.id if isinstance(host, HostInterface) else host
         logger.info("Stopping Docker container: {}", host_id)
 
-        # Disconnect SSH before stopping
-        cached_host = self._host_by_id_cache.get(host_id)
-        host_to_disconnect = cached_host if cached_host is not None else host
-        if isinstance(host_to_disconnect, Host):
-            host_to_disconnect.disconnect()
+        # Disconnect SSH before stopping (also disconnect the passed-in host
+        # in case it is a different instance than the cached one).
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
 
         container = self._find_container_by_host_id(host_id)
         if container is not None:
@@ -1011,7 +1040,6 @@ kill -TERM 1
             )
 
         self._container_cache_by_id.pop(host_id, None)
-        self._host_by_id_cache.pop(host_id, None)
 
     def start_host(
         self,
@@ -1058,7 +1086,7 @@ kill -TERM 1
                 container.start()
 
             self._container_cache_by_id[host_id] = container
-            self._host_by_id_cache.pop(host_id, None)
+            self._evict_cached_host(host_id)
 
             if host_record is None:
                 raise HostNotFoundError(host_id)
@@ -1079,7 +1107,7 @@ kill -TERM 1
                 host_data=host_record.certified_host_data,
             )
 
-            self._host_by_id_cache[host_id] = restored_host
+            self._evict_cached_host(host_id, replacement=restored_host)
             return restored_host
 
         # No container found, try snapshot restore
@@ -1153,7 +1181,7 @@ kill -TERM 1
             raise MngrError(f"Failed to create container from snapshot: {e}") from e
 
         self._container_cache_by_id[host_id] = new_container
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
         restored_host, _, _, _ = self._setup_container_ssh_and_create_host(
             container=new_container,
@@ -1164,7 +1192,7 @@ kill -TERM 1
             host_data=host_record.certified_host_data,
         )
 
-        self._host_by_id_cache[host_id] = restored_host
+        self._evict_cached_host(host_id, replacement=restored_host)
         return restored_host
 
     def destroy_host(
@@ -1207,18 +1235,18 @@ kill -TERM 1
                 logger.trace("No host volume to clean up for {}: {}", host_id, e)
 
         self._container_cache_by_id.pop(host_id, None)
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
     def delete_host(self, host: HostInterface) -> None:
         """Permanently delete all records associated with a (destroyed) host."""
         self._host_store.delete_host_record(host.id)
         self._container_cache_by_id.pop(host.id, None)
-        self._host_by_id_cache.pop(host.id, None)
+        self._evict_cached_host(host.id)
 
     def on_connection_error(self, host_id: HostId) -> None:
         """Clear all caches for a host on connection error."""
         self._container_cache_by_id.pop(host_id, None)
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         self._host_store.clear_cache()
 
     # =========================================================================
@@ -1272,7 +1300,7 @@ kill -TERM 1
                         break
 
         if host_obj is not None:
-            self._host_by_id_cache[host_obj.id] = host_obj
+            self._evict_cached_host(host_obj.id, replacement=host_obj)
             return host_obj
 
         raise HostNotFoundError(host)
@@ -1351,7 +1379,7 @@ kill -TERM 1
                     logger.warning("Failed to create host from container {}: {}", host_id, e)
 
         for h, _ in hosts_with_state:
-            self._host_by_id_cache[h.id] = h
+            self._evict_cached_host(h.id, replacement=h)
 
         return [
             DiscoveredHost(host_id=h.id, host_name=h.get_name(), provider_name=self.name, host_state=state)

--- a/libs/mngr/imbue/mngr/providers/docker/instance.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance.py
@@ -229,20 +229,6 @@ class DockerProviderInstance(BaseProviderInstance):
 
     # Instance-level caches
     _container_cache_by_id: dict[HostId, docker.models.containers.Container] = PrivateAttr(default_factory=dict)
-    _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
-
-    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
-        """Remove a Host from the cache, disconnecting it if it holds an SSH connection.
-
-        If replacement is provided and is a different instance than the cached one,
-        the old Host is disconnected before being evicted. If replacement is None,
-        the entry is simply removed (with disconnect).
-        """
-        old_host = self._host_by_id_cache.pop(host_id, None)
-        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
-            old_host.disconnect()
-        if replacement is not None:
-            self._host_by_id_cache[host_id] = replacement
 
     @property
     def supports_snapshots(self) -> bool:

--- a/libs/mngr/imbue/mngr/providers/docker/test_docker_lifecycle.py
+++ b/libs/mngr/imbue/mngr/providers/docker/test_docker_lifecycle.py
@@ -1,6 +1,5 @@
 from collections.abc import Generator
 from pathlib import Path
-
 import pytest
 
 from imbue.mngr.config.data_types import MngrContext
@@ -498,3 +497,42 @@ def test_persist_multiple_agents_for_same_host(docker_provider: DockerProviderIn
     assert len(records) == 2
     agent_ids = {r["id"] for r in records}
     assert agent_ids == {agent_id_1, agent_id_2}
+
+
+@pytest.mark.docker
+@pytest.mark.docker_sdk
+def test_disconnect_closes_paramiko_ssh_client(docker_provider: DockerProviderInstance) -> None:
+    """Verify that Host.disconnect() closes the underlying paramiko SSH client.
+
+    pyinfra's disconnect() only clears its SFTP cache and sets connected=False.
+    It does NOT close the paramiko SSHClient, so when connect() is called again
+    (e.g. during a retry after a transient SSH error), the old TCP connection
+    leaks as an orphaned sshd-session on the server.
+
+    This test creates a real Docker host, establishes an SSH connection, grabs
+    a reference to the paramiko transport, disconnects, and verifies that the
+    transport was actually closed.
+    """
+    host = docker_provider.create_host(HostName("test-disconnect"))
+
+    # Establish the SSH connection by running a command
+    result = host.execute_idempotent_command("echo connected")
+    assert result.success
+
+    # Grab the paramiko transport from the live connection.
+    # Access the pyinfra internals via cast(Any, ...) since these are
+    # not part of the public type surface.
+    old_client = host.connector.host.connector.client  # ty: ignore[unresolved-attribute]
+    assert old_client is not None
+    old_transport = old_client.get_transport()
+    assert old_transport is not None
+    assert old_transport.is_active()
+
+    # Disconnect
+    host.disconnect()
+
+    # The paramiko transport should be closed after disconnect
+    assert not old_transport.is_active(), (
+        "paramiko transport is still active after disconnect -- "
+        "the SSH connection was leaked"
+    )

--- a/libs/mngr/imbue/mngr/providers/docker/test_docker_lifecycle.py
+++ b/libs/mngr/imbue/mngr/providers/docker/test_docker_lifecycle.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from pathlib import Path
+
 import pytest
 
 from imbue.mngr.config.data_types import MngrContext
@@ -520,8 +521,8 @@ def test_disconnect_closes_paramiko_ssh_client(docker_provider: DockerProviderIn
     assert result.success
 
     # Grab the paramiko transport from the live connection.
-    # Access the pyinfra internals via cast(Any, ...) since these are
-    # not part of the public type surface.
+    # Access pyinfra internals directly (not part of the public type surface);
+    # the ty: ignore suppresses the unresolved-attribute type error.
     old_client = host.connector.host.connector.client  # ty: ignore[unresolved-attribute]
     assert old_client is not None
     old_transport = old_client.get_transport()
@@ -533,6 +534,5 @@ def test_disconnect_closes_paramiko_ssh_client(docker_provider: DockerProviderIn
 
     # The paramiko transport should be closed after disconnect
     assert not old_transport.is_active(), (
-        "paramiko transport is still active after disconnect -- "
-        "the SSH connection was leaked"
+        "paramiko transport is still active after disconnect -- the SSH connection was leaked"
     )

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -95,6 +95,14 @@ class LimaProviderInstance(BaseProviderInstance):
     _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
     _lima_checked: bool = PrivateAttr(default=False)
 
+    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
+        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
+        old_host = self._host_by_id_cache.pop(host_id, None)
+        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
+            old_host.disconnect()
+        if replacement is not None:
+            self._host_by_id_cache[host_id] = replacement
+
     def _ensure_lima_available(self) -> None:
         """Lazily check that limactl is installed and meets version requirements.
 
@@ -128,7 +136,8 @@ class LimaProviderInstance(BaseProviderInstance):
         return True
 
     def reset_caches(self) -> None:
-        self._host_by_id_cache.clear()
+        for host_id in list(self._host_by_id_cache):
+            self._evict_cached_host(host_id)
         self._host_store.clear_cache()
 
     # =========================================================================
@@ -537,7 +546,7 @@ sudo poweroff
                 with log_span("Adding {} known_hosts entries to VM", len(known_hosts)):
                     host.execute_stateful_command(f"sh -c '{add_known_hosts_cmd}'")
 
-        self._host_by_id_cache[host_id] = host
+        self._evict_cached_host(host_id, replacement=host)
         return host
 
     def _read_resources_from_config(self, lima_config: dict) -> HostResources:
@@ -568,9 +577,9 @@ sudo poweroff
         logger.info("Stopping Lima VM: {}", host_id)
 
         # Disconnect SSH before stopping
-        cached_host = self._host_by_id_cache.get(host_id)
-        if isinstance(cached_host, Host):
-            cached_host.disconnect()
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
 
         host_record = self._host_store.read_host_record(host_id, use_cache=False)
         if host_record is not None and host_record.config is not None:
@@ -582,19 +591,6 @@ sudo poweroff
                 logger.warning("Error stopping Lima VM: {}", e)
         else:
             logger.debug("No host record found for {}", host_id)
-
-        # Update host record with stop reason
-        if host_record is not None:
-            updated_certified_data = host_record.certified_host_data.model_copy_update(
-                to_update(host_record.certified_host_data.field_ref().stop_reason, HostState.STOPPED.value),
-            )
-            self._host_store.write_host_record(
-                host_record.model_copy_update(
-                    to_update(host_record.field_ref().certified_host_data, updated_certified_data),
-                )
-            )
-
-        self._host_by_id_cache.pop(host_id, None)
 
     def start_host(
         self,
@@ -655,7 +651,7 @@ sudo poweroff
             start_activity_watcher_cmd = build_start_activity_watcher_command(str(self.host_dir))
             host_obj.execute_stateful_command(f"sh -c '{start_activity_watcher_cmd}'")
 
-        self._host_by_id_cache[host_id] = host_obj
+        self._evict_cached_host(host_id, replacement=host_obj)
         return host_obj
 
     def destroy_host(self, host: HostInterface | HostId) -> None:
@@ -664,9 +660,9 @@ sudo poweroff
         logger.info("Destroying Lima VM: {}", host_id)
 
         # Disconnect SSH
-        cached_host = self._host_by_id_cache.get(host_id)
-        if isinstance(cached_host, Host):
-            cached_host.disconnect()
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
 
         host_record = self._host_store.read_host_record(host_id, use_cache=False)
         if host_record is not None and host_record.config is not None:
@@ -686,8 +682,6 @@ sudo poweroff
                 )
             )
 
-        self._host_by_id_cache.pop(host_id, None)
-
     def delete_host(self, host: HostInterface) -> None:
         """Permanently delete all records associated with a destroyed host."""
         host_id = host.id
@@ -706,11 +700,11 @@ sudo poweroff
         if tags_path.exists():
             tags_path.unlink(missing_ok=True)
 
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
     def on_connection_error(self, host_id: HostId) -> None:
         """Handle connection errors by clearing the cache."""
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
     # =========================================================================
     # Discovery Methods
@@ -746,7 +740,7 @@ sudo poweroff
         # Instance is running -- create online host
         ssh_config = self._get_ssh_config(instance_name)
         host_obj = self._create_host_object(host_id, ssh_config)
-        self._host_by_id_cache[host_id] = host_obj
+        self._evict_cached_host(host_id, replacement=host_obj)
         return host_obj
 
     def _get_host_by_name(self, name: HostName) -> HostInterface:

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -45,9 +45,9 @@ from imbue.mngr.providers.base_provider import BaseProviderInstance
 from imbue.mngr.providers.local.volume import LocalVolume
 from imbue.mngr.providers.ssh_host_setup import build_add_authorized_keys_command
 from imbue.mngr.providers.ssh_host_setup import build_add_known_hosts_command
-from imbue.mngr.providers.ssh_utils import clear_host_from_known_hosts
 from imbue.mngr.providers.ssh_host_setup import build_start_activity_watcher_command
 from imbue.mngr.providers.ssh_utils import add_host_to_known_hosts
+from imbue.mngr.providers.ssh_utils import clear_host_from_known_hosts
 from imbue.mngr.providers.ssh_utils import create_pyinfra_host
 from imbue.mngr.providers.ssh_utils import wait_for_sshd
 from imbue.mngr_lima.config import LimaProviderConfig

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -592,6 +592,16 @@ sudo poweroff
         else:
             logger.debug("No host record found for {}", host_id)
 
+        if host_record is not None:
+            updated_certified_data = host_record.certified_host_data.model_copy_update(
+                to_update(host_record.certified_host_data.field_ref().stop_reason, HostState.STOPPED.value),
+            )
+            self._host_store.write_host_record(
+                host_record.model_copy_update(
+                    to_update(host_record.field_ref().certified_host_data, updated_certified_data),
+                )
+            )
+
     def start_host(
         self,
         host: HostInterface | HostId,

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -92,16 +92,7 @@ class LimaProviderInstance(BaseProviderInstance):
 
     config: LimaProviderConfig = Field(frozen=True, description="Lima provider configuration")
 
-    _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
     _lima_checked: bool = PrivateAttr(default=False)
-
-    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
-        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
-        old_host = self._host_by_id_cache.pop(host_id, None)
-        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
-            old_host.disconnect()
-        if replacement is not None:
-            self._host_by_id_cache[host_id] = replacement
 
     def _ensure_lima_available(self) -> None:
         """Lazily check that limactl is installed and meets version requirements.

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -396,6 +396,14 @@ class ModalProviderInstance(BaseProviderInstance):
     _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
     # Cache for host records read from the volume to avoid repeated reads
     _host_record_cache_by_id: dict[HostId, HostRecord] = PrivateAttr(default_factory=dict)
+
+    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
+        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
+        old_host = self._host_by_id_cache.pop(host_id, None)
+        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
+            old_host.disconnect()
+        if replacement is not None:
+            self._host_by_id_cache[host_id] = replacement
     # a reference to the ssh process, just in case we ever need it (and to prevent it from being garbage collected)
     _ssh_process: ExecProcess | None = PrivateAttr(default=None)
     # a list of *all* currently running sandboxes for this app
@@ -627,7 +635,7 @@ class ModalProviderInstance(BaseProviderInstance):
         logger.trace("Deleted agent records from state volume dir: {}", host_dir)
 
         # Clear cache entries for this host
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         self._host_record_cache_by_id.pop(host_id, None)
 
     def _delete_host_record(self, host_id: HostId) -> None:
@@ -643,7 +651,7 @@ class ModalProviderInstance(BaseProviderInstance):
         logger.trace("Deleted host record from volume: {}", path)
 
         # Clear cache entries for this host
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         self._host_record_cache_by_id.pop(host_id, None)
 
     def _clear_snapshots_from_host_record(self, host_id: HostId) -> None:
@@ -1464,7 +1472,7 @@ log "=== Shutdown script completed ==="
         This should be called when a host transitions state (e.g., from online to offline
         or vice versa) to ensure the next lookup returns the correct host type.
         """
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
     def reset_caches(self) -> None:
         """Reset all caches on this instance.
@@ -1474,7 +1482,8 @@ log "=== Shutdown script completed ==="
         """
         self._sandbox_cache_by_id.clear()
         self._sandbox_cache_by_name.clear()
-        self._host_by_id_cache.clear()
+        for host_id in list(self._host_by_id_cache):
+            self._evict_cached_host(host_id)
         self._host_record_cache_by_id.clear()
         self._full_sandbox_list_cache = None
 
@@ -1578,6 +1587,14 @@ log "=== Shutdown script completed ==="
                     "Skipped sandbox {}: host record missing SSH info (likely failed host)", sandbox.get_object_id()
                 )
                 return None
+
+            # Reuse the cached Host if SSH details have not changed
+            cached = self._host_by_id_cache.get(host_id)
+            if isinstance(cached, Host):
+                cached_name = cached.connector.name
+                cached_port = cached.connector.host.data.get("ssh_port")
+                if cached_name == host_record.ssh_host and cached_port == host_record.ssh_port:
+                    return cached
 
             # Add the sandbox's host key to known_hosts so SSH connections will work
             with trace_span("Adding to known hosts {}", host_id, _is_trace_span_enabled=False):
@@ -1840,28 +1857,20 @@ log "=== Shutdown script completed ==="
         host_id = host.id if isinstance(host, HostInterface) else host
         logger.info("Stopping (terminating) Modal sandbox: {}", host_id)
 
-        # Disconnect the SSH connection before terminating the sandbox.
-        # This prevents stale socket state that can cause "Socket is closed" errors.
-        # We check the cache first, then fall back to the passed host object.
-        cached_host = self._host_by_id_cache.get(host_id)
-        if cached_host is not None and isinstance(cached_host, Host):
-            cached_host.disconnect()
-        elif isinstance(host, Host):
-            host.disconnect()
-        else:
-            # No Host instance available (e.g., only have a host_id string or HostInterface stub)
-            pass
-
         sandbox = self._find_sandbox_by_host_id(host_id)
-        if sandbox:
-            # Create a snapshot before termination if requested
-            if create_snapshot:
-                try:
-                    with log_span("Creating snapshot before termination", host_id=str(host_id)):
-                        self.create_snapshot(host_id, SnapshotName("stop"))
-                except (MngrError, ModalProxyError) as e:
-                    logger.warning("Failed to create snapshot before termination: {}", e)
+        if sandbox and create_snapshot:
+            try:
+                with log_span("Creating snapshot before termination", host_id=str(host_id)):
+                    self.create_snapshot(host_id, SnapshotName("stop"))
+            except (MngrError, ModalProxyError) as e:
+                logger.warning("Failed to create snapshot before termination: {}", e)
 
+        # Disconnect SSH after snapshot but before termination
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
+
+        if sandbox:
             try:
                 sandbox.terminate()
             except ModalProxyError as e:
@@ -2036,7 +2045,7 @@ log "=== Shutdown script completed ==="
         )
 
         # Cache the new online host
-        self._host_by_id_cache[host_id] = restored_host
+        self._evict_cached_host(host_id, replacement=restored_host)
 
         return restored_host
 
@@ -2076,7 +2085,7 @@ log "=== Shutdown script completed ==="
             host_name = HostName(host_record.certified_host_data.host_name)
             self._sandbox_cache_by_name.pop(host_name, None)
         self._sandbox_cache_by_id.pop(host_id, None)
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         self._host_record_cache_by_id.pop(host_id, None)
 
     # =========================================================================
@@ -2140,7 +2149,7 @@ log "=== Shutdown script completed ==="
 
         # finally save to the cache and return
         if host_obj is not None:
-            self._host_by_id_cache[host_obj.id] = host_obj
+            self._evict_cached_host(host_obj.id, replacement=host_obj)
             return host_obj
         # or raise:
         else:
@@ -2244,7 +2253,7 @@ log "=== Shutdown script completed ==="
 
         # add these hosts to a cache so we don't need to look them up by name or id again
         for host in hosts:
-            self._host_by_id_cache[host.id] = host
+            self._evict_cached_host(host.id, replacement=host)
 
         return [
             DiscoveredHost(

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -245,7 +245,6 @@ def handle_modal_auth_error(func: Callable[P, T]) -> Callable[P, T]:
     return wrapper
 
 
-
 class SandboxConfig(HostConfig):
     """Configuration parsed from build arguments."""
 
@@ -404,6 +403,7 @@ class ModalProviderInstance(BaseProviderInstance):
             old_host.disconnect()
         if replacement is not None:
             self._host_by_id_cache[host_id] = replacement
+
     # a reference to the ssh process, just in case we ever need it (and to prevent it from being garbage collected)
     _ssh_process: ExecProcess | None = PrivateAttr(default=None)
     # a list of *all* currently running sandboxes for this app

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -392,18 +392,8 @@ class ModalProviderInstance(BaseProviderInstance):
     # Modal's eventually consistent tag API for recently created sandboxes.
     _sandbox_cache_by_id: dict[HostId, SandboxInterface] = PrivateAttr(default_factory=dict)
     _sandbox_cache_by_name: dict[HostName, SandboxInterface] = PrivateAttr(default_factory=dict)
-    _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
     # Cache for host records read from the volume to avoid repeated reads
     _host_record_cache_by_id: dict[HostId, HostRecord] = PrivateAttr(default_factory=dict)
-
-    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
-        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
-        old_host = self._host_by_id_cache.pop(host_id, None)
-        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
-            old_host.disconnect()
-        if replacement is not None:
-            self._host_by_id_cache[host_id] = replacement
-
     # a reference to the ssh process, just in case we ever need it (and to prevent it from being garbage collected)
     _ssh_process: ExecProcess | None = PrivateAttr(default=None)
     # a list of *all* currently running sandboxes for this app

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -218,17 +218,8 @@ class VpsDockerProvider(BaseProviderInstance):
     config: VpsDockerProviderConfig = Field(frozen=True, description="VPS Docker provider configuration")
     vps_client: VpsClientInterface = Field(frozen=True, description="VPS provider API client")
 
-    _host_by_id_cache: dict[HostId, HostInterface] = PrivateAttr(default_factory=dict)
     _host_record_cache: dict[HostId, VpsDockerHostRecord] = PrivateAttr(default_factory=dict)
     _container_running_cache: dict[str, bool] = PrivateAttr(default_factory=dict)
-
-    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
-        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
-        old_host = self._host_by_id_cache.pop(host_id, None)
-        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
-            old_host.disconnect()
-        if replacement is not None:
-            self._host_by_id_cache[host_id] = replacement
 
     @property
     def supports_snapshots(self) -> bool:

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -222,6 +222,14 @@ class VpsDockerProvider(BaseProviderInstance):
     _host_record_cache: dict[HostId, VpsDockerHostRecord] = PrivateAttr(default_factory=dict)
     _container_running_cache: dict[str, bool] = PrivateAttr(default_factory=dict)
 
+    def _evict_cached_host(self, host_id: HostId, replacement: HostInterface | None = None) -> None:
+        """Remove a Host from the cache, disconnecting it if it holds an SSH connection."""
+        old_host = self._host_by_id_cache.pop(host_id, None)
+        if old_host is not None and old_host is not replacement and isinstance(old_host, Host):
+            old_host.disconnect()
+        if replacement is not None:
+            self._host_by_id_cache[host_id] = replacement
+
     @property
     def supports_snapshots(self) -> bool:
         return True
@@ -239,7 +247,8 @@ class VpsDockerProvider(BaseProviderInstance):
         return False
 
     def reset_caches(self) -> None:
-        self._host_by_id_cache.clear()
+        for host_id in list(self._host_by_id_cache):
+            self._evict_cached_host(host_id)
         self._host_record_cache.clear()
         self._container_running_cache.clear()
 
@@ -338,7 +347,7 @@ class VpsDockerProvider(BaseProviderInstance):
                 callback_host_id, certified_data, vps_ip
             ),
         )
-        self._host_by_id_cache[host_id] = host
+        self._evict_cached_host(host_id, replacement=host)
         return host
 
     def _create_offline_host(
@@ -357,7 +366,7 @@ class VpsDockerProvider(BaseProviderInstance):
                 callback_host_id, certified_data, vps_ip
             ),
         )
-        self._host_by_id_cache[host_id] = offline
+        self._evict_cached_host(host_id, replacement=offline)
         return offline
 
     def _on_certified_host_data_updated(self, host_id: HostId, certified_data: CertifiedHostData, vps_ip: str) -> None:
@@ -929,7 +938,7 @@ class VpsDockerProvider(BaseProviderInstance):
         updated_record = host_record.model_copy(update={"certified_host_data": updated_data})
         host_store.write_host_record(updated_record)
 
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         logger.info("Host {} stopped", host_id)
 
     # =========================================================================
@@ -1021,16 +1030,15 @@ class VpsDockerProvider(BaseProviderInstance):
             except Exception as e:
                 logger.trace("Failed to clean up container known_hosts: {}", e)
 
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
         logger.info("Host {} destroyed (VPS {})", host_id, vps_config.vps_instance_id)
 
     def delete_host(self, host: HostInterface) -> None:
         """Delete all local records for a destroyed host (does not destroy VPS)."""
-        host_id = host.id
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host.id)
 
     def on_connection_error(self, host_id: HostId) -> None:
-        self._host_by_id_cache.pop(host_id, None)
+        self._evict_cached_host(host_id)
 
     # =========================================================================
     # Discovery

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -928,6 +928,12 @@ class VpsDockerProvider(BaseProviderInstance):
             except MngrError as e:
                 logger.warning("Failed to create snapshot before stop: {}", e)
 
+        # Disconnect SSH before stopping (also disconnect the passed-in host
+        # in case it is a different instance than the cached one).
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
+
         with log_span("Stopping container on VPS"):
             docker_ssh.stop_container(host_record.config.container_name, timeout_seconds=int(timeout_seconds))
 
@@ -938,7 +944,6 @@ class VpsDockerProvider(BaseProviderInstance):
         updated_record = host_record.model_copy(update={"certified_host_data": updated_data})
         host_store.write_host_record(updated_record)
 
-        self._evict_cached_host(host_id)
         logger.info("Host {} stopped", host_id)
 
     # =========================================================================
@@ -974,6 +979,13 @@ class VpsDockerProvider(BaseProviderInstance):
 
     def destroy_host(self, host: HostInterface | HostId) -> None:
         host_id = host.id if isinstance(host, HostInterface) else host
+
+        # Disconnect SSH before destroying (also disconnect the passed-in host
+        # in case it is a different instance than the cached one).
+        if isinstance(host, Host):
+            host.disconnect()
+        self._evict_cached_host(host_id)
+
         host_record = self._find_host_record(host_id)
         if host_record is None or host_record.config is None:
             raise HostNotFoundError(host_id)
@@ -1030,7 +1042,6 @@ class VpsDockerProvider(BaseProviderInstance):
             except Exception as e:
                 logger.trace("Failed to clean up container known_hosts: {}", e)
 
-        self._evict_cached_host(host_id)
         logger.info("Host {} destroyed (VPS {})", host_id, vps_config.vps_instance_id)
 
     def delete_host(self, host: HostInterface) -> None:


### PR DESCRIPTION
## Summary

Fixes a bug where SSH connections (sshd-session processes) leaked inside Docker containers (and potentially Modal sandboxes, VPS Docker hosts, and Lima VMs) when `mngr observe` polled repeatedly.

**Root cause:** `discover_hosts()` created a new Host object (with new pyinfra SSH connector) for every running container on every 10-second poll cycle, then overwrote the `_host_by_id_cache` without closing the old Host's SSH connection. Since pyinfra's `disconnect()` doesn't close the underlying paramiko SSHClient and paramiko SSHClient has no `__del__`, the old TCP connections leaked permanently as orphaned sshd-session processes on the server.

With 18 orphaned `mngr observe` processes (separate bug: #1280), this caused ~2300 leaked sshd-sessions and ~2.4 new leaked connections/second.

**Fixes applied across all SSH-capable providers (Docker, Modal, VPS Docker, Lima):**

1. **Reuse cached Host when SSH details match** -- `_create_host_from_container` / `_create_host_from_sandbox` check the cache first and return the existing Host if the SSH host and port haven't changed. This eliminates the leak in the normal case (same container rediscovered each poll).

2. **`_evict_cached_host` helper** -- All `_host_by_id_cache` mutations go through this method, which disconnects the old Host before replacing or removing it. Ensures no connection is silently leaked regardless of code path (stop, start, destroy, discovery, connection error, cache reset).

3. **`Host.disconnect()` closes paramiko client** -- `_close_paramiko_client()` explicitly closes the paramiko SSHClient before pyinfra's disconnect clears its internal state. This is needed because pyinfra's `SSHConnector.disconnect()` only clears the SFTP cache.

4. **`Host.__del__`** -- Defense-in-depth: if a Host is garbage collected without being disconnected, the paramiko client is closed.

## Test plan

- [x] `test_disconnect_closes_paramiko_ssh_client` -- real Docker SSH test that creates a host, establishes SSH, disconnects, and verifies the paramiko transport is actually closed (failed before fix, passes after)
- [x] mngr: 3588 passed, 82.83% coverage
- [x] mngr_modal: 374 passed, 75.76% coverage
- [x] mngr_vps_docker: 139 passed, 40.77% coverage
- [x] mngr_lima: 98 passed, 87.13% coverage
- [x] No ratchet violations

Related: #1280 (orphaned observe processes that multiply the leak)

Generated with [Claude Code](https://claude.com/claude-code)