### PR TITLE
make resource guards automatically register pytest marks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,6 @@ are discovered (e.g., when running from the monorepo root).
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
@@ -18,13 +17,8 @@ from imbue.resource_guards.resource_guards import register_resource_guard
 # Suppress some pointless warnings from other library's loggers
 suppress_warnings()
 
-# Register mngr-specific pytest markers and guarded resources.
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
-register_marker("docker: marks tests that invoke the docker CLI via subprocess")
-register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
+# Register mngr-specific guarded resources.
+# The corresponding pytest marks are auto-registered by conftest_hooks.
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/conftest.py
+++ b/conftest.py
@@ -8,23 +8,14 @@ are discovered (e.g., when running from the monorepo root).
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.mngr_modal.register_guards import register_modal_guard
 from imbue.resource_guards.resource_guards import register_resource_guard
 
-# Suppress some pointless warnings from other library's loggers
 suppress_warnings()
 
-# Register mngr-specific pytest markers and guarded resources.
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
-register_marker("docker: marks tests that invoke the docker CLI via subprocess")
-register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ are discovered (e.g., when running from the monorepo root).
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
@@ -17,8 +18,13 @@ from imbue.resource_guards.resource_guards import register_resource_guard
 # Suppress some pointless warnings from other library's loggers
 suppress_warnings()
 
-# Register mngr-specific guarded resources.
-# The corresponding pytest marks are auto-registered by conftest_hooks.
+# Register mngr-specific pytest markers and guarded resources.
+register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
+register_marker("rsync: marks tests that invoke rsync for file transfer")
+register_marker("unison: marks tests that start a real unison file-sync process")
+register_marker("modal: marks tests that connect to the Modal cloud service")
+register_marker("docker: marks tests that invoke the docker CLI via subprocess")
+register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -537,19 +537,6 @@ def _pytest_sessionstart(session: pytest.Session) -> None:
         deadline = _compute_lock_deadline(start_time)
         _write_lock_info(lock_handle, os.getpid(), deadline)
 
-    # Auto-register marks for guarded resources. Done here (not in
-    # pytest_configure) because pytest_plugins conftest modules are imported
-    # after the declaring conftest's pytest_configure fires, so guards
-    # registered in inherited conftest files aren't visible at configure time.
-    # By session start, all conftest files have been imported.
-    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
-    for name in get_guarded_resource_names():
-        if name not in registered_names:
-            session.config.addinivalue_line(
-                "markers",
-                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
-            )
-
     start_resource_guards(session)
 
 
@@ -613,6 +600,16 @@ def _pytest_configure(config: pytest.Config) -> None:
     # Register shared markers and any additional markers from register_marker()
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
+
+    # Auto-register marks for guarded resources so projects that call
+    # register_resource_guard() don't also need a separate register_marker().
+    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
+    for name in get_guarded_resource_names():
+        if name not in registered_names:
+            config.addinivalue_line(
+                "markers",
+                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
+            )
 
     # Register shared filterwarnings
     for warning_filter in _SHARED_FILTER_WARNINGS:

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -50,7 +50,7 @@ from coverage.exceptions import CoverageException
 
 from imbue.imbue_common.test_profiles import ScopedProfile
 from imbue.imbue_common.test_profiles import resolve_active_profile
-from imbue.resource_guards.resource_guards import get_guarded_resource_names
+from imbue.resource_guards.resource_guards import register_guarded_resource_markers
 from imbue.resource_guards.resource_guards import start_resource_guards
 from imbue.resource_guards.resource_guards import stop_resource_guards
 
@@ -601,14 +601,13 @@ def _pytest_configure(config: pytest.Config) -> None:
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
 
-    # Register marks for guarded resources (skips any already registered above).
+    # Register marks for guarded resources. Standalone users would call
+    # register_guarded_resource_markers(config) from their own pytest_configure
+    # (see libs/resource_guards/README.md). We can't do that here because
+    # register_conftest_hooks injects _pytest_configure, not a user-defined one,
+    # so we inline the call to avoid needing a separate hook.
     registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
-    for name in get_guarded_resource_names():
-        if name not in registered_names:
-            config.addinivalue_line(
-                "markers",
-                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
-            )
+    register_guarded_resource_markers(config, skip_names=registered_names)
 
     # Register shared filterwarnings
     for warning_filter in _SHARED_FILTER_WARNINGS:

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -50,6 +50,7 @@ from coverage.exceptions import CoverageException
 
 from imbue.imbue_common.test_profiles import ScopedProfile
 from imbue.imbue_common.test_profiles import resolve_active_profile
+from imbue.resource_guards.resource_guards import get_guarded_resource_names
 from imbue.resource_guards.resource_guards import start_resource_guards
 from imbue.resource_guards.resource_guards import stop_resource_guards
 
@@ -148,6 +149,8 @@ _SHARED_FILTER_WARNINGS: Final[list[str]] = [
     r"ignore:Module imbue\..* was previously imported, but not measured:coverage.exceptions.CoverageWarning",
     # record_xml_attribute is marked experimental but we rely on it for JUnit test ID customization.
     "ignore::pytest.PytestExperimentalApiWarning",
+    # Promote unknown-mark warnings to errors so unregistered marks are caught immediately.
+    "error::pytest.PytestUnknownMarkWarning",
 ]
 
 # Lines matching any of these patterns are excluded from coverage measurement.
@@ -597,6 +600,16 @@ def _pytest_configure(config: pytest.Config) -> None:
     # Register shared markers and any additional markers from register_marker()
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
+
+    # Auto-register marks for guarded resources so projects that call
+    # register_resource_guard() don't also need a separate register_marker().
+    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
+    for name in get_guarded_resource_names():
+        if name not in registered_names:
+            config.addinivalue_line(
+                "markers",
+                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
+            )
 
     # Register shared filterwarnings
     for warning_filter in _SHARED_FILTER_WARNINGS:

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -601,13 +601,8 @@ def _pytest_configure(config: pytest.Config) -> None:
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
 
-    # Register marks for guarded resources. Standalone users would call
-    # register_guarded_resource_markers(config) from their own pytest_configure
-    # (see libs/resource_guards/README.md). We can't do that here because
-    # register_conftest_hooks injects _pytest_configure, not a user-defined one,
-    # so we inline the call to avoid needing a separate hook.
-    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
-    register_guarded_resource_markers(config, skip_names=registered_names)
+    # Register marks for guarded resources (see libs/resource_guards/README.md).
+    register_guarded_resource_markers(config)
 
     # Register shared filterwarnings
     for warning_filter in _SHARED_FILTER_WARNINGS:

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -601,8 +601,7 @@ def _pytest_configure(config: pytest.Config) -> None:
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
 
-    # Auto-register marks for guarded resources so projects that call
-    # register_resource_guard() don't also need a separate register_marker().
+    # Register marks for guarded resources (skips any already registered above).
     registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
     for name in get_guarded_resource_names():
         if name not in registered_names:

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -149,8 +149,6 @@ _SHARED_FILTER_WARNINGS: Final[list[str]] = [
     r"ignore:Module imbue\..* was previously imported, but not measured:coverage.exceptions.CoverageWarning",
     # record_xml_attribute is marked experimental but we rely on it for JUnit test ID customization.
     "ignore::pytest.PytestExperimentalApiWarning",
-    # Promote unknown-mark warnings to errors so unregistered marks are caught immediately.
-    "error::pytest.PytestUnknownMarkWarning",
 ]
 
 # Lines matching any of these patterns are excluded from coverage measurement.

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -537,6 +537,19 @@ def _pytest_sessionstart(session: pytest.Session) -> None:
         deadline = _compute_lock_deadline(start_time)
         _write_lock_info(lock_handle, os.getpid(), deadline)
 
+    # Auto-register marks for guarded resources. Done here (not in
+    # pytest_configure) because pytest_plugins conftest modules are imported
+    # after the declaring conftest's pytest_configure fires, so guards
+    # registered in inherited conftest files aren't visible at configure time.
+    # By session start, all conftest files have been imported.
+    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
+    for name in get_guarded_resource_names():
+        if name not in registered_names:
+            session.config.addinivalue_line(
+                "markers",
+                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
+            )
+
     start_resource_guards(session)
 
 
@@ -600,16 +613,6 @@ def _pytest_configure(config: pytest.Config) -> None:
     # Register shared markers and any additional markers from register_marker()
     for marker in _SHARED_MARKERS + _registered_markers:
         config.addinivalue_line("markers", marker)
-
-    # Auto-register marks for guarded resources so projects that call
-    # register_resource_guard() don't also need a separate register_marker().
-    registered_names = {m.split(":")[0].strip() for m in _SHARED_MARKERS + _registered_markers}
-    for name in get_guarded_resource_names():
-        if name not in registered_names:
-            config.addinivalue_line(
-                "markers",
-                f"{name}: marks tests that use the {name} resource (auto-registered by resource guard)",
-            )
 
     # Register shared filterwarnings
     for warning_filter in _SHARED_FILTER_WARNINGS:

