### PR TITLE
Rewrite Location headers in workspace_server service dispatcher

### DIFF
--- a/apps/minds_workspace_server/imbue/minds_workspace_server/proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/proxy.py
@@ -1,5 +1,7 @@
 import re
 from typing import Final
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
 from imbue.imbue_common.pure import pure
 from imbue.minds_workspace_server.primitives import ServiceName
@@ -151,6 +153,36 @@ def rewrite_cookie_path(
         return set_cookie_header[: match.start(2)] + new_path + set_cookie_header[match.end(2) :]
     else:
         return set_cookie_header + f"; Path={prefix}/"
+
+
+@pure
+def rewrite_location_header(
+    location_header: str,
+    service_name: ServiceName,
+) -> str:
+    """Rewrite a Location header so site-absolute redirects stay within the proxied service prefix.
+
+    Without this, a backend returning ``Location: /foo`` causes the browser to resolve
+    the redirect against the document origin, escaping the service prefix. Relative
+    paths are left untouched because the browser resolves a relative ``Location``
+    against the request URL, which already lives under the service prefix. Absolute
+    URLs (with scheme or protocol-relative ``//``) and already-prefixed paths are
+    also left unchanged.
+    """
+    parts = urlsplit(location_header)
+    # Absolute URL (e.g., https://example.com/...) or protocol-relative (//host/...).
+    # The browser will navigate to the explicit host regardless of our prefix, so leave it.
+    if parts.scheme or parts.netloc:
+        return location_header
+    # Relative path or fragment-only reference -- the browser resolves a relative
+    # Location against the request URL, which already lives under the service prefix.
+    if not parts.path.startswith("/"):
+        return location_header
+    prefix = get_service_prefix(service_name)
+    if parts.path == prefix or parts.path.startswith(prefix + "/"):
+        return location_header
+    new_path = prefix + parts.path
+    return urlunsplit(("", "", new_path, parts.query, parts.fragment))
 
 
 @pure

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py
@@ -7,6 +7,7 @@ from imbue.minds_workspace_server.proxy import generate_service_worker_js
 from imbue.minds_workspace_server.proxy import generate_websocket_shim_js
 from imbue.minds_workspace_server.proxy import rewrite_absolute_paths_in_html
 from imbue.minds_workspace_server.proxy import rewrite_cookie_path
+from imbue.minds_workspace_server.proxy import rewrite_location_header
 from imbue.minds_workspace_server.proxy import rewrite_proxied_html
 
 _TEST_SERVICE: ServiceName = ServiceName("web")
@@ -153,6 +154,99 @@ def test_rewrite_absolute_paths_handles_single_quotes() -> None:
         service_name=_TEST_SERVICE,
     )
     assert result == snapshot("<a href='/service/web/hello.txt'>link</a>")
