### PR TITLE
rename MNGR_PROJECT_DIR -> MNGR_PROJECT_CONFIG_DIR

### DIFF
--- a/libs/mngr/docs/concepts/environment_variables.md
+++ b/libs/mngr/docs/concepts/environment_variables.md
@@ -32,7 +32,7 @@ Changing those variables after creating a host is not supported.
 
 Additionally, the following variable controls where project-level config files are loaded from:
 
-- `MNGR_PROJECT_DIR` - Directory containing project-level config files (`settings.toml` and `settings.local.toml`). When set, overrides the default `.{root_name}/` directory at the git root. This only affects where project settings are loaded from; it does not affect `MNGR_HOST_DIR`. Unlike the variables above, this can be changed freely at any time.
+- `MNGR_PROJECT_CONFIG_DIR` - Directory containing project-level config files (`settings.toml` and `settings.local.toml`). When set, overrides the default `.{root_name}/` directory at the git root. This only affects where project settings are loaded from; it does not affect `MNGR_HOST_DIR`. Unlike the variables above, this can be changed freely at any time.
 
 ## Command-Specific Variables
 

--- a/libs/mngr/docs/customization.md
+++ b/libs/mngr/docs/customization.md
@@ -7,8 +7,8 @@
 `mngr` loads configuration from multiple sources with the following precedence (lowest to highest):
 
 1. User config: `~/.mngr/profiles/<profile_id>/settings.toml`
-2. Project config: `.mngr/settings.toml` (at git root, context dir, or `MNGR_PROJECT_DIR`)
-3. Local config: `.mngr/settings.local.toml` (at git root, context dir, or `MNGR_PROJECT_DIR`)
+2. Project config: `.mngr/settings.toml` (at git root, context dir, or `MNGR_PROJECT_CONFIG_DIR`)
+3. Local config: `.mngr/settings.local.toml` (at git root, context dir, or `MNGR_PROJECT_CONFIG_DIR`)
 4. Environment variables: `MNGR_PREFIX`, `MNGR_HOST_DIR`, `MNGR_ROOT_NAME`
 5. CLI arguments (highest precedence)
 

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -1075,7 +1075,7 @@ def test_disable_plugin_in_command_defaults_blocks_override_hook(
         [],
         obj=pm,
         catch_exceptions=False,
-        env={"MNGR_PROJECT_DIR": str(tmp_path)},
+        env={"MNGR_PROJECT_CONFIG_DIR": str(tmp_path)},
     )
     assert result.exit_code == 0
     assert len(captured_params) == 1

--- a/libs/mngr/imbue/mngr/cli/test_create.py
+++ b/libs/mngr/imbue/mngr/cli/test_create.py
@@ -789,7 +789,7 @@ ensure_clean = false
             ],
             obj=plugin_manager,
             catch_exceptions=False,
-            env={"MNGR_PROJECT_DIR": str(mngr_dir)},
+            env={"MNGR_PROJECT_CONFIG_DIR": str(mngr_dir)},
         )
 
         assert result.exit_code == 0, f"CLI failed with: {result.output}"
@@ -847,7 +847,7 @@ ensure_clean = false
             ],
             obj=plugin_manager,
             catch_exceptions=False,
-            env={"MNGR_PROJECT_DIR": str(mngr_dir)},
+            env={"MNGR_PROJECT_CONFIG_DIR": str(mngr_dir)},
         )
 
         assert result.exit_code == 0, f"CLI failed with: {result.output}"
@@ -905,7 +905,7 @@ ensure_clean = false
             "130006",
         ],
         obj=plugin_manager,
