### PR TITLE
WIP: Faster leasing startup (spec in progress)

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -61,11 +61,11 @@ from imbue.mngr.primitives import AgentId
 def _make_child_cg(name: str, parent: ConcurrencyGroup | None) -> ConcurrencyGroup:
     """Create a ``ConcurrencyGroup`` named ``name`` that is a child of ``parent``.
 
-    When ``parent`` is ``None`` (tests or other callers that don't supply a
-    root), falls back to a free-standing group so the current per-operation
-    behavior is preserved. In production the desktop client supplies its root
-    CG via ``start_desktop_client`` so every strand is tracked by a single
-    ancestor and cleaned up together on shutdown.
+    ``AgentCreator`` always supplies its ``root_concurrency_group`` (required
+    field), so the ``parent is None`` branch only fires when a module-level
+    helper (``clone_git_repo``, ``checkout_branch``, ``resolve_template_version``)
+    is called standalone by a test that doesn't thread a root CG in. Those
+    helpers still accept ``parent_cg=None`` for test ergonomics.
     """
     if parent is None:
         return ConcurrencyGroup(name=name)
@@ -291,15 +291,15 @@ def _build_latchkey_gateway_url(launch_mode: LaunchMode, info: LatchkeyGatewayIn
     """Return the ``LATCHKEY_GATEWAY`` URL the agent should see in its environment.
 
     DEV agents run on the bare host and reach the gateway on its dynamic host
-    port directly. Every other mode runs inside a container/VM/VPS whose own
-    loopback is bridged to the host-side gateway via an SSH reverse tunnel
-    bound to a fixed remote port, so the URL is the same constant for every
-    such agent.
+    port directly. Every other mode (container / VM / VPS / leased pool host)
+    runs inside an isolated runtime whose own loopback is bridged to the
+    host-side gateway via an SSH reverse tunnel bound to a fixed remote port,
+    so the URL is the same constant for every such agent.
     """
     match launch_mode:
         case LaunchMode.DEV:
             return f"http://{info.host}:{info.port}"
-        case LaunchMode.LOCAL | LaunchMode.LIMA | LaunchMode.CLOUD:
+        case LaunchMode.LOCAL | LaunchMode.LIMA | LaunchMode.CLOUD | LaunchMode.LEASED:
             return f"http://127.0.0.1:{AGENT_SIDE_LATCHKEY_PORT}"
         case _ as unreachable:
             assert_never(unreachable)
@@ -677,22 +677,20 @@ class AgentCreator(MutableModel):
             "bridges back via an SSH reverse tunnel once the agent is discovered."
         ),
     )
