### PR TITLE
Sync stop_hook_gates.sh with code-guardian upstream

### DIFF
--- a/scripts/stop_hook_gates.sh
+++ b/scripts/stop_hook_gates.sh
@@ -165,7 +165,7 @@ if [[ ${#MISSING[@]} -gt 1 ]]; then
         GUIDANCE="${GUIDANCE} Address any issues raised by /verify-architecture before running /autofix, since architecture changes may make autofix results obsolete."
     fi
     if [[ "$CONVO_NEEDED" == "true" ]]; then
-        GUIDANCE="${GUIDANCE} If possible, run /verify-conversation in the background while running the others."
+        GUIDANCE="${GUIDANCE} If possible, run /verify-conversation in the background while running the others. After the foreground tasks finish, block on any background tasks you launched (e.g. /verify-conversation) before finishing."
     fi
     echo "$GUIDANCE" >&2
 fi


### PR DESCRIPTION
## Summary
- Syncs `scripts/stop_hook_gates.sh` with the canonical version in `imbue-ai/code-guardian`
- Adds missing sentence to the `/verify-conversation` guidance: "After the foreground tasks finish, block on any background tasks you launched (e.g. /verify-conversation) before finishing."
- Fixes failing `test_shared_script_matches_code_guardian[stop_hook_gates.sh]` acceptance test

## Test plan
- [x] `test_shared_script_matches_code_guardian[stop_hook_gates.sh]` passes locally (1 passed)
- [ ] CI acceptance tests pass

Generated with [Claude Code](https://claude.com/claude-code)