### PR TITLE
Fix workspace server mngr observe subprocess never running

### DIFF
--- a/apps/minds/docs/desktop-app.md
+++ b/apps/minds/docs/desktop-app.md
@@ -37,15 +37,28 @@ When accessing an agent URL in a regular browser (not the Electron app), the Pyt
 
 ### Shutdown
 
-When the user closes the window, Electron sends SIGTERM to the backend process and waits up to 5 seconds. If the process doesn't exit, SIGKILL is sent.
+Closing an individual window just tears down that window's views -- the backend keeps running while any window is open. When the last window closes (or the user issues `Cmd+Q` / `Ctrl+Q`), Electron sends SIGTERM to the backend process and waits up to 5 seconds. If the process doesn't exit, SIGKILL is sent.
 
 ### Crash recovery
 
-If the backend exits unexpectedly, Electron shows an error screen with the last lines from the log file and a "Retry" button that restarts the backend.
+If the backend exits unexpectedly, every open window switches to the error screen (chrome view expanded to fill the window, content/sidebar/requests-panel views torn down) with the last lines from the log file. Clicking "Retry" from any window restarts the backend once; on success every window reloads to its pre-error URL.
 
 ### Keyboard shortcuts
 
 - **Open DevTools**: `Ctrl+Shift+C` (Windows/Linux) or `Cmd+Option+I` (macOS)
+- **New Window**: `Ctrl+N` / `Cmd+N` -- opens a fresh window on the home page. Also available on macOS via `File > New Window` and the dock icon's right-click menu.
+- **Close Window**: `Ctrl+W` / `Cmd+W` -- closes the focused window; the backend keeps running until the last window closes.
+- **Quit**: `Ctrl+Q` / `Cmd+Q` -- closes every window and shuts the backend down.
+
+### Multi-window behavior
+
+Each workspace (`/forwarding/{agent-id}/...`) can live in its own window. Uniqueness is enforced across the app: at most one window per workspace.
+
+- **Open in a new window** (from the sidebar): right-click a workspace entry for a native `Open in new window` context menu, or click the hover-revealed icon on the right of the row. Both are suppressed on the entry matching the window's current workspace.
+- **Open a blank window**: cmd+N / ctrl+N, `File > New Window`, or the macOS dock menu. Opens a window on the backend's home page (`/`).
+- **Plain sidebar click**: navigates the current window to that workspace -- unless some other window is already on it, in which case that window is focused and the sender is untouched.
+- **Notifications** pointing at `/forwarding/{X}/...` focus the existing window for workspace `X`, or open a new one. Non-workspace notification URLs and `auth_required` events navigate the most-recently-focused window.
+- **Session restore**: on quit, every open window's content URL is recorded to `~/.<MINDS_ROOT_NAME>/window-state.json`. On next launch (after the backend is ready) one window is reopened per recorded URL. URLs pointing at workspaces that no longer exist are silently dropped.
 
 ### Environment variables
 
@@ -83,6 +96,7 @@ All desktop app state lives in `~/.<MINDS_ROOT_NAME>/` (default: `~/.minds/`):
     minds-events.jsonl    # Structured JSONL event log
   auth/                   # Cookie signing key, one-time codes
   config.toml             # Optional minds config (cloudflare/supertokens URLs)
