### PR TITLE
lint

### DIFF
--- a/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
+++ b/apps/cloudflare_forwarding/imbue/cloudflare_forwarding/app.py
@@ -711,11 +711,13 @@ class ForwardingCtx:
         self.ops.create_cname(hostname, f"{tid}.cfargotunnel.com")
         config = self.ops.get_tunnel_config(tid)
         rules = non_catchall_rules(config.get("config", {}).get("ingress", []))
-        rules.append({
-            "hostname": hostname,
-            "service": service_url,
-            "originRequest": {"noTLSVerify": True},
-        })
+        rules.append(
+            {
+                "hostname": hostname,
+                "service": service_url,
+                "originRequest": {"noTLSVerify": True},
+            }
+        )
         self.ops.put_tunnel_config(tid, wrap_ingress(rules))
 
         self._apply_default_access_policy(tunnel_name, hostname)

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -34,7 +34,6 @@ from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import generate_api_key
 from imbue.minds.desktop_client.api_key_store import hash_api_key
 from imbue.minds.desktop_client.api_key_store import save_api_key_hash
-
 from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
@@ -331,7 +330,6 @@ def run_mngr_create(
     return api_key
 
 
-
 class AgentCreator(MutableModel):
     """Creates mngr agents in the background from git repositories or local paths.
 
@@ -493,4 +491,3 @@ class AgentCreator(MutableModel):
                 self._errors[aid] = str(e)
         finally:
             log_queue.put(LOG_SENTINEL)
-

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -24,11 +24,11 @@ from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import find_agent_by_api_key
 from imbue.minds.desktop_client.cloudflare_client import CloudflareForwardingClient
 from imbue.minds.desktop_client.deps import BackendResolverDep
-from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
-from imbue.minds.desktop_client.tunnel_token_store import save_tunnel_token
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
+from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
+from imbue.minds.desktop_client.tunnel_token_store import save_tunnel_token
 from imbue.minds.primitives import ServerName
 from imbue.minds.telegram.credential_store import load_agent_bot_credentials
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
@@ -46,7 +46,7 @@ def _authenticate_api_key(request: Request) -> AgentId:
     if not auth_header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or malformed Authorization header")
 
-    token = auth_header[len("Bearer "):]
+    token = auth_header[len("Bearer ") :]
     if not token:
         raise HTTPException(status_code=401, detail="Empty Bearer token")
 
@@ -243,10 +243,12 @@ async def _handle_telegram_setup(
         pass
 
     telegram_orchestrator.start_setup(agent_id=parsed_id, agent_name=agent_name)
-    return _json_response({
-        "agent_id": str(parsed_id),
-        "status": str(TelegramSetupStatus.CHECKING_CREDENTIALS),
-    })
+    return _json_response(
+        {
+            "agent_id": str(parsed_id),
+            "status": str(TelegramSetupStatus.CHECKING_CREDENTIALS),
+        }
+    )
 
 
 def _handle_telegram_status(
@@ -319,9 +321,7 @@ async def _handle_notification(
     try:
         urgency = NotificationUrgency(urgency_str.upper())
     except (ValueError, AttributeError):
-        return _json_error(
-            f"Invalid urgency: {urgency_str}. Must be one of: low, normal, critical", 400
-        )
+        return _json_error(f"Invalid urgency: {urgency_str}. Must be one of: low, normal, critical", 400)
 
     notification_request = NotificationRequest(
         message=message,

--- a/apps/minds/imbue/minds/desktop_client/api_v1_test.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1_test.py
@@ -794,5 +794,3 @@ def test_cloudflare_disable_returns_200_on_success(tmp_path: Path) -> None:
     )
     assert response.status_code == 200
     assert response.json()["ok"] is True
-
-

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -389,4 +389,3 @@ def test_run_tkinter_toast_with_fake_tk_succeeds() -> None:
         agent_display_name="test-agent",
         tk=tk,
     )
-

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -26,9 +26,9 @@ from imbue.minds.desktop_client.cloudflare_client import CloudflareUsername
 from imbue.minds.desktop_client.cloudflare_client import OwnerEmail
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
-from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelManager
+from imbue.minds.desktop_client.tunnel_token_store import load_tunnel_token
 from imbue.minds.primitives import OneTimeCode
 from imbue.minds.primitives import OutputFormat
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
@@ -38,7 +38,6 @@ from imbue.mngr.primitives import AgentId
 _ONE_TIME_CODE_LENGTH: Final[int] = 32
 
 _DEFAULT_MNGR_HOST_DIR: Final[Path] = Path.home() / ".mngr"
-
 
 
 _PROVIDER_HOST_DIR: Final[dict[str, str]] = {
@@ -156,7 +155,9 @@ def start_desktop_client(
     # Register callback to set up reverse tunnels and write API URL files
     # when agents are discovered
     discovery_handler = AgentDiscoveryHandler(
-        tunnel_manager=tunnel_manager, server_port=port, data_dir=data_directory,
+        tunnel_manager=tunnel_manager,
+        server_port=port,
+        data_dir=data_directory,
     )
     stream_manager.add_on_agent_discovered_callback(discovery_handler)
     stream_manager.start()

--- a/apps/minds/imbue/minds/desktop_client/runner_test.py
+++ b/apps/minds/imbue/minds/desktop_client/runner_test.py
@@ -44,8 +44,12 @@ def test_agent_discovery_handler_callable() -> None:
 
 def test_build_cloudflare_client_returns_none_when_not_configured() -> None:
     """Without env vars, _build_cloudflare_client returns None."""
-    for key in ("CLOUDFLARE_FORWARDING_URL", "CLOUDFLARE_FORWARDING_USERNAME",
-                "CLOUDFLARE_FORWARDING_SECRET", "OWNER_EMAIL"):
+    for key in (
+        "CLOUDFLARE_FORWARDING_URL",
+        "CLOUDFLARE_FORWARDING_USERNAME",
+        "CLOUDFLARE_FORWARDING_SECRET",
+        "OWNER_EMAIL",
+    ):
         os.environ.pop(key, None)
     result = _build_cloudflare_client()
     assert result is None
@@ -61,8 +65,12 @@ def test_build_cloudflare_client_returns_client_when_configured() -> None:
         result = _build_cloudflare_client()
         assert result is not None
     finally:
-        for key in ("CLOUDFLARE_FORWARDING_URL", "CLOUDFLARE_FORWARDING_USERNAME",
-                    "CLOUDFLARE_FORWARDING_SECRET", "OWNER_EMAIL"):
+        for key in (
+            "CLOUDFLARE_FORWARDING_URL",
+            "CLOUDFLARE_FORWARDING_USERNAME",
+            "CLOUDFLARE_FORWARDING_SECRET",
+            "OWNER_EMAIL",
+        ):
             os.environ.pop(key, None)
 
 

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -447,7 +447,9 @@ def render_landing_page(
     )
 
 
-_DEFAULT_GIT_URL: Final[str] = os.getenv("MINDS_WORKSPACE_GIT_URL", "https://github.com/imbue-ai/forever-claude-template.git")
+_DEFAULT_GIT_URL: Final[str] = os.getenv(
+    "MINDS_WORKSPACE_GIT_URL", "https://github.com/imbue-ai/forever-claude-template.git"
+)
 
 
 _DEFAULT_AGENT_NAME: Final[str] = os.getenv("MINDS_WORKSPACE_NAME", "selene")

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -62,7 +62,8 @@ class _ApplicationsFileHandler(FileSystemEventHandler):
 
 
 def _make_applications_file_handler(
-    agent_id: str, on_change: Any,
+    agent_id: str,
+    on_change: Any,
 ) -> _ApplicationsFileHandler:
     """Create an applications file handler for the given agent."""
     handler = _ApplicationsFileHandler()
@@ -398,9 +399,7 @@ class AgentManager:
             error = str(e)
             _loguru_logger.exception("Error creating agent {}", agent_id)
 
-        log_queue.put(
-            json.dumps({"done": True, "success": success, "error": error})
-        )
+        log_queue.put(json.dumps({"done": True, "success": success, "error": error}))
         log_queue.put(None)
 
         with self._lock:
@@ -419,9 +418,7 @@ class AgentManager:
         if success:
             self._broadcaster.broadcast_agents_updated(self.get_agents_serialized())
 
-        self._broadcaster.broadcast_proto_agent_completed(
-            agent_id=agent_id, success=success, error=error
-        )
+        self._broadcaster.broadcast_proto_agent_completed(agent_id=agent_id, success=success, error=error)
 
     def _initial_discover(self) -> None:
         """Perform initial agent discovery and start application watchers."""
@@ -505,8 +502,7 @@ class AgentManager:
             )
         except (OSError, InvalidConcurrencyGroupStateError):
             _loguru_logger.warning(
-                "Could not start mngr observe subprocess. "
-                "Agent lifecycle events will not be detected."
+                "Could not start mngr observe subprocess. Agent lifecycle events will not be detected."
             )
             self._observe_cg.__exit__(None, None, None)
             self._observe_cg = None
@@ -631,9 +627,7 @@ class AgentManager:
                     return
                 self._app_observers[agent_id] = observer
         except OSError:
-            _loguru_logger.exception(
-                "Failed to start application watcher for agent {}", agent_id
-            )
+            _loguru_logger.exception("Failed to start application watcher for agent {}", agent_id)
 
     def _stop_app_watcher(self, agent_id: str) -> None:
         """Stop watching applications.toml for an agent."""
@@ -653,9 +647,7 @@ class AgentManager:
 
         toml_path = Path(work_dir) / _APPLICATIONS_TOML_FILENAME
         self._read_applications(agent_id, toml_path)
-        self._broadcaster.broadcast_applications_updated(
-            self.get_applications_serialized()
-        )
+        self._broadcaster.broadcast_applications_updated(self.get_applications_serialized())
 
     def _read_applications(self, agent_id: str, toml_path: Path) -> None:
         """Read and parse runtime/applications.toml for an agent."""
@@ -669,9 +661,7 @@ class AgentManager:
                     if name and url:
                         apps.append(ApplicationEntry(name=name, url=url))
             except (OSError, tomllib.TOMLDecodeError, KeyError, ValueError):
-                _loguru_logger.exception(
-                    "Failed to parse {} for agent {}", toml_path, agent_id
-                )
+                _loguru_logger.exception("Failed to parse {} for agent {}", toml_path, agent_id)
 
         with self._lock:
             self._applications[agent_id] = apps

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
@@ -7,6 +7,12 @@ from pathlib import Path
 
 import pytest
 
+from imbue.minds_workspace_server.agent_manager import AgentManager
+from imbue.minds_workspace_server.agent_manager import _LogQueueCallback
+from imbue.minds_workspace_server.models import AgentCreationError
+from imbue.minds_workspace_server.models import AgentStateItem
+from imbue.minds_workspace_server.models import ApplicationEntry
+from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
 from imbue.mngr.api.discovery_events import AgentDestroyedEvent
 from imbue.mngr.api.discovery_events import DiscoveryEventType
 from imbue.mngr.api.discovery_events import HostDestroyedEvent
@@ -17,12 +23,6 @@ from imbue.mngr.primitives import AgentName as MngrAgentName
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import ProviderInstanceName
-from imbue.minds_workspace_server.agent_manager import AgentManager
-from imbue.minds_workspace_server.agent_manager import _LogQueueCallback
-from imbue.minds_workspace_server.models import AgentCreationError
-from imbue.minds_workspace_server.models import AgentStateItem
-from imbue.minds_workspace_server.models import ApplicationEntry
-from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
 
 
 def test_generate_random_name(agent_manager: AgentManager) -> None:
@@ -217,9 +217,7 @@ def test_create_worktree_agent_broadcasts_proto_created(
     assert proto_msg["parent_agent_id"] is None
 
 
-def test_get_log_queue_for_proto_agent(
-    agent_manager: AgentManager, git_work_dir: Path
-) -> None:
+def test_get_log_queue_for_proto_agent(agent_manager: AgentManager, git_work_dir: Path) -> None:
     """The log queue is available immediately after create_worktree_agent returns."""
     with agent_manager._lock:
         agent_manager._agents["parent-id"] = AgentStateItem(
@@ -246,9 +244,7 @@ def test_stop_without_start(agent_manager: AgentManager) -> None:
     agent_manager.stop()
 
 
-def test_handle_agent_discovered(
-    agent_manager: AgentManager, broadcaster: WebSocketBroadcaster
-) -> None:
+def test_handle_agent_discovered(agent_manager: AgentManager, broadcaster: WebSocketBroadcaster) -> None:
     """Agent discovered events update the agent list and broadcast."""
     q = broadcaster.register()
 
@@ -275,9 +271,7 @@ def test_handle_agent_discovered(
     assert msg["type"] == "agents_updated"
 
 
-def test_agent_destroyed_removes_agent(
-    agent_manager: AgentManager, broadcaster: WebSocketBroadcaster
-) -> None:
+def test_agent_destroyed_removes_agent(agent_manager: AgentManager, broadcaster: WebSocketBroadcaster) -> None:
     """Destroying an agent removes it from the tracked list and broadcasts."""
     test_agent_id = MngrAgentId()
     str_id = str(test_agent_id)
@@ -340,9 +334,7 @@ def test_on_applications_changed(
     assert msg["type"] == "applications_updated"
 
 
-def test_read_applications_handles_invalid_toml(
-    agent_manager: AgentManager, tmp_path: Path
-) -> None:
+def test_read_applications_handles_invalid_toml(agent_manager: AgentManager, tmp_path: Path) -> None:
     """Invalid TOML files are handled gracefully."""
     toml_file = tmp_path / "bad.toml"
     toml_file.write_text("this is [[ not valid toml {{")
@@ -394,17 +386,13 @@ def test_initial_discover_handles_errors(
     assert isinstance(manager.get_agents(), list)
 
 
-def test_refresh_agents_does_not_crash(
-    agent_manager: AgentManager, broadcaster: WebSocketBroadcaster
-) -> None:
+def test_refresh_agents_does_not_crash(agent_manager: AgentManager, broadcaster: WebSocketBroadcaster) -> None:
     """Refresh agents handles errors gracefully and does not raise."""
     agent_manager._refresh_agents()
     assert isinstance(agent_manager.get_agents(), list)
 
 
-def test_handle_full_snapshot(
-    agent_manager: AgentManager, broadcaster: WebSocketBroadcaster
-) -> None:
+def test_handle_full_snapshot(agent_manager: AgentManager, broadcaster: WebSocketBroadcaster) -> None:
     """Full snapshot events replace the entire agent list."""
     q = broadcaster.register()
 
@@ -436,9 +424,7 @@ def test_handle_full_snapshot(
     assert len(msg["agents"]) == 2
 
 
-def test_run_creation_logs_header_and_completion(
-    agent_manager: AgentManager, tmp_path: Path
-) -> None:
+def test_run_creation_logs_header_and_completion(agent_manager: AgentManager, tmp_path: Path) -> None:
     """Creation thread logs a header line and a done message."""
     log_q: queue.Queue[str | None] = queue.Queue(maxsize=10000)
     cmd = ["true"]
@@ -550,31 +536,33 @@ def test_handle_discovery_event_dispatches_agent_discovered(
 
 def _make_agent_destroyed_event(agent_id: MngrAgentId, host_id: HostId) -> AgentDestroyedEvent:
     """Build an AgentDestroyedEvent for testing."""
-    return AgentDestroyedEvent.model_validate({
-        "timestamp": "2026-01-01T00:00:00.000000000Z",
-        "type": DiscoveryEventType.AGENT_DESTROYED,
-        "event_id": "test-event-id",
-        "source": "mngr/discovery",
-        "agent_id": str(agent_id),
-        "host_id": str(host_id),
-    })
+    return AgentDestroyedEvent.model_validate(
+        {
+            "timestamp": "2026-01-01T00:00:00.000000000Z",
+            "type": DiscoveryEventType.AGENT_DESTROYED,
+            "event_id": "test-event-id",
+            "source": "mngr/discovery",
+            "agent_id": str(agent_id),
+            "host_id": str(host_id),
+        }
+    )
 
 
 def _make_host_destroyed_event(host_id: HostId, agent_ids: list[MngrAgentId]) -> HostDestroyedEvent:
     """Build a HostDestroyedEvent for testing."""
-    return HostDestroyedEvent.model_validate({
-        "timestamp": "2026-01-01T00:00:00.000000000Z",
-        "type": DiscoveryEventType.HOST_DESTROYED,
-        "event_id": "test-event-id",
-        "source": "mngr/discovery",
-        "host_id": str(host_id),
-        "agent_ids": [str(a) for a in agent_ids],
-    })
+    return HostDestroyedEvent.model_validate(
+        {
+            "timestamp": "2026-01-01T00:00:00.000000000Z",
+            "type": DiscoveryEventType.HOST_DESTROYED,
+            "event_id": "test-event-id",
+            "source": "mngr/discovery",
+            "host_id": str(host_id),
+            "agent_ids": [str(a) for a in agent_ids],
+        }
+    )
 
 
-def test_handle_agent_destroyed_removes_agent(
-    agent_manager: AgentManager, broadcaster: WebSocketBroadcaster
-) -> None:
+def test_handle_agent_destroyed_removes_agent(agent_manager: AgentManager, broadcaster: WebSocketBroadcaster) -> None:
     """_handle_agent_destroyed removes the agent and broadcasts the update."""
     test_agent_id = MngrAgentId()
     host_id = HostId()

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server.py
@@ -25,8 +25,8 @@ from starlette.websockets import WebSocketDisconnect
 
 from imbue.concurrency_group.subprocess_utils import run_local_command_modern_version
 from imbue.minds_workspace_server.agent_discovery import AgentInfo
-from imbue.minds_workspace_server.agent_discovery import read_claude_config_dir_from_env_file
 from imbue.minds_workspace_server.agent_discovery import discover_agents
+from imbue.minds_workspace_server.agent_discovery import read_claude_config_dir_from_env_file
 from imbue.minds_workspace_server.agent_discovery import send_message
 from imbue.minds_workspace_server.agent_manager import AgentManager
 from imbue.minds_workspace_server.config import Config
@@ -42,13 +42,13 @@ from imbue.minds_workspace_server.models import ErrorResponse
 from imbue.minds_workspace_server.models import RandomNameResponse
 from imbue.minds_workspace_server.models import SendMessageRequest
 from imbue.minds_workspace_server.models import SendMessageResponse
+from imbue.minds_workspace_server.plugins import get_plugin_manager
+from imbue.minds_workspace_server.session_watcher import AgentSessionWatcher
 from imbue.minds_workspace_server.sharing_proxy import SharingProxyError
 from imbue.minds_workspace_server.sharing_proxy import disable_sharing
 from imbue.minds_workspace_server.sharing_proxy import enable_sharing
 from imbue.minds_workspace_server.sharing_proxy import get_sharing_status
 from imbue.minds_workspace_server.sharing_proxy import update_sharing_auth
-from imbue.minds_workspace_server.plugins import get_plugin_manager
-from imbue.minds_workspace_server.session_watcher import AgentSessionWatcher
 from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
 
 logger = _loguru_logger
@@ -511,9 +511,7 @@ async def _create_chat_agent(request: Request) -> JSONResponse:
 
     try:
         create_request = CreateChatRequest(**body)
-        agent_id = agent_manager.create_chat_agent(
-            create_request.name, create_request.parent_agent_id
-        )
+        agent_id = agent_manager.create_chat_agent(create_request.name, create_request.parent_agent_id)
         return JSONResponse(
             content=CreateAgentResponse(agent_id=agent_id).model_dump(),
             status_code=201,
@@ -549,9 +547,7 @@ async def _ws_endpoint(websocket: WebSocket) -> None:
         )
 
         for proto in agent_manager.get_proto_agents():
-            await websocket.send_text(
-                json.dumps({"type": "proto_agent_created", **proto})
-            )
+            await websocket.send_text(json.dumps({"type": "proto_agent_created", **proto}))
 
         shutdown = False
         while not shutdown:
@@ -577,11 +573,7 @@ async def _proto_agent_logs_endpoint(websocket: WebSocket) -> None:
 
     log_queue = agent_manager.get_log_queue(agent_id)
     if log_queue is None:
-        await websocket.send_text(
-            json.dumps(
-                {"done": True, "success": False, "error": "Proto-agent not found"}
-            )
-        )
+        await websocket.send_text(json.dumps({"done": True, "success": False, "error": "Proto-agent not found"}))
         await websocket.close()
         return
 

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/server_test.py
@@ -274,7 +274,7 @@ def test_index_injects_hostname_meta_tag(tmp_path: Path) -> None:
         test_client = TestClient(test_app)
         response = test_client.get("/")
         assert response.status_code == 200
-        assert 'minds-workspace-server-hostname' in response.text
+        assert "minds-workspace-server-hostname" in response.text
 
 
 def test_random_name_endpoint(client: TestClient) -> None:

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/ws_broadcaster.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/ws_broadcaster.py
@@ -50,9 +50,7 @@ class WebSocketBroadcaster(MutableModel):
         """Broadcast an agents_updated event."""
         self.broadcast({"type": "agents_updated", "agents": agents})
 
-    def broadcast_applications_updated(
-        self, applications: dict[str, list[dict[str, str]]]
-    ) -> None:
+    def broadcast_applications_updated(self, applications: dict[str, list[dict[str, str]]]) -> None:
         """Broadcast an applications_updated event."""
         self.broadcast({"type": "applications_updated", "applications": applications})
 
@@ -74,9 +72,7 @@ class WebSocketBroadcaster(MutableModel):
             }
         )
 
-    def broadcast_proto_agent_completed(
-        self, agent_id: str, success: bool, error: str | None
-    ) -> None:
+    def broadcast_proto_agent_completed(self, agent_id: str, success: bool, error: str | None) -> None:
         """Broadcast a proto_agent_completed event."""
         self.broadcast(
             {

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/ws_broadcaster_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/ws_broadcaster_test.py
@@ -90,9 +90,7 @@ def test_broadcast_proto_agent_completed() -> None:
     broadcaster = WebSocketBroadcaster()
     q = broadcaster.register()
 
-    broadcaster.broadcast_proto_agent_completed(
-        agent_id="a1", success=True, error=None
-    )
+    broadcaster.broadcast_proto_agent_completed(agent_id="a1", success=True, error=None)
 
     msg = json.loads(_get_message(q))
     assert msg["type"] == "proto_agent_completed"

--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -198,6 +198,19 @@ Provider: docker
   Build args are passed directly to 'docker build'. Run 'docker build --help' for details.
   Start args are passed directly to 'docker run'. Run 'docker run --help' for details.
 
+Provider: lima
+  Supported build arguments for the lima provider:
+    --file PATH           Path to a Lima YAML config file for full VM customization.
+                          When not specified, a default config is generated with the
+                          mngr pre-built image.
+  Start args are passed directly to 'limactl start'. Common options:
+    --cpus=N              Number of CPU cores (default: 4)
+    --memory=NGiB         Memory size (default: 4GiB)
+    --disk=NGiB           Disk size (default: 100GiB)
+    --vm-type=TYPE        VM type: qemu or vz (default: auto-detected)
+    --mount-writable      Make default mounts writable
+  Run 'limactl start --help' for the full list.
+
 Provider: local
   No build arguments are supported for the local provider.
   No start arguments are supported for the local provider.
@@ -243,10 +256,11 @@ Provider: ssh
   No start arguments are supported for the SSH provider.
 
 Provider: vultr
-  VPS-specific args (--vps- prefix, consumed by provider):
+  VPS-specific args (consumed by provider, not passed to docker):
     --vps-region=REGION  Vultr region (default: ewr)
     --vps-plan=PLAN      Vultr plan (default: vc2-1c-1gb)
     --vps-os=OS_ID       Vultr OS ID (default: 2136 = Debian 12 x64)
+    --git-depth=N        Shallow-clone build context to depth N before upload
 
   All other build args are passed to 'docker build' on the VPS.
   Example: -b --vps-plan=vc2-2c-4gb -b --file=Dockerfile -b .

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -1050,10 +1050,7 @@ def test_disable_plugin_in_command_defaults_blocks_override_hook(
     project_dir = tmp_path / ".mngr"
     project_dir.mkdir(exist_ok=True)
     settings_path = project_dir / "settings.toml"
-    settings_path.write_text(
-        '[commands.create]\n'
-        'disable_plugin = ["fake_terminal"]\n'
-    )
+    settings_path.write_text('[commands.create]\ndisable_plugin = ["fake_terminal"]\n')
 
     pm = pluggy.PluginManager("mngr")
     pm.add_hookspecs(hookspecs)

--- a/libs/mngr/imbue/mngr/providers/listing_utils.py
+++ b/libs/mngr/imbue/mngr/providers/listing_utils.py
@@ -135,18 +135,18 @@ def _parse_agent_section(lines: list[str], idx: int) -> tuple[dict[str, Any], in
                 except json.JSONDecodeError as e:
                     logger.warning("Failed to parse agent data.json in listing output: {}", e)
         elif aline.startswith("USER_MTIME="):
-            agent_raw["user_activity_mtime"] = parse_optional_int(aline[len("USER_MTIME="):])
+            agent_raw["user_activity_mtime"] = parse_optional_int(aline[len("USER_MTIME=") :])
         elif aline.startswith("AGENT_MTIME="):
-            agent_raw["agent_activity_mtime"] = parse_optional_int(aline[len("AGENT_MTIME="):])
+            agent_raw["agent_activity_mtime"] = parse_optional_int(aline[len("AGENT_MTIME=") :])
         elif aline.startswith("START_MTIME="):
-            agent_raw["start_activity_mtime"] = parse_optional_int(aline[len("START_MTIME="):])
+            agent_raw["start_activity_mtime"] = parse_optional_int(aline[len("START_MTIME=") :])
         elif aline.startswith("TMUX_INFO="):
-            val = aline[len("TMUX_INFO="):].strip()
+            val = aline[len("TMUX_INFO=") :].strip()
             agent_raw["tmux_info"] = val if val else None
         elif aline.startswith("ACTIVE="):
-            agent_raw["is_active"] = aline[len("ACTIVE="):].strip() == "true"
+            agent_raw["is_active"] = aline[len("ACTIVE=") :].strip() == "true"
         elif aline.startswith("URL="):
-            val = aline[len("URL="):].strip()
+            val = aline[len("URL=") :].strip()
             agent_raw["url"] = val if val else None
         else:
             pass
@@ -166,13 +166,13 @@ def parse_listing_collection_output(stdout: str) -> dict[str, Any]:
         line = lines[idx]
 
         if line.startswith("UPTIME=") and "uptime_seconds" not in result:
-            result["uptime_seconds"] = parse_optional_float(line[len("UPTIME="):])
+            result["uptime_seconds"] = parse_optional_float(line[len("UPTIME=") :])
         elif line.startswith("BTIME=") and "btime" not in result:
-            result["btime"] = parse_optional_int(line[len("BTIME="):])
+            result["btime"] = parse_optional_int(line[len("BTIME=") :])
         elif line.startswith("LOCK_MTIME=") and "lock_mtime" not in result:
-            result["lock_mtime"] = parse_optional_int(line[len("LOCK_MTIME="):])
+            result["lock_mtime"] = parse_optional_int(line[len("LOCK_MTIME=") :])
         elif line.startswith("SSH_ACTIVITY_MTIME=") and "ssh_activity_mtime" not in result:
-            result["ssh_activity_mtime"] = parse_optional_int(line[len("SSH_ACTIVITY_MTIME="):])
+            result["ssh_activity_mtime"] = parse_optional_int(line[len("SSH_ACTIVITY_MTIME=") :])
         elif line.strip() == SEP_DATA_JSON_START:
             idx += 1
             json_str, idx = _extract_delimited_block(lines, idx, SEP_DATA_JSON_END)

--- a/libs/mngr/imbue/mngr/providers/listing_utils_test.py
+++ b/libs/mngr/imbue/mngr/providers/listing_utils_test.py
@@ -44,19 +44,21 @@ def test_build_listing_collection_script_contains_key_sections() -> None:
 
 
 def test_parse_listing_collection_output_basic() -> None:
-    output = "\n".join([
-        "UPTIME=12345.67",
-        "BTIME=1700000000",
-        "LOCK_MTIME=",
-        "SSH_ACTIVITY_MTIME=1700000100",
-        "---MNGR_DATA_JSON_START---",
-        json.dumps({"host_id": "host-abc", "host_name": "test-host"}),
-        "---MNGR_DATA_JSON_END---",
-        "---MNGR_PS_START---",
-        "  1     0 init",
-        " 42     1 sshd",
-        "---MNGR_PS_END---",
-    ])
+    output = "\n".join(
+        [
+            "UPTIME=12345.67",
+            "BTIME=1700000000",
+            "LOCK_MTIME=",
+            "SSH_ACTIVITY_MTIME=1700000100",
+            "---MNGR_DATA_JSON_START---",
+            json.dumps({"host_id": "host-abc", "host_name": "test-host"}),
+            "---MNGR_DATA_JSON_END---",
+            "---MNGR_PS_START---",
+            "  1     0 init",
+            " 42     1 sshd",
+            "---MNGR_PS_END---",
+        ]
+    )
     result = parse_listing_collection_output(output)
     assert result["uptime_seconds"] == 12345.67
     assert result["btime"] == 1700000000
@@ -69,26 +71,28 @@ def test_parse_listing_collection_output_basic() -> None:
 
 def test_parse_listing_collection_output_with_agent() -> None:
     agent_data = {"id": "agent-123", "name": "test-agent", "type": "claude", "command": "claude"}
-    output = "\n".join([
-        "UPTIME=100.0",
-        "BTIME=1700000000",
-        "---MNGR_DATA_JSON_START---",
-        "{}",
-        "---MNGR_DATA_JSON_END---",
-        "---MNGR_PS_START---",
-        "---MNGR_PS_END---",
-        "---MNGR_AGENT_START:agent-123---",
-        "---MNGR_AGENT_DATA_START---",
-        json.dumps(agent_data),
-        "---MNGR_AGENT_DATA_END---",
-        "USER_MTIME=1700000200",
-        "AGENT_MTIME=",
-        "START_MTIME=1700000100",
-        "TMUX_INFO=0|claude|42",
-        "ACTIVE=true",
-        "URL=http://localhost:8080",
-        "---MNGR_AGENT_END---",
-    ])
+    output = "\n".join(
+        [
+            "UPTIME=100.0",
+            "BTIME=1700000000",
+            "---MNGR_DATA_JSON_START---",
+            "{}",
+            "---MNGR_DATA_JSON_END---",
+            "---MNGR_PS_START---",
+            "---MNGR_PS_END---",
+            "---MNGR_AGENT_START:agent-123---",
+            "---MNGR_AGENT_DATA_START---",
+            json.dumps(agent_data),
+            "---MNGR_AGENT_DATA_END---",
+            "USER_MTIME=1700000200",
+            "AGENT_MTIME=",
+            "START_MTIME=1700000100",
+            "TMUX_INFO=0|claude|42",
+            "ACTIVE=true",
+            "URL=http://localhost:8080",
+            "---MNGR_AGENT_END---",
+        ]
+    )
     result = parse_listing_collection_output(output)
     assert len(result["agents"]) == 1
     agent = result["agents"][0]

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -45,9 +45,9 @@ from imbue.mngr.providers.base_provider import BaseProviderInstance
 from imbue.mngr.providers.local.volume import LocalVolume
 from imbue.mngr.providers.ssh_host_setup import build_add_authorized_keys_command
 from imbue.mngr.providers.ssh_host_setup import build_add_known_hosts_command
-from imbue.mngr.providers.ssh_utils import clear_host_from_known_hosts
 from imbue.mngr.providers.ssh_host_setup import build_start_activity_watcher_command
 from imbue.mngr.providers.ssh_utils import add_host_to_known_hosts
+from imbue.mngr.providers.ssh_utils import clear_host_from_known_hosts
 from imbue.mngr.providers.ssh_utils import create_pyinfra_host
 from imbue.mngr.providers.ssh_utils import wait_for_sshd
 from imbue.mngr_lima.config import LimaProviderConfig

--- a/libs/mngr_lima/imbue/mngr_lima/limactl.py
+++ b/libs/mngr_lima/imbue/mngr_lima/limactl.py
@@ -52,10 +52,10 @@ class _SerialLogTailerCallback(MutableModel):
             # Match an absolute path containing "serial" and ending with ".log".
             # limactl escapes quotes in its log output, so we match the path
             # directly rather than relying on surrounding quote characters.
-            match = re.search(r'(/\S+serial\S*\.log)', stripped)
+            match = re.search(r"(/\S+serial\S*\.log)", stripped)
             if match:
                 log_pattern = match.group(1)
-                serial_log = re.sub(r'\*', '', log_pattern)
+                serial_log = re.sub(r"\*", "", log_pattern)
                 self.tailer_started = True
                 _start_serial_tailer(self.cg, serial_log)
 

--- a/libs/mngr_lima/imbue/mngr_lima/limactl_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/limactl_test.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 from imbue.mngr.primitives import HostName
+from imbue.mngr_lima.limactl import LimaSshConfig
 from imbue.mngr_lima.limactl import _strip_ssh_config_quotes
 from imbue.mngr_lima.limactl import host_name_from_instance_name
 from imbue.mngr_lima.limactl import lima_instance_name
-from imbue.mngr_lima.limactl import LimaSshConfig
 
 
 def test_lima_instance_name() -> None:

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -245,7 +245,6 @@ def handle_modal_auth_error(func: Callable[P, T]) -> Callable[P, T]:
     return wrapper
 
 
-
 class SandboxConfig(HostConfig):
     """Configuration parsed from build arguments."""
 

--- a/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
@@ -32,6 +32,9 @@ from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotId
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import VolumeId
+from imbue.mngr.providers.listing_utils import build_listing_collection_script
+from imbue.mngr.providers.listing_utils import parse_optional_float
+from imbue.mngr.providers.listing_utils import parse_optional_int
 from imbue.mngr_modal.backend import ModalAppContextHandle
 from imbue.mngr_modal.backend import ModalProviderBackend
 from imbue.mngr_modal.backend import _create_environment
@@ -51,9 +54,6 @@ from imbue.mngr_modal.instance import SandboxConfig
 from imbue.mngr_modal.instance import TAG_HOST_ID
 from imbue.mngr_modal.instance import TAG_HOST_NAME
 from imbue.mngr_modal.instance import TAG_USER_PREFIX
-from imbue.mngr.providers.listing_utils import build_listing_collection_script
-from imbue.mngr.providers.listing_utils import parse_optional_float
-from imbue.mngr.providers.listing_utils import parse_optional_int
 from imbue.mngr_modal.instance import _build_image_from_dockerfile_contents
 from imbue.mngr_modal.instance import _build_modal_secrets_from_env
 from imbue.mngr_modal.instance import _build_modal_volumes

--- a/libs/mngr_ttyd/imbue/mngr_ttyd/plugin.py
+++ b/libs/mngr_ttyd/imbue/mngr_ttyd/plugin.py
@@ -100,7 +100,7 @@ def _build_ttyd_install_command() -> str:
         "ARCH=$(uname -m) && "
         '_SUDO=""; [ "$(id -u)" != "0" ] && _SUDO=sudo && '
         f'curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}/ttyd.${{ARCH}}" '
-        '-o /tmp/ttyd.$$ && $_SUDO mv /tmp/ttyd.$$ /usr/local/bin/ttyd && '
+        "-o /tmp/ttyd.$$ && $_SUDO mv /tmp/ttyd.$$ /usr/local/bin/ttyd && "
         "$_SUDO chmod +x /usr/local/bin/ttyd"
     )
 

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/docker_over_ssh.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/docker_over_ssh.py
@@ -101,9 +101,7 @@ class DockerOverSsh(MutableModel):
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait()
-            raise VpsConnectionError(
-                f"SSH command timed out after {timeout_seconds}s: {remote_command}"
-            ) from None
+            raise VpsConnectionError(f"SSH command timed out after {timeout_seconds}s: {remote_command}") from None
         if returncode != 0:
             error_output = "\n".join(collected_output[-50:])
             raise ContainerSetupError(f"Remote command failed (exit {returncode}): {error_output}")

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/host_store.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/host_store.py
@@ -162,11 +162,7 @@ class VpsDockerHostStore:
         """List all host records stored on the state volume in a single SSH command."""
         state_dir = f"{STATE_VOLUME_MOUNT_PATH}/host_state"
         script = (
-            f"for f in '{state_dir}'/*.json; do "
-            f"[ -f \"$f\" ] || continue; "
-            f"echo '{_FILE_SEP}'\"$f\"; "
-            f"cat \"$f\"; "
-            f"done"
+            f'for f in \'{state_dir}\'/*.json; do [ -f "$f" ] || continue; echo \'{_FILE_SEP}\'"$f"; cat "$f"; done'
         )
         try:
             output = self._exec(script)
@@ -193,11 +189,7 @@ class VpsDockerHostStore:
         """Read persisted agent data for a host in a single SSH command."""
         agent_dir = self._agent_data_dir(host_id)
         script = (
-            f"for f in '{agent_dir}'/*.json; do "
-            f"[ -f \"$f\" ] || continue; "
-            f"echo '{_FILE_SEP}'\"$f\"; "
-            f"cat \"$f\"; "
-            f"done"
+            f'for f in \'{agent_dir}\'/*.json; do [ -f "$f" ] || continue; echo \'{_FILE_SEP}\'"$f"; cat "$f"; done'
         )
         try:
             output = self._exec(script)
@@ -215,7 +207,9 @@ class VpsDockerHostStore:
         except ContainerSetupError as e:
             logger.warning("Failed to remove agent data {}: {}", path, e)
 
-    def list_all_host_records_with_agents(self) -> tuple[list[VpsDockerHostRecord], dict[HostId, list[dict[str, Any]]]]:
+    def list_all_host_records_with_agents(
+        self,
+    ) -> tuple[list[VpsDockerHostRecord], dict[HostId, list[dict[str, Any]]]]:
         """Read all host records and their agent data in a single SSH command.
 
         Returns (host_records, agent_data_by_host_id).
@@ -224,9 +218,9 @@ class VpsDockerHostStore:
         # Read all .json files at the top level (host records) and in subdirs (agent data)
         script = (
             f"for f in '{state_dir}'/*.json '{state_dir}'/*/*.json; do "
-            f"[ -f \"$f\" ] || continue; "
+            f'[ -f "$f" ] || continue; '
             f"echo '{_FILE_SEP}'\"$f\"; "
-            f"cat \"$f\"; "
+            f'cat "$f"; '
             f"done"
         )
         try:

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -40,7 +40,6 @@ from imbue.mngr.interfaces.data_types import HostDetails
 from imbue.mngr.interfaces.data_types import HostLifecycleOptions
 from imbue.mngr.interfaces.data_types import HostResources
 from imbue.mngr.interfaces.data_types import PyinfraConnector
-from imbue.mngr.primitives import SSHInfo
 from imbue.mngr.interfaces.data_types import SnapshotInfo
 from imbue.mngr.interfaces.data_types import SnapshotRecord
 from imbue.mngr.interfaces.data_types import VolumeInfo
@@ -58,6 +57,7 @@ from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import IdleMode
 from imbue.mngr.primitives import ImageReference
 from imbue.mngr.primitives import LogLevel
+from imbue.mngr.primitives import SSHInfo
 from imbue.mngr.primitives import SnapshotId
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import VolumeId
@@ -105,7 +105,9 @@ class _ParsedVpsBuildOptions(FrozenModel):
     region: str = Field(description="VPS region")
     plan: str = Field(description="VPS plan")
     os_id: int = Field(description="VPS OS image ID")
-    git_depth: int | None = Field(default=None, description="Git clone depth for build context, or None for full clone")
+    git_depth: int | None = Field(
+        default=None, description="Git clone depth for build context, or None for full clone"
+    )
     docker_build_args: tuple[str, ...] = Field(description="Remaining args passed to docker build")
 
 
@@ -139,7 +141,9 @@ def _parse_build_args(
             elif arg.startswith("--git-depth="):
                 git_depth = int(arg.split("=", 1)[1])
             elif arg.startswith("--vps-"):
-                raise MngrError(f"Unknown VPS build arg: {arg}. Valid VPS args: --vps-region=, --vps-plan=, --vps-os=, --git-depth=")
+                raise MngrError(
+                    f"Unknown VPS build arg: {arg}. Valid VPS args: --vps-region=, --vps-plan=, --vps-os=, --git-depth="
+                )
             else:
                 docker_build_args.append(arg)
 
@@ -176,7 +180,7 @@ def _resolve_dockerfile_paths(
         else:
             for prefix in ("--file=", "-f=", "--dockerfile="):
                 if arg.startswith(prefix):
-                    dockerfile_path = arg[len(prefix):]
+                    dockerfile_path = arg[len(prefix) :]
                     if not dockerfile_path.startswith("/"):
                         arg = f"{prefix}{remote_build_dir}/{dockerfile_path}"
                     break
@@ -828,13 +832,15 @@ class VpsDockerProvider(BaseProviderInstance):
                         timeout=120.0,
                     )
                 if clone_result.returncode != 0:
-                    raise ContainerSetupError(
-                        f"Failed to clone build context: {clone_result.stderr.strip()}"
-                    )
+                    raise ContainerSetupError(f"Failed to clone build context: {clone_result.stderr.strip()}")
                 context_args[-1] = str(local_clone_dir / "repo")
 
         try:
-            logger.log(LogLevel.BUILD.value, "Building Docker image on VPS (this may take several minutes)...", source="docker")
+            logger.log(
+                LogLevel.BUILD.value,
+                "Building Docker image on VPS (this may take several minutes)...",
+                source="docker",
+            )
             if context_args:
                 upload_context = Path(context_args[-1])
                 logger.log(LogLevel.BUILD.value, "Uploading build context to VPS...", source="vps")


### PR DESCRIPTION
## Summary
- Run `ruff check --select UP006,UP007,I,F401 --fix` and `ruff format` across the monorepo
- Fixes 9 lint errors (unused imports, outdated type annotation syntax, import ordering) and reformats 23 files
- Auto-generated CLI docs updated by pre-commit hook

## Test plan
- [ ] CI passes (mechanical formatting/import changes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)