### PR TITLE
mngr: GC reclaims offline hosts via destroy_host, not delete_host

### DIFF
--- a/libs/mngr/imbue/mngr/api/gc.py
+++ b/libs/mngr/imbue/mngr/api/gc.py
@@ -302,13 +302,7 @@ def _gc_single_host(
                     HostState.CRASHED,
                     HostState.DESTROYED,
                 ):
-                    # Reclaim the underlying VM (destroy_host) rather than just
-                    # wiping mngr's record (delete_host). For STOPPED/CRASHED/
-                    # FAILED hosts the VM is still live on the provider, so
-                    # delete_host on its own leaves it orphaned on disk. For
-                    # already-DESTROYED hosts destroy_host is idempotent --
-                    # the provider's destroy_host invokes limactl_delete /
-                    # equivalent which no-ops on already-gone VMs.
+                    # permanently delete the host's data
                     if not dry_run:
                         # FOLLOWUP: when there are multiple instance of gc running concurrently on different hosts
                         #  there's a risk of getting into a screwy situation here--if we delete this right as

--- a/libs/mngr/imbue/mngr/api/gc.py
+++ b/libs/mngr/imbue/mngr/api/gc.py
@@ -302,13 +302,19 @@ def _gc_single_host(
                     HostState.CRASHED,
                     HostState.DESTROYED,
                 ):
-                    # permanently delete the host's data
+                    # Reclaim the underlying VM (destroy_host) rather than just
+                    # wiping mngr's record (delete_host). For STOPPED/CRASHED/
+                    # FAILED hosts the VM is still live on the provider, so
+                    # delete_host on its own leaves it orphaned on disk. For
+                    # already-DESTROYED hosts destroy_host is idempotent --
+                    # the provider's destroy_host invokes limactl_delete /
+                    # equivalent which no-ops on already-gone VMs.
                     if not dry_run:
                         # FOLLOWUP: when there are multiple instance of gc running concurrently on different hosts
                         #  there's a risk of getting into a screwy situation here--if we delete this right as
                         #  someone else starts it, you might have a host that is running but is untracked
                         #  This can be easily fixed by adding some host-id-keyed locking at the provider level (which both create/start/delete would acquire)
