### PR TITLE
add assertions in clean_env

### DIFF
--- a/apps/minds/imbue/minds/testing.py
+++ b/apps/minds/imbue/minds/testing.py
@@ -89,14 +89,36 @@ def add_and_commit_git_repo(repo_dir: Path, tmp_path: Path, message: str = "upda
 def clean_env() -> dict[str, str]:
     """Build an environment dict for subprocesses.
 
-    Returns a copy of os.environ. The shared plugin test fixtures
+    Returns a copy of os.environ. Relies on the shared plugin test fixtures
     (registered in apps/minds/conftest.py via register_plugin_test_fixtures)
-    already set MNGR_HOST_DIR / MNGR_PREFIX / MNGR_ROOT_NAME to per-test
+    having set MNGR_HOST_DIR / MNGR_PREFIX / MNGR_ROOT_NAME to per-test
     tmp values, so the subprocess inherits proper isolation. With
     MNGR_ROOT_NAME set to `mngr-test-<id>`, the subprocess does not load
     the repo's .mngr/settings.toml, so the is_allowed_in_pytest=false
     guard there does not fire and no explicit opt-in is needed.
+
+    Asserts that the expected isolation is in place so a future test that
+    forgets to register the shared fixtures gets a loud failure instead of
+    a silent orphan-env leak.
     """
+    host_dir = os.environ.get("MNGR_HOST_DIR")
+    prefix = os.environ.get("MNGR_PREFIX", "")
+    root_name = os.environ.get("MNGR_ROOT_NAME", "")
+    assert host_dir is not None, (
+        "clean_env() requires MNGR_HOST_DIR to be set -- expected the shared plugin "
+        "test fixtures (register_plugin_test_fixtures in apps/minds/conftest.py) to "
+        "have populated it via the autouse setup_test_mngr_env fixture."
+    )
+    assert prefix.startswith("mngr_test-"), (
+        f"clean_env() requires MNGR_PREFIX to start with 'mngr_test-' so any leaked "
+        f"Modal env is visible to the CI cleanup script; got {prefix!r}. The "
+        f"apps/minds/conftest.py override points this at generate_test_environment_name()."
+    )
+    assert root_name.startswith("mngr-test-"), (
+        f"clean_env() requires MNGR_ROOT_NAME to start with 'mngr-test-' so the "
+        f"subprocess mngr does not load the repo's .mngr/settings.toml; got "
+        f"{root_name!r}. The autouse setup_test_mngr_env fixture sets this."
+    )
     return dict(os.environ)
 
 

--- a/apps/minds/imbue/minds/testing.py
+++ b/apps/minds/imbue/minds/testing.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.config.data_types import parse_agents_from_mngr_output
+from imbue.mngr.utils.testing import TEST_ENV_PREFIX
 
 _GIT_TEST_ENV_KEYS: Final[dict[str, str]] = {
     "GIT_AUTHOR_NAME": "test",
@@ -109,9 +110,9 @@ def clean_env() -> dict[str, str]:
         "test fixtures (register_plugin_test_fixtures in apps/minds/conftest.py) to "
         "have populated it via the autouse setup_test_mngr_env fixture."
     )
-    assert prefix.startswith("mngr_test-"), (
-        f"clean_env() requires MNGR_PREFIX to start with 'mngr_test-' so any leaked "
-        f"Modal env is visible to the CI cleanup script; got {prefix!r}. The "
+    assert prefix.startswith(TEST_ENV_PREFIX), (
+        f"clean_env() requires MNGR_PREFIX to start with {TEST_ENV_PREFIX!r} so any "
+        f"leaked Modal env is visible to the CI cleanup script; got {prefix!r}. The "
         f"apps/minds/conftest.py override points this at generate_test_environment_name()."
     )
     assert root_name.startswith("mngr-test-"), (


### PR DESCRIPTION
## Summary

Follow-up to #1352 addressing Josh's review comment on `apps/minds/imbue/minds/testing.py:clean_env()`:

> do you think it might be worth asserting some of those things in this function?

Yes. `clean_env()` now asserts the shared-autouse invariants it relies on, so a future test that calls `clean_env()` without the shared plugin fixtures registered (e.g. someone moves the test to a new directory or adds a caller from a test file that doesn't use `register_plugin_test_fixtures`) gets a loud `AssertionError` at test-setup time instead of silently spawning a subprocess mngr that mutates real state.

Asserts:
- `MNGR_HOST_DIR` is set (so subprocess does not land in developer's `~/.mngr`)
- `MNGR_PREFIX` starts with `mngr_test-` (so any leaked Modal env is visible to the CI cleanup script)
- `MNGR_ROOT_NAME` starts with `mngr-test-` (so subprocess does not load the repo's `.mngr/settings.toml` and trip `is_allowed_in_pytest=false`)

## Test plan

- [x] Syntax check (collection runs)
- [ ] Full CI via stop hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)