### PR TITLE
rewrite known_marketplaces.json plugin paths 

### DIFF
--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -881,6 +881,12 @@ def _write_generated_files(
         for relative, content in generated_files.items():
             dest = config_dir / relative
             dest.parent.mkdir(parents=True, exist_ok=True)
+            # Break any existing symlink so we write a regular file instead
+            # of following the symlink back to the source (e.g. ~/.claude/).
+            # _sync_user_resources creates child-level symlinks for plugins/;
+            # writing through them would corrupt the user's original files.
+            if dest.is_symlink():
+                dest.unlink()
             host.write_text_file(dest, content)
     else:
         local_host = _get_local_host(mngr_ctx)

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -101,6 +101,7 @@ _CLAUDE_HOME_SYNC_DIRS: Final[tuple[str, ...]] = ("skills", "agents", "commands"
 _CLAUDE_HOME_SYNC_FILES: Final[tuple[str, ...]] = ("keybindings.json",)
 
 _INSTALLED_PLUGINS_RELATIVE_PATH: Final[Path] = Path("plugins") / "installed_plugins.json"
+_KNOWN_MARKETPLACES_RELATIVE_PATH: Final[Path] = Path("plugins") / "known_marketplaces.json"
 
 _INSTALLED_PLUGINS_SENTINEL_PREFIX: Final[str] = "/__mngr_plugins_source__"
 """Sentinel prefix written into installPath values at deploy build time.
@@ -481,6 +482,51 @@ def _generate_installed_plugins_content(source_claude_dir: Path, target_config_d
         return None
     content = source_path.read_text()
     return _rewrite_installed_plugins_paths(content, source_claude_dir, target_config_dir)
+
+
+def _rewrite_known_marketplaces_paths(content: str, source_claude_dir: Path, target_config_dir: Path) -> str:
+    """Rewrite installLocation values in known_marketplaces.json for a target config dir.
+
+    Rebases absolute paths from source_claude_dir onto target_config_dir so that
+    Claude Code can find marketplace git clones in the per-agent config dir.
+    Without this, Claude Code re-clones marketplaces from GitHub on startup and
+    may invalidate plugin caches when the remote clone has a different HEAD.
+    """
+    data: dict[str, Any] = json.loads(content)
+    source_prefix = str(source_claude_dir) + "/"
+    for marketplace_name, marketplace_info in data.items():
+        install_location = marketplace_info.get("installLocation", "")
+        if install_location.startswith(source_prefix):
+            relative = install_location[len(source_prefix) :]
+            marketplace_info["installLocation"] = str(target_config_dir / relative)
+        else:
+            # Best-effort: extract relative path from last /plugins/ segment
+            marker_idx = install_location.rfind(_PLUGINS_DIR_MARKER)
+            if marker_idx != -1:
+                relative = "plugins/" + install_location[marker_idx + len(_PLUGINS_DIR_MARKER) :]
+                marketplace_info["installLocation"] = str(target_config_dir / relative)
+            else:
+                logger.warning(
+                    "Marketplace {!r} has installLocation {!r} that could not be rewritten "
+                    "(no '{}' segment found). Keeping path as-is; the marketplace may not "
+                    "work on the remote host.",
+                    marketplace_name,
+                    install_location,
+                    _PLUGINS_DIR_MARKER,
+                )
+    return json.dumps(data, indent=2) + "\n"
+
+
+def _generate_known_marketplaces_content(source_claude_dir: Path, target_config_dir: Path) -> str | None:
+    """Read known_marketplaces.json from source and rewrite paths to target.
+
+    Returns None if the file does not exist at source_claude_dir.
+    """
+    source_path = source_claude_dir / _KNOWN_MARKETPLACES_RELATIVE_PATH
+    if not source_path.exists():
+        return None
+    content = source_path.read_text()
+    return _rewrite_known_marketplaces_paths(content, source_claude_dir, target_config_dir)
 
 
 def _check_claude_installed(host: OnlineHostInterface) -> bool:
@@ -913,24 +959,37 @@ def _rsync_claude_home_directories(
 
 
 def _resolve_installed_plugins_sentinel(host: OnlineHostInterface) -> None:
-    """Resolve sentinel-prefixed installPaths in the claude home plugins directory.
+    """Resolve sentinel-prefixed paths in the claude home plugins directory.
 
-    Deploy images have installPath values rewritten to a sentinel prefix at
-    build time (because the container's home directory isn't known then). This
-    resolves them to the actual claude home path in place, so all downstream
+    Deploy images have paths rewritten to a sentinel prefix at build time
+    (because the container's home directory isn't known then). This resolves
+    them to the actual claude home path in place, so all downstream
     provisioning code can assume paths use the real claude home as the prefix.
 
-    No-op if the file doesn't exist or doesn't contain the sentinel.
+    Handles both installed_plugins.json (installPath) and
+    known_marketplaces.json (installLocation).
+
+    No-op if the files don't exist or don't contain the sentinel.
     """
     local_claude_dir = get_user_claude_config_dir()
+
     installed_plugins_path = local_claude_dir / _INSTALLED_PLUGINS_RELATIVE_PATH
-    if not installed_plugins_path.exists():
-        return
-    content = installed_plugins_path.read_text()
-    if _INSTALLED_PLUGINS_SENTINEL_PREFIX not in content:
-        return
-    rewritten = _rewrite_installed_plugins_paths(content, Path(_INSTALLED_PLUGINS_SENTINEL_PREFIX), local_claude_dir)
-    installed_plugins_path.write_text(rewritten)
+    if installed_plugins_path.exists():
+        content = installed_plugins_path.read_text()
+        if _INSTALLED_PLUGINS_SENTINEL_PREFIX in content:
+            rewritten = _rewrite_installed_plugins_paths(
+                content, Path(_INSTALLED_PLUGINS_SENTINEL_PREFIX), local_claude_dir
+            )
+            installed_plugins_path.write_text(rewritten)
+
+    known_marketplaces_path = local_claude_dir / _KNOWN_MARKETPLACES_RELATIVE_PATH
+    if known_marketplaces_path.exists():
+        content = known_marketplaces_path.read_text()
+        if _INSTALLED_PLUGINS_SENTINEL_PREFIX in content:
+            rewritten = _rewrite_known_marketplaces_paths(
+                content, Path(_INSTALLED_PLUGINS_SENTINEL_PREFIX), local_claude_dir
+            )
+            known_marketplaces_path.write_text(rewritten)
 
 
 def _load_claude_resource_script(filename: str) -> str:
@@ -1703,6 +1762,9 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
             installed_plugins = _generate_installed_plugins_content(source_claude_dir, config_dir)
             if installed_plugins:
                 generated_files[_INSTALLED_PLUGINS_RELATIVE_PATH] = installed_plugins
+            known_marketplaces = _generate_known_marketplaces_content(source_claude_dir, config_dir)
+            if known_marketplaces:
+                generated_files[_KNOWN_MARKETPLACES_RELATIVE_PATH] = known_marketplaces
 
         # Remote credentials: read locally, include in generated files for staging
         if not host.is_local and config.sync_claude_credentials:
@@ -2431,6 +2493,11 @@ def get_files_for_deploy(
                 # without needing to know the build machine's home directory
                 if relative_path == _INSTALLED_PLUGINS_RELATIVE_PATH:
                     content = _rewrite_installed_plugins_paths(
+                        file_path.read_text(), local_claude_dir, Path(_INSTALLED_PLUGINS_SENTINEL_PREFIX)
+                    )
+                    files[Path("~/.claude") / relative_path] = content
+                elif relative_path == _KNOWN_MARKETPLACES_RELATIVE_PATH:
+                    content = _rewrite_known_marketplaces_paths(
                         file_path.read_text(), local_claude_dir, Path(_INSTALLED_PLUGINS_SENTINEL_PREFIX)
                     )
                     files[Path("~/.claude") / relative_path] = content

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -109,7 +109,7 @@ _INSTALLED_PLUGINS_SENTINEL_PREFIX: Final[str] = "/__mngr_plugins_source__"
 At build time, ``get_files_for_deploy`` rewrites absolute local paths
 (e.g. /home/user/.claude/plugins/cache/...) to use this sentinel prefix
 in both installed_plugins.json (installPath) and known_marketplaces.json
-(installLocation).  At runtime, ``_resolve_installed_plugins_sentinel``
+(installLocation).  At runtime, ``_resolve_plugins_dir_sentinel``
 rewrites the sentinel to the actual per-agent config dir.  This avoids
 depending on the build machine's home directory path.
 """
@@ -960,7 +960,7 @@ def _rsync_claude_home_directories(
         host.copy_directory(local_host, local_claude_dir, config_dir, extra_args=" ".join(include_args))
 
 
-def _resolve_installed_plugins_sentinel(host: OnlineHostInterface) -> None:
+def _resolve_plugins_dir_sentinel(host: OnlineHostInterface) -> None:
     """Resolve sentinel-prefixed paths in the claude home plugins directory.
 
     Deploy images have paths rewritten to a sentinel prefix at build time
@@ -1815,7 +1815,7 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         # (because the container's home dir isn't known at build). Resolve
         # them to the actual ~/.claude/ path now, so all downstream code
         # can assume paths use ~/.claude/ as the prefix.
-        _resolve_installed_plugins_sentinel(host)
+        _resolve_plugins_dir_sentinel(host)
 
         with mngr_ctx.concurrency_group.make_concurrency_group("claude_provisioning") as concurrency_group:
             config = self.agent_config

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -1772,6 +1772,12 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
             installed_plugins = _generate_installed_plugins_content(source_claude_dir, config_dir)
             if installed_plugins:
                 generated_files[_INSTALLED_PLUGINS_RELATIVE_PATH] = installed_plugins
+        if config.sync_home_settings:
+            # Rewrite marketplace installLocation for both local and remote hosts.
+            # Claude Code expects installLocation to point inside $CLAUDE_CONFIG_DIR.
+            # Without rewriting, the paths point to ~/.claude/plugins/marketplaces/
+            # which Claude Code treats as "corrupted", silently skipping marketplace
+            # refreshes and leaving the plugin cache stale.
             known_marketplaces = _generate_known_marketplaces_content(source_claude_dir, config_dir)
             if known_marketplaces:
                 generated_files[_KNOWN_MARKETPLACES_RELATIVE_PATH] = known_marketplaces

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -104,12 +104,14 @@ _INSTALLED_PLUGINS_RELATIVE_PATH: Final[Path] = Path("plugins") / "installed_plu
 _KNOWN_MARKETPLACES_RELATIVE_PATH: Final[Path] = Path("plugins") / "known_marketplaces.json"
 
 _INSTALLED_PLUGINS_SENTINEL_PREFIX: Final[str] = "/__mngr_plugins_source__"
-"""Sentinel prefix written into installPath values at deploy build time.
+"""Sentinel prefix written into plugin/marketplace path values at deploy build time.
 
 At build time, ``get_files_for_deploy`` rewrites absolute local paths
-(e.g. /home/user/.claude/plugins/cache/...) to use this sentinel prefix.
-At runtime, the fixup rewrites the sentinel to the actual per-agent config dir.
-This avoids depending on the build machine's home directory path.
+(e.g. /home/user/.claude/plugins/cache/...) to use this sentinel prefix
+in both installed_plugins.json (installPath) and known_marketplaces.json
+(installLocation).  At runtime, ``_resolve_installed_plugins_sentinel``
+rewrites the sentinel to the actual per-agent config dir.  This avoids
+depending on the build machine's home directory path.
 """
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -904,7 +904,8 @@ def _sync_user_resources(host: OnlineHostInterface, config_dir: Path, *, symlink
     Syncs directories (skills/, agents/, commands/, plugins/) and individual
     files (keybindings.json) depending on the ``symlink`` flag. In symlink mode,
     plugins/ uses child-level symlinks (not a dir-level symlink) so that
-    installed_plugins.json can be rewritten in place without modifying the source.
+    per-agent generated files (installed_plugins.json, known_marketplaces.json)
+    can be written as real files without modifying the shared source.
     settings.json is handled separately by _build_settings_json.
     """
     home_claude = get_user_claude_config_dir()
@@ -918,9 +919,15 @@ def _sync_user_resources(host: OnlineHostInterface, config_dir: Path, *, symlink
                 f"cp -r {shlex.quote(str(source))} {shlex.quote(str(dest))}", timeout_seconds=5.0
             )
         elif dir_name == "plugins":
-            # Child-level symlinks so installed_plugins.json can be overwritten
+            # Child-level symlinks so per-agent generated files can coexist with
+            # shared directory contents (cache/, marketplaces/, etc.). Skip the
+            # files that will be overwritten by _write_generated_files; symlinking
+            # them would cause writes to corrupt the shared source.
             host.execute_idempotent_command(f"mkdir -p {shlex.quote(str(dest))}", timeout_seconds=5.0)
+            skip_names = {_INSTALLED_PLUGINS_RELATIVE_PATH.name, _KNOWN_MARKETPLACES_RELATIVE_PATH.name}
             for child in source.iterdir():
+                if child.name in skip_names:
+                    continue
                 host.execute_idempotent_command(
                     f"ln -sf {shlex.quote(str(child))} {shlex.quote(str(dest / child.name))}",
                     timeout_seconds=5.0,

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -326,6 +326,25 @@ is used as the relative path under the target config dir's plugins/ directory.
 """
 
 
+def _rebase_plugin_path(path: str, source_claude_dir: Path, target_config_dir: Path) -> str | None:
+    """Rebase an absolute plugin/marketplace path from source to target config dir.
+
+    Returns the rebased path, or None if the path could not be rewritten
+    (no '/plugins/' segment found). Handles two cases:
+    1. Path starts with source_claude_dir -- direct prefix replacement.
+    2. Path has a '/plugins/' segment -- best-effort extraction of the
+       relative path after the last '/plugins/' occurrence.
+    """
+    source_prefix = str(source_claude_dir) + "/"
+    if path.startswith(source_prefix):
+        return str(target_config_dir / path[len(source_prefix) :])
+    marker_idx = path.rfind(_PLUGINS_DIR_MARKER)
+    if marker_idx != -1:
+        relative = "plugins/" + path[marker_idx + len(_PLUGINS_DIR_MARKER) :]
+        return str(target_config_dir / relative)
+    return None
+
+
 def _rewrite_installed_plugins_paths(content: str, source_claude_dir: Path, target_config_dir: Path) -> str:
     """Rewrite installPath values in installed_plugins.json for a target config dir.
 
@@ -342,16 +361,11 @@ def _rewrite_installed_plugins_paths(content: str, source_claude_dir: Path, targ
     for plugin_name, plugin_entries in data.get("plugins", {}).items():
         for entry in plugin_entries:
             install_path = entry.get("installPath", "")
-            if install_path.startswith(source_prefix):
-                relative = install_path[len(source_prefix) :]
-                entry["installPath"] = str(target_config_dir / relative)
-            else:
-                # Best-effort rewrite: extract relative path from last /plugins/ segment.
-                marker_idx = install_path.rfind(_PLUGINS_DIR_MARKER)
-                if marker_idx != -1:
-                    relative = "plugins/" + install_path[marker_idx + len(_PLUGINS_DIR_MARKER) :]
-                    expected_path = str(source_claude_dir / relative)
-                    entry["installPath"] = str(target_config_dir / relative)
+            rewritten = _rebase_plugin_path(install_path, source_claude_dir, target_config_dir)
+            if rewritten is not None:
+                # Log warnings for best-effort rewrites (path didn't start with expected prefix).
+                if not install_path.startswith(source_prefix):
+                    expected_path = str(source_claude_dir / rewritten[len(str(target_config_dir)) + 1 :])
                     if _MNGR_AGENT_CONFIG_DIR_MARKER in install_path:
                         logger.warning(
                             "Plugin {!r} in {} has installPath pointing to a previous mngr agent's "
@@ -381,16 +395,17 @@ def _rewrite_installed_plugins_paths(content: str, source_claude_dir: Path, targ
                             source_claude_dir,
                             installed_plugins_path,
                         )
-                else:
-                    logger.warning(
-                        "Plugin {!r} in {} has installPath {!r} that could not be rewritten "
-                        "(no '{}' segment found). Keeping path as-is; the plugin may not "
-                        "work on the remote host.",
-                        plugin_name,
-                        installed_plugins_path,
-                        install_path,
-                        _PLUGINS_DIR_MARKER,
-                    )
+                entry["installPath"] = rewritten
+            else:
+                logger.warning(
+                    "Plugin {!r} in {} has installPath {!r} that could not be rewritten "
+                    "(no '{}' segment found). Keeping path as-is; the plugin may not "
+                    "work on the remote host.",
+                    plugin_name,
+                    installed_plugins_path,
+                    install_path,
+                    _PLUGINS_DIR_MARKER,
+                )
     return json.dumps(data, indent=2) + "\n"
 
 
@@ -495,27 +510,20 @@ def _rewrite_known_marketplaces_paths(content: str, source_claude_dir: Path, tar
     may invalidate plugin caches when the remote clone has a different HEAD.
     """
     data: dict[str, Any] = json.loads(content)
-    source_prefix = str(source_claude_dir) + "/"
     for marketplace_name, marketplace_info in data.items():
         install_location = marketplace_info.get("installLocation", "")
-        if install_location.startswith(source_prefix):
-            relative = install_location[len(source_prefix) :]
-            marketplace_info["installLocation"] = str(target_config_dir / relative)
+        rewritten = _rebase_plugin_path(install_location, source_claude_dir, target_config_dir)
+        if rewritten is not None:
+            marketplace_info["installLocation"] = rewritten
         else:
-            # Best-effort: extract relative path from last /plugins/ segment
-            marker_idx = install_location.rfind(_PLUGINS_DIR_MARKER)
-            if marker_idx != -1:
-                relative = "plugins/" + install_location[marker_idx + len(_PLUGINS_DIR_MARKER) :]
-                marketplace_info["installLocation"] = str(target_config_dir / relative)
-            else:
-                logger.warning(
-                    "Marketplace {!r} has installLocation {!r} that could not be rewritten "
-                    "(no '{}' segment found). Keeping path as-is; the marketplace may not "
-                    "work on the remote host.",
-                    marketplace_name,
-                    install_location,
-                    _PLUGINS_DIR_MARKER,
-                )
+            logger.warning(
+                "Marketplace {!r} has installLocation {!r} that could not be rewritten "
+                "(no '{}' segment found). Keeping path as-is; the marketplace may not "
+                "work on the remote host.",
+                marketplace_name,
+                install_location,
+                _PLUGINS_DIR_MARKER,
+            )
     return json.dumps(data, indent=2) + "\n"
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -3802,3 +3802,33 @@ def test_write_generated_files_writes_through_symlink_safely(tmp_path: Path, tem
     # The symlink and source file should both be untouched
     assert symlink.is_symlink()
     assert json.loads(source_file.read_text()) == {"original": True}
+
+
+def test_write_generated_files_breaks_symlink_before_writing(tmp_path: Path, temp_mngr_ctx: MngrContext) -> None:
+    """When a generated file targets a path that is a symlink, the symlink is broken and a regular file is written.
+
+    This prevents corruption of the source file (e.g. ~/.claude/plugins/known_marketplaces.json)
+    when _sync_user_resources creates child-level symlinks and a generated file needs to overwrite one.
+    """
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source_file = source_dir / "known_marketplaces.json"
+    source_file.write_text('{"original": true}')
+
+    config_dir = tmp_path / "config"
+    plugins_dir = config_dir / "plugins"
+    plugins_dir.mkdir(parents=True)
+    symlink = plugins_dir / "known_marketplaces.json"
+    symlink.symlink_to(source_file)
+
+    host = cast(OnlineHostInterface, FakeHost())
+    rewritten_content = '{"rewritten": true}'
+    generated_files = {Path("plugins") / "known_marketplaces.json": rewritten_content}
+
+    _write_generated_files(host, config_dir, generated_files, temp_mngr_ctx)
+
+    # The symlink should be replaced with a regular file containing the rewritten content
+    assert not symlink.is_symlink()
+    assert symlink.read_text() == rewritten_content
+    # The original source file must NOT be modified
+    assert json.loads(source_file.read_text()) == {"original": True}

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -60,6 +60,7 @@ from imbue.mngr_claude.plugin import _build_settings_json
 from imbue.mngr_claude.plugin import _check_settings_local_gitignored
 from imbue.mngr_claude.plugin import _claude_json_has_primary_api_key
 from imbue.mngr_claude.plugin import _generate_installed_plugins_content
+from imbue.mngr_claude.plugin import _generate_known_marketplaces_content
 from imbue.mngr_claude.plugin import _get_claude_version
 from imbue.mngr_claude.plugin import _get_preserved_sessions_dir
 from imbue.mngr_claude.plugin import _get_preserved_sessions_dir_for
@@ -71,6 +72,7 @@ from imbue.mngr_claude.plugin import _preserve_session_files_from_volume
 from imbue.mngr_claude.plugin import _provision_local_credentials
 from imbue.mngr_claude.plugin import _read_macos_keychain_credential
 from imbue.mngr_claude.plugin import _rewrite_installed_plugins_paths
+from imbue.mngr_claude.plugin import _rewrite_known_marketplaces_paths
 from imbue.mngr_claude.plugin import _should_preserve_sessions
 from imbue.mngr_claude.plugin import _write_generated_files
 from imbue.mngr_claude.plugin import agent_field_generators
@@ -3320,6 +3322,127 @@ def test_generate_installed_plugins_content_returns_none_when_no_file(tmp_path: 
     target_config_dir = tmp_path / "target"
 
     result = _generate_installed_plugins_content(source_claude_dir, target_config_dir)
+    assert result is None
+
+
+# =============================================================================
+# _rewrite_known_marketplaces_paths / _generate_known_marketplaces_content Tests
+# =============================================================================
+
+
+def test_rewrite_known_marketplaces_paths_rebases_install_location() -> None:
+    """installLocation values under local_claude_dir are rebased onto remote_config_dir."""
+    local_claude_dir = Path("/Users/testuser/.claude")
+    remote_config_dir = Path("/mngr/agents/abc123/plugin/claude/anthropic")
+    content = json.dumps(
+        {
+            "imbue-code-guardian": {
+                "source": {"source": "github", "repo": "imbue-ai/code-guardian"},
+                "installLocation": "/Users/testuser/.claude/plugins/marketplaces/imbue-code-guardian",
+                "lastUpdated": "2026-04-08T23:35:41.300Z",
+            }
+        }
+    )
+
+    result = json.loads(_rewrite_known_marketplaces_paths(content, local_claude_dir, remote_config_dir))
+
+    assert (
+        result["imbue-code-guardian"]["installLocation"]
+        == "/mngr/agents/abc123/plugin/claude/anthropic/plugins/marketplaces/imbue-code-guardian"
+    )
+
+
+def test_rewrite_known_marketplaces_paths_handles_multiple_marketplaces() -> None:
+    """All marketplaces in the file have their installLocation rewritten."""
+    local_claude_dir = Path("/home/user/.claude")
+    remote_config_dir = Path("/remote/config")
+    content = json.dumps(
+        {
+            "org-a": {
+                "installLocation": "/home/user/.claude/plugins/marketplaces/org-a",
+            },
+            "org-b": {
+                "installLocation": "/home/user/.claude/plugins/marketplaces/org-b",
+            },
+        }
+    )
+
+    result = json.loads(_rewrite_known_marketplaces_paths(content, local_claude_dir, remote_config_dir))
+
+    assert result["org-a"]["installLocation"] == "/remote/config/plugins/marketplaces/org-a"
+    assert result["org-b"]["installLocation"] == "/remote/config/plugins/marketplaces/org-b"
+
+
+def test_rewrite_known_marketplaces_paths_best_effort_for_non_matching_prefix() -> None:
+    """installLocation from a different base path is rewritten using /plugins/ marker."""
+    local_claude_dir = Path("/Users/testuser/.claude")
+    remote_config_dir = Path("/remote/config")
+    content = json.dumps(
+        {
+            "best-of-n": {
+                "installLocation": "/Users/other/.mngr/agents/old-agent/plugin/claude/anthropic/plugins/marketplaces/best-of-n",
+            }
+        }
+    )
+
+    result = json.loads(_rewrite_known_marketplaces_paths(content, local_claude_dir, remote_config_dir))
+
+    assert result["best-of-n"]["installLocation"] == "/remote/config/plugins/marketplaces/best-of-n"
+
+
+def test_rewrite_known_marketplaces_paths_preserves_other_fields() -> None:
+    """Fields other than installLocation are preserved unchanged."""
+    local_claude_dir = Path("/Users/testuser/.claude")
+    remote_config_dir = Path("/remote/config")
+    content = json.dumps(
+        {
+            "my-marketplace": {
+                "source": {"source": "github", "repo": "org/repo"},
+                "installLocation": "/Users/testuser/.claude/plugins/marketplaces/my-marketplace",
+                "lastUpdated": "2026-01-01T00:00:00.000Z",
+            }
+        }
+    )
+
+    result = json.loads(_rewrite_known_marketplaces_paths(content, local_claude_dir, remote_config_dir))
+
+    assert result["my-marketplace"]["source"] == {"source": "github", "repo": "org/repo"}
+    assert result["my-marketplace"]["lastUpdated"] == "2026-01-01T00:00:00.000Z"
+
+
+def test_generate_known_marketplaces_content_rewrites_paths(tmp_path: Path) -> None:
+    """_generate_known_marketplaces_content rewrites installLocation from source to target."""
+    source_claude_dir = tmp_path / "source_claude"
+    plugins_dir = source_claude_dir / "plugins"
+    plugins_dir.mkdir(parents=True)
+    target_config_dir = tmp_path / "target"
+
+    (plugins_dir / "known_marketplaces.json").write_text(
+        json.dumps(
+            {
+                "test-marketplace": {
+                    "installLocation": f"{source_claude_dir}/plugins/marketplaces/test-marketplace",
+                }
+            }
+        )
+    )
+
+    content = _generate_known_marketplaces_content(source_claude_dir, target_config_dir)
+
+    assert content is not None
+    result = json.loads(content)
+    assert result["test-marketplace"]["installLocation"] == str(
+        target_config_dir / "plugins" / "marketplaces" / "test-marketplace"
+    )
+
+
+def test_generate_known_marketplaces_content_returns_none_when_no_file(tmp_path: Path) -> None:
+    """_generate_known_marketplaces_content returns None when file does not exist."""
+    source_claude_dir = tmp_path / "source_claude"
+    source_claude_dir.mkdir()
+    target_config_dir = tmp_path / "target"
+
+    result = _generate_known_marketplaces_content(source_claude_dir, target_config_dir)
     assert result is None
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -3487,6 +3487,40 @@ def test_get_files_for_deploy_rewrites_install_paths_to_sentinel(temp_mngr_ctx: 
     assert marker_key not in result
 
 
+def test_get_files_for_deploy_rewrites_marketplace_paths_to_sentinel(
+    temp_mngr_ctx: MngrContext, tmp_path: Path
+) -> None:
+    """get_files_for_deploy rewrites installLocation values in known_marketplaces.json to use the sentinel prefix."""
+    claude_dir = Path.home() / ".claude"
+    plugins_dir = claude_dir / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    (plugins_dir / "known_marketplaces.json").write_text(
+        json.dumps(
+            {
+                "imbue-code-guardian": {
+                    "source": {"source": "github", "repo": "imbue-ai/code-guardian"},
+                    "installLocation": f"{claude_dir}/plugins/marketplaces/imbue-code-guardian",
+                    "lastUpdated": "2026-04-08T23:35:41.300Z",
+                }
+            }
+        )
+    )
+
+    result = get_files_for_deploy(
+        mngr_ctx=temp_mngr_ctx, include_user_settings=True, include_project_settings=False, repo_root=tmp_path
+    )
+
+    marketplaces_json_key = Path("~/.claude/plugins/known_marketplaces.json")
+    assert marketplaces_json_key in result
+    marketplaces_json_content = result[marketplaces_json_key]
+    assert isinstance(marketplaces_json_content, str)
+    data = json.loads(marketplaces_json_content)
+    assert (
+        data["imbue-code-guardian"]["installLocation"]
+        == "/__mngr_plugins_source__/plugins/marketplaces/imbue-code-guardian"
+    )
+
+
 # =============================================================================
 # _build_settings_json tests
 # =============================================================================


### PR DESCRIPTION
## Summary

**Root cause:** Claude Code's startup plugin update check removes cache entries on remote agents because `known_marketplaces.json` contains local filesystem paths that don't exist on the remote host. Claude Code re-clones the marketplace from GitHub, finds a different HEAD SHA than the cached `gitCommitSha`, and invalidates the plugin cache.

**Deeper insight:** Locally, `installLocation` points to `~/.claude/plugins/marketplaces/` instead of inside `$CLAUDE_CONFIG_DIR`, which Claude Code treats as "corrupted" and silently skips marketplace refreshes. This accidentally protects the local cache but lets `gitCommitSha` drift from the marketplace HEAD, making the stale state get propagated to remote agents where the refresh *does* succeed and then invalidates everything.

**Fix:** Rewrite `installLocation` values in `known_marketplaces.json` for both local and remote agents, mirroring the existing `installPath` rewriting for `installed_plugins.json`. This makes Claude Code's marketplace refresh work correctly, keeping `gitCommitSha` in sync so remote agents inherit a consistent state.

Additional hardening:
- Extract `_rebase_plugin_path` as shared helper between the two rewriters
- Skip symlinking `installed_plugins.json` and `known_marketplaces.json` in `_sync_user_resources` (they're always overwritten by generated content, so symlinking them risks corrupting the user's shared `~/.claude/plugins/` files)
- Defensive `is_symlink()` unlink in `_write_generated_files` as a guardrail against future additions
- Handle deploy-time sentinel prefix for `known_marketplaces.json`

## Test plan

- [x] 400 mngr_claude unit tests pass (added 6 tests for `known_marketplaces` rewriting + 1 for deploy sentinel + 1 for symlink-safe writes)
- [x] 3580 mngr core unit tests pass
- [x] Architecture review: approach approved (clean mirror of existing `installed_plugins.json` pattern)
- [x] Autofix: 3 iterations, 3 fixes applied (docstring, function rename, deploy test coverage); 1 CRITICAL issue caught and fixed (symlink corruption risk)
- [x] Conversation review: no behavioral issues
- [x] Manual end-to-end validation on local + Modal agents (see below)
- [ ] CI tests

### Manual validation (2026-04-16)

Created local and Modal agents, inspected plugin state, triggered stop hooks both with and without agent-side commits.

**Modal agent, commit-triggered stop hook** (`test-plugin-path-6`):
- `installPath` and `installLocation` correctly rewritten to per-agent config dir paths
- Cache intact with all 3 plugins after Claude Code startup (`best-of-n`, `claude-plugins-official`, `imbue-code-guardian`)
- Stop hook (initial, no commits): `hookErrors:[]`, completed in 316ms
- Stop hook (after agent committed a file): fired normal gate-failure output listing verify-architecture/autofix/verify-conversation -- same output we see in our own sessions. Critically: **no "Plugin directory does not exist" error**. The `${CLAUDE_PLUGIN_ROOT}/scripts/stop_hook_gates.sh` resolved and executed successfully.

**Local agent** (`test-plugin-path-3`, `test-plugin-path-5`):
- `installPath`: `/Users/ev/.claude/plugins/cache/...` (local hosts don't need `installPath` rewriting since original paths are directly accessible)
- `installLocation`: `/Users/ev/.mngr/agents/.../plugins/marketplaces/...` ✓ all 3 marketplaces correctly rewritten
- Generated files (`installed_plugins.json`, `known_marketplaces.json`) are real files, not symlinks. Other plugin children (`cache`, `marketplaces`, `blocklist.json`, etc.) still symlinked to `~/.claude/plugins/` as intended.
- Marketplaces actually refreshed by Claude Code (fresh `lastUpdated` timestamps after startup, confirming the rewrite enables the refresh)
- Cache survived refresh (no "corrupted installLocation" warning, no cache deletion)
- Source `~/.claude/plugins/known_marketplaces.json` untouched (both the skip-symlink fix and the defensive unlink work correctly)

Agents stopped (not destroyed) for post-mortem inspection.

Generated with [Claude Code](https://claude.com/claude-code)