### PR TITLE
include .reviewer/settings.local.json in worktrees

### DIFF
--- a/.mngr/settings.toml
+++ b/.mngr/settings.toml
@@ -4,6 +4,7 @@ default_destroyed_host_persisted_seconds = 10
 
 [work_dir_extra_paths]
 test-results = "COPY"
+".reviewer/settings.local.json" = "COPY"
 
 [pre_command_scripts]
 create = ["""bash -c './scripts/make_tar_of_repo.sh `cat .mngr/image_commit_hash` .mngr/dev/build'"""]


### PR DESCRIPTION
## Summary
- Add `.reviewer/settings.local.json` to `work_dir_extra_paths` with `COPY` mode in `.mngr/settings.toml`
- Fixes worktree agents not picking up local reviewer config overrides (e.g. disabling subagent conversation reviews, custom prompts)

## Test plan
- [x] All 3587 tests pass with coverage
- [ ] Create a worktree agent and verify `.reviewer/settings.local.json` is present

Generated with [Claude Code](https://claude.com/claude-code)