### PR TITLE
exclude minds from monorepo-wide coverage check

### DIFF
--- a/libs/mngr/pyproject.toml
+++ b/libs/mngr/pyproject.toml
@@ -107,6 +107,8 @@ omit = [
   "*/providers/docker/instance.py",
   "*/providers/docker/volume.py",
   "*/providers/docker/testing.py",
+  # Minds app has its own coverage configuration (apps/minds/pyproject.toml)
+  "*/minds/*",
 ]
 
 [tool.coverage.report]
@@ -122,6 +124,8 @@ omit = [
   "*/providers/docker/instance.py",
   "*/providers/docker/volume.py",
   "*/providers/docker/testing.py",
+  # Minds app has its own coverage configuration (apps/minds/pyproject.toml)
+  "*/minds/*",
 ]
 
 [tool.inline-snapshot]

--- a/libs/mngr/pyproject.toml
+++ b/libs/mngr/pyproject.toml
@@ -107,8 +107,6 @@ omit = [
   "*/providers/docker/instance.py",
   "*/providers/docker/volume.py",
   "*/providers/docker/testing.py",
-  # Minds app has its own coverage configuration (apps/minds/pyproject.toml)
-  "*/minds/*",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ addopts = [
   "--cov=imbue.mngr_lima",
   "--cov=imbue.mngr_tmr",
   "--cov=imbue.skitwright",
+  "--cov=imbue.minds",
   "--cov=imbue.slack_exporter",
   "--cov=imbue.cloudflare_forwarding",
   "--cov-report=term-missing",
@@ -159,8 +160,10 @@ omit = [
     "libs/mngr_lima/imbue/mngr_lima/instance.py",
     "libs/mngr_lima/imbue/mngr_lima/limactl.py",
     "libs/mngr_lima/imbue/mngr_lima/testing.py",
-    # Minds app has its own coverage configuration (apps/minds/pyproject.toml)
-    "apps/minds/*",
+    # Mind deploy modules run on Modal and require infrastructure to test
+    "apps/minds/imbue/minds/deploy/cron_runner.py",
+    "apps/minds/imbue/minds/deploy/remote_runner.py",
+    "apps/minds/imbue/minds/deploy/verification.py",
     # Schedule plugin cron runner and verification run on Modal and require infrastructure to test
     "libs/mngr_schedule/imbue/mngr_schedule/implementations/modal/cron_runner.py",
     "libs/mngr_schedule/imbue/mngr_schedule/implementations/modal/verification.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ addopts = [
   "--cov=imbue.mngr_lima",
   "--cov=imbue.mngr_tmr",
   "--cov=imbue.skitwright",
-  "--cov=imbue.minds",
   "--cov=imbue.slack_exporter",
   "--cov=imbue.cloudflare_forwarding",
   "--cov-report=term-missing",
@@ -160,10 +159,8 @@ omit = [
     "libs/mngr_lima/imbue/mngr_lima/instance.py",
     "libs/mngr_lima/imbue/mngr_lima/limactl.py",
     "libs/mngr_lima/imbue/mngr_lima/testing.py",
-    # Mind deploy modules run on Modal and require infrastructure to test
-    "apps/minds/imbue/minds/deploy/cron_runner.py",
-    "apps/minds/imbue/minds/deploy/remote_runner.py",
-    "apps/minds/imbue/minds/deploy/verification.py",
+    # Minds app has its own coverage configuration (apps/minds/pyproject.toml)
+    "apps/minds/*",
     # Schedule plugin cron runner and verification run on Modal and require infrastructure to test
     "libs/mngr_schedule/imbue/mngr_schedule/implementations/modal/cron_runner.py",
     "libs/mngr_schedule/imbue/mngr_schedule/implementations/modal/verification.py",


### PR DESCRIPTION
this makes minds coverage no longer be checked at all in ci (but will still be checked when running pytest from its directory)

---

## Summary
- Exclude minds app from monorepo-wide CI coverage threshold
- Single change: add `*/minds/*` to `[tool.coverage.report].omit` in `libs/mngr/pyproject.toml`
- Coverage collection is unchanged -- minds data is still gathered, just excluded from the combined report
- Minds retains its own 80% coverage threshold in `apps/minds/pyproject.toml`

## Context
New minds files (e.g. `templates_auth.py`) dropped the monorepo-wide coverage below 80%. Since minds has its own project-internal coverage gate, including it in the monorepo threshold is redundant and causes spurious CI failures.

The CI workflow runs `coverage report --rcfile=libs/mngr/pyproject.toml --fail-under=80`, so adding the omit to that file's `[tool.coverage.report]` section is sufficient.

## Test plan
- [x] `libs/mngr` full test suite passes (3769 passed, 84.94% coverage)
- [x] `apps/minds` full test suite passes (536 passed, 81.95% coverage with own 80% threshold)
- [x] CI `coverage` job passes (80% threshold)
- [x] CI `coverage-warning` job passes (81% threshold)


Generated with [Claude Code](https://claude.com/claude-code)