+  window-state.json       # Per-window content URLs, restored on next launch
   mngr/                   # mngr host directory (MNGR_HOST_DIR)
     agents/               # per-agent state managed by mngr
   <agent-id>/             # Per-agent workspace directories

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -492,6 +492,28 @@ function sendCurrentWorkspaceToBundleSidebar(bundle) {
 
 // -- Window opening / focusing --
 
+function loadUrlIntoBundleContentView(bundle, url) {
+  // Stamp the intended workspace synchronously so subsequent
+  // findBundleForWorkspace lookups see this bundle as occupying the workspace
+  // BEFORE its content view has fired did-navigate. Otherwise a second
+  // openOrFocusWorkspace / landing-click / notification-click arriving during
+  // the load window wouldn't see the pending bundle and would spawn a duplicate.
+  // Applies to every content-view loadURL aimed at a workspace URL, including
+  // session restore into the initial bundle.
+  if (!bundle) return;
+  const intendedAgentId = parseWorkspaceId(url);
+  if (intendedAgentId) {
+    bundle.currentWorkspaceId = intendedAgentId;
+    bundle.currentContentUrl = url;
+    bundle.preErrorUrl = url;
+    updateOsTitle(bundle);
+    sendCurrentWorkspaceToBundleSidebar(bundle);
+  }
+  if (bundle.contentView && !bundle.contentView.webContents.isDestroyed() && url) {
+    bundle.contentView.webContents.loadURL(url);
+  }
+}
+
 function openOrFocusWorkspace(agentId, url) {
   const existing = findBundleForWorkspace(agentId);
   if (existing) {
@@ -506,24 +528,10 @@ function openNewWindow(url) {
   const bundle = createBundle();
   bundle.isLoadingState = false;
   updateBundleBounds(bundle);
-  // Stamp the intended workspace synchronously so subsequent
-  // findBundleForWorkspace lookups see this window as occupying the workspace
-  // BEFORE its content view has fired did-navigate. Otherwise a second
-  // openOrFocusWorkspace / landing-click / notification-click arriving during
-  // the load window wouldn't see the pending bundle and would spawn a duplicate.
-  const intendedAgentId = parseWorkspaceId(url);
-  if (intendedAgentId) {
-    bundle.currentWorkspaceId = intendedAgentId;
-    bundle.currentContentUrl = url;
-    bundle.preErrorUrl = url;
-    updateOsTitle(bundle);
-  }
   if (bundle.chromeView && backendBaseUrl) {
     bundle.chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
   }
-  if (bundle.contentView && url) {
-    bundle.contentView.webContents.loadURL(url);
-  }
+  loadUrlIntoBundleContentView(bundle, url);
   return bundle;
 }
 
@@ -1081,9 +1089,7 @@ async function startBackendWithRetry() {
         }
       } else {
         const [first, ...rest] = restorable;
-        if (initialBundle.contentView && !initialBundle.contentView.webContents.isDestroyed()) {
-          initialBundle.contentView.webContents.loadURL(toAbsoluteUrl(first.url));
-        }
+        loadUrlIntoBundleContentView(initialBundle, toAbsoluteUrl(first.url));
         for (const entry of rest) {
           openNewWindow(toAbsoluteUrl(entry.url));
         }

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -247,6 +247,14 @@ function createBundle() {
   // destruction of child WebContentsView render processes on its own; leaking
   // them across create/close cycles eventually starves new ones of resources.
   win.on('close', () => {
+    // Snapshot session state on every manual window close: by the time
+    // `before-quit` fires on the `window-all-closed` path, every bundle has
+    // already been removed from `bundles` by its `closed` handler, so saving
+    // there would clobber the file with `[]`. Skip when we're tearing down as
+    // part of a `cmd+Q` / crash quit -- `before-quit` already saved the full
+    // set and we must not overwrite it with a progressively shrinking snapshot
+    // as the teardown closes each window.
+    if (!isShuttingDown) saveSessionState();
     const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView];
     for (const view of views) {
       if (!view) continue;
@@ -1297,8 +1305,12 @@ app.on('window-all-closed', async () => {
 
 app.on('before-quit', async (event) => {
   console.log('[lifecycle] before-quit fired, isShuttingDown=' + isShuttingDown + ', hasBackend=' + !!getBackendProcess());
-  // Capture session state for every open window before teardown.
-  saveSessionState();
+  // Capture session state for every open window before teardown. Only save
+  // when bundles is non-empty: on the `window-all-closed` -> `app.quit()`
+  // path, every bundle has already been removed from the Set by its `closed`
+  // handler (and the per-window `close` handler already wrote the last
+  // non-empty snapshot), so saving here would just clobber it with `[]`.
+  if (bundles.size > 0) saveSessionState();
   if (getBackendProcess() && !isShuttingDown) {
     isShuttingDown = true;
     event.preventDefault();

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1,4 +1,4 @@
-const { BaseWindow, WebContentsView, Menu, Notification, ipcMain, shell } = require('electron');
+const { BaseWindow, WebContentsView, Menu, Notification, ipcMain, net, shell, app } = require('electron');
 const todesktop = require('@todesktop/runtime');
 const path = require('path');
 const fs = require('fs');
@@ -8,44 +8,173 @@ const { startBackend, shutdown, getBackendProcess } = require('./backend');
 
 todesktop.init();
 
-let mainWindow = null;
-let chromeView = null;
-let contentView = null;
-let sidebarView = null;
-let requestsPanelView = null;
-let backendBaseUrl = null;
-
 const isMac = process.platform === 'darwin';
 const TITLEBAR_HEIGHT = 38;
 const SIDEBAR_WIDTH = 260;
 const REQUESTS_PANEL_WIDTH = 320;
 
-// -- Single instance lock --
-const gotLock = require('electron').app.requestSingleInstanceLock();
-if (!gotLock) {
-  require('electron').app.quit();
-} else {
-  require('electron').app.on('second-instance', () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
-  });
+// -- Per-window bundle registry --
+const bundles = new Set();
+const mruWindows = []; // most recently focused first
+let appMenuInstalled = false;
 
-  require('electron').app.whenReady().then(onReady);
+let backendBaseUrl = null;
+let backendPort = null;
+let workspaceList = []; // [{id, name, account}]
+let isShuttingDown = false;
+let initialBundle = null; // the first window created at startup
+let hasCompletedInitialStart = false;
+
+// Central cache of the latest SSE state from /_chrome/events so newly-loaded
+// chrome/sidebar webContents can be primed without opening their own SSE
+// connection.
+const latestChromeState = {
+  workspaces: null, // most recent workspaces payload
+  authStatus: null, // most recent auth_status payload
+  requestCount: 0,  // most recent request_count value
+};
+
+let chromeSseAbortRef = { current: null };
+let chromeSseReconnectTick = 0; // bumped to interrupt the current wait
+
+function getSessionStatePath() {
+  return path.join(paths.getDataDir(), 'window-state.json');
 }
 
-async function onReady() {
-  if (!isMac || process.env.MINDS_HIDE_MENU === '1') {
-    Menu.setApplicationMenu(null);
+// -- URL/workspace helpers --
+
+function parseWorkspaceId(url) {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    const m = parsed.pathname.match(/^\/forwarding\/([^\/]+)(?:\/|$)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(url) {
+  if (!url) return url;
+  if (url.startsWith('/') && backendBaseUrl) return backendBaseUrl + url;
+  return url;
+}
+
+function findBundleForWorkspace(agentId) {
+  if (!agentId) return null;
+  for (const b of bundles) {
+    if (!b.window.isDestroyed() && b.currentWorkspaceId === agentId) return b;
+  }
+  return null;
+}
+
+function getBundleFromEvent(event) {
+  if (!event || !event.sender) return null;
+  const senderId = event.sender.id;
+  for (const b of bundles) {
+    if (b.window.isDestroyed()) continue;
+    const views = [b.chromeView, b.contentView, b.sidebarView, b.requestsPanelView];
+    for (const v of views) {
+      if (!v) continue;
+      if (v.webContents.isDestroyed()) continue;
+      if (v.webContents.id === senderId) return b;
+    }
+  }
+  return null;
+}
+
+function getMostRecentWindow() {
+  for (const b of mruWindows) {
+    if (!b.window.isDestroyed()) return b;
+  }
+  for (const b of bundles) {
+    if (!b.window.isDestroyed()) return b;
+  }
+  return null;
+}
+
+function focusBundle(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (bundle.window.isMinimized()) bundle.window.restore();
+  if (!bundle.window.isVisible()) bundle.window.show();
+  bundle.window.focus();
+}
+
+
+// -- Title handling --
+
+function computeTitleFor(bundle) {
+  const agentId = bundle.currentWorkspaceId;
+  if (agentId) {
+    const ws = workspaceList.find((w) => w.id === agentId);
+    const name = ws ? (ws.name || ws.id) : null;
+    return name ? `${name} \u2014 Minds` : 'Minds';
+  }
+  return 'Minds';
+}
+
+function updateOsTitle(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  const title = computeTitleFor(bundle);
+  bundle.window.setTitle(title);
+  if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+    bundle.chromeView.webContents.send('window-title-changed', title);
+  }
+}
+
+function updateAllOsTitles() {
+  for (const b of bundles) updateOsTitle(b);
+}
+
+// -- Layout --
+
+function updateBundleBounds(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  const { width, height } = bundle.window.getContentBounds();
+
+  if (bundle.isErrorState || bundle.isLoadingState) {
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+      bundle.chromeView.setBounds({ x: 0, y: 0, width, height });
+    }
+    if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+      bundle.contentView.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+    }
+    return;
   }
 
-  createWindow();
-  registerShortcuts();
-  await runStartupSequence();
+  if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+    bundle.chromeView.setBounds({ x: 0, y: 0, width, height: TITLEBAR_HEIGHT });
+  }
+  if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+    const rightOffset = bundle.requestsPanelVisible ? REQUESTS_PANEL_WIDTH : 0;
+    bundle.contentView.setBounds({
+      x: 0,
+      y: TITLEBAR_HEIGHT,
+      width: width - rightOffset,
+      height: height - TITLEBAR_HEIGHT,
+    });
+  }
+  if (bundle.sidebarView && !bundle.sidebarView.webContents.isDestroyed()) {
+    bundle.sidebarView.setBounds({
+      x: 0,
+      y: TITLEBAR_HEIGHT,
+      width: SIDEBAR_WIDTH,
+      height: height - TITLEBAR_HEIGHT,
+    });
+  }
+  if (bundle.requestsPanelView && !bundle.requestsPanelView.webContents.isDestroyed()) {
+    bundle.requestsPanelView.setBounds({
+      x: width - REQUESTS_PANEL_WIDTH,
+      y: TITLEBAR_HEIGHT,
+      width: REQUESTS_PANEL_WIDTH,
+      height: height - TITLEBAR_HEIGHT,
+    });
+  }
 }
 
-function createWindow() {
+// -- Bundle lifecycle --
+
+function createBundle() {
   const windowOptions = {
     width: 1200,
     height: 800,
@@ -55,7 +184,6 @@ function createWindow() {
     show: false,
     autoHideMenuBar: true,
   };
-
   if (isMac) {
     windowOptions.titleBarStyle = 'hiddenInset';
     windowOptions.trafficLightPosition = { x: 12, y: (TITLEBAR_HEIGHT - 16) / 2 };
@@ -63,10 +191,9 @@ function createWindow() {
     windowOptions.frame = false;
   }
 
-  mainWindow = new BaseWindow(windowOptions);
+  const win = new BaseWindow(windowOptions);
 
-  // Create chrome view (title bar) -- loads /_chrome from backend
-  chromeView = new WebContentsView({
+  const chromeView = new WebContentsView({
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -74,319 +201,429 @@ function createWindow() {
     },
   });
 
-  // Create content view -- loads page content (landing page, workspaces, etc.)
-  contentView = new WebContentsView({
+  const contentView = new WebContentsView({
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
 
-  mainWindow.contentView.addChildView(chromeView);
-  mainWindow.contentView.addChildView(contentView);
+  win.contentView.addChildView(chromeView);
+  win.contentView.addChildView(contentView);
 
-  updateViewBounds();
+  const bundle = {
+    window: win,
+    chromeView,
+    contentView,
+    sidebarView: null,
+    sidebarVisible: false,
+    requestsPanelView: null,
+    requestsPanelVisible: false,
+    currentContentUrl: null,
+    currentWorkspaceId: null,
+    preErrorUrl: null,
+    isErrorState: false,
+    isLoadingState: true,
+    _maximizedByUs: false,
+    _boundsBeforeMaximize: null,
+  };
+  bundles.add(bundle);
+  mruWindows.unshift(bundle);
 
-  mainWindow._maximizedByUs = false;
-  mainWindow._boundsBeforeMaximize = null;
-  mainWindow.on('maximize', () => { mainWindow._maximizedByUs = true; });
-  mainWindow.on('unmaximize', () => { mainWindow._maximizedByUs = false; });
+  updateBundleBounds(bundle);
 
-  mainWindow.once('ready-to-show', () => {
-    console.log('[window] ready-to-show fired');
-    mainWindow.show();
+  win.on('focus', () => {
+    const idx = mruWindows.indexOf(bundle);
+    if (idx >= 0) mruWindows.splice(idx, 1);
+    mruWindows.unshift(bundle);
   });
 
-  // BaseWindow may not fire ready-to-show since it has no built-in web contents.
-  // Show the window immediately after a short delay as a fallback.
+  win.on('maximize', () => { bundle._maximizedByUs = true; });
+  win.on('unmaximize', () => { bundle._maximizedByUs = false; });
+  win.on('resize', () => updateBundleBounds(bundle));
+
+  // Run cleanup on `close` (before views are detached) rather than `closed`
+  // so we can still reach the child webContents. BaseWindow does not guarantee
+  // destruction of child WebContentsView render processes on its own; leaking
+  // them across create/close cycles eventually starves new ones of resources.
+  // Run cleanup on `close` (before views are detached) rather than `closed`
+  // so we can still reach the child webContents. BaseWindow does not guarantee
+  // destruction of child WebContentsView render processes on its own; leaking
+  // them across create/close cycles eventually starves new ones of resources.
+  win.on('close', () => {
+    const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView];
+    for (const view of views) {
+      if (!view) continue;
+      if (view.webContents.isDestroyed()) continue;
+      try {
+        view.webContents.close();
+      } catch { /* noop */ }
+    }
+  });
+
+  win.on('closed', () => {
+    bundles.delete(bundle);
+    const mruIdx = mruWindows.indexOf(bundle);
+    if (mruIdx >= 0) mruWindows.splice(mruIdx, 1);
+    if (initialBundle === bundle) initialBundle = null;
+  });
+
+  // Re-push the computed title when chrome finishes (re)loading; the in-window
+  // title bar otherwise has no way to learn its own window's title.
+  chromeView.webContents.on('did-finish-load', () => {
+    updateOsTitle(bundle);
+    primeViewWithCachedChromeState(chromeView.webContents);
+  });
+
+  // Forward content view nav events to the bundle's chrome view and update state
+  contentView.webContents.on('page-title-updated', (_e, title) => {
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+      bundle.chromeView.webContents.send('content-title-changed', title);
+    }
+  });
+
+  const onContentNavigate = (url, reason) => {
+    if (!bundle.isErrorState) {
+      bundle.currentContentUrl = url;
+      bundle.preErrorUrl = url;
+    }
+    const newAgentId = parseWorkspaceId(url);
+    const changed = bundle.currentWorkspaceId !== newAgentId;
+    if (changed) {
+      bundle.currentWorkspaceId = newAgentId;
+      sendCurrentWorkspaceToBundleSidebar(bundle);
+    }
+    console.log(
+      '[content-nav] reason=' + reason +
+      ' url=' + url +
+      ' parsedWs=' + (newAgentId || '-') +
+      ' changed=' + changed +
+      ' bundleWs=' + (bundle.currentWorkspaceId || '-'),
+    );
+    updateOsTitle(bundle);
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+      bundle.chromeView.webContents.send('content-url-changed', url);
+    }
+  };
+
+  contentView.webContents.on('did-navigate', (_e, url) => onContentNavigate(url, 'did-navigate'));
+  contentView.webContents.on('did-navigate-in-page', (_e, url) => onContentNavigate(url, 'did-navigate-in-page'));
+
+  // Enforce workspace uniqueness at the Electron level so it applies to EVERY
+  // path that can drive the content view to a /forwarding/X/ URL (landing-page
+  // row clicks, in-page anchors, pushState, etc.), not just sidebar-driven
+  // navigate-content IPC.
+  contentView.webContents.on('will-navigate', (event, url) => {
+    const targetAgentId = parseWorkspaceId(url);
+    if (!targetAgentId) return;
+    const existing = findBundleForWorkspace(targetAgentId);
+    if (!existing || existing === bundle) return;
+    event.preventDefault();
+    focusBundle(existing);
+  });
+
+  // Workspace pages (with live websockets) often attach `beforeunload`
+  // handlers. Without a dialog host, Electron stalls the unload forever,
+  // so the home button and workspace-switching navigate-content calls
+  // never complete. Always allow unload.
+  contentView.webContents.on('will-prevent-unload', (event) => {
+    event.preventDefault();
+  });
+  // Belt-and-suspenders: some pages install `onbeforeunload` in ways that
+  // Electron's will-prevent-unload doesn't intercept. Null it out after
+  // every top-level page load.
+  contentView.webContents.on('did-finish-load', () => {
+    contentView.webContents
+      .executeJavaScript('window.onbeforeunload = null;')
+      .catch(() => {});
+  });
+
+  registerShortcutsFor(bundle, chromeView.webContents);
+  registerShortcutsFor(bundle, contentView.webContents);
+
+  // Show the window once chrome has painted (avoids flashing a bare BaseWindow
+  // for the half-second before the WebContentsView renders). Fall back to a
+  // longer timer in case the chrome load never completes.
+  chromeView.webContents.once('did-finish-load', () => {
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  });
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  });
   setTimeout(() => {
-    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
-      console.log('[window] Showing window via fallback timeout');
-      mainWindow.show();
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  }, 3000);
+
+  return bundle;
+}
+
+function registerShortcutsFor(bundle, wc) {
+  wc.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return;
+    const key = input.key ? input.key.toLowerCase() : '';
+    const modifier = isMac ? input.meta : input.control;
+    const devTools =
+      (isMac && input.meta && input.alt && key === 'i') ||
+      (!isMac && input.control && input.shift && key === 'c');
+    if (devTools) {
+      event.preventDefault();
+      if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+        bundle.contentView.webContents.toggleDevTools();
+      }
+      return;
     }
-  }, 500);
-
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-    chromeView = null;
-    contentView = null;
-    sidebarView = null;
-    requestsPanelView = null;
-  });
-
-  mainWindow.on('resize', updateViewBounds);
-
-  // Forward content view navigation events to chrome view
-  contentView.webContents.on('page-title-updated', (_event, title) => {
-    if (chromeView && !chromeView.webContents.isDestroyed()) {
-      chromeView.webContents.send('content-title-changed', title);
+    // When the app menu is installed, it owns cmd+W / cmd+Q / cmd+N; handling
+    // them here too would double-fire (e.g. two new windows per cmd+N).
+    if (appMenuInstalled) return;
+    if (modifier && !input.shift && !input.alt && key === 'w') {
+      event.preventDefault();
+      if (!bundle.window.isDestroyed()) bundle.window.close();
+      return;
     }
-  });
-
-  contentView.webContents.on('did-navigate', (_event, url) => {
-    if (chromeView && !chromeView.webContents.isDestroyed()) {
-      chromeView.webContents.send('content-url-changed', url);
+    if (modifier && !input.shift && !input.alt && key === 'q') {
+      event.preventDefault();
+      initiateFullQuit();
+      return;
     }
-  });
-
-  contentView.webContents.on('did-navigate-in-page', (_event, url) => {
-    if (chromeView && !chromeView.webContents.isDestroyed()) {
-      chromeView.webContents.send('content-url-changed', url);
+    if (modifier && !input.shift && !input.alt && key === 'n') {
+      event.preventDefault();
+      openHomeInNewWindow();
+      return;
     }
   });
 }
 
-function updateViewBounds() {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+// -- Sidebar / requests panel helpers (per-bundle) --
 
-  const { width, height } = mainWindow.getContentBounds();
+// Sidebar and requests-panel views are created lazily the first time the
+// user toggles them on, then reused for all subsequent toggles via
+// setVisible(true/false). Destroying and recreating a WebContentsView on
+// every click means spawning a fresh render process + preload + loadURL
+// round-trip; on rapid clicks these queue up and take seconds to drain.
 
-  if (chromeView) {
-    chromeView.setBounds({ x: 0, y: 0, width, height: TITLEBAR_HEIGHT });
-  }
-  if (contentView) {
-    const rightOffset = requestsPanelView ? REQUESTS_PANEL_WIDTH : 0;
-    contentView.setBounds({ x: 0, y: TITLEBAR_HEIGHT, width: width - rightOffset, height: height - TITLEBAR_HEIGHT });
-  }
-  if (sidebarView) {
-    sidebarView.setBounds({ x: 0, y: TITLEBAR_HEIGHT, width: SIDEBAR_WIDTH, height: height - TITLEBAR_HEIGHT });
-  }
-  if (requestsPanelView) {
-    requestsPanelView.setBounds({
-      x: width - REQUESTS_PANEL_WIDTH,
-      y: TITLEBAR_HEIGHT,
-      width: REQUESTS_PANEL_WIDTH,
-      height: height - TITLEBAR_HEIGHT,
-    });
-  }
-}
-
-function toggleSidebar() {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-
-  if (sidebarView) {
-    // Remove sidebar
-    mainWindow.contentView.removeChildView(sidebarView);
-    sidebarView.webContents.close();
-    sidebarView = null;
-  } else {
-    // Create and show sidebar
-    sidebarView = new WebContentsView({
+function openSidebar(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.sidebarView) {
+    const sidebarView = new WebContentsView({
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         contextIsolation: true,
         nodeIntegration: false,
       },
     });
-    mainWindow.contentView.addChildView(sidebarView);
-    updateViewBounds();
-
+    bundle.sidebarView = sidebarView;
+    bundle.window.contentView.addChildView(sidebarView);
+    registerShortcutsFor(bundle, sidebarView.webContents);
+    sidebarView.webContents.on('did-finish-load', () => {
+      sendCurrentWorkspaceToBundleSidebar(bundle);
+      primeViewWithCachedChromeState(sidebarView.webContents);
+    });
     if (backendBaseUrl) {
       sidebarView.webContents.loadURL(backendBaseUrl + '/_chrome/sidebar');
     }
-  }
-}
-
-function toggleRequestsPanel() {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-
-  if (requestsPanelView) {
-    // Remove requests panel
-    mainWindow.contentView.removeChildView(requestsPanelView);
-    requestsPanelView.webContents.close();
-    requestsPanelView = null;
-    updateViewBounds();
   } else {
-    openRequestsPanel();
+    // Re-add to the parent to raise to the top of z-order, then make visible.
+    bundle.window.contentView.removeChildView(bundle.sidebarView);
+    bundle.window.contentView.addChildView(bundle.sidebarView);
+    bundle.sidebarView.setVisible(true);
   }
+  bundle.sidebarVisible = true;
+  updateBundleBounds(bundle);
 }
 
-function openRequestsPanel() {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
-  if (requestsPanelView) return; // Already open
-
-  requestsPanelView = new WebContentsView({
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
-  });
-  mainWindow.contentView.addChildView(requestsPanelView);
-  updateViewBounds();
-
-  if (backendBaseUrl) {
-    requestsPanelView.webContents.loadURL(backendBaseUrl + '/_chrome/requests-panel');
-  }
+function closeSidebar(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.sidebarView || !bundle.sidebarVisible) return;
+  bundle.sidebarView.setVisible(false);
+  bundle.sidebarVisible = false;
 }
 
-function registerShortcuts() {
-  chromeView.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown') return;
-    const devTools =
-      (isMac && input.meta && input.alt && input.key.toLowerCase() === 'i') ||
-      (!isMac && input.control && input.shift && input.key.toLowerCase() === 'c');
-    if (devTools) {
-      event.preventDefault();
-      contentView.webContents.toggleDevTools();
-    }
-  });
-
-  contentView.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown') return;
-    const devTools =
-      (isMac && input.meta && input.alt && input.key.toLowerCase() === 'i') ||
-      (!isMac && input.control && input.shift && input.key.toLowerCase() === 'c');
-    if (devTools) {
-      event.preventDefault();
-      contentView.webContents.toggleDevTools();
-    }
-  });
+function toggleSidebar(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (bundle.sidebarVisible) closeSidebar(bundle);
+  else openSidebar(bundle);
 }
 
-async function runStartupSequence() {
-  console.log('[startup] Loading shell.html in chrome view...');
-  // During startup, expand chrome view to full window to show loading screen
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    const { width, height } = mainWindow.getContentBounds();
-    chromeView.setBounds({ x: 0, y: 0, width, height });
-    // Hide content view during startup
-    contentView.setBounds({ x: 0, y: 0, width: 0, height: 0 });
-  }
-  await chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
-  console.log('[startup] shell.html loaded');
-
-  try {
-    await runEnvSetup((status) => {
-      if (chromeView && !chromeView.webContents.isDestroyed()) {
-        chromeView.webContents.send('status-update', status);
-      }
+function openRequestsPanel(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.requestsPanelView) {
+    const panel = new WebContentsView({
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
     });
-  } catch (err) {
-    showError(
-      'Setup failed -- you may not be connected to the internet',
-      err.message,
-    );
-    return;
+    bundle.requestsPanelView = panel;
+    bundle.window.contentView.addChildView(panel);
+    registerShortcutsFor(bundle, panel.webContents);
+    if (backendBaseUrl) {
+      panel.webContents.loadURL(backendBaseUrl + '/_chrome/requests-panel');
+    }
+  } else {
+    bundle.window.contentView.removeChildView(bundle.requestsPanelView);
+    bundle.window.contentView.addChildView(bundle.requestsPanelView);
+    bundle.requestsPanelView.setVisible(true);
   }
-
-  await startBackendWithRetry();
+  bundle.requestsPanelVisible = true;
+  updateBundleBounds(bundle);
 }
 
-async function startBackendWithRetry() {
-  if (chromeView && !chromeView.webContents.isDestroyed()) {
-    chromeView.webContents.send('status-update', 'Starting Minds...');
-  }
+function closeRequestsPanel(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.requestsPanelView || !bundle.requestsPanelVisible) return;
+  bundle.requestsPanelView.setVisible(false);
+  bundle.requestsPanelVisible = false;
+  updateBundleBounds(bundle);
+}
 
-  try {
-    const { loginUrl, port } = await startBackend((status) => {
-      if (chromeView && !chromeView.webContents.isDestroyed()) {
-        chromeView.webContents.send('status-update', status);
-      }
-    }, (event) => {
-      const agentName = event.agent_name || 'Agent';
-      const title = event.title || `Notification from ${agentName}`;
-      const notification = new Notification({
-        title,
-        body: event.message,
-      });
-      notification.on('click', () => {
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          if (mainWindow.isMinimized()) mainWindow.restore();
-          mainWindow.focus();
-          if (event.url && contentView && !contentView.webContents.isDestroyed()) {
-            const navUrl = event.url.startsWith('/') ? `http://127.0.0.1:${port}${event.url}` : event.url;
-            contentView.webContents.loadURL(navUrl);
+function toggleRequestsPanel(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (bundle.requestsPanelVisible) closeRequestsPanel(bundle);
+  else openRequestsPanel(bundle);
+}
+
+function sendCurrentWorkspaceToBundleSidebar(bundle) {
+  if (!bundle || !bundle.sidebarView) return;
+  if (bundle.sidebarView.webContents.isDestroyed()) return;
+  bundle.sidebarView.webContents.send('current-workspace-changed', bundle.currentWorkspaceId);
+}
+
+// -- Window opening / focusing --
+
+function openOrFocusWorkspace(agentId, url) {
+  const existing = findBundleForWorkspace(agentId);
+  if (existing) {
+    focusBundle(existing);
+    return existing;
+  }
+  const absolute = toAbsoluteUrl(url || ('/forwarding/' + agentId + '/'));
+  return openNewWindow(absolute);
+}
+
+function openNewWindow(url) {
+  const bundle = createBundle();
+  bundle.isLoadingState = false;
+  updateBundleBounds(bundle);
+  if (bundle.chromeView && backendBaseUrl) {
+    bundle.chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
+  }
+  if (bundle.contentView && url) {
+    bundle.contentView.webContents.loadURL(url);
+  }
+  return bundle;
+}
+
+function openHomeInNewWindow() {
+  // Backend isn't up yet (still in the shell.html loading state): just focus
+  // the existing initial window instead of creating a disconnected second one.
+  if (!backendBaseUrl) {
+    const target = getMostRecentWindow();
+    if (target) focusBundle(target);
+    return target;
+  }
+  return openNewWindow(backendBaseUrl + '/');
+}
+
+// -- Error / retry flow --
+
+function showErrorInAllWindows(message, details) {
+  for (const bundle of bundles) {
+    if (bundle.window.isDestroyed()) continue;
+    bundle.isErrorState = true;
+
+    if (bundle.sidebarView) closeSidebar(bundle);
+    if (bundle.requestsPanelView) closeRequestsPanel(bundle);
+
+    if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+      bundle.window.contentView.removeChildView(bundle.contentView);
+      bundle.contentView.webContents.close();
+      bundle.contentView = null;
+    }
+    updateBundleBounds(bundle);
+
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+      const url = bundle.chromeView.webContents.getURL();
+      if (!url.startsWith('file://')) {
+        bundle.chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
+        bundle.chromeView.webContents.once('did-finish-load', () => {
+          if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+            bundle.chromeView.webContents.send('error-details', { message, details });
           }
-        }
-      });
-      notification.show();
-    }, (event) => {
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      if (event.event === 'auth_success') {
-        // Reload chrome to update auth state
-        if (chromeView && !chromeView.webContents.isDestroyed()) {
-          chromeView.webContents.reload();
-        }
-      } else if (event.event === 'auth_required') {
-        if (mainWindow.isMinimized()) mainWindow.restore();
-        mainWindow.show();
-        mainWindow.focus();
-        const authUrl = `http://127.0.0.1:${port}/auth/login?message=` +
-          encodeURIComponent('You need to sign in to Imbue in order to share');
-        if (contentView && !contentView.webContents.isDestroyed()) {
-          contentView.webContents.loadURL(authUrl);
-        }
+        });
+      } else {
+        bundle.chromeView.webContents.send('error-details', { message, details });
       }
-    });
-
-    backendBaseUrl = `http://127.0.0.1:${port}`;
-
-    console.log('[startup] Backend ready. Loading chrome from', backendBaseUrl + '/_chrome');
-    console.log('[startup] Loading content from', loginUrl);
-
-    // Restore normal layout: chrome at top, content below
-    updateViewBounds();
-
-    // Load chrome from backend and content from landing page
-    if (chromeView && !chromeView.webContents.isDestroyed()) {
-      chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
     }
-    if (contentView && !contentView.webContents.isDestroyed()) {
-      contentView.webContents.loadURL(loginUrl);
-    }
-
-    const proc = getBackendProcess();
-    if (proc) {
-      proc.on('exit', (code) => {
-        if (mainWindow && !mainWindow.isDestroyed() && code !== 0 && code !== null) {
-          const logContent = readLastLogLines(50);
-          showError(
-            'Minds stopped unexpectedly',
-            logContent || `Process exited with code ${code}`,
-          );
-        }
-      });
-    }
-  } catch (err) {
-    showError('Failed to start Minds', err.message);
   }
 }
 
-function showError(message, details) {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+function prepareAllWindowsForRetry() {
+  for (const bundle of bundles) {
+    if (bundle.window.isDestroyed()) continue;
+    if (!bundle.contentView) {
+      const contentView = new WebContentsView({
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+        },
+      });
+      bundle.contentView = contentView;
+      bundle.window.contentView.addChildView(contentView);
+      registerShortcutsFor(bundle, contentView.webContents);
 
-  // Remove sidebar and content views on error
-  if (sidebarView) {
-    mainWindow.contentView.removeChildView(sidebarView);
-    sidebarView.webContents.close();
-    sidebarView = null;
-  }
-  if (contentView) {
-    mainWindow.contentView.removeChildView(contentView);
-    contentView.webContents.close();
-    contentView = null;
-  }
-
-  // Expand chrome view to fill the window for the error screen
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    const { width, height } = mainWindow.getContentBounds();
-    if (chromeView) {
-      chromeView.setBounds({ x: 0, y: 0, width, height });
-    }
-  }
-
-  if (chromeView && !chromeView.webContents.isDestroyed()) {
-    const url = chromeView.webContents.getURL();
-    if (!url.startsWith('file://')) {
-      chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
-      chromeView.webContents.once('did-finish-load', () => {
-        if (chromeView && !chromeView.webContents.isDestroyed()) {
-          chromeView.webContents.send('error-details', { message, details });
+      contentView.webContents.on('page-title-updated', (_e, title) => {
+        if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+          bundle.chromeView.webContents.send('content-title-changed', title);
         }
       });
-    } else {
-      chromeView.webContents.send('error-details', { message, details });
+      const onContentNavigate = (url) => {
+        if (!bundle.isErrorState) {
+          bundle.currentContentUrl = url;
+          bundle.preErrorUrl = url;
+        }
+        const newAgentId = parseWorkspaceId(url);
+        if (bundle.currentWorkspaceId !== newAgentId) {
+          bundle.currentWorkspaceId = newAgentId;
+          sendCurrentWorkspaceToBundleSidebar(bundle);
+        }
+        updateOsTitle(bundle);
+        if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+          bundle.chromeView.webContents.send('content-url-changed', url);
+        }
+      };
+      contentView.webContents.on('did-navigate', (_e, url) => onContentNavigate(url));
+      contentView.webContents.on('did-navigate-in-page', (_e, url) => onContentNavigate(url));
+      contentView.webContents.on('will-navigate', (event, url) => {
+        const targetAgentId = parseWorkspaceId(url);
+        if (!targetAgentId) return;
+        const existing = findBundleForWorkspace(targetAgentId);
+        if (!existing || existing === bundle) return;
+        event.preventDefault();
+        focusBundle(existing);
+      });
+    }
+
+    bundle.isLoadingState = true;
+    updateBundleBounds(bundle);
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+      bundle.chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
+    }
+  }
+}
+
+function reloadAllWindowsAfterRetry() {
+  for (const bundle of bundles) {
+    if (bundle.window.isDestroyed()) continue;
+    bundle.isErrorState = false;
+    bundle.isLoadingState = false;
+    updateBundleBounds(bundle);
+    if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed() && backendBaseUrl) {
+      bundle.chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
+    }
+    if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+      const target = bundle.preErrorUrl || (backendBaseUrl ? backendBaseUrl + '/' : null);
+      if (target) bundle.contentView.webContents.loadURL(target);
     }
   }
 }
@@ -403,82 +640,638 @@ function readLastLogLines(lineCount) {
   }
 }
 
-// -- IPC handlers --
+// -- Session state --
 
-ipcMain.on('go-home', () => {
-  if (contentView && !contentView.webContents.isDestroyed() && backendBaseUrl) {
-    contentView.webContents.loadURL(backendBaseUrl + '/');
+function loadSessionState() {
+  try {
+    const p = getSessionStatePath();
+    if (!fs.existsSync(p)) return [];
+    const raw = fs.readFileSync(p, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((e) => typeof e === 'object' && typeof e.url === 'string');
+  } catch {
+    return [];
   }
-});
+}
 
-ipcMain.on('navigate-content', (_event, url) => {
-  if (contentView && !contentView.webContents.isDestroyed()) {
-    // If the URL is relative, prepend the backend base URL
-    if (url.startsWith('/') && backendBaseUrl) {
-      url = backendBaseUrl + url;
+function toRelativeBackendUrl(url) {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.pathname + parsed.search + parsed.hash;
+  } catch {
+    return null;
+  }
+}
+
+function saveSessionState() {
+  try {
+    const state = [];
+    for (const b of bundles) {
+      if (b.window.isDestroyed()) continue;
+      const url = b.preErrorUrl || b.currentContentUrl;
+      const relative = toRelativeBackendUrl(url);
+      if (!relative) continue;
+      state.push({ url: relative });
     }
-    contentView.webContents.loadURL(url);
+    const p = getSessionStatePath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.log('[session] Failed to save state:', err.message);
   }
-  // Close sidebar after navigation
-  if (sidebarView && mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.contentView.removeChildView(sidebarView);
-    sidebarView.webContents.close();
-    sidebarView = null;
+}
+
+function filterRestorableUrls(state, knownAgentIdsSet) {
+  // If we have no agent list yet, pass everything through.
+  if (!knownAgentIdsSet) return state.slice();
+  const results = [];
+  for (const entry of state) {
+    const agentId = parseWorkspaceId(entry.url);
+    if (agentId && !knownAgentIdsSet.has(agentId)) {
+      continue; // workspace no longer exists, skip silently
+    }
+    results.push(entry);
   }
-});
+  return results;
+}
 
-ipcMain.on('content-go-back', () => {
-  if (contentView && !contentView.webContents.isDestroyed()) {
-    contentView.webContents.goBack();
+// ---------- Centralized chrome SSE ----------
+// Every chromeView and sidebarView used to open its own EventSource to
+// /_chrome/events. Chromium caps same-host HTTP/1.1 connections at 6, so
+// with a couple of workspace windows + sidebars, ALL subsequent requests
+// (/_chrome/sidebar, /_chrome/requests-panel, home navigation) queue
+// behind SSE streams -- you'd see load-finish latencies creep from 50ms
+// to 8+ seconds. Running one SSE connection in the main process and
+// broadcasting events via IPC avoids the exhaustion entirely.
+
+function handleChromeSSEEvent(evt) {
+  if (evt.type === 'workspaces' && Array.isArray(evt.workspaces)) {
+    latestChromeState.workspaces = evt.workspaces;
+    workspaceList = evt.workspaces.map((w) => ({
+      id: String(w.id),
+      name: w.name ? String(w.name) : '',
+      account: w.account ? String(w.account) : '',
+    }));
+    updateAllOsTitles();
+  } else if (evt.type === 'auth_status') {
+    latestChromeState.authStatus = evt;
+  } else if (evt.type === 'request_count') {
+    latestChromeState.requestCount = evt.count || 0;
   }
-});
+  broadcastChromeEvent(evt);
+}
 
-ipcMain.on('content-go-forward', () => {
-  if (contentView && !contentView.webContents.isDestroyed()) {
-    contentView.webContents.goForward();
+function broadcastChromeEvent(evt) {
+  for (const b of bundles) {
+    if (b.window.isDestroyed()) continue;
+    for (const view of [b.chromeView, b.sidebarView]) {
+      if (!view) continue;
+      if (view.webContents.isDestroyed()) continue;
+      try {
+        view.webContents.send('chrome-event', evt);
+      } catch { /* noop */ }
+    }
   }
-});
+}
 
-ipcMain.on('toggle-sidebar', () => {
-  toggleSidebar();
-});
+function primeViewWithCachedChromeState(wc) {
+  if (!wc || wc.isDestroyed()) return;
+  if (latestChromeState.workspaces !== null) {
+    wc.send('chrome-event', { type: 'workspaces', workspaces: latestChromeState.workspaces });
+  }
+  if (latestChromeState.authStatus) {
+    wc.send('chrome-event', latestChromeState.authStatus);
+  }
+  wc.send('chrome-event', { type: 'request_count', count: latestChromeState.requestCount });
+}
 
-ipcMain.on('toggle-requests-panel', () => {
-  toggleRequestsPanel();
-});
+function kickChromeSSEReconnect() {
+  chromeSseReconnectTick += 1;
+  const req = chromeSseAbortRef.current;
+  if (req) {
+    try { req.abort(); } catch { /* noop */ }
+  }
+}
 
-ipcMain.on('open-requests-panel', () => {
-  openRequestsPanel();
-});
-
-ipcMain.on('retry', async () => {
-  await shutdown();
-
-  // Recreate content view if it was removed during error
-  if (!contentView && mainWindow && !mainWindow.isDestroyed()) {
-    contentView = new WebContentsView({
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-      },
+async function runChromeSSELoop() {
+  // Runs until the app is shutting down. Maintains exactly one SSE
+  // connection to /_chrome/events, reconnecting on end/error with backoff.
+  while (!isShuttingDown) {
+    if (!backendBaseUrl) {
+      await sleepInterruptible(500);
+      continue;
+    }
+    await new Promise((resolve) => {
+      let finished = false;
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        chromeSseAbortRef.current = null;
+        resolve();
+      };
+      let req;
+      try {
+        req = net.request({
+          url: backendBaseUrl + '/_chrome/events',
+          method: 'GET',
+          useSessionCookies: true,
+        });
+      } catch {
+        finish();
+        return;
+      }
+      chromeSseAbortRef.current = req;
+      req.setHeader('Accept', 'text/event-stream');
+      req.on('response', (response) => {
+        if (response.statusCode !== 200) {
+          response.on('data', () => {});
+          response.on('end', finish);
+          response.on('error', finish);
+          return;
+        }
+        let buffer = '';
+        response.on('data', (chunk) => {
+          buffer += chunk.toString();
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() || '';
+          for (const part of parts) {
+            const dataLines = part.split('\n').filter((l) => l.startsWith('data:'));
+            if (dataLines.length === 0) continue;
+            const payload = dataLines.map((l) => l.slice(5).trim()).join('');
+            if (!payload) continue;
+            try {
+              handleChromeSSEEvent(JSON.parse(payload));
+            } catch { /* ignore bad frames */ }
+          }
+        });
+        response.on('end', finish);
+        response.on('error', finish);
+      });
+      req.on('error', finish);
+      req.end();
     });
-    // chromeView is never removed during the error path, so only add contentView
-    mainWindow.contentView.addChildView(contentView);
-    updateViewBounds();
+    // Brief backoff before reconnecting.
+    await sleepInterruptible(1500);
+  }
+}
+
+function sleepInterruptible(ms) {
+  const tick = chromeSseReconnectTick;
+  return new Promise((resolve) => {
+    const interval = 200;
+    let elapsed = 0;
+    const timer = setInterval(() => {
+      elapsed += interval;
+      if (isShuttingDown || tick !== chromeSseReconnectTick || elapsed >= ms) {
+        clearInterval(timer);
+        resolve();
+      }
+    }, interval);
+  });
+}
+
+function fetchInitialChromeState(timeoutMs = 4000) {
+  // Drives one round-trip to /_chrome/events (SSE) to learn both auth status
+  // and the current workspace list. Returns:
+  //   { authenticated: true, workspaces: [...] }  on authenticated success
+  //   { authenticated: false }                     when the backend says auth_required
+  //   null                                          on timeout / network error
+  return new Promise((resolve) => {
+    if (!backendBaseUrl) {
+      resolve(null);
+      return;
+    }
+    let done = false;
+    let req;
+    const finish = (value) => {
+      if (done) return;
+      done = true;
+      if (req) {
+        try { req.abort(); } catch { /* noop */ }
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    try {
+      req = net.request({
+        url: backendBaseUrl + '/_chrome/events',
+        method: 'GET',
+        useSessionCookies: true,
+      });
+    } catch {
+      clearTimeout(timer);
+      resolve(null);
+      return;
+    }
+    req.setHeader('Accept', 'text/event-stream');
+    let buffer = '';
+    req.on('response', (response) => {
+      if (response.statusCode !== 200) {
+        clearTimeout(timer);
+        finish(null);
+        return;
+      }
+      response.on('data', (chunk) => {
+        buffer += chunk.toString();
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() || '';
+        for (const part of parts) {
+          const dataLines = part.split('\n').filter((l) => l.startsWith('data:'));
+          if (dataLines.length === 0) continue;
+          const payload = dataLines.map((l) => l.slice(5).trim()).join('');
+          if (!payload) continue;
+          try {
+            const parsed = JSON.parse(payload);
+            if (parsed.type === 'workspaces' && Array.isArray(parsed.workspaces)) {
+              clearTimeout(timer);
+              finish({ authenticated: true, workspaces: parsed.workspaces });
+              return;
+            }
+            if (parsed.type === 'auth_required') {
+              clearTimeout(timer);
+              finish({ authenticated: false });
+              return;
+            }
+          } catch { /* ignore invalid frames */ }
+        }
+      });
+      response.on('end', () => {
+        clearTimeout(timer);
+        finish(null);
+      });
+      response.on('error', () => {
+        clearTimeout(timer);
+        finish(null);
+      });
+    });
+    req.on('error', () => {
+      clearTimeout(timer);
+      finish(null);
+    });
+    req.end();
+  });
+}
+
+// -- Single instance lock --
+
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    const mru = getMostRecentWindow();
+    if (mru) focusBundle(mru);
+  });
+  app.whenReady().then(onReady);
+}
+
+async function onReady() {
+  installApplicationMenu();
+  installDockMenu();
+
+  initialBundle = createBundle();
+  await runStartupSequence(initialBundle);
+}
+
+function installApplicationMenu() {
+  if (!isMac || process.env.MINDS_HIDE_MENU === '1') {
+    // On Windows/Linux the frame is custom-drawn; on macOS with MINDS_HIDE_MENU
+    // the user explicitly asked for no menu. cmd/ctrl+N still works via
+    // `registerShortcutsFor` in each bundle.
+    Menu.setApplicationMenu(null);
+    appMenuInstalled = false;
+    return;
+  }
+  appMenuInstalled = true;
+  const template = [
+    {
+      label: app.name || 'Minds',
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'New Window',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => openHomeInNewWindow(),
+        },
+        { type: 'separator' },
+        {
+          label: 'Close Window',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => {
+            const target = getMostRecentWindow();
+            if (target && !target.window.isDestroyed()) target.window.close();
+          },
+        },
+      ],
+    },
+    { role: 'editMenu' },
+    { role: 'windowMenu' },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+function installDockMenu() {
+  if (!isMac || !app.dock) return;
+  app.dock.setMenu(Menu.buildFromTemplate([
+    {
+      label: 'New Window',
+      click: () => openHomeInNewWindow(),
+    },
+  ]));
+}
+
+async function runStartupSequence(bundle) {
+  console.log('[startup] Loading shell.html in chrome view...');
+  bundle.isLoadingState = true;
+  updateBundleBounds(bundle);
+  await bundle.chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
+  console.log('[startup] shell.html loaded');
+
+  try {
+    await runEnvSetup((status) => {
+      if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
+        bundle.chromeView.webContents.send('status-update', status);
+      }
+    });
+  } catch (err) {
+    showErrorInAllWindows(
+      'Setup failed -- you may not be connected to the internet',
+      err.message,
+    );
+    return;
   }
 
-  if (chromeView && !chromeView.webContents.isDestroyed()) {
-    // Expand chrome view to full window and hide content view for the loading screen
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      const { width, height } = mainWindow.getContentBounds();
-      chromeView.setBounds({ x: 0, y: 0, width, height });
-      if (contentView) {
-        contentView.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+  await startBackendWithRetry();
+}
+
+function broadcastStatusToLoadingWindows(status) {
+  for (const b of bundles) {
+    if (b.window.isDestroyed()) continue;
+    if (!b.isLoadingState) continue;
+    if (b.chromeView && !b.chromeView.webContents.isDestroyed()) {
+      b.chromeView.webContents.send('status-update', status);
+    }
+  }
+}
+
+async function startBackendWithRetry() {
+  broadcastStatusToLoadingWindows('Starting Minds...');
+
+  try {
+    const { loginUrl, port } = await startBackend(
+      (status) => broadcastStatusToLoadingWindows(status),
+      (event) => handleNotification(event),
+      (event) => handleAuthEvent(event),
+    );
+
+    backendBaseUrl = `http://127.0.0.1:${port}`;
+    backendPort = port;
+
+    console.log('[startup] Backend ready. Loading chrome from', backendBaseUrl + '/_chrome');
+
+    // Kick off the shared chrome-events SSE consumer (idempotent: only starts once).
+    if (!runChromeSSELoop._started) {
+      runChromeSSELoop._started = true;
+      runChromeSSELoop();
+    } else {
+      // On retry after backend restart, force the live connection to reconnect.
+      kickChromeSSEReconnect();
+    }
+
+    const isFirstStart = !hasCompletedInitialStart;
+    hasCompletedInitialStart = true;
+
+    if (isFirstStart && initialBundle && !initialBundle.window.isDestroyed()) {
+      const savedState = loadSessionState();
+      const chromeState = await fetchInitialChromeState();
+      const authenticated = chromeState && chromeState.authenticated;
+
+      if (authenticated && chromeState.workspaces) {
+        workspaceList = chromeState.workspaces.map((w) => ({
+          id: String(w.id),
+          name: w.name ? String(w.name) : '',
+          account: w.account ? String(w.account) : '',
+        }));
+      }
+
+      const knownAgentIdsSet = authenticated
+        ? new Set(workspaceList.map((w) => w.id))
+        : null;
+      const restorable = authenticated
+        ? filterRestorableUrls(savedState, knownAgentIdsSet)
+        : [];
+
+      initialBundle.isLoadingState = false;
+      updateBundleBounds(initialBundle);
+      if (initialBundle.chromeView && !initialBundle.chromeView.webContents.isDestroyed()) {
+        initialBundle.chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
+      }
+
+      if (!authenticated) {
+        // No valid session cookie -- route through loginUrl to consume the
+        // one-time code. Keep saved state on disk so the next quit-and-relaunch
+        // after auth can restore. Don't open any additional restored windows
+        // because they'd all 403.
+        if (initialBundle.contentView && !initialBundle.contentView.webContents.isDestroyed()) {
+          initialBundle.contentView.webContents.loadURL(loginUrl);
+        }
+      } else if (restorable.length === 0) {
+        // Authenticated, but nothing to restore -- land on the home page.
+        if (initialBundle.contentView && !initialBundle.contentView.webContents.isDestroyed()) {
+          initialBundle.contentView.webContents.loadURL(backendBaseUrl + '/');
+        }
+      } else {
+        const [first, ...rest] = restorable;
+        if (initialBundle.contentView && !initialBundle.contentView.webContents.isDestroyed()) {
+          initialBundle.contentView.webContents.loadURL(toAbsoluteUrl(first.url));
+        }
+        for (const entry of rest) {
+          openNewWindow(toAbsoluteUrl(entry.url));
+        }
+      }
+    } else {
+      // Retry path: re-load every existing window
+      reloadAllWindowsAfterRetry();
+    }
+
+    const proc = getBackendProcess();
+    if (proc) {
+      proc.on('exit', (code) => {
+        if (code !== 0 && code !== null && bundles.size > 0) {
+          const logContent = readLastLogLines(50);
+          showErrorInAllWindows(
+            'Minds stopped unexpectedly',
+            logContent || `Process exited with code ${code}`,
+          );
+        }
+      });
+    }
+  } catch (err) {
+    showErrorInAllWindows('Failed to start Minds', err.message);
+  }
+}
+
+function handleNotification(event) {
+  const agentName = event.agent_name || 'Agent';
+  const title = event.title || `Notification from ${agentName}`;
+  const notification = new Notification({
+    title,
+    body: event.message,
+  });
+  notification.on('click', () => {
+    const url = event.url;
+    if (!url) {
+      const mru = getMostRecentWindow();
+      if (mru) focusBundle(mru);
+      return;
+    }
+    const absolute = toAbsoluteUrl(url);
+    const agentId = parseWorkspaceId(absolute);
+    if (agentId) {
+      openOrFocusWorkspace(agentId, absolute);
+    } else {
+      const mru = getMostRecentWindow();
+      if (mru && mru.contentView && !mru.contentView.webContents.isDestroyed()) {
+        focusBundle(mru);
+        mru.contentView.webContents.loadURL(absolute);
       }
     }
-    await chromeView.webContents.loadFile(path.join(__dirname, 'shell.html'));
-    startBackendWithRetry();
+  });
+  notification.show();
+}
+
+function handleAuthEvent(event) {
+  if (event.event === 'auth_success') {
+    for (const b of bundles) {
+      if (b.window.isDestroyed()) continue;
+      if (b.chromeView && !b.chromeView.webContents.isDestroyed()) {
+        b.chromeView.webContents.reload();
+      }
+    }
+  } else if (event.event === 'auth_required') {
+    const mru = getMostRecentWindow();
+    if (!mru) return;
+    focusBundle(mru);
+    if (mru.contentView && !mru.contentView.webContents.isDestroyed() && backendPort) {
+      const authUrl = `http://127.0.0.1:${backendPort}/auth/login?message=` +
+        encodeURIComponent('You need to sign in to Imbue in order to share');
+      mru.contentView.webContents.loadURL(authUrl);
+    }
   }
+}
+
+// -- IPC handlers --
+
+ipcMain.on('go-home', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (!bundle || !backendBaseUrl) return;
+  if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+    bundle.contentView.webContents.loadURL(backendBaseUrl + '/');
+  }
+});
+
+ipcMain.on('navigate-content', (event, url) => {
+  const bundle = getBundleFromEvent(event);
+  if (!bundle) return;
+  const absolute = toAbsoluteUrl(url);
+  const targetAgentId = parseWorkspaceId(absolute);
+
+  if (targetAgentId) {
+    const existing = findBundleForWorkspace(targetAgentId);
+    if (existing) {
+      focusBundle(existing);
+      closeSidebar(bundle);
+      return;
+    }
+  }
+
+  // Nobody is on this workspace (or it's a non-workspace URL): navigate sender
+  if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+    bundle.contentView.webContents.loadURL(absolute);
+  }
+  closeSidebar(bundle);
+});
+
+ipcMain.on('content-go-back', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (bundle && bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+    bundle.contentView.webContents.goBack();
+  }
+});
+
+ipcMain.on('content-go-forward', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (bundle && bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
+    bundle.contentView.webContents.goForward();
+  }
+});
+
+ipcMain.on('toggle-sidebar', (event) => {
+  toggleSidebar(getBundleFromEvent(event));
+});
+
+ipcMain.on('toggle-requests-panel', (event) => {
+  toggleRequestsPanel(getBundleFromEvent(event));
+});
+
+ipcMain.on('open-requests-panel', (event) => {
+  const bundle = getBundleFromEvent(event);
+  openRequestsPanel(bundle);
+});
+
+ipcMain.on('open-workspace-in-new-window', (event, agentId) => {
+  if (!agentId) return;
+  openOrFocusWorkspace(agentId, '/forwarding/' + agentId + '/');
+  // The sidebar is the sender for both the hover-icon click and the native
+  // context-menu "Open in new window" item; close it now that the action is done.
+  const bundle = getBundleFromEvent(event);
+  if (bundle) closeSidebar(bundle);
+});
+
+ipcMain.on('show-workspace-context-menu', (event, agentId, x, y) => {
+  const bundle = getBundleFromEvent(event);
+  if (!bundle || !agentId) return;
+  // Don't offer "Open in new window" if the sender's window is already on this workspace
+  if (bundle.currentWorkspaceId === agentId) return;
+  const menu = Menu.buildFromTemplate([
+    {
+      label: 'Open in new window',
+      click: () => {
+        openOrFocusWorkspace(agentId, '/forwarding/' + agentId + '/');
+        closeSidebar(bundle);
+      },
+    },
+  ]);
+  // sidebar coords are relative to the sidebar view, which sits at (0, TITLEBAR_HEIGHT)
+  const px = Math.round(x || 0);
+  const py = Math.round((y || 0) + TITLEBAR_HEIGHT);
+  menu.popup({ window: bundle.window, x: px, y: py });
+});
+
+ipcMain.on('retry', async (event) => {
+  // User clicked retry from one window's error screen. Shut down the old
+  // backend (if any), put all windows back in loading state, then restart.
+  const senderBundle = getBundleFromEvent(event);
+  if (senderBundle) focusBundle(senderBundle);
+  await shutdown();
+  prepareAllWindowsForRetry();
+  await startBackendWithRetry();
 });
 
 ipcMain.on('open-log-file', () => {
@@ -486,57 +1279,55 @@ ipcMain.on('open-log-file', () => {
   shell.openPath(logPath);
 });
 
-ipcMain.on('window-minimize', () => {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.minimize();
-  }
+ipcMain.on('window-minimize', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (bundle && !bundle.window.isDestroyed()) bundle.window.minimize();
 });
 
-ipcMain.on('window-maximize', () => {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    if (mainWindow.isMaximized() || mainWindow._maximizedByUs) {
-      mainWindow.unmaximize();
-      if (mainWindow._boundsBeforeMaximize) {
-        mainWindow.setBounds(mainWindow._boundsBeforeMaximize);
-        mainWindow._boundsBeforeMaximize = null;
-      }
-      mainWindow._maximizedByUs = false;
-    } else {
-      mainWindow._boundsBeforeMaximize = mainWindow.getBounds();
-      mainWindow.maximize();
+ipcMain.on('window-maximize', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (!bundle || bundle.window.isDestroyed()) return;
+  const win = bundle.window;
+  if (win.isMaximized() || bundle._maximizedByUs) {
+    win.unmaximize();
+    if (bundle._boundsBeforeMaximize) {
+      win.setBounds(bundle._boundsBeforeMaximize);
+      bundle._boundsBeforeMaximize = null;
     }
+    bundle._maximizedByUs = false;
+  } else {
+    bundle._boundsBeforeMaximize = win.getBounds();
+    win.maximize();
   }
 });
 
-ipcMain.on('window-close', () => {
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.close();
-  }
+ipcMain.on('window-close', (event) => {
+  const bundle = getBundleFromEvent(event);
+  if (bundle && !bundle.window.isDestroyed()) bundle.window.close();
 });
 
 // -- App lifecycle --
 
-let isShuttingDown = false;
+function initiateFullQuit() {
+  app.quit();
+}
 
-require('electron').app.on('window-all-closed', async () => {
+app.on('window-all-closed', async () => {
   console.log('[lifecycle] window-all-closed fired, isShuttingDown=' + isShuttingDown);
-  if (!isShuttingDown) {
-    isShuttingDown = true;
-    console.log('[lifecycle] Starting shutdown from window-all-closed...');
-    await shutdown();
-    console.log('[lifecycle] Shutdown complete, calling app.quit()');
-    require('electron').app.quit();
-  }
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  await shutdown();
+  app.quit();
 });
 
-require('electron').app.on('before-quit', async (event) => {
+app.on('before-quit', async (event) => {
   console.log('[lifecycle] before-quit fired, isShuttingDown=' + isShuttingDown + ', hasBackend=' + !!getBackendProcess());
+  // Capture session state for every open window before teardown.
+  saveSessionState();
   if (getBackendProcess() && !isShuttingDown) {
     isShuttingDown = true;
     event.preventDefault();
-    console.log('[lifecycle] Starting shutdown from before-quit...');
     await shutdown();
-    console.log('[lifecycle] Shutdown complete, calling app.quit()');
-    require('electron').app.quit();
+    app.quit();
   }
 });

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -246,10 +246,6 @@ function createBundle() {
   // so we can still reach the child webContents. BaseWindow does not guarantee
   // destruction of child WebContentsView render processes on its own; leaking
   // them across create/close cycles eventually starves new ones of resources.
-  // Run cleanup on `close` (before views are detached) rather than `closed`
-  // so we can still reach the child webContents. BaseWindow does not guarantee
-  // destruction of child WebContentsView render processes on its own; leaking
-  // them across create/close cycles eventually starves new ones of resources.
   win.on('close', () => {
     const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView];
     for (const view of views) {
@@ -275,39 +271,54 @@ function createBundle() {
     primeViewWithCachedChromeState(chromeView.webContents);
   });
 
-  // Forward content view nav events to the bundle's chrome view and update state
+  wireContentViewEvents(bundle, contentView);
+  registerShortcutsFor(bundle, chromeView.webContents);
+  registerShortcutsFor(bundle, contentView.webContents);
+
+  // Show the window once chrome has painted (avoids flashing a bare BaseWindow
+  // for the half-second before the WebContentsView renders). Fall back to a
+  // longer timer in case the chrome load never completes.
+  chromeView.webContents.once('did-finish-load', () => {
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  });
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  });
+  setTimeout(() => {
+    if (!win.isDestroyed() && !win.isVisible()) win.show();
+  }, 3000);
+
+  return bundle;
+}
+
+function wireContentViewEvents(bundle, contentView) {
+  // Forward content view nav events to the bundle's chrome view and update state.
+  // Called from both createBundle and prepareAllWindowsForRetry (which rebuilds
+  // the contentView that showErrorInAllWindows tore down).
   contentView.webContents.on('page-title-updated', (_e, title) => {
     if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
       bundle.chromeView.webContents.send('content-title-changed', title);
     }
   });
 
-  const onContentNavigate = (url, reason) => {
+  const onContentNavigate = (url) => {
     if (!bundle.isErrorState) {
       bundle.currentContentUrl = url;
       bundle.preErrorUrl = url;
     }
     const newAgentId = parseWorkspaceId(url);
-    const changed = bundle.currentWorkspaceId !== newAgentId;
-    if (changed) {
+    if (bundle.currentWorkspaceId !== newAgentId) {
       bundle.currentWorkspaceId = newAgentId;
       sendCurrentWorkspaceToBundleSidebar(bundle);
     }
-    console.log(
-      '[content-nav] reason=' + reason +
-      ' url=' + url +
-      ' parsedWs=' + (newAgentId || '-') +
-      ' changed=' + changed +
-      ' bundleWs=' + (bundle.currentWorkspaceId || '-'),
-    );
     updateOsTitle(bundle);
     if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
       bundle.chromeView.webContents.send('content-url-changed', url);
     }
   };
 
-  contentView.webContents.on('did-navigate', (_e, url) => onContentNavigate(url, 'did-navigate'));
-  contentView.webContents.on('did-navigate-in-page', (_e, url) => onContentNavigate(url, 'did-navigate-in-page'));
+  contentView.webContents.on('did-navigate', (_e, url) => onContentNavigate(url));
+  contentView.webContents.on('did-navigate-in-page', (_e, url) => onContentNavigate(url));
 
   // Enforce workspace uniqueness at the Electron level so it applies to EVERY
   // path that can drive the content view to a /forwarding/X/ URL (landing-page
@@ -337,24 +348,6 @@ function createBundle() {
       .executeJavaScript('window.onbeforeunload = null;')
       .catch(() => {});
   });
-
-  registerShortcutsFor(bundle, chromeView.webContents);
-  registerShortcutsFor(bundle, contentView.webContents);
-
-  // Show the window once chrome has painted (avoids flashing a bare BaseWindow
-  // for the half-second before the WebContentsView renders). Fall back to a
-  // longer timer in case the chrome load never completes.
-  chromeView.webContents.once('did-finish-load', () => {
-    if (!win.isDestroyed() && !win.isVisible()) win.show();
-  });
-  win.once('ready-to-show', () => {
-    if (!win.isDestroyed() && !win.isVisible()) win.show();
-  });
-  setTimeout(() => {
-    if (!win.isDestroyed() && !win.isVisible()) win.show();
-  }, 3000);
-
-  return bundle;
 }
 
 function registerShortcutsFor(bundle, wc) {
@@ -505,6 +498,18 @@ function openNewWindow(url) {
   const bundle = createBundle();
   bundle.isLoadingState = false;
   updateBundleBounds(bundle);
+  // Stamp the intended workspace synchronously so subsequent
+  // findBundleForWorkspace lookups see this window as occupying the workspace
+  // BEFORE its content view has fired did-navigate. Otherwise a second
+  // openOrFocusWorkspace / landing-click / notification-click arriving during
+  // the load window wouldn't see the pending bundle and would spawn a duplicate.
+  const intendedAgentId = parseWorkspaceId(url);
+  if (intendedAgentId) {
+    bundle.currentWorkspaceId = intendedAgentId;
+    bundle.currentContentUrl = url;
+    bundle.preErrorUrl = url;
+    updateOsTitle(bundle);
+  }
   if (bundle.chromeView && backendBaseUrl) {
     bundle.chromeView.webContents.loadURL(backendBaseUrl + '/_chrome');
   }
@@ -571,37 +576,7 @@ function prepareAllWindowsForRetry() {
       bundle.contentView = contentView;
       bundle.window.contentView.addChildView(contentView);
       registerShortcutsFor(bundle, contentView.webContents);
-
-      contentView.webContents.on('page-title-updated', (_e, title) => {
-        if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
-          bundle.chromeView.webContents.send('content-title-changed', title);
-        }
-      });
-      const onContentNavigate = (url) => {
-        if (!bundle.isErrorState) {
-          bundle.currentContentUrl = url;
-          bundle.preErrorUrl = url;
-        }
-        const newAgentId = parseWorkspaceId(url);
-        if (bundle.currentWorkspaceId !== newAgentId) {
-          bundle.currentWorkspaceId = newAgentId;
-          sendCurrentWorkspaceToBundleSidebar(bundle);
-        }
-        updateOsTitle(bundle);
-        if (bundle.chromeView && !bundle.chromeView.webContents.isDestroyed()) {
-          bundle.chromeView.webContents.send('content-url-changed', url);
-        }
-      };
-      contentView.webContents.on('did-navigate', (_e, url) => onContentNavigate(url));
-      contentView.webContents.on('did-navigate-in-page', (_e, url) => onContentNavigate(url));
-      contentView.webContents.on('will-navigate', (event, url) => {
-        const targetAgentId = parseWorkspaceId(url);
-        if (!targetAgentId) return;
-        const existing = findBundleForWorkspace(targetAgentId);
-        if (!existing || existing === bundle) return;
-        event.preventDefault();
-        focusBundle(existing);
-      });
+      wireContentViewEvents(bundle, contentView);
     }
 
     bundle.isLoadingState = true;

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -219,6 +219,7 @@ function createBundle() {
     sidebarVisible: false,
     requestsPanelView: null,
     requestsPanelVisible: false,
+    requestsPanelReloadTimer: null,
     currentContentUrl: null,
     currentWorkspaceId: null,
     preErrorUrl: null,
@@ -255,6 +256,10 @@ function createBundle() {
     // set and we must not overwrite it with a progressively shrinking snapshot
     // as the teardown closes each window.
     if (!isShuttingDown) saveSessionState();
+    if (bundle.requestsPanelReloadTimer) {
+      clearTimeout(bundle.requestsPanelReloadTimer);
+      bundle.requestsPanelReloadTimer = null;
+    }
     const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView];
     for (const view of views) {
       if (!view) continue;
@@ -466,7 +471,12 @@ function openRequestsPanel(bundle) {
     bundle.window.contentView.addChildView(bundle.requestsPanelView);
     bundle.requestsPanelView.setVisible(true);
     // The panel's HTML is rendered server-side and doesn't subscribe to SSE,
-    // so its cards go stale while hidden. Refresh on show.
+    // so its cards go stale while hidden. Refresh on show, and cancel any
+    // debounced SSE-driven reload that was pending so we don't double-load.
+    if (bundle.requestsPanelReloadTimer) {
+      clearTimeout(bundle.requestsPanelReloadTimer);
+      bundle.requestsPanelReloadTimer = null;
+    }
     if (!bundle.requestsPanelView.webContents.isDestroyed()) {
       bundle.requestsPanelView.webContents.reload();
     }
@@ -481,6 +491,27 @@ function closeRequestsPanel(bundle) {
   bundle.requestsPanelView.setVisible(false);
   bundle.requestsPanelVisible = false;
   updateBundleBounds(bundle);
+}
+
+// Coalesce rapid SSE-triggered reloads. A burst of request_count events
+// (e.g. count 1 -> 2 -> 3 within a few ms) would otherwise restart the
+// panel load multiple times in flight, potentially preventing it from
+// ever settling on a rendered state, and multiplying backend HTTP load
+// by (open windows) x (events).
+const REQUESTS_PANEL_RELOAD_DEBOUNCE_MS = 50;
+function scheduleRequestsPanelReload(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.requestsPanelView || !bundle.requestsPanelVisible) return;
+  if (bundle.requestsPanelReloadTimer) {
+    clearTimeout(bundle.requestsPanelReloadTimer);
+  }
+  bundle.requestsPanelReloadTimer = setTimeout(() => {
+    bundle.requestsPanelReloadTimer = null;
+    if (bundle.window.isDestroyed()) return;
+    if (!bundle.requestsPanelView || !bundle.requestsPanelVisible) return;
+    if (bundle.requestsPanelView.webContents.isDestroyed()) return;
+    bundle.requestsPanelView.webContents.reload();
+  }, REQUESTS_PANEL_RELOAD_DEBOUNCE_MS);
 }
 
 function toggleRequestsPanel(bundle) {
@@ -717,12 +748,10 @@ function handleChromeSSEEvent(evt) {
   } else if (evt.type === 'request_count') {
     latestChromeState.requestCount = evt.count || 0;
     // Requests panel HTML is static at load time. Refresh any visible panels
-    // so their cards reflect the new pending list.
+    // so their cards reflect the new pending list. Debounced per-bundle so
+    // a burst of count changes coalesces into one reload per panel.
     for (const b of bundles) {
-      if (b.window.isDestroyed()) continue;
-      if (!b.requestsPanelView || !b.requestsPanelVisible) continue;
-      if (b.requestsPanelView.webContents.isDestroyed()) continue;
-      b.requestsPanelView.webContents.reload();
+      scheduleRequestsPanelReload(b);
     }
   }
   broadcastChromeEvent(evt);

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -465,6 +465,11 @@ function openRequestsPanel(bundle) {
     bundle.window.contentView.removeChildView(bundle.requestsPanelView);
     bundle.window.contentView.addChildView(bundle.requestsPanelView);
     bundle.requestsPanelView.setVisible(true);
+    // The panel's HTML is rendered server-side and doesn't subscribe to SSE,
+    // so its cards go stale while hidden. Refresh on show.
+    if (!bundle.requestsPanelView.webContents.isDestroyed()) {
+      bundle.requestsPanelView.webContents.reload();
+    }
   }
   bundle.requestsPanelVisible = true;
   updateBundleBounds(bundle);
@@ -711,6 +716,14 @@ function handleChromeSSEEvent(evt) {
     latestChromeState.authStatus = evt;
   } else if (evt.type === 'request_count') {
     latestChromeState.requestCount = evt.count || 0;
+    // Requests panel HTML is static at load time. Refresh any visible panels
+    // so their cards reflect the new pending list.
+    for (const b of bundles) {
+      if (b.window.isDestroyed()) continue;
+      if (!b.requestsPanelView || !b.requestsPanelVisible) continue;
+      if (b.requestsPanelView.webContents.isDestroyed()) continue;
+      b.requestsPanelView.webContents.reload();
+    }
   }
   broadcastChromeEvent(evt);
 }
@@ -1231,6 +1244,29 @@ ipcMain.on('open-workspace-in-new-window', (event, agentId) => {
   // context-menu "Open in new window" item; close it now that the action is done.
   const bundle = getBundleFromEvent(event);
   if (bundle) closeSidebar(bundle);
+});
+
+ipcMain.on('navigate-to-request', (event, agentId, eventId) => {
+  if (!eventId) return;
+  const url = toAbsoluteUrl('/requests/' + eventId);
+  const sender = getBundleFromEvent(event);
+  // Route to the workspace's window when one is open so the request page
+  // lives alongside the workspace it's about, rather than wherever the user
+  // happened to click the request card from.
+  if (agentId) {
+    const existing = findBundleForWorkspace(agentId);
+    if (existing) {
+      focusBundle(existing);
+      if (existing.contentView && !existing.contentView.webContents.isDestroyed()) {
+        existing.contentView.webContents.loadURL(url);
+      }
+      return;
+    }
+  }
+  // Fallback: no window for this workspace -- open the request in the sender.
+  if (sender && sender.contentView && !sender.contentView.webContents.isDestroyed()) {
+    sender.contentView.webContents.loadURL(url);
+  }
 });
 
 ipcMain.on('show-workspace-context-menu', (event, agentId, x, y) => {

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -42,6 +42,8 @@ contextBridge.exposeInMainWorld('minds', {
   // Multi-window workspace actions
   openWorkspaceInNewWindow: (agentId) =>
     ipcRenderer.send('open-workspace-in-new-window', agentId),
+  navigateToRequest: (agentId, eventId) =>
+    ipcRenderer.send('navigate-to-request', agentId, eventId),
   showWorkspaceContextMenu: (agentId, x, y) =>
     ipcRenderer.send('show-workspace-context-menu', agentId, x, y),
   onCurrentWorkspaceChanged: (callback) => {

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -25,6 +25,12 @@ contextBridge.exposeInMainWorld('minds', {
   onContentURLChange: (callback) => {
     ipcRenderer.on('content-url-changed', (_event, url) => callback(url));
   },
+  onWindowTitleChange: (callback) => {
+    ipcRenderer.on('window-title-changed', (_event, title) => callback(title));
+  },
+  onChromeEvent: (callback) => {
+    ipcRenderer.on('chrome-event', (_event, data) => callback(data));
+  },
 
   // Sidebar
   toggleSidebar: () => ipcRenderer.send('toggle-sidebar'),
@@ -32,6 +38,15 @@ contextBridge.exposeInMainWorld('minds', {
   // Requests panel
   toggleRequestsPanel: () => ipcRenderer.send('toggle-requests-panel'),
   openRequestsPanel: () => ipcRenderer.send('open-requests-panel'),
+
+  // Multi-window workspace actions
+  openWorkspaceInNewWindow: (agentId) =>
+    ipcRenderer.send('open-workspace-in-new-window', agentId),
+  showWorkspaceContextMenu: (agentId, x, y) =>
+    ipcRenderer.send('show-workspace-context-menu', agentId, x, y),
+  onCurrentWorkspaceChanged: (callback) => {
+    ipcRenderer.on('current-workspace-changed', (_event, agentId) => callback(agentId));
+  },
 
   // Actions
   retry: () => ipcRenderer.send('retry'),

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1456,7 +1456,7 @@ def _handle_requests_panel(
             ws_name = info.agent_name if info else req.agent_id[:16]
         event_id = str(req.event_id)
         cards.append(
-            f'<div class="req-card" onclick="navigateToRequest(\'{event_id}\')">'
+            f'<div class="req-card" onclick="navigateToRequest(\'{event_id}\', \'{req.agent_id}\')">'
             f'<div style="font-size:13px;color:#e2e8f0;font-weight:500;">sharing: {ws_name}</div>'
             f'<div style="font-size:12px;color:#64748b;margin-top:2px;">{server_name}</div></div>'
         )
@@ -1471,9 +1471,14 @@ def _handle_requests_panel(
         "</style></head>"
         f"<body>"
         f"<script>"
-        f"function navigateToRequest(eventId) {{"
-        f'  if (window.minds) window.minds.navigateContent("/requests/" + eventId);'
-        f'  else window.top.location = "/requests/" + eventId;'
+        f"function navigateToRequest(eventId, agentId) {{"
+        f'  if (window.minds && window.minds.navigateToRequest) {{'
+        f'    window.minds.navigateToRequest(agentId, eventId);'
+        f'  }} else if (window.minds) {{'
+        f'    window.minds.navigateContent("/requests/" + eventId);'
+        f'  }} else {{'
+        f'    window.top.location = "/requests/" + eventId;'
+        f'  }}'
         f"}}"
         f"</script>"
         f"<h2>Requests ({len(pending)})</h2>"

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1481,13 +1481,13 @@ def _handle_requests_panel(
         f"<body>"
         f"<script>"
         f"function navigateToRequest(eventId, agentId) {{"
-        f'  if (window.minds && window.minds.navigateToRequest) {{'
-        f'    window.minds.navigateToRequest(agentId, eventId);'
-        f'  }} else if (window.minds) {{'
+        f"  if (window.minds && window.minds.navigateToRequest) {{"
+        f"    window.minds.navigateToRequest(agentId, eventId);"
+        f"  }} else if (window.minds) {{"
         f'    window.minds.navigateContent("/requests/" + eventId);'
-        f'  }} else {{'
+        f"  }} else {{"
         f'    window.top.location = "/requests/" + eventId;'
-        f'  }}'
+        f"  }}"
         f"}}"
         f"</script>"
         f"<h2>Requests ({len(pending)})</h2>"

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import json
 import os
 import queue
@@ -1455,13 +1456,21 @@ def _handle_requests_panel(
             info = backend_resolver.get_agent_display_info(parsed_id)
             ws_name = info.agent_name if info else req.agent_id[:16]
         event_id = str(req.event_id)
+        # Encode as JSON for safe embedding in the JS call, then HTML-escape
+        # the result so it is also safe inside the double-quoted onclick
+        # attribute. This is defense-in-depth: req.agent_id is validated as
+        # an AgentId above, but req.event_id is only required to be a
+        # non-empty string by its type, and relying on upstream validation
+        # at each interpolation site is fragile.
+        event_id_attr = html.escape(json.dumps(event_id), quote=True)
+        agent_id_attr = html.escape(json.dumps(req.agent_id), quote=True)
         cards.append(
-            f'<div class="req-card" onclick="navigateToRequest(\'{event_id}\', \'{req.agent_id}\')">'
+            f'<div class="req-card" onclick="navigateToRequest({event_id_attr}, {agent_id_attr})">'
             f'<div style="font-size:13px;color:#e2e8f0;font-weight:500;">sharing: {ws_name}</div>'
             f'<div style="font-size:12px;color:#64748b;margin-top:2px;">{server_name}</div></div>'
         )
 
-    html = (
+    html_content = (
         '<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Requests</title>'
         "<style>body{font-family:-apple-system,sans-serif;background:#0f172a;color:#cbd5e1;"
         "margin:0;padding:0;overflow-y:auto;height:100vh;}"
@@ -1492,7 +1501,7 @@ def _handle_requests_panel(
         f"Auto-open on new request</label></div>"
         "</body></html>"
     )
-    return HTMLResponse(content=html)
+    return HTMLResponse(content=html_content)
 
 
 async def _handle_requests_auto_open(

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -792,9 +792,18 @@ function refreshAuthStatus() {
 }
 
 if (isElectron) {
-  window.minds.onContentTitleChange(function(title) {
-    document.getElementById('page-title').textContent = title || 'Minds';
-  });
+  // In Electron, main process pushes an authoritative per-window title
+  // (mirrors the OS window title: "{workspace-name} -- Minds" or "Minds").
+  // Ignore content document.title entirely.
+  if (window.minds.onWindowTitleChange) {
+    window.minds.onWindowTitleChange(function(title) {
+      document.getElementById('page-title').textContent = title || 'Minds';
+    });
+  } else {
+    window.minds.onContentTitleChange(function(title) {
+      document.getElementById('page-title').textContent = title || 'Minds';
+    });
+  }
   window.minds.onContentURLChange(function() {
     refreshAuthStatus();
   });
@@ -871,25 +880,35 @@ function updateRequestsBadge(count) {
   if (badge) badge.style.display = count > 0 ? 'block' : 'none';
 }
 
-var evtSource = null;
-function connectSSE() {
-  if (evtSource) evtSource.close();
-  evtSource = new EventSource('/_chrome/events');
-  evtSource.onmessage = function(event) {
-    try {
-      var data = JSON.parse(event.data);
-      if (data.type === 'workspaces') renderWorkspaces(data.workspaces);
-      if (data.type === 'auth_status') updateAuthUI(data);
-      if (data.type === 'request_count') updateRequestsBadge(data.count);
-    } catch(e) {}
-  };
-  evtSource.onerror = function() {
-    evtSource.close();
-    evtSource = null;
-    setTimeout(connectSSE, 5000);
-  };
+function handleChromeEvent(data) {
+  try {
+    if (data.type === 'workspaces') renderWorkspaces(data.workspaces);
+    if (data.type === 'auth_status') updateAuthUI(data);
+    if (data.type === 'request_count') updateRequestsBadge(data.count);
+  } catch(e) {}
 }
-connectSSE();
+
+if (isElectron && window.minds.onChromeEvent) {
+  // Electron: main process maintains a single SSE to /_chrome/events and
+  // pushes events to every chrome/sidebar view. Each view opening its own
+  // EventSource used to saturate Chromium's 6-connection-per-host cap.
+  window.minds.onChromeEvent(handleChromeEvent);
+} else {
+  var evtSource = null;
+  function connectSSE() {
+    if (evtSource) evtSource.close();
+    evtSource = new EventSource('/_chrome/events');
+    evtSource.onmessage = function(event) {
+      try { handleChromeEvent(JSON.parse(event.data)); } catch(e) {}
+    };
+    evtSource.onerror = function() {
+      evtSource.close();
+      evtSource = null;
+      setTimeout(connectSSE, 5000);
+    };
+  }
+  connectSSE();
+}
 </script>
 </body>
 </html>"""
@@ -916,11 +935,30 @@ h2 {
 }
 
 .sidebar-item {
-  padding: 10px 12px; cursor: pointer; font-size: 13px; font-weight: 500;
+  position: relative;
+  padding: 10px 36px 10px 12px;
+  cursor: pointer; font-size: 13px; font-weight: 500;
   color: #cbd5e1; border-radius: 6px; margin: 2px 0;
   transition: background 100ms;
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
 }
 .sidebar-item:hover { background: rgba(255,255,255,0.06); }
+
+.sidebar-item-label {
+  flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+.sidebar-open-new {
+  display: none;
+  background: none; border: none; padding: 4px; cursor: pointer;
+  color: #94a3b8; border-radius: 4px;
+  align-items: center; justify-content: center;
+}
+.sidebar-open-new:hover { color: #e2e8f0; background: rgba(255,255,255,0.08); }
+.sidebar-open-new svg { width: 14px; height: 14px; fill: none; stroke: currentColor;
+  stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.sidebar-item:hover .sidebar-open-new { display: inline-flex; }
+.sidebar-item.is-current .sidebar-open-new { display: none !important; }
 
 .sidebar-empty {
   padding: 24px 16px; font-size: 13px; color: #64748b; text-align: center;
@@ -934,9 +972,23 @@ h2 {
 </div>
 <script>
 var isElectron = !!window.minds;
+var currentWorkspaceId = null;
+var lastWorkspaces = [];
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, function(c) {
+    return { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c];
+  });
+}
 
 function selectWorkspace(agentId) {
   if (isElectron) window.minds.navigateContent('/forwarding/' + agentId + '/');
+}
+
+function openInNewWindow(agentId) {
+  if (isElectron && window.minds.openWorkspaceInNewWindow) {
+    window.minds.openWorkspaceInNewWindow(agentId);
+  }
 }
 
 function renderWorkspaces(workspaces) {
@@ -956,34 +1008,95 @@ function renderWorkspaces(workspaces) {
     if (b === 'Private') return 1;
     return a.localeCompare(b);
   });
+  var openIcon = '<svg viewBox="0 0 24 24"><path d="M14 3h7v7"/>'
+    + '<path d="M10 14L21 3"/>'
+    + '<path d="M21 14v5a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h5"/></svg>';
   var html = '';
   keys.forEach(function(key) {
-    var label = key === 'Private' ? 'PRIVATE' : key;
+    var label = key === 'Private' ? 'PRIVATE' : escapeHtml(key);
     html += '<div style="padding:8px 12px 2px;font-size:11px;color:#64748b;letter-spacing:0.3px;">' + label + '</div>';
     groups[key].forEach(function(w) {
-      html += '<div class="sidebar-item" onclick="selectWorkspace(\\'' + w.id + '\\')">' + (w.name || w.id) + '</div>';
+      var id = escapeHtml(w.id);
+      var name = escapeHtml(w.name || w.id);
+      var isCurrent = w.id === currentWorkspaceId;
+      var classes = 'sidebar-item' + (isCurrent ? ' is-current' : '');
+      html += '<div class="' + classes + '" data-agent-id="' + id + '">'
+        + '<span class="sidebar-item-label">' + name + '</span>'
+        + '<button class="sidebar-open-new" data-open-new="' + id + '" title="Open in new window" tabindex="-1">'
+        + openIcon
+        + '</button>'
+        + '</div>';
     });
   });
   container.innerHTML = html;
 }
 
-var evtSource = null;
-function connectSSE() {
-  if (evtSource) evtSource.close();
-  evtSource = new EventSource('/_chrome/events');
-  evtSource.onmessage = function(event) {
-    try {
-      var data = JSON.parse(event.data);
-      if (data.type === 'workspaces') renderWorkspaces(data.workspaces);
-    } catch(e) {}
-  };
-  evtSource.onerror = function() {
-    evtSource.close();
-    evtSource = null;
-    setTimeout(connectSSE, 5000);
-  };
+function handleRowClick(target) {
+  var row = target.closest('.sidebar-item');
+  if (!row) return;
+  var openNewBtn = target.closest('.sidebar-open-new');
+  var agentId = row.getAttribute('data-agent-id');
+  if (!agentId) return;
+  if (openNewBtn) {
+    openInNewWindow(agentId);
+    return;
+  }
+  selectWorkspace(agentId);
 }
-connectSSE();
+
+document.addEventListener('click', function(e) {
+  handleRowClick(e.target);
+});
+
+document.addEventListener('contextmenu', function(e) {
+  var row = e.target.closest('.sidebar-item');
+  if (!row) return;
+  var agentId = row.getAttribute('data-agent-id');
+  if (!agentId) return;
+  // Suppress context menu for the current workspace row -- nothing actionable there.
+  if (agentId === currentWorkspaceId) {
+    e.preventDefault();
+    return;
+  }
+  e.preventDefault();
+  if (isElectron && window.minds.showWorkspaceContextMenu) {
+    window.minds.showWorkspaceContextMenu(agentId, e.clientX, e.clientY);
+  }
+});
+
+if (isElectron && window.minds.onCurrentWorkspaceChanged) {
+  window.minds.onCurrentWorkspaceChanged(function(agentId) {
+    currentWorkspaceId = agentId || null;
+    renderWorkspaces(lastWorkspaces);
+  });
+}
+
+function handleChromeEvent(data) {
+  if (data.type !== 'workspaces') return;
+  lastWorkspaces = data.workspaces || [];
+  renderWorkspaces(lastWorkspaces);
+}
+
+if (isElectron && window.minds.onChromeEvent) {
+  // In Electron, the main process maintains the single SSE connection and
+  // pushes events to us via IPC. See main.js/runChromeSSELoop.
+  window.minds.onChromeEvent(handleChromeEvent);
+} else {
+  var evtSource = null;
+  function connectSSE() {
+    if (evtSource) evtSource.close();
+    evtSource = new EventSource('/_chrome/events');
+    evtSource.onmessage = function(event) {
+      try { handleChromeEvent(JSON.parse(event.data)); } catch(e) {}
+    };
+    evtSource.onerror = function() {
+      evtSource.close();
+      evtSource = null;
+      setTimeout(connectSSE, 5000);
+    };
+  }
+  connectSSE();
+}
 </script>
 </body>
 </html>"""

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -24,6 +24,7 @@ from imbue.minds.desktop_client.conftest import make_server_log
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.minds_config import MindsConfig
 from imbue.minds.desktop_client.request_events import RequestInbox
+from imbue.minds.desktop_client.request_events import create_sharing_request_event
 from imbue.minds.desktop_client.session_store import MultiAccountSessionStore
 from imbue.minds.desktop_client.ssh_tunnel import RemoteSSHInfo
 from imbue.minds.desktop_client.ssh_tunnel import SSHTunnelError
@@ -1622,6 +1623,36 @@ def test_requests_panel_shows_empty_inbox(tmp_path: Path) -> None:
     response = client.get("/_chrome/requests-panel")
     assert response.status_code == 200
     assert "Requests (0)" in response.text
+
+
+def test_requests_panel_card_routes_via_minds_bridge(tmp_path: Path) -> None:
+    """A pending request renders a card whose onclick calls navigateToRequest
+    with both event_id and agent_id, and the inline script prefers the
+    window.minds.navigateToRequest bridge when available."""
+    client, auth_store = _create_test_client_with_stores(tmp_path)
+    _authenticate_client(client, auth_store)
+    agent_id = str(AgentId())
+    event = create_sharing_request_event(agent_id=agent_id, server_name="web")
+    client.app.state.request_inbox = client.app.state.request_inbox.add_request(event)
+
+    response = client.get("/_chrome/requests-panel")
+    assert response.status_code == 200
+    body = response.text
+
+    # The rendered card must reference both ids in its onclick.
+    assert "navigateToRequest" in body
+    assert str(event.event_id) in body
+    assert agent_id in body
+    # Defense-in-depth escaping: ids are embedded via JSON/HTML-escaped quotes
+    # rather than raw single quotes, so &quot; must appear in place of ".
+    assert f"&quot;{event.event_id}&quot;" in body
+    assert f"&quot;{agent_id}&quot;" in body
+
+    # The script must prefer the IPC bridge when present, and keep the
+    # in-window and top-level fallbacks.
+    assert "window.minds.navigateToRequest" in body
+    assert "window.minds.navigateContent" in body
+    assert "window.top.location" in body
 
 
 def test_request_page_not_found(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -1629,11 +1629,26 @@ def test_requests_panel_card_routes_via_minds_bridge(tmp_path: Path) -> None:
     """A pending request renders a card whose onclick calls navigateToRequest
     with both event_id and agent_id, and the inline script prefers the
     window.minds.navigateToRequest bridge when available."""
-    client, auth_store = _create_test_client_with_stores(tmp_path)
-    _authenticate_client(client, auth_store)
+    # Build the app inline so we can seed the inbox before creating the
+    # TestClient and still have a concretely-typed handle to app.state.
     agent_id = str(AgentId())
     event = create_sharing_request_event(agent_id=agent_id, server_name="web")
-    client.app.state.request_inbox = client.app.state.request_inbox.add_request(event)
+    auth_store = FileAuthStore(data_directory=tmp_path / "auth")
+    session_store = MultiAccountSessionStore(data_dir=tmp_path)
+    minds_config = MindsConfig(data_dir=tmp_path)
+    request_inbox = RequestInbox().add_request(event)
+    backend_resolver = StaticBackendResolver(url_by_agent_and_server={})
+    app = create_desktop_client(
+        auth_store=auth_store,
+        backend_resolver=backend_resolver,
+        http_client=None,
+        session_store=session_store,
+        minds_config=minds_config,
+        request_inbox=request_inbox,
+        paths=WorkspacePaths(data_dir=tmp_path),
+    )
+    client = TestClient(app)
+    _authenticate_client(client, auth_store)
 
     response = client.get("/_chrome/requests-panel")
     assert response.status_code == 200

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -2,7 +2,7 @@ import json
 import os
 import queue
 import shlex
-import sys
+import subprocess
 import threading
 import tomllib
 from pathlib import Path
@@ -18,7 +18,11 @@ from watchdog.observers import Observer as _Observer
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.concurrency_group import InvalidConcurrencyGroupStateError
 from imbue.concurrency_group.errors import ConcurrencyGroupError
+from imbue.concurrency_group.errors import EnvironmentStoppedError
+from imbue.concurrency_group.errors import ProcessError
+from imbue.concurrency_group.errors import ProcessSetupError
 from imbue.concurrency_group.event_utils import ShutdownEvent
+from imbue.concurrency_group.local_process import RunningProcess
 from imbue.concurrency_group.subprocess_utils import run_local_command_modern_version
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds_workspace_server.agent_discovery import discover_agents
@@ -37,6 +41,7 @@ from imbue.mngr.primitives import AgentNameStyle
 from imbue.mngr.utils.name_generator import generate_agent_name
 
 _APPLICATIONS_TOML_FILENAME = "runtime/applications.toml"
+_DEFAULT_MNGR_BINARY = "mngr"
 
 
 class _LogQueueCallback(MutableModel):
@@ -91,11 +96,19 @@ class AgentManager:
     _own_work_dir: str
     _shutdown_event: ShutdownEvent
     _observe_cg: ConcurrencyGroup | None
+    _observe_process: RunningProcess | None
     _creation_cg: ConcurrencyGroup
+    _mngr_binary: str
 
     @classmethod
-    def build(cls, broadcaster: WebSocketBroadcaster) -> "AgentManager":
-        """Build an AgentManager with the given broadcaster."""
+    def build(cls, broadcaster: WebSocketBroadcaster, mngr_binary: str = _DEFAULT_MNGR_BINARY) -> "AgentManager":
+        """Build an AgentManager with the given broadcaster.
+
+        ``mngr_binary`` is the path or name of the mngr executable used for
+        the discovery-only observe subprocess and for agent-creation commands.
+        Tests inject a stand-in (e.g. ``/usr/bin/false``) to exercise failure
+        paths without relying on a working mngr installation.
+        """
         manager = cls.__new__(cls)
         manager._broadcaster = broadcaster
         manager._lock = threading.Lock()
@@ -108,8 +121,10 @@ class AgentManager:
         manager._own_work_dir = os.environ.get("MNGR_AGENT_WORK_DIR", "")
         manager._shutdown_event = ShutdownEvent.build_root()
         manager._observe_cg = None
+        manager._observe_process = None
         manager._creation_cg = ConcurrencyGroup(name="agent-creation")
         manager._creation_cg.__enter__()
+        manager._mngr_binary = mngr_binary
         return manager
 
     def start(self) -> None:
@@ -219,7 +234,7 @@ class AgentManager:
         new_branch = f"mngr/{name}"
 
         cmd = [
-            "mngr",
+            self._mngr_binary,
             "create",
             name,
             "--id",
@@ -281,7 +296,7 @@ class AgentManager:
             raise AgentCreationError(msg)
 
         cmd = [
-            "mngr",
+            self._mngr_binary,
             "create",
             name,
             "--id",
@@ -463,8 +478,14 @@ class AgentManager:
         except (OSError, ValueError, RuntimeError, BaseMngrError):
             _loguru_logger.exception("Agent refresh failed")
 
-    def _start_observe(self) -> None:
-        """Start the mngr observe subprocess."""
+    def _build_observe_command(self) -> list[str]:
+        """Build the argv for the mngr observe discovery-only subprocess.
+
+        Exposed as a method so tests can assert that the first element
+        resolves to a real mngr binary (an earlier bug invoked
+        ``python -m imbue.mngr``, which has no ``__main__`` and crashed
+        silently on startup).
+        """
         agent_state_dir = os.environ.get("MNGR_AGENT_STATE_DIR", "")
         if agent_state_dir:
             events_dir = Path(agent_state_dir) / "workspace_server" / "observe"
@@ -473,10 +494,8 @@ class AgentManager:
 
         events_dir.mkdir(parents=True, exist_ok=True)
 
-        cmd = [
-            sys.executable,
-            "-m",
-            "imbue.mngr",
+        return [
+            self._mngr_binary,
             "observe",
             "--discovery-only",
             "--on-error",
@@ -485,12 +504,21 @@ class AgentManager:
             str(events_dir),
         ]
 
+    def _start_observe(self) -> None:
+        """Start the mngr observe subprocess and a watchdog for early exit."""
+        cmd = self._build_observe_command()
+
         self._observe_cg = ConcurrencyGroup(name="agent-manager-observe")
         self._observe_cg.__enter__()
 
         try:
-            self._observe_cg.run_process_in_background(
+            # Run from $HOME so mngr picks up its global config instead of any
+            # project-local .mngr/settings.toml in the current directory --
+            # in particular the monorepo's settings has is_allowed_in_pytest
+            # disabled, which would abort the observe subprocess.
+            process = self._observe_cg.run_process_in_background(
                 command=cmd,
+                cwd=Path.home(),
                 on_output=self._handle_observe_output_line,
                 shutdown_event=self._shutdown_event,
             )
@@ -500,11 +528,53 @@ class AgentManager:
             )
             self._observe_cg.__exit__(None, None, None)
             self._observe_cg = None
+            return
 
-    def _handle_observe_output_line(self, line: str, _is_stdout: bool) -> None:
-        """Parse and dispatch a single line of output from mngr observe."""
+        self._observe_process = process
+
+        # ``run_process_in_background`` returns immediately even if the spawned
+        # binary exits with a non-zero code (e.g. import failure). Attach a
+        # watchdog so a silently-dying subprocess surfaces as a loud error
+        # instead of a stale agent list.
+        self._observe_cg.start_new_thread(
+            target=self._watch_observe_process,
+            args=(process,),
+            name="observe-watchdog",
+            is_checked=False,
+        )
+
+    def _watch_observe_process(self, process: RunningProcess) -> None:
+        """Log an error if the observe subprocess exits before shutdown."""
+        try:
+            process.wait()
+        except (ProcessError, ProcessSetupError, EnvironmentStoppedError, subprocess.TimeoutExpired) as e:
+            if self._shutdown_event.is_set():
+                return
+            _loguru_logger.error("mngr observe subprocess failed: {}", e)
+            return
+
+        if self._shutdown_event.is_set():
+            return
+
+        stderr = process.read_stderr().strip()
+        _loguru_logger.error(
+            "mngr observe subprocess exited unexpectedly (returncode={}). "
+            "Agent lifecycle events will no longer be detected. stderr: {}",
+            process.returncode,
+            stderr if stderr else "(empty)",
+        )
+
+    def _handle_observe_output_line(self, line: str, is_stdout: bool) -> None:
+        """Parse and dispatch a single line of output from mngr observe.
+
+        stderr lines are surfaced as warnings so startup failures from the
+        subprocess (import errors, bad flags, etc.) are not lost.
+        """
         stripped = line.strip()
         if not stripped:
+            return
+        if not is_stdout:
+            _loguru_logger.warning("mngr observe stderr: {}", stripped)
             return
         try:
             event = parse_discovery_event_line(stripped)

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
@@ -2,6 +2,7 @@
 
 import json
 import queue
+import shutil
 import threading
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from imbue.mngr.primitives import AgentName as MngrAgentName
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.utils.polling import poll_until
 
 
 def test_generate_random_name(agent_manager: AgentManager) -> None:
@@ -639,3 +641,128 @@ def test_handle_discovery_event_dispatches_host_destroyed(
     event = _make_host_destroyed_event(host_id, [agent_id])
     agent_manager._handle_discovery_event(event)
     assert len(agent_manager.get_agents()) == 0
+
+
+def test_build_observe_command_starts_with_mngr_binary(agent_manager: AgentManager) -> None:
+    """The observe subprocess must invoke the ``mngr`` CLI, not ``python -m imbue.mngr``.
+
+    Regression test: a previous implementation used ``sys.executable -m imbue.mngr``,
+    which crashes because ``imbue.mngr`` is a package with no ``__main__``. The
+    failure was silent, leaving agents discovered after startup invisible to the
+    "+" tab menu.
+    """
+    cmd = agent_manager._build_observe_command()
+    assert cmd[0] == "mngr"
+    assert cmd[1] == "observe"
+    assert "--discovery-only" in cmd
+
+
+def test_build_observe_command_honors_injected_binary(broadcaster: WebSocketBroadcaster) -> None:
+    """The ``mngr_binary`` argument to ``build()`` overrides the default binary path."""
+    manager = AgentManager.build(broadcaster, mngr_binary="/path/to/custom-mngr")
+    try:
+        cmd = manager._build_observe_command()
+        assert cmd[0] == "/path/to/custom-mngr"
+    finally:
+        manager.stop()
+
+
+def test_start_observe_spawns_long_lived_subprocess(
+    broadcaster: WebSocketBroadcaster,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the observe subprocess stays alive after startup.
+
+    This is the regression test for the ``python -m imbue.mngr`` bug; with the
+    old command the subprocess exited immediately (Python package has no
+    ``__main__``) and this assertion would fire.
+    """
+    if shutil.which("mngr") is None:
+        pytest.skip("mngr binary not on PATH")
+
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    manager = AgentManager.build(broadcaster)
+    try:
+        manager._start_observe()
+        assert manager._observe_process is not None
+        # If the subprocess exits within the window it's a failure (bad command,
+        # crashed on startup, etc.). A healthy observe keeps running.
+        exited = poll_until(
+            lambda: manager._observe_process is not None and manager._observe_process.poll() is not None,
+            timeout=1.5,
+            poll_interval=0.1,
+        )
+        assert not exited, (
+            "mngr observe subprocess exited within 1.5s of startup "
+            f"(returncode={manager._observe_process.returncode}); stderr: "
+            f"{manager._observe_process.read_stderr()!r}"
+        )
+    finally:
+        manager.stop()
+
+
+def test_start_observe_logs_error_when_subprocess_exits_unexpectedly(
+    broadcaster: WebSocketBroadcaster,
+    false_binary: str,
+    loguru_records: list[str],
+) -> None:
+    """If the observe subprocess exits on its own, the watchdog logs an ERROR.
+
+    Uses ``/usr/bin/false`` (or equivalent) as a stand-in mngr binary so the
+    spawned process exits immediately with a non-zero code.
+    """
+    manager = AgentManager.build(broadcaster, mngr_binary=false_binary)
+    try:
+        manager._start_observe()
+        logged_error = poll_until(
+            lambda: any(r.startswith("ERROR") and "mngr observe" in r for r in loguru_records),
+            timeout=5.0,
+            poll_interval=0.05,
+        )
+        assert logged_error, (
+            "Expected an ERROR log from the observe watchdog; got: "
+            f"{[r for r in loguru_records if r.startswith('ERROR')]}"
+        )
+    finally:
+        manager.stop()
+
+
+def test_start_observe_watchdog_stays_quiet_on_clean_shutdown(
+    broadcaster: WebSocketBroadcaster,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    loguru_records: list[str],
+) -> None:
+    """Calling ``stop()`` on a healthy observe subprocess must not produce errors."""
+    if shutil.which("mngr") is None:
+        pytest.skip("mngr binary not on PATH")
+
+    monkeypatch.setenv("MNGR_AGENT_STATE_DIR", str(tmp_path))
+    manager = AgentManager.build(broadcaster)
+    manager._start_observe()
+    # Wait for the subprocess to actually be running before asking it to stop,
+    # so we exercise the "healthy subprocess shut down cleanly" path rather
+    # than a race where stop() fires before the child has started.
+    assert manager._observe_process is not None
+    poll_until(
+        lambda: manager._observe_process is not None and manager._observe_process.poll() is None,
+        timeout=2.0,
+        poll_interval=0.05,
+    )
+    manager.stop()
+
+    errors = [r for r in loguru_records if r.startswith("ERROR") and "mngr observe" in r]
+    assert errors == [], f"Watchdog logged errors during clean shutdown: {errors}"
+
+
+def test_handle_observe_output_line_logs_stderr_as_warning(
+    agent_manager: AgentManager,
+    loguru_records: list[str],
+) -> None:
+    """Stderr output from the observe subprocess is surfaced as a warning."""
+    agent_manager._handle_observe_output_line("something bad happened", is_stdout=False)
+
+    warnings = [r for r in loguru_records if r.startswith("WARNING") and "mngr observe stderr" in r]
+    assert warnings, f"Expected a stderr warning; got: {loguru_records}"
+    assert "something bad happened" in warnings[0]

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/conftest.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/conftest.py
@@ -1,8 +1,11 @@
 import os
+import shutil
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from loguru import logger as loguru_logger
 
 from imbue.minds_workspace_server.agent_manager import AgentManager
 from imbue.minds_workspace_server.ws_broadcaster import WebSocketBroadcaster
@@ -19,6 +22,38 @@ def agent_manager(broadcaster: WebSocketBroadcaster, monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("MNGR_AGENT_ID", "test-agent-id")
     monkeypatch.setenv("MNGR_AGENT_WORK_DIR", "/tmp/test-work")
     return AgentManager.build(broadcaster)
+
+
+@pytest.fixture
+def false_binary() -> str:
+    """Cross-platform path to a binary that exits immediately with failure.
+
+    Used by tests that exercise the observe watchdog's error path without
+    relying on a real mngr installation.
+    """
+    path = shutil.which("false")
+    assert path is not None, "Could not find 'false' binary on this system"
+    return path
+
+
+@pytest.fixture
+def loguru_records() -> Iterator[list[str]]:
+    """Capture loguru log messages as plain strings for test assertions.
+
+    Each entry in the yielded list is a ``"<LEVEL> <message>"`` line, so tests
+    can filter on both level and text without wiring up loguru into pytest's
+    stdlib-oriented ``caplog``.
+    """
+    messages: list[str] = []
+    handler_id = loguru_logger.add(
+        lambda msg: messages.append(f"{msg.record['level'].name} {msg.record['message']}"),
+        level="DEBUG",
+        format="{message}",
+    )
+    try:
+        yield messages
+    finally:
+        loguru_logger.remove(handler_id)
 
 
 @pytest.fixture

--- a/specs/multi-window-workspaces/concise.md
+++ b/specs/multi-window-workspaces/concise.md
@@ -1,0 +1,146 @@
+# Multi-Window Workspaces
+
+## Overview
+
+* Today the minds Electron app is single-window: one `BaseWindow` with one `contentView` that the sidebar navigates between workspaces (`/forwarding/{agent_id}/...`). To view two workspaces side-by-side, users must leave the app entirely.
+* This spec adds multi-window support: each workspace can live in its own window, with at most one window per workspace enforced across the whole app.
+* Opening a new window is always an explicit user action (right-click "Open in new window" or a hover icon in the sidebar). A plain sidebar click still navigates the current window — unless the target workspace is already open somewhere, in which case that other window is focused instead.
+* The backend is unchanged. All windows share the same backend session, same cookie-based auth, and the same set of backend routes. This is purely an Electron-layer refactor: module-level window state in `main.js` becomes a per-window registry, IPC handlers become sender-aware, and the backend's per-window views (content, sidebar, requests panel, chrome title bar) are instantiated once per window.
+* Shutdown becomes window-count-driven: closing a single window just closes that window; the backend only shuts down when the last window closes.
+
+## Expected Behavior
+
+### Window identity and uniqueness
+
+* A window is "on workspace X" whenever its content view's URL starts with `/forwarding/{X}/`. A window on `/` or any non-workspace route does not count as a workspace window.
+* There is no "home" window concept. A window is just a window; its role follows its current URL. A workspace window becomes a non-workspace window as soon as the user navigates it away (e.g. via the home button); a non-workspace window becomes a workspace window when it navigates into `/forwarding/X/`.
+* At most one window can be on any given workspace at any time. Two windows both on workspace X is never a valid state. Uniqueness is enforced at the Electron level via a `will-navigate` listener on every content view: any navigation to `/forwarding/{X}/...` that targets a workspace already open in a different window is cancelled (`event.preventDefault()`) and the existing window is focused instead. This catches every navigation path — sidebar IPC, landing-page row clicks, in-page anchors, `window.location` assignments — not just the sidebar.
+
+### Sidebar clicks
+
+* Clicking a workspace entry in the sidebar:
+  * If some window is already on that workspace → focus that window. The clicked window is untouched.
+  * Otherwise → navigate the current window to `/forwarding/{X}/` (works whether the current window was on `/`, on another workspace, or anywhere else). The previous workspace of this window, if any, is no longer open in any window.
+* The sidebar itself is unchanged visually. No indicator is shown for "currently open elsewhere" or "this window's current workspace."
+
+### Explicit "Open in new window"
+
+* Two affordances, both in the sidebar, both doing the same thing:
+  * Right-click on a sidebar workspace entry → context menu with a single item: "Open in new window."
+  * A small "open in new window" icon next to each sidebar entry, revealed on hover.
+* Both actions: if the target workspace is already open in another window, focus that window (uniqueness still wins); otherwise create a new window and load `/forwarding/{X}/` in it.
+* If the current window is itself on the target workspace, both affordances are hidden/disabled for that entry (you can't open a window that already exists).
+* The new window uses Electron default position/size. No cascade, no remembering per-workspace positions.
+
+### Window titles
+
+* OS-level window title (dock, taskbar, alt-tab):
+  * Workspace window: `{workspace-name} — Minds`, where `{workspace-name}` is the same `w.name || w.id` the sidebar uses. Until the name has loaded, the title is `Minds`; it updates in place when the workspace list is received.
+  * Non-workspace window: `Minds`.
+* In-window chrome title bar (the page title element inside the title bar): mirrors the OS title. The main process pushes a `window-title-changed` IPC to each window's chrome view whenever the computed title changes (content-view navigation or workspace-list update) and on chrome-view `did-finish-load`. `document.title` from the content view is ignored in Electron mode. (In plain-browser mode the chrome template still polls `document.title` from the iframe.)
+
+### Notifications and `auth_required`
+
+* Workspace-specific notifications (notification event's URL starts with `/forwarding/{X}/`): clicking the notification focuses the existing window for workspace X if one is open; otherwise opens a new window. The window navigates to the full URL from the event, preserving any deep path.
+* `auth_required` backend events, and notifications whose URL is non-workspace (e.g. `/auth/login`, `/accounts`): focus the most recently focused window and navigate it to that URL. No new window is created.
+* "Most recently focused window" is tracked via the OS-level `focus` event on each `BaseWindow` — the window that most recently gained OS focus (by click, alt-tab, or programmatic focus) wins.
+
+### Requests panel
+
+* Any window can independently open the right-side requests panel from its own title bar, identical to today.
+* Clicking a request in the requests panel follows the workspace-notification rule: focus the target workspace's window if open, otherwise open a new window pointed at that request's URL.
+
+### Shutdown
+
+* Closing a single window (via the close button, cmd+W, or `window-close` IPC) destroys only that window and its associated views (content, sidebar, requests panel). The backend keeps running.
+* When the last window closes, the backend is shut down (SIGTERM, then SIGKILL after 5s — same as today) and the app quits.
+* `cmd+Q` / `ctrl+Q` triggers the full quit path explicitly: close all windows, then shut down the backend.
+* macOS keeps the same cross-platform behavior — the app quits when the last window closes (no dock-icon-alive state).
+
+### Backend crash / startup error
+
+* If the backend exits unexpectedly, the error screen is shown in every open window simultaneously (each window's chrome view switches to the error UI, all content/sidebar/requests-panel views are torn down).
+* "Retry" from any window restarts the backend once. On success, every window reloads: chrome view returns to `/_chrome` and content view returns to its pre-error URL.
+
+### Single-instance lock and second-launch
+
+* The single-instance lock stays. A second `minds` launch focuses the most recently focused window of the running instance (same MRU signal as above).
+
+### Session restoration
+
+* On quit, the app records the set of open windows and each window's current URL (including deep paths within a workspace).
+* On next launch, after auth completes, reopen one window per recorded URL, each navigated to the exact URL it had at quit. Windows use default position/size (no position restoration).
+* Destroyed workspaces are silently skipped: for each recorded URL that targets `/forwarding/{X}/`, if workspace X no longer exists in the current agent list, drop that URL from the restoration set without opening a window or surfacing any error.
+* If no windows remain after filtering (e.g. fresh install, or every recorded workspace was destroyed), the app opens a single window at the landing URL, same as today.
+
+### Keyboard shortcuts
+
+* cmd+W / ctrl+W: close the current window. Does NOT shut down the backend unless it was the last window.
+* cmd+Q / ctrl+Q: quit the app — close all windows, shut down the backend.
+* cmd+N / ctrl+N: open a new window pointed at the home page (`/`). No workspace uniqueness check (the home page is not a workspace window).
+* Existing DevTools shortcut (cmd+opt+I / ctrl+shift+C) continues to toggle DevTools for the focused window's content view.
+
+### Opening a new home window
+
+There are three entry points, all of which open a fresh window on the backend's home page (`/`) — the same landing page a new install would see. None of them accept a workspace parameter; for workspace-specific "new window" see `Explicit "Open in new window"` above.
+
+* **Application menu → File → New Window** (macOS): a custom application menu is installed that keeps the standard app/edit/window submenus and adds a `File` menu containing `New Window` (bound to cmd+N) and `Close Window` (cmd+W).
+* **Dock context menu → New Window** (macOS): `app.dock.setMenu(...)` installs a single-item menu that opens a new home window.
+* **Keyboard shortcut cmd+N / ctrl+N**: works on every platform. On macOS it's bound via the File-menu accelerator; on Windows/Linux the application menu is hidden, so the shortcut is registered per-window via `before-input-event` alongside cmd+W / cmd+Q.
+
+The new window uses Electron default position/size, loads `/_chrome` in its chrome view, and loads `/` in its content view. It appears in the MRU list as soon as it receives focus.
+
+## Changes
+
+### Electron main process (`apps/minds/electron/main.js`)
+
+* Replace module-level window state (`mainWindow`, `chromeView`, `contentView`, `sidebarView`, `requestsPanelView`) with a per-window bundle registry. Each bundle owns its own `BaseWindow` plus its four `WebContentsView`s (chrome, content, sidebar, requests panel) and tracks its current content URL and current workspace ID (derived from URL).
+* Add a helper to parse the workspace ID from a URL (`/forwarding/{agentId}/...`) and update a window's recorded workspace ID on content view `did-navigate` / `did-navigate-in-page`.
+* Add a central `openOrFocusWorkspace(agentId, url)` routine used by sidebar clicks, notifications, and requests-panel clicks. It enforces uniqueness (focus if open, else create new window) and sets up the window's initial URL.
+* Add `navigateCurrentWindowToWorkspace(sourceWindow, agentId)` for the plain-click path: if workspace is already open elsewhere, focus that; else navigate the source window's content view.
+* Rewrite all IPC handlers (`go-home`, `navigate-content`, `content-go-back`, `content-go-forward`, `toggle-sidebar`, `toggle-requests-panel`, `open-requests-panel`, `retry`, `window-minimize`, `window-maximize`, `window-close`) to resolve the target window from the IPC event's sender (`event.sender.getOwnerBrowserWindow()` or equivalent) instead of the single `mainWindow`.
+* Update `navigate-content` to branch: if the URL is a workspace URL (`/forwarding/{X}/...`) and another window is already on workspace X, focus that window without navigating the sender; otherwise navigate the sender's content view.
+* Add a new IPC channel `open-workspace-in-new-window` invoked by the sidebar's right-click menu and hover-icon clicks; routes through `openOrFocusWorkspace`.
+* Update the OS window title to `{workspace-name} — Minds` on workspace windows and `Minds` elsewhere. Track the latest sidebar workspace list (received via a new IPC broadcast from the sidebar's SSE) per-window or app-wide, and update window titles when the list changes or when the content view navigates.
+* Push the same computed title into each window's chrome view via a new `window-title-changed` IPC (exposed on the preload bridge as `onWindowTitleChange`) so the in-window title bar mirrors the OS title. The chrome template uses this in Electron mode instead of `document.title`.
+* Centralize the `/_chrome/events` SSE subscription in the main process (`runChromeSSELoop`, using `net.request` with `useSessionCookies: true`). Broadcast each event to every window's chrome and sidebar view via a new `chrome-event` IPC; templates subscribe via `window.minds.onChromeEvent` and fall back to a direct `EventSource` only in plain-browser mode. This avoids exhausting Chromium's 6-connection-per-host cap once you open a couple of windows (each previously opened its own SSE connection, which starved subsequent `/_chrome/sidebar`, `/_chrome/requests-panel`, and in-app navigations for seconds at a time).
+* Lazy-create the sidebar/requests-panel `WebContentsView` per window and toggle with `setVisible` instead of destroy-and-recreate on every click. Destroying spawned a fresh render process and preload load per toggle, which in rapid-click scenarios queued many seconds of latency.
+* On `BaseWindow` `close`, explicitly call `webContents.close()` on every child view (chrome/content/sidebar/requests-panel). `BaseWindow` doesn't guarantee destruction of its child `WebContentsView` render processes; leaking them across create/close cycles eventually starves new ones.
+* On the content view, attach `will-prevent-unload` → `event.preventDefault()` so pages that install a `beforeunload` handler (e.g. workspace pages with open websockets) don't stall navigations waiting for a non-existent confirmation dialog.
+* Update `window-all-closed` handler: only call `shutdown()` + `app.quit()` when the last window is gone. Individual window close events just tear down that window's bundle.
+* Add a `cmd+Q` / `ctrl+Q` accelerator to trigger the full-quit path (close all bundles + shutdown).
+* Add a `cmd+W` / `ctrl+W` accelerator to close the focused window's bundle only.
+* Add a `cmd+N` / `ctrl+N` accelerator (and a `openHomeInNewWindow()` helper) that opens a fresh bundle pointed at `/`.
+* On macOS, install a custom application `Menu` that keeps the standard app/edit/window roles and adds a `File` menu containing `New Window` (cmd+N) and `Close Window` (cmd+W). When `MINDS_HIDE_MENU=1` the menu is suppressed and shortcuts fall back to per-window `before-input-event` handling.
+* On macOS, call `app.dock.setMenu(Menu.buildFromTemplate([{ label: 'New Window', click: openHomeInNewWindow }]))` so the dock icon's right-click menu offers the same action.
+* Maintain an app-wide MRU list of open windows: push to front on each `BaseWindow` `focus` event, drop on `closed`. The single-instance `second-instance` handler and the no-workspace code paths (`auth_required`, non-workspace notification clicks) resolve the target window from this list.
+* Rework the backend-crash / error flow: `showError` fans out to every open window's chrome view. `retry` IPC handler, once it succeeds, reloads every window to its recorded pre-error URL.
+* Update the notification `onClick` callback to route through `openOrFocusWorkspace` for workspace URLs, and through "focus most recent + navigate" for non-workspace URLs.
+* Update the `auth_required` handler similarly (no workspace involved — always uses the MRU window).
+* Write session state to disk on `before-quit`: a JSON list of content-view URLs, one per open window. Read it on `whenReady` and, after the backend is ready, open one window per recorded URL.
+
+### Sidebar (desktop-client backend + preload bridge)
+
+* Extend the sidebar HTML template (`_SIDEBAR_TEMPLATE` in `apps/minds/imbue/minds/desktop_client/templates.py`) so each workspace row supports:
+  * A right-click that triggers a native Electron context menu (not an in-page styled `<div>`). The sidebar HTML listens for the DOM `contextmenu` event on a workspace row and sends an IPC message to the main process with the row's agent ID and click coordinates (relative to the sidebar view). The main process builds a native menu via Electron's `Menu.buildFromTemplate([{ label: 'Open in new window', click: ... }])` and calls `menu.popup({ window, x, y })` on the sidebar window. This keeps visual fidelity (native OS menu appearance + behavior) while letting the sidebar still drive the content.
+  * A hover-only "open in new window" icon on the right of each row. Clicking it sends the same IPC as the context menu's "Open in new window" item.
+  * Suppression of both affordances for the entry matching the sender window's current workspace. The sidebar needs to know its owning window's current workspace — the main process pushes that information in via an IPC broadcast whenever the window's content view navigates.
+* The preload bridge (`apps/minds/electron/preload.js`) gains:
+  * `openWorkspaceInNewWindow(agentId)` — fires the `open-workspace-in-new-window` IPC.
+  * `showWorkspaceContextMenu(agentId, x, y)` — fires a `show-workspace-context-menu` IPC so the main process can pop up a native menu.
+  * `onCurrentWorkspaceChanged(callback)` — receives updates on this window's current workspace (used to suppress self-affordances).
+* The sidebar informs the main process of its rendered workspace list (ids + display names) via a new IPC message, so the main process can resolve workspace names for OS window titles without duplicating the SSE connection.
+* Auto-close behavior: the sender's sidebar closes after every sidebar action -- plain workspace click (whether it navigates the current window or focuses another), hover-icon "Open in new window" click, and native context-menu "Open in new window" click. The rationale is that once the user has picked a workspace the sidebar has served its purpose; leaving it open just occludes content.
+
+### Backend (`apps/minds/imbue/minds/desktop_client/`)
+
+* No behavior changes. The backend continues to serve `/_chrome`, `/_chrome/sidebar`, `/_chrome/requests-panel`, and all `/forwarding/{agent_id}/...` routes.
+* Sanity check: confirm that multiple Electron windows hitting the same backend on the same session cookie is a supported pattern for the sharing/auth endpoints (`auth_required`, SuperTokens token refresh). No changes expected.
+
+### Dev-mode parity
+
+* Dev mode (`pnpm start`, `uv run --package minds ...`) inherits all behavior automatically — no separate code paths in `backend.js`.
+
+## Open Questions
+
+* None outstanding.


### PR DESCRIPTION
## Summary

- The minds_workspace_server's `AgentManager._start_observe()` spawned the discovery-only observe subprocess as `python -m imbue.mngr`, which crashes on startup because `imbue.mngr` is a package with no `__main__`. The failure was silent, so `AgentManager._agents` only ever reflected what `_initial_discover()` saw once at startup.
- Symptom: when an agent runs `mngr create ... --label workspace=$MINDS_WORKSPACE_NAME` (e.g. via the launch-task skill in forever-claude-template), the new sub-agent never appeared in the "+" tab menu — the AgentManager never received the `AGENT_DISCOVERED` event, so the unified WebSocket never broadcast it to the frontend.
- Fix: invoke the `mngr` CLI directly (consistent with the desktop client's `MngrStreamManager` and the AgentManager's own create commands), pin `cwd=$HOME` so the monorepo's `.mngr/settings.toml` doesn't abort the subprocess under pytest, surface stderr lines as warnings, and attach a watchdog thread that logs an error when the subprocess exits before shutdown so a future silent-crash regression surfaces loudly.

## Test plan

- [x] `(cd apps/minds_workspace_server && uv run pytest --no-cov --cov-fail-under=0)` — all 177 tests pass locally
- [x] New regression test `test_start_observe_spawns_long_lived_subprocess` fails against the old `python -m imbue.mngr` command and passes against the fix
- [x] New `test_start_observe_logs_error_when_subprocess_exits_unexpectedly` verifies the watchdog fires on an immediate-exit binary
- [x] New `test_build_observe_command_starts_with_mngr_binary` pins the command shape so reintroducing `python -m imbue.mngr` would fail CI
- [x] `test_prevent_time_sleep` ratchet still satisfied (tests use `poll_until` from `imbue.mngr.utils.polling`)
- [ ] Manual: restart a running mindtest workspace server, run `mngr create sleep-test -t worker --label workspace=$MINDS_WORKSPACE_NAME ...`, confirm `sleep-test` appears in the "+" tab menu within a couple seconds