### PR TITLE
replace logger.exception with logger.opt(exception=).error

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -614,7 +614,7 @@ class AgentCreator(MutableModel):
                     self._redirect_urls[aid] = redirect_url
 
         except (GitCloneError, GitOperationError, MngrCommandError, ValueError, OSError) as e:
-            logger.error("Failed to create agent {}: {}", agent_id, e)
+            logger.opt(exception=e).error("Failed to create agent {}", agent_id)
             log_queue.put("[minds] ERROR: {}".format(e))
             with self._lock:
                 self._statuses[aid] = AgentCreationStatus.FAILED

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1838,7 +1838,7 @@ def create_desktop_client(
 
     @app.exception_handler(Exception)
     async def _unhandled_exception_handler(request: Request, exc: Exception) -> Response:
-        logger.error("Unhandled exception on {} {}: {}", request.method, request.url.path, exc, exc_info=exc)
+        logger.opt(exception=exc).error("Unhandled exception on {} {}", request.method, request.url.path)
         return Response(status_code=500, content=f"Internal Server Error: {exc}")
 
     @app.middleware("http")

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -555,7 +555,7 @@ class MngrStreamManager(MutableModel):
         try:
             event = parse_discovery_event_line(line)
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error("Failed to parse discovery event line: {} (line: {})", e, line[:200])
+            logger.opt(exception=e).error("Failed to parse discovery event line: (line: {})", line[:200])
             return
 
         if isinstance(event, FullDiscoverySnapshotEvent):
@@ -823,7 +823,7 @@ class MngrStreamManager(MutableModel):
                 services[str(record.service)] = record.url
             self.resolver.update_services(agent_id, dict(services))
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error("Failed to parse event line for {}: {} (line: {})", agent_id, e, stripped[:200])
+            logger.opt(exception=e).error("Failed to parse event line for {} (line: {})", agent_id, stripped[:200])
 
     def _start_events_stream(self, agent_id: AgentId) -> None:
         """Start mngr events <agent-id> services requests refresh --follow for a workspace agent."""

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -555,7 +555,7 @@ class MngrStreamManager(MutableModel):
         try:
             event = parse_discovery_event_line(line)
         except (json.JSONDecodeError, ValueError) as e:
-            logger.opt(exception=e).error("Failed to parse discovery event line: (line: {})", line[:200])
+            logger.opt(exception=e).error("Failed to parse discovery event line (line: {})", line[:200])
             return
 
         if isinstance(event, FullDiscoverySnapshotEvent):

--- a/apps/minds/imbue/minds/desktop_client/supertokens_routes.py
+++ b/apps/minds/imbue/minds/desktop_client/supertokens_routes.py
@@ -356,7 +356,7 @@ def _handle_oauth_callback(provider_id: str, request: Request) -> HTMLResponse:
             query_params=query_params,
         )
     except (httpx.HTTPError, AuthBackendError) as exc:
-        logger.error("OAuth callback failed for {}: {}", provider_id, exc)
+        logger.opt(exception=exc).error("OAuth callback failed for {}", provider_id)
         safe_exc = html.escape(str(exc), quote=True)
         return HTMLResponse(
             f"<html><body><h1>Authentication failed</h1><p>{safe_exc}</p></body></html>",

--- a/apps/minds/imbue/minds/telegram/setup.py
+++ b/apps/minds/imbue/minds/telegram/setup.py
@@ -236,7 +236,7 @@ class TelegramSetupOrchestrator(MutableModel):
             MngrCommandError,
             OSError,
         ) as exc:
-            logger.error("Telegram setup failed for agent {}: {}", agent_id, exc)
+            logger.opt(exception=exc).error("Telegram setup failed for agent {}", agent_id)
             with self._lock:
                 self._statuses[aid] = TelegramSetupStatus.FAILED
                 self._errors[aid] = str(exc)

--- a/apps/minds/imbue/minds/test_ratchets.py
+++ b/apps/minds/imbue/minds/test_ratchets.py
@@ -197,6 +197,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -501,7 +501,7 @@ class AgentManager:
                     error = f"mngr create exited with code {result.returncode}"
             except (OSError, ConcurrencyGroupError) as e:
                 error = str(e)
-                _loguru_logger.exception("Error creating agent {}", agent_id)
+                _loguru_logger.opt(exception=e).error("Error creating agent {}", agent_id)
 
             with self._lock:
                 self._proto_agents.pop(agent_id, None)
