### PR TITLE
mark test that creates real notifications as release instead of acceptance

### DIFF
--- a/libs/mngr_notifications/imbue/mngr_notifications/test_notify.py
+++ b/libs/mngr_notifications/imbue/mngr_notifications/test_notify.py
@@ -12,7 +12,7 @@ from imbue.mngr_notifications.mock_notifier_test import RecordingNotifier
 from imbue.mngr_notifications.watcher import watch_for_waiting_agents
 
 
-@pytest.mark.acceptance
+@pytest.mark.release
 def test_watcher_detects_running_to_waiting_via_observe_events(
     temp_mngr_ctx: MngrContext,
 ) -> None:


### PR DESCRIPTION
## Summary
- Flip `@pytest.mark.acceptance` to `@pytest.mark.release` on `test_watcher_detects_running_to_waiting_via_observe_events` in `libs/mngr_notifications/imbue/mngr_notifications/test_notify.py`.

## Test plan
- [ ] CI runs the test under the release suite.

Generated with [Claude Code](https://claude.com/claude-code)