+
+
+# -- Location header rewriting --
+
+
+def test_rewrite_location_header_with_site_absolute_path() -> None:
+    result = rewrite_location_header(
+        location_header="/foo",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == snapshot("/service/web/foo")
+
+
+def test_rewrite_location_header_with_site_absolute_root() -> None:
+    result = rewrite_location_header(
+        location_header="/",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == snapshot("/service/web/")
+
+
+def test_rewrite_location_header_preserves_query_string() -> None:
+    result = rewrite_location_header(
+        location_header="/foo?bar=1&baz=2",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == snapshot("/service/web/foo?bar=1&baz=2")
+
+
+def test_rewrite_location_header_preserves_fragment() -> None:
+    result = rewrite_location_header(
+        location_header="/foo#section",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == snapshot("/service/web/foo#section")
+
+
+def test_rewrite_location_header_does_not_double_prefix() -> None:
+    already_prefixed = f"/service/{_TEST_SERVICE}/foo"
+    result = rewrite_location_header(
+        location_header=already_prefixed,
+        service_name=_TEST_SERVICE,
+    )
+    assert result == already_prefixed
+
+
+def test_rewrite_location_header_does_not_double_prefix_exact_match() -> None:
+    prefix = f"/service/{_TEST_SERVICE}"
+    result = rewrite_location_header(
+        location_header=prefix,
+        service_name=_TEST_SERVICE,
+    )
+    assert result == prefix
+
+
+def test_rewrite_location_header_preserves_relative_path() -> None:
+    result = rewrite_location_header(
+        location_header="foo",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == "foo"
+
+
+def test_rewrite_location_header_preserves_dot_relative_path() -> None:
+    result = rewrite_location_header(
+        location_header="./foo",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == "./foo"
+
+
+def test_rewrite_location_header_preserves_protocol_relative_url() -> None:
+    result = rewrite_location_header(
+        location_header="//example.com/page",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == "//example.com/page"
+
+
+def test_rewrite_location_header_preserves_absolute_url() -> None:
+    result = rewrite_location_header(
+        location_header="https://example.com/page",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == "https://example.com/page"
+
+
+def test_rewrite_location_header_preserves_fragment_only() -> None:
+    result = rewrite_location_header(
+        location_header="#anchor",
+        service_name=_TEST_SERVICE,
+    )
+    assert result == "#anchor"
 
 
 # -- Full proxied HTML rewriting --

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher.py
@@ -39,6 +39,7 @@ from imbue.minds_workspace_server.proxy import generate_backend_loading_html
 from imbue.minds_workspace_server.proxy import generate_bootstrap_html
 from imbue.minds_workspace_server.proxy import generate_service_worker_js
 from imbue.minds_workspace_server.proxy import rewrite_cookie_path
+from imbue.minds_workspace_server.proxy import rewrite_location_header
 from imbue.minds_workspace_server.proxy import rewrite_proxied_html
 
 _PROXY_TIMEOUT_SECONDS: Final[float] = 30.0
@@ -168,15 +169,23 @@ def _build_proxy_response(
     """Transform a backend httpx response into a FastAPI Response with header/content rewriting."""
     resp_headers: dict[str, list[str]] = {}
     for header_key, header_value in backend_response.headers.multi_items():
-        if header_key.lower() in _EXCLUDED_RESPONSE_HEADERS:
+        header_key_lower = header_key.lower()
+        if header_key_lower in _EXCLUDED_RESPONSE_HEADERS:
             continue
-        if header_key.lower() == "set-cookie":
-            header_value = rewrite_cookie_path(
+        if header_key_lower == "set-cookie":
+            rewritten_value = rewrite_cookie_path(
                 set_cookie_header=header_value,
                 service_name=service_name,
             )
+        elif header_key_lower == "location":
+            rewritten_value = rewrite_location_header(
+                location_header=header_value,
+                service_name=service_name,
+            )
+        else:
+            rewritten_value = header_value
         resp_headers.setdefault(header_key, [])
-        resp_headers[header_key].append(header_value)
+        resp_headers[header_key].append(rewritten_value)
 
     content: str | bytes = backend_response.content
 

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py
@@ -18,6 +18,7 @@ from fastapi import Request
 from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
 from fastapi.responses import PlainTextResponse
+from fastapi.responses import RedirectResponse
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocket
@@ -103,6 +104,19 @@ def _build_stub_backend() -> FastAPI:
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache"},
         )
+
+    @stub.post("/redirect-absolute")
+    def redirect_absolute() -> RedirectResponse:
+        # Simulates a FastAPI 303-after-POST returning a site-absolute Location.
+        return RedirectResponse(url="/landed", status_code=303)
+
+    @stub.post("/redirect-relative")
+    def redirect_relative() -> RedirectResponse:
+        return RedirectResponse(url="./landed", status_code=303)
+
+    @stub.post("/redirect-absolute-url")
+    def redirect_absolute_url() -> RedirectResponse:
+        return RedirectResponse(url="https://example.com/landed", status_code=303)
 
     @stub.websocket("/ws-echo")
     async def ws_echo(websocket: WebSocket) -> None:
@@ -224,6 +238,39 @@ def test_set_cookie_is_rewritten_to_service_path(workspace_client: TestClient) -
     assert response.status_code == 200
     set_cookie = response.headers.get("set-cookie", "")
     assert "Path=/service/web/" in set_cookie
+
+
+def test_site_absolute_redirect_location_is_rewritten(workspace_client: TestClient) -> None:
+    """A backend 303-after-POST with site-absolute Location gets rewritten to the service prefix."""
+    response = workspace_client.post(
+        "/service/web/redirect-absolute",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "/service/web/landed"
+
+
+def test_relative_redirect_location_is_preserved(workspace_client: TestClient) -> None:
+    """Relative Location values pass through; the browser resolves them against the request URL."""
+    response = workspace_client.post(
+        "/service/web/redirect-relative",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "./landed"
+
+
+def test_external_absolute_url_redirect_is_preserved(workspace_client: TestClient) -> None:
+    """Location headers pointing to an external origin are left unchanged."""
+    response = workspace_client.post(
+        "/service/web/redirect-absolute-url",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://example.com/landed"
 
 
 def test_unknown_service_returns_loading_page_for_html(workspace_client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- Add `rewrite_location_header` to `minds_workspace_server/proxy.py` so site-absolute redirects (e.g. FastAPI `303`-after-POST with `Location: /foo`) stay within the `/service/<name>/` prefix instead of escaping to the origin root.
- Wire it into `service_dispatcher._build_proxy_response` next to the existing `Set-Cookie Path=` rewrite. Relative (`./foo`), protocol-relative (`//host/x`), absolute-URL (`https://…`), fragment-only, and already-prefixed paths pass through unchanged.
- Applies uniformly to both local (`<agent-id>.localhost`) and Cloudflare-tunneled access since both reach the same `_build_proxy_response`.

Supersedes #1372, which targeted the pre-refactor desktop-client proxy that #1375 deleted.

## Test plan

- [x] 11 new unit tests in `proxy_test.py` covering rewrite + passthrough cases.
- [x] 3 new integration tests in `service_dispatcher_test.py` that exercise a real stub backend's `RedirectResponse` through the real uvicorn-hosted proxy and assert the rewritten `Location`.
- [x] `just test-quick apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py` — 53 passed.
- [x] `just test-quick "apps/minds_workspace_server -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 227 passed (including ratchets).
- [x] `just test-quick "apps/minds -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 550 passed.
- [x] `ruff check` + `ruff format --check` — clean.
- [ ] Manual verification through a running workspace (e.g. a FastAPI service that 303s after a POST) — not done.

## Notes / follow-ups

- Not handled: `Refresh: 0; url=/foo` headers (uncommon, same class of bug).
- Not handled: `Location` headers containing the backend's own `127.0.0.1:PORT` host (possible when a service uses `request.url_for(...)`). Would require passing the backend base URL into the rewriter so the rewriter can detect same-host absolute URLs. Worth doing only if seen biting a real service.