### PR TITLE
minds desktop_client: rewrite chat-UI base-path meta for fetch/XHR routing

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/proxy.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy.py
@@ -281,6 +281,32 @@ setTimeout(function() {{ location.reload(); }}, {interval});
 </html>""".format(interval=_BACKEND_LOADING_RETRY_INTERVAL_MS, links=links_html)
 
 
+_BASE_PATH_META_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r'(<meta\s+name="minds-workspace-server-base-path"\s+content=")[^"]*(")',
+    re.IGNORECASE,
+)
+
+
+@pure
+def rewrite_base_path_meta(html_content: str, agent_id: AgentId, server_name: ServerName) -> str:
+    """Populate the `minds-workspace-server-base-path` <meta> tag with the proxy prefix.
+
+    The minds_workspace_server frontend reads this meta at page load and
+    prepends its content to every relative API URL it constructs (see
+    `apiUrl()` in `frontend/src/base-path.ts`). When the server is directly
+    accessed, content is empty -- URLs like `/api/agents/.../screen` resolve
+    against the document origin. But when we proxy it under
+    `/forwarding/{agent}/system_interface/`, that root-relative fetch bypasses
+    our `<base>` tag (which only applies to `<a href>`, `<img src>`, etc. --
+    not to fetch/XHR) and lands on the desktop client's backend, which has
+    no such route and returns 404. Populating this meta with our proxy
+    prefix makes the frontend build fully-prefixed URLs that route through
+    the proxy correctly.
+    """
+    prefix = _get_server_prefix(agent_id, server_name)
+    return _BASE_PATH_META_PATTERN.sub(rf"\g<1>{prefix}\g<2>", html_content, count=1)
+
+
 @pure
 def rewrite_proxied_html(
     html_content: str,
@@ -300,6 +326,10 @@ def rewrite_proxied_html(
         agent_id=agent_id,
         server_name=server_name,
     )
+
+    # Populate the minds_workspace_server base-path meta tag so the frontend
+    # builds prefixed URLs for fetch/XHR (which ignore <base>).
+    rewritten = rewrite_base_path_meta(rewritten, agent_id, server_name)
 
     # Build the injection: base tag + WS shim
     base_tag = f'<base href="{prefix}/">'


### PR DESCRIPTION
## Summary

Fixes "clicking Send in the minds chat UI does nothing" by rewriting the `<meta name=\"minds-workspace-server-base-path\" content=\"\">` tag in proxied HTML responses to include the proxy prefix.

## Why

The minds_workspace_server frontend's `apiUrl(path)` (from `frontend/src/base-path.ts`) returns `<meta base-path> + path`. The server serves `content=\"\"` on direct access -- correct when the frontend is at the origin root.

Our desktop client proxies that frontend under `/forwarding/<agent>/system_interface/` and injects a `<base>` tag for HTML attribute URL resolution. But **`<base>` has no effect on `fetch()` / XMLHttpRequest**, which resolve against `location.href`, not the base URL. Result: every XHR the chat UI makes (including the \"message sent to agent\" POST) goes to `http://<host>/api/agents/.../message` -- no forwarding prefix -- hits the desktop backend, 404s. The chat UI's `handleSend` does a `fire-and-forget catch {}` so the failure is invisible to the user: \"click Send, nothing happens\".

Observed via CDP instrumentation: up to 411 GETs/second to `/api/agents/<ghost-id>/screen` (from `ChatPanel::fetchScreenCapture`) all returning 404, plus zero POSTs to `/message` visibly succeeding, despite the user typing + clicking Send.

## Fix

Add `rewrite_base_path_meta(html, agent_id, server_name)` -- a new step in `rewrite_proxied_html` that replaces the meta tag's `content` attribute with `/forwarding/<agent>/<server>`. The frontend then builds fully-prefixed URLs that route through the proxy correctly.

One new helper function, one new call site. No behavior change on pages that don't have that meta tag (the regex simply doesn't match).

## Verified

End-to-end against a freshly-provisioned Lima agent: type message -> click send -> POST 200 -> Claude replies in the tmux pane. Previously the POST was silently swallowed at the 404 layer.

## Interaction with other in-flight work

Complements [forever-claude-template#8](https://github.com/imbue-ai/forever-claude-template/pull/8) (per-agent state in the chat UI's MessageInput component). **Both fixes are needed for the send button to work end-to-end through the minds proxy:**

- Without FCT#8, `handleSend` reads empty `messageText` and bails before issuing a POST.
- Without this PR, `handleSend` proceeds to POST but the URL lacks the forwarding prefix and 404s.

Either fix is safe to land standalone; they're orthogonal (one is a proxy-HTML-rewriter concern, the other is a pure frontend-state concern). This PR is best-effort mergeable -- nothing upstream depends on it.

## Test plan

- [ ] Unit-level rewrite test: smoke-tested via a Python REPL showing `content=\"\"` -> `content=\"/forwarding/agent-<id>/system_interface\"`.
- [ ] Existing `rewrite_proxied_html` tests still pass (no change to the other rewrite steps).
- [ ] End-to-end: provision a Lima agent, open chat UI, click Send. **(Requires also having the FCT#8 MessageInput fix on the template branch; verified with both on `pilot`.)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)