### PR TITLE
pass --progress=plain to docker build

### DIFF
--- a/libs/mngr/imbue/mngr/providers/docker/conftest.py
+++ b/libs/mngr/imbue/mngr/providers/docker/conftest.py
@@ -1,6 +1,4 @@
 import json
-import os
-import pwd
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -16,25 +14,8 @@ from imbue.mngr.utils.testing import get_subprocess_test_env
 from imbue.mngr.utils.testing import run_mngr_subprocess
 
 
-def _real_user_docker_config_dir() -> str:
-    """Return the user's real ~/.docker, resolved via pwd to bypass HOME overrides.
-
-    The autouse mngr test environment isolates HOME, which hides
-    ~/.docker/cli-plugins/docker-buildx (where Docker Desktop installs the
-    plugin via symlink). Without buildx the CLI falls back to the deprecated
-    legacy builder, which does not understand BuildKit flags like
-    --progress=plain. Restoring DOCKER_CONFIG to the real ~/.docker re-exposes
-    the plugin to tests that exercise `docker build`.
-    """
-    real_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
-    return str(real_home / ".docker")
-
-
 @pytest.fixture
-def docker_provider(
-    temp_mngr_ctx: MngrContext, monkeypatch: pytest.MonkeyPatch
-) -> Generator[DockerProviderInstance, None, None]:
-    monkeypatch.setenv("DOCKER_CONFIG", _real_user_docker_config_dir())
+def docker_provider(temp_mngr_ctx: MngrContext) -> Generator[DockerProviderInstance, None, None]:
     yield from make_docker_provider_with_cleanup(temp_mngr_ctx)
 
 
@@ -55,7 +36,6 @@ def docker_subprocess_env(tmp_path: Path) -> Generator[dict[str, str], None, Non
         prefix=prefix,
         host_dir=host_dir,
     )
-    env["DOCKER_CONFIG"] = _real_user_docker_config_dir()
     yield env
 
     # Destroy all agents created during the test.

--- a/libs/mngr/imbue/mngr/providers/docker/conftest.py
+++ b/libs/mngr/imbue/mngr/providers/docker/conftest.py
@@ -1,4 +1,6 @@
 import json
+import os
+import pwd
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -14,8 +16,25 @@ from imbue.mngr.utils.testing import get_subprocess_test_env
 from imbue.mngr.utils.testing import run_mngr_subprocess
 
 
+def _real_user_docker_config_dir() -> str:
+    """Return the user's real ~/.docker, resolved via pwd to bypass HOME overrides.
+
+    The autouse mngr test environment isolates HOME, which hides
+    ~/.docker/cli-plugins/docker-buildx (where Docker Desktop installs the
+    plugin via symlink). Without buildx the CLI falls back to the deprecated
+    legacy builder, which does not understand BuildKit flags like
+    --progress=plain. Restoring DOCKER_CONFIG to the real ~/.docker re-exposes
+    the plugin to tests that exercise `docker build`.
+    """
+    real_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    return str(real_home / ".docker")
+
+
 @pytest.fixture
-def docker_provider(temp_mngr_ctx: MngrContext) -> Generator[DockerProviderInstance, None, None]:
+def docker_provider(
+    temp_mngr_ctx: MngrContext, monkeypatch: pytest.MonkeyPatch
+) -> Generator[DockerProviderInstance, None, None]:
+    monkeypatch.setenv("DOCKER_CONFIG", _real_user_docker_config_dir())
     yield from make_docker_provider_with_cleanup(temp_mngr_ctx)
 
 
@@ -36,6 +55,7 @@ def docker_subprocess_env(tmp_path: Path) -> Generator[dict[str, str], None, Non
         prefix=prefix,
         host_dir=host_dir,
     )
+    env["DOCKER_CONFIG"] = _real_user_docker_config_dir()
     yield env
 
     # Destroy all agents created during the test.