@@ -525,7 +525,7 @@ class AgentManager:
             # failure", so force success=False regardless of prior state.
             success = False
             error = f"Unexpected {type(e).__name__}: {e}"
-            _loguru_logger.exception("Unexpected error creating agent {}", agent_id)
+            _loguru_logger.opt(exception=e).error("Unexpected error creating agent {}", agent_id)
             # The proto-agent entry may still be sitting in _proto_agents if
             # the exception fired before the cleanup block. Try once more,
             # safely, before we broadcast completion.
@@ -533,8 +533,8 @@ class AgentManager:
                 with self._lock:
                     self._proto_agents.pop(agent_id, None)
                     self._log_queues.pop(agent_id, None)
-            except (OSError, RuntimeError):
-                _loguru_logger.exception("Failed to clean proto-agent entry for {}", agent_id)
+            except (OSError, RuntimeError) as cleanup_exc:
+                _loguru_logger.opt(exception=cleanup_exc).error("Failed to clean proto-agent entry for {}", agent_id)
 
         _completion_signal_put(log_queue, json.dumps({"done": True, "success": success, "error": error}))
         _completion_signal_put(log_queue, None)
@@ -561,8 +561,8 @@ class AgentManager:
             for agent_info in agents:
                 if agent_info.id == self._own_agent_id and agent_info.work_dir:
                     self._start_app_watcher(agent_info.id, Path(agent_info.work_dir))
-        except (OSError, ValueError, RuntimeError, BaseMngrError):
-            _loguru_logger.exception("Initial agent discovery failed")
+        except (OSError, ValueError, RuntimeError, BaseMngrError) as e:
+            _loguru_logger.opt(exception=e).error("Initial agent discovery failed")
 
     def _refresh_agents(self) -> None:
         """Re-discover all agents and broadcast updates."""
@@ -589,8 +589,8 @@ class AgentManager:
             for agent_id in removed:
                 self._stop_app_watcher(agent_id)
 