--- a/libs/mngr/conftest.py
+++ b/libs/mngr/conftest.py
@@ -9,7 +9,6 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
@@ -17,13 +16,6 @@ from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register mngr-specific pytest markers and guarded resources.
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
-register_marker("docker: marks tests that invoke the docker CLI via subprocess")
-register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
 register_resource_guard("tmux")
 register_resource_guard("modal")
 register_resource_guard("rsync")

--- a/libs/mngr/conftest.py
+++ b/libs/mngr/conftest.py
@@ -9,7 +9,6 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
@@ -17,13 +16,8 @@ from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register mngr-specific pytest markers and guarded resources.
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
-register_marker("docker: marks tests that invoke the docker CLI via subprocess")
-register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
+# Register mngr-specific guarded resources.
+# The corresponding pytest marks are auto-registered by conftest_hooks.
 register_resource_guard("tmux")
 register_resource_guard("modal")
 register_resource_guard("rsync")

--- a/libs/mngr/conftest.py
+++ b/libs/mngr/conftest.py
@@ -9,6 +9,7 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.register_guards_docker import register_docker_cli_guard
 from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.logging import suppress_warnings
@@ -16,8 +17,13 @@ from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register mngr-specific guarded resources.
-# The corresponding pytest marks are auto-registered by conftest_hooks.
+# Register mngr-specific pytest markers and guarded resources.
+register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
+register_marker("rsync: marks tests that invoke rsync for file transfer")
+register_marker("unison: marks tests that start a real unison file-sync process")
+register_marker("modal: marks tests that connect to the Modal cloud service")
+register_marker("docker: marks tests that invoke the docker CLI via subprocess")
+register_marker("docker_sdk: marks tests that use the Docker Python SDK in-process")
 register_resource_guard("tmux")
 register_resource_guard("modal")
 register_resource_guard("rsync")

--- a/libs/mngr/imbue/mngr/conftest.py
+++ b/libs/mngr/imbue/mngr/conftest.py
@@ -36,6 +36,8 @@ from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr.providers.registry import load_local_backend_only
 from imbue.mngr.providers.registry import reset_backend_registry
+from imbue.mngr.register_guards_docker import register_docker_cli_guard
+from imbue.mngr.register_guards_docker import register_docker_sdk_guard
 from imbue.mngr.utils.testing import cleanup_tmux_session
 from imbue.mngr.utils.testing import init_git_repo
 from imbue.mngr.utils.testing import isolate_git
@@ -43,6 +45,16 @@ from imbue.mngr.utils.testing import isolate_tmux_server
 from imbue.mngr.utils.testing import make_mngr_ctx
 from imbue.mngr.utils.testing import setup_mngr_test_environment
 from imbue.mngr.utils.testing import worker_test_ids
+from imbue.resource_guards.resource_guards import register_resource_guard
+
+# Register resource guards so that projects inheriting this conftest via
+# pytest_plugins (e.g. mngr_claude) get guards registered at import time.
+register_resource_guard("tmux")
+register_resource_guard("rsync")
+register_resource_guard("unison")
+register_resource_guard("modal")
+register_docker_cli_guard()
+register_docker_sdk_guard()
 
 # The urwid import above triggers creation of deprecated module aliases.
 # These are the deprecated module aliases that urwid 3.x creates for backwards

--- a/libs/mngr_claude/conftest.py
+++ b/libs/mngr_claude/conftest.py
@@ -9,9 +9,12 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 
 suppress_warnings()
+
+register_marker("modal: marks tests that connect to the Modal cloud service")
 
 register_conftest_hooks(globals())
 

--- a/libs/mngr_claude/conftest.py
+++ b/libs/mngr_claude/conftest.py
@@ -9,12 +9,9 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 
 suppress_warnings()
-
-register_marker("modal: marks tests that connect to the Modal cloud service")
 
 register_conftest_hooks(globals())
 

--- a/libs/mngr_claude/conftest.py
+++ b/libs/mngr_claude/conftest.py
@@ -11,10 +11,19 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
 from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
+from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
+# Register marks and guards used directly by mngr-claude tests.
+# These must be registered here (not just in the inherited conftest files via
+# pytest_plugins below) because pytest_configure runs before pytest_plugins
+# modules are imported.
+register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
+register_marker("rsync: marks tests that invoke rsync for file transfer")
 register_marker("modal: marks tests that connect to the Modal cloud service")
+register_resource_guard("tmux")
+register_resource_guard("rsync")
 
 register_conftest_hooks(globals())
 

--- a/libs/mngr_claude/conftest.py
+++ b/libs/mngr_claude/conftest.py
@@ -9,22 +9,9 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
-from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
-
-# Register marks and guards used directly by mngr-claude tests.
-# These must be registered here (not just in the inherited conftest files via
-# pytest_plugins below) because pytest_configure runs before pytest_plugins
-# modules are imported.
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("modal: marks tests that connect to the Modal cloud service")
-register_resource_guard("tmux")
-register_resource_guard("rsync")
-
 register_conftest_hooks(globals())
 
 # Inherit fixtures from mngr's conftest (base test infrastructure) and

--- a/libs/mngr_lima/conftest.py
+++ b/libs/mngr_lima/conftest.py
@@ -4,13 +4,12 @@ Provides test infrastructure by inheriting from mngr's conftest.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("lima: marks tests that create real Lima VMs")
+# The corresponding pytest mark is auto-registered by conftest_hooks.
 register_resource_guard("lima")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_lima/conftest.py
+++ b/libs/mngr_lima/conftest.py
@@ -4,12 +4,13 @@ Provides test infrastructure by inheriting from mngr's conftest.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# The corresponding pytest mark is auto-registered by conftest_hooks.
+register_marker("lima: marks tests that create real Lima VMs")
 register_resource_guard("lima")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_lima/conftest.py
+++ b/libs/mngr_lima/conftest.py
@@ -4,13 +4,11 @@ Provides test infrastructure by inheriting from mngr's conftest.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("lima: marks tests that create real Lima VMs")
 register_resource_guard("lima")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_modal/conftest.py
+++ b/libs/mngr_modal/conftest.py
@@ -7,17 +7,13 @@ pytest_plugins.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.mngr_modal.register_guards import register_modal_guard
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
+# The corresponding pytest marks are auto-registered by conftest_hooks.
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/libs/mngr_modal/conftest.py
+++ b/libs/mngr_modal/conftest.py
@@ -7,13 +7,17 @@ pytest_plugins.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.mngr_modal.register_guards import register_modal_guard
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# The corresponding pytest marks are auto-registered by conftest_hooks.
+register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
+register_marker("rsync: marks tests that invoke rsync for file transfer")
+register_marker("unison: marks tests that start a real unison file-sync process")
+register_marker("modal: marks tests that connect to the Modal cloud service")
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/libs/mngr_modal/conftest.py
+++ b/libs/mngr_modal/conftest.py
@@ -7,17 +7,12 @@ pytest_plugins.
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.mngr_modal.register_guards import register_modal_guard
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("tmux: marks tests that create real tmux sessions or mngr agents")
-register_marker("rsync: marks tests that invoke rsync for file transfer")
-register_marker("unison: marks tests that start a real unison file-sync process")
-register_marker("modal: marks tests that connect to the Modal cloud service")
 register_resource_guard("tmux")
 register_resource_guard("rsync")
 register_resource_guard("unison")

--- a/libs/mngr_notifications/conftest.py
+++ b/libs/mngr_notifications/conftest.py
@@ -1,10 +1,11 @@
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# The corresponding pytest mark is auto-registered by conftest_hooks.
+register_marker("tmux: marks tests that start real tmux sessions")
 register_resource_guard("tmux")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_notifications/conftest.py
+++ b/libs/mngr_notifications/conftest.py
@@ -1,11 +1,10 @@
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("tmux: marks tests that start real tmux sessions")
+# The corresponding pytest mark is auto-registered by conftest_hooks.
 register_resource_guard("tmux")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_notifications/conftest.py
+++ b/libs/mngr_notifications/conftest.py
@@ -1,11 +1,9 @@
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-register_marker("tmux: marks tests that start real tmux sessions")
 register_resource_guard("tmux")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_pair/conftest.py
+++ b/libs/mngr_pair/conftest.py
@@ -9,13 +9,14 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register guarded resources used by mngr-pair tests.
-# The corresponding pytest mark is auto-registered by conftest_hooks.
+# Register markers and guarded resources used by mngr-pair tests.
+register_marker("unison: marks tests that start a real unison file-sync process")
 register_resource_guard("unison")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_pair/conftest.py
