### PR TITLE
Handle missing crontab binary to fix flaky schedule remove test

### DIFF
--- a/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab.py
@@ -95,14 +95,18 @@ def read_system_crontab() -> str:
     """Read the current user's crontab.
 
     Returns the crontab content as a string, or an empty string if
-    no crontab exists. Raises ScheduleDeployError for unexpected errors
-    (e.g. permission denied) to prevent silent data loss.
+    no crontab exists (including when the crontab binary is not
+    installed on the host). Raises ScheduleDeployError for unexpected
+    errors (e.g. permission denied) to prevent silent data loss.
     """
-    result = subprocess.run(
-        ["crontab", "-l"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["crontab", "-l"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ""
     if result.returncode != 0:
         if "no crontab" in result.stderr.lower():
             return ""
@@ -113,13 +117,17 @@ def read_system_crontab() -> str:
 def write_system_crontab(content: str) -> None:
     """Write content to the current user's crontab.
 
-    Raises ScheduleDeployError if the write fails.
+    Raises ScheduleDeployError if the write fails (including when
+    the crontab binary is not installed on the host).
     """
-    result = subprocess.run(
-        ["crontab", "-"],
-        input=content,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["crontab", "-"],
+            input=content,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ScheduleDeployError("Failed to write crontab: crontab binary not available on this host") from exc
     if result.returncode != 0:
         raise ScheduleDeployError(f"Failed to write crontab: {result.stderr.strip()}")

--- a/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab.py
@@ -6,6 +6,8 @@ for reading/writing the system crontab via subprocess.
 
 import subprocess
 
+from loguru import logger
+
 from imbue.imbue_common.pure import pure
 from imbue.mngr_schedule.errors import ScheduleDeployError
 
@@ -106,6 +108,7 @@ def read_system_crontab() -> str:
             text=True,
         )
     except FileNotFoundError:
+        logger.warning("crontab binary not found on this host; treating as empty crontab")
         return ""
     if result.returncode != 0:
         if "no crontab" in result.stderr.lower():

--- a/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
@@ -1,9 +1,16 @@
 """Unit tests for crontab.py pure functions."""
 
+from pathlib import Path
+
+import pytest
+
+from imbue.mngr_schedule.errors import ScheduleDeployError
 from imbue.mngr_schedule.implementations.local.crontab import add_crontab_entry
 from imbue.mngr_schedule.implementations.local.crontab import build_marker_comment
 from imbue.mngr_schedule.implementations.local.crontab import list_managed_trigger_names
+from imbue.mngr_schedule.implementations.local.crontab import read_system_crontab
 from imbue.mngr_schedule.implementations.local.crontab import remove_crontab_entry
+from imbue.mngr_schedule.implementations.local.crontab import write_system_crontab
 
 _TEST_PREFIX = "mngr-test-"
 
@@ -141,3 +148,28 @@ def test_add_crontab_entry_appends_newline_to_existing_content_without_trailing_
     lines = result.splitlines()
     assert lines[0] == "0 1 * * * /some/other/cron/job"
     assert lines[1] == f"# {_TEST_PREFIX}schedule:nightly"
+
+
+def test_read_system_crontab_returns_empty_when_binary_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the crontab binary is not on PATH, reading yields empty instead of crashing.
+
+    Regression: CI runners without crontab would raise FileNotFoundError from
+    subprocess.run, causing downstream schedule operations to fail intermittently.
+    """
+    with monkeypatch.context() as m:
+        m.setenv("PATH", str(tmp_path))
+        assert read_system_crontab() == ""
+
+
+def test_write_system_crontab_raises_schedule_deploy_error_when_binary_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the crontab binary is not on PATH, writing raises ScheduleDeployError."""
+    with monkeypatch.context() as m:
+        m.setenv("PATH", str(tmp_path))
+        with pytest.raises(ScheduleDeployError, match="crontab binary not available"):
+            write_system_crontab("0 2 * * * /path/run.sh\n")

--- a/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
@@ -1,8 +1,10 @@
 """Unit tests for crontab.py pure functions."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
+from loguru import logger
 
 from imbue.mngr_schedule.errors import ScheduleDeployError
 from imbue.mngr_schedule.implementations.local.crontab import add_crontab_entry
@@ -156,12 +158,26 @@ def test_read_system_crontab_returns_empty_when_binary_missing(
 ) -> None:
     """If the crontab binary is not on PATH, reading yields empty instead of crashing.
 
+    Asserts the warning log was emitted -- this distinguishes the
+    FileNotFoundError branch from the separate "no crontab for user"
+    branch, which also returns "" but without logging a warning.
+
     Regression: CI runners without crontab would raise FileNotFoundError from
     subprocess.run, causing downstream schedule operations to fail intermittently.
     """
-    with monkeypatch.context() as m:
-        m.setenv("PATH", str(tmp_path))
-        assert read_system_crontab() == ""
+    messages: list[str] = []
+
+    def sink(message: Any) -> None:
+        messages.append(message.record["message"])
+
+    handler_id = logger.add(sink, level="WARNING", format="{message}")
+    try:
+        with monkeypatch.context() as m:
+            m.setenv("PATH", str(tmp_path))
+            assert read_system_crontab() == ""
+    finally:
+        logger.remove(handler_id)
+    assert any("crontab binary not found" in msg for msg in messages), messages
 
 
 def test_write_system_crontab_raises_schedule_deploy_error_when_binary_missing(

--- a/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/implementations/local/crontab_test.py
@@ -172,6 +172,9 @@ def test_read_system_crontab_returns_empty_when_binary_missing(
 
     handler_id = logger.add(sink, level="WARNING", format="{message}")
     try:
+        # Scope the PATH override with monkeypatch.context() so it is reverted
+        # before the autouse _isolate_tmux_server fixture's teardown runs
+        # (which shells out to tmux and needs a working PATH).
         with monkeypatch.context() as m:
             m.setenv("PATH", str(tmp_path))
             assert read_system_crontab() == ""
@@ -185,6 +188,9 @@ def test_write_system_crontab_raises_schedule_deploy_error_when_binary_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If the crontab binary is not on PATH, writing raises ScheduleDeployError."""
+    # Scope the PATH override with monkeypatch.context() so it is reverted
+    # before the autouse _isolate_tmux_server fixture's teardown runs
+    # (which shells out to tmux and needs a working PATH).
     with monkeypatch.context() as m:
         m.setenv("PATH", str(tmp_path))
         with pytest.raises(ScheduleDeployError, match="crontab binary not available"):


### PR DESCRIPTION
## Summary
- Fixes flaky `test_schedule_remove_local_with_force` (and friends) on CI runners where the `crontab` binary is not installed.
- `read_system_crontab` now catches `FileNotFoundError` from `subprocess.run` and returns `""`, treating a missing `crontab` executable the same as "no crontab".
- `write_system_crontab` catches `FileNotFoundError` and raises `ScheduleDeployError` with an explicit "crontab binary not available" message, so schedule deploys still fail loudly on hosts where they cannot persist.
- Adds two unit tests in `crontab_test.py` that exercise the new branches by pointing `PATH` at an empty directory inside `monkeypatch.context()`.

The flaky test itself lives on sibling branch `mngr/schedule-run`; once that branch merges main it will pick up this fix.

## Test plan
- [x] `PYTEST_MAX_DURATION_SECONDS=300 uv run pytest --no-cov --cov-fail-under=0 -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'` in `libs/mngr_schedule` — 239 passed
- [x] `PYTEST_MAX_DURATION_SECONDS=120 uv run pytest --no-cov --cov-fail-under=0 imbue/mngr_schedule/test_ratchets.py` — 53 passed
- [ ] CI (offload) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)