### PR TITLE
stop macOS notification tests from firing real Notification Center banners

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -242,21 +242,30 @@ def _run_macos_notification_subprocess(
         logger.warning("Failed to show macOS notification: {}", e)
 
 
-def _dispatch_macos_notification(
+def _build_osascript_notification(
     request: NotificationRequest,
     agent_display_name: str,
-    runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
-) -> threading.Thread:
-    """Display a native macOS notification via osascript on a background thread.
+) -> str:
+    """Build the AppleScript command that displays a native macOS notification.
 
-    Returns the spawned daemon thread so callers (notably tests) can join it.
+    Extracted so the quote-escaping behavior is trivially testable as a pure
+    function, independent of subprocess or threading concerns.
     """
     display_title = request.title or f"Notification from {agent_display_name}"
     # Escape double quotes for AppleScript string literals
     escaped_title = display_title.replace('"', '\\"')
     escaped_message = request.message.replace('"', '\\"')
     escaped_subtitle = f"From: {agent_display_name}".replace('"', '\\"')
-    script = f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
+    return f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
+
+
+def _dispatch_macos_notification(
+    request: NotificationRequest,
+    agent_display_name: str,
+    runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
+) -> None:
+    """Display a native macOS notification via osascript on a background thread."""
+    script = _build_osascript_notification(request, agent_display_name)
     thread = threading.Thread(
         target=runner,
         args=(script,),
@@ -264,7 +273,6 @@ def _dispatch_macos_notification(
         name="macos-notification",
     )
     thread.start()
-    return thread
 
 
 class NotificationDispatcher(FrozenModel):

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -6,7 +6,6 @@ notifications, or a tkinter toast popup depending on the runtime context.
 
 import platform
 import threading
-from collections.abc import Callable
 from enum import auto
 from types import ModuleType
 from typing import Any
@@ -200,44 +199,15 @@ def _show_tkinter_toast(
     thread.start()
 
 
-# OsascriptCommandRunner executes an osascript command vector. The default
-# implementation shells out via ConcurrencyGroup; tests can inject a fake that
-# records commands and/or raises OSError to exercise the error-handling branch
-# of _run_macos_notification_subprocess without invoking the real subprocess.
-OsascriptCommandRunner = Callable[[list[str]], None]
-
-# MacOSNotificationRunner takes a built AppleScript string and runs it,
-# swallowing subprocess errors. The default implementation is
-# _run_macos_notification_subprocess; tests (and NotificationDispatcher.create)
-# can inject a fake so dispatch() never fires a real Notification Center banner.
-MacOSNotificationRunner = Callable[[str], None]
-
-
-def _run_osascript_command(command: list[str]) -> None:
-    """Execute an osascript command via ConcurrencyGroup.
-
-    Raises on failure; the caller (_run_macos_notification_subprocess) is
-    responsible for catching OSError/ExceptionGroup.
-    """
+def _run_macos_notification_subprocess(script: str) -> None:
+    """Run an AppleScript notification command via osascript on a background thread."""
     cg = ConcurrencyGroup(name="macos-notification")
-    with cg:
-        cg.run_process_to_completion(
-            command=command,
-            is_checked_after=False,
-        )
-
-
-def _run_macos_notification_subprocess(
-    script: str,
-    command_runner: OsascriptCommandRunner = _run_osascript_command,
-) -> None:
-    """Run an AppleScript notification command, logging and swallowing errors.
-
-    The command_runner parameter exists so tests can inject a runner that
-    raises OSError and verify the real error-handling branch below catches it.
-    """
     try:
-        command_runner(["osascript", "-e", script])
+        with cg:
+            cg.run_process_to_completion(
+                command=["osascript", "-e", script],
+                is_checked_after=False,
+            )
     except (OSError, ExceptionGroup) as e:
         logger.warning("Failed to show macOS notification: {}", e)
 
@@ -246,11 +216,7 @@ def _build_osascript_notification(
     request: NotificationRequest,
     agent_display_name: str,
 ) -> str:
-    """Build the AppleScript command that displays a native macOS notification.
-
-    Extracted so the quote-escaping behavior is trivially testable as a pure
-    function, independent of subprocess or threading concerns.
-    """
+    """Build the AppleScript command that displays a native macOS notification."""
     display_title = request.title or f"Notification from {agent_display_name}"
     # Escape double quotes for AppleScript string literals
     escaped_title = display_title.replace('"', '\\"')
@@ -262,12 +228,11 @@ def _build_osascript_notification(
 def _dispatch_macos_notification(
     request: NotificationRequest,
     agent_display_name: str,
-    runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
 ) -> None:
     """Display a native macOS notification via osascript on a background thread."""
     script = _build_osascript_notification(request, agent_display_name)
     thread = threading.Thread(
-        target=runner,
+        target=_run_macos_notification_subprocess,
         args=(script,),
         daemon=True,
         name="macos-notification",
@@ -284,15 +249,10 @@ class NotificationDispatcher(FrozenModel):
     # module-level _TKINTER value, or injected via NotificationDispatcher.create()
     # to allow testing without tkinter side effects.
     _tk: ModuleType | None = PrivateAttr(default=None)
-    # _macos_runner is the callable used to execute osascript. Defaults to the
-    # real subprocess runner; tests inject a fake via NotificationDispatcher.create()
-    # so dispatch() does not fire real Notification Center banners.
-    _macos_runner: MacOSNotificationRunner | None = PrivateAttr(default=None)
 
     def model_post_init(self, __context: object) -> None:
-        """Resolve module-level defaults after construction."""
+        """Resolve the tkinter module from the module-level auto-detection."""
         self._tk = _TKINTER
-        self._macos_runner = _run_macos_notification_subprocess
 
     @classmethod
     def create(
@@ -300,18 +260,14 @@ class NotificationDispatcher(FrozenModel):
         is_electron: bool,
         tkinter_module: ModuleType | None = _TKINTER,
         is_macos: bool = _IS_MACOS,
-        macos_runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
     ) -> "NotificationDispatcher":
         """Create a NotificationDispatcher with explicit platform overrides.
 
         Pass tkinter_module=None to disable tkinter toasts (e.g. in tests or on
-        headless servers where tkinter is unavailable). Pass macos_runner to
-        replace the osascript subprocess runner (used by tests to avoid firing
-        real macOS Notification Center banners).
+        headless servers where tkinter is unavailable).
         """
         dispatcher = cls(is_electron=is_electron, is_macos=is_macos)
         dispatcher._tk = tkinter_module
-        dispatcher._macos_runner = macos_runner
         return dispatcher
 
     def dispatch(
@@ -326,7 +282,6 @@ class NotificationDispatcher(FrozenModel):
         if self.is_electron:
             _dispatch_electron_notification(request, agent_display_name)
         elif self.is_macos:
-            runner = self._macos_runner or _run_macos_notification_subprocess
-            _dispatch_macos_notification(request, agent_display_name, runner=runner)
+            _dispatch_macos_notification(request, agent_display_name)
         else:
             _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -6,7 +6,6 @@ notifications, or a tkinter toast popup depending on the runtime context.
 
 import platform
 import threading
-from collections.abc import Callable
 from enum import auto
 from types import ModuleType
 from typing import Any
@@ -225,29 +224,15 @@ def _show_tkinter_toast(
     thread.start()
 
 
-OsascriptCommandRunner = Callable[[list[str]], None]
-
-
-def _run_osascript_command(command: list[str]) -> None:
-    """Execute an osascript command via ConcurrencyGroup.
-
-    Raises on subprocess failure; the caller swallows OSError/ExceptionGroup.
-    """
+def _run_macos_notification_subprocess(script: str) -> None:
+    """Run an AppleScript notification command via osascript on a background thread."""
     cg = ConcurrencyGroup(name="macos-notification")
-    with cg:
-        cg.run_process_to_completion(
-            command=command,
-            is_checked_after=False,
-        )
-
-
-def _run_macos_notification_subprocess(
-    script: str,
-    command_runner: OsascriptCommandRunner = _run_osascript_command,
-) -> None:
-    """Run an AppleScript notification command, logging and swallowing errors."""
     try:
-        command_runner(["osascript", "-e", script])
+        with cg:
+            cg.run_process_to_completion(
+                command=["osascript", "-e", script],
+                is_checked_after=False,
+            )
     except (OSError, ExceptionGroup) as e:
         logger.warning("Failed to show macOS notification: {}", e)
 

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -6,6 +6,7 @@ notifications, or a tkinter toast popup depending on the runtime context.
 
 import platform
 import threading
+from collections.abc import Callable
 from enum import auto
 from types import ModuleType
 from typing import Any
@@ -199,15 +200,44 @@ def _show_tkinter_toast(
     thread.start()
 
 
-def _run_macos_notification_subprocess(script: str) -> None:
-    """Run an AppleScript notification command via osascript on a background thread."""
+# OsascriptCommandRunner executes an osascript command vector. The default
+# implementation shells out via ConcurrencyGroup; tests can inject a fake that
+# records commands and/or raises OSError to exercise the error-handling branch
+# of _run_macos_notification_subprocess without invoking the real subprocess.
+OsascriptCommandRunner = Callable[[list[str]], None]
+
+# MacOSNotificationRunner takes a built AppleScript string and runs it,
+# swallowing subprocess errors. The default implementation is
+# _run_macos_notification_subprocess; tests (and NotificationDispatcher.create)
+# can inject a fake so dispatch() never fires a real Notification Center banner.
+MacOSNotificationRunner = Callable[[str], None]
+
+
+def _run_osascript_command(command: list[str]) -> None:
+    """Execute an osascript command via ConcurrencyGroup.
+
+    Raises on failure; the caller (_run_macos_notification_subprocess) is
+    responsible for catching OSError/ExceptionGroup.
+    """
     cg = ConcurrencyGroup(name="macos-notification")
+    with cg:
+        cg.run_process_to_completion(
+            command=command,
+            is_checked_after=False,
+        )
+
+
+def _run_macos_notification_subprocess(
+    script: str,
+    command_runner: OsascriptCommandRunner = _run_osascript_command,
+) -> None:
+    """Run an AppleScript notification command, logging and swallowing errors.
+
+    The command_runner parameter exists so tests can inject a runner that
+    raises OSError and verify the real error-handling branch below catches it.
+    """
     try:
-        with cg:
-            cg.run_process_to_completion(
-                command=["osascript", "-e", script],
-                is_checked_after=False,
-            )
+        command_runner(["osascript", "-e", script])
     except (OSError, ExceptionGroup) as e:
         logger.warning("Failed to show macOS notification: {}", e)
 
@@ -215,8 +245,12 @@ def _run_macos_notification_subprocess(script: str) -> None:
 def _dispatch_macos_notification(
     request: NotificationRequest,
     agent_display_name: str,
-) -> None:
-    """Display a native macOS notification via osascript on a background thread."""
+    runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
+) -> threading.Thread:
+    """Display a native macOS notification via osascript on a background thread.
+
+    Returns the spawned daemon thread so callers (notably tests) can join it.
+    """
     display_title = request.title or f"Notification from {agent_display_name}"
     # Escape double quotes for AppleScript string literals
     escaped_title = display_title.replace('"', '\\"')
@@ -224,12 +258,13 @@ def _dispatch_macos_notification(
     escaped_subtitle = f"From: {agent_display_name}".replace('"', '\\"')
     script = f'display notification "{escaped_message}" with title "{escaped_title}" subtitle "{escaped_subtitle}"'
     thread = threading.Thread(
-        target=_run_macos_notification_subprocess,
+        target=runner,
         args=(script,),
         daemon=True,
         name="macos-notification",
     )
     thread.start()
+    return thread
 
 
 class NotificationDispatcher(FrozenModel):
@@ -241,10 +276,15 @@ class NotificationDispatcher(FrozenModel):
     # module-level _TKINTER value, or injected via NotificationDispatcher.create()
     # to allow testing without tkinter side effects.
     _tk: ModuleType | None = PrivateAttr(default=None)
+    # _macos_runner is the callable used to execute osascript. Defaults to the
+    # real subprocess runner; tests inject a fake via NotificationDispatcher.create()
+    # so dispatch() does not fire real Notification Center banners.
+    _macos_runner: MacOSNotificationRunner | None = PrivateAttr(default=None)
 
     def model_post_init(self, __context: object) -> None:
-        """Resolve the tkinter module from the module-level auto-detection."""
+        """Resolve module-level defaults after construction."""
         self._tk = _TKINTER
+        self._macos_runner = _run_macos_notification_subprocess
 
     @classmethod
     def create(
@@ -252,14 +292,18 @@ class NotificationDispatcher(FrozenModel):
         is_electron: bool,
         tkinter_module: ModuleType | None = _TKINTER,
         is_macos: bool = _IS_MACOS,
+        macos_runner: MacOSNotificationRunner = _run_macos_notification_subprocess,
     ) -> "NotificationDispatcher":
         """Create a NotificationDispatcher with explicit platform overrides.
 
         Pass tkinter_module=None to disable tkinter toasts (e.g. in tests or on
-        headless servers where tkinter is unavailable).
+        headless servers where tkinter is unavailable). Pass macos_runner to
+        replace the osascript subprocess runner (used by tests to avoid firing
+        real macOS Notification Center banners).
         """
         dispatcher = cls(is_electron=is_electron, is_macos=is_macos)
         dispatcher._tk = tkinter_module
+        dispatcher._macos_runner = macos_runner
         return dispatcher
 
     def dispatch(
@@ -274,6 +318,7 @@ class NotificationDispatcher(FrozenModel):
         if self.is_electron:
             _dispatch_electron_notification(request, agent_display_name)
         elif self.is_macos:
-            _dispatch_macos_notification(request, agent_display_name)
+            runner = self._macos_runner or _run_macos_notification_subprocess
+            _dispatch_macos_notification(request, agent_display_name, runner=runner)
         else:
             _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -6,6 +6,7 @@ notifications, or a tkinter toast popup depending on the runtime context.
 
 import platform
 import threading
+from collections.abc import Callable
 from enum import auto
 from types import ModuleType
 from typing import Any
@@ -37,6 +38,31 @@ class NotificationUrgency(UpperCaseStrEnum):
     LOW = auto()
     NORMAL = auto()
     CRITICAL = auto()
+
+
+class DispatchChannel(UpperCaseStrEnum):
+    """Channel a NotificationDispatcher routes a notification to.
+
+    Electron takes priority when the server is running inside the desktop app;
+    otherwise macOS native notifications are used on Darwin, and tkinter toasts
+    elsewhere.
+    """
+
+    ELECTRON = auto()
+    MACOS = auto()
+    TKINTER = auto()
+
+
+def _select_dispatch_channel(is_electron: bool, is_macos: bool) -> DispatchChannel:
+    """Pick the dispatch channel for the given platform flags.
+
+    Priority: Electron > macOS native > tkinter toast.
+    """
+    if is_electron:
+        return DispatchChannel.ELECTRON
+    if is_macos:
+        return DispatchChannel.MACOS
+    return DispatchChannel.TKINTER
 
 
 class NotificationRequest(FrozenModel):
@@ -199,15 +225,29 @@ def _show_tkinter_toast(
     thread.start()
 
 
-def _run_macos_notification_subprocess(script: str) -> None:
-    """Run an AppleScript notification command via osascript on a background thread."""
+OsascriptCommandRunner = Callable[[list[str]], None]
+
+
+def _run_osascript_command(command: list[str]) -> None:
+    """Execute an osascript command via ConcurrencyGroup.
+
+    Raises on subprocess failure; the caller swallows OSError/ExceptionGroup.
+    """
     cg = ConcurrencyGroup(name="macos-notification")
+    with cg:
+        cg.run_process_to_completion(
+            command=command,
+            is_checked_after=False,
+        )
+
+
+def _run_macos_notification_subprocess(
+    script: str,
+    command_runner: OsascriptCommandRunner = _run_osascript_command,
+) -> None:
+    """Run an AppleScript notification command, logging and swallowing errors."""
     try:
-        with cg:
-            cg.run_process_to_completion(
-                command=["osascript", "-e", script],
-                is_checked_after=False,
-            )
+        command_runner(["osascript", "-e", script])
     except (OSError, ExceptionGroup) as e:
         logger.warning("Failed to show macOS notification: {}", e)
 
@@ -279,9 +319,10 @@ class NotificationDispatcher(FrozenModel):
 
         Priority: Electron > macOS native > tkinter toast.
         """
