### PR TITLE
Add hermes agent type plugin

### DIFF
--- a/libs/mngr_hermes/README.md
+++ b/libs/mngr_hermes/README.md
@@ -1,0 +1,39 @@
+# imbue-mngr-hermes
+
+Plugin that registers the `hermes` agent type for mngr.
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is an interactive AI agent framework by Nous Research with its own TUI. This plugin lets you run it as an mngr agent with isolated per-agent configuration.
+
+## Usage
+
+```bash
+mngr create my-agent hermes
+```
+
+Pass arguments to the hermes command with `--`:
+
+```bash
+mngr create my-agent hermes -- -m anthropic/claude-sonnet-4 -t code,web
+```
+
+## Configuration
+
+Define a custom variant in your mngr config (`mngr config edit`):
+
+```toml
+[agent_types.my_hermes]
+parent_type = "hermes"
+cli_args = ["-m", "anthropic/claude-sonnet-4"]
+```
+
+Then create agents with your custom type:
+
+```bash
+mngr create my-agent my_hermes
+```
+
+## How it works
+
+Each hermes agent gets an isolated `HERMES_HOME` directory inside its agent state directory. During provisioning, the plugin seeds this directory from your `~/.hermes` config (config.yaml, .env, auth.json, SOUL.md, memories/, skills/, home/). Runtime state (sessions, logs, plans, etc.) starts fresh for each agent.
+
+See the [mngr agent types documentation](https://github.com/imbue-ai/mngr/blob/main/libs/mngr/docs/concepts/agent_types.md) for more details.

--- a/libs/mngr_hermes/conftest.py
+++ b/libs/mngr_hermes/conftest.py
@@ -1,0 +1,17 @@
+"""Project-level conftest for mngr-hermes.
+
+When running tests from libs/mngr_hermes/, this conftest provides the common pytest hooks
+that would otherwise come from the monorepo root conftest.py (which is not discovered
+when pytest runs from a subdirectory).
+
+When running from the monorepo root, the root conftest.py registers the hooks first,
+and this file's register_conftest_hooks() call is a no-op (guarded by a module-level flag).
+"""
+
+from imbue.imbue_common.conftest_hooks import register_conftest_hooks
+from imbue.mngr.utils.logging import suppress_warnings
+from imbue.mngr.utils.plugin_testing import register_plugin_test_fixtures
+
+suppress_warnings()
+register_conftest_hooks(globals())
+register_plugin_test_fixtures(globals())

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin.py
@@ -115,12 +115,27 @@ class HermesAgentConfig(AgentTypeConfig):
         )
 
 
+_HERMES_TUI_READY_INDICATOR: Final[str] = "❯"
+
+
 class HermesAgent(BaseAgent[HermesAgentConfig]):
     """Agent implementation for Hermes with isolated HERMES_HOME per agent."""
 
     def _get_hermes_home_dir(self) -> Path:
         """Return the per-agent HERMES_HOME directory path."""
         return self._get_agent_dir() / _HERMES_HOME_DIR_NAME
