### PR TITLE
let headless_claude handle both streaming and regular messages

### DIFF
--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -268,15 +268,15 @@ class _StreamTailState(MutableModel):
         # delegate to the module-level extract helpers (their dict-accepting
         # variants) so dict-walking logic lives in one place. The string-
         # accepting public helpers are thin wrappers around the same dict logic.
-        event_type = parsed.get("type")
-
-        if event_type == "stream_event":
-            yield from self._handle_stream_event(parsed)
-            return
-
-        if event_type == "assistant":
-            yield from self._handle_assistant_event(parsed)
-            return
+        match parsed.get("type"):
+            case "stream_event":
+                yield from self._handle_stream_event(parsed)
+            case "assistant":
+                yield from self._handle_assistant_event(parsed)
+            case _:
+                # Other event types (system, user, etc.) carry no text to
+                # surface here and are intentionally skipped.
+                pass
 
     def _handle_stream_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # message_start (partial stream): begin a new turn. Any deltas for

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from typing import Callable
 
 from pydantic import Field
@@ -34,6 +35,24 @@ _STARTUP_GRACE_SECONDS: float = 10.0
 
 
 @pure
+def _parse_stream_line(line: str) -> dict[str, Any] | None:
+    """Decode a single stream-json line into a dict.
+
+    Returns the parsed dict on success, or None if the line is not valid
+    JSON or does not decode to a JSON object. Non-JSON lines (blank lines,
+    debug output that claude sometimes leaks to stdout) are expected and
+    silently skipped.
+    """
+    try:
+        parsed = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+@pure
 def extract_text_delta(line: str) -> str | None:
     """Extract text from a stream-json content_block_delta event.
 
@@ -41,11 +60,8 @@ def extract_text_delta(line: str) -> str | None:
     or None otherwise. This handles the partial-message envelope emitted by
     `claude --output-format stream-json --include-partial-messages`.
     """
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
-        # Expected: the stream contains non-JSON lines (blank lines, debug
-        # output that claude sometimes leaks to stdout). Skip them silently.
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return None
 
     if parsed.get("type") != "stream_event":
@@ -81,10 +97,8 @@ def extract_assistant_text(line: str) -> str | None:
     line per assistant turn. Returns the concatenation of all text blocks, or
     None if the line is not an `assistant` event with at least one text block.
     """
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
-        # Expected: non-JSON lines in the stream (see extract_text_delta).
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return None
 
     if parsed.get("type") != "assistant":
@@ -116,9 +130,8 @@ def extract_assistant_text(line: str) -> str | None:
 @pure
 def extract_assistant_message_id(line: str) -> str | None:
     """Extract `message.id` from a top-level `assistant` event, if present."""
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return None
     if parsed.get("type") != "assistant":
         return None
@@ -141,9 +154,8 @@ def extract_message_start_id(line: str) -> str | None:
     subsequent text deltas with a later top-level `assistant` summary that
     carries the same id.
     """
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return None
     if parsed.get("type") != "stream_event":
         return None
@@ -164,10 +176,8 @@ def extract_message_start_id(line: str) -> str | None:
 @pure
 def _is_result_event(line: str) -> bool:
     """Check if a stream-json line is a result event (signals completion)."""
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
-        # Expected: non-JSON lines in the stream (see extract_text_delta).
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return False
     return parsed.get("type") == "result"
 
@@ -178,10 +188,8 @@ def _extract_result_error(line: str) -> str | None:
 
     Returns the error message if this is an error result, None otherwise.
     """
-    try:
-        parsed = json.loads(line)
-    except (json.JSONDecodeError, ValueError):
-        # Expected: non-JSON lines in the stream (see extract_text_delta).
+    parsed = _parse_stream_line(line)
+    if parsed is None:
         return None
     if parsed.get("type") == "result" and parsed.get("is_error"):
         return parsed.get("result", "unknown error")
@@ -224,28 +232,82 @@ class _StreamTailState(MutableModel):
         self.yielded_text_in_current_turn = ""
 
     def _yield_text_for_line(self, stripped: str) -> Iterator[str]:
-        # message_start (partial stream): begin a new turn. Any deltas for the
-        # previous turn whose summary never arrived have already been yielded
-        # directly, so dropping the buffer here is safe.
-        started_id = extract_message_start_id(stripped)
-        if started_id is not None:
-            self._reset_turn_state()
-            self.streaming_message_id = started_id
+        # Parse the line once and dispatch on its `type`. The public
+        # extract_* helpers each call json.loads independently; using them
+        # in sequence here would parse the same line up to four times. The
+        # helpers are kept (and unit-tested) as standalone APIs but the
+        # streaming hot path decodes once and inspects the dict directly.
+        parsed = _parse_stream_line(stripped)
+        if parsed is None:
+            return
+
+        event_type = parsed.get("type")
+
+        if event_type == "stream_event":
+            yield from self._handle_stream_event(parsed)
+            return
+
+        if event_type == "assistant":
+            yield from self._handle_assistant_event(parsed)
+            return
+
+    def _handle_stream_event(self, parsed: dict[str, Any]) -> Iterator[str]:
+        event = parsed.get("event")
+        if not isinstance(event, dict):
+            return
+        inner_type = event.get("type")
+
+        # message_start (partial stream): begin a new turn. Any deltas for
+        # the previous turn whose summary never arrived have already been
+        # yielded directly, so dropping the buffer here is safe.
+        if inner_type == "message_start":
+            message = event.get("message")
+            if isinstance(message, dict):
+                message_id = message.get("id")
+                if isinstance(message_id, str):
+                    self._reset_turn_state()
+                    self.streaming_message_id = message_id
             return
 
         # text_delta (partial stream): yield the delta and record it in the
         # per-turn buffer so we can subtract it from the matching summary.
-        partial_text = extract_text_delta(stripped)
-        if partial_text is not None:
-            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + partial_text
-            yield partial_text
+        if inner_type == "content_block_delta":
+            delta = event.get("delta")
+            if not isinstance(delta, dict):
+                return
+            if delta.get("type") != "text_delta":
+                return
+            text = delta.get("text")
+            if not isinstance(text, str):
+                return
+            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + text
+            yield text
+
+    def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
+        # Top-level assistant event: reconcile against the per-turn buffer.
+        message = parsed.get("message")
+        if not isinstance(message, dict):
+            return
+        content_blocks = message.get("content")
+        if not isinstance(content_blocks, list):
             return
 
-        # Top-level assistant event: reconcile against the per-turn buffer.
-        assistant_text = extract_assistant_text(stripped)
-        if assistant_text is None:
+        text_parts: list[str] = []
+        for block in content_blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "text":
+                continue
+            text = block.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+
+        if not text_parts:
             return
-        assistant_id = extract_assistant_message_id(stripped)
+        assistant_text = "".join(text_parts)
+
+        message_id = message.get("id")
+        assistant_id = message_id if isinstance(message_id, str) else None
         is_definitely_different_message = (
             self.streaming_message_id is not None
             and assistant_id is not None

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 
+from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.mutable_model import MutableModel
@@ -273,10 +274,11 @@ class _StreamTailState(MutableModel):
                 yield from self._handle_stream_event(parsed)
             case "assistant":
                 yield from self._handle_assistant_event(parsed)
-            case _:
-                # Other event types (system, user, etc.) carry no text to
-                # surface here and are intentionally skipped.
-                pass
+            case other_event_type:
+                # Other event types (system, user, ping, future event types,
+                # etc.) carry no text to surface here and are intentionally
+                # skipped. Trace-log for debugging when something looks off.
+                logger.trace("Skipped stream-json event of unhandled type {!r}", other_event_type)
 
     def _handle_stream_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # message_start (partial stream): begin a new turn. Any deltas for

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -294,6 +294,15 @@ class _StreamTailState(MutableModel):
         if delta_text is not None:
             self.yielded_text_chunks.append(delta_text)
             yield delta_text
+            return
+
+        # Other inner stream_event types (content_block_start, content_block_stop,
+        # message_stop, ping, future event types, etc.) carry no text to surface
+        # and are intentionally skipped. Trace-log for consistency with the
+        # outer dispatcher's handling of unknown top-level types.
+        event = parsed.get("event")
+        inner_event_type = event.get("type") if isinstance(event, dict) else None
+        logger.trace("Skipped stream-json stream_event of unhandled inner type {!r}", inner_event_type)
 
     def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # Top-level assistant event: reconcile against the per-turn buffer.

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -114,6 +114,54 @@ def extract_assistant_text(line: str) -> str | None:
 
 
 @pure
+def extract_assistant_message_id(line: str) -> str | None:
+    """Extract `message.id` from a top-level `assistant` event, if present."""
+    try:
+        parsed = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if parsed.get("type") != "assistant":
+        return None
+    message = parsed.get("message")
+    if not isinstance(message, dict):
+        return None
+    message_id = message.get("id")
+    if isinstance(message_id, str):
+        return message_id
+    return None
+
+
+@pure
+def extract_message_start_id(line: str) -> str | None:
+    """Extract `message.id` from a partial-stream `message_start` event, if present.
+
+    With `--include-partial-messages`, claude emits a
+    `{"type":"stream_event","event":{"type":"message_start","message":{"id":"...",...}}}`
+    line at the start of each assistant message. The id lets us correlate
+    subsequent text deltas with a later top-level `assistant` summary that
+    carries the same id.
+    """
+    try:
+        parsed = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if parsed.get("type") != "stream_event":
+        return None
+    event = parsed.get("event")
+    if not isinstance(event, dict):
+        return None
+    if event.get("type") != "message_start":
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    message_id = message.get("id")
+    if isinstance(message_id, str):
+        return message_id
+    return None
+
+
+@pure
 def _is_result_event(line: str) -> bool:
     """Check if a stream-json line is a result event (signals completion)."""
     try:
@@ -154,11 +202,16 @@ class _StreamTailState(MutableModel):
     chars_consumed: int = 0
     line_buffer: str = ""
     result_error: str | None = None
-    # Tracks whether any partial text deltas (from `--include-partial-messages`)
-    # have been yielded during the current assistant turn. Used to avoid
-    # double-emitting text when claude also emits a final `assistant` summary
-    # message containing the same content. Resets at each `assistant` boundary.
-    is_partial_text_yielded_in_turn: bool = False
+    # Id of the assistant message currently being streamed via partial deltas
+    # (from `--include-partial-messages`'s `message_start` event), if any.
+    # Used to correlate deltas with the later top-level `assistant` summary
+    # that carries the same id. None when no partial-stream context is active.
+    streaming_message_id: str | None = None
+    # Concatenation of text already yielded for the in-progress turn. Used
+    # to compute the trailing diff when the `assistant` summary arrives, so
+    # that text present in the summary but not in the deltas is still emitted
+    # without re-emitting text already streamed.
+    yielded_text_in_current_turn: str = ""
 
     def _has_new_data_or_finished(self) -> bool:
         current_mtime = self.host.get_file_mtime(self.stdout_path)
@@ -166,23 +219,57 @@ class _StreamTailState(MutableModel):
             return True
         return self.is_finished()
 
+    def _reset_turn_state(self) -> None:
+        self.streaming_message_id = None
+        self.yielded_text_in_current_turn = ""
+
     def _yield_text_for_line(self, stripped: str) -> Iterator[str]:
-        # Partial-message envelope: yield the delta and remember we did so,
-        # so we can suppress the matching `assistant` summary later this turn.
+        # message_start (partial stream): begin a new turn. Any deltas for the
+        # previous turn whose summary never arrived have already been yielded
+        # directly, so dropping the buffer here is safe.
+        started_id = extract_message_start_id(stripped)
+        if started_id is not None:
+            self._reset_turn_state()
+            self.streaming_message_id = started_id
+            return
+
+        # text_delta (partial stream): yield the delta and record it in the
+        # per-turn buffer so we can subtract it from the matching summary.
         partial_text = extract_text_delta(stripped)
         if partial_text is not None:
-            self.is_partial_text_yielded_in_turn = True
+            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + partial_text
             yield partial_text
             return
 
-        # Whole-message envelope: yield only if no partial deltas were already
-        # streamed for this turn, then reset for the next turn.
+        # Top-level assistant event: reconcile against the per-turn buffer.
         assistant_text = extract_assistant_text(stripped)
         if assistant_text is None:
             return
-        if not self.is_partial_text_yielded_in_turn:
+        assistant_id = extract_assistant_message_id(stripped)
+        is_definitely_different_message = (
+            self.streaming_message_id is not None
+            and assistant_id is not None
+            and assistant_id != self.streaming_message_id
+        )
+
+        if is_definitely_different_message:
+            # The streamed deltas belonged to a previous message whose summary
+            # never arrived. Yield the full summary for this new message.
             yield assistant_text
-        self.is_partial_text_yielded_in_turn = False
+        elif assistant_text.startswith(self.yielded_text_in_current_turn):
+            # Summary continues / matches what we already yielded; emit only
+            # the trailing extra text (empty string when they match exactly).
+            trailing_text = assistant_text[len(self.yielded_text_in_current_turn) :]
+            if trailing_text:
+                yield trailing_text
+        else:
+            # Buffer is not a prefix of the summary. Either deltas drifted from
+            # the summary or this is a different message we cannot disambiguate
+            # by id. Yield the full summary; better a possible partial double-
+            # emit than dropping the assistant message entirely.
+            yield assistant_text
+
+        self._reset_turn_state()
 
     def tail_until_done(self) -> Iterator[str]:
         got_result = False

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -53,17 +53,8 @@ def _parse_stream_line(line: str) -> dict[str, Any] | None:
 
 
 @pure
-def extract_text_delta(line: str) -> str | None:
-    """Extract text from a stream-json content_block_delta event.
-
-    Returns the delta text if the line is a content_block_delta with a text_delta,
-    or None otherwise. This handles the partial-message envelope emitted by
-    `claude --output-format stream-json --include-partial-messages`.
-    """
-    parsed = _parse_stream_line(line)
-    if parsed is None:
-        return None
-
+def _extract_text_delta_from_parsed(parsed: dict[str, Any]) -> str | None:
+    """Extract text from an already-parsed stream-json content_block_delta event."""
     if parsed.get("type") != "stream_event":
         return None
 
@@ -89,18 +80,22 @@ def extract_text_delta(line: str) -> str | None:
 
 
 @pure
-def extract_assistant_text(line: str) -> str | None:
-    """Extract concatenated text from a top-level `assistant` event's content blocks.
+def extract_text_delta(line: str) -> str | None:
+    """Extract text from a stream-json content_block_delta event.
 
-    Without `--include-partial-messages`, `claude --output-format stream-json`
-    emits one `{"type":"assistant","message":{"content":[{"type":"text","text":...},...]}}`
-    line per assistant turn. Returns the concatenation of all text blocks, or
-    None if the line is not an `assistant` event with at least one text block.
+    Returns the delta text if the line is a content_block_delta with a text_delta,
+    or None otherwise. This handles the partial-message envelope emitted by
+    `claude --output-format stream-json --include-partial-messages`.
     """
     parsed = _parse_stream_line(line)
     if parsed is None:
         return None
