### PR TITLE
don't show annotation checks as failed when offload successfully recovers from a flaky test

### DIFF
--- a/.github/actions/report-flaky-aware-tests/action.yml
+++ b/.github/actions/report-flaky-aware-tests/action.yml
@@ -29,10 +29,13 @@ inputs:
 runs:
   using: composite
   steps:
-    # Detect flaky-recovered case: the test step succeeded (offload exit 0 or
-    # 2) but junit still records failing attempts. Exit 2 means offload
-    # retried flaky tests and they ultimately passed; we want a neutral
-    # (yellow) check rather than a red one in that case.
+    # Detect flaky-recovered case. The just recipes map offload's exit 2
+    # (flaky tests failed then passed on retry) to exit 0, so GitHub Actions
+    # records the test step as "success" for both offload exit 0 (no
+    # failures at all) and offload exit 2 (flaky recovery). We distinguish
+    # the two by scanning junit.xml for <failure>/<error> elements: their
+    # presence alongside a successful step outcome means flaky recovery,
+    # and we want a neutral (yellow) check rather than a red one.
     - name: Detect flaky-recovered tests
       id: flaky
       if: always()

--- a/.github/actions/report-flaky-aware-tests/action.yml
+++ b/.github/actions/report-flaky-aware-tests/action.yml
@@ -85,7 +85,7 @@ runs:
         jq -n \
           --arg name "$CHECK_NAME" \
           --arg head_sha "$HEAD_SHA" \
-          --arg summary "One or more tests failed on first attempt but passed on retry. See job logs and the \"$CHECK_NAME\" annotations for details." \
+          --arg summary "One or more tests failed on first attempt but passed on retry. See the workflow run summary and job logs for the failed-attempt annotations and details." \
           '{
             name: $name,
             head_sha: $head_sha,

