### PR TITLE
mngr: OfflineHost reflects provider's live observation, not just stored stop_reason

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -81,6 +81,18 @@ class BaseHost(HostInterface):
         default=None,
         description="Optional callback invoked when certified host data is updated",
     )
+    observed_state: HostState | None = Field(
+        frozen=True,
+        default=None,
+        description=(
+            "Provider's live observation of this host's state at the moment this "
+            "instance was constructed. When set, preferred over stop_reason-based "
+            "derivation in get_state() -- reflects external state changes (Mac "
+            "reboot, `limactl stop` outside mngr, etc.) that never wrote to our "
+            "stored record. None means 'no observation available'; get_state() "
+            "falls back to derive_offline_host_state in that case."
+        ),
+    )
 
     @property
     def host_dir(self) -> Path:
@@ -180,9 +192,14 @@ class BaseHost(HostInterface):
     def get_state(self) -> HostState:
         """Get the current state of the host.
 
-        Delegates to derive_offline_host_state() which contains the canonical
-        state-derivation logic shared with provider discovery code.
+        Prefers ``observed_state`` when set -- that's the provider's live view
+        captured at construction time, which reflects external state changes
+        (reboot, external ``limactl stop``, sandbox termination). Falls back
+        to ``derive_offline_host_state`` (reads only the stored record) when
+        no observation is available.
         """