+++ b/libs/mngr_pair/conftest.py
@@ -9,14 +9,11 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register markers and guarded resources used by mngr-pair tests.
-register_marker("unison: marks tests that start a real unison file-sync process")
 register_resource_guard("unison")
 
 register_conftest_hooks(globals())

--- a/libs/mngr_pair/conftest.py
+++ b/libs/mngr_pair/conftest.py
@@ -9,14 +9,13 @@ and this file's register_conftest_hooks() call is a no-op (guarded by a module-l
 """
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.resource_guards.resource_guards import register_resource_guard
 
 suppress_warnings()
 
-# Register markers and guarded resources used by mngr-pair tests.
-register_marker("unison: marks tests that start a real unison file-sync process")
+# Register guarded resources used by mngr-pair tests.
+# The corresponding pytest mark is auto-registered by conftest_hooks.
 register_resource_guard("unison")
 
 register_conftest_hooks(globals())

--- a/libs/resource_guards/README.md
+++ b/libs/resource_guards/README.md
@@ -28,7 +28,7 @@ In your `conftest.py`, register each resource you want to guard. You need two th
 ```python
 # conftest.py
 from imbue.resource_guards.resource_guards import (
-    get_guarded_resource_names,
+    register_guarded_resource_markers,
     register_resource_guard,
     start_resource_guards,
     stop_resource_guards,
@@ -37,8 +37,7 @@ from imbue.resource_guards.resource_guards import (
 register_resource_guard("tmux")
 
 def pytest_configure(config):
-    for name in get_guarded_resource_names():
-        config.addinivalue_line("markers", f"{name}: marks tests that use {name}")
+    register_guarded_resource_markers(config)
 
 def pytest_sessionstart(session):
     start_resource_guards(session)

--- a/libs/resource_guards/README.md
+++ b/libs/resource_guards/README.md
@@ -23,7 +23,7 @@ mngr provides Docker guards out of the box (in `imbue.mngr.register_guards_docke
 
 ## Setup
 
-In your `conftest.py`, register each resource you want to guard. You need two things per resource: a **marker** (so pytest knows about the mark) and a **guard** (so the enforcement hooks are installed).
+In your `conftest.py`, register each resource you want to guard. The corresponding pytest mark is auto-registered during `pytest_configure`, so you only need to register the guard itself.
 
 ```python
 # conftest.py
@@ -33,11 +33,8 @@ from imbue.resource_guards.resource_guards import (
     stop_resource_guards,
 )
 
-# Register a binary guard for tmux
+# Register a binary guard for tmux (also registers @pytest.mark.tmux automatically)
 register_resource_guard("tmux")
-
-def pytest_configure(config):
-    config.addinivalue_line("markers", "tmux: marks tests that use tmux")
 
 def pytest_sessionstart(session):
     start_resource_guards(session)

--- a/libs/resource_guards/README.md
+++ b/libs/resource_guards/README.md
@@ -23,18 +23,22 @@ mngr provides Docker guards out of the box (in `imbue.mngr.register_guards_docke
 
 ## Setup
 
-In your `conftest.py`, register each resource you want to guard. The corresponding pytest mark is auto-registered during `pytest_configure`, so you only need to register the guard itself.
+In your `conftest.py`, register each resource you want to guard. You need two things per resource: a **guard** (so the enforcement hooks are installed) and a **marker** (so pytest knows about the mark).
 
 ```python
 # conftest.py
 from imbue.resource_guards.resource_guards import (
+    get_guarded_resource_names,
     register_resource_guard,
     start_resource_guards,
     stop_resource_guards,
 )
 
-# Register a binary guard for tmux (also registers @pytest.mark.tmux automatically)
 register_resource_guard("tmux")
+
+def pytest_configure(config):
+    for name in get_guarded_resource_names():
+        config.addinivalue_line("markers", f"{name}: marks tests that use {name}")
 
 def pytest_sessionstart(session):
     start_resource_guards(session)

--- a/libs/resource_guards/README.md
+++ b/libs/resource_guards/README.md
@@ -23,7 +23,7 @@ mngr provides Docker guards out of the box (in `imbue.mngr.register_guards_docke
 
 ## Setup
 
-In your `conftest.py`, register each resource you want to guard. You need two things per resource: a **guard** (so the enforcement hooks are installed) and a **marker** (so pytest knows about the mark).
+In your `conftest.py`, register each resource you want to guard with `register_resource_guard()`, then wire up the three hooks. `register_guarded_resource_markers` registers the pytest marks for all guarded resources in one call.
 
 ```python
 # conftest.py
@@ -35,6 +35,7 @@ from imbue.resource_guards.resource_guards import (
 )
 
 register_resource_guard("tmux")
+register_resource_guard("rsync")
 
 def pytest_configure(config):
     register_guarded_resource_markers(config)

--- a/libs/resource_guards/README.md
+++ b/libs/resource_guards/README.md
@@ -23,7 +23,7 @@ mngr provides Docker guards out of the box (in `imbue.mngr.register_guards_docke
 
 ## Setup
 
-In your `conftest.py`, register each resource you want to guard with `register_resource_guard()`, then wire up the three hooks. `register_guarded_resource_markers` registers the pytest marks for all guarded resources in one call.
+In your `conftest.py`, register each resource you want to guard with `register_resource_guard()`, then add `pytest_configure`, `pytest_sessionstart`, and `pytest_sessionfinish` hooks as shown below. `register_guarded_resource_markers` registers the pytest marks for all guarded resources in one call.
 
 ```python
 # conftest.py

--- a/libs/resource_guards/imbue/resource_guards/conftest.py
+++ b/libs/resource_guards/imbue/resource_guards/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from imbue.resource_guards.testing import isolate_guard_state
@@ -7,3 +9,21 @@ from imbue.resource_guards.testing import isolate_guard_state
 def isolated_guard_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Isolate resource guard module state so create/cleanup don't affect the session."""
     isolate_guard_state(monkeypatch)
+
+
+@pytest.fixture()
+def clean_guard_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove outer guard-wrapper state from env + PATH before a pytester subprocess runs.
+
+    Pytester subprocesses inherit env + PATH from the parent. Without this fixture,
+    the child would see the parent's _PYTEST_GUARD_WRAPPER_DIR and its wrapper scripts
+    first on PATH, which shadows any wrappers the child creates.
+    """
+    outer_dir = os.environ.get("_PYTEST_GUARD_WRAPPER_DIR")
+    if outer_dir is None:
+        return
+    monkeypatch.delenv("_PYTEST_GUARD_WRAPPER_DIR")
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join(p for p in os.environ.get("PATH", "").split(os.pathsep) if p != outer_dir),
+    )

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -103,7 +103,7 @@ def register_guarded_resource_markers(
     Call this from pytest_configure to register marks for every resource
     registered via register_resource_guard() or register_sdk_guard().
 
-    Args overlap with existing markers can be skipped via skip_names.
+    Resources that overlap with existing markers can be skipped via skip_names.
     """
     skip = skip_names or set()
     for name in _guarded_resources:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -89,11 +89,29 @@ def register_resource_guard(name: str) -> None:
 
 
 def get_guarded_resource_names() -> tuple[str, ...]:
-    """Return the guarded resource names (binary + SDK guards).
-
-    Used by conftest_hooks to auto-register pytest marks for guarded resources.
-    """
+    """Return the guarded resource names (binary + SDK guards)."""
     return tuple(_guarded_resources)
+
+
+def register_guarded_resource_markers(
+    config: pytest.Config,
+    *,
+    skip_names: set[str] | None = None,
+) -> None:
+    """Register pytest markers for all guarded resources.
+
+    Call this from pytest_configure to register marks for every resource
+    registered via register_resource_guard() or register_sdk_guard().
+
+    Args overlap with existing markers can be skipped via skip_names.
+    """
+    skip = skip_names or set()
+    for name in _guarded_resources:
+        if name not in skip:
+            config.addinivalue_line(
+                "markers",
+                f"{name}: marks tests that use the {name} resource",
+            )
 
 
 def generate_wrapper_script(resource: str, real_path: str) -> str:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -90,12 +90,12 @@ def register_resource_guard(name: str) -> None:
         _guarded_resources.append(name)
 
 
