### PR TITLE
show minds loading page when backend hangs up without responding

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -440,6 +440,16 @@ async def _forward_http_request(
     except httpx.ReadError:
         logger.warning("Backend connection lost for {} server {}", agent_id, server_name)
         return Response(status_code=502, content="Backend connection lost")
+    except httpx.RemoteProtocolError:
+        # Raised when the SSH tunnel accepts the connection but closes it without
+        # sending a response, which happens when the SSH channel-open to the
+        # backend port fails (e.g. uvicorn inside the agent container hasn't
+        # finished binding to its port yet). Returning 502 lets the caller show
+        # the auto-retrying loading page for HTML requests.
+        logger.warning(
+            "Backend disconnected without response for {} server {} (likely still starting up)", agent_id, server_name
+        )
+        return Response(status_code=502, content="Backend disconnected without response")
     except httpx.TimeoutException:
         logger.warning("Backend request timed out for {} server {}", agent_id, server_name)
         return Response(status_code=504, content="Backend request timed out")
@@ -488,6 +498,10 @@ async def _forward_http_request_streaming(
             logger.debug("Backend connection lost during streaming for {} server {}", agent_id, server_name)
         except httpx.ReadError:
             logger.debug("Backend read error during streaming for {} server {}", agent_id, server_name)
+        except httpx.RemoteProtocolError:
+            logger.debug(
+                "Backend disconnected without response during streaming for {} server {}", agent_id, server_name
+            )
         except httpx.TimeoutException:
             logger.debug("Backend stream timed out for {} server {}", agent_id, server_name)
 

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -843,6 +843,67 @@ def test_http_proxy_without_tunnel_manager_works_for_local_backend(tmp_path: Pat
     assert response.json() == {"status": "ok"}
 
 
+# -- Backend not-yet-ready handling tests --
+
+
+class _DisconnectingTransport(httpx.AsyncBaseTransport):
+    """Transport that always raises RemoteProtocolError, simulating a backend
+    that accepted the TCP connection but hung up before sending any HTTP data.
+
+    This is what httpx surfaces when an SSH tunnel forwards to a port whose
+    server hasn't finished binding yet (e.g. uvicorn still starting up): the
+    SSH channel-open to the backend port fails and the tunnel relay closes
+    the local socket without writing anything.
+    """
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        raise httpx.RemoteProtocolError("Server disconnected without sending a response.", request=request)
+
+
+def _setup_disconnecting_backend_server(
+    tmp_path: Path,
+) -> tuple[TestClient, FileAuthStore, AgentId]:
+    """Set up a desktop client whose backend always raises RemoteProtocolError."""
+    agent_id = AgentId()
+    backend_resolver = StaticBackendResolver(
+        url_by_agent_and_server={str(agent_id): {str(DEFAULT_SERVER_NAME): "http://test-backend"}},
+    )
+    http_client = httpx.AsyncClient(transport=_DisconnectingTransport(), base_url="http://test-backend")
+    client, auth_store = _create_test_desktop_client(
+        tmp_path=tmp_path,
+        backend_resolver=backend_resolver,
+        http_client=http_client,
+    )
+    _authenticate_client(client=client, auth_store=auth_store)
+    return client, auth_store, agent_id
+
+
+def test_http_proxy_returns_loading_page_when_backend_disconnects_html(tmp_path: Path) -> None:
+    """When the backend hangs up without sending a response, HTML requests get the loading page."""
+    client, _, agent_id = _setup_disconnecting_backend_server(tmp_path)
+    client.cookies.set(f"sw_installed_{agent_id}_{DEFAULT_SERVER_NAME}", "1")
+
+    response = client.get(
+        f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert "Loading..." in response.text
+    assert "location.reload()" in response.text
+
+
+def test_http_proxy_returns_502_when_backend_disconnects_non_html(tmp_path: Path) -> None:
+    """When the backend hangs up without sending a response, non-HTML requests get a 502."""
+    client, _, agent_id = _setup_disconnecting_backend_server(tmp_path)
+    client.cookies.set(f"sw_installed_{agent_id}_{DEFAULT_SERVER_NAME}", "1")
+
+    response = client.get(
+        f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/api/status",
+        headers={"Accept": "application/json"},
+    )
+    assert response.status_code == 502
+
+
 # -- Backend URL with query string tests --
 
 


### PR DESCRIPTION
## Summary
- When the SSH tunnel accepts a local connection but the SSH channel-open to the backend port fails (e.g. sshd inside an agent container is ready before `uvicorn` finishes binding to port 8000), the tunnel relay closes the local socket without writing anything. httpx surfaces this as `RemoteProtocolError: Server disconnected without sending a response.`, which the proxy wasn't catching -- producing an unhandled exception and a dead-end 502 in the browser that required a manual reload.
- Catch `httpx.RemoteProtocolError` in both `_forward_http_request` and the streaming generator and return a 502. The existing logic at `app.py:649` already converts 5xx responses into the auto-retrying loading page for HTML requests, so the browser self-recovers as soon as the backend is up.

## Test plan
- [x] New `test_http_proxy_returns_loading_page_when_backend_disconnects_html` and `test_http_proxy_returns_502_when_backend_disconnects_non_html` pass; full `test_desktop_client.py` suite passes (78/78)
- [x] `ruff check` and `ruff format --check` clean; `ty` clean
- [ ] Manually verify by hitting `minds forward` URL during the agent-container startup window
- [ ] CI passes