### PR TITLE
Rewrite Location headers in desktop client proxy

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -49,6 +49,7 @@ from imbue.minds.desktop_client.proxy import generate_backend_loading_html
 from imbue.minds.desktop_client.proxy import generate_bootstrap_html
 from imbue.minds.desktop_client.proxy import generate_service_worker_js
 from imbue.minds.desktop_client.proxy import rewrite_cookie_path
+from imbue.minds.desktop_client.proxy import rewrite_location_header
 from imbue.minds.desktop_client.proxy import rewrite_proxied_html
 from imbue.minds.desktop_client.request_events import RequestInbox
 from imbue.minds.desktop_client.request_events import RequestStatus
@@ -540,16 +541,25 @@ def _build_proxy_response(
     # Build response headers, dropping hop-by-hop headers
     resp_headers: dict[str, list[str]] = {}
     for header_key, header_value in backend_response.headers.multi_items():
-        if header_key.lower() in _EXCLUDED_RESPONSE_HEADERS:
+        header_key_lower = header_key.lower()
+        if header_key_lower in _EXCLUDED_RESPONSE_HEADERS:
             continue
-        if header_key.lower() == "set-cookie":
-            header_value = rewrite_cookie_path(
+        if header_key_lower == "set-cookie":
+            rewritten_value = rewrite_cookie_path(
                 set_cookie_header=header_value,
                 agent_id=agent_id,
                 server_name=server_name,
             )
+        elif header_key_lower == "location":
+            rewritten_value = rewrite_location_header(
+                location_header=header_value,
+                agent_id=agent_id,
+                server_name=server_name,
+            )
+        else:
+            rewritten_value = header_value
         resp_headers.setdefault(header_key, [])
-        resp_headers[header_key].append(header_value)
+        resp_headers[header_key].append(rewritten_value)
 
     content: str | bytes = backend_response.content
 

--- a/apps/minds/imbue/minds/desktop_client/proxy.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy.py
@@ -1,5 +1,7 @@
 import re
 from typing import Final
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
 from imbue.imbue_common.pure import pure
 from imbue.minds.primitives import ServerName
@@ -153,6 +155,36 @@ def rewrite_cookie_path(
         return set_cookie_header[: match.start(2)] + new_path + set_cookie_header[match.end(2) :]
     else:
         return set_cookie_header + f"; Path={prefix}/"
+
+
+@pure
+def rewrite_location_header(
+    location_header: str,
+    agent_id: AgentId,
+    server_name: ServerName,
+) -> str:
+    """Rewrite a Location header so site-absolute redirects stay within the proxied server prefix.
+
+    Without this, a backend returning ``Location: /foo`` causes the browser to resolve
+    the redirect against the document origin, escaping the proxy prefix and landing on
+    the desktop client root. Relative paths resolve correctly via the injected
+    ``<base>`` tag, so they are left untouched. Absolute URLs (with scheme or
+    protocol-relative ``//``) and already-prefixed paths are also left unchanged.
+    """
+    parts = urlsplit(location_header)
+    # Absolute URL (e.g., https://example.com/...) or protocol-relative (//host/...).
+    # The browser will navigate to the explicit host regardless of our prefix, so leave it.
+    if parts.scheme or parts.netloc:
+        return location_header
+    # Relative path or fragment-only reference -- resolved against the document URL,
+    # which already lives under the proxied prefix thanks to the injected <base> tag.
+    if not parts.path.startswith("/"):
+        return location_header
+    prefix = _get_server_prefix(agent_id, server_name)
+    if parts.path == prefix or parts.path.startswith(prefix + "/"):
+        return location_header
+    new_path = prefix + parts.path
+    return urlunsplit(("", "", new_path, parts.query, parts.fragment))
 
 
 @pure

--- a/apps/minds/imbue/minds/desktop_client/proxy.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy.py
@@ -177,8 +177,8 @@ def rewrite_location_header(
     # The browser will navigate to the explicit host regardless of our prefix, so leave it.
     if parts.scheme or parts.netloc:
         return location_header
-    # Relative path or fragment-only reference -- resolved against the document URL,
-    # which already lives under the proxied prefix thanks to the injected <base> tag.
+    # Relative path or fragment-only reference -- the browser resolves a relative
+    # Location against the request URL, which already lives under the proxied prefix.
     if not parts.path.startswith("/"):
         return location_header
     prefix = _get_server_prefix(agent_id, server_name)

--- a/apps/minds/imbue/minds/desktop_client/proxy.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy.py
@@ -167,9 +167,10 @@ def rewrite_location_header(
 
     Without this, a backend returning ``Location: /foo`` causes the browser to resolve
     the redirect against the document origin, escaping the proxy prefix and landing on
-    the desktop client root. Relative paths resolve correctly via the injected
-    ``<base>`` tag, so they are left untouched. Absolute URLs (with scheme or
-    protocol-relative ``//``) and already-prefixed paths are also left unchanged.
+    the desktop client root. Relative paths are left untouched because the browser
+    resolves a relative ``Location`` against the request URL, which already lives under
+    the proxied prefix. Absolute URLs (with scheme or protocol-relative ``//``) and
+    already-prefixed paths are also left unchanged.
     """
     parts = urlsplit(location_header)
     # Absolute URL (e.g., https://example.com/...) or protocol-relative (//host/...).

--- a/apps/minds/imbue/minds/desktop_client/proxy_test.py
+++ b/apps/minds/imbue/minds/desktop_client/proxy_test.py
@@ -6,6 +6,7 @@ from imbue.minds.desktop_client.proxy import generate_service_worker_js
 from imbue.minds.desktop_client.proxy import generate_websocket_shim_js
 from imbue.minds.desktop_client.proxy import rewrite_absolute_paths_in_html
 from imbue.minds.desktop_client.proxy import rewrite_cookie_path
+from imbue.minds.desktop_client.proxy import rewrite_location_header
 from imbue.minds.desktop_client.proxy import rewrite_proxied_html
 from imbue.minds.primitives import ServerName
 from imbue.mngr.primitives import AgentId
@@ -168,6 +169,110 @@ def test_rewrite_absolute_paths_handles_single_quotes() -> None:
         server_name=_TEST_SERVER,
     )
     assert result == snapshot("<a href='/forwarding/agent-00000000000000000000000000000001/web/hello.txt'>link</a>")
+
+
+# -- Location header rewriting --
+
+
+def test_rewrite_location_header_with_site_absolute_path() -> None:
+    result = rewrite_location_header(
+        location_header="/foo",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == snapshot("/forwarding/agent-00000000000000000000000000000001/web/foo")
+
+
+def test_rewrite_location_header_with_site_absolute_root() -> None:
+    result = rewrite_location_header(
+        location_header="/",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == snapshot("/forwarding/agent-00000000000000000000000000000001/web/")
+
+
+def test_rewrite_location_header_preserves_query_string() -> None:
+    result = rewrite_location_header(
+        location_header="/foo?bar=1&baz=2",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == snapshot("/forwarding/agent-00000000000000000000000000000001/web/foo?bar=1&baz=2")
+
+
+def test_rewrite_location_header_preserves_fragment() -> None:
+    result = rewrite_location_header(
+        location_header="/foo#section",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == snapshot("/forwarding/agent-00000000000000000000000000000001/web/foo#section")
+
+
+def test_rewrite_location_header_does_not_double_prefix() -> None:
+    already_prefixed = f"/forwarding/{_TEST_AGENT}/{_TEST_SERVER}/foo"
+    result = rewrite_location_header(
+        location_header=already_prefixed,
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == already_prefixed
+
+
+def test_rewrite_location_header_does_not_double_prefix_exact_match() -> None:
+    prefix = f"/forwarding/{_TEST_AGENT}/{_TEST_SERVER}"
+    result = rewrite_location_header(
+        location_header=prefix,
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == prefix
+
+
+def test_rewrite_location_header_preserves_relative_path() -> None:
+    result = rewrite_location_header(
+        location_header="foo",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == "foo"
+
+
+def test_rewrite_location_header_preserves_dot_relative_path() -> None:
+    result = rewrite_location_header(
+        location_header="./foo",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == "./foo"
+
+
+def test_rewrite_location_header_preserves_protocol_relative_url() -> None:
+    result = rewrite_location_header(
+        location_header="//example.com/page",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == "//example.com/page"
+
+
+def test_rewrite_location_header_preserves_absolute_url() -> None:
+    result = rewrite_location_header(
+        location_header="https://example.com/page",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == "https://example.com/page"
+
+
+def test_rewrite_location_header_preserves_fragment_only() -> None:
+    result = rewrite_location_header(
+        location_header="#anchor",
+        agent_id=_TEST_AGENT,
+        server_name=_TEST_SERVER,
+    )
+    assert result == "#anchor"
 
 
 # -- Full proxied HTML rewriting --

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi import Request as FastAPIRequest
 from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
+from fastapi.responses import RedirectResponse
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -74,6 +75,19 @@ def _create_test_backend() -> FastAPI:
     async def backend_echo(request: FastAPIRequest) -> JSONResponse:
         body = await request.body()
         return JSONResponse({"echo": body.decode()})
+
+    @backend.post("/redirect-absolute")
+    def backend_redirect_absolute() -> RedirectResponse:
+        # Simulates a FastAPI 303-after-POST returning a site-absolute Location.
+        return RedirectResponse(url="/landed", status_code=303)
+
+    @backend.post("/redirect-relative")
+    def backend_redirect_relative() -> RedirectResponse:
+        return RedirectResponse(url="./landed", status_code=303)
+
+    @backend.post("/redirect-absolute-url")
+    def backend_redirect_absolute_url() -> RedirectResponse:
+        return RedirectResponse(url="https://example.com/landed", status_code=303)
 
     return backend
 
@@ -404,6 +418,48 @@ def test_agent_proxy_forwards_post_request_to_backend(tmp_path: Path) -> None:
     )
     assert response.status_code == 200
     assert response.json() == {"echo": "test-body-content"}
+
+
+def test_agent_proxy_rewrites_site_absolute_redirect_location(tmp_path: Path) -> None:
+    client, auth_store, agent_id = _setup_test_server(tmp_path)
+    _authenticate_client(client=client, auth_store=auth_store)
+
+    client.cookies.set(f"sw_installed_{agent_id}_{DEFAULT_SERVER_NAME}", "1")
+
+    response = client.post(
+        f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/redirect-absolute",
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/landed"
+
+
+def test_agent_proxy_preserves_relative_redirect_location(tmp_path: Path) -> None:
+    client, auth_store, agent_id = _setup_test_server(tmp_path)
+    _authenticate_client(client=client, auth_store=auth_store)
+
+    client.cookies.set(f"sw_installed_{agent_id}_{DEFAULT_SERVER_NAME}", "1")
+
+    response = client.post(
+        f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/redirect-relative",
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "./landed"
+
+
+def test_agent_proxy_preserves_external_absolute_url_redirect(tmp_path: Path) -> None:
+    client, auth_store, agent_id = _setup_test_server(tmp_path)
+    _authenticate_client(client=client, auth_store=auth_store)
+
+    client.cookies.set(f"sw_installed_{agent_id}_{DEFAULT_SERVER_NAME}", "1")
+
+    response = client.post(
+        f"/forwarding/{agent_id}/{DEFAULT_SERVER_NAME}/redirect-absolute-url",
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://example.com/landed"
 
 
 def test_agent_proxy_injects_websocket_shim_into_html_responses(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add `rewrite_location_header` to the desktop client proxy so site-absolute redirects (e.g. FastAPI `303`-after-POST with `Location: /foo`) stay within the `/forwarding/{agent_id}/{server_name}/` prefix instead of escaping to the desktop client root.
- Wire it into `_build_proxy_response` next to the existing `Set-Cookie Path=` rewrite. Relative (`./foo`), protocol-relative (`//host/x`), absolute-URL (`https://…`), fragment-only, and already-prefixed paths pass through unchanged.
- Removes the need for proxied FastAPI apps to work around the bug with relative URLs (e.g. `./?flash=…` instead of `/?flash=…`).

## Test plan

- [x] 11 new unit tests in `proxy_test.py` covering rewrite + passthrough cases.
- [x] 3 new integration tests in `test_desktop_client.py` that exercise a real backend `RedirectResponse` through the proxy and assert the rewritten `Location`.
- [x] `just test-quick apps/minds/imbue/minds/desktop_client/proxy_test.py` — 38 passed.
- [x] `just test-quick apps/minds/imbue/minds/desktop_client/test_desktop_client.py` — 92 passed.
- [x] `just test-quick "apps/minds -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 619 passed (including `test_ratchets.py`).
- [x] `ruff check` + `ruff format --check` — clean.
- [ ] Manual verification through a running minds container — not done; see notes below.

## Notes / follow-ups

- Not handled: `Refresh: 0; url=/foo` headers (uncommon, same class of bug).
- Not handled: `Location` headers containing the backend's own host (e.g. `http://127.0.0.1:PORT/foo`, which FastAPI emits when using `request.url_for(...)`). Would require passing the backend base URL into the rewriter. Worth doing only if seen biting a real app.