-    root_concurrency_group: ConcurrencyGroup | None = Field(
-        default=None,
+    root_concurrency_group: ConcurrencyGroup = Field(
         frozen=True,
         description=(
-            "Top-level ``ConcurrencyGroup`` owned by ``start_desktop_client``. When provided, "
-            "every subprocess and thread spawned by this creator is tracked under it so the "
-            "desktop-client shutdown can cleanly wait on (or cancel) in-flight work. When "
-            "``None`` (tests), each operation falls back to an ad-hoc free-standing group."
+            "Top-level ``ConcurrencyGroup`` owned by ``start_desktop_client`` and entered for "
+            "the duration of the FastAPI lifespan. Every subprocess and thread spawned by this "
+            "creator is tracked under it so the desktop-client shutdown can cleanly wait on "
+            "(or cancel) in-flight work."
         ),
     )
-    notification_dispatcher: NotificationDispatcher | None = Field(
-        default=None,
+    notification_dispatcher: NotificationDispatcher = Field(
         frozen=True,
         description=(
-            "Optional dispatcher for surfacing failures from background tasks (e.g. the "
-            "detached Cloudflare tunnel setup task). When ``None``, failures are only logged."
+            "Dispatcher for surfacing failures from background tasks (e.g. the detached "
+            "Cloudflare tunnel setup task) to the user as OS notifications."
         ),
     )
 

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -28,7 +28,9 @@ from loguru import logger
 from pydantic import Field
 from pydantic import PrivateAttr
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.errors import ProcessError
 from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.logging import log_span
@@ -45,6 +47,7 @@ from imbue.minds.desktop_client.latchkey.gateway import AGENT_SIDE_LATCHKEY_PORT
 from imbue.minds.desktop_client.latchkey.gateway import LatchkeyGatewayError
 from imbue.minds.desktop_client.latchkey.gateway import LatchkeyGatewayManager
 from imbue.minds.desktop_client.latchkey.store import LatchkeyGatewayInfo
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
@@ -53,6 +56,33 @@ from imbue.minds.primitives import GitBranch
 from imbue.minds.primitives import GitUrl
 from imbue.minds.primitives import LaunchMode
 from imbue.mngr.primitives import AgentId
+
+
+def _make_child_cg(name: str, parent: ConcurrencyGroup | None) -> ConcurrencyGroup:
+    """Create a ``ConcurrencyGroup`` named ``name`` that is a child of ``parent``.
+
+    When ``parent`` is ``None`` (tests or other callers that don't supply a
+    root), falls back to a free-standing group so the current per-operation
+    behavior is preserved. In production the desktop client supplies its root
+    CG via ``start_desktop_client`` so every strand is tracked by a single
+    ancestor and cleaned up together on shutdown.
+    """
+    if parent is None:
+        return ConcurrencyGroup(name=name)
+    return parent.make_concurrency_group(name=name)
+
+
+def _leased_agent_address(agent_id: AgentId) -> str:
+    """Explicit mngr address for a leased agent.
+
+    Uses ``<agent-id>@leased-<agent-id>.ssh`` so mngr discovery only loads the
+    SSH provider configured by ``imbue.minds.bootstrap._ensure_mngr_settings``
+    and skips name/ID lookup entirely. This assumes the leased-mode invariant
+    that the canonical agent id equals ``lease_result.agent_id`` (set in
+    ``_lease_host_synchronously``).
+    """
+    return f"{agent_id}@leased-{agent_id}.ssh"
+
 
 OutputCallback = Callable[[str, bool], None]
 
@@ -142,6 +172,7 @@ def clone_git_repo(
     on_output: OutputCallback | None = None,
     *,
     is_shallow: bool = False,
+    parent_cg: ConcurrencyGroup | None = None,
 ) -> None:
     """Clone a git repository into the specified directory.
 
@@ -154,7 +185,7 @@ def clone_git_repo(
     if is_shallow:
         command.extend(["--depth", "1"])
     command.extend([str(git_url), str(clone_dir)])
-    cg = ConcurrencyGroup(name="git-clone")
+    cg = _make_child_cg("git-clone", parent_cg)
     with cg:
         result = cg.run_process_to_completion(
             command=command,
@@ -174,13 +205,15 @@ def checkout_branch(
     repo_dir: Path,
     branch: GitBranch,
     on_output: OutputCallback | None = None,
+    *,
+    parent_cg: ConcurrencyGroup | None = None,
 ) -> None:
     """Check out a specific branch in a cloned repository.
 
     Raises GitOperationError if the checkout fails (e.g. branch does not exist).
     """
     logger.debug("Checking out branch {} in {}", branch, repo_dir)
-    cg = ConcurrencyGroup(name="git-checkout")
+    cg = _make_child_cg("git-checkout", parent_cg)
     with cg:
         result = cg.run_process_to_completion(
             command=["git", "checkout", str(branch)],
@@ -202,6 +235,8 @@ def _rsync_worktree_over_clone(
     worktree_dir: Path,
     clone_dir: Path,
     on_output: OutputCallback | None = None,
+    *,
+    parent_cg: ConcurrencyGroup | None = None,
 ) -> None:
     """Rsync a worktree's working directory over a shallow clone.
 
@@ -226,7 +261,7 @@ def _rsync_worktree_over_clone(
         f"{worktree_dir}/",
         f"{clone_dir}/",
     ]
-    cg = ConcurrencyGroup(name="rsync-worktree")
+    cg = _make_child_cg("rsync-worktree", parent_cg)
     with cg:
         result = cg.run_process_to_completion(
             command=command,
@@ -387,7 +422,11 @@ def _remote_host_env_flags() -> list[str]:
     ]
 
 
-def _load_or_create_leased_host_keypair(data_dir: Path) -> tuple[Path, str]:
+def _load_or_create_leased_host_keypair(
+    data_dir: Path,
+    *,
+    parent_cg: ConcurrencyGroup | None = None,
+) -> tuple[Path, str]:
     """Load or generate an SSH keypair for connecting to leased hosts.
 
     The keypair lives at ``<data_dir>/ssh/keys/leased_host/id_ed25519``. If
@@ -401,7 +440,7 @@ def _load_or_create_leased_host_keypair(data_dir: Path) -> tuple[Path, str]:
 
     if not private_key_path.exists():
         with log_span("Generating SSH keypair for leased hosts"):
-            cg = ConcurrencyGroup(name="ssh-keygen")
+            cg = _make_child_cg("ssh-keygen", parent_cg)
             with cg:
                 result = cg.run_process_to_completion(
                     command=[
@@ -504,7 +543,12 @@ def _remove_lease_info(data_dir: Path, agent_id: AgentId) -> None:
 _SEMVER_TAG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^refs/tags/(v\d+\.\d+\.\d+)$")
 
 
-def resolve_template_version(git_url: str, branch: str) -> str:
+def resolve_template_version(
+    git_url: str,
+    branch: str,
+    *,
+    parent_cg: ConcurrencyGroup | None = None,
+) -> str:
     """Resolve the template version to use when leasing a host.
 
     If branch is non-empty, the branch name is the version (dev workflow).
@@ -514,7 +558,7 @@ def resolve_template_version(git_url: str, branch: str) -> str:
     if branch:
         return branch
 
-    cg = ConcurrencyGroup(name="git-ls-remote-tags")
+    cg = _make_child_cg("git-ls-remote-tags", parent_cg)
     with cg:
         result = cg.run_process_to_completion(
             command=["git", "ls-remote", "--tags", git_url],
@@ -555,6 +599,8 @@ def run_mngr_create(
     on_output: OutputCallback | None = None,
     host_env_file: Path | None = None,
     latchkey_gateway_url: str | None = None,
+    *,
+    parent_cg: ConcurrencyGroup | None = None,
 ) -> str:
     """Create an mngr agent via ``mngr create``.
 
@@ -574,7 +620,7 @@ def run_mngr_create(
 
     logger.info("Running: {}", " ".join(mngr_command))
 
-    cg = ConcurrencyGroup(name="mngr-create")
+    cg = _make_child_cg("mngr-create", parent_cg)
     with cg:
         result = cg.run_process_to_completion(
             command=mngr_command,
@@ -629,6 +675,24 @@ class AgentCreator(MutableModel):
             "For DEV agents the URL is the gateway's dynamic host port; for container/VM/VPS "
             "agents it is a constant URL on the agent-side loopback that ``LatchkeyGatewayDiscoveryHandler`` "
             "bridges back via an SSH reverse tunnel once the agent is discovered."
+        ),
+    )
+    root_concurrency_group: ConcurrencyGroup | None = Field(
+        default=None,
+        frozen=True,
+        description=(
+            "Top-level ``ConcurrencyGroup`` owned by ``start_desktop_client``. When provided, "
+            "every subprocess and thread spawned by this creator is tracked under it so the "
+            "desktop-client shutdown can cleanly wait on (or cancel) in-flight work. When "
+            "``None`` (tests), each operation falls back to an ad-hoc free-standing group."
+        ),
+    )
+    notification_dispatcher: NotificationDispatcher | None = Field(
+        default=None,
+        frozen=True,
+        description=(
+            "Optional dispatcher for surfacing failures from background tasks (e.g. the "
+            "detached Cloudflare tunnel setup task). When ``None``, failures are only logged."
         ),
     )
 
@@ -728,7 +792,9 @@ class AgentCreator(MutableModel):
         if not version:
             raise MngrCommandError("LEASED mode requires a version string")
 
-        private_key_path, public_key = _load_or_create_leased_host_keypair(self.paths.data_dir)
+        private_key_path, public_key = _load_or_create_leased_host_keypair(
+            self.paths.data_dir, parent_cg=self.root_concurrency_group
+        )
         log_queue.put("[minds] Requesting a leased host (version: {})...".format(version))
         lease_result = self.host_pool_client.lease_host(access_token, public_key, version)
         logger.debug(
@@ -869,7 +935,7 @@ class AgentCreator(MutableModel):
 
     def _get_host_id_for_agent(self, agent_id: AgentId) -> str | None:
         """Look up the host ID for an agent via ``mngr list``."""
-        cg = ConcurrencyGroup(name="mngr-list-host")
+        cg = _make_child_cg("mngr-list-host", self.root_concurrency_group)
         with cg:
             result = cg.run_process_to_completion(
                 command=[
@@ -896,7 +962,7 @@ class AgentCreator(MutableModel):
 
     def _destroy_all_agents_on_host(self, host_id: str) -> None:
         """Destroy all agents on the given host via ``mngr destroy -f``."""
-        cg = ConcurrencyGroup(name="mngr-destroy-host")
+        cg = _make_child_cg("mngr-destroy-host", self.root_concurrency_group)
         with cg:
             result = cg.run_process_to_completion(
                 command=[
@@ -920,7 +986,7 @@ class AgentCreator(MutableModel):
 
     def _destroy_single_agent(self, agent_id: AgentId) -> None:
         """Destroy a single agent via ``mngr destroy``."""
-        cg = ConcurrencyGroup(name="mngr-destroy")
+        cg = _make_child_cg("mngr-destroy", self.root_concurrency_group)
         with cg:
             result = cg.run_process_to_completion(
                 command=[MNGR_BINARY, "destroy", str(agent_id), "-f"],
@@ -995,12 +1061,20 @@ class AgentCreator(MutableModel):
                         if clone_target.exists():
                             shutil.rmtree(clone_target)
                         file_url = GitUrl("file://{}".format(resolved_path))
-                        clone_git_repo(file_url, clone_target, on_output=emit_log, is_shallow=True)
+                        clone_git_repo(
+                            file_url,
+                            clone_target,
+                            on_output=emit_log,
+                            is_shallow=True,
+                            parent_cg=self.root_concurrency_group,
+                        )
                         # The shallow clone only contains committed content. Rsync
                         # the worktree's working directory over so that uncommitted
                         # changes (e.g. a locally-rsynced vendor/mngr/) are included
                         # in the Docker build context.
-                        _rsync_worktree_over_clone(resolved_path, clone_target, on_output=emit_log)
+                        _rsync_worktree_over_clone(
+                            resolved_path, clone_target, on_output=emit_log, parent_cg=self.root_concurrency_group
+                        )
                         workspace_dir = clone_target
                     else:
                         workspace_dir = resolved_path
@@ -1011,12 +1085,23 @@ class AgentCreator(MutableModel):
                     if clone_target.exists():
                         shutil.rmtree(clone_target)
                     log_queue.put("[minds] Cloning {}...".format(repo_source))
-                    clone_git_repo(GitUrl(repo_source), clone_target, on_output=emit_log, is_shallow=True)
+                    clone_git_repo(
+                        GitUrl(repo_source),
+                        clone_target,
+                        on_output=emit_log,
+                        is_shallow=True,
+                        parent_cg=self.root_concurrency_group,
+                    )
                     workspace_dir = clone_target
 
                 if branch:
                     log_queue.put("[minds] Checking out branch '{}'...".format(branch))
-                    checkout_branch(workspace_dir, GitBranch(branch), on_output=emit_log)
+                    checkout_branch(
+                        workspace_dir,
+                        GitBranch(branch),
+                        on_output=emit_log,
+                        parent_cg=self.root_concurrency_group,
+                    )
 
                 with self._lock:
                     self._statuses[aid] = AgentCreationStatus.CREATING
@@ -1038,6 +1123,7 @@ class AgentCreator(MutableModel):
                     on_output=emit_log,
                     host_env_file=host_env_file,
                     latchkey_gateway_url=latchkey_gateway_url,
+                    parent_cg=self.root_concurrency_group,
                 )
 
                 # Persist the API key hash
@@ -1047,18 +1133,19 @@ class AgentCreator(MutableModel):
 
                 log_queue.put("[minds] Agent created successfully.")
 
-                if on_created is not None:
-                    try:
-                        on_created(agent_id)
-                    except (ValueError, OSError) as callback_exc:
-                        logger.warning("on_created callback failed for {}: {}", agent_id, callback_exc)
-
                 port_suffix = ":{}".format(self.server_port) if self.server_port else ""
                 redirect_url = "http://{}.localhost{}/".format(agent_id, port_suffix)
 
+                # Set DONE before invoking on_created so the UI can redirect as
+                # soon as the agent is usable. ``on_created`` is expected to
+                # return quickly (it only schedules background work -- see
+                # ``_OnCreatedCallbackFactory``).
                 with self._lock:
                     self._statuses[aid] = AgentCreationStatus.DONE
                     self._redirect_urls[aid] = redirect_url
+
+                if on_created is not None:
+                    on_created(agent_id)
 
         except (GitCloneError, GitOperationError, MngrCommandError, HostPoolError, ValueError, OSError) as e:
             logger.error("Failed to create agent {}: {}", agent_id, e)
@@ -1115,7 +1202,9 @@ class AgentCreator(MutableModel):
     ) -> None:
         """Set up a leased host (write dynamic host entry, rename, start)."""
         aid = str(agent_id)
-        private_key_path = _load_or_create_leased_host_keypair(self.paths.data_dir)[0]
+        private_key_path = _load_or_create_leased_host_keypair(
+            self.paths.data_dir, parent_cg=self.root_concurrency_group
+        )[0]
 
         with log_span("Setting up leased agent {} on {}", agent_id, lease_result.vps_ip):
             with self._lock:
@@ -1172,101 +1261,101 @@ class AgentCreator(MutableModel):
         lease_result: LeaseHostResult,
         on_created: Callable[[AgentId], None] | None = None,
     ) -> None:
-        """Label, rename, and start the leased agent. Raises on failure."""
+        """Rename, apply labels, inject the API key, and start the leased agent.
+
+        Sequence:
+          1. ``mngr rename`` (sequential).
+          2. ``mngr label`` + ``mngr exec sed ... MINDS_API_KEY`` (parallel).
+          3. ``mngr start`` (sequential).
+
+        All four subprocesses share a single ``ConcurrencyGroup`` child of
+        ``self.root_concurrency_group``. Every mngr invocation addresses the
+        agent via ``_leased_agent_address(agent_id)`` so mngr only queries the
+        SSH provider (skipping name/ID resolution across every other provider).
+
+        Raises ``MngrCommandError`` on any failure; the parallel step uses
+        ``is_checked_by_group=True`` so a failure in either sibling aborts the
+        other and propagates through the shared group.
+        """
         parsed_name = AgentName(agent_name)
+        address = _leased_agent_address(agent_id)
 
-        log_queue.put("[minds] Setting workspace labels...")
-        cg_label = ConcurrencyGroup(name="mngr-label")
-        with cg_label:
-            label_result = cg_label.run_process_to_completion(
-                command=[
-                    MNGR_BINARY,
-                    "label",
-                    lease_result.agent_id,
-                    "-l",
-                    "workspace={}".format(parsed_name),
-                    "-l",
-                    "user_created=true",
-                    "-l",
-                    "is_primary=true",
-                ],
-                is_checked_after=False,
-                on_output=emit_log,
-            )
-        if label_result.returncode != 0:
-            raise MngrCommandError(
-                "mngr label failed (exit code {}): {}".format(
-                    label_result.returncode,
-                    label_result.stderr.strip() if label_result.stderr.strip() else label_result.stdout.strip(),
-                )
-            )
-
-        log_queue.put("[minds] Renaming agent to '{}'...".format(parsed_name))
-        cg_rename = ConcurrencyGroup(name="mngr-rename")
-        with cg_rename:
-            rename_result = cg_rename.run_process_to_completion(
-                command=[MNGR_BINARY, "rename", lease_result.agent_id, str(parsed_name)],
-                is_checked_after=False,
-                on_output=emit_log,
-            )
-        if rename_result.returncode != 0:
-            raise MngrCommandError(
-                "mngr rename failed (exit code {}): {}".format(
-                    rename_result.returncode,
-                    rename_result.stderr.strip() if rename_result.stderr.strip() else rename_result.stdout.strip(),
-                )
-            )
-
-        log_queue.put("[minds] Starting agent '{}'...".format(parsed_name))
-        cg_start = ConcurrencyGroup(name="mngr-start")
-        with cg_start:
-            start_result = cg_start.run_process_to_completion(
-                command=[MNGR_BINARY, "start", str(parsed_name)],
-                is_checked_after=False,
-                on_output=emit_log,
-            )
-        if start_result.returncode != 0:
-            raise MngrCommandError(
-                "mngr start failed (exit code {}): {}".format(
-                    start_result.returncode,
-                    start_result.stderr.strip() if start_result.stderr.strip() else start_result.stdout.strip(),
-                )
-            )
-
-        # Generate a new API key, inject it into the agent's env, and persist the hash
+        # Generate the API key up front so the parallel inject step has it
+        # ready; ``generate_api_key`` / ``hash_api_key`` are in-process and
+        # cheap. The on-disk hash is persisted after the agent starts so that
+        # a failure in the setup flow does not leave an orphan hash file.
         api_key = generate_api_key()
-        log_queue.put("[minds] Injecting MINDS_API_KEY...")
         env_path = "/mngr/agents/{}/env".format(agent_id)
         inject_command = ("sed -i '/^MINDS_API_KEY=/d' {path} && echo 'MINDS_API_KEY={key}' >> {path}").format(
             path=env_path, key=api_key
         )
-        cg_exec = ConcurrencyGroup(name="mngr-exec-apikey")
-        with cg_exec:
-            exec_result = cg_exec.run_process_to_completion(
-                command=[MNGR_BINARY, "exec", str(agent_id), inject_command],
-                is_checked_after=False,
-                on_output=emit_log,
-            )
-        if exec_result.returncode != 0:
-            logger.warning("Failed to inject MINDS_API_KEY: {}", exec_result.stderr.strip())
+
+        cg = _make_child_cg("mngr-leased-setup", self.root_concurrency_group)
+        try:
+            with cg:
+                log_queue.put("[minds] Renaming agent to '{}'...".format(parsed_name))
+                cg.run_process_to_completion(
+                    command=[MNGR_BINARY, "rename", address, str(parsed_name)],
+                    is_checked_after=True,
+                    on_output=emit_log,
+                )
+
+                log_queue.put("[minds] Applying labels and injecting MINDS_API_KEY in parallel...")
+                label_proc = cg.run_process_in_background(
+                    command=[
+                        MNGR_BINARY,
+                        "label",
+                        address,
+                        "-l",
+                        "workspace={}".format(parsed_name),
+                        "-l",
+                        "user_created=true",
+                        "-l",
+                        "is_primary=true",
+                    ],
+                    is_checked_by_group=True,
+                    on_output=emit_log,
+                )
+                apikey_proc = cg.run_process_in_background(
+                    command=[MNGR_BINARY, "exec", address, inject_command],
+                    is_checked_by_group=True,
+                    on_output=emit_log,
+                )
+                label_proc.wait()
+                apikey_proc.wait()
+
+                log_queue.put("[minds] Starting agent '{}'...".format(parsed_name))
+                cg.run_process_to_completion(
+                    command=[MNGR_BINARY, "start", address],
+                    is_checked_after=True,
+                    on_output=emit_log,
+                )
+        except (ProcessError, ConcurrencyExceptionGroup) as e:
+            # Convert CG exceptions into MngrCommandError so the caller's
+            # existing except clause (MngrCommandError, HostPoolError, ...)
+            # triggers lease cleanup. Preserve the original exception chain
+            # for debuggability.
+            raise MngrCommandError("Leased agent setup failed: {}".format(e)) from e
+
         key_hash = hash_api_key(api_key)
         save_api_key_hash(self.paths.data_dir, agent_id, key_hash)
-        log_queue.put("[minds] API key generated and hash stored.")
-
+        log_queue.put("[minds] API key hash stored.")
         log_queue.put("[minds] Leased agent started successfully.")
-
-        if on_created is not None:
-            try:
-                on_created(agent_id)
-            except (ValueError, OSError) as callback_exc:
-                logger.warning("on_created callback failed for {}: {}", agent_id, callback_exc)
 
         port_suffix = ":{}".format(self.server_port) if self.server_port else ""
         redirect_url = "http://{}.localhost{}/".format(agent_id, port_suffix)
 
+        # Set DONE before invoking on_created so the UI can redirect as soon
+        # as the agent is actually usable. ``on_created`` is expected to
+        # return quickly (it only schedules background work -- see
+        # ``_OnCreatedCallbackFactory``), so the try/except wrapper that
+        # previously guarded a blocking callback is intentionally gone.
         with self._lock:
             self._statuses[aid] = AgentCreationStatus.DONE
             self._redirect_urls[aid] = redirect_url
+
+        if on_created is not None:
+            on_created(agent_id)
 
     def _cleanup_failed_lease(
         self,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -15,6 +15,7 @@ from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.agent_creator import _build_latchkey_gateway_url
 from imbue.minds.desktop_client.agent_creator import _build_mngr_create_command
 from imbue.minds.desktop_client.agent_creator import _is_local_path
+from imbue.minds.desktop_client.agent_creator import _leased_agent_address
 from imbue.minds.desktop_client.agent_creator import _load_lease_info
 from imbue.minds.desktop_client.agent_creator import _load_or_create_leased_host_keypair
 from imbue.minds.desktop_client.agent_creator import _make_host_name
@@ -96,6 +97,15 @@ def test_is_local_path_url() -> None:
 
 
 # -- _build_mngr_create_command tests --
+
+
+def test_leased_agent_address_uses_ssh_provider_and_leased_host_name() -> None:
+    """The explicit address matches the SSH provider + host-name pattern that
+    ``imbue.minds.bootstrap._ensure_mngr_settings`` sets up, so mngr discovery
+    only hits the SSH provider and skips ID lookup entirely."""
+    agent_id = AgentId()
+    address = _leased_agent_address(agent_id)
+    assert address == f"{agent_id}@leased-{agent_id}.ssh"
 
 
 def test_make_host_name() -> None:

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -33,6 +33,7 @@ from imbue.minds.desktop_client.host_pool_client import HostPoolClient
 from imbue.minds.desktop_client.latchkey.gateway import AGENT_SIDE_LATCHKEY_PORT
 from imbue.minds.desktop_client.latchkey.gateway import LatchkeyGatewayManager
 from imbue.minds.desktop_client.latchkey.store import LatchkeyGatewayInfo
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
@@ -319,14 +320,23 @@ def test_checkout_branch_raises_on_nonexistent_branch(tmp_path: Path) -> None:
 # -- AgentCreator tests --
 
 
-def test_agent_creator_get_creation_info_returns_none_for_unknown() -> None:
+def test_agent_creator_get_creation_info_returns_none_for_unknown(
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=Path("/tmp/test")),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     assert creator.get_creation_info(AgentId()) is None
 
 
-def test_agent_creator_start_creation_returns_agent_id_and_tracks_status(tmp_path: Path) -> None:
+def test_agent_creator_start_creation_returns_agent_id_and_tracks_status(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """Verify start_creation returns an agent ID and sets initial CLONING status.
 
     The actual background thread will fail (since the git URL is invalid),
@@ -334,6 +344,8 @@ def test_agent_creator_start_creation_returns_agent_id_and_tracks_status(tmp_pat
     """
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=tmp_path / "minds"),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
 
     agent_id = creator.start_creation("file:///nonexistent-repo")
@@ -345,10 +357,16 @@ def test_agent_creator_start_creation_returns_agent_id_and_tracks_status(tmp_pat
     creator.wait_for_all()
 
 
-def test_agent_creator_start_creation_with_custom_name(tmp_path: Path) -> None:
+def test_agent_creator_start_creation_with_custom_name(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """Verify start_creation accepts a custom agent name."""
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=tmp_path / "minds"),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     agent_id = creator.start_creation("file:///nonexistent-repo", agent_name="my-agent")
     info = creator.get_creation_info(agent_id)
@@ -356,16 +374,26 @@ def test_agent_creator_start_creation_with_custom_name(tmp_path: Path) -> None:
     creator.wait_for_all()
 
 
-def test_agent_creator_get_log_queue_returns_none_for_unknown() -> None:
+def test_agent_creator_get_log_queue_returns_none_for_unknown(
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=Path("/tmp/test")),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     assert creator.get_log_queue(AgentId()) is None
 
 
-def test_agent_creator_get_log_queue_returns_queue_for_tracked() -> None:
+def test_agent_creator_get_log_queue_returns_queue_for_tracked(
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=Path("/tmp/test")),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     agent_id = creator.start_creation("file:///nonexistent-repo")
     q = creator.get_log_queue(agent_id)
@@ -373,10 +401,16 @@ def test_agent_creator_get_log_queue_returns_queue_for_tracked() -> None:
     creator.wait_for_all()
 
 
-def test_agent_creator_start_creation_with_local_path(tmp_path: Path) -> None:
+def test_agent_creator_start_creation_with_local_path(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """Verify start_creation with a nonexistent local path eventually reaches FAILED status."""
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=tmp_path / "minds"),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     agent_id = creator.start_creation("/nonexistent/local/path", agent_name="local-test")
     # The background thread runs immediately and fails because the path doesn't exist.
@@ -412,7 +446,11 @@ def test_make_log_callback_puts_lines_into_queue() -> None:
     assert log_queue.get_nowait() == "world"
 
 
-def test_agent_creator_accepts_server_port(tmp_path: Path) -> None:
+def test_agent_creator_accepts_server_port(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """AgentCreator exposes its configured server_port for redirect-URL construction.
 
     Regression guard: the happy-path redirect URL for a newly-created agent is
@@ -423,11 +461,16 @@ def test_agent_creator_accepts_server_port(tmp_path: Path) -> None:
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=tmp_path / "minds"),
         server_port=12345,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     assert creator.server_port == 12345
 
 
-def test_agent_creator_server_port_defaults_to_zero() -> None:
+def test_agent_creator_server_port_defaults_to_zero(
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """AgentCreator.server_port defaults to 0 for legacy test callers.
 
     Tests that don't exercise the happy-path redirect can construct an
@@ -435,6 +478,8 @@ def test_agent_creator_server_port_defaults_to_zero() -> None:
     """
     creator = AgentCreator(
         paths=WorkspacePaths(data_dir=Path("/tmp/test")),
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     assert creator.server_port == 0
 
@@ -627,6 +672,8 @@ def test_remove_lease_info_noop_for_missing(tmp_path: Path) -> None:
 def test_release_leased_host_with_pool_client(
     tmp_path: Path,
     fake_pool_server: HostPoolClient,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
 ) -> None:
     """release_leased_host removes the dynamic host entry, calls release, and removes lease info."""
     paths = WorkspacePaths(data_dir=tmp_path)
@@ -634,6 +681,8 @@ def test_release_leased_host_with_pool_client(
     creator = AgentCreator(
         paths=paths,
         host_pool_client=fake_pool_server,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
 
     # Set up state: lease info and a dynamic host entry
@@ -658,18 +707,34 @@ def test_release_leased_host_with_pool_client(
     assert host_name not in content
 
 
-def test_release_leased_host_noop_when_no_lease_info(tmp_path: Path) -> None:
+def test_release_leased_host_noop_when_no_lease_info(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """release_leased_host is a no-op when there is no lease info for the agent."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths)
+    creator = AgentCreator(
+        paths=paths,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     creator.release_leased_host(AgentId(), access_token="test-token")
 
 
-def test_release_leased_host_without_pool_client(tmp_path: Path) -> None:
+def test_release_leased_host_without_pool_client(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """release_leased_host logs a warning but does not crash when host_pool_client is None."""
     paths = WorkspacePaths(data_dir=tmp_path)
     agent_id = AgentId()
-    creator = AgentCreator(paths=paths)
+    creator = AgentCreator(
+        paths=paths,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
 
     test_uuid = UUID("00000000-0000-0000-0000-000000000007")
     _save_lease_info(tmp_path, agent_id, test_uuid)
@@ -679,21 +744,42 @@ def test_release_leased_host_without_pool_client(tmp_path: Path) -> None:
     assert _load_lease_info(tmp_path, agent_id) == test_uuid
 
 
-def test_agent_creator_has_host_pool_client_field(tmp_path: Path) -> None:
+def test_agent_creator_has_host_pool_client_field(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """AgentCreator accepts an optional host_pool_client field."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator_without = AgentCreator(paths=paths)
+    creator_without = AgentCreator(
+        paths=paths,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     assert creator_without.host_pool_client is None
 
     client = HostPoolClient(connector_url=RemoteServiceConnectorUrl("http://example.com"))
-    creator_with = AgentCreator(paths=paths, host_pool_client=client)
+    creator_with = AgentCreator(
+        paths=paths,
+        host_pool_client=client,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     assert creator_with.host_pool_client is not None
 
 
-def test_start_creation_leased_raises_without_pool_client(tmp_path: Path) -> None:
+def test_start_creation_leased_raises_without_pool_client(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """start_creation with LEASED mode raises immediately if no host_pool_client."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths)
+    creator = AgentCreator(
+        paths=paths,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     with pytest.raises(MngrCommandError, match="host_pool_client"):
         creator.start_creation(
             repo_source="https://example.com/repo.git",
@@ -707,10 +793,17 @@ def test_start_creation_leased_raises_without_pool_client(tmp_path: Path) -> Non
 def test_create_leased_agent_fails_without_access_token(
     tmp_path: Path,
     fake_pool_server: HostPoolClient,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
 ) -> None:
     """start_creation raises synchronously when access_token is empty for LEASED mode."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths, host_pool_client=fake_pool_server)
+    creator = AgentCreator(
+        paths=paths,
+        host_pool_client=fake_pool_server,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     with pytest.raises(MngrCommandError, match="access_token"):
         creator.start_creation(
             repo_source="https://example.com/repo.git",
@@ -724,10 +817,17 @@ def test_create_leased_agent_fails_without_access_token(
 def test_create_leased_agent_fails_without_version(
     tmp_path: Path,
     fake_pool_server: HostPoolClient,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
 ) -> None:
     """start_creation raises synchronously when version is empty for LEASED mode."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths, host_pool_client=fake_pool_server)
+    creator = AgentCreator(
+        paths=paths,
+        host_pool_client=fake_pool_server,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     with pytest.raises(MngrCommandError, match="version"):
         creator.start_creation(
             repo_source="https://example.com/repo.git",
@@ -741,6 +841,8 @@ def test_create_leased_agent_fails_without_version(
 def test_create_leased_agent_leases_and_writes_dynamic_host(
     tmp_path: Path,
     fake_pool_server: HostPoolClient,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
 ) -> None:
     """_create_leased_agent leases a host, writes dynamic host entry and lease info.
 
@@ -748,7 +850,12 @@ def test_create_leased_agent_leases_and_writes_dynamic_host(
     setup steps should complete, and cleanup should release the host.
     """
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths, host_pool_client=fake_pool_server)
+    creator = AgentCreator(
+        paths=paths,
+        host_pool_client=fake_pool_server,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     agent_id = creator.start_creation(
         repo_source="https://example.com/repo.git",
         agent_name="test-workspace",
@@ -767,10 +874,17 @@ def test_create_leased_agent_leases_and_writes_dynamic_host(
 def test_cleanup_failed_lease(
     tmp_path: Path,
     fake_pool_server: HostPoolClient,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
 ) -> None:
     """_cleanup_failed_lease removes dynamic host entry, releases host, and removes lease info."""
     paths = WorkspacePaths(data_dir=tmp_path)
-    creator = AgentCreator(paths=paths, host_pool_client=fake_pool_server)
+    creator = AgentCreator(
+        paths=paths,
+        host_pool_client=fake_pool_server,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
+    )
     agent_id = AgentId()
     dynamic_hosts_file = tmp_path / "ssh" / "dynamic_hosts.toml"
     host_entry_name = "leased-{}".format(agent_id)
@@ -853,7 +967,11 @@ def test_build_mngr_create_command_omits_latchkey_gateway_env_by_default() -> No
 
 
 @pytest.mark.timeout(30)
-def test_agent_creator_cleans_up_pre_spawned_latchkey_gateway_on_failure(tmp_path: Path) -> None:
+def test_agent_creator_cleans_up_pre_spawned_latchkey_gateway_on_failure(
+    tmp_path: Path,
+    root_concurrency_group: ConcurrencyGroup,
+    notification_dispatcher: NotificationDispatcher,
+) -> None:
     """When mngr create fails, any latchkey gateway pre-spawned for the agent must be torn down.
 
     Uses a fake ``latchkey`` binary so this test does not require a real
@@ -882,6 +1000,8 @@ def test_agent_creator_cleans_up_pre_spawned_latchkey_gateway_on_failure(tmp_pat
         creator = AgentCreator(
             paths=WorkspacePaths(data_dir=tmp_path / "minds"),
             latchkey_gateway_manager=gateway_manager,
+            root_concurrency_group=root_concurrency_group,
+            notification_dispatcher=notification_dispatcher,
         )
         # "Local path" that does not exist -- mngr create will not even get
         # the chance to fail; _create_agent_background aborts with MngrCommandError.

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -780,15 +780,15 @@ def _run_tunnel_setup(
     agent_id: AgentId,
     enriched_client: CloudflareClient,
     paths: WorkspacePaths,
-    notification_dispatcher: NotificationDispatcher | None,
+    notification_dispatcher: NotificationDispatcher,
     agent_display_name: str,
 ) -> None:
     """Create a Cloudflare tunnel and inject its token into the agent.
 
     Runs on a detached thread scheduled by ``_OnCreatedCallbackFactory`` on
     the desktop client's root ``ConcurrencyGroup``. Failures are logged via
-    loguru and (when ``notification_dispatcher`` is provided) surfaced to the
-    user as an OS notification -- every failure dispatches one, no rate limit.
+    loguru and surfaced to the user via ``notification_dispatcher`` -- every
+    failure dispatches one notification, no rate limit.
 
     ``create_tunnel`` returns ``(None, error_message)`` for every failure mode
     (HTTP, bad response, etc.) rather than raising, so no defensive wrapper is
@@ -809,7 +809,7 @@ def _run_tunnel_setup(
 
 
 def _notify_tunnel_failure(
-    notification_dispatcher: NotificationDispatcher | None,
+    notification_dispatcher: NotificationDispatcher,
     agent_display_name: str,
     error_message: str,
 ) -> None:
@@ -819,8 +819,6 @@ def _notify_tunnel_failure(
     subprocess per channel and swallows channel-specific errors internally,
     so a top-level ``except`` wrapper here would only mask genuine bugs.
     """
-    if notification_dispatcher is None:
-        return
     notification_dispatcher.dispatch(
         NotificationRequest(
             title="Tunnel setup failed",
@@ -846,18 +844,13 @@ class _OnCreatedCallbackFactory(MutableModel):
     session_store: MultiAccountSessionStore = Field(frozen=True, description="Session store for account lookup")
     cf_client: CloudflareClient = Field(frozen=True, description="Cloudflare client for tunnel creation")
     paths: WorkspacePaths = Field(frozen=True, description="Workspace paths for tunnel token storage")
-    root_concurrency_group: ConcurrencyGroup | None = Field(
-        default=None,
+    root_concurrency_group: ConcurrencyGroup = Field(
         frozen=True,
-        description=(
-            "Root group on which the detached tunnel task is scheduled. When ``None``, "
-            "falls back to running synchronously (used in tests that don't supply a root CG)."
-        ),
+        description="Root group on which the detached tunnel task is scheduled.",
     )
-    notification_dispatcher: NotificationDispatcher | None = Field(
-        default=None,
+    notification_dispatcher: NotificationDispatcher = Field(
         frozen=True,
-        description="Dispatcher for surfacing tunnel-setup failures as OS notifications",
+        description="Dispatcher for surfacing tunnel-setup failures as OS notifications.",
     )
 
     def __call__(self, agent_id: AgentId) -> None:
@@ -877,17 +870,6 @@ class _OnCreatedCallbackFactory(MutableModel):
         # user-chosen name at this point (see ``backend_resolver``), so fall
         # back to the short form of the agent id for the notification copy.
         agent_display_name = str(agent_id)[:8]
-        if self.root_concurrency_group is None:
-            # Test / standalone path: run synchronously. Production always
-            # supplies a root CG, so this fallback is not on the critical path.
-            _run_tunnel_setup(
-                agent_id=agent_id,
-                enriched_client=enriched_client,
-                paths=self.paths,
-                notification_dispatcher=self.notification_dispatcher,
-                agent_display_name=agent_display_name,
-            )
-            return
         self.root_concurrency_group.start_new_thread(
             target=_run_tunnel_setup,
             kwargs={
@@ -923,11 +905,17 @@ def _build_on_created_callback(
     except AttributeError:
         paths = None
 
-    if session_store is None or cf_client is None or paths is None:
-        return None
-
     root_concurrency_group: ConcurrencyGroup | None = request.app.state.root_concurrency_group
     notification_dispatcher: NotificationDispatcher | None = request.app.state.notification_dispatcher
+
+    if (
+        session_store is None
+        or cf_client is None
+        or paths is None
+        or root_concurrency_group is None
+        or notification_dispatcher is None
+    ):
+        return None
 
     return _OnCreatedCallbackFactory(
         session_store=session_store,

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -32,6 +32,8 @@ from loguru import logger
 from pydantic import Field
 from websockets import ClientConnection
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreationStatus
@@ -56,6 +58,8 @@ from imbue.minds.desktop_client.deps import BackendResolverDep
 from imbue.minds.desktop_client.latchkey.gateway import LatchkeyGatewayManager
 from imbue.minds.desktop_client.minds_config import MindsConfig
 from imbue.minds.desktop_client.notification import NotificationDispatcher
+from imbue.minds.desktop_client.notification import NotificationRequest
+from imbue.minds.desktop_client.notification import NotificationUrgency
 from imbue.minds.desktop_client.request_events import RequestInbox
 from imbue.minds.desktop_client.request_events import RequestStatus
 from imbue.minds.desktop_client.request_events import SharingRequestEvent
@@ -239,6 +243,19 @@ async def _managed_lifespan(
         tunnel_manager: SSHTunnelManager | None = inner_app.state.tunnel_manager
         if tunnel_manager is not None:
             tunnel_manager.cleanup()
+        # Exit the root ConcurrencyGroup last, after every other manager has
+        # stopped its strands. ``__exit__`` waits up to
+        # ``shutdown_timeout_seconds`` for any still-in-flight strands (e.g.
+        # a detached tunnel-setup task) to finish.
+        root_concurrency_group: ConcurrencyGroup | None = inner_app.state.root_concurrency_group
+        if root_concurrency_group is not None:
+            logger.info("Exiting root concurrency group...")
+            try:
+                root_concurrency_group.__exit__(None, None, None)
+            except ConcurrencyExceptionGroup as exc:
+                # Strands reported failures or timed out during shutdown;
+                # log but don't propagate so other cleanup below can run.
+                logger.warning("Root concurrency group exit reported errors: {}", exc)
 
 
 # -- Route handlers (module-level, using Depends for dependency injection) --
@@ -759,12 +776,89 @@ async def _handle_workspace_forward_websocket(websocket: WebSocket) -> None:
 # -- Agent creation route handlers --
 
 
+def _run_tunnel_setup(
+    agent_id: AgentId,
+    enriched_client: CloudflareClient,
+    paths: WorkspacePaths,
+    notification_dispatcher: NotificationDispatcher | None,
+    agent_display_name: str,
+) -> None:
+    """Create a Cloudflare tunnel and inject its token into the agent.
+
+    Runs on a detached thread scheduled by ``_OnCreatedCallbackFactory`` on
+    the desktop client's root ``ConcurrencyGroup``. Failures are logged via
+    loguru and (when ``notification_dispatcher`` is provided) surfaced to the
+    user as an OS notification -- every failure dispatches one, no rate limit.
+
+    ``create_tunnel`` returns ``(None, error_message)`` for every failure mode
+    (HTTP, bad response, etc.) rather than raising, so no defensive wrapper is
+    needed here; we just inspect the return value.
+    """
+    tunnel_token, message = enriched_client.create_tunnel(agent_id)
+    if tunnel_token is None:
+        logger.warning("Failed to create tunnel for {}: {}", agent_id, message)
+        _notify_tunnel_failure(
+            notification_dispatcher=notification_dispatcher,
+            agent_display_name=agent_display_name,
+            error_message=message,
+        )
+        return
+    _save_tunnel_token(paths.data_dir, agent_id, tunnel_token)
+    inject_tunnel_token_into_agent(agent_id, tunnel_token)
+    logger.debug("Injected tunnel token into agent {}", agent_id)
+
+
+def _notify_tunnel_failure(
+    notification_dispatcher: NotificationDispatcher | None,
+    agent_display_name: str,
+    error_message: str,
+) -> None:
+    """Dispatch an OS notification for a tunnel-setup failure (no rate limit).
+
+    ``NotificationDispatcher.dispatch`` spawns its own background thread or
+    subprocess per channel and swallows channel-specific errors internally,
+    so a top-level ``except`` wrapper here would only mask genuine bugs.
+    """
+    if notification_dispatcher is None:
+        return
+    notification_dispatcher.dispatch(
+        NotificationRequest(
+            title="Tunnel setup failed",
+            message=(
+                f"Couldn't set up the Cloudflare tunnel for '{agent_display_name}'. "
+                f"Sharing may be unavailable. Error: {error_message}"
+            ),
+            urgency=NotificationUrgency.NORMAL,
+        ),
+        agent_display_name=agent_display_name,
+    )
+
+
 class _OnCreatedCallbackFactory(MutableModel):
-    """Callable that injects a tunnel token into a newly created agent."""
+    """Callable that schedules Cloudflare tunnel setup as a detached background task.
+
+    ``__call__`` returns immediately after spawning a thread on the root
+    ``ConcurrencyGroup``; the actual ``create_tunnel`` + token inject work runs
+    asynchronously. This keeps ``_setup_and_start_leased_agent`` and
+    ``_create_agent_background`` off the critical path for the user redirect.
+    """
 
     session_store: MultiAccountSessionStore = Field(frozen=True, description="Session store for account lookup")
     cf_client: CloudflareClient = Field(frozen=True, description="Cloudflare client for tunnel creation")
     paths: WorkspacePaths = Field(frozen=True, description="Workspace paths for tunnel token storage")
+    root_concurrency_group: ConcurrencyGroup | None = Field(
+        default=None,
+        frozen=True,
+        description=(
+            "Root group on which the detached tunnel task is scheduled. When ``None``, "
+            "falls back to running synchronously (used in tests that don't supply a root CG)."
+        ),
+    )
+    notification_dispatcher: NotificationDispatcher | None = Field(
+        default=None,
+        frozen=True,
+        description="Dispatcher for surfacing tunnel-setup failures as OS notifications",
+    )
 
     def __call__(self, agent_id: AgentId) -> None:
         account = self.session_store.get_account_for_workspace(str(agent_id))
@@ -779,13 +873,36 @@ class _OnCreatedCallbackFactory(MutableModel):
             supertokens_user_id_prefix=str(derive_user_id_prefix(str(account.user_id))),
             supertokens_email=account.email,
         )
-        tunnel_token, message = enriched_client.create_tunnel(agent_id)
-        if tunnel_token is None:
-            logger.warning("Failed to create tunnel for {}: {}", agent_id, message)
+        # ``_build_on_created_callback`` doesn't have easy access to the
+        # user-chosen name at this point (see ``backend_resolver``), so fall
+        # back to the short form of the agent id for the notification copy.
+        agent_display_name = str(agent_id)[:8]
+        if self.root_concurrency_group is None:
+            # Test / standalone path: run synchronously. Production always
+            # supplies a root CG, so this fallback is not on the critical path.
+            _run_tunnel_setup(
+                agent_id=agent_id,
+                enriched_client=enriched_client,
+                paths=self.paths,
+                notification_dispatcher=self.notification_dispatcher,
+                agent_display_name=agent_display_name,
+            )
             return
-        _save_tunnel_token(self.paths.data_dir, agent_id, tunnel_token)
-        inject_tunnel_token_into_agent(agent_id, tunnel_token)
-        logger.debug("Injected tunnel token into agent {}", agent_id)
+        self.root_concurrency_group.start_new_thread(
+            target=_run_tunnel_setup,
+            kwargs={
+                "agent_id": agent_id,
+                "enriched_client": enriched_client,
+                "paths": self.paths,
+                "notification_dispatcher": self.notification_dispatcher,
+                "agent_display_name": agent_display_name,
+            },
+            name=f"tunnel-setup-{agent_id}",
+            # is_checked=False so that a failing tunnel task does not poison
+            # the root CG for unrelated strands; failures are surfaced via
+            # notifications + loguru from within ``_run_tunnel_setup``.
+            is_checked=False,
+        )
 
 
 def _build_on_created_callback(
@@ -809,10 +926,15 @@ def _build_on_created_callback(
     if session_store is None or cf_client is None or paths is None:
         return None
 
+    root_concurrency_group: ConcurrencyGroup | None = request.app.state.root_concurrency_group
+    notification_dispatcher: NotificationDispatcher | None = request.app.state.notification_dispatcher
+
     return _OnCreatedCallbackFactory(
         session_store=session_store,
         cf_client=cf_client,
         paths=paths,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
 
 
@@ -859,7 +981,7 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
         if session_store_for_token and account_id:
             token = session_store_for_token.get_access_token(account_id)
             access_token = str(token) if token else ""
-        version = resolve_template_version(git_url, branch)
+        version = resolve_template_version(git_url, branch, parent_cg=agent_creator.root_concurrency_group)
 
     # Build a post-creation callback that injects the tunnel token
     on_created = _build_on_created_callback(request, account_id)
@@ -2003,6 +2125,7 @@ def create_desktop_client(
     request_inbox: RequestInbox | None = None,
     server_port: int = 0,
     output_format: OutputFormat | None = None,
+    root_concurrency_group: ConcurrencyGroup | None = None,
 ) -> FastAPI:
     """Create the desktop client FastAPI application.
 
@@ -2065,6 +2188,7 @@ def create_desktop_client(
     app.state.request_inbox = request_inbox
     app.state.auth_server_port = server_port
     app.state.auth_output_format = output_format or OutputFormat.JSONL
+    app.state.root_concurrency_group = root_concurrency_group
     # Populated with the running loop by _managed_lifespan on startup. Defined
     # up-front as None so background callbacks fired before startup (e.g. mngr
     # events produced between stream_manager.start() and uvicorn.run()) see a

--- a/apps/minds/imbue/minds/desktop_client/conftest.py
+++ b/apps/minds/imbue/minds/desktop_client/conftest.py
@@ -9,6 +9,7 @@ from typing import Final
 
 import pytest
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.desktop_client.backend_resolver import MngrCliBackendResolver
 from imbue.minds.desktop_client.backend_resolver import ParsedAgentsResult
 from imbue.minds.desktop_client.backend_resolver import ServiceLogRecord
@@ -16,6 +17,7 @@ from imbue.minds.desktop_client.backend_resolver import parse_agents_from_json
 from imbue.minds.desktop_client.backend_resolver import parse_service_log_records
 from imbue.minds.desktop_client.cloudflare_client import RemoteServiceConnectorUrl
 from imbue.minds.desktop_client.host_pool_client import HostPoolClient
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.primitives import ServiceName
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
@@ -24,6 +26,33 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import ProviderInstanceName
 
 DEFAULT_SERVICE_NAME: ServiceName = ServiceName("web")
+
+
+@pytest.fixture
+def root_concurrency_group() -> Iterator[ConcurrencyGroup]:
+    """Root ``ConcurrencyGroup`` for tests that construct an ``AgentCreator``.
+
+    ``AgentCreator.root_concurrency_group`` is required (in production it is
+    owned by ``start_desktop_client`` and brackets the FastAPI lifespan); this
+    fixture enters an equivalent group for the test's duration and exits it
+    cleanly afterwards so any strand tracking / shutdown semantics match.
+    """
+    cg = ConcurrencyGroup(name="test-root")
+    with cg:
+        yield cg
+
+
+@pytest.fixture
+def notification_dispatcher() -> NotificationDispatcher:
+    """``NotificationDispatcher`` wired to the tkinter channel in tests.
+
+    Tests generally do not exercise the dispatch path; this fixture just
+    satisfies the required ``AgentCreator.notification_dispatcher`` field.
+    Pass ``is_electron=False`` so no ``emit_event`` JSONL lines leak into the
+    test's stdout. ``NotificationDispatcher.create`` skips tkinter setup when
+    ``tkinter_module`` is ``None``, which is what we want for unit tests.
+    """
+    return NotificationDispatcher.create(is_electron=False, tkinter_module=None, is_macos=False)
 
 
 @pytest.fixture

--- a/apps/minds/imbue/minds/desktop_client/runner.py
+++ b/apps/minds/imbue/minds/desktop_client/runner.py
@@ -12,6 +12,7 @@ from loguru import logger
 from pydantic import AnyUrl
 from pydantic import Field
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
@@ -140,6 +141,13 @@ def start_desktop_client(
     latchkey_gateway_manager = _build_latchkey_gateway_manager(data_directory=data_directory)
     latchkey_gateway_manager.start(data_dir=data_directory)
 
+    # Top-level ConcurrencyGroup that brackets the FastAPI lifespan. Every
+    # subprocess/thread spawned by the desktop client (agent setup subprocesses,
+    # background tunnel work, etc.) is tracked as a descendant so shutdown can
+    # wait on or cancel in-flight strands via the default ``__exit__`` path.
+    root_concurrency_group = ConcurrencyGroup(name="desktop-client")
+    root_concurrency_group.__enter__()
+
     minds_config = MindsConfig(data_dir=data_directory)
     cloudflare_client = _build_cloudflare_client(minds_config.remote_service_connector_url)
     auth_backend_client = AuthBackendClient(base_url=minds_config.remote_service_connector_url)
@@ -149,6 +157,8 @@ def start_desktop_client(
         server_port=port,
         latchkey_gateway_manager=latchkey_gateway_manager,
         host_pool_client=host_pool_client,
+        root_concurrency_group=root_concurrency_group,
+        notification_dispatcher=notification_dispatcher,
     )
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
 
@@ -239,6 +249,7 @@ def start_desktop_client(
         request_inbox=request_inbox,
         server_port=port,
         output_format=output_format,
+        root_concurrency_group=root_concurrency_group,
     )
 
     if not is_no_browser:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -8,6 +8,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
 from starlette.testclient import TestClient
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.app import _build_workspace_list
@@ -23,6 +24,7 @@ from imbue.minds.desktop_client.conftest import make_service_log
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.minds_config import MindsConfig
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.request_events import RequestInbox
 from imbue.minds.desktop_client.request_events import create_sharing_request_event
 from imbue.minds.desktop_client.session_store import MultiAccountSessionStore
@@ -558,10 +560,20 @@ def _create_test_server_with_agent_creator(
     """Create a desktop client with an agent creator for testing.
 
     The returned client is already authenticated with a global session.
+
+    The ``AgentCreator.root_concurrency_group`` is an ad-hoc group entered for
+    the helper and left active for the caller's test duration. These tests only
+    exercise HTTP endpoints (status polling, form rendering, etc.) -- they do
+    not actually run agent creation subprocesses against the group, so leaving
+    it in the ACTIVE state until GC is acceptable here.
     """
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
+    root_cg = ConcurrencyGroup(name="test-root")
+    root_cg.__enter__()
     agent_creator = AgentCreator(
         paths=WorkspacePaths(data_dir=tmp_path / "minds"),
+        root_concurrency_group=root_cg,
+        notification_dispatcher=NotificationDispatcher.create(is_electron=False, tkinter_module=None, is_macos=False),
     )
     client, auth_store = _create_test_desktop_client(
         tmp_path=tmp_path,

--- a/apps/minds/test_desktop_client_e2e.py
+++ b/apps/minds/test_desktop_client_e2e.py
@@ -32,12 +32,14 @@ import uvicorn
 from loguru import logger
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import MngrCliBackendResolver
 from imbue.minds.desktop_client.backend_resolver import MngrStreamManager
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.primitives import OneTimeCode
 from imbue.minds.testing import clean_env
 
@@ -135,7 +137,18 @@ class DesktopClientFixture:
 
         backend_resolver = MngrCliBackendResolver()
         self._stream_manager = MngrStreamManager(resolver=backend_resolver)
-        agent_creator = AgentCreator(paths=paths)
+        # ``AgentCreator.root_concurrency_group`` is required; this e2e harness
+        # runs the real ``start_desktop_client`` flow so an equivalent root CG
+        # is entered here and relied on by any creator operations.
+        root_cg = ConcurrencyGroup(name="test-root")
+        root_cg.__enter__()
+        agent_creator = AgentCreator(
+            paths=paths,
+            root_concurrency_group=root_cg,
+            notification_dispatcher=NotificationDispatcher.create(
+                is_electron=False, tkinter_module=None, is_macos=False
+            ),
+        )
 
         app = create_desktop_client(
             auth_store=auth_store,

--- a/apps/minds/test_sse_redirect.py
+++ b/apps/minds/test_sse_redirect.py
@@ -20,6 +20,7 @@ import uvicorn
 from loguru import logger
 from playwright.sync_api import sync_playwright
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.agent_creator import AgentCreationStatus
 from imbue.minds.desktop_client.agent_creator import AgentCreator
@@ -27,6 +28,7 @@ from imbue.minds.desktop_client.agent_creator import LOG_SENTINEL
 from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import MngrCliBackendResolver
+from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.primitives import OneTimeCode
 from imbue.mngr.primitives import AgentId
 
@@ -53,7 +55,13 @@ def test_sse_redirect_on_done(tmp_path: Path) -> None:
     auth_store = FileAuthStore(data_directory=paths.auth_dir)
     auth_store.add_one_time_code(code=code)
     resolver = MngrCliBackendResolver()
-    creator = AgentCreator(paths=paths)
+    root_cg = ConcurrencyGroup(name="test-root")
+    root_cg.__enter__()
+    creator = AgentCreator(
+        paths=paths,
+        root_concurrency_group=root_cg,
+        notification_dispatcher=NotificationDispatcher.create(is_electron=False, tkinter_module=None, is_macos=False),
+    )
 
     # Manually set up a fake agent creation that completes immediately
     agent_id = AgentId()

--- a/specs/faster-leased-agent-setup/spec.md
+++ b/specs/faster-leased-agent-setup/spec.md
@@ -1,0 +1,121 @@
+# Faster leased-agent setup
+
+## Overview
+
+- Creating a new minds project in LEASED mode currently takes ~67s end-to-end: rename 25s, start 20s, tunnel create 5s, tunnel inject 17s.
+- Cause: each step spawns a fresh `mngr` subprocess that re-runs provider discovery (scanning every provider, resolving names to IDs), and tunnel creation/injection blocks `DONE`.
+- Fix A — skip the discovery tax: invoke every `mngr` command with an explicit `agent-id@host-id.provider-name` address so discovery only loads the SSH provider and does no ID lookup.
+- Fix B — parallelize the independent work: reorder setup to `rename → (label ∥ MINDS_API_KEY inject) → start`, sharing a single `ConcurrencyGroup`.
+- Fix C — remove tunnel from the critical path: `_OnCreatedCallbackFactory` schedules tunnel creation+injection as a fire-and-forget background task on a new root `ConcurrencyGroup` and returns immediately (applies to both LEASED and non-LEASED modes).
+- Failures in the detached tunnel task are surfaced to the user via the existing `NotificationDispatcher` (distinct copy, no rate limit).
+- Scope excludes the destroy path's code and non-LEASED modes' explicit-address conversion; those CGs are reparented under the root for hierarchy coherence but otherwise untouched.
+
+## Expected Behavior
+
+- LEASED agent creation reaches `DONE` noticeably faster than the current 67s baseline; rename / label / start / apikey-inject phase runs in visibly less wall-clock time than today's sequential trio.
+- Tunnel setup is no longer on the critical path; the user is redirected to the working agent as soon as `mngr start` completes, and the Cloudflare tunnel appears shortly afterward.
+- When the background tunnel task fails, the user sees an OS notification titled "Tunnel setup failed" naming the affected agent and the underlying error; they can retry via the Share UI (unchanged).
+- When the background tunnel task succeeds, nothing user-visible happens (same as today).
+- If `rename` fails, the flow aborts and cleanup runs (same as today).
+- If either the `label` or apikey-inject subprocess fails, the shared `ConcurrencyGroup` propagates shutdown to its sibling and aggregates the failures; the flow aborts and cleanup runs.
+- If `mngr start` fails, the flow aborts and cleanup runs (same as today).
+- On desktop client shutdown, the root `ConcurrencyGroup` waits the default `shutdown_timeout_seconds` for any in-flight tunnel tasks to complete before forcing exit (default CG behavior).
+- Concrete timing numbers will be measured manually post-implementation; no automated benchmark is added.
+
+## Implementation Plan
+
+Packaged as a single PR.
+
+### New: root `ConcurrencyGroup`
+
+- `apps/minds/imbue/minds/desktop_client/runner.py`
+  - In `run_desktop_client` (or equivalent lifecycle entry point), construct a root `ConcurrencyGroup(name="desktop-client")` and enter it with a `with` block that brackets the FastAPI lifespan.
+  - Pass the root CG as a new parameter to `AgentCreator` at construction.
+
+### `AgentCreator` (`apps/minds/imbue/minds/desktop_client/agent_creator.py`)
+
+- Add two new `Field`s on `AgentCreator`:
+  - `root_concurrency_group: ConcurrencyGroup` — the top-level CG owned by `runner.py`.
+  - `notification_dispatcher: NotificationDispatcher | None` — for surfacing tunnel failures from background tasks; default `None` so tests that don't care can skip it.
+- Every existing `ConcurrencyGroup(name=...)` constructed inside this module (`git-clone`, `git-checkout`, `rsync-worktree`, `ssh-keygen`, `git-ls-remote-tags`, `mngr-create`, `mngr-list-host`, `mngr-destroy-host`, `mngr-destroy`, and the new leased-setup group) becomes a child group created via the parent-CG `child_group()`/`parent=` mechanism.
+  - Helper-level functions that currently create their own CG (`clone_git_repo`, `checkout_branch`, `_rsync_worktree_over_clone`, `_load_or_create_leased_host_keypair`, `resolve_template_version`, `run_mngr_create`) gain a new required `parent_cg: ConcurrencyGroup` parameter and create their child group from it. Callers thread the root CG through.
+- New helper `_leased_agent_address(agent_id: AgentId) -> str` returns `f"{agent_id}@leased-{agent_id}.ssh"`. Centralizes the format so all mngr calls in the leased flow share one definition.
+
+### Leased-setup flow (`_setup_and_start_leased_agent`)
+
+- Replace the three independent `ConcurrencyGroup(name="mngr-label"/"mngr-rename"/"mngr-start"/"mngr-exec-apikey")` groups with a single shared child `ConcurrencyGroup(name="mngr-leased-setup")` whose parent is `self.root_concurrency_group`.
+- New sequence inside the single `with cg:` block:
+  1. **rename** (sequential) — `cg.run_process_to_completion(command=[MNGR_BINARY, "rename", _leased_agent_address(agent_id), str(parsed_name)], ...)`, raise `MngrCommandError` on non-zero.
+  2. **Emit** both log lines (`log_queue.put("[minds] Applying labels and injecting MINDS_API_KEY in parallel...")` — single consolidated line).
+  3. **label + apikey inject** (parallel):
+     - `label_proc = cg.run_process_in_background(command=[MNGR_BINARY, "label", _leased_agent_address(agent_id), "-l", f"workspace={parsed_name}", "-l", "user_created=true", "-l", "is_primary=true"], is_checked_by_group=True, on_output=emit_log)`
+     - `apikey_proc = cg.run_process_in_background(command=[MNGR_BINARY, "exec", _leased_agent_address(agent_id), sed_inject_command], is_checked_by_group=True, on_output=emit_log)`
+     - `label_proc.wait(); apikey_proc.wait()` — failures propagate through the group's `is_checked_by_group` aggregation.
+  4. **start** (sequential) — `cg.run_process_to_completion(command=[MNGR_BINARY, "start", _leased_agent_address(agent_id)], ...)`.
+- Generate + hash + save the API key *before* the parallel step (same function calls as today — `generate_api_key`, `hash_api_key`, `save_api_key_hash`) so the sed command already has the key to inject.
+- Keep the `sed -i '/^MINDS_API_KEY=/d' && echo 'MINDS_API_KEY=...' >> /mngr/agents/<id>/env` command unchanged; just move it to run in parallel with label (still via `mngr exec`).
+- After `start` succeeds: immediately set `self._statuses[aid] = AgentCreationStatus.DONE` and set `redirect_url` — before invoking any `on_created` callback.
+- Call `on_created(agent_id)` last (after DONE). `on_created` now returns quickly (spawns a background task); the existing try/except around the callback is **removed** per the "callback never raises synchronously" contract.
+
+### `_OnCreatedCallbackFactory` (`apps/minds/imbue/minds/desktop_client/app.py`)
+
+- New field `root_concurrency_group: ConcurrencyGroup` (frozen).
+- New field `notification_dispatcher: NotificationDispatcher | None` (frozen).
+- `__call__(agent_id)` no longer does the Cloudflare work inline. It:
+  1. Looks up the account / access token exactly as today.
+  2. If no account or token: return (same as today).
+  3. Otherwise: schedule a background task on `self.root_concurrency_group` that performs the current body (`enriched_client.create_tunnel` → `_save_tunnel_token` → `inject_tunnel_token_into_agent`) and returns immediately.
+- The background task uses `root_concurrency_group.start_thread(...)` with a small wrapper function `_run_tunnel_setup(agent_id, ...)` defined in `app.py`. The wrapper catches exceptions from the tunnel work and dispatches notifications/logs (see below).
+- `_build_on_created_callback` gains `root_concurrency_group` and `notification_dispatcher` arguments, plumbed from `request.app.state` / the runner.
+
+### Tunnel background task (`_run_tunnel_setup`)
+
+- Defined in `app.py`; takes `(agent_id, enriched_client, paths, notification_dispatcher, agent_display_name)`.
+- Calls `create_tunnel` unconditionally (it's idempotent on the Cloudflare side — no `load_tunnel_token` short-circuit).
+- On `create_tunnel` success: `_save_tunnel_token`, then `inject_tunnel_token_into_agent`. On injection failure (non-zero exit): `logger.warning(...)` AND dispatch a `NotificationRequest(title="Tunnel setup failed", message=f"Couldn't set up the Cloudflare tunnel for '{agent_display_name}'. Sharing may be unavailable. Error: {msg}", urgency=NotificationUrgency.NORMAL)` via `self.notification_dispatcher.dispatch(...)`.
+- On `create_tunnel` failure: same notification + loguru error.
+- No rate limiting — every failure dispatches one notification.
+- `inject_tunnel_token_into_agent` continues to use `mngr exec` with a bare agent id (non-LEASED paths also call this; out-of-scope for explicit-address conversion this PR).
+
+### Non-LEASED path (`_create_agent_background`)
+
+- Keep the body unchanged except for the `on_created` call site: still invokes the callback at the same point, but the callback now returns quickly and the real work happens in the background thread.
+- The `try/except (ValueError, OSError)` around `on_created(agent_id)` is **removed** per the tightened contract.
+
+### `AgentCreator` construction in `runner.py`
+
+- Thread `root_concurrency_group` and `notification_dispatcher` into `AgentCreator(...)`.
+- `_OnCreatedCallbackFactory` construction (inside `_build_on_created_callback`) gets both wired in from `request.app.state`.
+
+### API endpoint parity
+
+- The `_handle_cloudflare_enable` endpoint in `api_v1.py` keeps its existing synchronous `create_tunnel` + `inject_tunnel_token_into_agent` call — it's a user-initiated retry path where blocking is acceptable. No change.
+
+## Implementation Phases
+
+1. **Root `ConcurrencyGroup` plumbing.** Add the root CG in `runner.py`; pass it into `AgentCreator` and `_build_on_created_callback`. Reparent every existing CG in `agent_creator.py` under it. No behavior change yet; tests should still pass.
+2. **Leased-setup reorder + shared CG.** Consolidate the four per-operation CGs into one shared child group; switch to `rename → (label ∥ apikey) → start`; convert every mngr call in the leased flow to use `_leased_agent_address()`. Update `agent_creator_test.py` assertions for the new sequence. Tests green.
+3. **Tunnel out-of-band.** Move `_OnCreatedCallbackFactory.__call__` body into a background task scheduled on the root CG; set `DONE` in `_setup_and_start_leased_agent` before invoking `on_created`; remove the try/except around `on_created` in both caller sites; wire `notification_dispatcher` into `AgentCreator` and the factory; implement `_run_tunnel_setup` with failure notifications. Update tests.
+4. **Manual end-to-end measurement.** Run a fresh LEASED create flow against a staging pool and record timings for rename / label+apikey / start / time-to-DONE; include a commit-message summary in the PR description.
+
+Each phase leaves the system in a working state and is individually verifiable via `just test-quick apps/minds`.
+
+## Testing Strategy
+
+- **`agent_creator_test.py` updates.** Existing assertions that expect sequential `mngr label` → `mngr rename` → `mngr start` → `mngr exec` subprocess calls are revised to expect:
+  - first subprocess: `mngr rename {agent_id}@leased-{agent_id}.ssh {name}`
+  - next two subprocesses: `mngr label ...` and `mngr exec ... sed ...` started in either order (assert both were started before `mngr start`)
+  - final subprocess: `mngr start {agent_id}@leased-{agent_id}.ssh`
+  - `DONE` status observable before the tunnel task's work is observable
+- **`app.py` / `_OnCreatedCallbackFactory` test update.** Assert that invoking the callback returns immediately (does not block on `create_tunnel`) and that a fake `CloudflareClient`'s `create_tunnel` is invoked asynchronously; a fake `NotificationDispatcher` receives a dispatch when `create_tunnel` raises.
+- **Failure-path tests.** Simulate label / apikey-inject failure and assert the flow aborts with an aggregated `ConcurrencyExceptionGroup` (or equivalent from `ConcurrencyGroup`); simulate rename failure and assert cleanup runs (same as today).
+- **No new overlap-timing test.** Per agreed scope; parallelism is asserted structurally (both subprocesses started before `start`), not by measuring wall-clock.
+- **Ratchets.** If any regex-based ratchet in `apps/minds/imbue/minds/test_ratchets.py` flags the new patterns (e.g. multiple `run_process_in_background` calls in sequence), fix in the spirit of the ratchet or bump the count with explanation.
+- **CI.** Full `just test-offload` run post-implementation; manual tmux verification of an end-to-end LEASED create against a real pool.
+
+## Open Questions
+
+- Other `ConcurrencyGroup` call sites outside `agent_creator.py` (`api_v1.inject_tunnel_token_into_agent`, `backend_resolver.StreamManager._cg`, `notification.py`, `cli/pool.py`) are not reparented by this PR — is that worth a follow-up sweep? The spec leaves them as-is.
+- The background tunnel task uses `mngr exec` with a bare agent id (not the explicit `id@host.ssh` address). Converting it would require knowing whether the agent is LEASED vs not at tunnel-inject time; out of scope.
+- `shutdown_timeout_seconds` for the root CG uses `ConcurrencyGroup` defaults; no custom tuning for "possibly-long Cloudflare API call" cases. Acceptable risk — worst case the shutdown forcibly aborts a tunnel task that would have succeeded, and the user retries via Share UI on next launch.
+- Qualitative measurement only — no automated regression guard for the timing improvement. If the wins later regress, we'll notice via manual timing, not a test.


### PR DESCRIPTION
## Summary

Spec-writing in progress for speeding up the LEASED-mode agent creation path in the minds app (currently ~67s per the original task description).

Target approach (per discussion with @joshalbrecht):
- Keep subprocess `mngr` calls (do not switch to in-process Python API).
- Pass explicit `agent-id@host-id.provider-name` addresses so `mngr` discovery only loads the SSH provider.
- Reorder leased setup: (1) rename, (2) label + MINDS_API_KEY update in parallel, (3) start.
- Share a single `ConcurrencyGroup` across the setup subprocesses.
- Move Cloudflare tunnel creation + injection fully out-of-band after the agent is DONE.

Still answering clarifying questions with the author; no code changes yet on top of the `josh/minds_faster_leasing` base.

## Test plan

- [ ] Spec written to `specs/` once Q&A is complete
- [ ] Implementation follows the agreed spec
- [ ] Measure end-to-end LEASED setup time against the baseline table in the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)