### PR TITLE
Scope minds chat MessageInput and SSE stream state per agent

### DIFF
--- a/apps/minds_workspace_server/frontend/src/models/StreamingMessage.ts
+++ b/apps/minds_workspace_server/frontend/src/models/StreamingMessage.ts
@@ -10,6 +10,10 @@ import { apiUrl } from "../base-path";
 import { appendEvents, type TranscriptEvent } from "./Response";
 
 const activeStreams = new Map<string, EventSource>();
+// Tombstones for agents whose streams were explicitly closed via
+// disconnectFromStream. Used by pending error-triggered reconnect timeouts
+// to distinguish an intentional shutdown from a transient error.
+const explicitlyDisconnectedAgents = new Set<string>();
 
 export interface StreamingMessage {
   conversationId: string;
@@ -25,6 +29,9 @@ export function connectToStream(agentId: string): void {
     return;
   }
 
+  // A fresh connect supersedes any prior explicit-disconnect tombstone.
+  explicitlyDisconnectedAgents.delete(agentId);
+
   const eventSource = new EventSource(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/stream`));
   activeStreams.set(agentId, eventSource);
 
@@ -34,14 +41,16 @@ export function connectToStream(agentId: string): void {
   };
 
   eventSource.onerror = () => {
-    // Close this specific stream and schedule a reconnect. The map check
-    // before reconnect avoids reviving a stream for an agent that has been
-    // explicitly disconnected (e.g. its panel was unmounted).
+    // Close this specific stream and schedule a reconnect. Reconnect is
+    // skipped if another caller already reconnected this agent, or if the
+    // agent was explicitly disconnected (e.g. its panel was unmounted) while
+    // this timeout was pending.
     if (activeStreams.get(agentId) === eventSource) {
       eventSource.close();
       activeStreams.delete(agentId);
       setTimeout(() => {
-        if (!activeStreams.has(agentId)) {
+        const wasExplicitlyDisconnected = explicitlyDisconnectedAgents.delete(agentId);
+        if (!wasExplicitlyDisconnected && !activeStreams.has(agentId)) {
           connectToStream(agentId);
         }
       }, 3000);
@@ -50,6 +59,10 @@ export function connectToStream(agentId: string): void {
 }
 
 export function disconnectFromStream(agentId: string): void {
+  // Always record the intent, even if no stream is currently active. A
+  // pending error-triggered reconnect timeout for this agent must see the
+  // tombstone so it does not revive the stream.
+  explicitlyDisconnectedAgents.add(agentId);
   const eventSource = activeStreams.get(agentId);
   if (eventSource !== undefined) {
     eventSource.close();

--- a/apps/minds_workspace_server/frontend/src/models/StreamingMessage.ts
+++ b/apps/minds_workspace_server/frontend/src/models/StreamingMessage.ts
@@ -1,13 +1,15 @@
 /**
  * SSE connection management for real-time agent events.
  * Connects to the backend's SSE stream and appends new events.
+ *
+ * Streams are keyed by agentId so multiple chat panels can subscribe
+ * independently; each agent gets its own EventSource.
  */
 
 import { apiUrl } from "../base-path";
 import { appendEvents, type TranscriptEvent } from "./Response";
 
-let activeEventSource: EventSource | null = null;
-let activeAgentId: string | null = null;
+const activeStreams = new Map<string, EventSource>();
 
 export interface StreamingMessage {
   conversationId: string;
@@ -19,14 +21,12 @@ export interface StreamingMessage {
 }
 
 export function connectToStream(agentId: string): void {
-  if (agentId === activeAgentId && activeEventSource !== null) {
+  if (activeStreams.has(agentId)) {
     return;
   }
-  disconnectFromStream();
 
-  activeAgentId = agentId;
   const eventSource = new EventSource(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/stream`));
