### PR TITLE
fix ssh bug + document cel filter fields for mngr list

### DIFF
--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -27,8 +27,8 @@ mngr list [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--include` | text | Include agents matching CEL expression (repeatable) | None |
-| `--exclude` | text | Exclude agents matching CEL expression (repeatable) | None |
+| `--include` | text | Include agents matching CEL expression, repeatable (e.g. 'state == "RUNNING"'); see 'Available Fields' below | None |
+| `--exclude` | text | Exclude agents matching CEL expression, repeatable (e.g. 'host.provider == "local"'); see 'Available Fields' below | None |
 | `--running` | boolean | Show only running agents (alias for --include 'state == "RUNNING"') | `False` |
 | `--stopped` | boolean | Show only stopped agents (alias for --include 'state == "STOPPED"') | `False` |
 | `--archived` | boolean | Show only stopped agents (alias for --include 'has(labels.archived_at)') | `False` |
@@ -116,7 +116,12 @@ All agent fields from the "Available Fields" section can be used in filter expre
 
 ## Available Fields
 
-**Agent fields** (same syntax for `--fields` and CEL filters):
+The fields below can be used in three places, with the same names everywhere:
+- CEL expressions for `--include`/`--exclude` (filtering)
+- CEL expressions for `--sort` (ordering)
+- `--fields` and `--format` template strings (selecting and formatting displayed data)
+
+**Agent fields:**
 - `name` - Agent name
 - `id` - Agent ID
 - `type` - Agent type (claude, codex, etc.)
@@ -129,7 +134,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active
+- `idle_seconds` - How long since the agent was active (as reported by the agent)
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection
@@ -139,10 +144,15 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - `labels.$KEY` - Specific label value (e.g., `labels.project`)
 - `plugin.$PLUGIN_NAME.*` - Plugin-defined fields (e.g., `plugin.chat_history.messages`)
 
-**Host fields** (dot notation for both `--fields` and CEL filters):
+**Computed fields** (derived from other fields, available in CEL filters and `--sort`):
+- `age` - Seconds since `create_time`
+- `runtime` - Alias for `runtime_seconds`
+- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+
+**Host fields** (dot notation):
 - `host.name` - Host name
 - `host.id` - Host ID
-- `host.provider_name` - Host provider (local, docker, modal, etc.) (in CEL filters, use `host.provider`)
+- `host.provider` - Host provider (local, docker, modal, etc.); also accessible as `host.provider_name`
 - `host.state` - Current host state (RUNNING, STOPPED, BUILDING, etc.)
 - `host.image` - Host image (Docker image name, Modal image ID, etc.)
 - `host.tags` - Host labels (metadata key-value pairs)

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -147,7 +147,7 @@ The fields below can be used in three places, with the same names everywhere:
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -136,7 +136,7 @@ Each subsection notes where its fields are available; agent and host fields work
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active (also factors in host SSH activity)
+- `idle_seconds` - How long since the agent was active
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -27,8 +27,8 @@ mngr list [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--include` | text | Include agents matching CEL expression, repeatable (e.g. 'state == "RUNNING"'); see 'Available Fields' below | None |
-| `--exclude` | text | Exclude agents matching CEL expression, repeatable (e.g. 'host.provider == "local"'); see 'Available Fields' below | None |
+| `--include` | text | Include agents matching CEL expression (repeatable) | None |
+| `--exclude` | text | Exclude agents matching CEL expression (repeatable) | None |
 | `--running` | boolean | Show only running agents (alias for --include 'state == "RUNNING"') | `False` |
 | `--stopped` | boolean | Show only stopped agents (alias for --include 'state == "STOPPED"') | `False` |
 | `--archived` | boolean | Show only stopped agents (alias for --include 'has(labels.archived_at)') | `False` |

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -116,10 +116,12 @@ All agent fields from the "Available Fields" section can be used in filter expre
 
 ## Available Fields
 
-The fields below can be used in three places, with the same names everywhere:
+The fields below use the same names across the three places they can appear:
 - CEL expressions for `--include`/`--exclude` (filtering)
 - CEL expressions for `--sort` (ordering)
 - `--fields` and `--format` template strings (selecting and formatting displayed data)
+
+Each subsection notes where its fields are available; agent and host fields work in all three contexts, while computed fields are only available in the CEL contexts.
 
 **Agent fields:**
 - `name` - Agent name

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -147,7 +147,7 @@ The fields below can be used in three places, with the same names everywhere:
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which also factors in host SSH activity)
+- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -134,7 +134,7 @@ The fields below can be used in three places, with the same names everywhere:
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active (as reported by the agent)
+- `idle_seconds` - How long since the agent was active (also factors in host SSH activity)
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection
@@ -147,7 +147,7 @@ The fields below can be used in three places, with the same names everywhere:
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which also factors in host SSH activity)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -485,7 +485,6 @@ def agent_details_to_cel_context(agent: AgentDetails) -> dict[str, Any]:
         result["runtime"] = result["runtime_seconds"]
 
     # Add idle: seconds since the most recent activity across user, agent, and host SSH.