-def get_guarded_resource_names() -> list[str]:
-    """Return the list of guarded resource names (binary + SDK guards).
+def get_guarded_resource_names() -> tuple[str, ...]:
+    """Return the guarded resource names (binary + SDK guards).
 
     Used by conftest_hooks to auto-register pytest marks for guarded resources.
     """
-    return list(_guarded_resources)
+    return tuple(_guarded_resources)
 
 
 def generate_wrapper_script(resource: str, real_path: str) -> str:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -61,8 +61,8 @@ class _PerTestGuardState:
 # process via the _PYTEST_GUARD_WRAPPER_DIR env var.
 # _session_env_patcher is the patch.dict that manages PATH and _PYTEST_GUARD_WRAPPER_DIR;
 # stopping it automatically restores PATH to its original value.
-# _guarded_resources is populated by register_resource_guard() and extended by
-# create_sdk_resource_guards(); the hooks read from it at session start.
+# _guarded_resources is populated by register_resource_guard() and register_sdk_guard();
+# the hooks read from it at session start.
 _guard_wrapper_dir: str | None = None
 _owns_guard_wrapper_dir: bool = False
 _session_env_patcher: patch.dict | None = None  # ty: ignore[invalid-type-form]

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -81,10 +81,21 @@ def register_resource_guard(name: str) -> None:
     mark name (e.g., register_resource_guard("tmux") guards the tmux binary
     and enforces @pytest.mark.tmux).
 
+    The corresponding pytest mark is auto-registered by conftest_hooks during
+    pytest_configure, so a separate register_marker() call is not needed.
+
     Duplicate registrations are ignored.
     """
     if name not in _guarded_resources:
         _guarded_resources.append(name)
+
+
+def get_guarded_resource_names() -> list[str]:
+    """Return the list of guarded resource names (binary + SDK guards).
+
+    Used by conftest_hooks to auto-register pytest marks for guarded resources.
+    """
+    return list(_guarded_resources)
 
 
 def generate_wrapper_script(resource: str, real_path: str) -> str:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -61,11 +61,16 @@ class _PerTestGuardState:
 # process via the _PYTEST_GUARD_WRAPPER_DIR env var.
 # _session_env_patcher is the patch.dict that manages PATH and _PYTEST_GUARD_WRAPPER_DIR;
 # stopping it automatically restores PATH to its original value.
-# _guarded_resources is populated by register_resource_guard() and register_sdk_guard();
-# the hooks read from it at session start.
+# _binary_guarded_resources is populated only by register_resource_guard() and drives
+# PATH wrapper script creation. _guarded_resources is the union of binary and SDK
+# guard names (populated by register_resource_guard() and register_sdk_guard()); it
+# drives pytest mark registration, per-test env var setup, and violation checks. The
+# distinction matters so we only create wrapper scripts for names that were meant to
+# guard a real binary -- SDK-only names must not produce stray wrapper scripts.
 _guard_wrapper_dir: str | None = None
 _owns_guard_wrapper_dir: bool = False
 _session_env_patcher: patch.dict | None = None  # ty: ignore[invalid-type-form]
+_binary_guarded_resources: list[str] = []
 _guarded_resources: list[str] = []
 
 # Module-level state for SDK guards. Each entry is (name, install_fn, cleanup_fn).
@@ -83,6 +88,8 @@ def register_resource_guard(name: str) -> None:
 
     Duplicate registrations are ignored.
     """
+    if name not in _binary_guarded_resources:
+        _binary_guarded_resources.append(name)
     if name not in _guarded_resources:
         _guarded_resources.append(name)
 
@@ -180,11 +187,13 @@ exit 127
 
 
 def create_resource_guard_wrappers() -> None:
-    """Create wrapper scripts for guarded resources and prepend to PATH.
+    """Create wrapper scripts for binary-guarded resources and prepend to PATH.
 
     Each wrapper intercepts calls to the corresponding binary and enforces
     that the test has the appropriate pytest mark. The list of resources
-    comes from prior register_resource_guard() calls.
+    comes from prior register_resource_guard() calls; SDK-only guards are
+    intentionally excluded so they do not produce stray wrapper scripts
+    named after internal SDK identifiers.
 
     For xdist: the controller creates the wrappers and modifies PATH. Workers
     inherit the modified PATH and wrapper directory via environment variables.
@@ -205,7 +214,7 @@ def create_resource_guard_wrappers() -> None:
     _guard_wrapper_dir = tempfile.mkdtemp(prefix="pytest_resource_guards_")
     _owns_guard_wrapper_dir = True
 
-    for resource in _guarded_resources:
+    for resource in _binary_guarded_resources:
         real_path = shutil.which(resource)
         wrapper_path = Path(_guard_wrapper_dir) / resource
         if real_path is not None:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -280,10 +280,16 @@ def register_sdk_guard(
     before register_conftest_hooks() to push SDK-specific guard
     implementations into the infrastructure. Deduplicates by name so
     multiple conftest files can safely call the registration function.
+
+    The guard name is added to _guarded_resources immediately (so it is
+    visible at pytest_configure time for auto mark registration), while
+    the install/cleanup functions are deferred to create_sdk_resource_guards().
     """
     registered_names = {entry[0] for entry in _registered_sdk_guards}
     if name not in registered_names:
         _registered_sdk_guards.append((name, install, cleanup))
+        if name not in _guarded_resources:
+            _guarded_resources.append(name)
 
 
 class MethodKind(StrEnum):
@@ -366,15 +372,13 @@ def create_sdk_method_guard(
 
 
 def create_sdk_resource_guards() -> None:
-    """Install all registered SDK guards and add their names to _guarded_resources.
+    """Install all registered SDK guards.
 
-    Iterates through guards registered via register_sdk_guard(), calls each
-    install function, and extends _guarded_resources so the per-test hooks
-    set up env vars for them.
+    Iterates through guards registered via register_sdk_guard() and calls
+    each install function. Guard names are already in _guarded_resources
+    (added by register_sdk_guard at registration time).
     """
-    for name, install, _cleanup in _registered_sdk_guards:
-        if name not in _guarded_resources:
-            _guarded_resources.append(name)
+    for _name, install, _cleanup in _registered_sdk_guards:
         install()
 
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -297,8 +297,8 @@ def register_sdk_guard(
     implementations into the infrastructure. Deduplicates by name so
     multiple conftest files can safely call the registration function.
 
-    The guard name is added to _guarded_resources immediately; the
-    install/cleanup functions are deferred to create_sdk_resource_guards().
+    Adds the guard name to _guarded_resources and defers the install/cleanup
+    functions to create_sdk_resource_guards().
     """
     registered_names = {entry[0] for entry in _registered_sdk_guards}
     if name not in registered_names:
@@ -390,8 +390,7 @@ def create_sdk_resource_guards() -> None:
     """Install all registered SDK guards.
 
     Iterates through guards registered via register_sdk_guard() and calls
-    each install function. Guard names are already in _guarded_resources
-    (added by register_sdk_guard at registration time).
+    each install function.
     """
     for _name, install, _cleanup in _registered_sdk_guards:
         install()

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -79,10 +79,8 @@ def register_resource_guard(name: str) -> None:
     Call this from each project's conftest.py before register_conftest_hooks().
     The resource name must correspond to both a binary on PATH and a pytest
     mark name (e.g., register_resource_guard("tmux") guards the tmux binary
-    and enforces @pytest.mark.tmux).
-
-    The corresponding pytest mark is auto-registered by conftest_hooks during
-    pytest_configure, so a separate register_marker() call is not needed.
+    and enforces @pytest.mark.tmux). The corresponding pytest mark is
+    auto-registered during pytest_configure.
 
     Duplicate registrations are ignored.
     """
@@ -281,9 +279,8 @@ def register_sdk_guard(
     implementations into the infrastructure. Deduplicates by name so
     multiple conftest files can safely call the registration function.
 
-    The guard name is added to _guarded_resources immediately (so it is
-    visible at pytest_configure time for auto mark registration), while
-    the install/cleanup functions are deferred to create_sdk_resource_guards().
+    The guard name is added to _guarded_resources immediately; the
+    install/cleanup functions are deferred to create_sdk_resource_guards().
     """
     registered_names = {entry[0] for entry in _registered_sdk_guards}
     if name not in registered_names:

--- a/libs/resource_guards/imbue/resource_guards/resource_guards.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards.py
@@ -76,11 +76,10 @@ _registered_sdk_guards: list[tuple[str, Callable[[], None], Callable[[], None]]]
 def register_resource_guard(name: str) -> None:
     """Register a binary to be guarded by PATH wrapper scripts.
 
-    Call this from each project's conftest.py before register_conftest_hooks().
     The resource name must correspond to both a binary on PATH and a pytest
     mark name (e.g., register_resource_guard("tmux") guards the tmux binary
-    and enforces @pytest.mark.tmux). The corresponding pytest mark is
-    auto-registered during pytest_configure.
+    and enforces @pytest.mark.tmux). Call register_guarded_resource_markers()
+    from pytest_configure to register the corresponding pytest marks.
 
     Duplicate registrations are ignored.
     """

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -29,25 +29,30 @@ from imbue.resource_guards.resource_guards import stop_resource_guards
 # Use ubiquitous coreutils binaries so these tests run on any system.
 _TEST_RESOURCES = ["echo", "cat", "ls"]
 
