### PR TITLE
propagate_changes: tolerate missing Electron; fix skill SSH key path

### DIFF
--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -61,15 +61,17 @@ cd apps/minds && npm install && cd ../..
 
 ### 4. Find your Docker SSH key
 
-The Docker provider stores SSH keys at:
+Minds agents register their hosts under `~/.minds/mngr/`, not the default `~/.mngr/`, because the minds desktop client overrides `MNGR_HOST_DIR` (see `propagate_changes` lines ~43-46). The SSH key for a minds Docker agent lives at:
 ```
-~/.mngr/profiles/<profile_id>/providers/docker/docker/keys/docker_ssh_key
+~/.minds/mngr/profiles/<profile_id>/providers/docker/docker/keys/docker_ssh_key
 ```
 
 Find yours with:
 ```bash
-find ~/.mngr/profiles -path "*/docker/*/keys/docker_ssh_key"
+find ~/.minds/mngr/profiles -path "*/docker/*/keys/docker_ssh_key"
 ```
+
+Do NOT use a key from `~/.mngr/profiles/...` -- that belongs to non-minds mngr agents and will silently fail with "Permission denied (publickey)".
 
 ### 5. Start the Electron app
 
@@ -86,7 +88,7 @@ TEMPLATE_BRANCH=$(cd .external_worktrees/forever-claude-template && git branch -
 (
   set -a
   source .env
-  source .test_env
+  [ -f .test_env ] && source .test_env
   set +a
   export MINDS_WORKSPACE_GIT_URL="$(pwd)/.external_worktrees/forever-claude-template"
   export MINDS_WORKSPACE_NAME="mindtest"

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -202,15 +202,14 @@ agent_update() {
 # --- Track B: Desktop client stop and restart ---
 
 electron_stop() {
-    echo "[electron] Stopping desktop client..."
     local electron_pid
     electron_pid=$(pgrep -if "electron/dist/.*electron \\.$" 2>/dev/null | head -1 || true)
     if [[ -z "${electron_pid}" ]]; then
-        echo "[electron] No running desktop client; nothing to stop. Will start a fresh one at the end."
+        echo "[electron] No running desktop client; will start a fresh one at the end."
         return 0
     fi
 
-    echo "[electron] Sending SIGTERM to electron PID ${electron_pid}"
+    echo "[electron] Stopping desktop client (PID ${electron_pid})..."
     if ! kill -TERM "${electron_pid}"; then
         echo "[electron] ERROR: Failed to send SIGTERM to PID ${electron_pid}" >&2
         return 1

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -206,9 +206,8 @@ electron_stop() {
     local electron_pid
     electron_pid=$(pgrep -if "electron/dist/.*electron \\.$" 2>/dev/null | head -1 || true)
     if [[ -z "${electron_pid}" ]]; then
-        echo "[electron] ERROR: No running electron app found. If this is unexpected, check for orphaned processes:" >&2
-        echo "[electron]   pgrep -af 'electron|uv run.*minds'" >&2
-        return 1
+        echo "[electron] No running desktop client; nothing to stop. Will start a fresh one at the end."
+        return 0
     fi
 
     echo "[electron] Sending SIGTERM to electron PID ${electron_pid}"


### PR DESCRIPTION
## Summary

Three small fixes to the minds dev iteration loop:

- **`propagate_changes`**: don't fail when no Electron is running. The script already starts a fresh Electron at the end, so treating "nothing to stop" as a hard error forced a manual restart after any earlier-step failure (wrong SSH key, unreachable container, etc.) and blocked bootstrap use cases where Electron hasn't been started yet.
- **minds-dev-iterate skill**: point at `~/.minds/mngr/profiles/` for the Docker SSH key instead of `~/.mngr/profiles/`. Minds agents register their hosts under `~/.minds/mngr/` (the desktop client overrides `MNGR_HOST_DIR`), so the previous path returned a non-minds key that silently failed with "Permission denied (publickey)".
- **minds-dev-iterate skill**: guard `.test_env` sourcing with `[ -f ]` so the startup snippet works without a `.test_env` file.

## Test plan

- [x] Run `propagate_changes` with Electron already stopped; verify it succeeds and starts a fresh Electron at the end
- [x] Run `propagate_changes` with Electron running; verify the normal stop/sync/restart path still works
- [x] Follow the skill's setup steps in a fresh worktree without a `.test_env` file