-        if self.is_electron:
+        channel = _select_dispatch_channel(is_electron=self.is_electron, is_macos=self.is_macos)
+        if channel == DispatchChannel.ELECTRON:
             _dispatch_electron_notification(request, agent_display_name)
-        elif self.is_macos:
+        elif channel == DispatchChannel.MACOS:
             _dispatch_macos_notification(request, agent_display_name)
         else:
             _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification.py
+++ b/apps/minds/imbue/minds/desktop_client/notification.py
@@ -305,9 +305,10 @@ class NotificationDispatcher(FrozenModel):
         Priority: Electron > macOS native > tkinter toast.
         """
         channel = _select_dispatch_channel(is_electron=self.is_electron, is_macos=self.is_macos)
-        if channel == DispatchChannel.ELECTRON:
-            _dispatch_electron_notification(request, agent_display_name)
-        elif channel == DispatchChannel.MACOS:
-            _dispatch_macos_notification(request, agent_display_name)
-        else:
-            _show_tkinter_toast(request, agent_display_name, tk=self._tk)
+        match channel:
+            case DispatchChannel.ELECTRON:
+                _dispatch_electron_notification(request, agent_display_name)
+            case DispatchChannel.MACOS:
+                _dispatch_macos_notification(request, agent_display_name)
+            case DispatchChannel.TKINTER:
+                _show_tkinter_toast(request, agent_display_name, tk=self._tk)

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,5 +1,4 @@
 import json
-import threading
 import types
 from types import SimpleNamespace
 from typing import Any
@@ -13,33 +12,8 @@ from imbue.minds.desktop_client.notification import _build_osascript_notificatio
 from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 from imbue.minds.desktop_client.notification import _position_toast_window
-from imbue.minds.desktop_client.notification import _run_macos_notification_subprocess
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
-
-# Short timeout for waiting on the background daemon thread spawned by
-# _dispatch_macos_notification to call the injected runner. The runner is
-# synchronous and returns almost immediately, so a few seconds is ample.
-_MACOS_DISPATCH_WAIT_TIMEOUT_SECONDS: float = 5.0
-
-
-class _RecordingMacOSRunner:
-    """Fake MacOSNotificationRunner that records scripts it is called with.
-
-    Sets call_done once invoked, so a test can wait on the background daemon
-    thread spawned by _dispatch_macos_notification to reach the call site
-    without polling.
-    """
-
-    def __init__(self) -> None:
-        self.scripts: list[str] = []
-        self.call_done = threading.Event()
-
-    def __call__(self, script: str) -> None:
-        try:
-            self.scripts.append(script)
-        finally:
-            self.call_done.set()
 
 
 def _make_fake_tk() -> Any:
@@ -271,36 +245,9 @@ def test_dispatcher_default_constructor_resolves_tkinter() -> None:
 # -- macOS notification tests --
 
 
-def test_run_macos_notification_subprocess_swallows_osascript_oserror() -> None:
-    """_run_macos_notification_subprocess must catch OSError from the command
-    runner (e.g. osascript missing from PATH) without re-raising.
-
-    Exercises the real "except (OSError, ExceptionGroup)" branch synchronously,
-    without involving daemon threads -- the branch is a pure concern of the
-    subprocess function, not of dispatch().
-    """
-    captured_commands: list[list[str]] = []
-
-    def raising_command_runner(command: list[str]) -> None:
-        captured_commands.append(command)
-        raise OSError("osascript not found")
-
-    request = NotificationRequest(message="hi", title="Test Title")
-    script = _build_osascript_notification(request, "agent-mac")
-
-    # Must not raise.
-    _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
-
-    assert len(captured_commands) == 1
-    assert captured_commands[0][0] == "osascript"
-    assert captured_commands[0][1] == "-e"
-
-
 def test_build_osascript_notification_escapes_double_quotes() -> None:
     """Double quotes in title, message, and subtitle must be escaped to \\" so the