+    return _extract_text_delta_from_parsed(parsed)
 
+
+@pure
+def _extract_assistant_text_from_parsed(parsed: dict[str, Any]) -> str | None:
+    """Extract concatenated text from an already-parsed top-level `assistant` event."""
     if parsed.get("type") != "assistant":
         return None
 
@@ -128,14 +123,54 @@ def extract_assistant_text(line: str) -> str | None:
 
 
 @pure
+def extract_assistant_text(line: str) -> str | None:
+    """Extract concatenated text from a top-level `assistant` event's content blocks.
+
+    Without `--include-partial-messages`, `claude --output-format stream-json`
+    emits one `{"type":"assistant","message":{"content":[{"type":"text","text":...},...]}}`
+    line per assistant turn. Returns the concatenation of all text blocks, or
+    None if the line is not an `assistant` event with at least one text block.
+    """
+    parsed = _parse_stream_line(line)
+    if parsed is None:
+        return None
+    return _extract_assistant_text_from_parsed(parsed)
+
+
+@pure
+def _extract_assistant_message_id_from_parsed(parsed: dict[str, Any]) -> str | None:
+    """Extract `message.id` from an already-parsed top-level `assistant` event."""
+    if parsed.get("type") != "assistant":
+        return None
+    message = parsed.get("message")
+    if not isinstance(message, dict):
+        return None
+    message_id = message.get("id")
+    if isinstance(message_id, str):
+        return message_id
+    return None
+
+
+@pure
 def extract_assistant_message_id(line: str) -> str | None:
     """Extract `message.id` from a top-level `assistant` event, if present."""
     parsed = _parse_stream_line(line)
     if parsed is None:
         return None
-    if parsed.get("type") != "assistant":
+    return _extract_assistant_message_id_from_parsed(parsed)
+
+
+@pure
+def _extract_message_start_id_from_parsed(parsed: dict[str, Any]) -> str | None:
+    """Extract `message.id` from an already-parsed partial-stream `message_start` event."""
+    if parsed.get("type") != "stream_event":
         return None
-    message = parsed.get("message")
+    event = parsed.get("event")
+    if not isinstance(event, dict):
+        return None
+    if event.get("type") != "message_start":
+        return None
+    message = event.get("message")
     if not isinstance(message, dict):
         return None
     message_id = message.get("id")
@@ -157,20 +192,7 @@ def extract_message_start_id(line: str) -> str | None:
     parsed = _parse_stream_line(line)
     if parsed is None:
         return None
-    if parsed.get("type") != "stream_event":
-        return None
-    event = parsed.get("event")
-    if not isinstance(event, dict):
-        return None
-    if event.get("type") != "message_start":
-        return None
-    message = event.get("message")
-    if not isinstance(message, dict):
-        return None
-    message_id = message.get("id")
-    if isinstance(message_id, str):
-        return message_id
-    return None
+    return _extract_message_start_id_from_parsed(parsed)
 
 
 @pure
@@ -232,11 +254,10 @@ class _StreamTailState(MutableModel):
         self.yielded_text_in_current_turn = ""
 
     def _yield_text_for_line(self, stripped: str) -> Iterator[str]:
-        # Parse the line once and dispatch on its `type`. The public
-        # extract_* helpers each call json.loads independently; using them
-        # in sequence here would parse the same line up to four times. The
-        # helpers are kept (and unit-tested) as standalone APIs but the
-        # streaming hot path decodes once and inspects the dict directly.
+        # Parse the line once and dispatch on its `type`, then delegate to
+        # the module-level extract helpers (their dict-accepting variants)
+        # so dict-walking logic lives in one place. The string-accepting
+        # public helpers are thin wrappers around the same dict logic.
         parsed = _parse_stream_line(stripped)
         if parsed is None:
             return
@@ -252,62 +273,29 @@ class _StreamTailState(MutableModel):
             return
 
     def _handle_stream_event(self, parsed: dict[str, Any]) -> Iterator[str]:
-        event = parsed.get("event")
-        if not isinstance(event, dict):
-            return
-        inner_type = event.get("type")
-
         # message_start (partial stream): begin a new turn. Any deltas for
         # the previous turn whose summary never arrived have already been
         # yielded directly, so dropping the buffer here is safe.
