### PR TITLE
Convert ModalProxyError to ProviderUnavailableError

### DIFF
--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -21,6 +21,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.errors import ConfigStructureError
 from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
@@ -484,6 +485,8 @@ Supported build arguments for the modal provider:
                 "Modal is not authorized: run 'uvx modal token set' to authenticate, or disable this provider with "
                 f"'mngr config set --scope local providers.{name}.is_enabled false'. (original error: {e})",
             ) from e
+        except ModalProxyError as e:
+            raise ProviderUnavailableError(name, str(e)) from e
 
         return ModalProviderInstance(
             name=name,

--- a/libs/mngr_modal/imbue/mngr_modal/backend_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend_test.py
@@ -67,7 +67,7 @@ def test_get_files_for_deploy_includes_non_key_files(temp_mngr_ctx: MngrContext,
 
 
 # =============================================================================
-# _get_or_create_app Error Propagation Tests
+# build_provider_instance Error Conversion Tests
 # =============================================================================
 
 
@@ -84,8 +84,15 @@ class _FailingModalInterface(TestingModalInterface):
         raise ModalProxyError("Could not connect to the Modal server.")
 
 
-def test_get_or_create_app_propagates_modal_proxy_error(tmp_path: Path) -> None:
-    """ModalProxyError from the interface propagates out of _get_or_create_app."""
+def test_get_or_create_app_raises_modal_proxy_error_on_connection_failure(tmp_path: Path) -> None:
+    """ModalProxyError from a failing ModalInterface propagates out of _get_or_create_app.
+
+    build_provider_instance calls _get_or_create_app inside a try block with an
+    except ModalProxyError clause that converts the error to ProviderUnavailableError.
+    This test verifies that the error path from _get_or_create_app is reachable:
+    a ModalProxyError raised by app_lookup escapes _get_or_create_app unchanged,
+    which is the precondition for build_provider_instance's conversion clause to fire.
+    """
     failing_interface = _FailingModalInterface(
         root_dir=tmp_path,
         concurrency_group=ConcurrencyGroup(name="test"),

--- a/libs/mngr_modal/imbue/mngr_modal/backend_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend_test.py
@@ -67,8 +67,19 @@ def test_get_files_for_deploy_includes_non_key_files(temp_mngr_ctx: MngrContext,
 
 
 # =============================================================================
-# build_provider_instance Error Conversion Tests
+# _get_or_create_app Error Propagation Tests
 # =============================================================================
+#
+# build_provider_instance wraps _get_or_create_app in a try/except block:
+#
+#   except ModalProxyError as e:
+#       raise ProviderUnavailableError(name, str(e)) from e
+#
+# The test below verifies the precondition for this conversion: that a
+# ModalProxyError raised inside _get_or_create_app propagates out unchanged.
+# Because build_provider_instance constructs its own ModalInterface internally
+# with no injection point, the conversion clause itself cannot be exercised
+# at the unit-test level without structural changes to the production code.
 
 
 class _FailingModalInterface(TestingModalInterface):
@@ -84,14 +95,12 @@ class _FailingModalInterface(TestingModalInterface):
         raise ModalProxyError("Could not connect to the Modal server.")
 
 
-def test_get_or_create_app_raises_modal_proxy_error_on_connection_failure(tmp_path: Path) -> None:
-    """ModalProxyError from a failing ModalInterface propagates out of _get_or_create_app.
+def test_modal_proxy_error_propagates_out_of_get_or_create_app(tmp_path: Path) -> None:
+    """ModalProxyError raised by app_lookup escapes _get_or_create_app unchanged.
 
-    build_provider_instance calls _get_or_create_app inside a try block with an
-    except ModalProxyError clause that converts the error to ProviderUnavailableError.
-    This test verifies that the error path from _get_or_create_app is reachable:
-    a ModalProxyError raised by app_lookup escapes _get_or_create_app unchanged,
-    which is the precondition for build_provider_instance's conversion clause to fire.
+    This verifies the precondition for build_provider_instance's error conversion:
+    _get_or_create_app does not swallow ModalProxyError, so the caller's
+    except-ModalProxyError clause can convert it to ProviderUnavailableError.
     """
     failing_interface = _FailingModalInterface(
         root_dir=tmp_path,

--- a/libs/mngr_modal/imbue/mngr_modal/backend_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend_test.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
+import pytest
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr_modal.backend import ModalProviderBackend
 from imbue.mngr_modal.backend import get_files_for_deploy
+from imbue.modal_proxy.errors import ModalProxyError
+from imbue.modal_proxy.interface import AppInterface
+from imbue.modal_proxy.testing import TestingModalInterface
 
 # =============================================================================
 # get_files_for_deploy Tests
@@ -57,3 +64,37 @@ def test_get_files_for_deploy_includes_non_key_files(temp_mngr_ctx: MngrContext,
     assert len(result) == 1
     matched_values = list(result.values())
     assert matched_values[0] == config_file
+
+
+# =============================================================================
+# _get_or_create_app Error Propagation Tests
+# =============================================================================
+
+
+class _FailingModalInterface(TestingModalInterface):
+    """Concrete ModalInterface that raises ModalProxyError on app_lookup."""
+
+    def app_lookup(
+        self,
+        name: str,
+        *,
+        create_if_missing: bool = True,
+        environment_name: str,
+    ) -> AppInterface:
+        raise ModalProxyError("Could not connect to the Modal server.")
+
+
+def test_get_or_create_app_propagates_modal_proxy_error(tmp_path: Path) -> None:
+    """ModalProxyError from the interface propagates out of _get_or_create_app."""
+    failing_interface = _FailingModalInterface(
+        root_dir=tmp_path,
+        concurrency_group=ConcurrencyGroup(name="test"),
+    )
+    with pytest.raises(ModalProxyError, match="Could not connect"):
+        ModalProviderBackend._get_or_create_app(
+            app_name="fail-test",
+            environment_name="test-env",
+            is_persistent=True,
+            modal_interface=failing_interface,
+            is_testing=True,
+        )


### PR DESCRIPTION
## Summary
- Catch `ModalProxyError` in `ModalProviderBackend.build_provider_instance` and convert to `ProviderUnavailableError`, matching the existing pattern for `ModalProxyAuthError` and the Docker provider
- When Modal server is unreachable, CLI now shows a user-friendly error instead of crashing with an unhandled exception
- Added test with concrete `_FailingModalInterface` to verify error propagation from `_get_or_create_app`

## Test plan
- [x] Unit tests pass (375 passed, 75.92% coverage)
- [x] Ratchets pass (no unittest.mock usage added)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)