-        except (OSError, ValueError, RuntimeError, BaseMngrError):
-            _loguru_logger.exception("Agent refresh failed")
+        except (OSError, ValueError, RuntimeError, BaseMngrError) as e:
+            _loguru_logger.opt(exception=e).error("Agent refresh failed")
 
     def _resolve_observe_events_dir(self) -> Path:
         """Return the path to the mngr observe events directory.
@@ -688,7 +688,7 @@ class AgentManager:
         except (ProcessError, EnvironmentStoppedError) as e:
             if self._shutdown_event.is_set():
                 return
-            _loguru_logger.error("mngr observe subprocess failed: {}", e)
+            _loguru_logger.opt(exception=e).error("mngr observe subprocess failed")
             return
 
         if self._shutdown_event.is_set():
@@ -718,8 +718,8 @@ class AgentManager:
             event = parse_discovery_event_line(stripped)
             if event is not None:
                 self._handle_discovery_event(event)
-        except (json.JSONDecodeError, ValueError, KeyError):
-            _loguru_logger.exception("Error parsing observe line: {}", stripped[:200])
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            _loguru_logger.opt(exception=e).error("Error parsing observe line: {}", stripped[:200])
 
     def _handle_discovery_event(self, event: object) -> None:
         """Handle a discovery event from mngr observe."""
@@ -826,8 +826,8 @@ class AgentManager:
                     observer.stop()
                     return
                 self._app_observers[agent_id] = observer
-        except OSError:
-            _loguru_logger.exception("Failed to start application watcher for agent {}", agent_id)
+        except OSError as e:
+            _loguru_logger.opt(exception=e).error("Failed to start application watcher for agent {}", agent_id)
 
     def _stop_app_watcher(self, agent_id: str) -> None:
         """Stop watching applications.toml for an agent."""
@@ -860,8 +860,8 @@ class AgentManager:
                     url = entry.get("url", "")
                     if name and url:
                         apps.append(ApplicationEntry(name=name, url=url))
-            except (OSError, tomllib.TOMLDecodeError, KeyError, ValueError):
-                _loguru_logger.exception("Failed to parse {}", toml_path)
+            except (OSError, tomllib.TOMLDecodeError, KeyError, ValueError) as e:
+                _loguru_logger.opt(exception=e).error("Failed to parse {}", toml_path)
 
         with self._lock:
             self._applications = apps

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/test_ratchets.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/test_ratchets.py
@@ -194,6 +194,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/apps/remote_service_connector/imbue/remote_service_connector/app.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/app.py
@@ -1159,7 +1159,7 @@ def raise_as_http(exc: Exception) -> NoReturn:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if isinstance(exc, TunnelComponentTooLongError):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    logger.exception("Unexpected error in endpoint handler")
+    logger.error("Unexpected error in endpoint handler", exc_info=exc)
     raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/apps/remote_service_connector/imbue/remote_service_connector/app.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/app.py
@@ -1451,7 +1451,7 @@ async def auth_signup(body: SignUpRequest) -> AuthResponse:
             email=email,
         )
     except (SuperTokensSessionError, SuperTokensGeneralError) as exc:
-        logger.error("SuperTokens SDK error during signup: %s", exc)
+        logger.error("SuperTokens SDK error during signup", exc_info=exc)
         return AuthResponse(status="ERROR", message="Auth backend unavailable")
     return AuthResponse(
         status="OK",
@@ -1495,7 +1495,7 @@ async def auth_signin(body: SignInRequest) -> AuthResponse:
                 email=email,
             )
     except (SuperTokensSessionError, SuperTokensGeneralError) as exc:
-        logger.error("SuperTokens SDK error during signin: %s", exc)
+        logger.error("SuperTokens SDK error during signin", exc_info=exc)
         return AuthResponse(status="ERROR", message="Auth backend unavailable")
     return AuthResponse(
         status="OK",
@@ -1593,7 +1593,7 @@ async def auth_verify_email_page(request: Request) -> HTMLResponse:
     try:
         result = await verify_email_using_token(tenant_id=tenant_id, token=token)
     except (SuperTokensSessionError, SuperTokensGeneralError, ValueError) as exc:
-        logger.error("Email verification error: %s", exc)
+        logger.error("Email verification error", exc_info=exc)
         return HTMLResponse(_VERIFY_EMAIL_FAILED_HTML, status_code=400)
     if isinstance(result, VerifyEmailUsingTokenOkResult):
         return HTMLResponse(_VERIFY_EMAIL_SUCCESS_HTML)
@@ -1695,7 +1695,7 @@ async def auth_oauth_callback(body: OAuthCallbackRequest) -> AuthResponse:
         )
         oauth_user = await provider.get_user_info(oauth_tokens=oauth_tokens, user_context={})
     except (ValueError, KeyError, OSError) as exc:
-        logger.error("OAuth callback failed for %s: %s", body.provider_id, exc)
+        logger.error("OAuth callback failed for %s", body.provider_id, exc_info=exc)
         return AuthResponse(status="ERROR", message=str(exc))
 
     if oauth_user.email is None or oauth_user.email.id is None:

--- a/apps/remote_service_connector/imbue/remote_service_connector/test_ratchets.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/test_ratchets.py
@@ -181,6 +181,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/apps/slack_exporter/imbue/slack_exporter/test_ratchets.py
+++ b/apps/slack_exporter/imbue/slack_exporter/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/concurrency_group/imbue/concurrency_group/test_ratchets.py
+++ b/libs/concurrency_group/imbue/concurrency_group/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/imbue_common/imbue/imbue_common/logging_test.py
+++ b/libs/imbue_common/imbue/imbue_common/logging_test.py
@@ -482,8 +482,8 @@ def test_build_flat_log_dict_includes_exception_info() -> None:
     try:
         try:
             raise ValueError("test error")
-        except ValueError:
-            logger.exception("Something failed")
+        except ValueError as e:
+            logger.opt(exception=e).error("Something failed")
     finally:
         logger.remove(handler_id)
 

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
@@ -303,6 +303,18 @@ PREVENT_FSTRING_LOGGING = RegexRatchetRule(
     pattern_string=r"logger\.(trace|debug|info|warning|error|exception)\(f[\"']",
 )
 
+PREVENT_LOGGER_EXCEPTION = RegexRatchetRule(
+    rule_name="logger.exception() usages",
+    rule_description=(
+        "Never use logger.exception() -- it relies on sys.exc_info(), which is unreliable "
+        "in threaded code (the exception context can be cleared or replaced by another "
+        "thread between the except block and the actual log emission). Use "
+        "logger.opt(exception=exc).error(msg) instead so the exception is bound explicitly "
+        "and the traceback is captured deterministically."
+    ),
+    pattern_string=r"\w*logger\.exception\(",
+)
+
 PREVENT_CLICK_ECHO = RegexRatchetRule(
     rule_name="click.echo usage",
     rule_description=(

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/standard_ratchet_checks.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/standard_ratchet_checks.py
@@ -31,6 +31,7 @@ from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_INIT_IN_N
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_INLINE_FUNCTIONS
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_INLINE_IMPORTS
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_LITERAL_MULTIPLE_OPTIONS
+from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_LOGGER_EXCEPTION
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MODEL_COPY
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_MONKEYPATCH_SETATTR
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_NAMEDTUPLE
@@ -267,6 +268,12 @@ def check_model_copy(source_dir: Path, max_count: int) -> None:
 
 def check_fstring_logging(source_dir: Path, max_count: int) -> None:
     assert_ratchet(PREVENT_FSTRING_LOGGING, source_dir, max_count)
+
+
+def check_logger_exception(source_dir: Path, max_count: int) -> None:
+    excluded = _SELF_EXCLUSION + ("common_ratchets.py",)
+    chunks = check_ratchet_rule(PREVENT_LOGGER_EXCEPTION, source_dir, excluded)
+    assert len(chunks) <= max_count, PREVENT_LOGGER_EXCEPTION.format_failure(chunks)
 
 
 def check_click_echo(source_dir: Path, max_count: int) -> None:

--- a/libs/imbue_common/imbue/imbue_common/test_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(2))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr/imbue/mngr/api/gc.py
+++ b/libs/mngr/imbue/mngr/api/gc.py
@@ -803,7 +803,7 @@ def _handle_error(error_msg: str, error_behavior: ErrorBehavior, exc: Exception 
             raise MngrError(error_msg)
         case ErrorBehavior.CONTINUE:
             if exc:
-                logger.exception(exc)
+                logger.opt(exception=exc).error(error_msg)
             else:
                 logger.error(error_msg)
         case _ as unreachable:

--- a/libs/mngr/imbue/mngr/api/observe.py
+++ b/libs/mngr/imbue/mngr/api/observe.py
@@ -392,7 +392,7 @@ class AgentObserver(MutableModel):
                 activity_worker.join(timeout=5.0)
 
     def _on_activity_failure(self, e: BaseException):
-        logger.error("Activity worker thread failed: {}", e)
+        logger.opt(exception=e).error("Activity worker thread failed")
         self._stop_event.set()
 
     def stop(self) -> None:

--- a/libs/mngr/imbue/mngr/utils/test_ratchets.py
+++ b/libs/mngr/imbue/mngr/utils/test_ratchets.py
@@ -202,6 +202,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/test_ratchets.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_ratchets.py
@@ -206,6 +206,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_file/imbue/mngr_file/test_ratchets.py
+++ b/libs/mngr_file/imbue/mngr_file/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_lima/imbue/mngr_lima/test_ratchets.py
+++ b/libs/mngr_lima/imbue/mngr_lima/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_modal/imbue/mngr_modal/test_ratchets.py
+++ b/libs/mngr_modal/imbue/mngr_modal/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_notifications/imbue/mngr_notifications/test_ratchets.py
+++ b/libs/mngr_notifications/imbue/mngr_notifications/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_opencode/imbue/mngr_opencode/test_ratchets.py
+++ b/libs/mngr_opencode/imbue/mngr_opencode/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
+++ b/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_pi_coding/imbue/mngr_pi_coding/test_ratchets.py
+++ b/libs/mngr_pi_coding/imbue/mngr_pi_coding/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_recursive/imbue/mngr_recursive/test_ratchets.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_schedule/imbue/mngr_schedule/test_ratchets.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/test_ratchets.py
@@ -197,6 +197,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(2))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py
@@ -199,6 +199,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_ttyd/imbue/mngr_ttyd/test_ratchets.py
+++ b/libs/mngr_ttyd/imbue/mngr_ttyd/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_tutor/imbue/mngr_tutor/test_ratchets.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/test_ratchets.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/test_ratchets.py
@@ -183,6 +183,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_vultr/imbue/mngr_vultr/test_ratchets.py
+++ b/libs/mngr_vultr/imbue/mngr_vultr/test_ratchets.py
@@ -181,6 +181,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
+++ b/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/modal_proxy/imbue/modal_proxy/test_ratchets.py
+++ b/libs/modal_proxy/imbue/modal_proxy/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/libs/skitwright/imbue/skitwright/test_ratchets.py
+++ b/libs/skitwright/imbue/skitwright/test_ratchets.py
@@ -196,6 +196,10 @@ def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 # --- Testing conventions ---
 
 

--- a/scripts/style_guide.py
+++ b/scripts/style_guide.py
@@ -938,7 +938,7 @@ class TodoNotificationService(MutableModel):
         try:
             self._send_notification(reminder)
         except ConnectionError as e:
-            logger.exception(e, "Failed to send notification")
+            logger.opt(exception=e).error("Failed to send notification")
             raise
 
 

--- a/style_guide.md
+++ b/style_guide.md
@@ -1294,8 +1294,8 @@ Always use `loguru` for logging
 
 Always use the right log level for your statement:
 
-- `logger.opt(exception=exc).error(msg)`: use this to capture *unexpected* exceptions (see "Exception logging" below). After logging, `raise` to continue propagating the exception
-- `logger.error`: use this for unexpected error situations where there is no Exception, or for *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`) via `logger.error("...: {}", exc)`
+- `logger.opt(exception=exc).error(msg)`: use this to capture all *unexpected* exceptions (don't use `logger.exception` -- it relies on `sys.exc_info()`, which is unreliable in threaded code). After calling this, just call "raise" to continue propagating the exception (since it is unexpected)
+- `logger.error`: use this for unexpected error situations (where there is no Exception, otherwise use)
 - `logger.warning`: use this for things that seem suspicious, but not worth crashing over (or you are in a part of the code that should not crash). These should be purged aggressively if ever seen in a log
 - `logger.info`: Use this to describe _what_ the application is doing at a high level. These messages are ideally something that would make sense to a user of the program. Info logs belong in CLI/user-facing code, not in library/API code
 - `logger.debug`: Use this to describe _how_ the application is doing it. These messages ideally make sense to the developer of the program. This is the primary level for library/API code
@@ -1360,11 +1360,7 @@ def create_todo(title: str) -> TodoItem:
 
 ## Exception logging
 
-Never use `logger.exception`: it relies on `sys.exc_info()`, which is unreliable in
-threaded code. For unexpected exceptions, bind the exception explicitly with
-`logger.opt(exception=exc).error(msg)` so the full traceback is captured. For expected
-domain exceptions (subtypes of `MngrError` / `BaseMngrError`), `logger.error("...: {}", exc)`
-is fine.
+Use `logger.opt(exception=e).error` only for unexpected exceptions.
 
 ```python
 from loguru import logger

--- a/style_guide.md
+++ b/style_guide.md
@@ -1294,8 +1294,8 @@ Always use `loguru` for logging
 
 Always use the right log level for your statement:
 
-- `logger.exception`: use this to capture all *unexpected* exceptions. After calling this, just call "raise" to continue propagating the exception (since it is unexpected)
-- `logger.error`: use this for unexpected error situations (where there is no Exception, otherwise use)
+- `logger.opt(exception=exc).error(msg)`: use this to capture all *unexpected* exceptions. Never use `logger.exception` -- it relies on `sys.exc_info()`, which is unreliable in threaded code (the exception context can be cleared or replaced by another thread between the `except` block and the actual log emission). Always bind the exception explicitly via `logger.opt(exception=exc)`. After logging, just call "raise" to continue propagating the exception (since it is unexpected)
+- `logger.error`: use this for unexpected error situations (where there is no Exception). For *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`), `logger.error("...: {}", exc)` is acceptable since the message captures the known error condition
 - `logger.warning`: use this for things that seem suspicious, but not worth crashing over (or you are in a part of the code that should not crash). These should be purged aggressively if ever seen in a log
 - `logger.info`: Use this to describe _what_ the application is doing at a high level. These messages are ideally something that would make sense to a user of the program. Info logs belong in CLI/user-facing code, not in library/API code
 - `logger.debug`: Use this to describe _how_ the application is doing it. These messages ideally make sense to the developer of the program. This is the primary level for library/API code
@@ -1360,7 +1360,13 @@ def create_todo(title: str) -> TodoItem:
 
 ## Exception logging
 
-Use `logger.exception` only for unexpected exceptions.
+Never use `logger.exception` -- it relies on `sys.exc_info()`, which is unreliable in
+threaded code. Always bind the exception explicitly with `logger.opt(exception=exc).error(msg)`
+when logging unexpected exceptions, so the full traceback is captured deterministically.
+
+For *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`), formatting
+the exception into the message via `logger.error("...: {}", exc)` is fine -- the message
+itself describes the known error condition.
 
 ```python
 from loguru import logger
@@ -1379,7 +1385,7 @@ class TodoNotificationService(MutableModel):
         try:
             self._send_notification(reminder)
         except ConnectionError as e:
-            logger.exception(e, "Failed to send notification")
+            logger.opt(exception=e).error("Failed to send notification")
             raise
 ```
 

--- a/style_guide.md
+++ b/style_guide.md
@@ -1294,8 +1294,8 @@ Always use `loguru` for logging
 
 Always use the right log level for your statement:
 
-- `logger.opt(exception=exc).error(msg)`: use this to capture all *unexpected* exceptions. Never use `logger.exception` -- it relies on `sys.exc_info()`, which is unreliable in threaded code (the exception context can be cleared or replaced by another thread between the `except` block and the actual log emission). Always bind the exception explicitly via `logger.opt(exception=exc)`. After logging, just call "raise" to continue propagating the exception (since it is unexpected)
-- `logger.error`: use this for unexpected error situations (where there is no Exception). For *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`), `logger.error("...: {}", exc)` is acceptable since the message captures the known error condition
+- `logger.opt(exception=exc).error(msg)`: use this to capture *unexpected* exceptions (see "Exception logging" below). After logging, `raise` to continue propagating the exception
+- `logger.error`: use this for unexpected error situations where there is no Exception, or for *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`) via `logger.error("...: {}", exc)`
 - `logger.warning`: use this for things that seem suspicious, but not worth crashing over (or you are in a part of the code that should not crash). These should be purged aggressively if ever seen in a log
 - `logger.info`: Use this to describe _what_ the application is doing at a high level. These messages are ideally something that would make sense to a user of the program. Info logs belong in CLI/user-facing code, not in library/API code
 - `logger.debug`: Use this to describe _how_ the application is doing it. These messages ideally make sense to the developer of the program. This is the primary level for library/API code
@@ -1360,13 +1360,11 @@ def create_todo(title: str) -> TodoItem:
 
 ## Exception logging
 
-Never use `logger.exception` -- it relies on `sys.exc_info()`, which is unreliable in
-threaded code. Always bind the exception explicitly with `logger.opt(exception=exc).error(msg)`
-when logging unexpected exceptions, so the full traceback is captured deterministically.
-
-For *expected* domain exceptions (subtypes of `MngrError` / `BaseMngrError`), formatting
-the exception into the message via `logger.error("...: {}", exc)` is fine -- the message
-itself describes the known error condition.
+Never use `logger.exception`: it relies on `sys.exc_info()`, which is unreliable in
+threaded code. For unexpected exceptions, bind the exception explicitly with
+`logger.opt(exception=exc).error(msg)` so the full traceback is captured. For expected
+domain exceptions (subtypes of `MngrError` / `BaseMngrError`), `logger.error("...: {}", exc)`
+is fine.
 
 ```python
 from loguru import logger


### PR DESCRIPTION
## Summary

- `logger.exception()` relies on `sys.exc_info()`, which is unreliable in threaded code -- the exception context can be cleared or replaced by another thread between the `except` block and the log emission, silently losing the traceback. Bind the exception explicitly via `logger.opt(exception=exc).error(msg)` (loguru) or `logger.error(msg, exc_info=exc)` (stdlib) so the traceback is captured deterministically.
- Audit `logger.error` calls that format an unexpected exception into the message string and convert them to bind the exception explicitly so the full traceback is preserved.
- Add a `PREVENT_LOGGER_EXCEPTION` ratchet (snapshot `0` across all projects) and update the style guide to document the convention.

### Going beyond the issue

The issue scopes "expected" exceptions to subtypes of `MngrError` / `BaseMngrError`. This PR also rebinds a handful of `logger.error("...: %s", exc)` calls in `apps/remote_service_connector/app.py` whose catches are external (`SuperTokensSessionError`, `SuperTokensGeneralError`) or builtin (`ValueError`, `KeyError`, `OSError`). They aren't `MngrError` subtypes, so under the issue's strict reading they're "unexpected" and should bind the exception -- but they aren't `MngrError` subtypes via the literal text either, so flagging the broader interpretation here.

Closes #1096

## Test plan

- [x] `just test-quick` on touched projects (`libs/imbue_common`, `libs/mngr`, `apps/minds`, `apps/minds_workspace_server`, `apps/remote_service_connector`) -- all unit tests pass
- [x] `test_prevent_logger_exception` ratchet passes (snapshot `0`) in every project's `test_ratchets.py`
- [x] Style guide example (`scripts/style_guide.py`) recompiles cleanly from `style_guide.md`
- [ ] CI runs the full `just test-offload` and `just test-offload-acceptance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)