-    AppleScript string literals are syntactically valid. Tested as a pure function
-    so the assertion is decoupled from subprocess/threading concerns.
-    """
+    AppleScript string literals are syntactically valid."""
     request = NotificationRequest(
         message='He said "hello"',
         title='Title with "quotes"',
@@ -312,33 +259,11 @@ def test_build_osascript_notification_escapes_double_quotes() -> None:
     # Escaped quotes (\") must be present for message and title contents.
     assert 'He said \\"hello\\"' in script
     assert 'Title with \\"quotes\\"' in script
-    # The raw unescaped quoted phrases must not appear as bare substrings
-    # between AppleScript string delimiters (i.e. the payload must be escaped,
-    # not just textually present from the surrounding AppleScript syntax).
+    # Raw unescaped quoted payload must not appear as a bare substring between
+    # AppleScript string delimiters -- the contents must be escaped, not just
+    # textually present from the surrounding AppleScript syntax.
     assert '"He said "hello""' not in script
     assert '"Title with "quotes""' not in script
-
-
-def test_dispatcher_routes_to_macos_when_is_macos() -> None:
-    """dispatch() with is_macos=True and is_electron=False must invoke the
-    macOS runner exactly once, not the tkinter path."""
-    runner = _RecordingMacOSRunner()
-    dispatcher = NotificationDispatcher.create(
-        is_electron=False,
-        is_macos=True,
-        tkinter_module=None,
-        macos_runner=runner,
-    )
-    assert dispatcher.is_macos is True
-
-    request = NotificationRequest(message="macos dispatch test")
-    dispatcher.dispatch(request, "agent-mac-dispatch")
-
-    assert runner.call_done.wait(timeout=_MACOS_DISPATCH_WAIT_TIMEOUT_SECONDS), (
-        "macOS runner was never called; dispatch did not route to the macOS path"
-    )
-    # Exactly one dispatch means exactly one runner invocation.
-    assert len(runner.scripts) == 1
 
 
 def test_dispatcher_prefers_electron_over_macos(capsys: pytest.CaptureFixture[str]) -> None:

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import types
 from types import SimpleNamespace
 from typing import Any
@@ -12,8 +13,37 @@ from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 from imbue.minds.desktop_client.notification import _dispatch_macos_notification
 from imbue.minds.desktop_client.notification import _position_toast_window
+from imbue.minds.desktop_client.notification import _run_macos_notification_subprocess
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
+
+# Short timeout used when joining the background daemon thread spawned by
+# _dispatch_macos_notification. The fake runners used below are synchronous
+# and return almost immediately, so a few seconds is plenty of slack for CI.
+_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS: float = 5.0
+
+
+class _RecordingMacOSRunner:
+    """Fake MacOSNotificationRunner that records the scripts it is called with.
+
+    A threading.Event is set once the runner has been invoked, so tests can wait
+    for the background daemon thread spawned by _dispatch_macos_notification to
+    reach the call site without polling. If side_effect is provided, the runner
+    raises it after recording the script (used to simulate osascript missing).
+    """
+
+    def __init__(self, side_effect: Exception | None = None) -> None:
+        self.scripts: list[str] = []
+        self.call_done = threading.Event()
+        self._side_effect = side_effect
+
+    def __call__(self, script: str) -> None:
+        try:
+            self.scripts.append(script)
+            if self._side_effect is not None:
+                raise self._side_effect
+        finally:
+            self.call_done.set()
 
 
 def _make_fake_tk() -> Any:
@@ -203,8 +233,13 @@ def test_show_tkinter_toast_with_no_tkinter_does_not_raise() -> None:
 
 
 def test_dispatch_non_electron_does_not_raise() -> None:
-    """The non-Electron dispatch path starts a background toast and does not raise."""
-    dispatcher = NotificationDispatcher.create(is_electron=False, tkinter_module=None)
+    """The non-Electron/non-macOS dispatch path starts a background toast and does not raise.
+
+    is_macos is forced to False so the test exercises the tkinter branch regardless
+    of the host platform (and does not fire a real macOS Notification Center banner
+    when the suite runs on a developer's Mac).
+    """
+    dispatcher = NotificationDispatcher.create(is_electron=False, is_macos=False, tkinter_module=None)
     request = NotificationRequest(message="background toast")
     dispatcher.dispatch(request, "agent-y")
 
@@ -240,35 +275,96 @@ def test_dispatcher_default_constructor_resolves_tkinter() -> None:
 # -- macOS notification tests --
 
 
-def test_dispatch_macos_notification_does_not_raise() -> None:
-    """On non-macOS, osascript won't exist, but the function should not raise."""
+def test_dispatch_macos_notification_swallows_osascript_oserror() -> None:
+    """When osascript is missing (OSError from the command runner), the real
+    _run_macos_notification_subprocess must catch it and the dispatch daemon
+    thread must terminate cleanly without propagating the error.
+
+    This exercises the real "except (OSError, ExceptionGroup)" branch inside
+    _run_macos_notification_subprocess by injecting at the command-runner level
+    (not replacing _run_macos_notification_subprocess wholesale), so the error
+    is caught inside the function under test rather than by the daemon thread's
+    default exception hook.
+    """
+    captured_commands: list[list[str]] = []
+    command_done = threading.Event()
+
+    def raising_command_runner(command: list[str]) -> None:
+        captured_commands.append(command)
+        try:
+            raise OSError("osascript not found")
+        finally:
+            command_done.set()
+
+    # Wrap the real _run_macos_notification_subprocess with the raising command
+    # runner bound in, so the real try/except executes inside the daemon thread.
+    def runner(script: str) -> None:
+        _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
+
     request = NotificationRequest(
         message="test macOS notification",
         title="Test Title",
         urgency=NotificationUrgency.CRITICAL,
     )
-    # Should not raise even if osascript is not available (caught internally)
-    _dispatch_macos_notification(request, "agent-mac")
+    thread = _dispatch_macos_notification(request, "agent-mac", runner=runner)
+    thread.join(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS)
+
+    # The command runner was invoked (proving the thread actually reached it),
+    # and the thread terminated cleanly -- the real function caught the OSError.
+    assert command_done.is_set()
+    assert len(captured_commands) == 1
+    assert captured_commands[0][0] == "osascript"
+    assert captured_commands[0][1] == "-e"
+    assert not thread.is_alive()
 
 
-def test_dispatch_macos_notification_handles_quotes() -> None:
-    """Verify double quotes in title/message are escaped for AppleScript."""
+def test_dispatch_macos_notification_escapes_double_quotes_in_script() -> None:
+    """Double quotes in title, message, and subtitle must be escaped to \\" so the
+    AppleScript string literals are syntactically valid.
+    """
+    runner = _RecordingMacOSRunner()
+
     request = NotificationRequest(
         message='He said "hello"',
         title='Title with "quotes"',
         urgency=NotificationUrgency.NORMAL,
     )
-    # Should not raise
-    _dispatch_macos_notification(request, "agent-quotes")
+    thread = _dispatch_macos_notification(request, "agent-quotes", runner=runner)
+    thread.join(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS)
+
+    assert runner.call_done.is_set()
+    assert len(runner.scripts) == 1
+    script = runner.scripts[0]
+    # Escaped quotes (\") must be present for message and title contents.
+    assert 'He said \\"hello\\"' in script
+    assert 'Title with \\"quotes\\"' in script
+    # The raw unescaped quoted phrases must not appear as bare substrings
+    # between AppleScript string delimiters (i.e. the payload must be escaped,
+    # not just textually present from the surrounding AppleScript syntax).
+    assert '"He said "hello""' not in script
+    assert '"Title with "quotes""' not in script
 
 
 def test_dispatcher_routes_to_macos_when_is_macos() -> None:
-    """Verify dispatch routes to macOS native notifications when is_macos=True."""
-    dispatcher = NotificationDispatcher.create(is_electron=False, is_macos=True, tkinter_module=None)
+    """dispatch() with is_macos=True and is_electron=False must invoke the
+    macOS runner exactly once, not the tkinter path."""
+    runner = _RecordingMacOSRunner()
+    dispatcher = NotificationDispatcher.create(
+        is_electron=False,
+        is_macos=True,
+        tkinter_module=None,
+        macos_runner=runner,
+    )
     assert dispatcher.is_macos is True
+
     request = NotificationRequest(message="macos dispatch test")
-    # Should not raise -- osascript may fail on Linux but error is caught
     dispatcher.dispatch(request, "agent-mac-dispatch")
+
+    assert runner.call_done.wait(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS), (
+        "macOS runner was never called; dispatch did not route to the macOS path"
+    )
+    # Exactly one dispatch means exactly one runner invocation.
+    assert len(runner.scripts) == 1
 
 
 def test_dispatcher_prefers_electron_over_macos(capsys: pytest.CaptureFixture[str]) -> None:

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -13,7 +13,6 @@ from imbue.minds.desktop_client.notification import _build_osascript_notificatio
 from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 from imbue.minds.desktop_client.notification import _position_toast_window
-from imbue.minds.desktop_client.notification import _run_macos_notification_subprocess
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _select_dispatch_channel
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
@@ -281,25 +280,6 @@ def test_build_osascript_notification_escapes_double_quotes() -> None:
 def test_select_dispatch_channel(is_electron: bool, is_macos: bool, expected: DispatchChannel) -> None:
     """Electron wins when set; macOS takes over when not in Electron; tkinter otherwise."""
     assert _select_dispatch_channel(is_electron=is_electron, is_macos=is_macos) == expected
-
-
-def test_run_macos_notification_subprocess_swallows_osascript_oserror() -> None:
-    """_run_macos_notification_subprocess must catch OSError from the command runner
-    (e.g. osascript missing from PATH) and not re-raise."""
-    captured_commands: list[list[str]] = []
-
-    def raising_command_runner(command: list[str]) -> None:
-        captured_commands.append(command)
-        raise OSError("osascript not found")
-
-    request = NotificationRequest(message="hi", title="Test Title")
-    script = _build_osascript_notification(request, "agent-mac")
-
-    _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
-
-    assert len(captured_commands) == 1
-    assert captured_commands[0][0] == "osascript"
-    assert captured_commands[0][1] == "-e"
 
 
 def test_dispatcher_prefers_electron_over_macos(capsys: pytest.CaptureFixture[str]) -> None:

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from imbue.minds.desktop_client.notification import DispatchChannel
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
@@ -12,7 +13,9 @@ from imbue.minds.desktop_client.notification import _build_osascript_notificatio
 from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
 from imbue.minds.desktop_client.notification import _position_toast_window
+from imbue.minds.desktop_client.notification import _run_macos_notification_subprocess
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
+from imbue.minds.desktop_client.notification import _select_dispatch_channel
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
 
 
@@ -264,6 +267,39 @@ def test_build_osascript_notification_escapes_double_quotes() -> None:
     # textually present from the surrounding AppleScript syntax.
     assert '"He said "hello""' not in script
     assert '"Title with "quotes""' not in script
+
+
+@pytest.mark.parametrize(
+    "is_electron,is_macos,expected",
+    [
+        (True, True, DispatchChannel.ELECTRON),
+        (True, False, DispatchChannel.ELECTRON),
+        (False, True, DispatchChannel.MACOS),
+        (False, False, DispatchChannel.TKINTER),
+    ],
+)
+def test_select_dispatch_channel(is_electron: bool, is_macos: bool, expected: DispatchChannel) -> None:
+    """Electron wins when set; macOS takes over when not in Electron; tkinter otherwise."""
+    assert _select_dispatch_channel(is_electron=is_electron, is_macos=is_macos) == expected
+
+
+def test_run_macos_notification_subprocess_swallows_osascript_oserror() -> None:
+    """_run_macos_notification_subprocess must catch OSError from the command runner
+    (e.g. osascript missing from PATH) and not re-raise."""
+    captured_commands: list[list[str]] = []
+
+    def raising_command_runner(command: list[str]) -> None:
+        captured_commands.append(command)
+        raise OSError("osascript not found")
+
+    request = NotificationRequest(message="hi", title="Test Title")
+    script = _build_osascript_notification(request, "agent-mac")
+
+    _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
+
+    assert len(captured_commands) == 1
+    assert captured_commands[0][0] == "osascript"
+    assert captured_commands[0][1] == "-e"
 
 
 def test_dispatcher_prefers_electron_over_macos(capsys: pytest.CaptureFixture[str]) -> None:

--- a/apps/minds/imbue/minds/desktop_client/notification_test.py
+++ b/apps/minds/imbue/minds/desktop_client/notification_test.py
@@ -9,39 +9,35 @@ import pytest
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.notification import NotificationRequest
 from imbue.minds.desktop_client.notification import NotificationUrgency
+from imbue.minds.desktop_client.notification import _build_osascript_notification
 from imbue.minds.desktop_client.notification import _build_toast_widgets
 from imbue.minds.desktop_client.notification import _dispatch_electron_notification
-from imbue.minds.desktop_client.notification import _dispatch_macos_notification
 from imbue.minds.desktop_client.notification import _position_toast_window
 from imbue.minds.desktop_client.notification import _run_macos_notification_subprocess
 from imbue.minds.desktop_client.notification import _run_tkinter_toast
 from imbue.minds.desktop_client.notification import _show_tkinter_toast
 
-# Short timeout used when joining the background daemon thread spawned by
-# _dispatch_macos_notification. The fake runners used below are synchronous
-# and return almost immediately, so a few seconds is plenty of slack for CI.
-_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS: float = 5.0
+# Short timeout for waiting on the background daemon thread spawned by
+# _dispatch_macos_notification to call the injected runner. The runner is
+# synchronous and returns almost immediately, so a few seconds is ample.
+_MACOS_DISPATCH_WAIT_TIMEOUT_SECONDS: float = 5.0
 
 
 class _RecordingMacOSRunner:
-    """Fake MacOSNotificationRunner that records the scripts it is called with.
+    """Fake MacOSNotificationRunner that records scripts it is called with.
 
-    A threading.Event is set once the runner has been invoked, so tests can wait
-    for the background daemon thread spawned by _dispatch_macos_notification to
-    reach the call site without polling. If side_effect is provided, the runner
-    raises it after recording the script (used to simulate osascript missing).
+    Sets call_done once invoked, so a test can wait on the background daemon
+    thread spawned by _dispatch_macos_notification to reach the call site
+    without polling.
     """
 
-    def __init__(self, side_effect: Exception | None = None) -> None:
+    def __init__(self) -> None:
         self.scripts: list[str] = []
         self.call_done = threading.Event()
-        self._side_effect = side_effect
 
     def __call__(self, script: str) -> None:
         try:
             self.scripts.append(script)
-            if self._side_effect is not None:
-                raise self._side_effect
         finally:
             self.call_done.set()
 
@@ -275,66 +271,44 @@ def test_dispatcher_default_constructor_resolves_tkinter() -> None:
 # -- macOS notification tests --
 
 
-def test_dispatch_macos_notification_swallows_osascript_oserror() -> None:
-    """When osascript is missing (OSError from the command runner), the real
-    _run_macos_notification_subprocess must catch it and the dispatch daemon
-    thread must terminate cleanly without propagating the error.
+def test_run_macos_notification_subprocess_swallows_osascript_oserror() -> None:
+    """_run_macos_notification_subprocess must catch OSError from the command
+    runner (e.g. osascript missing from PATH) without re-raising.
 
-    This exercises the real "except (OSError, ExceptionGroup)" branch inside
-    _run_macos_notification_subprocess by injecting at the command-runner level
-    (not replacing _run_macos_notification_subprocess wholesale), so the error
-    is caught inside the function under test rather than by the daemon thread's
-    default exception hook.
+    Exercises the real "except (OSError, ExceptionGroup)" branch synchronously,
+    without involving daemon threads -- the branch is a pure concern of the
+    subprocess function, not of dispatch().
     """
     captured_commands: list[list[str]] = []
-    command_done = threading.Event()
 
     def raising_command_runner(command: list[str]) -> None:
         captured_commands.append(command)
-        try:
-            raise OSError("osascript not found")
-        finally:
-            command_done.set()
+        raise OSError("osascript not found")
 
-    # Wrap the real _run_macos_notification_subprocess with the raising command
-    # runner bound in, so the real try/except executes inside the daemon thread.
-    def runner(script: str) -> None:
-        _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
+    request = NotificationRequest(message="hi", title="Test Title")
+    script = _build_osascript_notification(request, "agent-mac")
 
-    request = NotificationRequest(
-        message="test macOS notification",
-        title="Test Title",
-        urgency=NotificationUrgency.CRITICAL,
-    )
-    thread = _dispatch_macos_notification(request, "agent-mac", runner=runner)
-    thread.join(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS)
+    # Must not raise.
+    _run_macos_notification_subprocess(script, command_runner=raising_command_runner)
 
-    # The command runner was invoked (proving the thread actually reached it),
-    # and the thread terminated cleanly -- the real function caught the OSError.
-    assert command_done.is_set()
     assert len(captured_commands) == 1
     assert captured_commands[0][0] == "osascript"
     assert captured_commands[0][1] == "-e"
-    assert not thread.is_alive()
 
 
-def test_dispatch_macos_notification_escapes_double_quotes_in_script() -> None:
+def test_build_osascript_notification_escapes_double_quotes() -> None:
     """Double quotes in title, message, and subtitle must be escaped to \\" so the
-    AppleScript string literals are syntactically valid.
+    AppleScript string literals are syntactically valid. Tested as a pure function
+    so the assertion is decoupled from subprocess/threading concerns.
     """
-    runner = _RecordingMacOSRunner()
-
     request = NotificationRequest(
         message='He said "hello"',
         title='Title with "quotes"',
         urgency=NotificationUrgency.NORMAL,
     )
-    thread = _dispatch_macos_notification(request, "agent-quotes", runner=runner)
-    thread.join(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS)
 
-    assert runner.call_done.is_set()
-    assert len(runner.scripts) == 1
-    script = runner.scripts[0]
+    script = _build_osascript_notification(request, "agent-quotes")
+
     # Escaped quotes (\") must be present for message and title contents.
     assert 'He said \\"hello\\"' in script
     assert 'Title with \\"quotes\\"' in script
@@ -360,7 +334,7 @@ def test_dispatcher_routes_to_macos_when_is_macos() -> None:
     request = NotificationRequest(message="macos dispatch test")
     dispatcher.dispatch(request, "agent-mac-dispatch")
 
-    assert runner.call_done.wait(timeout=_MACOS_DISPATCH_JOIN_TIMEOUT_SECONDS), (
+    assert runner.call_done.wait(timeout=_MACOS_DISPATCH_WAIT_TIMEOUT_SECONDS), (
         "macOS runner was never called; dispatch did not route to the macOS path"
     )
     # Exactly one dispatch means exactly one runner invocation.


### PR DESCRIPTION
## Summary

Three macOS notification tests in `apps/minds/imbue/minds/desktop_client/notification_test.py` called `_dispatch_macos_notification` directly. The function spawns a daemon thread that shells out to real `osascript`, so every run fired a visible Notification Center banner -- leaving hundreds of stale banners on a developer Mac. The tests also had weak assertions (just "does not raise"), with no real coverage of quote escaping, routing, or error handling.

### Production changes

Two pure helpers extracted from existing logic -- no new injection seams, no new `PrivateAttr`s, no test-only kwargs:

- **`_build_osascript_notification(request, agent_display_name) -> str`**: the AppleScript-string construction lifted out of `_dispatch_macos_notification`, which now delegates to it.
- **`DispatchChannel` enum + `_select_dispatch_channel(is_electron, is_macos) -> DispatchChannel`**: the routing decision lifted out of `dispatch()`. `dispatch()` now computes the channel via the helper and `match`es on the variants.

### Test changes

- **Quote escaping**: `test_build_osascript_notification_escapes_double_quotes` calls the pure builder and asserts `\"` appears for the quoted payload in both title and message. The old `..._handles_quotes` test had no such assertion.
- **Routing**: `test_select_dispatch_channel` is parametrized across all four `(is_electron, is_macos)` combinations against the pure selector. No `dispatch()` call, no subprocess, no threads. The old routing test only asserted `dispatcher.is_macos is True`, which told you nothing about actual routing.
- **Tkinter-branch test fix**: `test_dispatch_non_electron_does_not_raise` now passes `is_macos=False`. On macOS, the default `is_macos=True` was silently routing this test through the real osascript path too.
- **Dropped**: `test_dispatch_macos_notification_does_not_raise`. The behavior it claimed to cover -- `_run_macos_notification_subprocess` catching `OSError`/`ExceptionGroup` -- is tested by the real code path at runtime; a dedicated test would require an injection seam that the repo rules (`~/.claude/CLAUDE.md`: no test-only hooks in production code) rightly forbid.

### Production behavior

Unchanged for all callers. `_dispatch_macos_notification` signature is unchanged. `dispatch()` routes to the same three branches in the same priority order.

## Test plan

- [x] `(cd apps/minds && uv run pytest --no-cov --cov-fail-under=0 -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release')` -- 600 passed locally (host is macOS)
- [x] No Notification Center banner can fire by construction: the quote test hits only the pure builder, the routing test hits only the pure selector, and the one remaining `dispatch()`-calling test on a non-Electron path forces `is_macos=False`
- [ ] Full offload via CI stop hook