### PR TITLE
make propagate_changes work on macOS

### DIFF
--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -156,7 +156,7 @@ agent_update() {
 electron_stop() {
     echo "[electron] Stopping desktop client..."
     local electron_pid
-    electron_pid=$(pgrep -f "electron/dist/electron \\.$" 2>/dev/null | head -1)
+    electron_pid=$(pgrep -if "electron/dist/.*electron \\.$" 2>/dev/null | head -1 || true)
     if [[ -z "${electron_pid}" ]]; then
         echo "[electron] ERROR: No running electron app found. If this is unexpected, check for orphaned processes:" >&2
         echo "[electron]   pgrep -af 'electron|uv run.*minds'" >&2


### PR DESCRIPTION
## Summary

- macOS uses `electron/dist/Electron.app/Contents/MacOS/Electron` for its Electron binary (capital E, nested under `Electron.app`), so the `electron_stop` pgrep pattern (`electron/dist/electron \.$`) never matched on macOS
- Compounded by `set -e -o pipefail`: the non-zero pgrep exit propagated through the pipe and killed the function *before* it could print its "No running electron app found" error. Net effect was a silent exit 1, and Electron never got restarted after a propagation round

## Fix

- `pgrep` gains `-i` (case-insensitive) and `.*` between `dist/` and `electron` so it matches both Linux (`electron/dist/electron`) and macOS (`electron/dist/Electron.app/.../Electron`) paths
- `|| true` inside the command substitution prevents pipefail from aborting the function on no-match, so the explicit error path runs as intended

## Test plan

- [x] Fixed pgrep finds the macOS Electron main process by PID
- [x] Full propagation round completes with exit 0 on macOS
- [x] Electron PID changes after the round (confirming it was actually restarted, not left running)
- [x] Agent (`mindtest`) stopped and restarted cleanly, with frontend rebuild in between
- [x] `bash -n` syntax check passes
- [ ] Verify still works on Linux (no breaking change expected -- regex is strictly broader)
