### PR TITLE
clear error on `mngr create` in repo with no commits

### DIFF
--- a/libs/mngr/imbue/mngr/api/test_create.py
+++ b/libs/mngr/imbue/mngr/api/test_create.py
@@ -37,6 +37,7 @@ from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import TransferMode
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
+from imbue.mngr.utils.testing import init_git_repo
 from imbue.mngr.utils.testing import make_ctx_with_plugins
 from imbue.mngr.utils.testing import tmux_session_cleanup
 from imbue.mngr.utils.testing import tmux_session_exists
@@ -467,6 +468,43 @@ def test_worktree_already_checked_out_gives_helpful_error(
     )
 
     with pytest.raises(UserInputError, match="To create a new branch instead, use --branch BASE:"):
+        create(
+            source_location=source_location,
+            target_host=local_host,
+            agent_options=agent_options,
+            mngr_ctx=temp_mngr_ctx,
+        )
+
+
+def test_worktree_in_repo_with_no_commits_gives_helpful_error(
+    temp_mngr_ctx: MngrContext,
+    tmp_path: Path,
+    setup_git_config: None,
+) -> None:
+    """Worktree mode in a freshly init'd repo with no commits raises a clear UserInputError.
+
+    Mirrors the default `mngr create` flow, which passes both base_branch (current
+    branch, e.g. "main") and a new_branch_name. Without an initial commit, the
+    base branch reference does not resolve and `git worktree add` would fail with
+    a cryptic "fatal: invalid reference" error.
+    """
+    empty_repo = tmp_path / "empty_repo"
+    init_git_repo(empty_repo, initial_commit=False)
+
+    local_host, source_location = _get_local_host_and_location(temp_mngr_ctx, empty_repo)
+
+    agent_options = CreateAgentOptions(
+        agent_type=AgentTypeName("worktree-test"),
+        name=AgentName("test-no-commits"),
+        command=CommandString("sleep 60"),
+        transfer_mode=TransferMode.GIT_WORKTREE,
+        git=AgentGitOptions(
+            base_branch="main",
+            new_branch_name="mngr/no-commits",
+        ),
+    )
+
+    with pytest.raises(UserInputError, match="no commits"):
         create(
             source_location=source_location,
             target_host=local_host,

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2120,16 +2120,6 @@ class Host(BaseHost, OnlineHostInterface):
             git_c = f"git -C {shlex.quote(str(source_path))}"
             mkdir_cmd = f"mkdir -p {work_dir_path.parent}"
 
-            # `git worktree add` cannot resolve any commit reference in a repo
-            # with no commits, producing a cryptic "fatal: invalid reference"
-            # error. Detect this up front so the user gets actionable guidance.
-            head_check = self.execute_idempotent_command(f"{git_c} rev-parse --verify HEAD")
-            if not head_check.success:
-                raise UserInputError(
-                    f"Cannot create an agent in {source_path}: the git repository has no commits. "
-                    f"Please make an initial commit first."
-                )
-
             # git worktree add <path> [-b <new>] [<base>]
             worktree_args = [mkdir_cmd, "&&", git_c, "worktree", "add", shlex.quote(str(work_dir_path))]
             if new_branch_name:
@@ -2148,6 +2138,18 @@ class Host(BaseHost, OnlineHostInterface):
                         f"To create a new branch instead, use --branch BASE: or --branch BASE:new-name\n"
                         f"To work directly in the existing worktree, use --in-place from that directory"
                     )
+                # `git worktree add` cannot resolve any commit reference in a
+                # repo with no commits, producing a cryptic "fatal: invalid
+                # reference" error. Disambiguate that case from a genuine bad
+                # branch reference by checking HEAD on the failure path only,
+                # so the success path stays a single command.
+                if "invalid reference" in stderr:
+                    head_check = self.execute_idempotent_command(f"{git_c} rev-parse --verify HEAD")
+                    if not head_check.success:
+                        raise UserInputError(
+                            f"Cannot create an agent in {source_path}: the git repository has no commits. "
+                            "Please make an initial commit first."
+                        )
                 raise MngrError(f"Failed to create git worktree: {stderr}")
 
             # Track generated work directories at the host level

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2120,6 +2120,16 @@ class Host(BaseHost, OnlineHostInterface):
             git_c = f"git -C {shlex.quote(str(source_path))}"
             mkdir_cmd = f"mkdir -p {work_dir_path.parent}"
 
+            # `git worktree add` cannot resolve any commit reference in a repo
+            # with no commits, producing a cryptic "fatal: invalid reference"
+            # error. Detect this up front so the user gets actionable guidance.
+            head_check = self.execute_idempotent_command(f"{git_c} rev-parse --verify HEAD")
+            if not head_check.success:
+                raise UserInputError(
+                    f"Cannot create an agent in {source_path}: the git repository has no commits. "
+                    f"Please make an initial commit first."
+                )
+
             # git worktree add <path> [-b <new>] [<base>]
             worktree_args = [mkdir_cmd, "&&", git_c, "worktree", "add", shlex.quote(str(work_dir_path))]
             if new_branch_name:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2139,17 +2139,15 @@ class Host(BaseHost, OnlineHostInterface):
                         f"To work directly in the existing worktree, use --in-place from that directory"
                     )
                 # `git worktree add` cannot resolve any commit reference in a
-                # repo with no commits, producing a cryptic "fatal: invalid
-                # reference" error. Disambiguate that case from a genuine bad
-                # branch reference by checking HEAD on the failure path only,
-                # so the success path stays a single command.
-                if "invalid reference" in stderr:
-                    head_check = self.execute_idempotent_command(f"{git_c} rev-parse --verify HEAD")
-                    if not head_check.success:
-                        raise UserInputError(
-                            f"Cannot create an agent in {source_path}: the git repository has no commits. "
-                            "Please make an initial commit first."
-                        )
+                # repo with no commits and reports a cryptic error. Probe HEAD
+                # directly on the failure path so the empty-repo case gets a
+                # clear message regardless of git's exact stderr wording.
+                head_check = self.execute_idempotent_command(f"{git_c} rev-parse --verify HEAD")
+                if not head_check.success:
+                    raise UserInputError(
+                        f"Cannot create an agent in {source_path}: the git repository has no commits. "
+                        "Please make an initial commit first."
+                    )
                 raise MngrError(f"Failed to create git worktree: {stderr}")
 
             # Track generated work directories at the host level


### PR DESCRIPTION
## Summary

- Detect the empty-git-repo case in `_create_work_dir_as_git_worktree` via `git rev-parse --verify HEAD` and raise a `UserInputError` pointing the user to make an initial commit.
- Without this, `mngr create` (default GIT_WORKTREE transfer mode + base branch) failed with a cryptic `fatal: invalid reference: main`.
- Adds an integration test in `test_create.py` exercising the empty-repo path.

Closes #1043

## Test plan

- [x] `just test-quick "libs/mngr/imbue/mngr/api/test_create.py -k worktree"` (7 passed)
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (3628 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)