-  activeEventSource = eventSource;
+  activeStreams.set(agentId, eventSource);
 
   eventSource.onmessage = (messageEvent: MessageEvent) => {
     const event = JSON.parse(messageEvent.data) as TranscriptEvent;
@@ -34,10 +34,14 @@ export function connectToStream(agentId: string): void {
   };
 
   eventSource.onerror = () => {
-    if (eventSource === activeEventSource) {
-      disconnectFromStream();
+    // Close this specific stream and schedule a reconnect. The map check
+    // before reconnect avoids reviving a stream for an agent that has been
+    // explicitly disconnected (e.g. its panel was unmounted).
+    if (activeStreams.get(agentId) === eventSource) {
+      eventSource.close();
+      activeStreams.delete(agentId);
       setTimeout(() => {
-        if (activeAgentId === null && agentId) {
+        if (!activeStreams.has(agentId)) {
           connectToStream(agentId);
         }
       }, 3000);
@@ -45,11 +49,11 @@ export function connectToStream(agentId: string): void {
   };
 }
 
-export function disconnectFromStream(): void {
-  if (activeEventSource !== null) {
-    activeEventSource.close();
-    activeEventSource = null;
-    activeAgentId = null;
+export function disconnectFromStream(agentId: string): void {
+  const eventSource = activeStreams.get(agentId);
+  if (eventSource !== undefined) {
+    eventSource.close();
+    activeStreams.delete(agentId);
   }
 }
 

--- a/apps/minds_workspace_server/frontend/src/views/ChatPanel.ts
+++ b/apps/minds_workspace_server/frontend/src/views/ChatPanel.ts
@@ -38,9 +38,7 @@ function getAgentTerminalUrl(agentId: string): string {
   // agent isn't in the local cache yet, fall back to no name arg and let
   // agent.sh attach to the ambient session.
   const agent = getAgentById(agentId);
-  const args = agent?.name
-    ? `arg=_&arg=agent&arg=${encodeURIComponent(agent.name)}`
-    : "arg=_&arg=agent";
+  const args = agent?.name ? `arg=_&arg=agent&arg=${encodeURIComponent(agent.name)}` : "arg=_&arg=agent";
   return `${baseUrl}${separator}${args}`;
 }
 
@@ -213,7 +211,7 @@ export function ChatPanel(): m.Component<{ agentId: string }> {
     if (!isConversationNotFound(agentId)) {
       connectToStream(agentId);
     } else {
-      disconnectFromStream();
+      disconnectFromStream(agentId);
     }
   }
 
@@ -386,6 +384,9 @@ export function ChatPanel(): m.Component<{ agentId: string }> {
   return {
     onremove() {
       disconnectLogWs();
+      if (currentAgentId !== null) {
+        disconnectFromStream(currentAgentId);
+      }
     },
 
     view(vnode) {

--- a/apps/minds_workspace_server/frontend/src/views/MessageInput.ts
+++ b/apps/minds_workspace_server/frontend/src/views/MessageInput.ts
@@ -9,109 +9,111 @@ function messageTextKey(agentId: string): string {
   return `${MESSAGE_TEXT_KEY_PREFIX}${agentId}`;
 }
 
-let messageText = "";
-let currentAgentId: string | null = null;
-let messageTextareaElement: HTMLTextAreaElement | null = null;
-
 function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.height = "auto";
   textarea.style.height = `${Math.min(textarea.scrollHeight, MAX_TEXTAREA_HEIGHT_PX)}px`;
   textarea.style.overflowY = textarea.scrollHeight > MAX_TEXTAREA_HEIGHT_PX ? "auto" : "hidden";
 }
 
-function focusMessageTextarea(): void {
-  messageTextareaElement?.focus();
-}
-
 // Compatibility export
 export function setSelectedModelId(_modelId: string): void {}
 
-export const MessageInput: m.Component<{ agentId: string | null }> = {
-  view(vnode) {
-    const agentId = vnode.attrs.agentId;
+export function MessageInput(): m.Component<{ agentId: string | null }> {
+  let messageText = "";
+  let currentAgentId: string | null = null;
+  let messageTextareaElement: HTMLTextAreaElement | null = null;
 
-    if (!agentId) {
-      return null;
-    }
+  function focusMessageTextarea(): void {
+    messageTextareaElement?.focus();
+  }
 
-    if (currentAgentId !== agentId) {
-      currentAgentId = agentId;
-      messageText = localStorage.getItem(messageTextKey(agentId)) ?? "";
-    }
+  return {
+    view(vnode) {
+      const agentId = vnode.attrs.agentId;
 
-    async function handleSend(): Promise<void> {
-      if (!agentId || !messageText.trim()) {
-        return;
+      if (!agentId) {
+        return null;
       }
 
-      const text = messageText;
-      messageText = "";
-      localStorage.removeItem(messageTextKey(agentId));
-      m.redraw();
-
-      try {
-        await sendMessage(agentId, text);
-      } catch {
-        // Fire-and-forget: response comes via SSE
+      if (currentAgentId !== agentId) {
+        currentAgentId = agentId;
+        messageText = localStorage.getItem(messageTextKey(agentId)) ?? "";
       }
 
-      requestAnimationFrame(() => {
-        focusMessageTextarea();
-      });
-    }
+      async function handleSend(): Promise<void> {
+        if (!agentId || !messageText.trim()) {
+          return;
+        }
 
-    function handleKeydown(event: KeyboardEvent): void {
-      if (event.key === "Enter" && !event.shiftKey) {
-        event.preventDefault();
-        handleSend();
+        const text = messageText;
+        messageText = "";
+        localStorage.removeItem(messageTextKey(agentId));
+        m.redraw();
+
+        try {
+          await sendMessage(agentId, text);
+        } catch {
+          // Fire-and-forget: response comes via SSE
+        }
+
+        requestAnimationFrame(() => {
+          focusMessageTextarea();
+        });
       }
-    }
 
-    const hasMessageText = messageText.trim().length > 0;
+      function handleKeydown(event: KeyboardEvent): void {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          handleSend();
+        }
+      }
 
-    return m("div", { class: "message-input mx-auto w-full" }, [
-      m("div", { class: "message-input-box flex flex-col" }, [
-        m("textarea", {
-          class: "message-input-textbox w-full resize-none focus:outline-none",
-          placeholder: "Type a message...",
-          rows: 1,
-          value: messageText,
-          oncreate: (textareaVnode: m.VnodeDOM) => {
-            messageTextareaElement = textareaVnode.dom as HTMLTextAreaElement;
-            autoResizeTextarea(messageTextareaElement);
-            focusMessageTextarea();
-          },
-          onupdate: (textareaVnode: m.VnodeDOM) => {
-            messageTextareaElement = textareaVnode.dom as HTMLTextAreaElement;
-            autoResizeTextarea(messageTextareaElement);
-          },
-          onremove: () => {
-            messageTextareaElement = null;
-          },
-          oninput: (event: Event) => {
-            const textarea = event.target as HTMLTextAreaElement;
-            messageText = textarea.value;
-            localStorage.setItem(messageTextKey(agentId), messageText);
-            autoResizeTextarea(textarea);
-          },
-          onkeydown: handleKeydown,
-        }),
-        m("div", { class: "message-input-toolbar" }, [
-          m("div", { class: "message-input-toolbar-left" }),
-          hasMessageText
-            ? m(
-                "button",
-                {
-                  class: "message-input-send-button",
-                  onclick: handleSend,
-                },
-                m.trust(
-                  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>',
-                ),
-              )
-            : null,
+      const hasMessageText = messageText.trim().length > 0;
+
+      return m("div", { class: "message-input mx-auto w-full" }, [
+        m("div", { class: "message-input-box flex flex-col" }, [
+          m("textarea", {
+            class: "message-input-textbox w-full resize-none focus:outline-none",
+            placeholder: "Type a message...",
+            rows: 1,
+            value: messageText,
+            oncreate: (textareaVnode: m.VnodeDOM) => {
+              messageTextareaElement = textareaVnode.dom as HTMLTextAreaElement;
+              autoResizeTextarea(messageTextareaElement);
+              focusMessageTextarea();
+            },
+            onupdate: (textareaVnode: m.VnodeDOM) => {
+              messageTextareaElement = textareaVnode.dom as HTMLTextAreaElement;
+              autoResizeTextarea(messageTextareaElement);
+            },
+            onremove: () => {
+              messageTextareaElement = null;
+            },
+            oninput: (event: Event) => {
+              const textarea = event.target as HTMLTextAreaElement;
+              messageText = textarea.value;
+              localStorage.setItem(messageTextKey(agentId), messageText);
+              autoResizeTextarea(textarea);
+            },
+            onkeydown: handleKeydown,
+          }),
+          m("div", { class: "message-input-toolbar" }, [
+            m("div", { class: "message-input-toolbar-left" }),
+            hasMessageText
+              ? m(
+                  "button",
+                  {
+                    class: "message-input-send-button",
+                    onclick: handleSend,
+                  },
+                  m.trust(
+                    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>',
+                  ),
+                )
+              : null,
+          ]),
         ]),
-      ]),
-    ]);
-  },
-};
+      ]);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Fixes a class of stuck-state bugs in the minds chat UI when multiple agent tabs are open: in particular, the send button silently does nothing on all but one agent's chat tab. Root cause is module-level globals in two frontend files; they become cross-tab contended when dockview keeps multiple ChatPanel/MessageInput instances mounted.

**Theory 1 confirmed by live debug session**: with 3 agent tabs open, only the agent whose `MessageInput` view function happens to run last wins the `messageText` / `currentAgentId` module globals. The other tabs' `handleSend` sees an empty `messageText` and early-returns. Closing the other tabs reliably unbreaks the failing one.

**Theory 2 same-class bug** in `StreamingMessage.ts`: a single `activeEventSource` / `activeAgentId` means multiple mounted ChatPanels fight over the SSE stream; the losers silently miss streamed events (the "output not rendering mid-turn" symptom).

## Changes

- `apps/minds_workspace_server/frontend/src/views/MessageInput.ts`: convert to closure factory (matches `SubagentView.ts:36`). `messageText`, `currentAgentId`, `messageTextareaElement`, and `focusMessageTextarea` are now closure-local. `handleSend` is defined inside `view()` so it closes over the correct `agentId`. No API change — `m(MessageInput, { agentId })` works identically.
- `apps/minds_workspace_server/frontend/src/models/StreamingMessage.ts`: replace `activeEventSource`/`activeAgentId` with `Map<agentId, EventSource>`. `connectToStream(agentId)` is idempotent per agent. `disconnectFromStream(agentId)` now takes an agentId. The existing 3-second onerror reconnect behavior is preserved, just scoped per-agent.
- `apps/minds_workspace_server/frontend/src/views/ChatPanel.ts`: pass `agentId` to `disconnectFromStream`; release this panel's SSE stream in `onremove` so closing a tab cleans up.

## Not in this PR

- **UI indicator for in-flight turns / stream health** (separate ask).
- **`DockviewWorkspace.ts` prettier formatting** — this file is already unformatted on `origin/main` and causes `npm run test`'s `lint-and-format.test.ts` to fail today. Out of scope here; worth a standalone cleanup commit.
- **Terminal-freeze symptom** — lives in iframe + SSH tunnel, decoupled from this bug. The `_check_and_repair_tunnels` loop in `apps/minds/imbue/minds/desktop_client/ssh_tunnel.py:363-366` only checks `transport.is_active()`, not accept-loop thread liveness; worth a separate look.
- **`sendMessage` has no UI signal when a POST is in flight or fails** (try/catch swallows errors silently). Unrelated but worth a follow-up for robustness.

## Test plan

- [x] `npm run lint` (tsc + eslint) clean
- [x] `npm run test` (vitest) — the lint-and-format test goes from 2 failing files to 1. Remaining failure (`DockviewWorkspace.ts`) is pre-existing on `main`.
- [x] Live debug session reproduced the bug and confirmed the module-globals theory (closing other agent tabs restored the failing one).
- [ ] Manual verification with 3+ agent tabs open after the fix: each chat's send button works independently; typing in one doesn't clobber others; streaming output renders per-agent.
- [ ] CI (unit + integration + acceptance via offload).

## Notes

No API signature changes exposed outside the files touched. `m(MessageInput, ...)` call sites are unchanged. The only external signature change is `disconnectFromStream()` → `disconnectFromStream(agentId)`, with the single caller (`ChatPanel.manageStreamConnection`) updated.