+
+    def get_tui_ready_indicator(self) -> str | None:
+        """Return the hermes prompt character.
+
+        prompt_toolkit renders the '❯' character in its input area only after
+        ``Application.run()`` has started the event loop and bound the Enter
+        handler. It is not present in hermes's startup banner. Waiting for it
+        before sending the initial message avoids a race where the message
+        text is typed into the buffer but Enter arrives before the handler is
+        bound, leaving the message queued but unsubmitted.
+        """
+        return _HERMES_TUI_READY_INDICATOR
 
     def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
         """Inject HERMES_HOME pointing to the per-agent hermes home directory."""

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin.py
@@ -1,0 +1,162 @@
+import shlex
+from pathlib import Path
+from typing import Final
+
+from loguru import logger
+from pydantic import Field
+
+from imbue.imbue_common.logging import log_span
+from imbue.mngr import hookimpl
+from imbue.mngr.agents.base_agent import BaseAgent
+from imbue.mngr.api.providers import get_provider_instance
+from imbue.mngr.config.data_types import AgentTypeConfig
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import ConfigParseError
+from imbue.mngr.errors import MngrError
+from imbue.mngr.interfaces.agent import AgentInterface
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.primitives import CommandString
+from imbue.mngr.primitives import HostName
+from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
+
+_HERMES_HOME_DIR_NAME: Final[str] = "hermes_home"
+
+# Files to seed from ~/.hermes into each agent's HERMES_HOME
+_HERMES_HOME_SEED_FILES: Final[tuple[str, ...]] = (
+    "config.yaml",
+    ".env",
+    "auth.json",
+    "SOUL.md",
+)
+
+# Directories to seed from ~/.hermes into each agent's HERMES_HOME
+_HERMES_HOME_SEED_DIRS: Final[tuple[str, ...]] = (
+    "memories",
+    "skills",
+    "home",
+)
+
+
+def _get_user_hermes_dir() -> Path:
+    """Return the path to the user's default hermes config directory."""
+    return Path.home() / ".hermes"
+
+
+def _get_local_host(mngr_ctx: MngrContext) -> OnlineHostInterface:
+    """Get the local host instance for file operations."""
+    local_host_ref = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx).get_host(HostName("localhost"))
+    if not isinstance(local_host_ref, OnlineHostInterface):
+        raise MngrError("Local host is not online")
+    return local_host_ref
+
+
+def _seed_hermes_home(
+    host: OnlineHostInterface,
+    source_host: OnlineHostInterface,
+    source_hermes_dir: Path,
+    target_hermes_home: Path,
+) -> None:
+    """Transfer seed files and directories from the user's hermes dir to the agent's HERMES_HOME.
+
+    Uses a single rsync call with include/exclude filters to transfer only the
+    enumerated config files and directories, skipping runtime state.
+    """
+    include_args: list[str] = []
+    for dir_name in _HERMES_HOME_SEED_DIRS:
+        if not (source_hermes_dir / dir_name).exists():
+            continue
+        include_args.extend([f"--include={dir_name}/", f"--include={dir_name}/**"])
+    for file_name in _HERMES_HOME_SEED_FILES:
+        if not (source_hermes_dir / file_name).exists():
+            continue
+        include_args.append(f"--include={file_name}")
+    if not include_args:
+        return
+    include_args.append("--exclude=*")
+    with log_span("Seeding hermes home from user config"):
+        host.copy_directory(source_host, source_hermes_dir, target_hermes_home, extra_args=" ".join(include_args))
+
+
+class HermesAgentConfig(AgentTypeConfig):
+    """Config for the hermes agent type."""
+
+    command: CommandString = Field(
+        default=CommandString("hermes chat"),
+        description="Command to run hermes agent",
+    )
+
+    def merge_with(self, override: AgentTypeConfig) -> AgentTypeConfig:
+        """Merge this config with an override config."""
+        if not isinstance(override, HermesAgentConfig):
+            raise ConfigParseError("Cannot merge HermesAgentConfig with different agent config type")
+
+        # Merge parent_type (scalar -- override wins if not None)
+        merged_parent_type = override.parent_type if override.parent_type is not None else self.parent_type
+
+        # Merge command (scalar -- override wins if not None)
+        merged_command = self.command
+        if hasattr(override, "command") and override.command is not None:
+            merged_command = override.command
+
+        # Merge cli_args (concatenate both tuples)
+        merged_cli_args = self.cli_args + override.cli_args if override.cli_args else self.cli_args
+
+        # Merge permissions (list -- concatenate if override is not None)
+        merged_permissions = self.permissions
+        if override.permissions is not None:
+            merged_permissions = list(self.permissions) + list(override.permissions)
+
+        return self.__class__(
+            parent_type=merged_parent_type,
+            cli_args=merged_cli_args,
+            command=merged_command,
+            permissions=merged_permissions,
+        )
+
+
+class HermesAgent(BaseAgent[HermesAgentConfig]):
+    """Agent implementation for Hermes with isolated HERMES_HOME per agent."""
+
+    def _get_hermes_home_dir(self) -> Path:
+        """Return the per-agent HERMES_HOME directory path."""
+        return self._get_agent_dir() / _HERMES_HOME_DIR_NAME
+
+    def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
+        """Inject HERMES_HOME pointing to the per-agent hermes home directory."""
+        env_vars["HERMES_HOME"] = str(self._get_hermes_home_dir())
+
+    def provision(
+        self,
+        host: OnlineHostInterface,
+        options: CreateAgentOptions,
+        mngr_ctx: MngrContext,
+    ) -> None:
+        """Seed the per-agent HERMES_HOME from the user's ~/.hermes directory.
+
+        Copies config files, secrets, memories, skills, and home directory
+        while skipping runtime state (sessions, logs, plans, etc.).
+        Silently skips if ~/.hermes does not exist.
+        """
+        source_hermes_dir = _get_user_hermes_dir()
+        if not source_hermes_dir.exists():
+            logger.debug("Skipping hermes home seeding: {} does not exist", source_hermes_dir)
+            return
+
+        hermes_home_dir = self._get_hermes_home_dir()
+        host.execute_idempotent_command(f"mkdir -p {shlex.quote(str(hermes_home_dir))}", timeout_seconds=5.0)
+
+        # Determine source host: always the local machine running mngr
+        if host.is_local:
+            source_host = host
+        else:
+            source_host = _get_local_host(mngr_ctx)
+
+        _seed_hermes_home(host, source_host, source_hermes_dir, hermes_home_dir)
+
+
+# Module-level hook implementation for pluggy entry point discovery
+@hookimpl
+def register_agent_type() -> tuple[str, type[AgentInterface] | None, type[AgentTypeConfig]]:
+    """Register the hermes agent type."""
+    return ("hermes", HermesAgent, HermesAgentConfig)

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from datetime import timezone
 from pathlib import Path
 