+        if self.observed_state is not None:
+            return self.observed_state
         return derive_offline_host_state(
             certified_data=self.get_certified_data(),
             supports_shutdown_hosts=self.provider_instance.supports_shutdown_hosts,

--- a/libs/mngr/imbue/mngr/hosts/offline_host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host_test.py
@@ -231,6 +231,83 @@ def test_get_state_returns_crashed_when_no_stop_reason(offline_host: OfflineHost
     assert state == HostState.CRASHED
 
 
+# =========================================================================
+# observed_state: provider's live view preferred over stored-record derivation.
+#
+# Regression for: reboot / external-limactl-stop false-positive CRASHED.
+# When the provider observed the host Stopped at get_host time, that
+# observation reflects reality -- the stored record's stop_reason=None
+# is just mngr never having been told. get_state() must trust the
+# observation, not the pessimistic derivation.
+# =========================================================================
+
+
+def test_get_state_uses_observed_state_when_provided(
+    fake_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """When observed_state is set, get_state returns it regardless of stored stop_reason."""
+    now = datetime.now(timezone.utc)
+    certified_data = CertifiedHostData(
+        host_id=str(HostId.generate()),
+        host_name="rebooted-host",
+        # stop_reason None -> stored derivation would return CRASHED
+        stop_reason=None,
+        created_at=now - timedelta(days=1),
+        updated_at=now - timedelta(days=1),
+    )
+
+    observed = make_offline_host(
+        certified_data, fake_provider, temp_mngr_ctx, observed_state=HostState.STOPPED
+    )
+
+    # Provider observation wins over the stored "None -> CRASHED" fallback.
+    assert observed.get_state() == HostState.STOPPED
+
+
+def test_get_state_falls_back_to_derivation_when_observed_state_none(
+    fake_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """When observed_state is None (no provider observation available), falls back to
+    derive_offline_host_state reading only the stored record. Preserves the legacy
+    behavior for any caller that constructs OfflineHost without querying the provider
+    (e.g. to_offline_host, failed-host paths)."""
+    now = datetime.now(timezone.utc)
+    certified_data = CertifiedHostData(
+        host_id=str(HostId.generate()),
+        host_name="no-observation-host",
+        stop_reason=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    host = make_offline_host(certified_data, fake_provider, temp_mngr_ctx, observed_state=None)
+
+    assert host.get_state() == HostState.CRASHED  # same as legacy behavior
+
+
+def test_get_state_observed_state_takes_precedence_over_stop_reason(
+    fake_provider: MockProviderInstance, temp_mngr_ctx: MngrContext
+) -> None:
+    """Observation wins even when stored stop_reason disagrees. Scenario: stored
+    record says STOPPED (mngr did a graceful stop at some point), but the VM was
+    later started externally and is now Running -- provider says RUNNING, we should
+    believe the provider."""
+    now = datetime.now(timezone.utc)
+    certified_data = CertifiedHostData(
+        host_id=str(HostId.generate()),
+        host_name="resumed-host",
+        stop_reason=HostState.STOPPED.value,
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(hours=2),
+    )
+
+    host = make_offline_host(
+        certified_data, fake_provider, temp_mngr_ctx, observed_state=HostState.RUNNING
+    )
+
+    assert host.get_state() == HostState.RUNNING
+
+
 def test_get_state_returns_crashed_when_provider_does_not_support_snapshots_and_no_stop_reason(
     offline_host: OfflineHost, fake_provider: MockProviderInstance
 ) -> None:

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance.py
@@ -366,6 +366,26 @@ class ProviderInstanceInterface(MutableModel, ABC):
         """Return an offline representation of the given host for use when it is unreachable."""
         ...
 
+    def get_observed_host_state(self, host_id: HostId) -> HostState | None:
+        """Provider's best current observation of this host's state.
+
+        Unlike ``derive_offline_host_state`` (which reads only the stored
+        record), this queries the underlying provider directly, so it reflects
+        external state changes the stored record never learned about -- user
+        rebooted their Mac, someone ran ``limactl stop`` outside mngr, a
+        sandbox terminated, etc.
+
+        Returns the observed ``HostState`` when the provider can answer;
+        returns ``None`` when the provider cannot (daemon unreachable, etc.)
+        in which case callers should fall back to the stored-record derivation.
+
+        The default implementation returns ``None`` so providers that haven't
+        implemented this yet keep the legacy "derive from stored record"
+        behavior. Providers that can observe cheaply (Lima's ``limactl list``,
+        Docker's ``docker inspect``, Modal's sandbox SDK) should override.
+        """
+        return None
+
     @abstractmethod
     def discover_hosts(
         self,

--- a/libs/mngr/imbue/mngr/providers/mock_provider_test.py
+++ b/libs/mngr/imbue/mngr/providers/mock_provider_test.py
@@ -17,6 +17,7 @@ from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
+from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import SnapshotId
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import VolumeId
@@ -143,6 +144,7 @@ def make_offline_host(
     certified_data: CertifiedHostData,
     provider: MockProviderInstance,
     mngr_ctx: MngrContext,
+    observed_state: HostState | None = None,
 ) -> OfflineHost:
     host_id = HostId(certified_data.host_id)
     return OfflineHost(
@@ -150,4 +152,5 @@ def make_offline_host(
         certified_host_data=certified_data,
         provider_instance=provider,
         mngr_ctx=mngr_ctx,
+        observed_state=observed_state,
     )

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -290,14 +290,24 @@ class LimaProviderInstance(BaseProviderInstance):
             )
             self._host_store.write_host_record(updated_host_record)
 
-    def _create_offline_host(self, host_record: HostRecord) -> OfflineHost:
-        """Create an OfflineHost from a host record."""
+    def _create_offline_host(
+        self, host_record: HostRecord, observed_state: HostState | None = None
+    ) -> OfflineHost:
+        """Create an OfflineHost from a host record.
+
+        ``observed_state`` is the lima-reported state at the moment of
+        construction, when the caller has already done a ``limactl_list``
+        query. Passing it through lets ``OfflineHost.get_state()`` reflect
+        external state changes (Mac reboot, ``limactl stop`` outside mngr)
+        instead of the pessimistic ``stop_reason == None → CRASHED`` default.
+        """
         host_id = HostId(host_record.certified_host_data.host_id)
         return OfflineHost(
             id=host_id,
             certified_host_data=host_record.certified_host_data,
             provider_instance=self,
             mngr_ctx=self.mngr_ctx,
+            observed_state=observed_state,
             on_updated_host_data=lambda callback_host_id, certified_data: self._on_certified_host_data_updated(
                 callback_host_id, certified_data
             ),
@@ -730,19 +740,50 @@ sudo poweroff
             # Failed or offline host
             return self._create_offline_host(host_record)
 
-        # Check if the Lima instance is running
+        # Check Lima's live status. Used for two things: deciding Online vs
+        # Offline below, AND -- critically -- passing the observed state
+        # through to OfflineHost so its get_state() reflects reality rather
+        # than the stop_reason-None → CRASHED default.
         instances = limactl_list(self.mngr_ctx.concurrency_group)
         instance_name = host_record.config.instance_name
-        is_running = any(inst.get("name") == instance_name and inst.get("status") == "Running" for inst in instances)
-
-        if not is_running:
-            return self._create_offline_host(host_record)
+        lima_status = next(
+            (inst.get("status") for inst in instances if inst.get("name") == instance_name),
+            None,
+        )
+        if lima_status != "Running":
+            observed = _LIMA_STATUS_TO_HOST_STATE.get(lima_status) if lima_status is not None else None
+            return self._create_offline_host(host_record, observed_state=observed)
 
         # Instance is running -- create online host
         ssh_config = self._get_ssh_config(instance_name)
         host_obj = self._create_host_object(host_id, ssh_config)
         self._evict_cached_host(host_id, replacement=host_obj)
         return host_obj
+
+    def get_observed_host_state(self, host_id: HostId) -> HostState | None:
+        """Lima's current view of this host, mapped to HostState.
+
+        Returns None if we can't find the instance in lima's list (daemon
+        down, instance never existed, or was deleted externally). Callers
+        should treat None as 'no observation available' and fall back to
+        stored-record derivation.
+        """
+        host_record = self._host_store.read_host_record(host_id, use_cache=True)
+        if host_record is None or host_record.config is None:
+            return None
+        try:
+            instances = limactl_list(self.mngr_ctx.concurrency_group)
+        except (LimaCommandError, OSError) as e:
+            logger.debug("Failed to query lima for observed state of {}: {}", host_id, e)
+            return None
+        instance_name = host_record.config.instance_name
+        lima_status = next(
+            (inst.get("status") for inst in instances if inst.get("name") == instance_name),
+            None,
+        )
+        if lima_status is None:
+            return None
+        return _LIMA_STATUS_TO_HOST_STATE.get(lima_status)
 
     def _get_host_by_name(self, name: HostName) -> HostInterface:
         """Get a host by name."""

--- a/libs/mngr_lima/imbue/mngr_lima/instance_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance_test.py
@@ -98,3 +98,31 @@ def test_provider_dir_structure(lima_provider: LimaProviderInstance) -> None:
     assert "lima-test" in str(lima_provider._provider_dir)
     assert "providers" in str(lima_provider._provider_dir)
     assert "lima" in str(lima_provider._provider_dir)
+
+
+def test_lima_status_to_host_state_mapping() -> None:
+    """Lima's native status strings map to mngr's HostState.
+
+    This mapping is the critical translation for get_observed_host_state --
+    a wrong mapping here would cause the GC to classify live VMs incorrectly.
+    """
+    from imbue.mngr.primitives import HostState
+    from imbue.mngr_lima.instance import _LIMA_STATUS_TO_HOST_STATE
+
+    assert _LIMA_STATUS_TO_HOST_STATE["Running"] == HostState.RUNNING
+    assert _LIMA_STATUS_TO_HOST_STATE["Stopped"] == HostState.STOPPED
+    assert _LIMA_STATUS_TO_HOST_STATE["Broken"] == HostState.CRASHED
+    assert _LIMA_STATUS_TO_HOST_STATE["Unknown"] == HostState.CRASHED
+
+
+def test_get_observed_host_state_returns_none_for_unknown_host(
+    lima_provider: LimaProviderInstance,
+) -> None:
+    """When the host_id is not in our store, observed-state is None.
+
+    Callers should interpret None as 'no observation available' and fall back
+    to stored-record derivation. This prevents lima-specific absence handling
+    from leaking into the generic path.
+    """
+    result = lima_provider.get_observed_host_state(HostId.generate())
+    assert result is None


### PR DESCRIPTION
## Summary

`mngr list`, GC, and every caller routing through `get_host()` today re-derive host state from the stored record (`certified_data.stop_reason`). Because that field is only written when mngr itself stops a host, any externally-stopped VM — Mac reboot, `limactl stop` outside mngr, power-off — has `stop_reason=None` → `derive_offline_host_state` → **CRASHED**.

In practice, "CRASHED" in mngr's vocabulary mostly means "stopped via a path mngr didn't mediate," not "the VM actually crashed." That false-positive density is what made the aggressive GC dangerous: it auto-reclaims CRASHED hosts, and when the classification is wrong the reclamation kills user data.

Related: #1390 narrows the GC policy to avoid destroying CRASHED+agents. This PR fixes the CRASHED classification *itself* — post-reboot a host now shows STOPPED, so #1390's skip-CRASHED guard isn't even reached. The two are complementary.

## Abstraction (not a lima-specific patch)

1. **New method on `ProviderInstanceInterface`** — `get_observed_host_state(host_id) -> HostState | None`. Returns the provider's live view, or `None` when the provider can't answer. Default implementation returns `None`, so providers that haven't opted in keep the legacy stored-derivation behavior.

2. **`OfflineHost` gains an `observed_state: HostState | None = None` field.** When set, `get_state()` returns it directly; when `None`, falls back to `derive_offline_host_state`. Captured at construction time to match the implicit 'as-of' semantics callers already expect from `get_host`.

3. **Lima opts in.** `get_observed_host_state` does a one-time `limactl list` query and maps native status via the existing `_LIMA_STATUS_TO_HOST_STATE` table (no new mapping logic, just surfacing it through a method). `_get_host_by_id` threads the observed status through to `_create_offline_host` instead of discarding it after the Online/Offline dispatch decision.

Zero changes to `derive_offline_host_state` — it stays pure (reads only the stored record), works as the last-resort fallback.

## Why this abstraction over a lima-specific hack

- `OfflineHost` is provider-agnostic — passing `observed_lima_status: str` would leak lima vocabulary into the generic host layer, and Docker/Modal/SSH/Local would all have to carry a parameter they don't care about.
- The *concept* ("provider's best current guess at this host's liveness") is universal. Each provider has a native query; the abstraction names that uniformly.
- Docker, Modal, SSH, Local can opt in incrementally (or not at all — default returns None). No breakage.

## Tests

- 3 new tests in `offline_host_test.py`:
  - `observed_state` takes precedence over `stop_reason=None → CRASHED` fallback.
  - `observed_state=None` falls back to `derive_offline_host_state` (preserves legacy behavior for paths that don't observe, e.g. `to_offline_host`).
  - Observation wins even when stored `stop_reason` disagrees (resumed-after-external-stop case).
- 2 new tests in lima's `instance_test.py`:
  - `_LIMA_STATUS_TO_HOST_STATE` mapping correctness.
  - `get_observed_host_state` returns `None` for an unknown host_id.
- All 1145 tests in `libs/mngr/hosts` + `libs/mngr/api` + `libs/mngr_lima` pass.

## Not in this PR

- Docker / Modal / SSH / Local provider implementations of `get_observed_host_state` — default `None` today, can be added incrementally as providers adopt.
- Using `get_observed_host_state` in lima's `discover_hosts` (currently has its own inline mapping at `instance.py:787-803`) to consolidate on a single source of truth.
- GC policy changes — covered by #1390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)