-# Conftest that pytester injects into its temp directory.  It registers the
-# resource guard hooks for "cat" only, which is enough for end-to-end tests.
-# cat is a good choice: `cat /dev/null` succeeds, `cat /nonexistent` fails.
-_PYTESTER_CONFTEST = """\
+# Shared preamble for every pytester conftest we generate: clears the outer
+# process's guard state so the pytester child creates its own wrappers, and
+# strips the outer wrapper dir from PATH so the outer wrappers (still first
+# on PATH) don't shadow the child's.
+_PYTESTER_GUARD_RESET_PREAMBLE = """\
 import os
-from imbue.resource_guards.resource_guards import (
-    register_resource_guard,
-    start_resource_guards,
-    stop_resource_guards,
-)
 
-# Clear inherited guard state so the child creates fresh wrappers.
-# Must also strip the outer wrapper dir from PATH, otherwise the outer
-# wrapper scripts (still first on PATH) shadow the child's wrappers.
 _outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
 if _outer_dir:
     os.environ["PATH"] = os.pathsep.join(
         p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
     )
+"""
+
+# Conftest that pytester injects into its temp directory.  It registers the
+# resource guard hooks for "cat" only, which is enough for end-to-end tests.
+# cat is a good choice: `cat /dev/null` succeeds, `cat /nonexistent` fails.
+_PYTESTER_CONFTEST = f"""\
+{_PYTESTER_GUARD_RESET_PREAMBLE}
+from imbue.resource_guards.resource_guards import (
+    register_resource_guard,
+    start_resource_guards,
+    stop_resource_guards,
+)
 
 register_resource_guard("cat")
 
@@ -758,20 +763,13 @@ def test_enforce_sdk_guard_skips_when_no_phase_set(
 # Conftest for SDK guard pytester tests. Registers a no-op SDK guard, then uses
 # start/stop_resource_guards to initialize the infrastructure. Tests trigger the
 # guard by calling enforce_sdk_guard directly (no real SDK needed).
-_PYTESTER_SDK_CONFTEST = """\
-import os
+_PYTESTER_SDK_CONFTEST = f"""\
+{_PYTESTER_GUARD_RESET_PREAMBLE}
 from imbue.resource_guards.resource_guards import (
     register_sdk_guard,
     start_resource_guards,
     stop_resource_guards,
 )
-
-# Clear inherited guard state and strip outer wrapper dir from PATH.
-_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
-if _outer_dir:
-    os.environ["PATH"] = os.pathsep.join(
-        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
-    )
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "test_sdk: test uses test_sdk")
@@ -876,17 +874,10 @@ def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
 # Conftest that uses register_conftest_hooks for the auto-registration path.
 # Notably, there is NO manual config.addinivalue_line("markers", ...) call --
 # the mark is registered automatically by conftest_hooks._pytest_configure.
-_PYTESTER_AUTO_MARKER_CONFTEST = """\
-import os
+_PYTESTER_AUTO_MARKER_CONFTEST = f"""\
+{_PYTESTER_GUARD_RESET_PREAMBLE}
 from imbue.resource_guards.resource_guards import register_resource_guard
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-
-# Clear inherited guard state and strip outer wrapper dir from PATH.
-_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
-if _outer_dir:
-    os.environ["PATH"] = os.pathsep.join(
-        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
-    )
 
 # Pretend to be an xdist worker so register_conftest_hooks skips the global
 # test lock (outer pytest already holds it -> deadlock).