-        if inner_type == "message_start":
-            message = event.get("message")
-            if isinstance(message, dict):
-                message_id = message.get("id")
-                if isinstance(message_id, str):
-                    self._reset_turn_state()
-                    self.streaming_message_id = message_id
+        start_id = _extract_message_start_id_from_parsed(parsed)
+        if start_id is not None:
+            self._reset_turn_state()
+            self.streaming_message_id = start_id
             return
 
         # text_delta (partial stream): yield the delta and record it in the
         # per-turn buffer so we can subtract it from the matching summary.
-        if inner_type == "content_block_delta":
-            delta = event.get("delta")
-            if not isinstance(delta, dict):
-                return
-            if delta.get("type") != "text_delta":
-                return
-            text = delta.get("text")
-            if not isinstance(text, str):
-                return
-            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + text
-            yield text
+        delta_text = _extract_text_delta_from_parsed(parsed)
+        if delta_text is not None:
+            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + delta_text
+            yield delta_text
 
     def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # Top-level assistant event: reconcile against the per-turn buffer.
-        message = parsed.get("message")
-        if not isinstance(message, dict):
-            return
-        content_blocks = message.get("content")
-        if not isinstance(content_blocks, list):
+        assistant_text = _extract_assistant_text_from_parsed(parsed)
+        if assistant_text is None:
             return
 
-        text_parts: list[str] = []
-        for block in content_blocks:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") != "text":
-                continue
-            text = block.get("text")
-            if isinstance(text, str):
-                text_parts.append(text)
-
-        if not text_parts:
-            return
-        assistant_text = "".join(text_parts)
-
-        message_id = message.get("id")
-        assistant_id = message_id if isinstance(message_id, str) else None
+        assistant_id = _extract_assistant_message_id_from_parsed(parsed)
         is_definitely_different_message = (
             self.streaming_message_id is not None
             and assistant_id is not None

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -240,11 +240,13 @@ class _StreamTailState(MutableModel):
     # Used to correlate deltas with the later top-level `assistant` summary
     # that carries the same id. None when no partial-stream context is active.
     streaming_message_id: str | None = None
-    # Concatenation of text already yielded for the in-progress turn. Used
+    # Chunks of text already yielded for the in-progress turn, in order. Used
     # to compute the trailing diff when the `assistant` summary arrives, so
     # that text present in the summary but not in the deltas is still emitted
-    # without re-emitting text already streamed.
-    yielded_text_in_current_turn: str = ""
+    # without re-emitting text already streamed. Stored as a list (and joined
+    # lazily on summary arrival) to avoid O(N*M) repeated concatenation when
+    # a turn contains many small deltas.
+    yielded_text_chunks: list[str] = Field(default_factory=list)
 
     def _has_new_data_or_finished(self) -> bool:
         current_mtime = self.host.get_file_mtime(self.stdout_path)
@@ -254,7 +256,7 @@ class _StreamTailState(MutableModel):
 
     def _reset_turn_state(self) -> None:
         self.streaming_message_id = None
-        self.yielded_text_in_current_turn = ""
+        self.yielded_text_chunks = []
 
     def _yield_text_for_parsed(self, parsed: dict[str, Any]) -> Iterator[str]:
         # Dispatch an already-parsed stream-json line on its `type`, then
@@ -285,7 +287,7 @@ class _StreamTailState(MutableModel):
         # per-turn buffer so we can subtract it from the matching summary.
         delta_text = _extract_text_delta_from_parsed(parsed)
         if delta_text is not None:
-            self.yielded_text_in_current_turn = self.yielded_text_in_current_turn + delta_text
+            self.yielded_text_chunks.append(delta_text)
             yield delta_text
 
     def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
@@ -302,15 +304,18 @@ class _StreamTailState(MutableModel):
                 and assistant_id is not None
                 and assistant_id != self.streaming_message_id
             )
+            # Materialize the per-turn buffer once, here, instead of after every
+            # delta -- this turns an O(N*M) per-turn cost into O(M).
+            yielded_so_far = "".join(self.yielded_text_chunks)
 
             if is_definitely_different_message:
                 # The streamed deltas belonged to a previous message whose summary
                 # never arrived. Yield the full summary for this new message.
                 yield assistant_text
-            elif assistant_text.startswith(self.yielded_text_in_current_turn):
+            elif assistant_text.startswith(yielded_so_far):
                 # Summary continues / matches what we already yielded; emit only
                 # the trailing extra text (empty string when they match exactly).
-                trailing_text = assistant_text[len(self.yielded_text_in_current_turn) :]
+                trailing_text = assistant_text[len(yielded_so_far) :]
                 if trailing_text:
                     yield trailing_text
             else:

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -38,7 +38,8 @@ def extract_text_delta(line: str) -> str | None:
     """Extract text from a stream-json content_block_delta event.
 
     Returns the delta text if the line is a content_block_delta with a text_delta,
-    or None otherwise.
+    or None otherwise. This handles the partial-message envelope emitted by
+    `claude --output-format stream-json --include-partial-messages`.
     """
     try:
         parsed = json.loads(line)
@@ -69,6 +70,47 @@ def extract_text_delta(line: str) -> str | None:
         return text
 
     return None
+
+
+@pure
+def extract_assistant_text(line: str) -> str | None:
+    """Extract concatenated text from a top-level `assistant` event's content blocks.
+
+    Without `--include-partial-messages`, `claude --output-format stream-json`
+    emits one `{"type":"assistant","message":{"content":[{"type":"text","text":...},...]}}`
+    line per assistant turn. Returns the concatenation of all text blocks, or
+    None if the line is not an `assistant` event with at least one text block.
+    """
+    try:
+        parsed = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        # Expected: non-JSON lines in the stream (see extract_text_delta).
+        return None
+
+    if parsed.get("type") != "assistant":
+        return None
+
+    message = parsed.get("message")
+    if not isinstance(message, dict):
+        return None
+
+    content_blocks = message.get("content")
+    if not isinstance(content_blocks, list):
+        return None
+
+    text_parts: list[str] = []
+    for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            text_parts.append(text)
+
+    if not text_parts:
+        return None
+    return "".join(text_parts)
 
 
 @pure
@@ -112,12 +154,35 @@ class _StreamTailState(MutableModel):
     chars_consumed: int = 0
     line_buffer: str = ""
     result_error: str | None = None
+    # Tracks whether any partial text deltas (from `--include-partial-messages`)
+    # have been yielded during the current assistant turn. Used to avoid
+    # double-emitting text when claude also emits a final `assistant` summary
+    # message containing the same content. Resets at each `assistant` boundary.
+    is_partial_text_yielded_in_turn: bool = False
 
     def _has_new_data_or_finished(self) -> bool:
         current_mtime = self.host.get_file_mtime(self.stdout_path)
         if current_mtime is not None and current_mtime != self.last_mtime:
             return True
         return self.is_finished()
+
+    def _yield_text_for_line(self, stripped: str) -> Iterator[str]:
+        # Partial-message envelope: yield the delta and remember we did so,
+        # so we can suppress the matching `assistant` summary later this turn.
+        partial_text = extract_text_delta(stripped)
+        if partial_text is not None:
+            self.is_partial_text_yielded_in_turn = True
+            yield partial_text
+            return
+
+        # Whole-message envelope: yield only if no partial deltas were already
+        # streamed for this turn, then reset for the next turn.
+        assistant_text = extract_assistant_text(stripped)
+        if assistant_text is None:
+            return
+        if not self.is_partial_text_yielded_in_turn:
+            yield assistant_text
+        self.is_partial_text_yielded_in_turn = False
 
     def tail_until_done(self) -> Iterator[str]:
         got_result = False
@@ -153,9 +218,7 @@ class _StreamTailState(MutableModel):
                         self.result_error = _extract_result_error(stripped)
                         got_result = True
                         break
-                    text = extract_text_delta(stripped)
-                    if text is not None:
-                        yield text
+                    yield from self._yield_text_for_line(stripped)
 
         if not got_result:
             # Final drain after agent exits
@@ -172,9 +235,7 @@ class _StreamTailState(MutableModel):
                     if _is_result_event(stripped):
                         self.result_error = _extract_result_error(stripped)
                         break
-                    text = extract_text_delta(stripped)
-                    if text is not None:
-                        yield text
+                    yield from self._yield_text_for_line(stripped)
 
 
 class NoPermissionsClaudeAgent(ClaudeAgent, NoPermissionsAgentMixin):

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -203,9 +203,15 @@ def _result_error_from_parsed(parsed: dict[str, Any]) -> str | None:
 
     Returns the error message when `parsed` is a `result` event with
     `is_error=true`, None otherwise (including for non-`result` events).
