### PR TITLE
Detach HEAD on target before mirror push with --prune

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -1680,6 +1680,20 @@ class Host(BaseHost, OnlineHostInterface):
 
         with log_span("Pushing git repo to target: {}", git_url):
             if source_host.is_local:
+                # When re-pushing into an existing target (e.g. `mngr create
+                # --reuse --update`), the mirror push's `--prune` may try to
+                # delete the target's currently-checked-out branch. Git
+                # refuses that by default ("refusing to delete the current
+                # branch"). Detach HEAD on the target and set
+                # receive.denyDeleteCurrent=ignore so prune can replace all
+                # branches cleanly. `2>/dev/null` tolerates a fresh bare
+                # repo with no branch to detach from.
+                detach_cmd = (
+                    "git -C " + shlex.quote(str(target_path)) + " checkout --detach HEAD 2>/dev/null;"
+                    " git -C " + shlex.quote(str(target_path)) + " config receive.denyDeleteCurrent ignore"
+                )
+                self.execute_idempotent_command(detach_cmd)
+
                 command_args = [
                     "git",
                     "-C",

--- a/libs/mngr/imbue/mngr/hosts/test_host.py
+++ b/libs/mngr/imbue/mngr/hosts/test_host.py
@@ -1730,6 +1730,69 @@ def test_create_work_dir_copy_with_git(
 
 
 @pytest.mark.rsync
+def test_create_work_dir_idempotent_when_target_has_checked_out_work_branch(
+    host_with_temp_dir: tuple[Host, Path],
+    setup_git_config: None,
+) -> None:
+    """Regression: re-running create_agent_work_dir against an existing target
+    whose current branch no longer exists on source (the case minds hits when
+    `mngr create --reuse --update` re-creates an agent that already ran work
+    branches) must not fail on `git push --prune`.
+
+    Without the detach-HEAD + `receive.denyDeleteCurrent=ignore` fix in
+    `_git_push_to_target`, the second create raises because git refuses to
+    delete the target's currently-checked-out branch.
+    """
+    host, temp_dir = host_with_temp_dir
+
+    source_path = temp_dir / "source_prune"
+    source_path.mkdir()
+    (source_path / "file.txt").write_text("initial")
+    _init_git_repo(source_path)
+
+    target_path = temp_dir / "target_prune"
+    branch_name = "mngr-regression-foo-1"
+
+    options = CreateAgentOptions(
+        name=AgentName("regression-prune"),
+        agent_type=AgentTypeName("generic"),
+        command=CommandString("sleep 1"),
+        target_path=target_path,
+        transfer_mode=TransferMode.GIT_MIRROR,
+        git=AgentGitOptions(new_branch_name=branch_name),
+    )
+
+    # First call: sets up target with the work branch checked out.
+    first_result = host.create_agent_work_dir(host, source_path, options)
+    assert first_result.path == target_path
+    assert first_result.created_branch_name == branch_name
+
+    # Confirm the failure preconditions: target is on branch_name, source is not.
+    env = {**os.environ, "GIT_CONFIG_NOSYSTEM": "1"}
+    target_head = subprocess.run(
+        ["git", "-C", str(target_path), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True, text=True, env=env, check=True,
+    ).stdout.strip()
+    assert target_head == branch_name
+    source_branches = subprocess.run(
+        ["git", "-C", str(source_path), "branch", "--format=%(refname:short)"],
+        capture_output=True, text=True, env=env, check=True,
+    ).stdout.split()
+    assert branch_name not in source_branches
+
+    # Second call: simulates `mngr create --reuse --update`. The `git push
+    # --prune` inside would fail without the detach-HEAD fix because it'd
+    # try to delete `branch_name`, which is the target's current branch.
+    second_result = host.create_agent_work_dir(host, source_path, options)
+    assert second_result.path == target_path
+    target_head_after = subprocess.run(
+        ["git", "-C", str(target_path), "symbolic-ref", "--short", "HEAD"],
+        capture_output=True, text=True, env=env, check=True,
+    ).stdout.strip()
+    assert target_head_after == branch_name
+
+
+@pytest.mark.rsync
 def test_create_work_dir_copy_with_git_copies_info_exclude(
     host_with_temp_dir: tuple[Host, Path],
     setup_git_config: None,


### PR DESCRIPTION
## Summary

Fixes `mngr create --reuse --update` on agents whose current branch doesn't exist on source. Without the fix, the internal `git push --prune` refuses to delete the target's checked-out branch, and agent creation fails.

Minds' agent creation unconditionally passes `--reuse --update` ([apps/minds/.../agent_creator.py:274-275](https://github.com/imbue-ai/mngr/blob/main/apps/minds/imbue/minds/desktop_client/agent_creator.py#L274-L275)), so any second creation with the same agent name hits this failure without the fix.

## Change

In \`_git_push_to_target\` (host.py), before the mirror push:

\`\`\`
git -C <target> checkout --detach HEAD 2>/dev/null
git -C <target> config receive.denyDeleteCurrent ignore
\`\`\`

Detaching HEAD means no branch is "current," so the prune can delete any branch. `receive.denyDeleteCurrent=ignore` is belt-and-suspenders. After the push, the existing `git checkout -B` step re-attaches HEAD to the requested branch.

This ports the same pattern already used in `sync.py::_remote_git_push_mirror` (which backs `mngr push --mirror`). Future cleanup candidate: extract a shared helper.

## Test plan

- [x] Added regression test `test_create_work_dir_idempotent_when_target_has_checked_out_work_branch` in test_host.py
- [x] Verified test fails WITHOUT the fix with `imbue.mngr.errors.MngrError: ... deletion of the current branch prohibited`
- [x] Verified test passes WITH the fix
- [ ] CI green

## Context

Extracted from #1317 (minds_onboard) so the fix can land independently of the larger wheel-bundling work in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)