@@ -924,21 +915,14 @@ def test_register_resource_guard_auto_registers_pytest_mark(
 
 # Conftest that mirrors the README example: standalone pytest_configure
 # using register_guarded_resource_markers() (no conftest_hooks).
-_PYTESTER_STANDALONE_CONFTEST = """\
-import os
+_PYTESTER_STANDALONE_CONFTEST = f"""\
+{_PYTESTER_GUARD_RESET_PREAMBLE}
 from imbue.resource_guards.resource_guards import (
     register_guarded_resource_markers,
     register_resource_guard,
     start_resource_guards,
     stop_resource_guards,
 )
-
-# Clear inherited guard state and strip outer wrapper dir from PATH.
-_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
-if _outer_dir:
-    os.environ["PATH"] = os.pathsep.join(
-        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
-    )
 
 register_resource_guard("cat")
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -20,6 +20,7 @@ from imbue.resource_guards.resource_guards import enforce_sdk_guard
 from imbue.resource_guards.resource_guards import generate_stub_wrapper_script
 from imbue.resource_guards.resource_guards import generate_wrapper_script
 from imbue.resource_guards.resource_guards import get_guarded_resource_names
+from imbue.resource_guards.resource_guards import register_guarded_resource_markers
 from imbue.resource_guards.resource_guards import register_resource_guard
 from imbue.resource_guards.resource_guards import register_sdk_guard
 from imbue.resource_guards.resource_guards import start_resource_guards
@@ -349,6 +350,34 @@ def test_get_guarded_resource_names_returns_binary_and_sdk_guards(
     names = get_guarded_resource_names()
     assert "binary_guard" in names
     assert "sdk_guard" in names
+
+
+def test_register_guarded_resource_markers(
+    isolated_guard_state: None,
+    pytestconfig: pytest.Config,
+) -> None:
+    """register_guarded_resource_markers registers marks on the config."""
+    register_resource_guard("test_res_a")
+    register_resource_guard("test_res_b")
+
+    register_guarded_resource_markers(pytestconfig, skip_names={"test_res_a"})
+
+    marker_names = {m.split(":")[0] for m in pytestconfig.getini("markers")}
+    assert "test_res_b" in marker_names
+    assert "test_res_a" not in marker_names
+
+
+def test_register_guarded_resource_markers_no_skip(
+    isolated_guard_state: None,
+    pytestconfig: pytest.Config,
+) -> None:
+    """register_guarded_resource_markers with no skip_names registers all."""
+    register_resource_guard("test_all")
+
+    register_guarded_resource_markers(pytestconfig)
+
+    marker_names = {m.split(":")[0] for m in pytestconfig.getini("markers")}
+    assert "test_all" in marker_names
 
 
 def test_custom_sdk_guard_end_to_end(
@@ -858,11 +887,11 @@ def test_register_resource_guard_auto_registers_pytest_mark(
 
 
 # Conftest that mirrors the README example: standalone pytest_configure
-# using get_guarded_resource_names() to register marks (no conftest_hooks).
+# using register_guarded_resource_markers() (no conftest_hooks).
 _PYTESTER_STANDALONE_CONFTEST = """\
 import os
 from imbue.resource_guards.resource_guards import (
-    get_guarded_resource_names,
+    register_guarded_resource_markers,
     register_resource_guard,
     start_resource_guards,
     stop_resource_guards,
@@ -873,8 +902,7 @@ os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
 register_resource_guard("cat")
 
 def pytest_configure(config):
-    for name in get_guarded_resource_names():
-        config.addinivalue_line("markers", f"{name}: marks tests that use {name}")
+    register_guarded_resource_markers(config)
 
 def pytest_sessionstart(session):
     start_resource_guards(session)

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -357,6 +357,25 @@ def test_get_guarded_resource_names_returns_binary_and_sdk_guards(
     assert "sdk_guard" in names
 
 
+def test_sdk_only_guard_does_not_create_binary_wrapper(
+    isolated_guard_state: None,
+) -> None:
+    """SDK-only guard names must not produce PATH wrapper scripts.
+
+    Binary wrappers are only meaningful for names registered via
+    register_resource_guard(). Creating a wrapper for an SDK-only guard
+    would silently shadow any binary with the same name on PATH.
+    """
+    register_sdk_guard("sdk_only", lambda: None, lambda: None)
+    create_resource_guard_wrappers()
+
+    wrapper_dir = resource_guards._guard_wrapper_dir
+    assert wrapper_dir is not None
+    assert not (Path(wrapper_dir) / "sdk_only").exists()
+
+    cleanup_resource_guard_wrappers()
+
+
 def test_register_guarded_resource_markers(
     isolated_guard_state: None,
     pytestconfig: pytest.Config,

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -818,14 +818,10 @@ def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
 
 # Conftest that uses register_conftest_hooks for the auto-registration path.
 # Notably, there is NO manual config.addinivalue_line("markers", ...) call --
-# the mark is registered automatically by conftest_hooks._pytest_configure.
+# the mark is registered automatically by conftest_hooks._pytest_sessionstart.
 _PYTESTER_AUTO_MARKER_CONFTEST = """\
 import os
-from imbue.resource_guards.resource_guards import (
-    register_resource_guard,
-    start_resource_guards,
-    stop_resource_guards,
-)
+from imbue.resource_guards.resource_guards import register_resource_guard
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
 
 # Clear inherited guard state so we create fresh wrappers for our resources.
@@ -833,22 +829,16 @@ os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
 
 register_resource_guard("cat")
 
-# register_conftest_hooks injects pytest_configure, which auto-registers markers
-# for all resources registered via register_resource_guard().
+# register_conftest_hooks injects pytest_sessionstart, which auto-registers
+# markers for all resources and calls start_resource_guards().
 register_conftest_hooks(globals())
-
-def pytest_sessionstart(session):
-    start_resource_guards(session)
-
-def pytest_sessionfinish(session, exitstatus):
-    stop_resource_guards()
 """
 
 
 def test_register_resource_guard_auto_registers_pytest_mark(
     pytester: pytest.Pytester,
 ) -> None:
-    """register_resource_guard() auto-registers the pytest mark via conftest_hooks.
+    """register_resource_guard() auto-registers the pytest mark at session start.
 
     With --strict-markers, an unregistered mark causes a collection error.
     This test verifies that calling register_resource_guard("cat") is sufficient

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -869,6 +869,10 @@ if _outer_dir:
         p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
     )
 
+# Pretend to be an xdist worker so register_conftest_hooks skips the global
+# test lock (outer pytest already holds it -> deadlock).
+os.environ["PYTEST_XDIST_WORKER"] = "gw_pytester"
+
 register_resource_guard("cat")
 
 # register_conftest_hooks injects pytest_configure (which auto-registers markers

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -855,3 +855,51 @@ def test_register_resource_guard_auto_registers_pytest_mark(
     """)
     result = pytester.runpytest_subprocess("-n0", "--no-header", "-p", "no:cacheprovider", "--strict-markers")
     result.assert_outcomes(passed=1)
+
+
+# Conftest that mirrors the README example: standalone pytest_configure
+# using get_guarded_resource_names() to register marks (no conftest_hooks).
+_PYTESTER_STANDALONE_CONFTEST = """\
+import os
+from imbue.resource_guards.resource_guards import (
+    get_guarded_resource_names,
+    register_resource_guard,
+    start_resource_guards,
+    stop_resource_guards,
+)
+
+os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+
+register_resource_guard("cat")
+
+def pytest_configure(config):
+    for name in get_guarded_resource_names():
+        config.addinivalue_line("markers", f"{name}: marks tests that use {name}")
+
+def pytest_sessionstart(session):
+    start_resource_guards(session)
+
+def pytest_sessionfinish(session, exitstatus):
+    stop_resource_guards()
+"""
+
+
+def test_standalone_pytest_configure_registers_marks(
+    pytester: pytest.Pytester,
+) -> None:
+    """The README pattern (pytest_configure + get_guarded_resource_names) works.
+
+    Verifies that external users who don't use conftest_hooks can register
+    marks via their own pytest_configure and get_guarded_resource_names().
+    """
+    pytester.makeconftest(_PYTESTER_STANDALONE_CONFTEST)
+    pytester.makepyfile("""
+        import subprocess
+        import pytest
+
+        @pytest.mark.cat
+        def test_cat_dev_null():
+            subprocess.run(["cat", "/dev/null"], check=True)
+    """)
+    result = pytester.runpytest_subprocess("-n0", "--no-header", "-p", "no:cacheprovider", "--strict-markers")
+    result.assert_outcomes(passed=1)

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -306,6 +306,9 @@ def test_register_sdk_guard_adds_entry(isolated_guard_state: None) -> None:
 
     assert len(resource_guards._registered_sdk_guards) == 1
     assert resource_guards._registered_sdk_guards[0][0] == "test_sdk"
+    # Guard name is added to _guarded_resources immediately at registration time,
+    # not deferred to create_sdk_resource_guards().
+    assert "test_sdk" in resource_guards._guarded_resources
 
 
 def test_register_sdk_guard_deduplicates(isolated_guard_state: None) -> None:
@@ -315,14 +318,13 @@ def test_register_sdk_guard_deduplicates(isolated_guard_state: None) -> None:
     assert len(resource_guards._registered_sdk_guards) == 1
 
 
-def test_create_sdk_resource_guards_installs_and_populates(
+def test_create_sdk_resource_guards_calls_install(
     isolated_guard_state: None,
 ) -> None:
     install_called = []
     register_sdk_guard("test_sdk", lambda: install_called.append(1), lambda: None)
     create_sdk_resource_guards()
 
-    assert "test_sdk" in resource_guards._guarded_resources
     assert install_called == [1]
 
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -915,10 +915,10 @@ def pytest_sessionfinish(session, exitstatus):
 def test_standalone_pytest_configure_registers_marks(
     pytester: pytest.Pytester,
 ) -> None:
-    """The README pattern (pytest_configure + get_guarded_resource_names) works.
+    """The README pattern (pytest_configure + register_guarded_resource_markers) works.
 
     Verifies that external users who don't use conftest_hooks can register
-    marks via their own pytest_configure and get_guarded_resource_names().
+    marks via their own pytest_configure and register_guarded_resource_markers().
     """
     pytester.makeconftest(_PYTESTER_STANDALONE_CONFTEST)
     pytester.makepyfile("""

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -40,8 +40,14 @@ from imbue.resource_guards.resource_guards import (
     stop_resource_guards,
 )
 
-# Clear inherited guard state so we create fresh wrappers for our resources.
-os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+# Clear inherited guard state so the child creates fresh wrappers.
+# Must also strip the outer wrapper dir from PATH, otherwise the outer
+# wrapper scripts (still first on PATH) shadow the child's wrappers.
+_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+if _outer_dir:
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
+    )
 
 register_resource_guard("cat")
 
@@ -741,8 +747,12 @@ from imbue.resource_guards.resource_guards import (
     stop_resource_guards,
 )
 
-# Clear inherited guard state so we create fresh wrappers.
-os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+# Clear inherited guard state and strip outer wrapper dir from PATH.
+_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+if _outer_dir:
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
+    )
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "test_sdk: test uses test_sdk")
@@ -852,8 +862,12 @@ import os
 from imbue.resource_guards.resource_guards import register_resource_guard
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
 
-# Clear inherited guard state so we create fresh wrappers for our resources.
-os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+# Clear inherited guard state and strip outer wrapper dir from PATH.
+_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+if _outer_dir:
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
+    )
 
 register_resource_guard("cat")
 
@@ -896,7 +910,12 @@ from imbue.resource_guards.resource_guards import (
     stop_resource_guards,
 )
 
-os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+# Clear inherited guard state and strip outer wrapper dir from PATH.
+_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+if _outer_dir:
+    os.environ["PATH"] = os.pathsep.join(
+        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
+    )
 
 register_resource_guard("cat")
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -818,7 +818,7 @@ def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
 
 # Conftest that uses register_conftest_hooks for the auto-registration path.
 # Notably, there is NO manual config.addinivalue_line("markers", ...) call --
-# the mark is registered automatically by conftest_hooks._pytest_sessionstart.
+# the mark is registered automatically by conftest_hooks._pytest_configure.
 _PYTESTER_AUTO_MARKER_CONFTEST = """\
 import os
 from imbue.resource_guards.resource_guards import register_resource_guard
@@ -829,8 +829,8 @@ os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
 
 register_resource_guard("cat")
 
-# register_conftest_hooks injects pytest_sessionstart, which auto-registers
-# markers for all resources and calls start_resource_guards().
+# register_conftest_hooks injects pytest_configure (which auto-registers markers
+# for all resources) and pytest_sessionstart (which calls start_resource_guards).
 register_conftest_hooks(globals())
 """
 
@@ -838,7 +838,7 @@ register_conftest_hooks(globals())
 def test_register_resource_guard_auto_registers_pytest_mark(
     pytester: pytest.Pytester,
 ) -> None:
-    """register_resource_guard() auto-registers the pytest mark at session start.
+    """register_resource_guard() auto-registers the pytest mark via conftest_hooks.
 
     With --strict-markers, an unregistered mark causes a collection error.
     This test verifies that calling register_resource_guard("cat") is sufficient

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -308,8 +308,7 @@ def test_register_sdk_guard_adds_entry(isolated_guard_state: None) -> None:
 
     assert len(resource_guards._registered_sdk_guards) == 1
     assert resource_guards._registered_sdk_guards[0][0] == "test_sdk"
-    # Guard name is added to _guarded_resources immediately at registration time,
-    # not deferred to create_sdk_resource_guards().
+    # Guard name is in _guarded_resources (added by register_sdk_guard).
     assert "test_sdk" in resource_guards._guarded_resources
 
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -29,25 +29,12 @@ from imbue.resource_guards.resource_guards import stop_resource_guards
 # Use ubiquitous coreutils binaries so these tests run on any system.
 _TEST_RESOURCES = ["echo", "cat", "ls"]
 
