### PR TITLE
fix macOS Cmd+Opt+I devtools shortcut in minds Electron app

### DIFF
--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -381,9 +381,12 @@ function registerShortcutsFor(bundle, wc) {
     if (input.type !== 'keyDown') return;
     const key = input.key ? input.key.toLowerCase() : '';
     const modifier = isMac ? input.meta : input.control;
+    // Match on `input.code` (physical key) rather than `input.key`: on macOS,
+    // holding Option transforms `key` into the Option-composed character
+    // (e.g. 'ˆ' or 'Dead' for Option+I), so `key === 'i'` never matches.
     const devTools =
-      (isMac && input.meta && input.alt && key === 'i') ||
-      (!isMac && input.control && input.shift && key === 'c');
+      (isMac && input.meta && input.alt && input.code === 'KeyI') ||
+      (!isMac && input.control && input.shift && input.code === 'KeyC');
     if (devTools) {
       event.preventDefault();
       if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {


### PR DESCRIPTION
## Summary

The Electron main-process shortcut for toggling DevTools (`registerShortcutsFor` in `apps/minds/electron/main.js`) was silently broken on macOS: pressing Cmd+Opt+I did nothing.

**Root cause.** The `before-input-event` handler matched on `input.key.toLowerCase() === 'i'`. Per the [KeyboardEvent.key spec](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key), `key` reflects modifier composition, so on macOS with Option held, `input.key` for the I key is `'ˆ'` (modifier circumflex) or `'Dead'` — never `'i'`. The non-Option shortcuts in the same handler (Cmd+N/W/Q) are unaffected because Option isn't part of their combos.

**Fix.** Match on `input.code` (physical key code, e.g. `'KeyI'`) instead, which is unaffected by modifier composition. Applied the same change to the Windows/Linux Ctrl+Shift+C branch for symmetry, though that path doesn't have the same composition problem.

Diff is 5 lines (3 code + 3 comment - 2 old) in one file.

## Test plan

- [ ] Pull branch, restart the Electron app (`cd apps/minds && npm start`), open a mind, press Cmd+Opt+I with the content view focused — DevTools should toggle open/closed.
- [ ] Verify the existing Cmd+N / Cmd+W / Cmd+Q shortcuts still work (untouched, but worth a smoke check).
- [ ] On Windows/Linux: Ctrl+Shift+C should still toggle DevTools (unchanged behavior, change is logically equivalent there).