### PR TITLE
wait for child concurrency groups to exit

### DIFF
--- a/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
+++ b/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
@@ -150,11 +150,10 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
         timeout_exception_group: ConcurrencyExceptionGroup | None = None
         failure_exception_group: ConcurrencyExceptionGroup | None = None
 
+        total_timeout_seconds = self.shutdown_timeout_seconds if self.is_shutting_down() else self.exit_timeout_seconds
+        exit_start_time_seconds = time.monotonic()
         try:
-            if self.is_shutting_down():
-                self._wait_for_all_strands_to_finish_with_timeout(self.shutdown_timeout_seconds)
-            else:
-                self._wait_for_all_strands_to_finish_with_timeout(self.exit_timeout_seconds)
+            self._wait_for_all_strands_to_finish_with_timeout(total_timeout_seconds)
         except ConcurrencyExceptionGroup as exception_group:
             timeout_exception_group = exception_group
 
@@ -179,10 +178,8 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
                 exceptions.append(main_exception)
                 message = str(main_exception)
 
-        children_timeout_seconds = (
-            self.shutdown_timeout_seconds if self.is_shutting_down() else self.exit_timeout_seconds
-        )
-        self._wait_for_children_to_exit(children_timeout_seconds)
+        remaining_timeout_seconds = self._get_remaining_timeout(exit_start_time_seconds, total_timeout_seconds)
+        self._wait_for_children_to_exit(remaining_timeout_seconds)
         for child in self._children:
             if child.state not in (ConcurrencyGroupState.EXITED, ConcurrencyGroupState.INSTANTIATED):
                 child_message = f"A child concurrency group did not exit: `{child.name}` (state: {child.state})."

--- a/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
+++ b/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
@@ -5,6 +5,7 @@ from enum import auto
 from functools import wraps
 from pathlib import Path
 from subprocess import TimeoutExpired
+from threading import Event
 from threading import Lock
 from typing import Any
 from typing import Callable
@@ -111,6 +112,7 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
 
     _lock: Lock = PrivateAttr(default_factory=Lock)
     _children: list["ConcurrencyGroup"] = PrivateAttr(default_factory=list)
+    _exited_event: Event = PrivateAttr(default_factory=Event)
 
     # Did the concurrency group already exit with an exception?
     _exit_exception: BaseException | None = PrivateAttr(default=None)
@@ -141,6 +143,7 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
             raise
         finally:
             self._state = ConcurrencyGroupState.EXITED
+            self._exited_event.set()
 
     def _exit(self, exc_value: BaseException | None) -> None:
         main_exception: BaseException | None = exc_value if exc_value is not None else None
@@ -176,6 +179,10 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
                 exceptions.append(main_exception)
                 message = str(main_exception)
 
+        children_timeout_seconds = (
+            self.shutdown_timeout_seconds if self.is_shutting_down() else self.exit_timeout_seconds
+        )
+        self._wait_for_children_to_exit(children_timeout_seconds)
         for child in self._children:
             if child.state not in (ConcurrencyGroupState.EXITED, ConcurrencyGroupState.INSTANTIATED):
                 child_message = f"A child concurrency group did not exit: `{child.name}` (state: {child.state})."
@@ -255,6 +262,21 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
     def _get_remaining_timeout(self, start_time_seconds: float, total_timeout_seconds: float) -> float:
         elapsed_seconds = time.monotonic() - start_time_seconds
         return max(0, total_timeout_seconds - elapsed_seconds)
+
+    def _wait_for_children_to_exit(self, timeout_seconds: float) -> None:
+        # Children may be managed from a different thread than the one exiting this CG, so they
+        # can still be in ACTIVE/EXITING when we reach the state check. Wait for each child's
+        # exited event (set in __exit__'s finally) within a shared deadline.
+        if not self._children:
+            return
+        deadline = time.monotonic() + timeout_seconds
+        for child in self._children:
+            if child.state == ConcurrencyGroupState.INSTANTIATED:
+                continue
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            child._exited_event.wait(timeout=remaining)
 
     def _raise_if_not_active(self) -> None:
         if self._state != ConcurrencyGroupState.ACTIVE:

--- a/libs/concurrency_group/imbue/concurrency_group/concurrency_group_test.py
+++ b/libs/concurrency_group/imbue/concurrency_group/concurrency_group_test.py
@@ -1,7 +1,6 @@
 import contextlib
 from pathlib import Path
 from threading import Event
-from threading import Thread
 from time import monotonic
 from typing import Any
 from typing import Final