-# Shared preamble for every pytester conftest we generate: clears the outer
-# process's guard state so the pytester child creates its own wrappers, and
-# strips the outer wrapper dir from PATH so the outer wrappers (still first
-# on PATH) don't shadow the child's.
-_PYTESTER_GUARD_RESET_PREAMBLE = """\
-import os
-
-_outer_dir = os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
-if _outer_dir:
-    os.environ["PATH"] = os.pathsep.join(
-        p for p in os.environ.get("PATH", "").split(os.pathsep) if p != _outer_dir
-    )
-"""
-
 # Conftest that pytester injects into its temp directory.  It registers the
 # resource guard hooks for "cat" only, which is enough for end-to-end tests.
 # cat is a good choice: `cat /dev/null` succeeds, `cat /nonexistent` fails.
-_PYTESTER_CONFTEST = f"""\
-{_PYTESTER_GUARD_RESET_PREAMBLE}
+# Tests using pytester must request the clean_guard_env fixture so the
+# child subprocess doesn't inherit the outer process's guard wrapper PATH.
+_PYTESTER_CONFTEST = """\
 from imbue.resource_guards.resource_guards import (
     register_resource_guard,
     start_resource_guards,
@@ -101,7 +88,7 @@ def test_generate_wrapper_script_contains_guard_check() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_marked_test_that_calls_resource_passes(pytester: pytest.Pytester) -> None:
+def test_marked_test_that_calls_resource_passes(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test with @pytest.mark.cat that calls cat should pass."""
     pytester.makeconftest(_PYTESTER_CONFTEST)
     pytester.makepyfile("""
@@ -116,7 +103,7 @@ def test_marked_test_that_calls_resource_passes(pytester: pytest.Pytester) -> No
     result.assert_outcomes(passed=1)
 
 
-def test_guards_work_with_xdist_workers(pytester: pytest.Pytester) -> None:
+def test_guards_work_with_xdist_workers(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """Guards enforce correctly when xdist distributes tests across workers.
 
     The controller creates wrapper scripts and sets PATH; workers inherit
@@ -141,7 +128,7 @@ def test_guards_work_with_xdist_workers(pytester: pytest.Pytester) -> None:
     result.stdout.fnmatch_lines(["*without @pytest.mark.cat*"])
 
 
-def test_unmarked_test_that_calls_resource_fails(pytester: pytest.Pytester) -> None:
+def test_unmarked_test_that_calls_resource_fails(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test without the mark that calls cat should fail."""
     pytester.makeconftest(_PYTESTER_CONFTEST)
     pytester.makepyfile("""
@@ -155,7 +142,7 @@ def test_unmarked_test_that_calls_resource_fails(pytester: pytest.Pytester) -> N
     result.stdout.fnmatch_lines(["*without @pytest.mark.cat*"])
 
 
-def test_unmarked_test_that_handles_guard_error_still_fails(pytester: pytest.Pytester) -> None:
+def test_unmarked_test_that_handles_guard_error_still_fails(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test that expects a resource to fail should still be caught by the guard.
 
     This simulates a realistic scenario: a test checks that cat fails on a
@@ -178,7 +165,7 @@ def test_unmarked_test_that_handles_guard_error_still_fails(pytester: pytest.Pyt
     result.stdout.fnmatch_lines(["*without @pytest.mark.cat*"])
 
 
-def test_marked_test_that_never_calls_resource_fails(pytester: pytest.Pytester) -> None:
+def test_marked_test_that_never_calls_resource_fails(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test with @pytest.mark.cat that never calls cat should fail (superfluous mark)."""
     pytester.makeconftest(_PYTESTER_CONFTEST)
     pytester.makepyfile("""
@@ -193,7 +180,7 @@ def test_marked_test_that_never_calls_resource_fails(pytester: pytest.Pytester) 
     result.stdout.fnmatch_lines(["*never invoked cat*"])
 
 
-def test_blocked_resource_appended_to_failing_test(pytester: pytest.Pytester) -> None:
+def test_blocked_resource_appended_to_failing_test(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """When a test fails AND a blocked resource was invoked, both should be visible."""
     pytester.makeconftest(_PYTESTER_CONFTEST)
     pytester.makepyfile("""
@@ -213,7 +200,7 @@ def test_blocked_resource_appended_to_failing_test(pytester: pytest.Pytester) ->
     )
 
 
-def test_unmarked_test_that_does_not_call_resource_passes(pytester: pytest.Pytester) -> None:
+def test_unmarked_test_that_does_not_call_resource_passes(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test with no mark and no resource call should pass."""
     pytester.makeconftest(_PYTESTER_CONFTEST)
     pytester.makepyfile("""
@@ -763,8 +750,7 @@ def test_enforce_sdk_guard_skips_when_no_phase_set(
 # Conftest for SDK guard pytester tests. Registers a no-op SDK guard, then uses
 # start/stop_resource_guards to initialize the infrastructure. Tests trigger the
 # guard by calling enforce_sdk_guard directly (no real SDK needed).
-_PYTESTER_SDK_CONFTEST = f"""\
-{_PYTESTER_GUARD_RESET_PREAMBLE}
+_PYTESTER_SDK_CONFTEST = """\
 from imbue.resource_guards.resource_guards import (
     register_sdk_guard,
     start_resource_guards,
@@ -784,7 +770,7 @@ def pytest_sessionfinish(session, exitstatus):
 """
 
 
-def test_sdk_marked_test_that_triggers_guard_passes(pytester: pytest.Pytester) -> None:
+def test_sdk_marked_test_that_triggers_guard_passes(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test with the SDK mark that triggers the guard should pass."""
     pytester.makeconftest(_PYTESTER_SDK_CONFTEST)
     pytester.makepyfile("""
@@ -799,7 +785,7 @@ def test_sdk_marked_test_that_triggers_guard_passes(pytester: pytest.Pytester) -
     result.assert_outcomes(passed=1)
 
 
-def test_sdk_unmarked_test_that_triggers_guard_fails(pytester: pytest.Pytester) -> None:
+def test_sdk_unmarked_test_that_triggers_guard_fails(pytester: pytest.Pytester, clean_guard_env: None) -> None:
     """A test without the SDK mark that triggers the guard should fail."""
     pytester.makeconftest(_PYTESTER_SDK_CONFTEST)
     pytester.makepyfile("""
@@ -815,6 +801,7 @@ def test_sdk_unmarked_test_that_triggers_guard_fails(pytester: pytest.Pytester) 
 
 def test_sdk_unmarked_test_that_catches_guard_error_still_fails(
     pytester: pytest.Pytester,
+    clean_guard_env: None,
 ) -> None:
     """A test that catches ResourceGuardViolation should still be caught by the guard.
 
@@ -839,6 +826,7 @@ def test_sdk_unmarked_test_that_catches_guard_error_still_fails(
 
 def test_sdk_marked_test_that_never_triggers_guard_fails(
     pytester: pytest.Pytester,
+    clean_guard_env: None,
 ) -> None:
     """A test with the SDK mark that never triggers the guard fails (superfluous mark)."""
     pytester.makeconftest(_PYTESTER_SDK_CONFTEST)
@@ -856,6 +844,7 @@ def test_sdk_marked_test_that_never_triggers_guard_fails(
 
 def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
     pytester: pytest.Pytester,
+    clean_guard_env: None,
 ) -> None:
     """A test with no SDK mark and no guard trigger should pass."""
     pytester.makeconftest(_PYTESTER_SDK_CONFTEST)
@@ -868,55 +857,12 @@ def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
 
 
 # ---------------------------------------------------------------------------
-# Auto-registration of marks via conftest_hooks (pytester)
+# Mark auto-registration via register_guarded_resource_markers (pytester)
 # ---------------------------------------------------------------------------
-
-# Conftest that uses register_conftest_hooks for the auto-registration path.
-# Notably, there is NO manual config.addinivalue_line("markers", ...) call --
-# the mark is registered automatically by conftest_hooks._pytest_configure.
-_PYTESTER_AUTO_MARKER_CONFTEST = f"""\
-{_PYTESTER_GUARD_RESET_PREAMBLE}
-from imbue.resource_guards.resource_guards import register_resource_guard
-from imbue.imbue_common.conftest_hooks import register_conftest_hooks
-
-# Pretend to be an xdist worker so register_conftest_hooks skips the global
-# test lock (outer pytest already holds it -> deadlock).
-os.environ["PYTEST_XDIST_WORKER"] = "gw_pytester"
-
-register_resource_guard("cat")
-
-# register_conftest_hooks injects pytest_configure (which auto-registers markers
-# for all resources) and pytest_sessionstart (which calls start_resource_guards).
-register_conftest_hooks(globals())
-"""
-
-
-def test_register_resource_guard_auto_registers_pytest_mark(
-    pytester: pytest.Pytester,
-) -> None:
-    """register_resource_guard() auto-registers the pytest mark via conftest_hooks.
-
-    With --strict-markers, an unregistered mark causes a collection error.
-    This test verifies that calling register_resource_guard("cat") is sufficient
-    to register @pytest.mark.cat without a separate register_marker() call.
-    """
-    pytester.makeconftest(_PYTESTER_AUTO_MARKER_CONFTEST)
-    pytester.makepyfile("""
-        import subprocess
-        import pytest
-
-        @pytest.mark.cat
-        def test_cat_dev_null():
-            subprocess.run(["cat", "/dev/null"], check=True)
-    """)
-    result = pytester.runpytest_subprocess("-n0", "--no-header", "-p", "no:cacheprovider", "--strict-markers")
-    result.assert_outcomes(passed=1)
-
 
 # Conftest that mirrors the README example: standalone pytest_configure
 # using register_guarded_resource_markers() (no conftest_hooks).
-_PYTESTER_STANDALONE_CONFTEST = f"""\
-{_PYTESTER_GUARD_RESET_PREAMBLE}
+_PYTESTER_STANDALONE_CONFTEST = """\
 from imbue.resource_guards.resource_guards import (
     register_guarded_resource_markers,
     register_resource_guard,
@@ -939,6 +885,7 @@ def pytest_sessionfinish(session, exitstatus):
 
 def test_standalone_pytest_configure_registers_marks(
     pytester: pytest.Pytester,
+    clean_guard_env: None,
 ) -> None:
     """The README pattern (pytest_configure + register_guarded_resource_markers) works.
 

--- a/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
+++ b/libs/resource_guards/imbue/resource_guards/resource_guards_test.py
@@ -19,6 +19,7 @@ from imbue.resource_guards.resource_guards import create_sdk_resource_guards
 from imbue.resource_guards.resource_guards import enforce_sdk_guard
 from imbue.resource_guards.resource_guards import generate_stub_wrapper_script
 from imbue.resource_guards.resource_guards import generate_wrapper_script
+from imbue.resource_guards.resource_guards import get_guarded_resource_names
 from imbue.resource_guards.resource_guards import register_resource_guard
 from imbue.resource_guards.resource_guards import register_sdk_guard
 from imbue.resource_guards.resource_guards import start_resource_guards
@@ -336,6 +337,18 @@ def test_cleanup_sdk_resource_guards_calls_cleanup(
     cleanup_sdk_resource_guards()
 
     assert cleanup_called == [1]
+
+
+def test_get_guarded_resource_names_returns_binary_and_sdk_guards(
+    isolated_guard_state: None,
+) -> None:
+    """get_guarded_resource_names() returns names from both registration paths."""
+    register_resource_guard("binary_guard")
+    register_sdk_guard("sdk_guard", lambda: None, lambda: None)
+
+    names = get_guarded_resource_names()
+    assert "binary_guard" in names
+    assert "sdk_guard" in names
 
 
 def test_custom_sdk_guard_end_to_end(
@@ -796,4 +809,59 @@ def test_sdk_unmarked_test_that_does_not_trigger_guard_passes(
             assert 1 + 1 == 2
     """)
     result = pytester.runpytest_subprocess("-n0", "--no-header", "-p", "no:cacheprovider")
+    result.assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# Auto-registration of marks via conftest_hooks (pytester)
+# ---------------------------------------------------------------------------
+
+# Conftest that uses register_conftest_hooks for the auto-registration path.
+# Notably, there is NO manual config.addinivalue_line("markers", ...) call --
+# the mark is registered automatically by conftest_hooks._pytest_configure.
+_PYTESTER_AUTO_MARKER_CONFTEST = """\
+import os
+from imbue.resource_guards.resource_guards import (
+    register_resource_guard,
+    start_resource_guards,
+    stop_resource_guards,
+)
+from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+
+# Clear inherited guard state so we create fresh wrappers for our resources.
+os.environ.pop("_PYTEST_GUARD_WRAPPER_DIR", None)
+
+register_resource_guard("cat")
+
+# register_conftest_hooks injects pytest_configure, which auto-registers markers
+# for all resources registered via register_resource_guard().
+register_conftest_hooks(globals())
+
+def pytest_sessionstart(session):
+    start_resource_guards(session)
+
+def pytest_sessionfinish(session, exitstatus):
+    stop_resource_guards()
+"""
+
+
+def test_register_resource_guard_auto_registers_pytest_mark(
+    pytester: pytest.Pytester,
+) -> None:
+    """register_resource_guard() auto-registers the pytest mark via conftest_hooks.
+
+    With --strict-markers, an unregistered mark causes a collection error.
+    This test verifies that calling register_resource_guard("cat") is sufficient
+    to register @pytest.mark.cat without a separate register_marker() call.
+    """
+    pytester.makeconftest(_PYTESTER_AUTO_MARKER_CONFTEST)
+    pytester.makepyfile("""
+        import subprocess
+        import pytest
+
+        @pytest.mark.cat
+        def test_cat_dev_null():
+            subprocess.run(["cat", "/dev/null"], check=True)
+    """)
+    result = pytester.runpytest_subprocess("-n0", "--no-header", "-p", "no:cacheprovider", "--strict-markers")
     result.assert_outcomes(passed=1)

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -66,7 +66,7 @@ def test_prevent_builtin_exception_raises() -> None:
 
 
 def test_prevent_inline_imports() -> None:
-    rc.check_inline_imports(_DIR, snapshot(18))
+    rc.check_inline_imports(_DIR, snapshot(16))
 
 
 def test_prevent_relative_imports() -> None:

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -66,7 +66,7 @@ def test_prevent_builtin_exception_raises() -> None:
 
 
 def test_prevent_inline_imports() -> None:
-    rc.check_inline_imports(_DIR, snapshot(16))
+    rc.check_inline_imports(_DIR, snapshot(18))
 
 
 def test_prevent_relative_imports() -> None:

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -200,7 +200,7 @@ def test_prevent_unittest_mock_imports() -> None:
 
 
 def test_prevent_monkeypatch_setattr() -> None:
-    rc.check_monkeypatch_setattr(_DIR, snapshot(5))
+    rc.check_monkeypatch_setattr(_DIR, snapshot(6))
 
 
 def test_prevent_test_container_classes() -> None:

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -66,7 +66,7 @@ def test_prevent_builtin_exception_raises() -> None:
 
 
 def test_prevent_inline_imports() -> None:
-    rc.check_inline_imports(_DIR, snapshot(14))
+    rc.check_inline_imports(_DIR, snapshot(16))
 
 
 def test_prevent_relative_imports() -> None:

--- a/libs/resource_guards/imbue/resource_guards/testing.py
+++ b/libs/resource_guards/imbue/resource_guards/testing.py
@@ -13,6 +13,7 @@ def isolate_guard_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(resource_guards, "_guard_wrapper_dir", None)
     monkeypatch.setattr(resource_guards, "_owns_guard_wrapper_dir", False)
     monkeypatch.setattr(resource_guards, "_session_env_patcher", None)
+    monkeypatch.setattr(resource_guards, "_binary_guarded_resources", [])
     monkeypatch.setattr(resource_guards, "_guarded_resources", [])
     monkeypatch.setattr(resource_guards, "_registered_sdk_guards", [])
     monkeypatch.delenv("_PYTEST_GUARD_WRAPPER_DIR", raising=False)


### PR DESCRIPTION
we had some resource guards that were getting silently skipped because their corresponding mark was not registered

---

## Summary

Eliminates the need to separately call `register_marker()` for each guarded resource. `register_resource_guard()` (and `register_sdk_guard()`) now handle mark registration automatically via `register_guarded_resource_markers()`.

**What changed:**
- New `register_guarded_resource_markers(config)` helper in the resource-guards library -- registers pytest marks for all guarded resources. Used by both standalone users (in their own `pytest_configure`) and our monorepo (via `conftest_hooks._pytest_configure`)
- `register_sdk_guard()` adds guard names to `_guarded_resources` at registration time (not deferred to session start), so they're visible at `pytest_configure` time
- Removed all redundant `register_marker()` calls from project conftest files (conftest.py, libs/mngr, libs/mngr_modal, libs/mngr_pair, libs/mngr_notifications, libs/mngr_lima, libs/mngr_claude)
- Added guard registrations to `libs/mngr/imbue/mngr/conftest.py` (the inner conftest that `pytest_plugins` actually imports), so projects inheriting via `pytest_plugins` get guards registered at import time
- Updated resource-guards README with the standalone setup pattern
- `get_guarded_resource_names()` returns an immutable `tuple[str, ...]`

## Test plan
- [x] resource_guards: 95 passed, 100% coverage
- [x] imbue_common: 214 passed, 95.20% coverage
- [x] mngr: 3600 passed, 82.81% coverage
- [x] mngr_claude: 393 passed, 82.68% coverage
- [x] mngr_kanpan: 313 passed
- [x] mngr_notifications: 111 passed
- [x] mngr_pair: 104 passed
- [x] mngr_lima: 98 passed
- [x] mngr_modal: 374 passed
- [ ] CI validates all projects