### PR TITLE
fix kanpan regression + require uniform dict inputs instead of a mix of dict and typed

### DIFF
--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
@@ -123,7 +123,7 @@ class KanpanPluginConfig(PluginConfig):
         "Each entry should have 'name', 'header', and 'command' (all str).",
     )
 
-    columns: dict[str, Any] = Field(
+    columns: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
         description="Label-backed columns keyed by field key. "
         "Each entry should have 'header' (str) and optionally 'colors' (dict[str, str]).",

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
@@ -55,21 +55,15 @@ class BoardSnapshot(FrozenModel):
 
 
 class DataSourceConfig(FrozenModel):
-    """Generic configuration for a data source (enable/disable only).
+    """Base configuration for a data source (enable/disable only).
 
-    Source-specific configuration (e.g. GitHub field toggles) is owned by
-    each data source implementation and read directly from the config dict.
+    Used as the base class for source-specific configs (e.g. GitHubDataSourceConfig)
+    that add their own fields. User-facing `KanpanPluginConfig.data_sources` stores
+    raw dicts because the TOML loader uses ``model_construct`` and each source parses
+    its own shape.
     """
 
     enabled: bool = Field(default=True, description="Whether this data source is enabled")
-
-
-class ShellCommandSourceConfig(FrozenModel):
-    """Configuration for a shell command data source."""
-
-    name: str = Field(description="Human-readable name")
-    header: str = Field(description="Column header text")
-    command: str = Field(description="Shell command to run per agent")
 
 
 class CustomCommand(FrozenModel):
@@ -118,13 +112,15 @@ class KanpanPluginConfig(PluginConfig):
         default=60.0,
         description="Minimum seconds before retrying after a failed full refresh",
     )
-    data_sources: dict[str, DataSourceConfig] = Field(
+    data_sources: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
-        description="Data source configurations keyed by source name (e.g. 'github', 'repo_paths')",
+        description="Data source configurations keyed by source name (e.g. 'github', 'repo_paths'). "
+        "Each entry is a raw dict -- source-specific fields are parsed by the matching data source.",
     )
-    shell_commands: dict[str, ShellCommandSourceConfig] = Field(
+    shell_commands: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
-        description="Shell command data sources keyed by field key",
+        description="Shell command data sources keyed by field key. "
+        "Each entry should have 'name', 'header', and 'command' (all str).",
     )
 
     columns: dict[str, Any] = Field(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types_test.py
@@ -11,9 +11,7 @@ from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_types import AgentBoardEntry
 from imbue.mngr_kanpan.data_types import BoardSection
 from imbue.mngr_kanpan.data_types import BoardSnapshot
-from imbue.mngr_kanpan.data_types import DataSourceConfig
 from imbue.mngr_kanpan.data_types import KanpanPluginConfig
-from imbue.mngr_kanpan.data_types import ShellCommandSourceConfig
 
 
 def test_ci_status_color() -> None:
@@ -154,24 +152,24 @@ def test_kanpan_plugin_config_merge_with_section_order_none_keeps_base() -> None
 
 def test_kanpan_config_merge_with_data_sources() -> None:
     base = KanpanPluginConfig(
-        data_sources={"github": DataSourceConfig(enabled=True)},
+        data_sources={"github": {"enabled": True}},
     )
     override = KanpanPluginConfig(
-        data_sources={"github": DataSourceConfig(enabled=False)},
+        data_sources={"github": {"enabled": False}},
     )
     merged = base.merge_with(override)
-    assert merged.data_sources["github"].enabled is False
+    assert merged.data_sources["github"]["enabled"] is False
 
 
 def test_kanpan_config_merge_with_shell_commands() -> None:
     base = KanpanPluginConfig(
         shell_commands={
-            "slack": ShellCommandSourceConfig(name="Slack", header="SLACK", command="find-slack"),
+            "slack": {"name": "Slack", "header": "SLACK", "command": "find-slack"},
         },
     )
     override = KanpanPluginConfig(
         shell_commands={
-            "jira": ShellCommandSourceConfig(name="Jira", header="JIRA", command="find-jira"),
+            "jira": {"name": "Jira", "header": "JIRA", "command": "find-jira"},
         },
     )
     merged = base.merge_with(override)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -408,6 +408,31 @@ def test_plugin_kanpan_data_sources_with_github_config() -> None:
     assert any(s.name == "github" for s in result)
 
 
+def test_plugin_kanpan_data_sources_with_raw_dict_source_config() -> None:
+    """Regression: loader uses model_construct, so data_sources come in as raw dicts."""
+    config = KanpanPluginConfig.model_construct(
+        data_sources={"github": {"enabled": False}},
+        shell_commands={},
+        columns={},
+    )
+    ctx = make_mngr_ctx_with_config(config)
+    result = kanpan_data_sources(mngr_ctx=ctx)
+    assert result is not None
+    assert not any(s.name == "github" for s in result)
+
+
+def test_is_source_enabled_raw_dict_disabled() -> None:
+    """Regression: _is_source_enabled must handle raw dict values from the loader."""
+    config = KanpanPluginConfig.model_construct(data_sources={"github": {"enabled": False}})
+    assert _is_source_enabled(config, "github") is False
+
+
+def test_is_source_enabled_raw_dict_enabled_default() -> None:
+    """A raw dict without an 'enabled' key defaults to True."""
+    config = KanpanPluginConfig.model_construct(data_sources={"github": {"pr": True}})
+    assert _is_source_enabled(config, "github") is True
+
+
 def test_plugin_kanpan_data_sources_shell_config_as_dict() -> None:
     # Shell command config as a raw dict (tests the isinstance dict branch for shell)
     ctx: MngrContext = SimpleNamespace(  # ty: ignore[invalid-assignment]

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -15,14 +15,11 @@ from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
 from imbue.mngr_kanpan.data_source import StringField
 from imbue.mngr_kanpan.data_sources.github import CiField
 from imbue.mngr_kanpan.data_sources.github import CiStatus
-from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_sources.repo_paths import _parse_github_repo_path
 from imbue.mngr_kanpan.data_sources.repo_paths import repo_path_from_labels
 from imbue.mngr_kanpan.data_types import BoardSection
-from imbue.mngr_kanpan.data_types import DataSourceConfig
 from imbue.mngr_kanpan.data_types import KanpanPluginConfig
-from imbue.mngr_kanpan.data_types import ShellCommandSourceConfig
 from imbue.mngr_kanpan.fetcher import _get_local_work_dir
 from imbue.mngr_kanpan.fetcher import _is_agent_muted
 from imbue.mngr_kanpan.fetcher import _run_data_sources_parallel
@@ -364,17 +361,23 @@ def test_is_source_enabled_default() -> None:
 
 
 def test_is_source_enabled_dict_disabled() -> None:
-    config = KanpanPluginConfig(data_sources={"github": DataSourceConfig(enabled=False)})
+    config = KanpanPluginConfig(data_sources={"github": {"enabled": False}})
     assert _is_source_enabled(config, "github") is False
 
 
 def test_is_source_enabled_dict_enabled() -> None:
-    config = KanpanPluginConfig(data_sources={"github": DataSourceConfig(enabled=True)})
+    config = KanpanPluginConfig(data_sources={"github": {"enabled": True}})
+    assert _is_source_enabled(config, "github") is True
+
+
+def test_is_source_enabled_dict_missing_enabled_defaults_true() -> None:
+    """A raw dict without an 'enabled' key defaults to True (source-specific fields only)."""
+    config = KanpanPluginConfig(data_sources={"github": {"pr": True}})
     assert _is_source_enabled(config, "github") is True
 
 
 def test_plugin_excludes_disabled_github() -> None:
-    config = KanpanPluginConfig(data_sources={"github": DataSourceConfig(enabled=False)})
+    config = KanpanPluginConfig(data_sources={"github": {"enabled": False}})
     ctx = make_mngr_ctx_with_config(config)
     result = kanpan_data_sources(mngr_ctx=ctx)
     assert result is not None
@@ -382,7 +385,7 @@ def test_plugin_excludes_disabled_github() -> None:
 
 
 def test_plugin_excludes_disabled_repo_paths() -> None:
-    config = KanpanPluginConfig(data_sources={"repo_paths": DataSourceConfig(enabled=False)})
+    config = KanpanPluginConfig(data_sources={"repo_paths": {"enabled": False}})
     ctx = make_mngr_ctx_with_config(config)
     result = kanpan_data_sources(mngr_ctx=ctx)
     assert result is not None
@@ -391,7 +394,7 @@ def test_plugin_excludes_disabled_repo_paths() -> None:
 
 def test_plugin_kanpan_data_sources_with_shell_commands() -> None:
     config = KanpanPluginConfig(
-        shell_commands={"my_cmd": ShellCommandSourceConfig(name="My Command", header="CMD", command="echo hi")}
+        shell_commands={"my_cmd": {"name": "My Command", "header": "CMD", "command": "echo hi"}}
     )
     ctx = make_mngr_ctx_with_config(config)
     result = kanpan_data_sources(mngr_ctx=ctx)
@@ -401,15 +404,15 @@ def test_plugin_kanpan_data_sources_with_shell_commands() -> None:
 
 
 def test_plugin_kanpan_data_sources_with_github_config() -> None:
-    config = KanpanPluginConfig(data_sources={"github": GitHubDataSourceConfig(pr=True)})
+    config = KanpanPluginConfig(data_sources={"github": {"pr": True}})
     ctx = make_mngr_ctx_with_config(config)
     result = kanpan_data_sources(mngr_ctx=ctx)
     assert result is not None
     assert any(s.name == "github" for s in result)
 
 
-def test_plugin_kanpan_data_sources_with_raw_dict_source_config() -> None:
-    """Regression: loader uses model_construct, so data_sources come in as raw dicts."""
+def test_plugin_kanpan_data_sources_from_loader_path() -> None:
+    """Regression: loader uses model_construct, so configs may reach the plugin via that path."""
     config = KanpanPluginConfig.model_construct(
         data_sources={"github": {"enabled": False}},
         shell_commands={},
@@ -419,33 +422,6 @@ def test_plugin_kanpan_data_sources_with_raw_dict_source_config() -> None:
     result = kanpan_data_sources(mngr_ctx=ctx)
     assert result is not None
     assert not any(s.name == "github" for s in result)
-
-
-def test_is_source_enabled_raw_dict_disabled() -> None:
-    """Regression: _is_source_enabled must handle raw dict values from the loader."""
-    config = KanpanPluginConfig.model_construct(data_sources={"github": {"enabled": False}})
-    assert _is_source_enabled(config, "github") is False
-
-
-def test_is_source_enabled_raw_dict_enabled_default() -> None:
-    """A raw dict without an 'enabled' key defaults to True."""
-    config = KanpanPluginConfig.model_construct(data_sources={"github": {"pr": True}})
-    assert _is_source_enabled(config, "github") is True
-
-
-def test_plugin_kanpan_data_sources_shell_config_as_dict() -> None:
-    # Shell command config as a raw dict (tests the isinstance dict branch for shell)
-    ctx: MngrContext = SimpleNamespace(  # ty: ignore[invalid-assignment]
-        get_plugin_config=lambda name, cls: SimpleNamespace(
-            data_sources={},
-            shell_commands={"my_cmd": {"name": "My Command", "header": "CMD", "command": "echo hi"}},
-            columns={},
-        )
-    )
-    result = kanpan_data_sources(mngr_ctx=ctx)
-    assert result is not None
-    names = [s.name for s in result]
-    assert "shell_my_cmd" in names
 
 
 # === save_field_cache / load_field_cache ===

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
@@ -24,11 +24,18 @@ register_plugin_config("kanpan", KanpanPluginConfig)
 
 
 def _is_source_enabled(config: KanpanPluginConfig, name: str) -> bool:
-    """Check if a data source is enabled in the plugin config."""
+    """Check if a data source is enabled in the plugin config.
+
+    `data_sources` values arrive as raw dicts from the TOML loader (which uses
+    ``model_construct`` and skips nested coercion) but as ``DataSourceConfig``
+    instances when built in tests or in-code. Handle both.
+    """
     source_config = config.data_sources.get(name)
-    if source_config is not None:
-        return source_config.enabled
-    return True
+    if source_config is None:
+        return True
+    if isinstance(source_config, dict):
+        return source_config.get("enabled", True)
+    return source_config.enabled
 
 
 @hookimpl

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
@@ -18,24 +18,16 @@ from imbue.mngr_kanpan.data_sources.repo_paths import RepoPathsDataSource
 from imbue.mngr_kanpan.data_sources.shell import ShellCommandConfig
 from imbue.mngr_kanpan.data_sources.shell import ShellCommandDataSource
 from imbue.mngr_kanpan.data_types import KanpanPluginConfig
-from imbue.mngr_kanpan.data_types import ShellCommandSourceConfig
 
 register_plugin_config("kanpan", KanpanPluginConfig)
 
 
 def _is_source_enabled(config: KanpanPluginConfig, name: str) -> bool:
-    """Check if a data source is enabled in the plugin config.
-
-    `data_sources` values arrive as raw dicts from the TOML loader (which uses
-    ``model_construct`` and skips nested coercion) but as ``DataSourceConfig``
-    instances when built in tests or in-code. Handle both.
-    """
+    """Check if a data source is enabled in the plugin config."""
     source_config = config.data_sources.get(name)
     if source_config is None:
         return True
-    if isinstance(source_config, dict):
-        return source_config.get("enabled", True)
-    return source_config.enabled
+    return source_config.get("enabled", True)
 
 
 @hookimpl
@@ -67,21 +59,16 @@ def kanpan_data_sources(mngr_ctx: MngrContext) -> Sequence[Any] | None:
         sources.append(GitInfoDataSource())
 
     if _is_source_enabled(config, "github"):
-        github_config_raw = config.data_sources.get("github")
-        if isinstance(github_config_raw, dict):
-            github_ds_config = GitHubDataSourceConfig(**github_config_raw)
-        else:
-            github_ds_config = GitHubDataSourceConfig()
-        sources.append(GitHubDataSource(config=github_ds_config))
+        github_raw = config.data_sources.get("github") or {}
+        sources.append(GitHubDataSource(config=GitHubDataSourceConfig(**github_raw)))
 
     # Label-backed columns from config
     for field_key, col_config in config.columns.items():
-        if isinstance(col_config, dict):
-            header = col_config.get("header", field_key.upper())
-            colors = col_config.get("colors", {})
-            label_key = col_config.get("label_key", field_key)
-        else:
+        if not isinstance(col_config, dict):
             continue
+        header = col_config.get("header", field_key.upper())
+        colors = col_config.get("colors", {})
+        label_key = col_config.get("label_key", field_key)
         sources.append(
             LabelsDataSource(
                 field_key=field_key,
@@ -91,16 +78,6 @@ def kanpan_data_sources(mngr_ctx: MngrContext) -> Sequence[Any] | None:
 
     # Shell command data sources from config
     for field_key, shell_config in config.shell_commands.items():
-        if isinstance(shell_config, ShellCommandSourceConfig):
-            sc = ShellCommandConfig(
-                name=shell_config.name,
-                header=shell_config.header,
-                command=shell_config.command,
-            )
-        elif isinstance(shell_config, dict):
-            sc = ShellCommandConfig(**shell_config)
-        else:
-            continue
-        sources.append(ShellCommandDataSource(field_key=field_key, config=sc))
+        sources.append(ShellCommandDataSource(field_key=field_key, config=ShellCommandConfig(**shell_config)))
 
     return sources

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/plugin.py
@@ -64,8 +64,6 @@ def kanpan_data_sources(mngr_ctx: MngrContext) -> Sequence[Any] | None:
 
     # Label-backed columns from config
     for field_key, col_config in config.columns.items():
-        if not isinstance(col_config, dict):
-            continue
         header = col_config.get("header", field_key.upper())
         colors = col_config.get("colors", {})
         label_key = col_config.get("label_key", field_key)


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'dict' object has no attribute 'enabled'` in `_is_source_enabled` when a user configures any data source under `[plugins.kanpan.*]` in TOML. Root cause: the plugin config's declared field types (`dict[str, DataSourceConfig]`, `dict[str, ShellCommandSourceConfig]`, `dict[str, Any]`) did not match the runtime shape produced by the TOML loader, which uses `model_construct` and stores raw dicts. Only tests ever exercised the declared shape.

## Approach

Align types with reality rather than fight the loader.

- `c609c6ec2` — Restore the defensive raw-dict branch in `_is_source_enabled` that a prior commit removed on a false premise.
- `a8c01ed84` — Retype `data_sources` and `shell_commands` on `KanpanPluginConfig` as `dict[str, dict[str, Any]]`. Delete `ShellCommandSourceConfig` (duplicate of `ShellCommandConfig` in `data_sources/shell.py`; only tests used it). Collapse the dual-isinstance branches in `plugin.py` to a single dict path. Rewrite tests to pass raw dicts instead of model instances; add a `model_construct` regression test.
- `eff99ad70` — Same treatment for `columns`: retype `dict[str, dict[str, Any]]`, drop the `isinstance(col_config, dict)` defensive check.

`DataSourceConfig` is kept as the base class for `GitHubDataSourceConfig` (source-specific fields like `pr`, `ci`, `conflicts`, `unresolved`).

## Why not fix the loader?

`DataSourceConfig` has `extra=\"forbid\"` but `GitHubDataSourceConfig` adds source-specific fields. If `_parse_plugins` used `model_validate`, any user TOML `[plugins.kanpan.data_sources.github]` block containing `pr = true` would be rejected. Source-specific configs are parsed by each data source at the point of use; this PR makes the type annotations honest about that.

## Test plan

- [x] `just test-offload` — 7430 passed, 0 failed.
- [x] Architecture verified (independent agent).
- [x] Autofix clean.
- [ ] CI green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>