-    # ssh_activity_time lives on the host, not at the top level of the agent dict.
     host_dict = result["host"] if isinstance(result.get("host"), dict) else None
     activity_candidates = [
         result.get("user_activity_time"),

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -507,10 +507,8 @@ def agent_details_to_cel_context(agent: AgentDetails) -> dict[str, Any]:
 
     # Expose host.provider_name as host.provider too, so CEL filters can use either name
     # (host.provider is the documented short form; host.provider_name matches the data type)
-    if result.get("host") and isinstance(result["host"], dict):
-        host = result["host"]
-        if "provider_name" in host:
-            host["provider"] = host["provider_name"]
+    if host_dict is not None and "provider_name" in host_dict:
+        host_dict["provider"] = host_dict["provider_name"]
 
     return result
 

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -484,20 +484,26 @@ def agent_details_to_cel_context(agent: AgentDetails) -> dict[str, Any]:
     if result.get("runtime_seconds") is not None:
         result["runtime"] = result["runtime_seconds"]
 
-    # Add idle_seconds if available (computed from activity times)
-    if result.get("user_activity_time") or result.get("agent_activity_time"):
-        latest_activity = None
-        for activity_field in ["user_activity_time", "agent_activity_time", "ssh_activity_time"]:
-            activity_time = result.get(activity_field)
-            if activity_time:
-                if isinstance(activity_time, str):
-                    activity_dt = datetime.fromisoformat(activity_time.replace("Z", "+00:00"))
-                else:
-                    activity_dt = activity_time
-                if latest_activity is None or activity_dt > latest_activity:
-                    latest_activity = activity_dt
-        if latest_activity:
-            result["idle"] = (datetime.now(timezone.utc) - latest_activity).total_seconds()
+    # Add idle: seconds since the most recent activity across user, agent, and host SSH.
+    # ssh_activity_time lives on the host, not at the top level of the agent dict.
+    host_dict = result["host"] if isinstance(result.get("host"), dict) else None
+    activity_candidates = [
+        result.get("user_activity_time"),
+        result.get("agent_activity_time"),
+        host_dict.get("ssh_activity_time") if host_dict else None,
+    ]
+    latest_activity = None
+    for activity_time in activity_candidates:
+        if not activity_time:
+            continue
+        if isinstance(activity_time, str):
+            activity_dt = datetime.fromisoformat(activity_time.replace("Z", "+00:00"))
+        else:
+            activity_dt = activity_time
+        if latest_activity is None or activity_dt > latest_activity:
+            latest_activity = activity_dt
+    if latest_activity:
+        result["idle"] = (datetime.now(timezone.utc) - latest_activity).total_seconds()
 
     # Expose host.provider_name as host.provider too, so CEL filters can use either name
     # (host.provider is the documented short form; host.provider_name matches the data type)

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -499,11 +499,12 @@ def agent_details_to_cel_context(agent: AgentDetails) -> dict[str, Any]:
         if latest_activity:
             result["idle"] = (datetime.now(timezone.utc) - latest_activity).total_seconds()
 
-    # Normalize host.provider_name to host.provider for consistency
+    # Expose host.provider_name as host.provider too, so CEL filters can use either name
+    # (host.provider is the documented short form; host.provider_name matches the data type)
     if result.get("host") and isinstance(result["host"], dict):
         host = result["host"]
         if "provider_name" in host:
-            host["provider"] = host.pop("provider_name")
+            host["provider"] = host["provider_name"]
 
     return result
 

--- a/libs/mngr/imbue/mngr/api/list_test.py
+++ b/libs/mngr/imbue/mngr/api/list_test.py
@@ -369,8 +369,12 @@ def test_agent_details_to_cel_context_computes_idle() -> None:
     assert context["idle"] < 320
 
 
-def test_agent_details_to_cel_context_normalizes_host_provider() -> None:
-    """agent_details_to_cel_context should rename host.provider_name to host.provider."""
+def test_agent_details_to_cel_context_exposes_host_provider_under_both_names() -> None:
+    """agent_details_to_cel_context exposes host.provider_name as host.provider too.
+
+    Both names must work in CEL filters and templates so users do not have to remember
+    which form the implementation chose.
+    """
     host_details = HostDetails(
         id=HostId.generate(),
         name="test-host",
@@ -381,9 +385,8 @@ def test_agent_details_to_cel_context_normalizes_host_provider() -> None:
 
     assert "host" in context
     host = context["host"]
-    assert "provider" in host
-    assert "provider_name" not in host
     assert host["provider"] == "modal"
+    assert host["provider_name"] == "modal"
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/api/list_test.py
+++ b/libs/mngr/imbue/mngr/api/list_test.py
@@ -39,7 +39,9 @@ from imbue.mngr.errors import MngrError
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.data_types import CertifiedHostData
+from imbue.mngr.interfaces.data_types import CpuResources
 from imbue.mngr.interfaces.data_types import HostDetails
+from imbue.mngr.interfaces.data_types import HostResources
 from imbue.mngr.interfaces.host import CreateAgentOptions
 from imbue.mngr.interfaces.provider_backend import ProviderBackendInterface
 from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
@@ -53,6 +55,8 @@ from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
+from imbue.mngr.primitives import HostState
+from imbue.mngr.primitives import IdleMode
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SSHInfo
@@ -367,6 +371,148 @@ def test_agent_details_to_cel_context_computes_idle() -> None:
     # Idle should be approximately 300 seconds (5 minutes)
     assert context["idle"] > 280
     assert context["idle"] < 320
+
+
+def test_agent_details_to_cel_context_preserves_full_model_structure() -> None:
+    """Regression test: every AgentDetails / HostDetails field must be reachable at its
+    declared nesting in the CEL context.
+
+    Catches the class of bug where computed-field code or normalization reads a field at the
+    wrong level of the dict (e.g. ``result.get("ssh_activity_time")`` instead of
+    ``result["host"]["ssh_activity_time"]``). If a future change drops a field, hoists a
+    nested field to the top level, or buries a top-level field, this test fails.
+    """
+    now = datetime.now(timezone.utc)
+    host_details = HostDetails(
+        id=HostId.generate(),
+        name="full-host",
+        provider_name=ProviderInstanceName("modal"),
+        state=HostState.RUNNING,
+        image="my-image",
+        tags={"env": "prod"},
+        boot_time=now - timedelta(hours=2),
+        uptime_seconds=7200.0,
+        resource=HostResources(cpu=CpuResources(count=4), memory_gb=8.0),
+        ssh=SSHInfo(
+            host="example.com",
+            port=22,
+            user="root",
+            key_path=Path("/key"),
+            command="ssh -i /key -p 22 root@example.com",
+        ),
+        snapshots=[],
+        is_locked=False,
+        locked_time=None,
+        plugin={"some_plugin": {"k": "v"}},
+        ssh_activity_time=now - timedelta(minutes=1),
+        failure_reason=None,
+    )
+    agent = AgentDetails(
+        id=AgentId.generate(),
+        name=AgentName("full-agent"),
+        type="claude",
+        command=CommandString("sleep 100"),
+        work_dir=Path("/work"),
+        initial_branch="mngr/full-agent",
+        create_time=now - timedelta(minutes=10),
+        start_on_boot=True,
+        state=AgentLifecycleState.RUNNING,
+        url="http://example.com",
+        start_time=now - timedelta(minutes=9),
+        runtime_seconds=540.0,
+        user_activity_time=now - timedelta(minutes=8),
+        agent_activity_time=now - timedelta(minutes=7),
+        idle_seconds=420.0,
+        idle_mode=IdleMode.IO.value,
+        idle_timeout_seconds=600,
+        activity_sources=("user", "agent"),
+        labels={"project": "mngr"},
+        host=host_details,
+        plugin={"chat_history": {"messages": []}},
+    )
+    context = agent_details_to_cel_context(agent)
+
+    # Every declared AgentDetails field must appear at the top level of the context.
+    for field_name in AgentDetails.model_fields:
+        assert field_name in context, f"AgentDetails field {field_name!r} missing from CEL context"
+
+    # Every declared HostDetails field must appear under context["host"].
+    assert "host" in context and isinstance(context["host"], dict)
+    for field_name in HostDetails.model_fields:
+        assert field_name in context["host"], f"HostDetails field {field_name!r} missing from CEL context['host']"
+
+    # Host-only fields must not be silently hoisted to the top level. This catches the bug
+    # class where computed-field code reads a host field as if it were a top-level agent
+    # field (e.g. result.get("ssh_activity_time")) and gets None instead of the real value.
+    host_only_fields = (
+        set(HostDetails.model_fields) - set(AgentDetails.model_fields) - {"id", "name", "type", "command"}
+    )
+    for field_name in host_only_fields:
+        assert field_name not in context, f"Host-only field {field_name!r} must live under context['host']"
+
+    # Computed fields must each draw from their declared inputs. A wrong-nesting bug in any
+    # of them would either drop the field or compute the wrong value.
+    assert context["age"] == pytest.approx(600, abs=10)
+    assert context["runtime"] == 540.0
+    # idle uses the most recent of user/agent/host.ssh activity; ssh is the freshest at 1 min.
+    assert context["idle"] == pytest.approx(60, abs=10)
+
+
+def test_agent_details_to_cel_context_idle_includes_host_ssh_activity() -> None:
+    """The computed `idle` field must include host SSH activity, since it lives on the host."""
+    ssh_activity = datetime.now(timezone.utc) - timedelta(minutes=5)
+    host_details = HostDetails(
+        id=HostId.generate(),
+        name="test-host",
+        provider_name=ProviderInstanceName("local"),
+        ssh_activity_time=ssh_activity,
+    )
+    agent = AgentDetails(
+        id=AgentId.generate(),
+        name=AgentName("ssh-only-agent"),
+        type="claude",
+        command=CommandString("sleep 100"),
+        work_dir=Path("/work"),
+        initial_branch="mngr/ssh-only-agent",
+        create_time=datetime.now(timezone.utc),
+        start_on_boot=False,
+        state=AgentLifecycleState.RUNNING,
+        host=host_details,
+    )
+    context = agent_details_to_cel_context(agent)
+
+    assert "idle" in context
+    assert 280 < context["idle"] < 320
+
+
+def test_agent_details_to_cel_context_idle_uses_most_recent_activity() -> None:
+    """When multiple activity sources are set, `idle` uses the most recent one."""
+    now = datetime.now(timezone.utc)
+    host_details = HostDetails(
+        id=HostId.generate(),
+        name="test-host",
+        provider_name=ProviderInstanceName("local"),
+        ssh_activity_time=now - timedelta(minutes=10),
+    )
+    agent = AgentDetails(
+        id=AgentId.generate(),
+        name=AgentName("multi-activity-agent"),
+        type="claude",
+        command=CommandString("sleep 100"),
+        work_dir=Path("/work"),
+        initial_branch="mngr/multi-activity-agent",
+        create_time=now,
+        start_on_boot=False,
+        state=AgentLifecycleState.RUNNING,
+        user_activity_time=now - timedelta(hours=1),
+        agent_activity_time=now - timedelta(minutes=30),
+        host=host_details,
+    )
+    context = agent_details_to_cel_context(agent)
+
+    # SSH activity (10 min ago) is the most recent, so idle should be ~600s.
+    assert "idle" in context
+    assert 580 < context["idle"] < 620
 
 
 def test_agent_details_to_cel_context_exposes_host_provider_under_both_names() -> None:

--- a/libs/mngr/imbue/mngr/api/list_test.py
+++ b/libs/mngr/imbue/mngr/api/list_test.py
@@ -444,9 +444,7 @@ def test_agent_details_to_cel_context_preserves_full_model_structure() -> None:
     # Host-only fields must not be silently hoisted to the top level. This catches the bug
     # class where computed-field code reads a host field as if it were a top-level agent
     # field (e.g. result.get("ssh_activity_time")) and gets None instead of the real value.
-    host_only_fields = (
-        set(HostDetails.model_fields) - set(AgentDetails.model_fields) - {"id", "name", "type", "command"}
-    )
+    host_only_fields = set(HostDetails.model_fields) - set(AgentDetails.model_fields)
     for field_name in host_only_fields:
         assert field_name not in context, f"Host-only field {field_name!r} must live under context['host']"
 

--- a/libs/mngr/imbue/mngr/api/test_list.py
+++ b/libs/mngr/imbue/mngr/api/test_list.py
@@ -136,7 +136,9 @@ def test_agent_details_to_cel_context_basic_fields() -> None:
     assert context["type"] == "claude"
     assert context["name"] == "test-agent"
     assert context["host"]["name"] == "test-host"
+    # Both names are exposed so CEL filters and templates can use either.
     assert context["host"]["provider"] == "local"
+    assert context["host"]["provider_name"] == "local"
     assert "age" in context
 
 
@@ -362,6 +364,36 @@ def test_apply_cel_filters_with_host_provider_filter() -> None:
 
     include_filters, exclude_filters = compile_cel_filters(
         include_filters=('host.provider == "local"',),
+        exclude_filters=(),
+    )
+
+    result = _apply_cel_filters(agent_details, include_filters, exclude_filters)
+
+    assert result is True
+
+
+def test_apply_cel_filters_accepts_host_provider_name() -> None:
+    """host.provider_name should also work in CEL filters (alongside the short host.provider)."""
+    host_details = HostDetails(
+        id=HostId.generate(),
+        name="test-host",
+        provider_name=ProviderInstanceName("local"),
+    )
+    agent_details = AgentDetails(
+        id=AgentId.generate(),
+        name=AgentName("test-agent"),
+        type="claude",
+        command=CommandString("sleep 100"),
+        work_dir=Path("/work/dir"),
+        initial_branch="mngr/test-agent",
+        create_time=datetime.now(timezone.utc),
+        start_on_boot=False,
+        state=AgentLifecycleState.RUNNING,
+        host=host_details,
+    )
+
+    include_filters, exclude_filters = compile_cel_filters(
+        include_filters=('host.provider_name == "local"',),
         exclude_filters=(),
     )
 

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1226,7 +1226,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which also factors in host SSH activity)
+- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -73,6 +73,19 @@ _HEADER_LABELS: Final[dict[str, str]] = {
     "activity_sources": "ACTIVITY",
 }
 
+# Aliases that let users reference fields by the same name in --fields/--format
+# templates as they do in CEL filters and --sort. host.provider is the short form
+# documented for CEL; the underlying attribute is host.provider_name.
+_FIELD_ALIASES: Final[dict[str, str]] = {
+    "host.provider": "host.provider_name",
+}
+
+
+@pure
+def _resolve_field_alias(field: str) -> str:
+    """Map a user-supplied field name to its canonical form for attribute/dict lookups."""
+    return _FIELD_ALIASES.get(field, field)
+
 
 @pure
 def _is_streaming_eligible(
@@ -1004,19 +1017,6 @@ def _format_value_as_string(value: Any) -> str:
 # Pattern to match a field part with optional bracket notation
 # Matches: "fieldname", "fieldname[0]", "fieldname[-1]", "fieldname[:3]", "fieldname[1:3]", etc.
 _BRACKET_PATTERN = re.compile(r"^([^\[]+)(?:\[([^\]]+)\])?$")
-
-# Aliases that let users reference fields by the same name in --fields/--format
-# templates as they do in CEL filters and --sort. host.provider is the short form
-# documented for CEL; the underlying attribute is host.provider_name.
-_FIELD_ALIASES: Final[dict[str, str]] = {
-    "host.provider": "host.provider_name",
-}
-
-
-@pure
-def _resolve_field_alias(field: str) -> str:
-    """Map a user-supplied field name to its canonical form for attribute/dict lookups."""
-    return _FIELD_ALIASES.get(field, field)
 
 
 class _CelSortKeyExtractor:

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1213,7 +1213,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active (as reported by the agent)
+- `idle_seconds` - How long since the agent was active (also factors in host SSH activity)
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection
@@ -1226,7 +1226,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which also factors in host SSH activity)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1195,10 +1195,12 @@ All agent fields from the "Available Fields" section can be used in filter expre
         ),
         (
             "Available Fields",
-            """The fields below can be used in three places, with the same names everywhere:
+            """The fields below use the same names across the three places they can appear:
 - CEL expressions for `--include`/`--exclude` (filtering)
 - CEL expressions for `--sort` (ordering)
 - `--fields` and `--format` template strings (selecting and formatting displayed data)
+
+Each subsection notes where its fields are available; agent and host fields work in all three contexts, while computed fields are only available in the CEL contexts.
 
 **Agent fields:**
 - `name` - Agent name

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1215,7 +1215,7 @@ Each subsection notes where its fields are available; agent and host fields work
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active (also factors in host SSH activity)
+- `idle_seconds` - How long since the agent was active
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -722,8 +722,9 @@ def _get_header_label(field: str, custom_headers: dict[str, str] | None = None) 
     """Get the display label for a column header."""
     if custom_headers and field in custom_headers:
         return custom_headers[field]
-    if field in _HEADER_LABELS:
-        return _HEADER_LABELS[field]
+    canonical_field = _resolve_field_alias(field)
+    if canonical_field in _HEADER_LABELS:
+        return _HEADER_LABELS[canonical_field]
     return field.upper().replace(".", " ")
 
 
@@ -734,10 +735,12 @@ def _compute_column_widths(
     """Compute column widths sized to the terminal, distributing extra space to expandable columns."""
     separator_total = len(_COLUMN_SEPARATOR) * max(len(fields) - 1, 0)
 
-    # Start with minimum widths, ensuring each column is at least as wide as its header
+    # Start with minimum widths, ensuring each column is at least as wide as its header.
+    # Column-width tables are keyed by canonical field names, so resolve aliases before lookup.
     width_by_field: dict[str, int] = {}
     for field in fields:
-        min_data_width = _MIN_COLUMN_WIDTHS.get(field, _DEFAULT_MIN_COLUMN_WIDTH)
+        canonical_field = _resolve_field_alias(field)
+        min_data_width = _MIN_COLUMN_WIDTHS.get(canonical_field, _DEFAULT_MIN_COLUMN_WIDTH)
         header_width = len(_get_header_label(field, custom_headers))
         width_by_field[field] = max(min_data_width, header_width)
 
@@ -748,14 +751,14 @@ def _compute_column_widths(
     # Process columns sorted by tightest max cap first so capped leftovers flow to less
     # constrained columns in a single pass.
     if fields and extra_space > 0:
-        sorted_fields = sorted(fields, key=lambda f: _MAX_COLUMN_WIDTHS.get(f, float("inf")))
+        sorted_fields = sorted(fields, key=lambda f: _MAX_COLUMN_WIDTHS.get(_resolve_field_alias(f), float("inf")))
         remaining = extra_space
         for idx, field in enumerate(sorted_fields):
             fields_left = len(sorted_fields) - idx
             per_column = remaining // fields_left
             extra = 1 if (remaining % fields_left) > 0 else 0
             bonus = per_column + extra
-            max_width = _MAX_COLUMN_WIDTHS.get(field)
+            max_width = _MAX_COLUMN_WIDTHS.get(_resolve_field_alias(field))
             if max_width is not None and width_by_field[field] + bonus > max_width:
                 bonus = max(max_width - width_by_field[field], 0)
             width_by_field[field] = width_by_field[field] + bonus
@@ -1002,11 +1005,18 @@ def _format_value_as_string(value: Any) -> str:
 # Matches: "fieldname", "fieldname[0]", "fieldname[-1]", "fieldname[:3]", "fieldname[1:3]", etc.
 _BRACKET_PATTERN = re.compile(r"^([^\[]+)(?:\[([^\]]+)\])?$")
 
-# Aliases that let users reference fields by the same name in --fields/templates and CEL filters.
-# host.provider is the short form documented for CEL; the underlying attribute is host.provider_name.
+# Aliases that let users reference fields by the same name in --fields/--format
+# templates as they do in CEL filters and --sort. host.provider is the short form
+# documented for CEL; the underlying attribute is host.provider_name.
 _FIELD_ALIASES: Final[dict[str, str]] = {
     "host.provider": "host.provider_name",
 }
+
+
+@pure
+def _resolve_field_alias(field: str) -> str:
+    """Map a user-supplied field name to its canonical form for attribute/dict lookups."""
+    return _FIELD_ALIASES.get(field, field)
 
 
 class _CelSortKeyExtractor:
@@ -1060,8 +1070,9 @@ def _get_field_value(agent: AgentDetails, field: str) -> str:
     Supports nested fields like "host.name" and list slicing syntax like
     "host.snapshots[0]" or "host.snapshots[:3]".
     """
-    # Resolve aliases first so the same field names work in --fields and CEL filters
-    field = _FIELD_ALIASES.get(field, field)
+    # Resolve aliases first so a user-supplied alias (e.g. host.provider) maps to the
+    # canonical attribute name (host.provider_name) before walking the agent object.
+    field = _resolve_field_alias(field)
     # Handle nested fields (e.g., "host.name") with optional bracket notation
     # Also supports dict key access for plugin fields (e.g., "host.plugin.aws.iam_user")
     parts = field.split(".")

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -153,12 +153,12 @@ class ListCliOptions(CommonCliOptions):
 @optgroup.option(
     "--include",
     multiple=True,
-    help="Include agents matching CEL expression, repeatable (e.g. 'state == \"RUNNING\"'); see 'Available Fields' below",
+    help="Include agents matching CEL expression (repeatable)",
 )
 @optgroup.option(
     "--exclude",
     multiple=True,
-    help="Exclude agents matching CEL expression, repeatable (e.g. 'host.provider == \"local\"'); see 'Available Fields' below",
+    help="Exclude agents matching CEL expression (repeatable)",
 )
 @optgroup.option(
     "--running",

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -1226,7 +1226,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 **Computed fields** (derived from other fields, available in CEL filters and `--sort`):
 - `age` - Seconds since `create_time`
 - `runtime` - Alias for `runtime_seconds`
-- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+- `idle` - Seconds since the more recent of `user_activity_time` and `agent_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
 
 **Host fields** (dot notation):
 - `host.name` - Host name

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -140,12 +140,12 @@ class ListCliOptions(CommonCliOptions):
 @optgroup.option(
     "--include",
     multiple=True,
-    help="Include agents matching CEL expression (repeatable)",
+    help="Include agents matching CEL expression, repeatable (e.g. 'state == \"RUNNING\"'); see 'Available Fields' below",
 )
 @optgroup.option(
     "--exclude",
     multiple=True,
-    help="Exclude agents matching CEL expression (repeatable)",
+    help="Exclude agents matching CEL expression, repeatable (e.g. 'host.provider == \"local\"'); see 'Available Fields' below",
 )
 @optgroup.option(
     "--running",
@@ -1002,6 +1002,12 @@ def _format_value_as_string(value: Any) -> str:
 # Matches: "fieldname", "fieldname[0]", "fieldname[-1]", "fieldname[:3]", "fieldname[1:3]", etc.
 _BRACKET_PATTERN = re.compile(r"^([^\[]+)(?:\[([^\]]+)\])?$")
 
+# Aliases that let users reference fields by the same name in --fields/templates and CEL filters.
+# host.provider is the short form documented for CEL; the underlying attribute is host.provider_name.
+_FIELD_ALIASES: Final[dict[str, str]] = {
+    "host.provider": "host.provider_name",
+}
+
 
 class _CelSortKeyExtractor:
     """Extracts a sort key from an (agent, cel_context) pair for a single CEL expression."""
@@ -1054,6 +1060,8 @@ def _get_field_value(agent: AgentDetails, field: str) -> str:
     Supports nested fields like "host.name" and list slicing syntax like
     "host.snapshots[0]" or "host.snapshots[:3]".
     """
+    # Resolve aliases first so the same field names work in --fields and CEL filters
+    field = _FIELD_ALIASES.get(field, field)
     # Handle nested fields (e.g., "host.name") with optional bracket notation
     # Also supports dict key access for plugin fields (e.g., "host.plugin.aws.iam_user")
     parts = field.split(".")
@@ -1176,7 +1184,12 @@ All agent fields from the "Available Fields" section can be used in filter expre
         ),
         (
             "Available Fields",
-            """**Agent fields** (same syntax for `--fields` and CEL filters):
+            """The fields below can be used in three places, with the same names everywhere:
+- CEL expressions for `--include`/`--exclude` (filtering)
+- CEL expressions for `--sort` (ordering)
+- `--fields` and `--format` template strings (selecting and formatting displayed data)
+
+**Agent fields:**
 - `name` - Agent name
 - `id` - Agent ID
 - `type` - Agent type (claude, codex, etc.)
@@ -1189,7 +1202,7 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - `runtime_seconds` - How long the agent has been running
 - `user_activity_time` - Timestamp of the last user activity
 - `agent_activity_time` - Timestamp of the last agent activity
-- `idle_seconds` - How long since the agent was active
+- `idle_seconds` - How long since the agent was active (as reported by the agent)
 - `idle_mode` - Idle detection mode
 - `idle_timeout_seconds` - Idle timeout before host stops
 - `activity_sources` - Activity sources used for idle detection
@@ -1199,10 +1212,15 @@ All agent fields from the "Available Fields" section can be used in filter expre
 - `labels.$KEY` - Specific label value (e.g., `labels.project`)
 - `plugin.$PLUGIN_NAME.*` - Plugin-defined fields (e.g., `plugin.chat_history.messages`)
 
-**Host fields** (dot notation for both `--fields` and CEL filters):
+**Computed fields** (derived from other fields, available in CEL filters and `--sort`):
+- `age` - Seconds since `create_time`
+- `runtime` - Alias for `runtime_seconds`
+- `idle` - Seconds since the most recent activity across `user_activity_time`, `agent_activity_time`, and `host.ssh_activity_time` (only present when at least one is set; differs from `idle_seconds`, which is the agent-reported value)
+
+**Host fields** (dot notation):
 - `host.name` - Host name
 - `host.id` - Host ID
-- `host.provider_name` - Host provider (local, docker, modal, etc.) (in CEL filters, use `host.provider`)
+- `host.provider` - Host provider (local, docker, modal, etc.); also accessible as `host.provider_name`
 - `host.state` - Current host state (RUNNING, STOPPED, BUILDING, etc.)
 - `host.image` - Host image (Docker image name, Modal image ID, etc.)
 - `host.tags` - Host labels (metadata key-value pairs)

--- a/libs/mngr/imbue/mngr/cli/list_test.py
+++ b/libs/mngr/imbue/mngr/cli/list_test.py
@@ -187,6 +187,13 @@ def test_get_field_value_provider_name() -> None:
     assert result == "local"
 
 
+def test_get_field_value_provider_alias() -> None:
+    """host.provider should resolve via the alias to the same value as host.provider_name."""
+    agent = make_test_agent_details()
+    result = _get_field_value(agent, "host.provider")
+    assert result == "local"
+
+
 def test_get_field_value_list_index_first() -> None:
     """_get_field_value should extract first element with [0]."""
     snapshots = [

--- a/libs/mngr/imbue/mngr/cli/list_test.py
+++ b/libs/mngr/imbue/mngr/cli/list_test.py
@@ -194,6 +194,18 @@ def test_get_field_value_provider_alias() -> None:
     assert result == "local"
 
 
+def test_get_header_label_resolves_alias() -> None:
+    """The alias host.provider should produce the same header label as host.provider_name."""
+    assert _get_header_label("host.provider") == _get_header_label("host.provider_name") == "PROVIDER"
+
+
+def test_compute_column_widths_resolves_alias_for_min_widths() -> None:
+    """Alias fields (host.provider) should pick up the same configured min width as the canonical name."""
+    aliased = _compute_column_widths(["host.provider"], 120)
+    canonical = _compute_column_widths(["host.provider_name"], 120)
+    assert aliased["host.provider"] == canonical["host.provider_name"]
+
+
 def test_get_field_value_list_index_first() -> None:
     """_get_field_value should extract first element with [0]."""
     snapshots = [


### PR DESCRIPTION
## Summary
- Update `--include`/`--exclude` help text to point users at the existing Available Fields section.
- Document the `age`, `runtime`, and `idle` computed fields, and clarify that they are available in CEL filters and `--sort`.
- Make `host.provider` and `host.provider_name` interchangeable in CEL filters and in `--fields`/`--format` templates (alias plumbing extended through `_get_field_value`, `_get_header_label`, and `_compute_column_widths` so the column header and width lookup also resolve under both names).
- Reorganize the Available Fields section so the three places fields can appear (filters, sort, templates) are listed up front. Correct the `idle_seconds` description to match its actual derivation (computed from activity-time mtimes, not agent-reported).
- **Fix:** the CEL-context `idle` computed field used to read `ssh_activity_time` from the top level of the agent dict, but that field lives under `host`. SSH activity was silently never included, and SSH-only agents got no `idle` value. Now read it from the host dict and include it in the gate, so the docs' claim that `idle` covers user/agent/SSH activity is actually true.
- Add a structural regression test that round-trips a fully-populated `AgentDetails` through `agent_details_to_cel_context` and asserts every declared agent field appears at the top level of the CEL context and every declared host field appears under `context["host"]`. Catches the broader class of bugs where computed-field code reads a field at the wrong level of the dict.

Closes #1101

## Test plan
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (3634 passed, 0 failed)
- [ ] CI offload covers acceptance/release tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)