+    Falls back to "unknown error" when the `result` field is missing or
+    not a string, so the declared `str | None` return type is honored
+    even if claude emits a non-string `result` payload.
     """
     if parsed.get("type") == "result" and parsed.get("is_error"):
-        return parsed.get("result", "unknown error")
+        result_value = parsed.get("result")
+        if isinstance(result_value, str):
+            return result_value
+        return "unknown error"
     return None
 
 
@@ -276,7 +282,7 @@ class _StreamTailState(MutableModel):
                 # Other event types (system, user, ping, future event types,
                 # etc.) carry no text to surface here and are intentionally
                 # skipped. Trace-log for debugging when something looks off.
-                logger.trace("Skipped stream-json event of unhandled type {!r}", other_event_type)
+                logger.trace("Skipped stream-json event of type {!r} (no text to surface)", other_event_type)
 
     def _handle_stream_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # message_start (partial stream): begin a new turn. Any deltas for
@@ -302,7 +308,7 @@ class _StreamTailState(MutableModel):
         # outer dispatcher's handling of unknown top-level types.
         event = parsed.get("event")
         inner_event_type = event.get("type") if isinstance(event, dict) else None
-        logger.trace("Skipped stream-json stream_event of unhandled inner type {!r}", inner_event_type)
+        logger.trace("Skipped stream-json stream_event with inner type {!r} (no text to surface)", inner_event_type)
 
     def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # Top-level assistant event: reconcile against the per-turn buffer.

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -196,12 +196,17 @@ def extract_message_start_id(line: str) -> str | None:
 
 
 @pure
-def _is_result_event(line: str) -> bool:
-    """Check if a stream-json line is a result event (signals completion)."""
-    parsed = _parse_stream_line(line)
-    if parsed is None:
-        return False
-    return parsed.get("type") == "result"
+def _result_error_from_parsed(parsed: dict[str, Any]) -> str | None:
+    """Extract error text from an already-parsed stream-json result event.
+
+    Returns the error message when `parsed` is a result event with
+    is_error=true, None otherwise. Caller is responsible for confirming
+    `parsed.get("type") == "result"` if they only want errors from result
+    events; this helper still gates on that internally for safety.
+    """
+    if parsed.get("type") == "result" and parsed.get("is_error"):
+        return parsed.get("result", "unknown error")
+    return None
 
 
 @pure
@@ -213,9 +218,7 @@ def _extract_result_error(line: str) -> str | None:
     parsed = _parse_stream_line(line)
     if parsed is None:
         return None
-    if parsed.get("type") == "result" and parsed.get("is_error"):
-        return parsed.get("result", "unknown error")
-    return None
+    return _result_error_from_parsed(parsed)
 
 
 class _StreamTailState(MutableModel):
@@ -253,15 +256,11 @@ class _StreamTailState(MutableModel):
         self.streaming_message_id = None
         self.yielded_text_in_current_turn = ""
 
-    def _yield_text_for_line(self, stripped: str) -> Iterator[str]:
-        # Parse the line once and dispatch on its `type`, then delegate to
-        # the module-level extract helpers (their dict-accepting variants)
-        # so dict-walking logic lives in one place. The string-accepting
-        # public helpers are thin wrappers around the same dict logic.
-        parsed = _parse_stream_line(stripped)
-        if parsed is None:
-            return
-
+    def _yield_text_for_parsed(self, parsed: dict[str, Any]) -> Iterator[str]:
+        # Dispatch an already-parsed stream-json line on its `type`, then
+        # delegate to the module-level extract helpers (their dict-accepting
+        # variants) so dict-walking logic lives in one place. The string-
+        # accepting public helpers are thin wrappers around the same dict logic.
         event_type = parsed.get("type")
 
         if event_type == "stream_event":
@@ -353,11 +352,14 @@ class _StreamTailState(MutableModel):
                     stripped = line.strip()
                     if not stripped:
                         continue
-                    if _is_result_event(stripped):
-                        self.result_error = _extract_result_error(stripped)
+                    parsed = _parse_stream_line(stripped)
+                    if parsed is None:
+                        continue
+                    if parsed.get("type") == "result":
+                        self.result_error = _result_error_from_parsed(parsed)
                         got_result = True
                         break
-                    yield from self._yield_text_for_line(stripped)
+                    yield from self._yield_text_for_parsed(parsed)
 
         if not got_result:
             # Final drain after agent exits
@@ -371,10 +373,13 @@ class _StreamTailState(MutableModel):
                     stripped = line.strip()
                     if not stripped:
                         continue
-                    if _is_result_event(stripped):
-                        self.result_error = _extract_result_error(stripped)
+                    parsed = _parse_stream_line(stripped)
+                    if parsed is None:
+                        continue
+                    if parsed.get("type") == "result":
+                        self.result_error = _result_error_from_parsed(parsed)
                         break
-                    yield from self._yield_text_for_line(stripped)
+                    yield from self._yield_text_for_parsed(parsed)
 
 
 class NoPermissionsClaudeAgent(ClaudeAgent, NoPermissionsAgentMixin):

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -309,26 +309,28 @@ class _StreamTailState(MutableModel):
                 and assistant_id is not None
                 and assistant_id != self.streaming_message_id
             )
-            # Materialize the per-turn buffer once, here, instead of after every
-            # delta -- this turns an O(N*M) per-turn cost into O(M).
-            yielded_so_far = "".join(self.yielded_text_chunks)
 
             if is_definitely_different_message:
                 # The streamed deltas belonged to a previous message whose summary
-                # never arrived. Yield the full summary for this new message.
+                # never arrived. Yield the full summary for this new message; the
+                # per-turn buffer is irrelevant here so we don't bother joining it.
                 yield assistant_text
-            elif assistant_text.startswith(yielded_so_far):
-                # Summary continues / matches what we already yielded; emit only
-                # the trailing extra text (empty string when they match exactly).
-                trailing_text = assistant_text[len(yielded_so_far) :]
-                if trailing_text:
-                    yield trailing_text
             else:
-                # Buffer is not a prefix of the summary. Either deltas drifted from
-                # the summary or this is a different message we cannot disambiguate
-                # by id. Yield the full summary; better a possible partial double-
-                # emit than dropping the assistant message entirely.
-                yield assistant_text
+                # Materialize the per-turn buffer once, here, instead of after every
+                # delta -- this turns an O(N*M) per-turn cost into O(M).
+                yielded_so_far = "".join(self.yielded_text_chunks)
+                if assistant_text.startswith(yielded_so_far):
+                    # Summary continues / matches what we already yielded; emit only
+                    # the trailing extra text (empty string when they match exactly).
+                    trailing_text = assistant_text[len(yielded_so_far) :]
+                    if trailing_text:
+                        yield trailing_text
+                else:
+                    # Buffer is not a prefix of the summary. Either deltas drifted from
+                    # the summary or this is a different message we cannot disambiguate
+                    # by id. Yield the full summary; better a possible partial double-
+                    # emit than dropping the assistant message entirely.
+                    yield assistant_text
 
         self._reset_turn_state()
 

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -366,6 +366,10 @@ class _StreamTailState(MutableModel):
                 continue
             parsed = _parse_stream_line(stripped)
             if parsed is None:
+                # Non-JSON output that claude leaked to stdout (debug, banners,
+                # warnings) or, more rarely, valid JSON that isn't an object.
+                # Truncate so a runaway line cannot blow up the log.
+                logger.trace("Skipped stream-json line that did not decode to a JSON object: {!r}", stripped[:200])
                 continue
             if parsed.get("type") == "result":
                 self.result_error = _result_error_from_parsed(parsed)

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -235,6 +236,10 @@ class _StreamTailState(MutableModel):
     chars_consumed: int = 0
     line_buffer: str = ""
     result_error: str | None = None
+    # Set to True once a stream-json `result` event has been seen. Once set,
+    # the tail loop stops; further lines (typically there are none) are not
+    # consumed.
+    got_result: bool = False
     # Id of the assistant message currently being streamed via partial deltas
     # (from `--include-partial-messages`'s `message_start` event), if any.
     # Used to correlate deltas with the later top-level `assistant` summary
@@ -327,9 +332,29 @@ class _StreamTailState(MutableModel):
 
         self._reset_turn_state()
 
+    def _yield_text_from_lines(self, lines: Iterable[str]) -> Iterator[str]:
+        """Process already-split stream-json lines, yielding text deltas.
+
+        Skips blank/non-JSON lines, records `result_error` and sets
+        `got_result` when a `result` event is seen (then stops iterating;
+        any lines after a result event are not consumed). Other events are
+        dispatched through `_yield_text_for_parsed` which yields any text.
+        """
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parsed = _parse_stream_line(stripped)
+            if parsed is None:
+                continue
+            if parsed.get("type") == "result":
+                self.result_error = _result_error_from_parsed(parsed)
+                self.got_result = True
+                return
+            yield from self._yield_text_for_parsed(parsed)
+
     def tail_until_done(self) -> Iterator[str]:
-        got_result = False
-        while not got_result and not self.is_finished():
+        while not self.got_result and not self.is_finished():
             poll_until(
                 self._has_new_data_or_finished,
                 timeout=TAIL_POLL_TIMEOUT,
@@ -353,20 +378,9 @@ class _StreamTailState(MutableModel):
                 if not combined.endswith("\n"):
                     self.line_buffer = lines.pop()
 
-                for line in lines:
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    parsed = _parse_stream_line(stripped)
-                    if parsed is None:
-                        continue
-                    if parsed.get("type") == "result":
-                        self.result_error = _result_error_from_parsed(parsed)
-                        got_result = True
-                        break
-                    yield from self._yield_text_for_parsed(parsed)
+                yield from self._yield_text_from_lines(lines)
 
-        if not got_result:
+        if not self.got_result:
             # Final drain after agent exits
             try:
                 content = self.host.read_text_file(self.stdout_path)
@@ -374,17 +388,7 @@ class _StreamTailState(MutableModel):
                 return
             remaining = self.line_buffer + content[self.chars_consumed :]
             if remaining:
-                for line in remaining.split("\n"):
-                    stripped = line.strip()
-                    if not stripped:
-                        continue
-                    parsed = _parse_stream_line(stripped)
-                    if parsed is None:
-                        continue
-                    if parsed.get("type") == "result":
-                        self.result_error = _result_error_from_parsed(parsed)
-                        break
-                    yield from self._yield_text_for_parsed(parsed)
+                yield from self._yield_text_from_lines(remaining.split("\n"))
 
 
 class NoPermissionsClaudeAgent(ClaudeAgent, NoPermissionsAgentMixin):

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -201,10 +201,8 @@ def extract_message_start_id(line: str) -> str | None:
 def _result_error_from_parsed(parsed: dict[str, Any]) -> str | None:
     """Extract error text from an already-parsed stream-json result event.
 