--- a/.github/actions/report-flaky-aware-tests/action.yml
+++ b/.github/actions/report-flaky-aware-tests/action.yml
@@ -1,0 +1,89 @@
+name: Report flaky-aware test results
+description: >-
+  Report junit test results to a GitHub check. If the test step succeeded but
+  junit.xml still records failing attempts (meaning offload retried flaky
+  tests and they ultimately passed), post the check as neutral (yellow)
+  instead of failure (red). Neutral counts as success for branch protection.
+
+inputs:
+  check-name:
+    description: >-
+      Name of the GitHub check to create (e.g. "Unit + Integration Tests").
+    required: true
+  junit-path:
+    description: Path to the junit.xml file.
+    required: false
+    default: test-results/junit.xml
+  tests-outcome:
+    description: >-
+      Outcome of the test-running step. Pass `${{ steps.<id>.outcome }}`
+      where `<id>` is the id of the step that ran the tests. The flaky-
+      recovered path only triggers when this is "success".
+    required: true
+  github-token:
+    description: >-
+      Token used to POST the neutral check-run via `gh api`. Needs
+      `checks: write` permission.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Detect flaky-recovered case: the test step succeeded (offload exit 0 or
+    # 2) but junit still records failing attempts. Exit 2 means offload
+    # retried flaky tests and they ultimately passed; we want a neutral
+    # (yellow) check rather than a red one in that case.
+    - name: Detect flaky-recovered tests
+      id: flaky
+      if: always()
+      shell: bash
+      env:
+        TESTS_OUTCOME: ${{ inputs.tests-outcome }}
+        JUNIT_PATH: ${{ inputs.junit-path }}
+      run: |
+        if [ "$TESTS_OUTCOME" = "success" ] \
+            && [ -f "$JUNIT_PATH" ] \
+            && grep -qE '<(failure|error)[ >/]' "$JUNIT_PATH"; then
+          echo "is_flaky_recovered=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "is_flaky_recovered=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Report test results
+      if: always() && steps.flaky.outputs.is_flaky_recovered != 'true'
+      uses: mikepenz/action-junit-report@v5
+      with:
+        report_paths: ${{ inputs.junit-path }}
+        include_passed: false
+        check_name: ${{ inputs.check-name }}
+
+    - name: Report test annotations (flaky recovered)
+      if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+      uses: mikepenz/action-junit-report@v5
+      with:
+        report_paths: ${{ inputs.junit-path }}
+        include_passed: false
+        check_name: ${{ inputs.check-name }}
+        annotate_only: true
+
+    - name: Post neutral check (flaky recovered)
+      if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        CHECK_NAME: ${{ inputs.check-name }}
+        REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        gh api --method POST "repos/$REPO/check-runs" --input - <<EOF
+        {
+          "name": "$CHECK_NAME",
+          "head_sha": "$HEAD_SHA",
+          "status": "completed",
+          "conclusion": "neutral",
+          "output": {
+            "title": "Tests passed after flaky retries",
+            "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"$CHECK_NAME\" annotations for details."
+          }
+        }
+        EOF

--- a/.github/actions/report-flaky-aware-tests/action.yml
+++ b/.github/actions/report-flaky-aware-tests/action.yml
@@ -74,16 +74,22 @@ runs:
         CHECK_NAME: ${{ inputs.check-name }}
         REPO: ${{ github.repository }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      # Build the JSON body with `jq -n --arg` so that any special characters
+      # in $CHECK_NAME (quotes, backslashes, etc.) are properly escaped rather
+      # than interpolated raw into a JSON string literal. `jq` is preinstalled
+      # on GitHub-hosted runners.
       run: |
-        gh api --method POST "repos/$REPO/check-runs" --input - <<EOF
-        {
-          "name": "$CHECK_NAME",
-          "head_sha": "$HEAD_SHA",
-          "status": "completed",
-          "conclusion": "neutral",
-          "output": {
-            "title": "Tests passed after flaky retries",
-            "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"$CHECK_NAME\" annotations for details."
-          }
-        }
-        EOF
+        jq -n \
+          --arg name "$CHECK_NAME" \
+          --arg head_sha "$HEAD_SHA" \
+          --arg summary "One or more tests failed on first attempt but passed on retry. See job logs and the \"$CHECK_NAME\" annotations for details." \
+          '{
+            name: $name,
+            head_sha: $head_sha,
+            status: "completed",
+            conclusion: "neutral",
+            output: {
+              title: "Tests passed after flaky retries",
+              summary: $summary
+            }
+          }' | gh api --method POST "repos/$REPO/check-runs" --input -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           restore-keys: offload-durations-${{ github.ref }}-
 
       - name: Run tests via offload
+        id: tests
         run: just test-offload
 
       - name: Save offload test durations for next run
@@ -79,13 +80,57 @@ jobs:
           uv run coverage combine .coverage.*
           uv run coverage report --rcfile=libs/mngr/pyproject.toml --fail-under=80
 
-      - name: Report test results
+      # Detect flaky-recovered case: the test step succeeded (offload exit 0 or
+      # 2) but junit still records failing attempts. Exit 2 means offload retried
+      # flaky tests and they ultimately passed; we want a neutral (yellow) check
+      # rather than a red one in that case.
+      - name: Detect flaky-recovered tests
+        id: flaky
         if: always()
+        run: |
+          if [ "${{ steps.tests.outcome }}" = "success" ] \
+              && [ -f test-results/junit.xml ] \
+              && grep -qE '<(failure|error)[ >/]' test-results/junit.xml; then
+            echo "is_flaky_recovered=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_flaky_recovered=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report test results
+        if: always() && steps.flaky.outputs.is_flaky_recovered != 'true'
         uses: mikepenz/action-junit-report@v5
         with:
           report_paths: test-results/junit.xml
           include_passed: false
           check_name: Unit + Integration Tests
+
+      - name: Report test annotations (flaky recovered)
+        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: test-results/junit.xml
+          include_passed: false
+          check_name: Unit + Integration Tests
+          annotate_only: true
+
+      - name: Post neutral check (flaky recovered)
+        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          gh api --method POST "repos/${{ github.repository }}/check-runs" --input - <<EOF
+          {
+            "name": "Unit + Integration Tests",
+            "head_sha": "$sha",
+            "status": "completed",
+            "conclusion": "neutral",
+            "output": {
+              "title": "Tests passed after flaky retries",
+              "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"Unit + Integration Tests\" annotations for details."
+            }
+          }
+          EOF
 
       - name: Upload test results
         if: always()
@@ -179,6 +224,7 @@ jobs:
           restore-keys: offload-acceptance-durations-${{ github.ref }}-
 
       - name: Run acceptance tests via offload
+        id: tests
         run: just test-offload-acceptance
 
       - name: Save offload test durations for next run
@@ -188,13 +234,54 @@ jobs:
           path: test-results/junit.xml
           key: offload-acceptance-durations-${{ github.ref }}-${{ github.run_id }}
 
-      - name: Report test results
+      # See "Detect flaky-recovered tests" in the test-offload job for rationale.
+      - name: Detect flaky-recovered tests
+        id: flaky
         if: always()
+        run: |
+          if [ "${{ steps.tests.outcome }}" = "success" ] \
+              && [ -f test-results/junit.xml ] \
+              && grep -qE '<(failure|error)[ >/]' test-results/junit.xml; then
+            echo "is_flaky_recovered=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_flaky_recovered=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report test results
+        if: always() && steps.flaky.outputs.is_flaky_recovered != 'true'
         uses: mikepenz/action-junit-report@v5
         with:
           report_paths: test-results/junit.xml
           include_passed: false
           check_name: Acceptance Tests
+
+      - name: Report test annotations (flaky recovered)
+        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: test-results/junit.xml
+          include_passed: false
+          check_name: Acceptance Tests
+          annotate_only: true
+
+      - name: Post neutral check (flaky recovered)
+        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="${{ github.event.pull_request.head.sha || github.sha }}"
+          gh api --method POST "repos/${{ github.repository }}/check-runs" --input - <<EOF
+          {
+            "name": "Acceptance Tests",
+            "head_sha": "$sha",
+            "status": "completed",
+            "conclusion": "neutral",
+            "output": {
+              "title": "Tests passed after flaky retries",
+              "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"Acceptance Tests\" annotations for details."
+            }
+          }
+          EOF
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,57 +80,14 @@ jobs:
           uv run coverage combine .coverage.*
           uv run coverage report --rcfile=libs/mngr/pyproject.toml --fail-under=80
 
-      # Detect flaky-recovered case: the test step succeeded (offload exit 0 or
-      # 2) but junit still records failing attempts. Exit 2 means offload retried
-      # flaky tests and they ultimately passed; we want a neutral (yellow) check
-      # rather than a red one in that case.
-      - name: Detect flaky-recovered tests
-        id: flaky
+      - name: Report test results (neutral on flaky recovery)
         if: always()
-        run: |
-          if [ "${{ steps.tests.outcome }}" = "success" ] \
-              && [ -f test-results/junit.xml ] \
-              && grep -qE '<(failure|error)[ >/]' test-results/junit.xml; then
-            echo "is_flaky_recovered=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_flaky_recovered=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Report test results
-        if: always() && steps.flaky.outputs.is_flaky_recovered != 'true'
-        uses: mikepenz/action-junit-report@v5
+        uses: ./.github/actions/report-flaky-aware-tests
         with:
-          report_paths: test-results/junit.xml
-          include_passed: false
-          check_name: Unit + Integration Tests
-
-      - name: Report test annotations (flaky recovered)
-        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
-        uses: mikepenz/action-junit-report@v5
-        with:
-          report_paths: test-results/junit.xml
-          include_passed: false
-          check_name: Unit + Integration Tests
-          annotate_only: true
-
-      - name: Post neutral check (flaky recovered)
-        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sha="${{ github.event.pull_request.head.sha || github.sha }}"
-          gh api --method POST "repos/${{ github.repository }}/check-runs" --input - <<EOF
-          {
-            "name": "Unit + Integration Tests",
-            "head_sha": "$sha",
-            "status": "completed",
-            "conclusion": "neutral",
-            "output": {
-              "title": "Tests passed after flaky retries",
-              "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"Unit + Integration Tests\" annotations for details."
-            }
-          }
-          EOF
+          check-name: Unit + Integration Tests
+          junit-path: test-results/junit.xml
+          tests-outcome: ${{ steps.tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
         if: always()
@@ -234,54 +191,14 @@ jobs:
           path: test-results/junit.xml
           key: offload-acceptance-durations-${{ github.ref }}-${{ github.run_id }}
 
-      # See "Detect flaky-recovered tests" in the test-offload job for rationale.
-      - name: Detect flaky-recovered tests
-        id: flaky
+      - name: Report test results (neutral on flaky recovery)
         if: always()
-        run: |
-          if [ "${{ steps.tests.outcome }}" = "success" ] \
-              && [ -f test-results/junit.xml ] \
-              && grep -qE '<(failure|error)[ >/]' test-results/junit.xml; then
-            echo "is_flaky_recovered=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_flaky_recovered=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Report test results
-        if: always() && steps.flaky.outputs.is_flaky_recovered != 'true'
-        uses: mikepenz/action-junit-report@v5
+        uses: ./.github/actions/report-flaky-aware-tests
         with:
-          report_paths: test-results/junit.xml
-          include_passed: false
-          check_name: Acceptance Tests
-
-      - name: Report test annotations (flaky recovered)
-        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
-        uses: mikepenz/action-junit-report@v5
-        with:
-          report_paths: test-results/junit.xml
-          include_passed: false
-          check_name: Acceptance Tests
-          annotate_only: true
-
-      - name: Post neutral check (flaky recovered)
-        if: always() && steps.flaky.outputs.is_flaky_recovered == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sha="${{ github.event.pull_request.head.sha || github.sha }}"
-          gh api --method POST "repos/${{ github.repository }}/check-runs" --input - <<EOF
-          {
-            "name": "Acceptance Tests",
-            "head_sha": "$sha",
-            "status": "completed",
-            "conclusion": "neutral",
-            "output": {
-              "title": "Tests passed after flaky retries",
-              "summary": "One or more tests failed on first attempt but passed on retry. See job logs and the \"Acceptance Tests\" annotations for details."
-            }
-          }
-          EOF
+          check-name: Acceptance Tests
+          junit-path: test-results/junit.xml
+          tests-outcome: ${{ steps.tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ jobs:
   test-offload:
     if: github.ref != 'refs/heads/release'
     runs-on: ubuntu-latest
+    # `checks: write` is required by the report-flaky-aware-tests composite
+    # action: both its `mikepenz/action-junit-report@v5` invocations and its
+    # `gh api POST /repos/.../check-runs` call need it. `contents: read` is
+    # the minimum needed by actions/checkout. Declaring permissions
+    # explicitly avoids depending on the repo-level default, which may be
+    # restricted (contents: read only).
+    permissions:
+      contents: read
+      checks: write
     env:
       MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -129,6 +138,12 @@ jobs:
   test-offload-acceptance:
     if: github.ref != 'refs/heads/release'
     runs-on: ubuntu-latest
+    # See note on `test-offload` above: the report-flaky-aware-tests
+    # composite action needs `checks: write` to post both its junit-report
+    # check-run and (on flaky-recovered runs) its neutral check-run.
+    permissions:
+      contents: read
+      checks: write
     env:
       MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}


### PR DESCRIPTION
## Summary
- When offload retries flaky tests and they eventually pass (exit code 2), the job succeeds, but `mikepenz/action-junit-report` still posts the `Unit + Integration Tests` / `Acceptance Tests` check as **failure** (red) because `junit.xml` records the failed first attempt.
- Example: [PR #1337, check run 72186281622](https://github.com/imbue-ai/mngr/pull/1337/checks?check_run_id=72186281622) showed red for a `ConnectionResetError` on `raw.githubusercontent.com` that passed on retry.
- This change detects the flaky-recovered case (test step succeeded but `junit.xml` has `<failure>`/`<error>` elements) and posts a **neutral** (yellow) check instead of red, while still attaching annotations so the underlying failure is visible.
- Neutral checks count as success for branch protection, so this does not weaken merge gating.

## How it works
For each of the two `action-junit-report` sites (`test-offload` and `test-offload-acceptance`):
1. Give the test run step `id: tests` so its `outcome` is visible downstream.
2. Add a `Detect flaky-recovered tests` step that sets `is_flaky_recovered=true` when `steps.tests.outcome == 'success'` **and** `junit.xml` contains `<failure>` or `<error>` tags.
3. If not flaky-recovered: run `action-junit-report` as before (posts green or red check).
4. If flaky-recovered: run `action-junit-report` with `annotate_only: true` (annotations only, no check run) and then post a neutral check run with the original check name via `gh api`.

## Test plan
- [ ] Merge triggers CI. Verify: on a PR with no flakes, `Unit + Integration Tests` and `Acceptance Tests` remain green.
- [ ] Verify manually (e.g. by re-running CI on a PR with a known flaky test, such as #1337) that the check goes yellow (neutral) instead of red when a flaky test is retried to success.
- [ ] Verify that a genuine, unrecovered failure still produces a red check.

Generated with [Claude Code](https://claude.com/claude-code)