-        env={"MNGR_PROJECT_DIR": str(mngr_dir)},
+        env={"MNGR_PROJECT_CONFIG_DIR": str(mngr_dir)},
     )
 
     assert result.exit_code != 0

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -75,8 +75,8 @@ def load_config(
 
     Precedence (lowest to highest):
     1. User config (~/.{root_name}/profiles/<profile_id>/settings.toml)
-    2. Project config (.{root_name}/settings.toml at context_dir, git root, or MNGR_PROJECT_DIR)
-    3. Local config (.{root_name}/settings.local.toml at context_dir, git root, or MNGR_PROJECT_DIR)
+    2. Project config (.{root_name}/settings.toml at context_dir, git root, or MNGR_PROJECT_CONFIG_DIR)
+    3. Local config (.{root_name}/settings.local.toml at context_dir, git root, or MNGR_PROJECT_CONFIG_DIR)
     4. Environment variables (MNGR_ROOT_NAME, MNGR_PREFIX, MNGR_HOST_DIR)
     5. CLI arguments (handled by caller)
 
@@ -86,7 +86,7 @@ def load_config(
 
     Explicit MNGR_PREFIX/MNGR_HOST_DIR values override MNGR_ROOT_NAME-derived defaults.
 
-    MNGR_PROJECT_DIR overrides where project settings are found. When set, project
+    MNGR_PROJECT_CONFIG_DIR overrides where project settings are found. When set, project
     and local config files are loaded from that directory instead of .{root_name}/
     at the git root.
 
@@ -237,7 +237,7 @@ def load_config(
         # pytest -- that's the actual leak-prevention gate.
 
     # Resolve project root for use as cwd in pre-command scripts.
-    # Note: MNGR_PROJECT_DIR is NOT used here because it points to the config
+    # Note: MNGR_PROJECT_CONFIG_DIR is NOT used here because it points to the config
     # directory (containing settings.toml), not the project root.
     project_root = context_dir or find_git_worktree_root(start=None, cg=concurrency_group)
 

--- a/libs/mngr/imbue/mngr/config/pre_readers.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers.py
@@ -76,11 +76,11 @@ def resolve_project_config_dir(
 ) -> Path | None:
     """Resolve the project config directory.
 
-    If MNGR_PROJECT_DIR is set, returns that path directly.
+    If MNGR_PROJECT_CONFIG_DIR is set, returns that path directly.
     Otherwise, returns <git_root>/.<root_name>/ (the default behavior).
-    Returns None if no project root can be determined and MNGR_PROJECT_DIR is not set.
+    Returns None if no project root can be determined and MNGR_PROJECT_CONFIG_DIR is not set.
     """
-    env_project_dir = os.environ.get("MNGR_PROJECT_DIR")
+    env_project_dir = os.environ.get("MNGR_PROJECT_CONFIG_DIR")
     if env_project_dir:
         return Path(env_project_dir)
     root = context_dir or _find_project_root(cg=cg)

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -264,7 +264,7 @@ def test_load_project_config_uses_mngr_project_config_dir(
     assert result["prefix"] == "custom-"
 
 
-def test_load_local_config_uses_mngr_project_dir(
+def test_load_local_config_uses_mngr_project_config_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     cg: ConcurrencyGroup,

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -189,10 +189,10 @@ def test_resolve_project_config_dir_uses_env_var_when_set(
     temp_git_repo_cwd: Path,
     cg: ConcurrencyGroup,
 ) -> None:
-    """resolve_project_config_dir should use MNGR_PROJECT_DIR when set."""
+    """resolve_project_config_dir should use MNGR_PROJECT_CONFIG_DIR when set."""
     custom_dir = tmp_path / "custom_project_config"
     custom_dir.mkdir()
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
 
     result = resolve_project_config_dir(None, "mngr", cg)
     assert result == custom_dir
@@ -204,8 +204,8 @@ def test_resolve_project_config_dir_falls_back_to_git_root_when_env_var_not_set(
     mngr_test_root_name: str,
     cg: ConcurrencyGroup,
 ) -> None:
-    """resolve_project_config_dir should use <git_root>/.<root_name> when MNGR_PROJECT_DIR is not set."""
-    monkeypatch.delenv("MNGR_PROJECT_DIR", raising=False)
+    """resolve_project_config_dir should use <git_root>/.<root_name> when MNGR_PROJECT_CONFIG_DIR is not set."""
+    monkeypatch.delenv("MNGR_PROJECT_CONFIG_DIR", raising=False)
 
     result = resolve_project_config_dir(None, mngr_test_root_name, cg)
     assert result == temp_git_repo_cwd / f".{mngr_test_root_name}"
@@ -217,8 +217,8 @@ def test_resolve_project_config_dir_context_dir_overrides_git_root(
     mngr_test_root_name: str,
     cg: ConcurrencyGroup,
 ) -> None:
-    """resolve_project_config_dir should use context_dir when provided and MNGR_PROJECT_DIR is not set."""
-    monkeypatch.delenv("MNGR_PROJECT_DIR", raising=False)
+    """resolve_project_config_dir should use context_dir when provided and MNGR_PROJECT_CONFIG_DIR is not set."""
+    monkeypatch.delenv("MNGR_PROJECT_CONFIG_DIR", raising=False)
     context_dir = tmp_path / "context"
     context_dir.mkdir()
 
@@ -232,19 +232,19 @@ def test_resolve_project_config_dir_env_var_takes_precedence_over_context_dir(
     mngr_test_root_name: str,
     cg: ConcurrencyGroup,
 ) -> None:
-    """resolve_project_config_dir should prefer MNGR_PROJECT_DIR over context_dir."""
+    """resolve_project_config_dir should prefer MNGR_PROJECT_CONFIG_DIR over context_dir."""
     custom_dir = tmp_path / "custom"
     custom_dir.mkdir()
     context_dir = tmp_path / "context"
     context_dir.mkdir()
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
 
     result = resolve_project_config_dir(context_dir, mngr_test_root_name, cg)
     assert result == custom_dir
 
 
 # =============================================================================
-# Tests for MNGR_PROJECT_DIR affecting config loading
+# Tests for MNGR_PROJECT_CONFIG_DIR affecting config loading
 # =============================================================================
 
 
@@ -253,11 +253,11 @@ def test_load_project_config_uses_mngr_project_dir(
     tmp_path: Path,
     cg: ConcurrencyGroup,
 ) -> None:
-    """load_project_config should load settings.toml from MNGR_PROJECT_DIR when set."""
+    """load_project_config should load settings.toml from MNGR_PROJECT_CONFIG_DIR when set."""
     custom_dir = tmp_path / "custom_project"
     custom_dir.mkdir()
     (custom_dir / "settings.toml").write_text('prefix = "custom-"\n')
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
 
     result = load_project_config(None, "mngr", cg)
     assert result is not None
@@ -269,11 +269,11 @@ def test_load_local_config_uses_mngr_project_dir(
     tmp_path: Path,
     cg: ConcurrencyGroup,
 ) -> None:
-    """load_local_config should load settings.local.toml from MNGR_PROJECT_DIR when set."""
+    """load_local_config should load settings.local.toml from MNGR_PROJECT_CONFIG_DIR when set."""
     custom_dir = tmp_path / "custom_project"
     custom_dir.mkdir()
     (custom_dir / "settings.local.toml").write_text('prefix = "local-custom-"\n')
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
 
     result = load_local_config(None, "mngr", cg)
     assert result is not None
@@ -284,11 +284,11 @@ def test_read_default_command_uses_mngr_project_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """read_default_command should find config from MNGR_PROJECT_DIR."""
+    """read_default_command should find config from MNGR_PROJECT_CONFIG_DIR."""
     custom_dir = tmp_path / "custom_project"
     custom_dir.mkdir()
     (custom_dir / "settings.toml").write_text('[commands.mngr]\ndefault_subcommand = "create"\n')
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
     monkeypatch.setenv("MNGR_HOST_DIR", str(tmp_path / "nonexistent"))
 
     assert read_default_command("mngr") == "create"
@@ -298,11 +298,11 @@ def test_read_disabled_plugins_uses_mngr_project_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """read_disabled_plugins should find config from MNGR_PROJECT_DIR."""
+    """read_disabled_plugins should find config from MNGR_PROJECT_CONFIG_DIR."""
     custom_dir = tmp_path / "custom_project"
     custom_dir.mkdir()
     (custom_dir / "settings.toml").write_text("[plugins.modal]\nenabled = false\n")
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(custom_dir))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(custom_dir))
     monkeypatch.setenv("MNGR_HOST_DIR", str(tmp_path / "nonexistent"))
 
     assert "modal" in read_disabled_plugins()

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -294,7 +294,7 @@ def test_read_default_command_uses_mngr_project_config_dir(
     assert read_default_command("mngr") == "create"
 
 
-def test_read_disabled_plugins_uses_mngr_project_dir(
+def test_read_disabled_plugins_uses_mngr_project_config_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -248,7 +248,7 @@ def test_resolve_project_config_dir_env_var_takes_precedence_over_context_dir(
 # =============================================================================
 
 
-def test_load_project_config_uses_mngr_project_dir(
+def test_load_project_config_uses_mngr_project_config_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     cg: ConcurrencyGroup,

--- a/libs/mngr/imbue/mngr/config/pre_readers_test.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers_test.py
@@ -280,7 +280,7 @@ def test_load_local_config_uses_mngr_project_config_dir(
     assert result["prefix"] == "local-custom-"
 
 
-def test_read_default_command_uses_mngr_project_dir(
+def test_read_default_command_uses_mngr_project_config_dir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:

--- a/libs/mngr/imbue/mngr/utils/testing.py
+++ b/libs/mngr/imbue/mngr/utils/testing.py
@@ -276,7 +276,7 @@ def setup_mngr_test_environment(
     monkeypatch.setenv("MNGR_HOST_DIR", str(host_dir))
     monkeypatch.setenv("MNGR_PREFIX", prefix)
     monkeypatch.setenv("MNGR_ROOT_NAME", root_name)
-    monkeypatch.delenv("MNGR_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("MNGR_PROJECT_CONFIG_DIR", raising=False)
 
     # Unison derives its config directory from $HOME. Since we override HOME
     # above, unison tries to create its config dir inside the temp home, which


### PR DESCRIPTION
## Summary
- Rename `MNGR_PROJECT_DIR` to `MNGR_PROJECT_CONFIG_DIR` to reflect that it points to the project *config* directory (containing `settings.toml`), not the project root itself.
- Updated across config loader, pre-readers, tests, and docs.

Closes #1038

## Test plan
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (3627 passed)
- [ ] CI offload (acceptance/release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)