-    Returns the error message when `parsed` is a result event with
-    is_error=true, None otherwise. Caller is responsible for confirming
-    `parsed.get("type") == "result"` if they only want errors from result
-    events; this helper still gates on that internally for safety.
+    Returns the error message when `parsed` is a `result` event with
+    `is_error=true`, None otherwise (including for non-`result` events).
     """
     if parsed.get("type") == "result" and parsed.get("is_error"):
         return parsed.get("result", "unknown error")

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -291,33 +291,35 @@ class _StreamTailState(MutableModel):
 
     def _handle_assistant_event(self, parsed: dict[str, Any]) -> Iterator[str]:
         # Top-level assistant event: reconcile against the per-turn buffer.
+        # An assistant event always ends the current turn (it is the message
+        # summary), so the per-turn state is reset unconditionally on exit --
+        # even when the message has no text (e.g. tool_use-only) and no
+        # reconciliation is needed.
         assistant_text = _extract_assistant_text_from_parsed(parsed)
-        if assistant_text is None:
-            return
+        if assistant_text is not None:
+            assistant_id = _extract_assistant_message_id_from_parsed(parsed)
+            is_definitely_different_message = (
+                self.streaming_message_id is not None
+                and assistant_id is not None
+                and assistant_id != self.streaming_message_id
+            )
 
-        assistant_id = _extract_assistant_message_id_from_parsed(parsed)
-        is_definitely_different_message = (
-            self.streaming_message_id is not None
-            and assistant_id is not None
-            and assistant_id != self.streaming_message_id
-        )
-
-        if is_definitely_different_message:
-            # The streamed deltas belonged to a previous message whose summary
-            # never arrived. Yield the full summary for this new message.
-            yield assistant_text
-        elif assistant_text.startswith(self.yielded_text_in_current_turn):
-            # Summary continues / matches what we already yielded; emit only
-            # the trailing extra text (empty string when they match exactly).
-            trailing_text = assistant_text[len(self.yielded_text_in_current_turn) :]
-            if trailing_text:
-                yield trailing_text
-        else:
-            # Buffer is not a prefix of the summary. Either deltas drifted from
-            # the summary or this is a different message we cannot disambiguate
-            # by id. Yield the full summary; better a possible partial double-
-            # emit than dropping the assistant message entirely.
-            yield assistant_text
+            if is_definitely_different_message:
+                # The streamed deltas belonged to a previous message whose summary
+                # never arrived. Yield the full summary for this new message.
+                yield assistant_text
+            elif assistant_text.startswith(self.yielded_text_in_current_turn):
+                # Summary continues / matches what we already yielded; emit only
+                # the trailing extra text (empty string when they match exactly).
+                trailing_text = assistant_text[len(self.yielded_text_in_current_turn) :]
+                if trailing_text:
+                    yield trailing_text
+            else:
+                # Buffer is not a prefix of the summary. Either deltas drifted from
+                # the summary or this is a different message we cannot disambiguate
+                # by id. Yield the full summary; better a possible partial double-
+                # emit than dropping the assistant message entirely.
+                yield assistant_text
 
         self._reset_turn_state()
 

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py
@@ -299,10 +299,13 @@ class _StreamTailState(MutableModel):
         # Top-level assistant event: reconcile against the per-turn buffer.
         # An assistant event always ends the current turn (it is the message
         # summary), so the per-turn state is reset unconditionally on exit --
-        # even when the message has no text (e.g. tool_use-only) and no
-        # reconciliation is needed.
+        # even when the message has no text (e.g. tool_use-only, or the rare
+        # case of a single empty text block) and no reconciliation is needed.
+        # The truthiness check skips the empty-text case for free, matching
+        # the `if trailing_text:` guard one branch deeper that prevents
+        # yielding an empty string.
         assistant_text = _extract_assistant_text_from_parsed(parsed)
-        if assistant_text is not None:
+        if assistant_text:
             assistant_id = _extract_assistant_message_id_from_parsed(parsed)
             is_definitely_different_message = (
                 self.streaming_message_id is not None

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -951,6 +951,25 @@ def test_extract_assistant_message_id_returns_none_for_non_assistant_event() -> 
     assert extract_assistant_message_id(line) is None
 
 
+def test_extract_assistant_message_id_returns_none_for_malformed_json() -> None:
+    assert extract_assistant_message_id("not valid json {{{") is None
+
+
+def test_extract_assistant_message_id_returns_none_when_message_not_dict() -> None:
+    line = json.dumps({"type": "assistant", "message": "not_a_dict"})
+    assert extract_assistant_message_id(line) is None
+
+
+def test_extract_assistant_message_id_returns_none_when_id_not_string() -> None:
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"id": 42, "role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        }
+    )
+    assert extract_assistant_message_id(line) is None
+
+
 def test_extract_message_start_id_returns_id_for_message_start_event() -> None:
     line = _make_message_start_line("msg_abc")
     assert extract_message_start_id(line) == "msg_abc"
@@ -967,3 +986,28 @@ def test_extract_message_start_id_returns_none_for_top_level_assistant_event() -
 
 def test_extract_message_start_id_returns_none_for_malformed_json() -> None:
     assert extract_message_start_id("not valid json {{{") is None
+
+
+def test_extract_message_start_id_returns_none_when_event_not_dict() -> None:
+    line = json.dumps({"type": "stream_event", "event": "not_a_dict"})
+    assert extract_message_start_id(line) is None
+
+
+def test_extract_message_start_id_returns_none_when_message_not_dict() -> None:
+    line = json.dumps(
+        {
+            "type": "stream_event",
+            "event": {"type": "message_start", "message": "not_a_dict"},
+        }
+    )
+    assert extract_message_start_id(line) is None
+
+
+def test_extract_message_start_id_returns_none_when_id_not_string() -> None:
+    line = json.dumps(
+        {
+            "type": "stream_event",
+            "event": {"type": "message_start", "message": {"id": 42, "role": "assistant"}},
+        }
+    )
+    assert extract_message_start_id(line) is None

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -775,29 +775,28 @@ _TOOL_USE_ONLY_ASSISTANT_EVENT = json.dumps(
     }
 )
 
-# Each entry: (scenario_id, lines, expected_chunks). The scenario_id is the
-# pytest id and serves as the behavioral name; the docstring above the
-# parametrize decorator covers the contract these scenarios collectively
-# describe (the dual-envelope stream_output parser).
-_DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
-    (
+# Each entry is a pytest.param wrapping (lines, expected_chunks) and tagged
+# with a behavioral id. The docstring above the parametrize decorator covers
+# the contract these scenarios collectively describe (the dual-envelope
+# stream_output parser).
+_DUAL_ENVELOPE_SCENARIOS = [
+    pytest.param(
         # Without --include-partial-messages, claude emits only
         # system/assistant/result events (no `stream_event` deltas, as on
         # claude CLI v2.1.114+). The parser must still surface the response.
-        "yields_assistant_envelope_without_partial_messages",
         [
             '{"type":"system","subtype":"init","session_id":"abc"}',
             _make_assistant_message_line("Hello from claude"),
             '{"type":"result","subtype":"success","is_error":false,"result":"Hello from claude"}',
         ],
         ["Hello from claude"],
+        id="yields_assistant_envelope_without_partial_messages",
     ),
-    (
+    pytest.param(
         # With --include-partial-messages, claude emits per-token stream_event
         # deltas AND a final `assistant` summary containing the same text. The
         # parser must yield each token once (from the deltas) and skip the
         # summary so text is not double-emitted.
-        "does_not_double_emit_when_partial_and_assistant_interleave",
         [
             _make_stream_json_line("Hello "),
             _make_stream_json_line("world!"),
@@ -805,13 +804,13 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"Hello world!"}',
         ],
         ["Hello ", "world!"],
+        id="does_not_double_emit_when_partial_and_assistant_interleave",
     ),
-    (
+    pytest.param(
         # A subsequent assistant turn after a fully-streamed turn must still be
         # yielded -- the dedup state resets at each `assistant` boundary. A
         # tool-using session (partial deltas + assistant summary, then a second
         # assistant-only turn) otherwise loses the second turn's text.
-        "yields_assistant_envelopes_across_multiple_turns",
         [
             _make_stream_json_line("first "),
             _make_stream_json_line("answer"),
@@ -820,14 +819,14 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"second answer"}',
         ],
         ["first ", "answer", "second answer"],
+        id="yields_assistant_envelopes_across_multiple_turns",
     ),
-    (
+    pytest.param(
         # When the assistant summary contains text beyond what the deltas
         # yielded, that trailing text is emitted instead of silently dropped.
         # Models the failure mode where partial deltas end early (dropped
         # frame, truncated stream, etc.) and only the final summary carries
         # the full message text.
-        "emits_trailing_text_when_summary_extends_past_deltas",
         [
             _make_message_start_line("msg_a"),
             _make_stream_json_line("Hello "),
@@ -836,14 +835,14 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"Hello world! And then some."}',
         ],
         ["Hello ", "world", "! And then some."],
+        id="emits_trailing_text_when_summary_extends_past_deltas",
     ),
-    (
+    pytest.param(
         # If the partial-stream message_start id does not match the assistant
         # summary id, treat them as separate messages: the deltas are already
         # yielded and the full summary is yielded too, with no dedup attempt.
         # Models a streamed message whose summary was dropped before a new
         # message's summary arrived.
-        "yields_full_summary_when_assistant_id_does_not_match_streaming_id",
         [
             _make_message_start_line("msg_a"),
             _make_stream_json_line("first message body"),
@@ -851,11 +850,11 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"second message body"}',
         ],
         ["first message body", "second message body"],
+        id="yields_full_summary_when_assistant_id_does_not_match_streaming_id",
     ),
-    (
+    pytest.param(
         # A new `message_start` clears per-turn state so the second turn's
         # summary diff is computed against the second turn's deltas only.
-        "message_start_resets_buffer_across_turns",
         [
             _make_message_start_line("msg_a"),
             _make_stream_json_line("first"),
@@ -866,21 +865,22 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"second extra"}',
         ],
         ["first", "second", " extra"],
+        id="message_start_resets_buffer_across_turns",
     ),
-    (
+    pytest.param(
         # If deltas drift from the summary and no id info is available, fall
         # back to yielding the full summary rather than silently dropping it.
         # A possible partial double-emit is preferred over losing the
         # assistant message entirely.
-        "yields_full_summary_when_buffer_is_not_a_prefix",
         [
             _make_stream_json_line("drifted prefix"),
             _make_assistant_message_line("totally different summary text"),
             '{"type":"result","subtype":"success","is_error":false,"result":"totally different summary text"}',
         ],
         ["drifted prefix", "totally different summary text"],
+        id="yields_full_summary_when_buffer_is_not_a_prefix",
     ),
-    (
+    pytest.param(
         # A tool_use-only assistant event must end the current turn's dedup
         # state. Otherwise stale `yielded_text_chunks` from the streamed
         # deltas would dedup the next assistant text event whose id we
@@ -890,7 +890,6 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
         # yielded as-is; the tool_use-only event ends the turn with no text
         # emit AND clears the per-turn buffer; the second assistant event's
         # full text is then yielded.
-        "tool_use_only_assistant_event_ends_turn",
         [
             _make_message_start_line("msg_a"),
             _make_stream_json_line("Hello"),
@@ -899,15 +898,12 @@ _DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
             '{"type":"result","subtype":"success","is_error":false,"result":"Hello there"}',
         ],
         ["Hello", "Hello there"],
+        id="tool_use_only_assistant_event_ends_turn",
     ),
 ]
 
 
-@pytest.mark.parametrize(
-    ("lines", "expected_chunks"),
-    [(lines, expected) for _scenario_id, lines, expected in _DUAL_ENVELOPE_SCENARIOS],
-    ids=[scenario_id for scenario_id, _lines, _expected in _DUAL_ENVELOPE_SCENARIOS],
-)
+@pytest.mark.parametrize(("lines", "expected_chunks"), _DUAL_ENVELOPE_SCENARIOS)
 def test_stream_output_dual_envelope_dispatch(
     local_provider: LocalProviderInstance,
     tmp_path: Path,

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -24,6 +24,7 @@ from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr_claude.headless_claude_agent import HeadlessClaude
 from imbue.mngr_claude.headless_claude_agent import HeadlessClaudeAgentConfig
+from imbue.mngr_claude.headless_claude_agent import extract_assistant_text
 from imbue.mngr_claude.headless_claude_agent import extract_text_delta
 from imbue.mngr_claude.plugin import ClaudeAgent
 
@@ -259,6 +260,23 @@ def _make_stream_json_line(text: str) -> str:
                 "type": "content_block_delta",
                 "index": 0,
                 "delta": {"type": "text_delta", "text": text},
+            },
+        }
+    )
+
+
+def _make_assistant_message_line(text: str) -> str:
+    """Build a stream-json line for a top-level `assistant` event with one text block.
+
+    This is the envelope `claude --output-format stream-json` emits by default
+    (without `--include-partial-messages`) on v2.1.114 and similar versions.
+    """
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": text}],
             },
         }
     )
@@ -643,3 +661,163 @@ def test_extract_text_delta_text_not_string() -> None:
         }
     )
     assert extract_text_delta(event) is None
+
+
+# =============================================================================
+# Tests for extract_assistant_text and dual-envelope stream_output
+# =============================================================================
+
+
+def test_extract_assistant_text_single_text_block() -> None:
+    event = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        }
+    )
+    assert extract_assistant_text(event) == "hello"
+
+
+def test_extract_assistant_text_concatenates_multiple_text_blocks() -> None:
+    event = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Hello "},
+                    {"type": "text", "text": "world!"},
+                ],
+            },
+        }
+    )
+    assert extract_assistant_text(event) == "Hello world!"
+
+
+def test_extract_assistant_text_skips_non_text_blocks() -> None:
+    event = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tu_1", "name": "bash", "input": {}},
+                    {"type": "text", "text": "after tool"},
+                ],
+            },
+        }
+    )
+    assert extract_assistant_text(event) == "after tool"
+
+
+def test_extract_assistant_text_returns_none_when_no_text_blocks() -> None:
+    event = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tu_1", "name": "bash", "input": {}}],
+            },
+        }
+    )
+    assert extract_assistant_text(event) is None
+
+
+def test_extract_assistant_text_returns_none_for_non_assistant_event() -> None:
+    event = json.dumps({"type": "system", "subtype": "init"})
+    assert extract_assistant_text(event) is None
+
+
+def test_extract_assistant_text_returns_none_for_malformed_json() -> None:
+    assert extract_assistant_text("not valid json {{{") is None
+
+
+def test_extract_assistant_text_returns_none_when_message_not_dict() -> None:
+    event = json.dumps({"type": "assistant", "message": "not_a_dict"})
+    assert extract_assistant_text(event) is None
+
+
+def test_extract_assistant_text_returns_none_when_content_not_list() -> None:
+    event = json.dumps({"type": "assistant", "message": {"content": "not_a_list"}})
+    assert extract_assistant_text(event) is None
+
+
+def test_stream_output_yields_assistant_envelope_without_partial_messages(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stream_output should yield text from the default `assistant`-event envelope.
+
+    Reproduces the issue from claude CLI v2.1.114+: without
+    --include-partial-messages, claude emits only system/assistant/result events
+    (no `stream_event` deltas). The parser must still surface the response text.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        '{"type":"system","subtype":"init","session_id":"abc"}',
+        _make_assistant_message_line("Hello from claude"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"Hello from claude"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["Hello from claude"]
+
+
+def test_stream_output_does_not_double_emit_when_partial_and_assistant_interleave(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stream_output must not double-yield text when both envelopes appear in one turn.
+
+    With --include-partial-messages, claude emits per-token stream_event deltas
+    AND a final `assistant` summary message containing the same text. The parser
+    must yield each token once (from the deltas) and skip the summary.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_stream_json_line("Hello "),
+        _make_stream_json_line("world!"),
+        _make_assistant_message_line("Hello world!"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"Hello world!"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["Hello ", "world!"]
+
+
+def test_stream_output_yields_assistant_envelopes_across_multiple_turns(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subsequent assistant turn after a fully-streamed turn should still be yielded.
+
+    Verifies the dedup flag resets at each `assistant` boundary. Otherwise a
+    tool-using session (partial deltas + assistant summary, then a second
+    assistant-only turn) would lose the second turn's text.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_stream_json_line("first "),
+        _make_stream_json_line("answer"),
+        _make_assistant_message_line("first answer"),
+        _make_assistant_message_line("second answer"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"second answer"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["first ", "answer", "second answer"]

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -951,6 +951,55 @@ def test_stream_output_yields_full_summary_when_buffer_is_not_a_prefix(
     assert chunks == ["drifted prefix", "totally different summary text"]
 
 
+def test_stream_output_resets_turn_state_after_tool_use_only_assistant_event(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool_use-only assistant event must end the current turn's dedup state.
+
+    Otherwise, stale `yielded_text_in_current_turn` from the streamed deltas
+    would dedup the next assistant text event whose id we cannot disambiguate
+    -- causing the second message's text to be partially suppressed when it
+    happens to share a prefix with the first message's already-yielded text.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    # tool_use-only assistant event for the same message id as the deltas.
+    # `is_definitely_different_message` is False (same id), so without a
+    # state reset the next assistant text would be diffed against the stale
+    # buffer "Hello" rather than treated as a fresh turn.
+    tool_use_only = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_a",
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tu_1", "name": "bash", "input": {}}],
+            },
+        }
+    )
+    # Second assistant text -- no id provided -- whose text shares the
+    # prefix "Hello" with the prior turn's already-yielded delta.
+    lines = [
+        _make_message_start_line("msg_a"),
+        _make_stream_json_line("Hello"),
+        tool_use_only,
+        _make_assistant_message_line("Hello there"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"Hello there"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    # The streamed delta is yielded as-is. The tool_use-only assistant event
+    # ends the turn with no text emit AND clears the per-turn buffer. The
+    # second assistant event's full text is yielded -- it must NOT be
+    # treated as a continuation of the now-finished prior turn.
+    assert chunks == ["Hello", "Hello there"]
+
+
 def test_extract_assistant_message_id_returns_id_when_present() -> None:
     line = json.dumps(
         {

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -24,7 +24,9 @@ from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr_claude.headless_claude_agent import HeadlessClaude
 from imbue.mngr_claude.headless_claude_agent import HeadlessClaudeAgentConfig
+from imbue.mngr_claude.headless_claude_agent import extract_assistant_message_id
 from imbue.mngr_claude.headless_claude_agent import extract_assistant_text
+from imbue.mngr_claude.headless_claude_agent import extract_message_start_id
 from imbue.mngr_claude.headless_claude_agent import extract_text_delta
 from imbue.mngr_claude.plugin import ClaudeAgent
 
@@ -265,18 +267,34 @@ def _make_stream_json_line(text: str) -> str:
     )
 
 
-def _make_assistant_message_line(text: str) -> str:
+def _make_assistant_message_line(text: str, message_id: str | None = None) -> str:
     """Build a stream-json line for a top-level `assistant` event with one text block.
 
     This is the envelope `claude --output-format stream-json` emits by default
     (without `--include-partial-messages`) on v2.1.114 and similar versions.
     """
+    message: dict[str, object] = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+    }
+    if message_id is not None:
+        message["id"] = message_id
+    return json.dumps({"type": "assistant", "message": message})
+
+
+def _make_message_start_line(message_id: str) -> str:
+    """Build a stream-json `message_start` line carrying a message id.
+
+    With `--include-partial-messages`, claude emits this before the per-token
+    text deltas. The id lets the parser correlate the deltas with a later
+    top-level `assistant` summary that carries the same id.
+    """
     return json.dumps(
         {
-            "type": "assistant",
-            "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": text}],
+            "type": "stream_event",
+            "event": {
+                "type": "message_start",
+                "message": {"id": message_id, "role": "assistant"},
             },
         }
     )
@@ -821,3 +839,156 @@ def test_stream_output_yields_assistant_envelopes_across_multiple_turns(
     chunks = list(agent.stream_output())
 
     assert chunks == ["first ", "answer", "second answer"]
+
+
+def test_stream_output_emits_trailing_text_when_summary_extends_past_deltas(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the assistant summary contains text beyond what the deltas yielded,
+    that trailing text must be emitted instead of silently dropped.
+
+    Reproduces the failure mode where partial deltas end early (dropped frame,
+    truncated stream, etc.) and only the final `assistant` summary carries the
+    full message text.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_message_start_line("msg_a"),
+        _make_stream_json_line("Hello "),
+        _make_stream_json_line("world"),
+        _make_assistant_message_line("Hello world! And then some.", message_id="msg_a"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"Hello world! And then some."}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["Hello ", "world", "! And then some."]
+
+
+def test_stream_output_yields_full_summary_when_assistant_id_does_not_match_streaming_id(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the partial-stream message_start id does not match the assistant
+    summary's id, treat them as separate messages: yield the deltas (already
+    streamed) AND the full summary, with no dedup attempt.
+
+    Covers the failure mode where a streamed message's summary is dropped and
+    a new message's summary arrives instead.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_message_start_line("msg_a"),
+        _make_stream_json_line("first message body"),
+        _make_assistant_message_line("second message body", message_id="msg_b"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"second message body"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["first message body", "second message body"]
+
+
+def test_stream_output_message_start_resets_buffer_across_turns(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new `message_start` must clear per-turn state so the second turn's
+    summary diff is computed against the second turn's deltas only.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_message_start_line("msg_a"),
+        _make_stream_json_line("first"),
+        _make_assistant_message_line("first", message_id="msg_a"),
+        _make_message_start_line("msg_b"),
+        _make_stream_json_line("second"),
+        _make_assistant_message_line("second extra", message_id="msg_b"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"second extra"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["first", "second", " extra"]
+
+
+def test_stream_output_yields_full_summary_when_buffer_is_not_a_prefix(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If deltas drift from the summary and no id info is available, fall back
+    to yielding the full summary rather than silently dropping it.
+
+    A possible partial double-emit is preferred over losing the assistant
+    message entirely.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    lines = [
+        _make_stream_json_line("drifted prefix"),
+        _make_assistant_message_line("totally different summary text"),
+        '{"type":"result","subtype":"success","is_error":false,"result":"totally different summary text"}',
+    ]
+    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
+
+    chunks = list(agent.stream_output())
+
+    assert chunks == ["drifted prefix", "totally different summary text"]
+
+
+def test_extract_assistant_message_id_returns_id_when_present() -> None:
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"id": "msg_xyz", "role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        }
+    )
+    assert extract_assistant_message_id(line) == "msg_xyz"
+
+
+def test_extract_assistant_message_id_returns_none_when_id_missing() -> None:
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        }
+    )
+    assert extract_assistant_message_id(line) is None
+
+
+def test_extract_assistant_message_id_returns_none_for_non_assistant_event() -> None:
+    line = json.dumps({"type": "system", "subtype": "init"})
+    assert extract_assistant_message_id(line) is None
+
+
+def test_extract_message_start_id_returns_id_for_message_start_event() -> None:
+    line = _make_message_start_line("msg_abc")
+    assert extract_message_start_id(line) == "msg_abc"
+
+
+def test_extract_message_start_id_returns_none_for_text_delta_event() -> None:
+    assert extract_message_start_id(_make_stream_json_line("hello")) is None
+
+
+def test_extract_message_start_id_returns_none_for_top_level_assistant_event() -> None:
+    line = _make_assistant_message_line("hi", message_id="msg_abc")
+    assert extract_message_start_id(line) is None
+
+
+def test_extract_message_start_id_returns_none_for_malformed_json() -> None:
+    assert extract_message_start_id("not valid json {{{") is None

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -760,244 +760,174 @@ def test_extract_assistant_text_returns_none_when_content_not_list() -> None:
     assert extract_assistant_text(event) is None
 
 
-def test_stream_output_yields_assistant_envelope_without_partial_messages(
+# A tool_use-only assistant event for the "tool_use_only_assistant_event_ends_turn"
+# scenario. `is_definitely_different_message` is False (same id), so without a
+# state reset the next assistant text would be diffed against the stale buffer
+# "Hello" rather than treated as a fresh turn.
+_TOOL_USE_ONLY_ASSISTANT_EVENT = json.dumps(
+    {
+        "type": "assistant",
+        "message": {
+            "id": "msg_a",
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "tu_1", "name": "bash", "input": {}}],
+        },
+    }
+)
+
+# Each entry: (scenario_id, lines, expected_chunks). The scenario_id is the
+# pytest id and serves as the behavioral name; the docstring above the
+# parametrize decorator covers the contract these scenarios collectively
+# describe (the dual-envelope stream_output parser).
+_DUAL_ENVELOPE_SCENARIOS: list[tuple[str, list[str], list[str]]] = [
+    (
+        # Without --include-partial-messages, claude emits only
+        # system/assistant/result events (no `stream_event` deltas, as on
+        # claude CLI v2.1.114+). The parser must still surface the response.
+        "yields_assistant_envelope_without_partial_messages",
+        [
+            '{"type":"system","subtype":"init","session_id":"abc"}',
+            _make_assistant_message_line("Hello from claude"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"Hello from claude"}',
+        ],
+        ["Hello from claude"],
+    ),
+    (
+        # With --include-partial-messages, claude emits per-token stream_event
+        # deltas AND a final `assistant` summary containing the same text. The
+        # parser must yield each token once (from the deltas) and skip the
+        # summary so text is not double-emitted.
+        "does_not_double_emit_when_partial_and_assistant_interleave",
+        [
+            _make_stream_json_line("Hello "),
+            _make_stream_json_line("world!"),
+            _make_assistant_message_line("Hello world!"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"Hello world!"}',
+        ],
+        ["Hello ", "world!"],
+    ),
+    (
+        # A subsequent assistant turn after a fully-streamed turn must still be
+        # yielded -- the dedup state resets at each `assistant` boundary. A
+        # tool-using session (partial deltas + assistant summary, then a second
+        # assistant-only turn) otherwise loses the second turn's text.
+        "yields_assistant_envelopes_across_multiple_turns",
+        [
+            _make_stream_json_line("first "),
+            _make_stream_json_line("answer"),
+            _make_assistant_message_line("first answer"),
+            _make_assistant_message_line("second answer"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"second answer"}',
+        ],
+        ["first ", "answer", "second answer"],
+    ),
+    (
+        # When the assistant summary contains text beyond what the deltas
+        # yielded, that trailing text is emitted instead of silently dropped.
+        # Models the failure mode where partial deltas end early (dropped
+        # frame, truncated stream, etc.) and only the final summary carries
+        # the full message text.
+        "emits_trailing_text_when_summary_extends_past_deltas",
+        [
+            _make_message_start_line("msg_a"),
+            _make_stream_json_line("Hello "),
+            _make_stream_json_line("world"),
+            _make_assistant_message_line("Hello world! And then some.", message_id="msg_a"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"Hello world! And then some."}',
+        ],
+        ["Hello ", "world", "! And then some."],
+    ),
+    (
+        # If the partial-stream message_start id does not match the assistant
+        # summary id, treat them as separate messages: the deltas are already
+        # yielded and the full summary is yielded too, with no dedup attempt.
+        # Models a streamed message whose summary was dropped before a new
+        # message's summary arrived.
+        "yields_full_summary_when_assistant_id_does_not_match_streaming_id",
+        [
+            _make_message_start_line("msg_a"),
+            _make_stream_json_line("first message body"),
+            _make_assistant_message_line("second message body", message_id="msg_b"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"second message body"}',
+        ],
+        ["first message body", "second message body"],
+    ),
+    (
+        # A new `message_start` clears per-turn state so the second turn's
+        # summary diff is computed against the second turn's deltas only.
+        "message_start_resets_buffer_across_turns",
+        [
+            _make_message_start_line("msg_a"),
+            _make_stream_json_line("first"),
+            _make_assistant_message_line("first", message_id="msg_a"),
+            _make_message_start_line("msg_b"),
+            _make_stream_json_line("second"),
+            _make_assistant_message_line("second extra", message_id="msg_b"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"second extra"}',
+        ],
+        ["first", "second", " extra"],
+    ),
+    (
+        # If deltas drift from the summary and no id info is available, fall
+        # back to yielding the full summary rather than silently dropping it.
+        # A possible partial double-emit is preferred over losing the
+        # assistant message entirely.
+        "yields_full_summary_when_buffer_is_not_a_prefix",
+        [
+            _make_stream_json_line("drifted prefix"),
+            _make_assistant_message_line("totally different summary text"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"totally different summary text"}',
+        ],
+        ["drifted prefix", "totally different summary text"],
+    ),
+    (
+        # A tool_use-only assistant event must end the current turn's dedup
+        # state. Otherwise stale `yielded_text_chunks` from the streamed
+        # deltas would dedup the next assistant text event whose id we
+        # cannot disambiguate -- causing the second message's text to be
+        # partially suppressed when it shares a prefix with the first
+        # message's already-yielded text. Here the streamed "Hello" delta is
+        # yielded as-is; the tool_use-only event ends the turn with no text
+        # emit AND clears the per-turn buffer; the second assistant event's
+        # full text is then yielded.
+        "tool_use_only_assistant_event_ends_turn",
+        [
+            _make_message_start_line("msg_a"),
+            _make_stream_json_line("Hello"),
+            _TOOL_USE_ONLY_ASSISTANT_EVENT,
+            _make_assistant_message_line("Hello there"),
+            '{"type":"result","subtype":"success","is_error":false,"result":"Hello there"}',
+        ],
+        ["Hello", "Hello there"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected_chunks"),
+    [(lines, expected) for _scenario_id, lines, expected in _DUAL_ENVELOPE_SCENARIOS],
+    ids=[scenario_id for scenario_id, _lines, _expected in _DUAL_ENVELOPE_SCENARIOS],
+)
+def test_stream_output_dual_envelope_dispatch(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    lines: list[str],
+    expected_chunks: list[str],
 ) -> None:
-    """stream_output should yield text from the default `assistant`-event envelope.
+    """stream_output correctly dispatches between the partial-stream `stream_event`
+    deltas and the top-level `assistant` summary envelope.
 
-    Reproduces the issue from claude CLI v2.1.114+: without
-    --include-partial-messages, claude emits only system/assistant/result events
-    (no `stream_event` deltas). The parser must still surface the response text.
+    Each parametrized case covers one behavioral contract of the dual-envelope
+    parser. See _DUAL_ENVELOPE_SCENARIOS above for the per-case rationale.
     """
     _patch_agent_as_stopped(monkeypatch)
     agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        '{"type":"system","subtype":"init","session_id":"abc"}',