--- a/libs/mngr/imbue/mngr/providers/docker/instance.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance.py
@@ -585,6 +585,12 @@ kill -TERM 1
         env = dict(os.environ)
         if self.config.host:
             env["DOCKER_HOST"] = self.config.host
+        # BuildKit's default progress mode emits ANSI cursor/color escapes that
+        # show up as garbage in the BUILD log channel. `plain` produces clean
+        # line-oriented output. The env form is preferred over `--progress=plain`
+        # because it is silently ignored by the legacy builder, so mngr does not
+        # require buildx to be installed.
+        env.setdefault("BUILDKIT_PROGRESS", "plain")
         return env
 
     def _run_docker_creation_command(self, args: list[str], timeout: float = 300) -> FinishedProcess:
@@ -604,7 +610,7 @@ kill -TERM 1
 
     def _build_image(self, build_args: Sequence[str], tag: str) -> str:
         """Build a Docker image using native docker build with passthrough args."""
-        cmd = ["build", "--progress=plain", "-t", tag] + list(build_args)
+        cmd = ["build", "-t", tag] + list(build_args)
         with log_span("Running docker build with {} args", len(build_args)):
             self._run_docker_creation_command(cmd)
         return tag

--- a/libs/mngr/imbue/mngr/providers/docker/instance.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance.py
@@ -604,7 +604,7 @@ kill -TERM 1
 
     def _build_image(self, build_args: Sequence[str], tag: str) -> str:
         """Build a Docker image using native docker build with passthrough args."""
-        cmd = ["build", "-t", tag] + list(build_args)
+        cmd = ["build", "--progress=plain", "-t", tag] + list(build_args)
         with log_span("Running docker build with {} args", len(build_args)):
             self._run_docker_creation_command(cmd)
         return tag


### PR DESCRIPTION
## Summary
- Set `BUILDKIT_PROGRESS=plain` in `DockerProviderInstance._docker_env()` so the docker CLI emits plain, line-oriented build output without ANSI cursor/color escapes that show up as garbage in the BUILD log channel.
- Using the env form (rather than `--progress=plain` on the argv) is silently ignored by the legacy builder, so mngr does not pick up a hard dependency on buildx and the test fixtures stay HOME-isolated.

Closes #1046

## Validation
- Manually compared docker build output before vs. after (TTY capture under `script`):
  - Before: `^[[34m => [internal] load build definition... ^[[0m^[[34m => => transferring dockerfile...` — ANSI escapes everywhere.
  - After (BuildKit): clean `#1 [internal] load build definition from Dockerfile / #1 DONE 0.0s` step format, no escapes.
  - After (legacy builder, in HOME-isolated test env): clean `Step 1/2 : FROM busybox:latest / ---> Using cache` line-oriented output, no escapes. `BUILDKIT_PROGRESS` is silently ignored, build still succeeds.
- `test_build_image_from_dockerfile` BUILD log lines confirm clean output post-fix in both builder modes.

## History
The first commit on this branch took the literal one-line fix from the issue (`--progress=plain` on the argv) and then patched the docker test fixtures to expose the developer's real `~/.docker` so the legacy-builder fallback in HOME-isolated tests would still understand the flag. Architecture review pointed out that this introduced an implicit dependency on the host's `pwd` database and Docker Desktop's symlink layout — undoing the autouse `setup_test_mngr_env` HOME isolation. The follow-up commit switches to `BUILDKIT_PROGRESS=plain`, which works on BuildKit and is harmless on the legacy builder, and reverts the conftest changes.

## Test plan
- [x] `libs/mngr/imbue/mngr/providers/docker/test_docker_integration.py::test_build_image_from_dockerfile`
- [x] All 66 docker provider unit + integration tests under `libs/mngr/imbue/mngr/providers/docker/`
- [x] All 5 `docker_create` subprocess tests (which exercise `mngr create` end-to-end through the CLI)
- [x] Wider `libs/mngr` unit tests (3627 passed)
- [ ] CI offload (acceptance + release tiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)