### PR TITLE
Make cmd+w close the active tab in minds Electron app

### DIFF
--- a/apps/minds/electron/content-preload.js
+++ b/apps/minds/electron/content-preload.js
@@ -1,0 +1,36 @@
+// Narrow preload attached to the content view only. The content view loads
+// pages that can be shaped by agent-controlled code (the workspace_server
+// frontend, served from inside the agent's sandbox), so we deliberately do
+// not expose the full `window.minds` surface from preload.js here -- window
+// controls, navigation, retry, etc. stay reserved for the chrome-origin
+// views (chromeView / sidebarView / requestsPanelView).
+//
+// The only capability exposed here is registering a cmd+W close-tab handler.
+// When the user presses cmd+W, main.js sends 'close-active-tab-request' with
+// a correlation id; this preload forwards that to the handler the renderer
+// registered (typically DockviewWorkspace closing its active panel) and
+// sends 'close-active-tab-response' back with the handler's boolean result.
+// Main falls back to closing the window when the response is false.
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+let closeActiveTabHandler = null;
+
+ipcRenderer.on('close-active-tab-request', async (_event, requestId) => {
+  let closed = false;
+  try {
+    if (typeof closeActiveTabHandler === 'function') {
+      closed = !!(await closeActiveTabHandler());
+    }
+  } catch (err) {
+    console.error('close-active-tab handler threw:', err);
+    closed = false;
+  }
+  ipcRenderer.send('close-active-tab-response', requestId, closed);
+});
+
+contextBridge.exposeInMainWorld('minds', {
+  setCloseActiveTabHandler: (handler) => {
+    closeActiveTabHandler = typeof handler === 'function' ? handler : null;
+  },
+});

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -216,6 +216,7 @@ function createBundleWebContentsViews(win) {
   });
   const contentView = new WebContentsView({
     webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
@@ -692,6 +693,7 @@ function prepareAllWindowsForRetry() {
     if (!bundle.contentView) {
       const contentView = new WebContentsView({
         webPreferences: {
+          preload: path.join(__dirname, 'preload.js'),
           contextIsolation: true,
           nodeIntegration: false,
         },

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -390,6 +390,44 @@ function wireContentViewEvents(bundle, contentView) {
   });
 }
 
+// Ask the content view's renderer (the Dockview workspace) to close its
+// active tab via IPC. If the renderer didn't close anything -- no handler
+// registered, no active panel, or no response within the timeout -- fall
+// back to closing the window. Matches browser convention where closing the
+// last tab closes the window.
+const CLOSE_ACTIVE_TAB_TIMEOUT_MS = 500;
+let closeActiveTabRequestSeq = 0;
+
+async function requestCloseActiveTab(cv) {
+  if (!cv || cv.webContents.isDestroyed()) return false;
+  const requestId = `close-tab-${++closeActiveTabRequestSeq}`;
+  return new Promise((resolve) => {
+    let settled = false;
+    const onResponse = (_event, id, closed) => {
+      if (id !== requestId) return;
+      finish(!!closed);
+    };
+    const finish = (closed) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ipcMain.removeListener('close-active-tab-response', onResponse);
+      resolve(closed);
+    };
+    const timer = setTimeout(() => finish(false), CLOSE_ACTIVE_TAB_TIMEOUT_MS);
+    ipcMain.on('close-active-tab-response', onResponse);
+    cv.webContents.send('close-active-tab-request', requestId);
+  });
+}
+
+async function closeActiveTabOrWindow(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  const closed = await requestCloseActiveTab(bundle.contentView);
+  if (!closed && !bundle.window.isDestroyed()) {
+    bundle.window.close();
+  }
+}
+
 function registerShortcutsFor(bundle, wc) {
   wc.on('before-input-event', (event, input) => {
     if (input.type !== 'keyDown') return;
@@ -405,12 +443,18 @@ function registerShortcutsFor(bundle, wc) {
       }
       return;
     }
-    // When the app menu is installed, it owns cmd+W / cmd+Q / cmd+N; handling
-    // them here too would double-fire (e.g. two new windows per cmd+N).
+    // When the app menu is installed, it owns cmd+W / cmd+Shift+W / cmd+Q /
+    // cmd+N; handling them here too would double-fire (e.g. two new windows
+    // per cmd+N).
     if (appMenuInstalled) return;
-    if (modifier && !input.shift && !input.alt && key === 'w') {
+    if (modifier && input.shift && !input.alt && key === 'w') {
       event.preventDefault();
       if (!bundle.window.isDestroyed()) bundle.window.close();
+      return;
+    }
+    if (modifier && !input.shift && !input.alt && key === 'w') {
+      event.preventDefault();
+      closeActiveTabOrWindow(bundle);
       return;
     }
     if (modifier && !input.shift && !input.alt && key === 'q') {
@@ -1031,8 +1075,16 @@ function installApplicationMenu() {
         },
         { type: 'separator' },
         {
-          label: 'Close Window',
+          label: 'Close Tab',
           accelerator: 'CmdOrCtrl+W',
+          click: () => {
+            const target = getMostRecentWindow();
+            if (target) closeActiveTabOrWindow(target);
+          },
+        },
+        {
+          label: 'Close Window',
+          accelerator: 'CmdOrCtrl+Shift+W',
           click: () => {
             const target = getMostRecentWindow();
             if (target && !target.window.isDestroyed()) target.window.close();

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -216,7 +216,10 @@ function createBundleWebContentsViews(win) {
   });
   const contentView = new WebContentsView({
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
+      // Narrow preload: only exposes setCloseActiveTabHandler, not the full
+      // window.minds surface that chrome-origin views get. See
+      // content-preload.js for why.
+      preload: path.join(__dirname, 'content-preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
@@ -693,7 +696,8 @@ function prepareAllWindowsForRetry() {
     if (!bundle.contentView) {
       const contentView = new WebContentsView({
         webPreferences: {
-          preload: path.join(__dirname, 'preload.js'),
+          // See createBundleWebContentsViews for why content-preload.js.
+          preload: path.join(__dirname, 'content-preload.js'),
           contextIsolation: true,
           nodeIntegration: false,
         },

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -426,9 +426,15 @@ async function requestCloseActiveTab(cv) {
 
 async function closeActiveTabOrWindow(bundle) {
   if (!bundle || bundle.window.isDestroyed()) return;
-  const closed = await requestCloseActiveTab(bundle.contentView);
-  if (!closed && !bundle.window.isDestroyed()) {
-    bundle.window.close();
+  // Log-and-swallow so fire-and-forget call sites (keyboard shortcut and
+  // app-menu click handlers) don't surface unhandled promise rejections.
+  try {
+    const closed = await requestCloseActiveTab(bundle.contentView);
+    if (!closed && !bundle.window.isDestroyed()) {
+      bundle.window.close();
+    }
+  } catch (err) {
+    console.error('[close-tab] closeActiveTabOrWindow failed:', err);
   }
 }
 

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -1,23 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
-// Handler registered by the renderer (e.g. the Dockview workspace) to close
-// its "active tab". The main process sends 'close-active-tab-request' with a
-// correlation id and awaits 'close-active-tab-response' on that same id.
-// Responses carry a boolean: true if a tab was closed, false otherwise --
-// main uses that to decide whether to fall back to closing the window.
-let closeActiveTabHandler = null;
-ipcRenderer.on('close-active-tab-request', async (_event, requestId) => {
-  let closed = false;
-  try {
-    if (typeof closeActiveTabHandler === 'function') {
-      closed = !!(await closeActiveTabHandler());
-    }
-  } catch (err) {
-    console.error('close-active-tab handler threw:', err);
-    closed = false;
-  }
-  ipcRenderer.send('close-active-tab-response', requestId, closed);
-});
+// This preload is attached to the chrome-origin views (chromeView,
+// sidebarView, requestsPanelView). The content view uses a narrower
+// preload at content-preload.js -- see that file for rationale.
 
 contextBridge.exposeInMainWorld('minds', {
   // Platform info
@@ -77,11 +62,4 @@ contextBridge.exposeInMainWorld('minds', {
   minimize: () => ipcRenderer.send('window-minimize'),
   maximize: () => ipcRenderer.send('window-maximize'),
   close: () => ipcRenderer.send('window-close'),
-
-  // Close-active-tab hook: the renderer (e.g. DockviewWorkspace) registers
-  // a handler invoked when the user presses cmd+w. The handler should close
-  // the currently focused tab if one exists and return true, else false.
-  setCloseActiveTabHandler: (handler) => {
-    closeActiveTabHandler = typeof handler === 'function' ? handler : null;
-  },
 });

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -12,7 +12,8 @@ ipcRenderer.on('close-active-tab-request', async (_event, requestId) => {
     if (typeof closeActiveTabHandler === 'function') {
       closed = !!(await closeActiveTabHandler());
     }
-  } catch {
+  } catch (err) {
+    console.error('close-active-tab handler threw:', err);
     closed = false;
   }
   ipcRenderer.send('close-active-tab-response', requestId, closed);

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -1,5 +1,23 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+// Handler registered by the renderer (e.g. the Dockview workspace) to close
+// its "active tab". The main process sends 'close-active-tab-request' with a
+// correlation id and awaits 'close-active-tab-response' on that same id.
+// Responses carry a boolean: true if a tab was closed, false otherwise --
+// main uses that to decide whether to fall back to closing the window.
+let closeActiveTabHandler = null;
+ipcRenderer.on('close-active-tab-request', async (_event, requestId) => {
+  let closed = false;
+  try {
+    if (typeof closeActiveTabHandler === 'function') {
+      closed = !!(await closeActiveTabHandler());
+    }
+  } catch {
+    closed = false;
+  }
+  ipcRenderer.send('close-active-tab-response', requestId, closed);
+});
+
 contextBridge.exposeInMainWorld('minds', {
   // Platform info
   platform: process.platform,
@@ -58,4 +76,11 @@ contextBridge.exposeInMainWorld('minds', {
   minimize: () => ipcRenderer.send('window-minimize'),
   maximize: () => ipcRenderer.send('window-maximize'),
   close: () => ipcRenderer.send('window-close'),
+
+  // Close-active-tab hook: the renderer (e.g. DockviewWorkspace) registers
+  // a handler invoked when the user presses cmd+w. The handler should close
+  // the currently focused tab if one exists and return true, else false.
+  setCloseActiveTabHandler: (handler) => {
+    closeActiveTabHandler = typeof handler === 'function' ? handler : null;
+  },
 });

--- a/apps/minds_workspace_server/frontend/src/index.ts
+++ b/apps/minds_workspace_server/frontend/src/index.ts
@@ -9,7 +9,9 @@ import "./style.css";
 import { App } from "./views/App";
 
 interface MindsDesktopBridge {
-  setCloseActiveTabHandler?: (handler: () => boolean) => void;
+  // The preload awaits the handler's return value, so sync or async
+  // implementations are both fine.
+  setCloseActiveTabHandler?: (handler: () => boolean | Promise<boolean>) => void;
 }
 
 declare global {

--- a/apps/minds_workspace_server/frontend/src/index.ts
+++ b/apps/minds_workspace_server/frontend/src/index.ts
@@ -8,9 +8,16 @@ import m from "mithril";
 import "./style.css";
 import { App } from "./views/App";
 
+interface MindsDesktopBridge {
+  setCloseActiveTabHandler?: (handler: () => boolean) => void;
+}
+
 declare global {
   interface Window {
     $llm: LlmApi;
+    // Provided by the Electron preload script in the minds desktop shell;
+    // undefined when the workspace frontend is served in a plain browser.
+    minds?: MindsDesktopBridge;
   }
   var $llm: LlmApi;
 }

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -262,9 +262,7 @@ function buildDropdownItems(): Array<{ label: string; action: () => void; divide
   // (that's the surrounding chrome UI, not a tab-able app) and "terminal"
   // (reachable via the "New terminal" menu item further down). Everything
   // else, including the default "web" example server, is openable.
-  const apps = getApplications().filter(
-    (app) => app.name !== "system_interface" && app.name !== "terminal",
-  );
+  const apps = getApplications().filter((app) => app.name !== "system_interface" && app.name !== "terminal");
   for (const app of apps) {
     if (!openAppNames.has(app.name)) {
       const proxyUrl = getServiceUrl(app.name);

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -628,6 +628,17 @@ function initializeDockview(parentElement: HTMLElement): void {
 
   dockview = dv;
 
+  // Register a handler so the Electron shell can forward cmd+w to close the
+  // active dockview tab. The handler returns true when a panel was closed;
+  // the shell falls back to closing the window otherwise.
+  const minds = (window as { minds?: { setCloseActiveTabHandler?: (handler: () => boolean) => void } }).minds;
+  minds?.setCloseActiveTabHandler?.(() => {
+    const active = dv.activePanel;
+    if (!active) return false;
+    active.api.close();
+    return true;
+  });
+
   // Listen for layout changes and auto-save
   _layoutChangeDisposable = dv.api.onDidLayoutChange(() => {
     scheduleSave();

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -629,8 +629,7 @@ function initializeDockview(parentElement: HTMLElement): void {
   // Register a handler so the Electron shell can forward cmd+w to close the
   // active dockview tab. The handler returns true when a panel was closed;
   // the shell falls back to closing the window otherwise.
-  const minds = (window as { minds?: { setCloseActiveTabHandler?: (handler: () => boolean) => void } }).minds;
-  minds?.setCloseActiveTabHandler?.(() => {
+  window.minds?.setCloseActiveTabHandler?.(() => {
     const active = dv.activePanel;
     if (!active) return false;
     active.api.close();


### PR DESCRIPTION
## Summary

Previously cmd+w in the minds Electron app closed the whole window. Browser convention is that cmd+w closes the current tab while cmd+shift+w closes the window. This PR brings the shortcut behavior in line with that.

- **cmd+w**: closes the active Dockview tab in the content view. If nothing is closed (no active panel, dockview not yet loaded, or no response within a short timeout), falls back to closing the window -- matching Chrome's "closing the last tab closes the window" behavior.
- **cmd+shift+w**: always closes the window.

### Implementation

The workspace's Dockview registers a `setCloseActiveTabHandler` callback through the `minds` preload API. When the Electron shell receives cmd+w (from the app menu on macOS, or from `before-input-event` on Windows/Linux / `MINDS_HIDE_MENU=1`), it forwards the request to the content view's renderer over IPC with a correlation id and waits for the response. If the renderer closes the active panel, it replies `true`; otherwise it replies `false`. A 500ms timeout guards against a hung renderer.

Touched:

- `apps/minds/electron/main.js` -- new `closeActiveTabOrWindow` + `requestCloseActiveTab` helpers; updated app menu ("Close Tab" on `CmdOrCtrl+W`, "Close Window" on `CmdOrCtrl+Shift+W`); updated `before-input-event` for the no-menu path.
- `apps/minds/electron/preload.js` -- expose `minds.setCloseActiveTabHandler(fn)` and wire the IPC correlation-id round-trip.
- `apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts` -- register the handler during `initializeDockview`; call `dv.activePanel.api.close()` if there is an active panel, return whether one was closed.

The second commit (`Reformat DockviewWorkspace line to satisfy prettier`) is unrelated drift: a pre-existing line in this file failed `npx prettier --check` on main. Rolled into this PR because the frontend vitest `lint-and-format` job was failing without it.

## Test plan

- [ ] Pull branch, build and start the Electron app. Open a workspace with multiple Dockview tabs.
- [ ] Press cmd+w with the content view focused: active tab should close; remaining tabs stay open.
- [ ] Press cmd+w when only one tab is open: the tab closes, then the window closes (or, if the tab is the last one and can't be closed, the window closes directly).
- [ ] Press cmd+w on the loading/error shell (before the workspace has loaded): the window should close.
- [ ] Press cmd+shift+w: the window should close regardless of tabs.
- [ ] Confirm the Close Tab / Close Window entries appear correctly in the File menu on macOS.
- [ ] Windows/Linux (or with `MINDS_HIDE_MENU=1`): same behavior via the `before-input-event` path.