-        _make_assistant_message_line("Hello from claude"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"Hello from claude"}',
-    ]
     _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
 
     chunks = list(agent.stream_output())
 
-    assert chunks == ["Hello from claude"]
-
-
-def test_stream_output_does_not_double_emit_when_partial_and_assistant_interleave(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """stream_output must not double-yield text when both envelopes appear in one turn.
-
-    With --include-partial-messages, claude emits per-token stream_event deltas
-    AND a final `assistant` summary message containing the same text. The parser
-    must yield each token once (from the deltas) and skip the summary.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_stream_json_line("Hello "),
-        _make_stream_json_line("world!"),
-        _make_assistant_message_line("Hello world!"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"Hello world!"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["Hello ", "world!"]
-
-
-def test_stream_output_yields_assistant_envelopes_across_multiple_turns(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A subsequent assistant turn after a fully-streamed turn should still be yielded.
-
-    Verifies the dedup flag resets at each `assistant` boundary. Otherwise a
-    tool-using session (partial deltas + assistant summary, then a second
-    assistant-only turn) would lose the second turn's text.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_stream_json_line("first "),
-        _make_stream_json_line("answer"),
-        _make_assistant_message_line("first answer"),
-        _make_assistant_message_line("second answer"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"second answer"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["first ", "answer", "second answer"]
-
-
-def test_stream_output_emits_trailing_text_when_summary_extends_past_deltas(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When the assistant summary contains text beyond what the deltas yielded,
-    that trailing text must be emitted instead of silently dropped.
-
-    Reproduces the failure mode where partial deltas end early (dropped frame,
-    truncated stream, etc.) and only the final `assistant` summary carries the
-    full message text.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_message_start_line("msg_a"),
-        _make_stream_json_line("Hello "),
-        _make_stream_json_line("world"),
-        _make_assistant_message_line("Hello world! And then some.", message_id="msg_a"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"Hello world! And then some."}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["Hello ", "world", "! And then some."]
-
-
-def test_stream_output_yields_full_summary_when_assistant_id_does_not_match_streaming_id(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the partial-stream message_start id does not match the assistant
-    summary's id, treat them as separate messages: yield the deltas (already
-    streamed) AND the full summary, with no dedup attempt.
-
-    Covers the failure mode where a streamed message's summary is dropped and
-    a new message's summary arrives instead.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_message_start_line("msg_a"),
-        _make_stream_json_line("first message body"),
-        _make_assistant_message_line("second message body", message_id="msg_b"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"second message body"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["first message body", "second message body"]
-
-
-def test_stream_output_message_start_resets_buffer_across_turns(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A new `message_start` must clear per-turn state so the second turn's
-    summary diff is computed against the second turn's deltas only.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_message_start_line("msg_a"),
-        _make_stream_json_line("first"),
-        _make_assistant_message_line("first", message_id="msg_a"),
-        _make_message_start_line("msg_b"),
-        _make_stream_json_line("second"),
-        _make_assistant_message_line("second extra", message_id="msg_b"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"second extra"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["first", "second", " extra"]
-
-
-def test_stream_output_yields_full_summary_when_buffer_is_not_a_prefix(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If deltas drift from the summary and no id info is available, fall back
-    to yielding the full summary rather than silently dropping it.
-
-    A possible partial double-emit is preferred over losing the assistant
-    message entirely.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    lines = [
-        _make_stream_json_line("drifted prefix"),
-        _make_assistant_message_line("totally different summary text"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"totally different summary text"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    assert chunks == ["drifted prefix", "totally different summary text"]
-
-
-def test_stream_output_resets_turn_state_after_tool_use_only_assistant_event(
-    local_provider: LocalProviderInstance,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A tool_use-only assistant event must end the current turn's dedup state.
-
-    Otherwise, stale `yielded_text_chunks` from the streamed deltas would
-    dedup the next assistant text event whose id we cannot disambiguate --
-    causing the second message's text to be partially suppressed when it
-    happens to share a prefix with the first message's already-yielded text.
-    """
-    _patch_agent_as_stopped(monkeypatch)
-    agent, host = _make_headless_agent(local_provider, tmp_path)
-
-    # tool_use-only assistant event for the same message id as the deltas.
-    # `is_definitely_different_message` is False (same id), so without a
-    # state reset the next assistant text would be diffed against the stale
-    # buffer "Hello" rather than treated as a fresh turn.
-    tool_use_only = json.dumps(
-        {
-            "type": "assistant",
-            "message": {
-                "id": "msg_a",
-                "role": "assistant",
-                "content": [{"type": "tool_use", "id": "tu_1", "name": "bash", "input": {}}],
-            },
-        }
-    )
-    # Second assistant text -- no id provided -- whose text shares the
-    # prefix "Hello" with the prior turn's already-yielded delta.
-    lines = [
-        _make_message_start_line("msg_a"),
-        _make_stream_json_line("Hello"),
-        tool_use_only,
-        _make_assistant_message_line("Hello there"),
-        '{"type":"result","subtype":"success","is_error":false,"result":"Hello there"}',
-    ]
-    _write_fake_agent_output(host, agent, stdout="\n".join(lines) + "\n")
-
-    chunks = list(agent.stream_output())
-
-    # The streamed delta is yielded as-is. The tool_use-only assistant event
-    # ends the turn with no text emit AND clears the per-turn buffer. The
-    # second assistant event's full text is yielded -- it must NOT be
-    # treated as a continuation of the now-finished prior turn.
-    assert chunks == ["Hello", "Hello there"]
+    assert chunks == expected_chunks
 
 
 def test_extract_assistant_message_id_returns_id_when_present() -> None:

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -380,6 +380,31 @@ def test_stream_output_raises_with_stream_json_error_result(
         list(agent.stream_output())
 
 
+def test_stream_output_handles_non_string_result_error_payload(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stream_output should fall back to 'unknown error' when `result` is non-string.
+
+    Defensive: claude's API contract says `result` is a string for error
+    results, but if a future version emits null / a number / a structured
+    object, we honor the declared str | None return type rather than
+    leaking a non-string into the error path.
+    """
+    _patch_agent_as_stopped(monkeypatch)
+    agent, host = _make_headless_agent(local_provider, tmp_path)
+
+    _write_fake_agent_output(
+        host,
+        agent,
+        stdout='{"type":"result","subtype":"success","is_error":true,"result":null}\n',
+    )
+
+    with pytest.raises(MngrError, match="unknown error"):
+        list(agent.stream_output())
+
+
 def test_stream_output_raises_error_result_even_after_yielding_text(
     local_provider: LocalProviderInstance,
     tmp_path: Path,

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -958,9 +958,9 @@ def test_stream_output_resets_turn_state_after_tool_use_only_assistant_event(
 ) -> None:
     """A tool_use-only assistant event must end the current turn's dedup state.
 
-    Otherwise, stale `yielded_text_in_current_turn` from the streamed deltas
-    would dedup the next assistant text event whose id we cannot disambiguate
-    -- causing the second message's text to be partially suppressed when it
+    Otherwise, stale `yielded_text_chunks` from the streamed deltas would
+    dedup the next assistant text event whose id we cannot disambiguate --
+    causing the second message's text to be partially suppressed when it
     happens to share a prefix with the first message's already-yielded text.
     """
     _patch_agent_as_stopped(monkeypatch)


### PR DESCRIPTION
## Summary

- `claude --output-format stream-json` emits a different envelope by default in current versions (v2.1.114+): a top-level `{"type":"assistant","message":{"content":[{"type":"text","text":...}]}}` per turn, not the `{"type":"stream_event", "event":{"type":"content_block_delta", ...}}` wrapper. The previous parser only recognized the latter, so successful runs surfaced as `claude exited without producing output`.
- Adds `extract_assistant_text` alongside the existing `extract_text_delta` and routes both envelopes through a per-turn dedup flag on `_StreamTailState` so a final `assistant` summary after partial deltas does not double-emit.
- Keeps the `result` event completion / error path untouched. Both `mngr ask` (which hardcodes `--include-partial-messages`) and bare `mngr create ... headless_claude` invocations now work.

## Test plan

- [x] `just test-quick "libs/mngr_claude -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 411 passed
- [x] Unit tests for the new envelope (assistant-only) and the dedup guard (interleaved partial + assistant; multiple assistant turns)
- [ ] CI

Closes #1411

Generated with [Claude Code](https://claude.com/claude-code)