-                        provider.delete_host(host)
+                        provider.destroy_host(host)
                         emit_host_destroyed(
                             mngr_ctx.config,
                             host_ref.host_id,

--- a/libs/mngr/imbue/mngr/api/gc_test.py
+++ b/libs/mngr/imbue/mngr/api/gc_test.py
@@ -129,7 +129,9 @@ def _run_gc_machines(provider: MockProviderInstance, *, dry_run: bool = False) -
 def test_gc_machines_deletes_old_offline_host_with_no_agents(
     gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """Old offline hosts with no agents are deleted to prevent data accumulation."""
+    """Old offline hosts with no agents are reclaimed via destroy_host (kills
+    the VM + marks record DESTROYED), not delete_host (record-only wipe,
+    which would orphan the VM on disk)."""
     host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, days_old=14)
     gc_mock_provider.mock_hosts = [host]
 
@@ -137,7 +139,8 @@ def test_gc_machines_deletes_old_offline_host_with_no_agents(
 
     assert len(result.machines_deleted) == 1
     assert result.machines_deleted[0].host_id == host.id
-    assert gc_mock_provider.deleted_hosts == [host.id]
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
 
 
 def test_gc_machines_skips_recent_offline_host(
@@ -162,7 +165,9 @@ def _add_mock_agent(provider: MockProviderInstance) -> None:
 def test_gc_machines_deletes_old_crashed_host_with_agents(
     gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """Old offline hosts in CRASHED state are deleted even if they have agents."""
+    """Old offline hosts in CRASHED state are reclaimed via destroy_host even
+    if they still have agent refs (the agents are already unreachable on a
+    crashed host)."""
     # None stop_reason means the host CRASHED
     host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, stop_reason=None)
     _add_mock_agent(gc_mock_provider)
@@ -171,7 +176,8 @@ def test_gc_machines_deletes_old_crashed_host_with_agents(
     result = _run_gc_machines(gc_mock_provider)
 
     assert len(result.machines_deleted) == 1
-    assert gc_mock_provider.deleted_hosts == [host.id]
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
 
 
 def test_gc_machines_skips_old_stopped_host_with_agents(
@@ -188,23 +194,26 @@ def test_gc_machines_skips_old_stopped_host_with_agents(
     assert gc_mock_provider.deleted_hosts == []
 
 
-def test_gc_machines_dry_run_does_not_call_delete_host(
+def test_gc_machines_dry_run_does_not_reclaim_host(
     gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """Dry run identifies hosts for deletion but does not actually delete them."""
+    """Dry run identifies hosts for deletion but does not actually destroy or
+    delete them."""
     host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, days_old=14)
     gc_mock_provider.mock_hosts = [host]
 
     result = _run_gc_machines(gc_mock_provider, dry_run=True)
 
     assert len(result.machines_deleted) == 1
+    assert gc_mock_provider.destroyed_hosts == []
     assert gc_mock_provider.deleted_hosts == []
 
 
 def test_gc_machines_deletes_old_failed_host_with_agents(
     gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """Old offline hosts in FAILED state are deleted even if they have agents."""
+    """Old offline hosts in FAILED state are reclaimed via destroy_host even
+    if they still have agent refs."""
     host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, failure_reason="Build failed")
     _add_mock_agent(gc_mock_provider)
     gc_mock_provider.mock_hosts = [host]
@@ -212,13 +221,17 @@ def test_gc_machines_deletes_old_failed_host_with_agents(
     result = _run_gc_machines(gc_mock_provider)
 
     assert len(result.machines_deleted) == 1
-    assert gc_mock_provider.deleted_hosts == [host.id]
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
 
 
 def test_gc_machines_deletes_old_destroyed_host_with_agents(
     gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """Old offline hosts in DESTROYED state are deleted even if they have agents."""
+    """Old offline hosts in DESTROYED state are reclaimed via destroy_host.
+    destroy_host is idempotent -- on an already-destroyed host the provider's
+    kill-the-VM call is a no-op (or swallowed error), so this path stays
+    symmetric with every other offline case."""
     host = _make_offline_host(gc_mock_provider, temp_mngr_ctx)
     # Make the provider not support snapshots and not support shutdown hosts
     # so the state resolves to DESTROYED
@@ -230,7 +243,75 @@ def test_gc_machines_deletes_old_destroyed_host_with_agents(
     result = _run_gc_machines(gc_mock_provider)
 
     assert len(result.machines_deleted) == 1
-    assert gc_mock_provider.deleted_hosts == [host.id]
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
+
+
+# =========================================================================
+# Orphan-prevention regression: gc must destroy (kill VM), not just delete
+# the record, for offline hosts that are still-live-on-provider.
+#
+# Regression for: "delete <agent>, other Lima VMs orphan and accumulate."
+# Before the fix, gc_machines' offline branch called provider.delete_host()
+# which on Lima removes mngr's JSON but does NOT invoke limactl_delete --
+# leaving the VM orphaned on disk. After the fix, the non-DESTROYED offline
+# path must call provider.destroy_host() so the underlying VM actually goes
+# away alongside the record.
+# =========================================================================
+
+
+def test_gc_machines_destroys_vm_for_old_offline_host_with_no_agents(
+    gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """gc must call destroy_host (not delete_host) for STOPPED hosts so the
+    underlying VM is actually reclaimed, not just mngr's record wiped."""
+    host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, days_old=14)
+    gc_mock_provider.mock_hosts = [host]
+
+    _run_gc_machines(gc_mock_provider)
+
+    assert gc_mock_provider.destroyed_hosts == [host.id], (
+        "gc must call destroy_host (kills VM + marks record DESTROYED) for a "
+        "live-on-provider host it intends to reclaim, not delete_host (record-only "
+        "wipe, which orphans the VM)."
+    )
+    assert gc_mock_provider.deleted_hosts == [], (
+        "gc must not call delete_host for a non-DESTROYED offline host -- that "
+        "leaves the underlying VM orphaned on disk."
+    )
+
+
+def test_gc_machines_destroys_vm_for_old_crashed_host(
+    gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """CRASHED hosts exist (Lima sees 'Stopped' but mngr derives CRASHED when
+    stop_reason wasn't set by a graceful mngr-stop). These are exactly the
+    hosts the orphan-accumulation bug affected in production -- gc must
+    destroy them, not just wipe the record."""
+    # None stop_reason -> host state resolves to CRASHED
+    host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, stop_reason=None)
+    _add_mock_agent(gc_mock_provider)
+    gc_mock_provider.mock_hosts = [host]
+
+    _run_gc_machines(gc_mock_provider)
+
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
+
+
+def test_gc_machines_destroys_vm_for_old_failed_host(
+    gc_mock_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """FAILED hosts are still live on the provider (the 'failure' is mngr-side);
+    gc must actually destroy them, not leak them."""
+    host = _make_offline_host(gc_mock_provider, temp_mngr_ctx, failure_reason="Build failed")
+    _add_mock_agent(gc_mock_provider)
+    gc_mock_provider.mock_hosts = [host]
+
+    _run_gc_machines(gc_mock_provider)
+
+    assert gc_mock_provider.destroyed_hosts == [host.id]
+    assert gc_mock_provider.deleted_hosts == []
 
 
 # =========================================================================

--- a/libs/mngr/imbue/mngr/providers/mock_provider_test.py
+++ b/libs/mngr/imbue/mngr/providers/mock_provider_test.py
@@ -40,6 +40,7 @@ class MockProviderInstance(BaseProviderInstance):
     mock_hosts: list[HostInterface] = Field(default_factory=list)
     mock_offline_hosts: dict[str, HostInterface] = Field(default_factory=dict)
     deleted_hosts: list[HostId] = Field(default_factory=list)
+    destroyed_hosts: list[HostId] = Field(default_factory=list)
     deleted_snapshots: list[tuple[HostId, SnapshotId]] = Field(default_factory=list)
     deleted_volumes: list[VolumeId] = Field(default_factory=list)
 
@@ -95,7 +96,8 @@ class MockProviderInstance(BaseProviderInstance):
         ]
 
     def destroy_host(self, host: HostInterface | HostId) -> None:
-        raise NotImplementedError()
+        host_id = host.id if isinstance(host, HostInterface) else host
+        self.destroyed_hosts.append(host_id)
 
     def delete_host(self, host: HostInterface) -> None:
         self.deleted_hosts.append(host.id)


### PR DESCRIPTION
## Summary

`gc_machines`' offline branch called `provider.delete_host(host)` on hosts it decided to reap. On Lima, `delete_host` removes mngr's JSON record but does *not* invoke `limactl delete`, so the underlying VM stays on disk as a ~20 GiB orphan that mngr can no longer reach. Every minds delete-workspace that happened to run `--gc` against an offline target left one of these behind.

Fix: `libs/mngr/imbue/mngr/api/gc.py:311` — flip the terminal call in the offline branch from `delete_host` to `destroy_host`. On Lima, `destroy_host` calls `limactl_delete` (kills VM) and marks the record DESTROYED. On already-DESTROYED hosts it's idempotent: the VM-kill call swallows "already gone" errors (`instance.py:701-702`).

## Reproduction (confirmed on `origin/main` before this change)

```bash
# Isolated state dirs so nothing touches ~/.minds / ~/.lima
export MNGR_HOST_DIR=/tmp/mngr-gc-test/mngr  LIMA_HOME=/tmp/lima-gc
export MNGR_PREFIX=gc-

# 1. Create one Lima agent
mkdir -p /tmp/gctest-work && cd /tmp/gctest-work && git init -q && git commit --allow-empty -qm init
mngr create v@.lima --command "sleep 3600" --no-connect --no-rsync --disable-plugin modal

# 2. Destroy the agent while host is online -> host record survives with 0 agents
mngr destroy v --force --no-gc --disable-plugin modal

# 3. Stop the VM externally (mimics idle-timeout / Mac reboot)
limactl stop gc-<auto-name>-host

# 4. Age the host record so gc's age threshold triggers
python3 -c "import json, datetime, sys; p=sys.argv[1]; d=json.load(open(p)); \
  old=(datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(days=10)).isoformat(); \
  d['certified_host_data']['updated_at']=old; d['certified_host_data']['stop_reason']='STOPPED'; \
  json.dump(d, open(p,'w'), indent=2)" $HOST_JSON

# 5. Run gc
mngr gc --provider lima --disable-plugin modal
```

Before this change: `host_state/*.json` is gone, `limactl list` still shows the VM → orphan.
After this change: `limactl list` no longer has the VM. Clean.

## Test plan

- [x] Three new regression tests in `gc_test.py` assert the anti-orphan invariant: for STOPPED / CRASHED / FAILED offline hosts that gc reaps, `destroy_host` is called and `delete_host` is not. All three fail on `origin/main` and pass after the fix.
- [x] Four existing tests that encoded the buggy behavior (asserting `deleted_hosts == [host.id]`) are updated to assert `destroyed_hosts` instead.
- [x] The dry-run test is updated to assert neither `destroy_host` nor `delete_host` is called.
- [x] `MockProviderInstance.destroy_host` used to raise `NotImplementedError`; now it records calls so tests can observe both paths independently.
- [x] All 711 tests in `libs/mngr/imbue/mngr/api` pass.
- [x] All 284 tests in `libs/mngr/imbue/mngr/providers` pass.
- [ ] CI (offload)

## Not in this PR — tracked as follow-ups

- `_run_post_destroy_gc` still runs *global* gc after every destroy; scoping it to just the destroyed agent's provider is a separate issue (the "`mngr destroy agent-X --gc` wiped state for unrelated offline hosts" report).
- Decoupling `--gc` from `destroy` entirely (opt-in `mngr gc` only) is also separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)