### PR TITLE
show tab action buttons on every visible panel, not just the active one

### DIFF
--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -190,8 +190,8 @@ function createCustomTab(options: { id: string; name: string }): {
     api: {
       close: () => void;
       onDidTitleChange: (cb: (e: { title: string }) => void) => { dispose: () => void };
-      isActive: boolean;
-      onDidActiveChange: (cb: (e: { isActive: boolean }) => void) => { dispose: () => void };
+      isVisible: boolean;
+      onDidVisibilityChange: (cb: (e: { isVisible: boolean }) => void) => { dispose: () => void };
     };
   }) => void;
   dispose: () => void;
@@ -268,14 +268,16 @@ function createCustomTab(options: { id: string; name: string }): {
         }),
       );
 
-      // Show/hide actions based on active state
-      function updateActionsVisibility(isActive: boolean): void {
-        actions.style.display = isActive ? "flex" : "none";
+      // Show/hide actions based on visibility -- any panel whose content is
+      // currently displayed (including non-focused panes in a split layout)
+      // shows its action buttons.
+      function updateActionsVisibility(isVisible: boolean): void {
+        actions.style.display = isVisible ? "flex" : "none";
       }
-      updateActionsVisibility(params.api.isActive);
+      updateActionsVisibility(params.api.isVisible);
       disposables.push(
-        params.api.onDidActiveChange((event) => {
-          updateActionsVisibility(event.isActive);
+        params.api.onDidVisibilityChange((event) => {
+          updateActionsVisibility(event.isVisible);
         }),
       );
     },


### PR DESCRIPTION
## Summary

In the minds workspace server's dockview tab bar, the close / destroy / share buttons were gated on `panel.api.isActive`, which is true for at most one panel globally. Once a user dragged a tab into a split layout, the other fronted pane(s) had no action buttons on their tab bar entry -- even though their content was fully visible -- so there was no way to close or destroy from the tab bar without first clicking into that pane.

`createCustomTab` in `apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts` now reads `panel.api.isVisible` and subscribes to `onDidVisibilityChange` instead. In dockview each group independently fronts one tab, so `isVisible` is true for every pane whose content is currently displayed -- which is exactly the "user can see this, should be able to act on it" semantics we want. In a single-group layout the behavior is unchanged (only one visible panel = the active one).

No other call sites of the tab API needed changes; the one remaining `.isActive` reference (`focusOrCreateChatPanel`) is unrelated -- it guards a `setActivePanel` call when re-opening an already-open chat.

## Test plan

- [ ] Manually verify in the minds desktop app: open two+ tabs, drag one into a split, confirm both fronted panes show their action buttons, and that background tabs within each group still hide their buttons.
- [ ] CI (offload + frontend lint/typecheck).