### PR TITLE
stop eagerly instantiating unrelated provider backends during post-destroy GC

### DIFF
--- a/libs/mngr/imbue/mngr/api/cleanup.py
+++ b/libs/mngr/imbue/mngr/api/cleanup.py
@@ -21,6 +21,7 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import CleanupAction
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import ProviderInstanceName
 
 
 @log_call
@@ -70,9 +71,15 @@ def execute_cleanup(
             agents_by_host[host_id] = []
         agents_by_host[host_id].append(agent)
 
+    # Track which providers actually had agents destroyed so post-destroy GC can
+    # skip providers we never touched. This prevents side effects from eagerly
+    # instantiating unrelated providers (e.g. creating a Modal environment when
+    # the destroyed agents all live on the local provider).
+    destroyed_provider_names: set[ProviderInstanceName] = set()
+
     match action:
         case CleanupAction.DESTROY:
-            _execute_destroy(mngr_ctx, agents_by_host, result, error_behavior)
+            _execute_destroy(mngr_ctx, agents_by_host, result, error_behavior, destroyed_provider_names)
         case CleanupAction.STOP:
             _execute_stop(mngr_ctx, agents_by_host, result, error_behavior)
         case _ as unreachable:
@@ -80,7 +87,11 @@ def execute_cleanup(
 
     # Run post-destroy GC when destroying
     if action == CleanupAction.DESTROY and result.destroyed_agents:
-        _run_post_cleanup_gc(mngr_ctx, result)
+        _run_post_cleanup_gc(
+            mngr_ctx,
+            result,
+            provider_names=tuple(sorted(str(p) for p in destroyed_provider_names)),
+        )
 
     return result
 
@@ -90,6 +101,7 @@ def _execute_destroy(
     agents_by_host: dict[HostId, list[AgentDetails]],
     result: CleanupResult,
     error_behavior: ErrorBehavior,
+    destroyed_provider_names: set[ProviderInstanceName],
 ) -> None:
     """Destroy agents, grouped by host."""
     for host_id, host_agents in agents_by_host.items():
@@ -110,6 +122,7 @@ def _execute_destroy(
                                         online_host.destroy_agent(agent)
                                         mngr_ctx.pm.hook.on_agent_destroyed(agent=agent, host=online_host)
                                         result.destroyed_agents.append(agent_details.name)
+                                        destroyed_provider_names.add(provider_name)
                                         logger.debug("Destroyed agent: {}", agent_details.name)
                                         emit_agent_destroyed(mngr_ctx.config, agent_details.id, host_id)
                                         emit_discovery_events_for_host(mngr_ctx.config, online_host)
@@ -121,6 +134,7 @@ def _execute_destroy(
                                         agent_details.name,
                                     )
                                     result.destroyed_agents.append(agent_details.name)
+                                    destroyed_provider_names.add(provider_name)
                             except MngrError as e:
                                 error_msg = f"Error destroying agent {agent_details.name}: {e}"
                                 logger.warning(error_msg)
@@ -136,6 +150,7 @@ def _execute_destroy(
                             for agent_details in host_agents:
                                 result.destroyed_agents.append(agent_details.name)
                                 logger.debug("Destroyed agent: {} (via host destruction)", agent_details.name)
+                            destroyed_provider_names.add(provider_name)
                             emit_host_destroyed(mngr_ctx.config, host_id, [ad.id for ad in host_agents])
                         except MngrError as e:
                             error_msg = f"Error destroying offline host {host_id}: {e}"
@@ -201,11 +216,17 @@ def _execute_stop(
 def _run_post_cleanup_gc(
     mngr_ctx: MngrContext,
     result: CleanupResult,
+    provider_names: tuple[str, ...],
 ) -> None:
-    """Run garbage collection after destroying agents."""
+    """Run garbage collection after destroying agents.
+
+    provider_names scopes GC to the providers whose agents were actually destroyed,
+    so unrelated providers are not eagerly instantiated (which could create cloud
+    resources as a side effect, e.g. a Modal environment).
+    """
     try:
         with log_span("Running post-cleanup garbage collection"):
-            providers = get_all_provider_instances(mngr_ctx)
+            providers = get_all_provider_instances(mngr_ctx, provider_names=provider_names)
             resource_types = GcResourceTypes(
                 is_machines=True,
                 is_work_dirs=True,

--- a/libs/mngr/imbue/mngr/api/cleanup_test.py
+++ b/libs/mngr/imbue/mngr/api/cleanup_test.py
@@ -39,6 +39,8 @@ from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LocalProviderInstance
+from imbue.mngr.providers.mock_tracking_backend_test import TrackingBackend
+from imbue.mngr.providers.mock_tracking_backend_test import tracking_backend_registered
 from imbue.mngr.utils.polling import wait_for
 from imbue.mngr.utils.testing import make_ctx_with_plugins
 from imbue.mngr.utils.testing import make_test_agent_details
@@ -647,10 +649,27 @@ def test_run_post_cleanup_gc_provider_error_is_recorded_in_result(
     bad_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().config, bad_config))
 
     result = CleanupResult()
-    _run_post_cleanup_gc(bad_ctx, result)
+    _run_post_cleanup_gc(bad_ctx, result, provider_names=("bad-gc-provider",))
 
     assert len(result.errors) == 1
     assert result.errors[0].startswith("Post-cleanup garbage collection failed:")
+
+
+def test_run_post_cleanup_gc_scopes_to_provided_provider_names(
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """_run_post_cleanup_gc must pass provider_names through so unrelated providers
+    are not eagerly instantiated.
+
+    Regression: previously, post-cleanup GC called get_all_provider_instances()
+    without a filter, causing every enabled backend to be instantiated even when
+    destroyed agents all lived on a single provider. For some backends (Modal),
+    instantiation has side effects like creating a cloud environment.
+    """
+    with tracking_backend_registered():
+        result = CleanupResult()
+        _run_post_cleanup_gc(temp_mngr_ctx, result, provider_names=(str(LOCAL_PROVIDER_NAME),))
+        assert TrackingBackend.build_count == 0
 
 
 def test_execute_cleanup_destroy_offline_host_success(
@@ -688,6 +707,44 @@ def test_execute_cleanup_destroy_offline_host_success(
         assert result.errors == []
         assert AgentName("offline-success-agent-one") in result.destroyed_agents
         assert AgentName("offline-success-agent-two") in result.destroyed_agents
+
+
+def test_execute_cleanup_destroy_scopes_post_destroy_gc_to_destroyed_provider(
+    temp_host_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """execute_cleanup DESTROY propagates the destroyed provider's name to post-destroy GC.
+
+    Destroying an agent on provider A must not cause GC to instantiate an unrelated
+    provider B; this prevents side effects like auto-creating a Modal environment
+    while destroying a purely local agent.
+    """
+    provider_name = ProviderInstanceName("offline-scoped-gc-provider")
+    success_provider = _OfflineHostSuccessProvider(
+        name=provider_name,
+        host_dir=temp_host_dir,
+        mngr_ctx=temp_mngr_ctx,
+    )
+
+    with _injected_provider(provider_name, temp_mngr_ctx, success_provider), tracking_backend_registered():
+        agent = make_test_agent_details(
+            name="scoped-gc-agent",
+            host_id=HostId.generate(),
+            provider_name=provider_name,
+        )
+
+        result = execute_cleanup(
+            mngr_ctx=temp_mngr_ctx,
+            agents=[agent],
+            action=CleanupAction.DESTROY,
+            is_dry_run=False,
+            error_behavior=ErrorBehavior.CONTINUE,
+        )
+
+        assert AgentName("scoped-gc-agent") in result.destroyed_agents
+        # The tracking backend is unrelated to the destroyed agent's provider,
+        # so post-destroy GC must not have instantiated it.
+        assert TrackingBackend.build_count == 0
 
 
 def test_execute_cleanup_stop_on_offline_host_skips_with_warning(

--- a/libs/mngr/imbue/mngr/cli/destroy.py
+++ b/libs/mngr/imbue/mngr/cli/destroy.py
@@ -49,6 +49,7 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.base_provider import BaseProviderInstance
 from imbue.mngr.utils.git_utils import find_source_repo_of_worktree
 from imbue.mngr.utils.git_utils import remove_worktree
@@ -70,8 +71,8 @@ class _DestroyTargets(FrozenModel):
 
     model_config = {**FrozenModel.model_config, "arbitrary_types_allowed": True}
 
-    online_agents: list[tuple[AgentInterface, OnlineHostInterface]] = Field(
-        description="Agents on online hosts to destroy, paired with their host"
+    online_agents: list[tuple[AgentInterface, OnlineHostInterface, ProviderInstanceName]] = Field(
+        description="Agents on online hosts to destroy, paired with their host and provider name"
     )
     offline_hosts: list[_OfflineHostToDestroy] = Field(
         description="Offline hosts where all agents are targeted for destruction"
@@ -226,6 +227,7 @@ def destroy(ctx: click.Context, **kwargs) -> None:
 
     # Destroy all targets (online agents + offline hosts) in parallel
     destroyed_agents: list[AgentName] = []
+    destroyed_provider_names: set[ProviderInstanceName] = set()
     worktrees_to_remove: list[tuple[Path, Path]] = []
     branches_to_remove: list[tuple[str, Path]] = []
     results_lock = threading.Lock()
@@ -234,17 +236,19 @@ def destroy(ctx: click.Context, **kwargs) -> None:
         parent_cg=mngr_ctx.concurrency_group, name="destroy_agents", max_workers=32
     ) as executor:
         futures: list[Future[None]] = []
-        for agent, host in targets.online_agents:
+        for agent, host, provider_name in targets.online_agents:
             futures.append(
                 executor.submit(
                     _destroy_single_online_agent,
                     agent,
                     host,
+                    provider_name,
                     opts,
                     output_opts,
                     mngr_ctx,
                     results_lock,
                     destroyed_agents,
+                    destroyed_provider_names,
                     worktrees_to_remove,
                     branches_to_remove,
                 )
@@ -258,6 +262,7 @@ def destroy(ctx: click.Context, **kwargs) -> None:
                     mngr_ctx,
                     results_lock,
                     destroyed_agents,
+                    destroyed_provider_names,
                 )
             )
 
@@ -277,9 +282,15 @@ def destroy(ctx: click.Context, **kwargs) -> None:
     for created_branch, source_repo_path in branches_to_remove:
         _remove_created_branch(created_branch, source_repo_path, mngr_ctx.concurrency_group, output_opts)
 
-    # Run garbage collection if enabled
+    # Run garbage collection if enabled, scoped to the providers we actually touched
+    # so we don't eagerly instantiate unrelated providers (which could create cloud
+    # resources as a side effect, e.g. a Modal environment).
     if opts.gc and destroyed_agents:
-        _run_post_destroy_gc(mngr_ctx=mngr_ctx, output_opts=output_opts)
+        _run_post_destroy_gc(
+            mngr_ctx=mngr_ctx,
+            output_opts=output_opts,
+            provider_names=tuple(sorted(str(p) for p in destroyed_provider_names)),
+        )
 
     # Output final result
     _output_result(destroyed_agents, output_opts)
@@ -324,7 +335,7 @@ def _partition_destroy_targets(
 
     Each host is resolved in parallel via a ConcurrencyGroupExecutor.
     """
-    online_agents: list[tuple[AgentInterface, OnlineHostInterface]] = []
+    online_agents: list[tuple[AgentInterface, OnlineHostInterface, ProviderInstanceName]] = []
     offline_hosts: list[_OfflineHostToDestroy] = []
     results_lock = threading.Lock()
 
@@ -364,7 +375,7 @@ def _resolve_host_for_partition(
     matches: Sequence[AgentMatch],
     mngr_ctx: MngrContext,
     results_lock: threading.Lock,
-    online_agents: list[tuple[AgentInterface, OnlineHostInterface]],
+    online_agents: list[tuple[AgentInterface, OnlineHostInterface, ProviderInstanceName]],
     offline_hosts: list[_OfflineHostToDestroy],
 ) -> None:
     """Resolve a single host and categorize its agents for destruction."""
@@ -392,7 +403,7 @@ def _resolve_host_for_partition(
             with results_lock:
                 for agent in agents:
                     if agent.id in matched_ids:
-                        online_agents.append((agent, online_host))
+                        online_agents.append((agent, online_host, provider_name))
         case HostInterface() as offline_host:
             _check_all_agents_targeted_on_offline_host(
                 offline_host, matched_ids, host_id_str, offline_hosts, provider, results_lock
@@ -404,11 +415,13 @@ def _resolve_host_for_partition(
 def _destroy_single_online_agent(
     agent: AgentInterface,
     host: OnlineHostInterface,
+    provider_name: ProviderInstanceName,
     opts: DestroyCliOptions,
     output_opts: OutputOptions,
     mngr_ctx: MngrContext,
     results_lock: threading.Lock,
     destroyed_agents: list[AgentName],
+    destroyed_provider_names: set[ProviderInstanceName],
     worktrees_to_remove: list[tuple[Path, Path]],
     branches_to_remove: list[tuple[str, Path]],
 ) -> None:
@@ -439,6 +452,7 @@ def _destroy_single_online_agent(
         mngr_ctx.pm.hook.on_agent_destroyed(agent=agent, host=host)
         with results_lock:
             destroyed_agents.append(agent.name)
+            destroyed_provider_names.add(provider_name)
         _output(f"Destroyed agent: {agent_display}", output_opts)
 
         # Emit agent_destroyed event, then re-emit remaining host state
@@ -455,6 +469,7 @@ def _destroy_single_offline_host(
     mngr_ctx: MngrContext,
     results_lock: threading.Lock,
     destroyed_agents: list[AgentName],
+    destroyed_provider_names: set[ProviderInstanceName],
 ) -> None:
     """Destroy a single offline host and all its agents. Thread-safe."""
     host_name = offline.host.get_name()
@@ -465,6 +480,7 @@ def _destroy_single_offline_host(
         mngr_ctx.pm.hook.on_host_destroyed(host=offline.host, mngr_ctx=mngr_ctx)
         with results_lock:
             destroyed_agents.extend(offline.agent_names)
+            destroyed_provider_names.add(offline.provider.name)
         for name in offline.agent_names:
             _output(f"Destroyed agent: {name}@{host_name} (via host destruction)", output_opts)
 
@@ -511,7 +527,7 @@ def _check_all_agents_targeted_on_offline_host(
 def _confirm_destruction(targets: _DestroyTargets) -> None:
     """Prompt user to confirm destruction of agents."""
     write_human_line("\nThe following agents will be destroyed:")
-    for agent, host in targets.online_agents:
+    for agent, host, _provider_name in targets.online_agents:
         write_human_line("  - {}@{}", agent.name, host.get_name())
     for offline in targets.offline_hosts:
         host_name = offline.host.get_name()
@@ -573,16 +589,24 @@ def _remove_created_branch(
         logger.warning("Failed to delete branch {}: {}", branch_name, e)
 
 
-def _run_post_destroy_gc(mngr_ctx: MngrContext, output_opts: OutputOptions) -> None:
+def _run_post_destroy_gc(
+    mngr_ctx: MngrContext,
+    output_opts: OutputOptions,
+    provider_names: tuple[str, ...],
+) -> None:
     """Run garbage collection after destroying agents.
 
     This cleans up orphaned host-level resources (machines, work dirs, snapshots, volumes).
     Errors are logged but don't prevent destroy from reporting success.
+
+    provider_names scopes GC to the providers whose agents were actually destroyed,
+    so unrelated providers are not eagerly instantiated. This matters because some
+    provider backends (e.g. Modal) create cloud resources on construction.
     """
     try:
         _output("Garbage collecting...", output_opts)
 
-        providers = get_all_provider_instances(mngr_ctx)
+        providers = get_all_provider_instances(mngr_ctx, provider_names=provider_names)
 
         resource_types = GcResourceTypes(
             is_machines=True,

--- a/libs/mngr/imbue/mngr/cli/destroy_test.py
+++ b/libs/mngr/imbue/mngr/cli/destroy_test.py
@@ -10,11 +10,16 @@ from imbue.mngr.cli.destroy import DestroyCliOptions
 from imbue.mngr.cli.destroy import _DestroyTargets
 from imbue.mngr.cli.destroy import _OfflineHostToDestroy
 from imbue.mngr.cli.destroy import _output_result
+from imbue.mngr.cli.destroy import _run_post_destroy_gc
 from imbue.mngr.cli.destroy import destroy
 from imbue.mngr.cli.destroy import get_agent_name_from_session
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.providers.mock_tracking_backend_test import TrackingBackend
+from imbue.mngr.providers.mock_tracking_backend_test import tracking_backend_registered
 
 
 def test_get_agent_name_from_session_extracts_name() -> None:
@@ -289,3 +294,27 @@ def test_destroy_dash_strips_whitespace(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
+
+
+# =============================================================================
+# Post-destroy GC provider scoping
+# =============================================================================
+
+
+def test_run_post_destroy_gc_does_not_instantiate_unrelated_providers(
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Post-destroy GC should only touch providers that actually held destroyed agents.
+
+    Regression: previously, destroying a local agent eagerly instantiated every
+    enabled backend during GC (including Modal), causing side effects like
+    auto-creating Modal environments.
+    """
+    with tracking_backend_registered():
+        output_opts = OutputOptions(output_format=OutputFormat.HUMAN)
+        _run_post_destroy_gc(
+            mngr_ctx=temp_mngr_ctx,
+            output_opts=output_opts,
+            provider_names=(str(LOCAL_PROVIDER_NAME),),
+        )
+        assert TrackingBackend.build_count == 0

--- a/libs/mngr/imbue/mngr/providers/mock_tracking_backend_test.py
+++ b/libs/mngr/imbue/mngr/providers/mock_tracking_backend_test.py
@@ -1,0 +1,74 @@
+"""Shared test backend that counts its instantiations.
+
+Used to assert that code paths don't eagerly instantiate unrelated provider
+backends. Lives in a mock_*_test.py file so other test modules can import it
+without running into the ratchet against inline imports.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import ClassVar
+
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.data_types import ProviderInstanceConfig
+from imbue.mngr.config.provider_config_registry import _provider_config_registry
+from imbue.mngr.interfaces.provider_backend import ProviderBackendInterface
+from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
+from imbue.mngr.primitives import ProviderBackendName
+from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.providers.mock_provider_test import MockProviderInstance
+from imbue.mngr.providers.registry import _backend_registry
+
+TRACKING_BACKEND_NAME = ProviderBackendName("test-tracking-backend")
+
+
+class TrackingBackend(ProviderBackendInterface):
+    """Backend whose build_provider_instance increments a class-level counter."""
+
+    build_count: ClassVar[int] = 0
+
+    @staticmethod
+    def get_name() -> ProviderBackendName:
+        return TRACKING_BACKEND_NAME
+
+    @staticmethod
+    def get_description() -> str:
+        return "Counts instantiations"
+
+    @staticmethod
+    def get_config_class() -> type[ProviderInstanceConfig]:
+        return ProviderInstanceConfig
+
+    @staticmethod
+    def get_build_args_help() -> str:
+        return "No arguments supported."
+
+    @staticmethod
+    def get_start_args_help() -> str:
+        return "No arguments supported."
+
+    @staticmethod
+    def build_provider_instance(
+        name: ProviderInstanceName,
+        config: ProviderInstanceConfig,
+        mngr_ctx: MngrContext,
+    ) -> ProviderInstanceInterface:
+        TrackingBackend.build_count += 1
+        return MockProviderInstance(
+            name=name,
+            host_dir=mngr_ctx.config.default_host_dir,
+            mngr_ctx=mngr_ctx,
+        )
+
+
+@contextmanager
+def tracking_backend_registered() -> Generator[None, None, None]:
+    """Register the tracking backend and reset its counter."""
+    _backend_registry[TRACKING_BACKEND_NAME] = TrackingBackend
+    _provider_config_registry[TRACKING_BACKEND_NAME] = ProviderInstanceConfig
+    TrackingBackend.build_count = 0
+    try:
+        yield
+    finally:
+        del _backend_registry[TRACKING_BACKEND_NAME]
+        del _provider_config_registry[TRACKING_BACKEND_NAME]


### PR DESCRIPTION
## Summary

- Destroying a local agent previously instantiated every enabled provider backend during post-destroy GC. For the Modal backend this auto-creates a Modal environment (and issues several Modal API roundtrips) as a side effect of a purely local operation — the symptom the user saw as \`Created Modal environment: mngr-...\` after \`mngr destroy --force\` on a local agent.
- Track the providers of successfully destroyed agents in both the \`destroy\` CLI (\`libs/mngr/imbue/mngr/cli/destroy.py\`) and the shared cleanup API (\`libs/mngr/imbue/mngr/api/cleanup.py\`), and pass them through to \`get_all_provider_instances\` via the existing \`provider_names\` filter so unrelated backends are not constructed.
- Added a shared \`TrackingBackend\` + \`tracking_backend_registered()\` helper in \`libs/mngr/imbue/mngr/providers/mock_tracking_backend_test.py\` and three regression tests covering: direct unit tests of \`_run_post_destroy_gc\` and \`_run_post_cleanup_gc\`, and an end-to-end test through \`execute_cleanup\`.

## Manual repro

\`mngr destroy --force -vv <local-agent>\`, with verbose logs:

Before:
- \`Creating ephemeral Modal app with output capture: mngr-modal\`
- \`Looking up persistent Modal app: mngr-modal [done in 0.36880 sec]\`
- \`Ensuring state volume: mngr-modal-state\`
- \`Listed all mngr sandboxes for app=mngr-modal in env=mngr-...\`
- \`Built provider instance {modal,docker,lima,ssh} ...\`
- \`Loaded 5 total provider instances\`, GC phase ≈1.0s, total destroy ≈2.75s

After:
- \`Skipped provider modal (not in provider filter)\` (+docker, lima, ssh)
- \`Loaded 1 total provider instances\`, GC phase ≈0.11s, total destroy ≈1.85s

## Test plan

- [x] \`uv run pytest\` in \`libs/mngr\` with slow-infra marks excluded — 3589 passed
- [x] \`uv run pytest\` in \`libs/mngr_modal\` with slow-infra marks excluded — 377 passed
- [x] Ratchet tests (\`test_ratchets.py\`) — 54 passed
- [x] Manual repro at CLI level (create + destroy a local agent, verify no Modal roundtrips with \`-vv\`)
- [ ] CI (offload + acceptance)