### PR TITLE
Vendor tk, rename workspace UI labels to project, rename web service to system_interface

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -328,11 +328,11 @@ def _handle_agent_default_redirect(
     request: Request,
     auth_store: AuthStoreDep,
 ) -> Response:
-    """Redirect to the agent's web server by default."""
+    """Redirect to the agent's system_interface server by default."""
     if not _is_authenticated(cookies=request.cookies, auth_store=auth_store):
         return Response(status_code=403, content="Not authenticated")
 
-    return Response(status_code=307, headers={"Location": f"/forwarding/{agent_id}/web/"})
+    return Response(status_code=307, headers={"Location": f"/forwarding/{agent_id}/system_interface/"})
 
 
 async def _handle_agent_servers_page(

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -30,7 +30,7 @@ _LANDING_PAGE_TEMPLATE: Final[str] = (
     """<!DOCTYPE html>
 <html>
 <head>
-  <title>Workspaces</title>
+  <title>Projects</title>
   <style>
     """
     + _COMMON_STYLES
@@ -191,7 +191,7 @@ _LANDING_PAGE_TEMPLATE: Final[str] = (
     <script>setTimeout(function() { location.reload(); }, 2000);</script>
       {% else %}
     <div style="text-align: center; padding: 48px 0;">
-      <p class="empty-state" style="margin-bottom: 24px;">No workspaces yet</p>
+      <p class="empty-state" style="margin-bottom: 24px;">No projects yet</p>
       <a href="/create" class="create-btn">Create</a>
     </div>
       {% endif %}
@@ -205,7 +205,7 @@ _CREATE_FORM_TEMPLATE: Final[str] = (
     """<!DOCTYPE html>
 <html>
 <head>
-  <title>Create a Workspace</title>
+  <title>Create a Project</title>
   <style>
     """
     + _COMMON_STYLES
@@ -237,7 +237,7 @@ _CREATE_FORM_TEMPLATE: Final[str] = (
 <body>
   <div class="page">
     <div class="page-header">
-      <a href="/">Back to workspace list</a>
+      <a href="/">Back to project list</a>
       <button type="submit" form="create-form" class="submit-btn">Create</button>
     </div>
     <form id="create-form" action="/create" method="post">
@@ -293,7 +293,7 @@ _CREATING_PAGE_TEMPLATE: Final[str] = (
     """<!DOCTYPE html>
 <html>
 <head>
-  <title>Creating your workspace...</title>
+  <title>Creating your project...</title>
   <style>
     """
     + _COMMON_STYLES
@@ -315,7 +315,7 @@ _CREATING_PAGE_TEMPLATE: Final[str] = (
   </style>
 </head>
 <body>
-  <h1>Creating your workspace...</h1>
+  <h1>Creating your project...</h1>
   <p class="status" id="status"><span class="spinner"></span> {{ status_text }}</p>
   <div id="logs"></div>
   <script>
@@ -374,7 +374,7 @@ _LOGIN_PAGE_TEMPLATE: Final[str] = (
     """<!DOCTYPE html>
 <html>
 <head>
-  <title>Login - Workspaces</title>
+  <title>Login - Projects</title>
   <style>
     """
     + _COMMON_STYLES
@@ -383,7 +383,7 @@ _LOGIN_PAGE_TEMPLATE: Final[str] = (
   </style>
 </head>
 <body>
-  <h1>Workspaces</h1>
+  <h1>Projects</h1>
   <p class="login-message">
     Please use the login URL printed in the terminal where the server is running.
   </p>
@@ -593,7 +593,7 @@ _AGENT_SERVERS_TEMPLATE: Final[str] = """<!DOCTYPE html>
     No servers are currently running for this agent.
   </p>
   {% endif %}
-  <div class="back-link"><a href="/">Back to all workspaces</a></div>
+  <div class="back-link"><a href="/">Back to all projects</a></div>
   <script>
   async function toggleGlobal(agentId, serverName, enable) {
     try {
@@ -744,7 +744,7 @@ body {
 <body>
 <div id="minds-titlebar">
   <div class="minds-nav">
-    <button id="sidebar-toggle" title="Workspaces">
+    <button id="sidebar-toggle" title="Projects">
       <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
     </button>
     <button id="home-btn" title="Home">
@@ -777,7 +777,7 @@ body {
 <!-- Sidebar panel (used in browser mode; hidden by default) -->
 <div id="sidebar-panel">
   <div id="sidebar-workspaces">
-    <div class="sidebar-empty">No workspaces</div>
+    <div class="sidebar-empty">No projects</div>
   </div>
 </div>
 
@@ -893,7 +893,7 @@ document.getElementById('user-btn').onclick = function() {
 function renderWorkspaces(workspaces) {
   var container = document.getElementById('sidebar-workspaces');
   if (!workspaces || workspaces.length === 0) {
-    container.innerHTML = '<div class="sidebar-empty">No workspaces</div>';
+    container.innerHTML = '<div class="sidebar-empty">No projects</div>';
     return;
   }
   container.innerHTML = workspaces.map(function(w) {
@@ -930,7 +930,7 @@ _SIDEBAR_TEMPLATE: Final[str] = """<!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Workspaces</title>
+<title>Projects</title>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -954,7 +954,7 @@ body {
 </head>
 <body>
 <div id="sidebar-workspaces">
-  <div class="sidebar-empty">No workspaces</div>
+  <div class="sidebar-empty">No projects</div>
 </div>
 <script>
 var isElectron = !!window.minds;
@@ -966,7 +966,7 @@ function selectWorkspace(agentId) {
 function renderWorkspaces(workspaces) {
   var container = document.getElementById('sidebar-workspaces');
   if (!workspaces || workspaces.length === 0) {
-    container.innerHTML = '<div class="sidebar-empty">No workspaces</div>';
+    container.innerHTML = '<div class="sidebar-empty">No projects</div>';
     return;
   }
   container.innerHTML = workspaces.map(function(w) {

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -29,14 +29,14 @@ def test_render_landing_page_with_agents_lists_them_as_links() -> None:
 
 def test_render_landing_page_with_no_agents_shows_empty_state() -> None:
     html = render_landing_page(accessible_agent_ids=())
-    assert "No workspaces yet" in html
+    assert "No projects yet" in html
 
 
 def test_render_landing_page_discovering_shows_auto_refresh() -> None:
     html = render_landing_page(accessible_agent_ids=(), is_discovering=True)
     assert "Discovering agents" in html
     assert "reload" in html
-    assert "No workspaces yet" not in html
+    assert "No projects yet" not in html
     assert "/forwarding/" not in html
 
 
@@ -87,7 +87,7 @@ def test_render_agent_servers_page_with_no_servers_shows_empty_state() -> None:
 def test_render_agent_servers_page_has_back_link() -> None:
     html = render_agent_servers_page(agent_id=_AGENT_A, server_names=())
     assert 'href="/"' in html
-    assert "Back to all workspaces" in html
+    assert "Back to all projects" in html
 
 
 def test_render_agent_servers_page_with_cf_services_shows_global_links() -> None:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -251,7 +251,7 @@ def test_agent_default_page_redirects_to_web_server(tmp_path: Path) -> None:
 
     response = client.get(f"/forwarding/{agent_id}/", follow_redirects=False)
     assert response.status_code == 307
-    assert response.headers["location"] == f"/forwarding/{agent_id}/web/"
+    assert response.headers["location"] == f"/forwarding/{agent_id}/system_interface/"
 
 
 def test_agent_default_page_rejects_unauthenticated_requests(tmp_path: Path) -> None:
@@ -996,7 +996,7 @@ def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path
 
     response = client.get("/")
     assert response.status_code == 200
-    assert "Create a Workspace" in response.text
+    assert "Create a Project" in response.text
     assert "git_url" in response.text
 
 
@@ -1027,7 +1027,7 @@ def test_create_page_shows_form(tmp_path: Path) -> None:
 
     response = client.get("/create")
     assert response.status_code == 200
-    assert "Create a Workspace" in response.text
+    assert "Create a Project" in response.text
 
 
 def test_creation_status_returns_404_for_unknown_agent(tmp_path: Path) -> None:
@@ -1216,7 +1216,7 @@ def test_creating_page_shows_status(tmp_path: Path) -> None:
 
     response = client.get("/creating/{}".format(agent_id))
     assert response.status_code == 200
-    assert "Creating your workspace" in response.text
+    assert "Creating your project" in response.text
     agent_creator.wait_for_all()
 
 

--- a/apps/minds/test_desktop_client_e2e.py
+++ b/apps/minds/test_desktop_client_e2e.py
@@ -227,7 +227,7 @@ def _wait_for_web_server(client: httpx.Client, agent_id: str, timeout_seconds: i
     logger.info("Waiting for server discovery (up to {}s)...", timeout_seconds)
     for i in range(timeout_seconds):
         resp = client.get(f"/agents/{agent_id}/servers/")
-        if resp.status_code == 200 and "web" in resp.text:
+        if resp.status_code == 200 and "system_interface" in resp.text:
             logger.info("Web server discovered after {} seconds", i)
             break
         if i % 10 == 0 and i > 0:
@@ -238,7 +238,7 @@ def _wait_for_web_server(client: httpx.Client, agent_id: str, timeout_seconds: i
         logger.error("Servers page ({}): {}", resp.status_code, resp.text[:500])
         pytest.fail(f"Web server not discovered within {timeout_seconds} seconds")
 
-    resp = client.get(f"/agents/{agent_id}/web/", follow_redirects=True)
+    resp = client.get(f"/agents/{agent_id}/system_interface/", follow_redirects=True)
     assert resp.status_code == 200, f"Web proxy failed: {resp.status_code}"
     logger.info("Web server accessible via proxy (status {})", resp.status_code)
 


### PR DESCRIPTION
## Summary

Three small tweaks spanning this repo and the forever-claude-template:

1. **Vendor tk** at `vendor/tk` in forever-claude-template (in a sibling worktree / branch), alongside the existing `vendor/mngr`. Tickets themselves stay local via `.gitignore` (`.tickets/`). Pre-commit and ruff/pyright/pytest configs are updated to skip the entire `vendor/` tree so the vendored copy stays byte-identical to upstream.
2. **Rename UI labels** "workspace"/"Workspaces" to "project"/"Projects" in the Electron chrome + browser-served HTML templates. Internal variable names, DOM IDs, and SSE event keys are intentionally left alone (per scope).
3. **Rename the `web` service to `system_interface`** in both services.toml (FCT) and the matching default redirect in the minds desktop client, since the service actually runs minds_workspace_server rather than a generic web server.

The forever-claude-template side of the changes lives on a `mngr/minds-tweaks` branch in that repo (committed via an external worktree at `.external_worktrees/forever-claude-template/`).

## Test plan

- [x] `cd apps/minds && uv run pytest --no-cov --cov-fail-under=0 -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'` -> 540 passed
- [ ] Manually verify the electron desktop app renders the new "Projects" labels
- [ ] Verify a freshly created agent's default redirect lands on `/forwarding/{id}/system_interface/`

Release E2E test (`test_desktop_client_e2e.py`) was updated to look for `system_interface` instead of `web`. That test uses stale `/agents/...` URLs unrelated to this change, so it may be broken on other axes; this PR does not try to fix that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)