+import pytest
+
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.interfaces.host import CreateAgentOptions
@@ -175,6 +177,7 @@ def test_provision_skips_when_hermes_dir_missing(
     assert not hermes_home.exists()
 
 
+@pytest.mark.rsync
 def test_provision_seeds_files_from_hermes_dir(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
@@ -211,6 +214,7 @@ def test_provision_seeds_files_from_hermes_dir(
     assert not (hermes_home / ".hermes_history").exists()
 
 
+@pytest.mark.rsync
 def test_provision_handles_partial_hermes_dir(
     local_provider: LocalProviderInstance,
     tmp_path: Path,

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
@@ -1,0 +1,277 @@
+"""Unit tests for the Hermes agent plugin."""
+
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.hosts.host import Host
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import CommandString
+from imbue.mngr.primitives import HostName
+from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
+from imbue.mngr.providers.local.instance import LocalProviderInstance
+from imbue.mngr_hermes.plugin import HermesAgent
+from imbue.mngr_hermes.plugin import HermesAgentConfig
+from imbue.mngr_hermes.plugin import _HERMES_HOME_DIR_NAME
+from imbue.mngr_hermes.plugin import _HERMES_HOME_SEED_DIRS
+from imbue.mngr_hermes.plugin import _HERMES_HOME_SEED_FILES
+from imbue.mngr_hermes.plugin import _get_user_hermes_dir
+from imbue.mngr_hermes.plugin import register_agent_type
+
+
+def _make_hermes_agent(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    mngr_ctx: MngrContext,
+    agent_config: HermesAgentConfig | None = None,
+) -> tuple[HermesAgent, Host]:
+    """Create a HermesAgent with a real local host for testing."""
+    host = local_provider.create_host(HostName(LOCAL_HOST_NAME))
+    assert isinstance(host, Host)
+    work_dir = tmp_path / f"work-{str(AgentId.generate().get_uuid())[:8]}"
+    work_dir.mkdir()
+
+    if agent_config is None:
+        agent_config = HermesAgentConfig()
+
+    agent = HermesAgent.model_construct(
+        id=AgentId.generate(),
+        name=AgentName("test-hermes"),
+        agent_type=AgentTypeName("hermes"),
+        work_dir=work_dir,
+        create_time=datetime.now(timezone.utc),
+        host_id=host.id,
+        mngr_ctx=mngr_ctx,
+        agent_config=agent_config,
+        host=host,
+    )
+    return agent, host
+
+
+def _create_fake_hermes_dir(home_dir: Path) -> Path:
+    """Create a fake .hermes directory under the given home with all seed files and dirs."""
+    hermes_dir = home_dir / ".hermes"
+    hermes_dir.mkdir()
+
+    # Seed files (reference constants to avoid hardcoding filenames)
+    (hermes_dir / _HERMES_HOME_SEED_FILES[0]).write_text("model: anthropic/claude-sonnet-4")
+    (hermes_dir / _HERMES_HOME_SEED_FILES[1]).write_text("ANTHROPIC_API_KEY=sk-test")
+    (hermes_dir / _HERMES_HOME_SEED_FILES[2]).write_text('{"token": "test"}')
+    (hermes_dir / _HERMES_HOME_SEED_FILES[3]).write_text("I am a helpful agent.")
+
+    # Seed directories with content
+    (hermes_dir / "memories").mkdir()
+    (hermes_dir / "memories" / "MEMORY.md").write_text("# Memories")
+    (hermes_dir / "skills").mkdir()
+    (hermes_dir / "skills" / "test_skill.md").write_text("# Skill")
+    (hermes_dir / "home").mkdir()
+    (hermes_dir / "home" / ".gitconfig").write_text("[user]\nname = Test")
+
+    # Runtime state files that should NOT be copied
+    (hermes_dir / "state.db").write_text("runtime state")
+    (hermes_dir / "sessions").mkdir()
+    (hermes_dir / "sessions" / "session1.json").write_text("{}")
+    (hermes_dir / "logs").mkdir()
+    (hermes_dir / ".hermes_history").write_text("history")
+
+    return hermes_dir
+
+
+# =============================================================================
+# Config Tests
+# =============================================================================
+
+
+def test_hermes_agent_config_has_correct_defaults() -> None:
+    """HermesAgentConfig should default to 'hermes chat' command."""
+    config = HermesAgentConfig()
+
+    assert str(config.command) == "hermes chat"
+    assert config.cli_args == ()
+    assert config.permissions == []
+    assert config.parent_type is None
+
+
+def test_hermes_agent_config_merge_with_override_cli_args() -> None:
+    """merge_with should concatenate cli_args from base and override."""
+    base = HermesAgentConfig()
+    override = HermesAgentConfig(cli_args=("-m", "anthropic/claude-sonnet-4"))
+
+    merged = base.merge_with(override)
+
+    assert isinstance(merged, HermesAgentConfig)
+    assert merged.cli_args == ("-m", "anthropic/claude-sonnet-4")
+    assert str(merged.command) == "hermes chat"
+
+
+def test_hermes_agent_config_merge_with_override_command() -> None:
+    """merge_with should prefer override command when set."""
+    base = HermesAgentConfig()
+    override = HermesAgentConfig(command=CommandString("hermes --debug chat"))
+
+    merged = base.merge_with(override)
+
+    assert isinstance(merged, HermesAgentConfig)
+    assert str(merged.command) == "hermes --debug chat"
+
+
+# =============================================================================
+# Hook Registration Tests
+# =============================================================================
+
+
+def test_register_agent_type_returns_correct_tuple() -> None:
+    """register_agent_type should return the hermes agent type, class, and config."""
+    result = register_agent_type()
+
+    assert result[0] == "hermes"
+    assert result[1] is HermesAgent
+    assert result[2] is HermesAgentConfig
+
+
+# =============================================================================
+# modify_env_vars Tests
+# =============================================================================
+
+
+def test_modify_env_vars_injects_hermes_home(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """modify_env_vars should set HERMES_HOME to the per-agent hermes home directory."""
+    agent, host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+
+    env_vars: dict[str, str] = {}
+    agent.modify_env_vars(host, env_vars)
+
+    assert "HERMES_HOME" in env_vars
+    expected_suffix = f"agents/{agent.id}/{_HERMES_HOME_DIR_NAME}"
+    assert env_vars["HERMES_HOME"].endswith(expected_suffix)
+
+
+# =============================================================================
+# Provision Tests
+# =============================================================================
+
+
+def test_provision_skips_when_hermes_dir_missing(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """provision should silently skip when ~/.hermes does not exist."""
+    # The setup_test_mngr_env fixture already sets HOME to tmp_path,
+    # so ~/.hermes does not exist by default.
+    agent, host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+    options = CreateAgentOptions(agent_type=AgentTypeName("hermes"))
+
+    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    # The hermes_home directory should NOT have been created
+    hermes_home = agent._get_hermes_home_dir()
+    assert not hermes_home.exists()
+
+
+def test_provision_seeds_files_from_hermes_dir(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """provision should copy seed files and directories from ~/.hermes to the agent's HERMES_HOME."""
+    agent, host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+    options = CreateAgentOptions(agent_type=AgentTypeName("hermes"))
+
+    # HOME is already set to tmp_path by the autouse fixture.
+    # Create .hermes under the fake HOME so _get_user_hermes_dir() finds it.
+    hermes_dir = _create_fake_hermes_dir(tmp_path)
+
+    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    hermes_home = agent._get_hermes_home_dir()
+
+    # Verify seed files were copied
+    first_seed_file = _HERMES_HOME_SEED_FILES[0]
+    assert (hermes_home / first_seed_file).read_text() == "model: anthropic/claude-sonnet-4"
+    assert (hermes_home / ".env").read_text() == "ANTHROPIC_API_KEY=sk-test"
+    assert (hermes_home / "auth.json").read_text() == '{"token": "test"}'
+    assert (hermes_home / "SOUL.md").read_text() == "I am a helpful agent."
+
+    # Verify seed directories were copied
+    assert (hermes_home / "memories" / "MEMORY.md").read_text() == "# Memories"
+    assert (hermes_home / "skills" / "test_skill.md").read_text() == "# Skill"
+    assert (hermes_home / "home" / ".gitconfig").read_text() == "[user]\nname = Test"
+
+    # Verify runtime state was NOT copied
+    assert not (hermes_home / "state.db").exists()
+    assert not (hermes_home / "sessions").exists()
+    assert not (hermes_home / "logs").exists()
+    assert not (hermes_home / ".hermes_history").exists()
+
+
+def test_provision_handles_partial_hermes_dir(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """provision should handle a ~/.hermes that only has some of the expected files."""
+    agent, host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+    options = CreateAgentOptions(agent_type=AgentTypeName("hermes"))
+
+    # Create .hermes with only the first seed file
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+    first_seed_file = _HERMES_HOME_SEED_FILES[0]
+    (hermes_dir / first_seed_file).write_text("model: test")
+
+    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    hermes_home = agent._get_hermes_home_dir()
+
+    # Only the seed file should be present
+    assert (hermes_home / first_seed_file).read_text() == "model: test"
+    assert not (hermes_home / ".env").exists()
+    assert not (hermes_home / "memories").exists()
+
+
+def test_provision_skips_seeding_when_hermes_dir_empty(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """provision should create hermes_home dir but skip rsync when ~/.hermes has no seed files."""
+    agent, host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+    options = CreateAgentOptions(agent_type=AgentTypeName("hermes"))
+
+    # Create an empty .hermes (exists but has no seed files)
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+
+    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    # hermes_home dir should exist (created by mkdir -p) but be empty
+    hermes_home = agent._get_hermes_home_dir()
+    assert hermes_home.exists()
+    assert list(hermes_home.iterdir()) == []
+
+
+# =============================================================================
+# Constant Validation
+# =============================================================================
+
+
+def test_seed_lists_contain_expected_entries() -> None:
+    """Verify the seed file and directory lists match the spec."""
+    assert len(_HERMES_HOME_SEED_FILES) == 4
+    assert ".env" in _HERMES_HOME_SEED_FILES
+    assert "auth.json" in _HERMES_HOME_SEED_FILES
+    assert "SOUL.md" in _HERMES_HOME_SEED_FILES
+    assert set(_HERMES_HOME_SEED_DIRS) == {"memories", "skills", "home"}
+
+
+def test_get_user_hermes_dir_returns_dot_hermes() -> None:
+    """_get_user_hermes_dir should return ~/.hermes."""
+    result = _get_user_hermes_dir()
+    assert result == Path.home() / ".hermes"

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
@@ -186,7 +186,7 @@ def test_provision_seeds_files_from_hermes_dir(
 
     # HOME is already set to tmp_path by the autouse fixture.
     # Create .hermes under the fake HOME so _get_user_hermes_dir() finds it.
-    hermes_dir = _create_fake_hermes_dir(tmp_path)
+    _create_fake_hermes_dir(tmp_path)
 
     agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 

--- a/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/plugin_test.py
@@ -21,6 +21,7 @@ from imbue.mngr_hermes.plugin import HermesAgentConfig
 from imbue.mngr_hermes.plugin import _HERMES_HOME_DIR_NAME
 from imbue.mngr_hermes.plugin import _HERMES_HOME_SEED_DIRS
 from imbue.mngr_hermes.plugin import _HERMES_HOME_SEED_FILES
+from imbue.mngr_hermes.plugin import _HERMES_TUI_READY_INDICATOR
 from imbue.mngr_hermes.plugin import _get_user_hermes_dir
 from imbue.mngr_hermes.plugin import register_agent_type
 
@@ -138,6 +139,20 @@ def test_register_agent_type_returns_correct_tuple() -> None:
 # =============================================================================
 # modify_env_vars Tests
 # =============================================================================
+
+
+def test_get_tui_ready_indicator_returns_prompt_character(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """get_tui_ready_indicator should return the hermes prompt character.
+
+    This is what base_agent.wait_for_ready_signal polls for before sending the
+    initial message; without it, /welcome races with prompt_toolkit's handler
+    installation and the Enter key is lost.
+    """
+    agent, _host = _make_hermes_agent(local_provider, tmp_path, temp_mngr_ctx)
+
+    assert agent.get_tui_ready_indicator() == _HERMES_TUI_READY_INDICATOR
 
 
 def test_modify_env_vars_injects_hermes_home(

--- a/libs/mngr_hermes/imbue/mngr_hermes/test_ratchets.py
+++ b/libs/mngr_hermes/imbue/mngr_hermes/test_ratchets.py
@@ -1,0 +1,271 @@
+from pathlib import Path
+
+import pytest
+from inline_snapshot import snapshot
+
+from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
+from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
+from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
+
+_DIR = Path(__file__).parent.parent.parent
+
+pytestmark = pytest.mark.xdist_group(name="ratchets")
+
+
+# --- Code safety ---
+
+
+def test_prevent_todos() -> None:
+    rc.check_todos(_DIR, snapshot(0))
+
+
+def test_prevent_exec() -> None:
+    rc.check_exec(_DIR, snapshot(0))
+
+
+def test_prevent_eval() -> None:
+    rc.check_eval(_DIR, snapshot(0))
+
+
+def test_prevent_while_true() -> None:
+    rc.check_while_true(_DIR, snapshot(0))
+
+
+def test_prevent_time_sleep() -> None:
+    rc.check_time_sleep(_DIR, snapshot(0))
+
+
+def test_prevent_global_keyword() -> None:
+    rc.check_global_keyword(_DIR, snapshot(0))
+
+
+def test_prevent_bare_print() -> None:
+    rc.check_bare_print(_DIR, snapshot(0))
+
+
+# --- Exception handling ---
+
+
+def test_prevent_bare_except() -> None:
+    rc.check_bare_except(_DIR, snapshot(0))
+
+
+def test_prevent_broad_exception_catch() -> None:
+    rc.check_broad_exception_catch(_DIR, snapshot(0))
+
+
+def test_prevent_base_exception_catch() -> None:
+    rc.check_base_exception_catch(_DIR, snapshot(0))
+
+
+def test_prevent_builtin_exception_raises() -> None:
+    rc.check_builtin_exception_raises(_DIR, snapshot(0))
+
+
+# --- Import style ---
+
+
+def test_prevent_inline_imports() -> None:
+    rc.check_inline_imports(_DIR, snapshot(0))
+
+
+def test_prevent_relative_imports() -> None:
+    rc.check_relative_imports(_DIR, snapshot(0))
+
+
+def test_prevent_import_datetime() -> None:
+    rc.check_import_datetime(_DIR, snapshot(0))
+
+
+def test_prevent_importlib_import_module() -> None:
+    rc.check_importlib_import_module(_DIR, snapshot(0))
+
+
+def test_prevent_getattr() -> None:
+    rc.check_getattr(_DIR, snapshot(0))
+
+
+def test_prevent_setattr() -> None:
+    rc.check_setattr(_DIR, snapshot(0))
+
+
+# --- Banned libraries and patterns ---
+
+
+def test_prevent_asyncio_import() -> None:
+    rc.check_asyncio_import(_DIR, snapshot(0))
+
+
+def test_prevent_pandas_import() -> None:
+    rc.check_pandas_import(_DIR, snapshot(0))
+
+
+def test_prevent_dataclasses_import() -> None:
+    rc.check_dataclasses_import(_DIR, snapshot(0))
+
+
+def test_prevent_namedtuple() -> None:
+    rc.check_namedtuple(_DIR, snapshot(0))
+
+
+def test_prevent_yaml_usage() -> None:
+    # 1 misfire: plugin.py references "config.yaml" (a Hermes-native filename, not YAML usage by mngr)
+    rc.check_yaml_usage(_DIR, snapshot(1))
+
+
+def test_prevent_functools_partial() -> None:
+    rc.check_functools_partial(_DIR, snapshot(0))
+
+
+def test_prevent_exit_stack() -> None:
+    rc.check_exit_stack(_DIR, snapshot(0))
+
+
+# --- Hardcoded paths ---
+
+
+def test_prevent_hardcoded_claude_dir() -> None:
+    rc.check_hardcoded_claude_dir(_DIR, snapshot(0))
+
+
+# --- Naming conventions ---
+
+
+def test_prevent_num_prefix() -> None:
+    rc.check_num_prefix(_DIR, snapshot(0))
+
+
+# --- Documentation ---
+
+
+def test_prevent_trailing_comments() -> None:
+    rc.check_trailing_comments(_DIR, snapshot(0))
+
+
+def test_prevent_init_docstrings() -> None:
+    rc.check_init_docstrings(_DIR, snapshot(0))
+
+
+@pytest.mark.timeout(10)
+def test_prevent_args_in_docstrings() -> None:
+    rc.check_args_in_docstrings(_DIR, snapshot(0))
+
+
+@pytest.mark.timeout(10)
+def test_prevent_returns_in_docstrings() -> None:
+    rc.check_returns_in_docstrings(_DIR, snapshot(0))
+
+
+# --- Type safety ---
+
+
+def test_prevent_literal_with_multiple_options() -> None:
+    rc.check_literal_with_multiple_options(_DIR, snapshot(0))
+
+
+def test_prevent_bare_generic_types() -> None:
+    rc.check_bare_generic_types(_DIR, snapshot(0))
+
+
+def test_prevent_typing_builtin_imports() -> None:
+    rc.check_typing_builtin_imports(_DIR, snapshot(0))
+
+
+def test_prevent_short_uuid_ids() -> None:
+    rc.check_short_uuid_ids(_DIR, snapshot(0))
+
+
+# --- Pydantic / models ---
+
+
+def test_prevent_model_copy() -> None:
+    rc.check_model_copy(_DIR, snapshot(0))
+
+
+# --- Logging ---
+
+
+def test_prevent_fstring_logging() -> None:
+    rc.check_fstring_logging(_DIR, snapshot(0))
+
+
+def test_prevent_click_echo() -> None:
+    rc.check_click_echo(_DIR, snapshot(0))
+
+
+# --- Testing conventions ---
+
+
+def test_prevent_unittest_mock_imports() -> None:
+    rc.check_unittest_mock_imports(_DIR, snapshot(0))
+
+
+def test_prevent_monkeypatch_setattr() -> None:
+    rc.check_monkeypatch_setattr(_DIR, snapshot(0))
+
+
+def test_prevent_test_container_classes() -> None:
+    rc.check_test_container_classes(_DIR, snapshot(0))
+
+
+def test_prevent_pytest_mark_integration() -> None:
+    rc.check_pytest_mark_integration(_DIR, snapshot(0))
+
+
+# --- Process management ---
+
+
+def test_prevent_os_fork() -> None:
+    rc.check_os_fork(_DIR, snapshot(0))
+
+
+def test_prevent_bare_urwid_tty_signal_keys() -> None:
+    rc.check_bare_urwid_tty_signal_keys(_DIR, snapshot(0))
+
+
+def test_prevent_direct_subprocess() -> None:
+    rc.check_direct_subprocess(_DIR, snapshot(0))
+
+
+# --- AST-based ratchets ---
+
+
+def test_prevent_if_elif_without_else() -> None:
+    rc.check_if_elif_without_else(_DIR, snapshot(0))
+
+
+def test_prevent_inline_functions() -> None:
+    rc.check_inline_functions(_DIR, snapshot(0))
+
+
+def test_prevent_underscore_imports() -> None:
+    rc.check_underscore_imports(_DIR, snapshot(0))
+
+
+def test_prevent_init_methods_in_non_exception_classes() -> None:
+    rc.check_init_methods_in_non_exception_classes(_DIR, snapshot(0))
+
+
+def test_prevent_cast_usage() -> None:
+    rc.check_cast_usage(_DIR, snapshot(0))
+
+
+def test_prevent_assert_isinstance() -> None:
+    rc.check_assert_isinstance(_DIR, snapshot(0))
+
+
+# --- Project-level checks ---
+
+
+def test_prevent_code_in_init_files() -> None:
+    rc.check_code_in_init_files(_DIR, snapshot(0))
+
+
+def test_no_type_errors() -> None:
+    """Ensure the codebase has zero type errors."""
+    check_no_type_errors(_DIR)
+
+
+def test_no_ruff_errors() -> None:
+    """Ensure the codebase has zero ruff linting errors."""
+    check_no_ruff_errors(_DIR)

--- a/libs/mngr_hermes/pyproject.toml
+++ b/libs/mngr_hermes/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "imbue-mngr-hermes"
+version = "0.2.4"
+description = "Hermes agent type plugin for mngr"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "imbue-mngr==0.2.4",
+]
+
+[project.entry-points.mngr]
+hermes = "imbue.mngr_hermes.plugin"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["imbue"]
+
+[tool.uv.sources]
+imbue-mngr = { workspace = true }
+
+# Shared pytest settings (markers, filterwarnings, coverage report config)
+# are centralized in:
+#   libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+# The settings below remain here because they are read from pyproject.toml
+# before any hooks run: addopts, coverage.run, inline-snapshot, timeout_func_only.
+[tool.pytest.ini_options]
+timeout_func_only = true
+junit_family = "xunit1"
+testpaths = ["."]
+addopts = [
+  "-n 4",
+  "--dist=worksteal",
+  "--cov=imbue.mngr_hermes",
+  "--cov-report=term-missing",
+  "--cov-report=html",
+  "--cov-report=xml",
+  "--cov-fail-under=90",
+  "--durations=20",
+  "--timeout=10",
+  "--timeout-method=signal",
+  "--max-worker-restart=0",
+  "-m not acceptance and not release",
+  "--slow-tests-to-file",
+  "--coverage-to-file",
+]
+
+[tool.coverage.run]
+parallel = true
+concurrency = ["multiprocessing", "thread"]
+omit = [
+  "*_test.py",
+  "test_*.py",
+  "*/tests/*",
+  "*/conftest.py",
+  "*/utils/testing.py",
+]
+
+[tool.inline-snapshot]
+default-flags=["report"]
+default-flags-tui=["report"]
+default-flags-ide=["report"]
+format-command="uv run ruff format --force-exclude --config pyproject.toml --stdin-filename {filename}"
+
+[tool.pyright]
+venvPath = "../.."
+venv = ".venv"
+pythonVersion = "3.12"
+strict = ["**/*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ addopts = [
   "--cov=imbue.resource_guards",
   "--cov=imbue.mngr_claude",
   "--cov=imbue.mngr_opencode",
+  "--cov=imbue.mngr_hermes",
   "--cov=imbue.mngr_pi_coding",
   "--cov=imbue.mngr_pair",
   "--cov=imbue.mngr_schedule",

--- a/specs/hermes-agent-plugin/concise.md
+++ b/specs/hermes-agent-plugin/concise.md
@@ -1,0 +1,39 @@
+# Hermes Agent Plugin for mngr
+
+## Overview
+
+* Add a new `hermes` agent type to mngr, allowing `mngr create --type hermes` to spawn interactive Hermes Agent sessions in tmux -- the same workflow as the `claude` agent type
+* Hermes is an external AI agent framework (Nous Research) with its own TUI (prompt_toolkit), config system (`~/.hermes/config.yaml`, `~/.hermes/.env`), and multi-instance isolation via `HERMES_HOME` env var
+* The plugin lives in the mngr monorepo as `libs/mngr_hermes`, following the same structure as `libs/mngr_opencode`
+* Each mngr-managed hermes agent gets an isolated `HERMES_HOME` inside its agent state directory (`$MNGR_AGENT_STATE_DIR/hermes_home/`), seeded from the user's existing `~/.hermes` during provisioning
+* The plugin uses a thin custom agent class extending `BaseAgent` -- overrides `modify_env_vars` (to inject `HERMES_HOME`) and `provision` (to seed the hermes home directory) while reusing BaseAgent for all other behavior
+* Assumes `hermes` is pre-installed on the host (no preflight validation)
+
+## Expected Behavior
+
+* `mngr create --type hermes` spawns a `hermes chat` session inside a tmux pane, identical to how `--type claude` spawns claude code
+* The agent's hermes instance uses `$MNGR_AGENT_STATE_DIR/hermes_home/` as its `HERMES_HOME`, fully isolated from the user's default `~/.hermes` and from other hermes agents
+* During provisioning, the following are copied from `~/.hermes` to the per-agent `HERMES_HOME`:
+  - `config.yaml` -- model, display, terminal backend settings
+  - `.env` -- API keys and secrets
+  - `memories/` -- agent memory files (MEMORY.md, USER.md)
+  - `skills/` -- user-created and synced skills
+  - `home/` -- per-profile subprocess isolation (git, ssh, npm configs)
+  - `auth.json` -- OAuth tokens, pooled API credentials
+  - `SOUL.md` -- agent personality file
+* The following are intentionally NOT seeded (runtime state that should start fresh): `state.db`, `sessions/`, `logs/`, `plans/`, `cron/`, `skins/`, `.hermes_history`
+* If `~/.hermes` does not exist on the source machine, seeding is silently skipped -- hermes handles its own first-time setup
+* The agent's hermes config is mutable at runtime (hermes can modify its own config.yaml), but changes are lost on agent destroy since the next create re-seeds from `~/.hermes`
+* For remote hosts, the local machine's `~/.hermes` contents are transferred to the remote host during provisioning
+* `mngr attach`, `mngr send`, `mngr list`, and other standard mngr commands work with hermes agents via the inherited BaseAgent tmux integration
+* Users can pass hermes-specific CLI flags via `mngr create --type hermes -- -m anthropic/claude-sonnet-4 -t code,web` (agent_args forwarded to `hermes chat`)
+
+## Changes
+
+* Create new package `libs/mngr_hermes/` with the standard mngr plugin structure:
+  - `pyproject.toml` -- package metadata, `imbue-mngr` dependency, `[project.entry-points.mngr]` registering `hermes = "imbue.mngr_hermes.plugin"`
+  - `imbue/mngr_hermes/__init__.py` -- blank (with `hookimpl` marker if needed)
+  - `imbue/mngr_hermes/plugin.py` -- `HermesAgentConfig` (extends `AgentTypeConfig`, sets default command to `hermes chat`), `HermesAgent` (extends `BaseAgent`, overrides `modify_env_vars` and `provision`), and the `register_agent_type` hookimpl
+* `HermesAgent.modify_env_vars`: injects `HERMES_HOME` pointing to `$MNGR_AGENT_STATE_DIR/hermes_home/`
+* `HermesAgent.provision`: creates the `hermes_home/` directory inside the agent state dir, then copies the enumerated config files and directories from the local `~/.hermes` (or the source host's `~/.hermes`) using `host.copy_directory` with appropriate exclusions; silently skips if source `~/.hermes` does not exist; handles both individual files (`config.yaml`, `.env`, `auth.json`, `SOUL.md`) and directories (`memories/`, `skills/`, `home/`)
+* Register the new package in the workspace `pyproject.toml` (members list and dependency sources) -- the package is discovered automatically by pluggy via its `[project.entry-points.mngr]` entry point when installed, not added as a dependency of the core `imbue-mngr` package (same pattern as `imbue-mngr-opencode` and `imbue-mngr-claude`)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -17,6 +17,7 @@ members = [
     "imbue-mngr",
     "imbue-mngr-claude",
     "imbue-mngr-file",
+    "imbue-mngr-hermes",
     "imbue-mngr-kanpan",
     "imbue-mngr-lima",
     "imbue-mngr-modal",
@@ -1556,6 +1557,17 @@ requires-dist = [
     { name = "imbue-mngr", editable = "libs/mngr" },
     { name = "tabulate", specifier = ">=0.9.0" },
 ]
+
+[[package]]
+name = "imbue-mngr-hermes"
+version = "0.2.4"
+source = { editable = "libs/mngr_hermes" }
+dependencies = [
+    { name = "imbue-mngr" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "imbue-mngr", editable = "libs/mngr" }]
 
 [[package]]
 name = "imbue-mngr-kanpan"


### PR DESCRIPTION
## Summary

- Add a new `hermes` agent type to mngr, allowing `mngr create --type hermes` to spawn interactive Hermes Agent sessions in tmux
- Plugin lives in `libs/mngr_hermes/` following the same structure as `libs/mngr_opencode/`
- Each agent gets an isolated `HERMES_HOME` inside its agent state directory, seeded from the user's `~/.hermes` during provisioning (config, secrets, memories, skills -- runtime state starts fresh)
- Uses a thin `HermesAgent` subclass of `BaseAgent` that overrides `modify_env_vars` (injects `HERMES_HOME`) and `provision` (seeds from `~/.hermes` via rsync)

## Test plan

- [x] Config defaults and merge_with behavior verified
- [x] modify_env_vars correctly injects HERMES_HOME
- [x] provision seeds files/dirs from ~/.hermes, skips runtime state
- [x] provision silently skips when ~/.hermes doesn't exist
- [x] provision handles partial ~/.hermes (only some files present)
- [x] All 64 unit and ratchet tests pass locally
- [ ] CI passes