@@ -380,23 +379,30 @@ def _enter_child_group_on_thread(
 
 
 def test_parent_exit_waits_for_child_group_on_other_thread_to_exit() -> None:
-    # Regression test: when a child CG is created on a worker thread (sibling-hierarchy
-    # pattern), parent.__exit__ on the main thread used to race against the child's own
-    # exit, raising a spurious ChildConcurrencyGroupDidNotExitError. The parent must wait
-    # for the child to settle before checking its state.
+    # When a child CG is created on a worker thread (sibling-hierarchy pattern),
+    # parent.__exit__ on the main thread must wait for the child to finish its own
+    # __exit__ before checking the child's state, otherwise a spurious
+    # ChildConcurrencyGroupDidNotExitError can be raised.
     release = Event()
     child_entered = Event()
     top = ConcurrencyGroup(name="top", exit_timeout_seconds=5.0)
     top.__enter__()
     thread = ObservableThread(target=_enter_child_group_on_thread, args=(top, child_entered, release), daemon=True)
     thread.start()
-    child_entered.wait(timeout=5.0)
-    # Release the worker on a separate thread so the main thread reaches __exit__ first and
-    # has to wait for the child to settle.
-    Thread(target=release.set).start()
-    top.__exit__(None, None, None)
-    assert top._children[0].state == ConcurrencyGroupState.EXITED
-    thread.join(timeout=5.0)
+    try:
+        child_entered.wait(timeout=5.0)
+        # Release the worker on a separate thread so the main thread reaches __exit__ first
+        # and has to wait for the child to settle.
+        releaser = ObservableThread(target=release.set, daemon=True)
+        releaser.start()
+        try:
+            top.__exit__(None, None, None)
+            assert top._children[0].state == ConcurrencyGroupState.EXITED
+        finally:
+            releaser.join(timeout=5.0)
+    finally:
+        release.set()
+        thread.join(timeout=5.0)
 
 
 def test_exhausted_concurrency_group_cannot_be_entered_again() -> None:

--- a/libs/concurrency_group/imbue/concurrency_group/concurrency_group_test.py
+++ b/libs/concurrency_group/imbue/concurrency_group/concurrency_group_test.py
@@ -1,6 +1,7 @@
 import contextlib
 from pathlib import Path
 from threading import Event
+from threading import Thread
 from time import monotonic
 from typing import Any
 from typing import Final
@@ -11,6 +12,7 @@ from imbue.concurrency_group.concurrency_group import AncestorConcurrentFailure
 from imbue.concurrency_group.concurrency_group import ChildConcurrencyGroupDidNotExitError
 from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroupState
 from imbue.concurrency_group.concurrency_group import ConcurrentShutdownError
 from imbue.concurrency_group.concurrency_group import InvalidConcurrencyGroupStateError
 from imbue.concurrency_group.concurrency_group import StrandTimedOutError
@@ -364,6 +366,37 @@ def test_parent_failures_propagate_recursively() -> None:
     assert outer_thread is not None
     outer_thread.join()
     assert closure["i"] == 2
+
+
+def _enter_child_group_on_thread(
+    parent: ConcurrencyGroup,
+    child_entered: Event,
+    release: Event,
+) -> None:
+    with parent.make_concurrency_group(name="sibling_child") as child_cg:
+        child_cg.start_new_thread(target=lambda: release.wait(timeout=5.0))
+        child_entered.set()
+        release.wait(timeout=5.0)
+
+
+def test_parent_exit_waits_for_child_group_on_other_thread_to_exit() -> None:
+    # Regression test: when a child CG is created on a worker thread (sibling-hierarchy
+    # pattern), parent.__exit__ on the main thread used to race against the child's own
+    # exit, raising a spurious ChildConcurrencyGroupDidNotExitError. The parent must wait
+    # for the child to settle before checking its state.
+    release = Event()
+    child_entered = Event()
+    top = ConcurrencyGroup(name="top", exit_timeout_seconds=5.0)
+    top.__enter__()
+    thread = ObservableThread(target=_enter_child_group_on_thread, args=(top, child_entered, release), daemon=True)
+    thread.start()
+    child_entered.wait(timeout=5.0)
+    # Release the worker on a separate thread so the main thread reaches __exit__ first and
+    # has to wait for the child to settle.
+    Thread(target=release.set).start()
+    top.__exit__(None, None, None)
+    assert top._children[0].state == ConcurrencyGroupState.EXITED
+    thread.join(timeout=5.0)
 
 
 def test_exhausted_concurrency_group_cannot_be_entered_again() -> None:


### PR DESCRIPTION
this fix makes sense to me but also makes me suspicious that i'm missing something about how the concurrency group exit is supposed to work

---

## Summary

- Fix `ConcurrencyGroup._exit` racing against children that live on other threads, which caused a spurious `ChildConcurrencyGroupDidNotExitError` cascade on Ctrl+C during mngr discovery.
- Add a per-CG `_exited_event` and a `_wait_for_children_to_exit` step (shared deadline) before the existing state check in `_exit`.

## Root cause

mngr discovery creates modal sub-CGs as siblings of `discover_hosts_and_agents` (all children of the top-level CG). A slow Modal API call + Ctrl+C on the main thread abandons `thread.join` before the worker threads return, leaving sibling CGs in `ACTIVE`/`EXITING`. The `ctx.call_on_close(lambda: cg.__exit__(None, None, None))` in `libs/mngr/imbue/mngr/cli/common_opts.py` then hits the children check and raises. I reproduced both with Ctrl+C and, without any signal, by exiting a parent CG while a child was still running on another thread.

The library-level fix addresses the race regardless of how it's triggered; the issue's suggested `except BaseException` would silently swallow the user's Ctrl+C, so I deliberately skipped it.

## Test plan

- [x] New regression test `test_parent_exit_waits_for_child_group_on_other_thread_to_exit` (passes with fix; fails without).
- [x] `uv run pytest libs/concurrency_group/` - 154 passed.
- [x] Manual: reproduction script with SIGINT during nested CG now exits cleanly once children finish (previously raised `ChildConcurrencyGroupDidNotExitError`).
- [ ] CI to run broader test suite.

Closes #1320