### PR TITLE
add docker usage guide; improve template example in modal usage guide

### DIFF
--- a/libs/mngr/docs/concepts/docker_usage.md
+++ b/libs/mngr/docs/concepts/docker_usage.md
@@ -108,23 +108,35 @@ User-supplied bind mounts (`-s -v=...`) are independent of the host volume. They
 
 Three options, roughly in order of convenience for the local-Docker case.
 
-### Option A: Read directly from the host volume
+### Option A: Fetch the branch directly from the host volume
 
-When `is_host_volume_created = true` (the default), the agent's `host_dir` (and anything mngr puts under it, including worktree-mode work directories at `host_dir/worktrees/...`) lives on the shared Docker named volume. You can read it directly from the daemon host without any SSH:
+When `is_host_volume_created = true` (the default) and the agent's work directory lives under `host_dir` (the default for worktree/git-mirror transfer modes -- e.g. `/mngr/worktrees/<name>-<uuid>/`), the agent's git repo sits on the shared Docker named volume. You can git-fetch from it without involving SSH or `mngr pull`.
+
+On **Linux**, the volume is a real path on the daemon host, so you can fetch from it directly:
 
 ```bash
-# On Linux, the volume is mounted at a real path on disk:
-sudo ls /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/
+# Find the agent's work dir on the volume (one entry per agent):
+sudo ls /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/
 
-# Anywhere (including Docker Desktop on macOS), use the state container:
-docker exec <prefix>docker-state-<user_id> ls /mngr-state/volumes/
-
-# Or copy out via any throwaway container that mounts the volume:
-docker run --rm -v <prefix>docker-state-<user_id>:/data alpine \
-    tar -C /data/volumes/vol-<host_hex> -cf - . | tar -C ./local-out -xf -
+# Add it as a remote and fetch the agent's branch into your local checkout:
+git remote add my-agent /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/<name>-<uuid>
+git fetch my-agent
+git merge my-agent/<branch-name>     # or: git checkout my-agent/<branch-name>
 ```
 
-This bypasses SSH entirely and is the fastest option when the daemon is local. It only sees files mngr placed under `host_dir` -- if the agent's work dir is somewhere else (e.g. you used `target_path = /code/...` with a custom Dockerfile), use Option B or C instead.
+On **macOS Docker Desktop or remote daemons**, the volume isn't mounted on your filesystem. Copy the agent's `.git` (or the whole work dir) out via the state container, then fetch from the copy:
+
+```bash
+# Copy the agent's work dir out of the volume:
+docker cp <prefix>docker-state-<user_id>:/mngr-state/volumes/vol-<host_hex>/worktrees/<name>-<uuid> /tmp/my-agent
+
+# Fetch the branch from the copy:
+git remote add my-agent /tmp/my-agent
+git fetch my-agent
+git merge my-agent/<branch-name>
+```
+
+This bypasses SSH entirely and is the fastest option when the agent has already committed. It only works when the work dir is under `host_dir` -- if you set `target_path` to a path outside `host_dir` (e.g. `/code/my-project`), the work dir is on the container's overlay filesystem instead, and you need Option B or C.
 
 ### Option B: Give the agent git credentials
 

--- a/libs/mngr/docs/concepts/docker_usage.md
+++ b/libs/mngr/docs/concepts/docker_usage.md
@@ -106,43 +106,11 @@ User-supplied bind mounts (`-s -v=...`) are independent of the host volume. They
 
 ## Getting changes back
 
-Three options, roughly in order of convenience for the local-Docker case.
-
-### Option A: Fetch the branch directly from the host volume
-
-When `is_host_volume_created = true` (the default) and the agent's work directory lives under `host_dir` (the default for worktree/git-mirror transfer modes -- e.g. `/mngr/worktrees/<name>-<uuid>/`), the agent's git repo sits on the shared Docker named volume. You can git-fetch from it without involving SSH or `mngr pull`.
-
-On **Linux**, the volume is a real path on the daemon host, so you can fetch from it directly:
-
-```bash
-# Find the agent's work dir on the volume (one entry per agent):
-sudo ls /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/
-
-# Add it as a remote and fetch the agent's branch into your local checkout:
-git remote add my-agent /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/<name>-<uuid>
-git fetch my-agent
-git merge my-agent/<branch-name>     # or: git checkout my-agent/<branch-name>
-```
-
-On **macOS Docker Desktop or remote daemons**, the volume isn't mounted on your filesystem. Copy the agent's `.git` (or the whole work dir) out via the state container, then fetch from the copy:
-
-```bash
-# Copy the agent's work dir out of the volume:
-docker cp <prefix>docker-state-<user_id>:/mngr-state/volumes/vol-<host_hex>/worktrees/<name>-<uuid> /tmp/my-agent
-
-# Fetch the branch from the copy:
-git remote add my-agent /tmp/my-agent
-git fetch my-agent
-git merge my-agent/<branch-name>
-```
-
-This bypasses SSH entirely and is the fastest option when the agent has already committed. It only works when the work dir is under `host_dir` -- if you set `target_path` to a path outside `host_dir` (e.g. `/code/my-project`), the work dir is on the container's overlay filesystem instead, and you need Option B or C.
-
-### Option B: Give the agent git credentials
+### Option A: Give the agent git credentials
 
 If the agent has `GH_TOKEN` (via `pass_env` in a template or `--pass-env` on the CLI), it can `git push` directly.
 
-### Option C: Use `mngr pull`
+### Option B: Use `mngr pull`
 
 `mngr pull` transfers changes from the agent to your local machine without needing git credentials on the agent. It supports two sync modes:
 
@@ -179,6 +147,36 @@ mngr push my-agent:config ./config
 ```
 
 See [mngr pull](../commands/primary/pull.md) and [mngr push](../commands/primary/push.md) for all options.
+
+### Option C: Fetch the branch directly from the host volume
+
+When `is_host_volume_created = true` (the default) and the agent's work directory lives under `host_dir` (the default for worktree/git-mirror transfer modes -- e.g. `/mngr/worktrees/<name>-<uuid>/`), the agent's git repo sits on the shared Docker named volume. You can git-fetch from it without involving SSH or `mngr pull`.
+
+On **Linux**, the volume is a real path on the daemon host, so you can fetch from it directly:
+
+```bash
+# Find the agent's work dir on the volume (one entry per agent):
+sudo ls /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/
+
+# Add it as a remote and fetch the agent's branch into your local checkout:
+git remote add my-agent /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/vol-<host_hex>/worktrees/<name>-<uuid>
+git fetch my-agent
+git merge my-agent/<branch-name>     # or: git checkout my-agent/<branch-name>
+```
+
+On **macOS Docker Desktop or remote daemons**, the volume isn't mounted on your filesystem. Copy the agent's `.git` (or the whole work dir) out via the state container, then fetch from the copy:
+
+```bash
+# Copy the agent's work dir out of the volume:
+docker cp <prefix>docker-state-<user_id>:/mngr-state/volumes/vol-<host_hex>/worktrees/<name>-<uuid> /tmp/my-agent
+
+# Fetch the branch from the copy:
+git remote add my-agent /tmp/my-agent
+git fetch my-agent
+git merge my-agent/<branch-name>
+```
+
+This bypasses SSH entirely and is the fastest option when the agent has already committed. It only works when the work dir is under `host_dir` -- if you set `target_path` to a path outside `host_dir` (e.g. `/code/my-project`), the work dir is on the container's overlay filesystem instead, and you need Option A or B.
 
 ## Lifecycle and snapshots
 

--- a/libs/mngr/docs/concepts/docker_usage.md
+++ b/libs/mngr/docs/concepts/docker_usage.md
@@ -7,7 +7,7 @@ Run coding agents in Docker containers. For general agent management, see [mngr 
 - Docker installed and a reachable daemon (local Docker Desktop, a remote daemon via `DOCKER_HOST`, or a configured Docker context)
 - mngr installed and working locally
 
-The Docker client used by mngr resolves the daemon in the same order as the Docker CLI: `DOCKER_HOST`, then the active Docker context (from `~/.docker/config.json`), then the platform default. This means Docker Desktop on macOS works without extra configuration.
+The Docker client used by mngr resolves the daemon in the same order as the Docker CLI: `DOCKER_HOST`, then the active Docker context (from `~/.docker/config.json`), then the platform default.
 
 ## Creating a local agent
 
@@ -21,6 +21,10 @@ This builds a container, drops you into a tmux session, and gives you the same i
 
 If you do not pass an image or a Dockerfile, mngr builds a default image from `debian:bookworm-slim` with the packages it needs (`openssh-server`, `tmux`, `curl`, `rsync`, `git`, `jq`, `xxd`, `ca-certificates`). For faster startup on repeated creates, supply your own image (see below) so these packages are pre-installed alongside your project's dependencies.
 
+### How `-b` and `-s` flags work
+
+The Docker provider passes `-b` (or `--build-arg`) flags straight through to `docker build` and `-s` (or `--start-arg`) flags straight through to `docker run`. So anything those CLIs support is available -- `-b --no-cache`, `-b --build-arg=KEY=VAL`, `-s --device=...`, `-s --ulimit=...`, capabilities, secrets, networks, etc. Check `docker build --help` and `docker run --help` for the full set.
+
 ### Using a template
 
 If your project has a Docker template defined in `.mngr/settings.toml`, you can use `-t my-docker` instead of passing flags manually:
@@ -29,17 +33,18 @@ If your project has a Docker template defined in `.mngr/settings.toml`, you can 
 mngr create my-agent -t my-docker
 ```
 
-Example template:
+A typical Docker template builds the project's own Dockerfile and points the agent at the path inside the container where the source ends up:
 
 ```toml
 [create_templates.my-docker]
 provider = "docker"
+build_arg = ["--file=path/to/Dockerfile", "build/context/dir"]
+target_path = "/code/my-project"
 agent_args = ["--dangerously-skip-permissions"]
 pass_env = ["GH_TOKEN"]
-extra_window = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && git remote set-url origin https://github.com/<org>/<repo>.git && gh auth setup-git'"]
 ```
 
-The container is an isolated environment, so `--dangerously-skip-permissions` is reasonable for the container itself -- but credentials forwarded via `pass_env` (e.g. `GH_TOKEN`) can still be used by the agent without confirmation. Note also that the container can read/write any bind-mounted host paths you pass via `-s -v=...`, so do not rely on the container as a strong sandbox if you mount sensitive host directories.
+`build_arg` entries are appended to `docker build -t <generated-tag>` (so the last entry is the build context). The container is an isolated environment, so `--dangerously-skip-permissions` is reasonable for the container itself -- but credentials forwarded via `pass_env` (e.g. `GH_TOKEN`) can still be used by the agent without confirmation. The container can also read/write any bind-mounted host paths you pass via `-s -v=...`, so do not rely on the container as a strong sandbox if you mount sensitive host directories.
 
 See [Create Templates](../customization.md#create-templates) for the full set of template options.
 
@@ -101,13 +106,31 @@ User-supplied bind mounts (`-s -v=...`) are independent of the host volume. They
 
 ## Getting changes back
 
-To retrieve changes from the agent's container, either **let the agent push via git** or **use `mngr pull`**.
+Three options, roughly in order of convenience for the local-Docker case.
 
-### Option A: Give the agent git credentials
+### Option A: Reach into the host volume
+
+When `is_host_volume_created = true` (the default), the agent's `host_dir` (and anything mngr puts under it, including worktree-mode work directories at `host_dir/worktrees/...`) lives on the shared Docker named volume. You can read it directly from the daemon host without any SSH:
+
+```bash
+# On Linux, the volume is mounted at a real path on disk:
+sudo ls /var/lib/docker/volumes/<prefix>docker-state-<user_id>/_data/volumes/
+
+# Anywhere (including Docker Desktop on macOS), use the state container:
+docker exec <prefix>docker-state-<user_id> ls /mngr-state/volumes/
+
+# Or copy out via any throwaway container that mounts the volume:
+docker run --rm -v <prefix>docker-state-<user_id>:/data alpine \
+    tar -C /data/volumes/vol-<host_hex> -cf - . | tar -C ./local-out -xf -
+```
+
+This bypasses SSH entirely and is the fastest option when the daemon is local. It only sees files mngr placed under `host_dir` -- if the agent's work dir is somewhere else (e.g. you used `target_path = /code/...` with a custom Dockerfile), use Option B or C instead.
+
+### Option B: Give the agent git credentials
 
 If the agent has `GH_TOKEN` (via `pass_env` in a template or `--pass-env` on the CLI), it can `git push` directly.
 
-### Option B: Use `mngr pull`
+### Option C: Use `mngr pull`
 
 `mngr pull` transfers changes from the agent to your local machine without needing git credentials on the agent. It supports two sync modes:
 
@@ -192,4 +215,4 @@ The SSH hostname is derived only from the explicit `host` config field, not from
 
 ## What else is possible
 
-The Docker provider passes `-b` flags through to `docker build` and `-s` flags through to `docker run`, so anything those CLIs support is available -- secrets via `--build-arg` / `--secret`, multi-stage builds, custom networks, devices via `--device`, ulimits, capabilities, etc. See `docker build --help` and `docker run --help` for the full set, and the [Docker provider reference](../core_plugins/providers/docker.md) for mngr-specific configuration.
+See the [Docker provider reference](../core_plugins/providers/docker.md) for the full list of provider config options. Anything supported by `docker build` / `docker run` is reachable via `-b` / `-s` -- secrets via `--secret`, multi-stage builds, `--device`, `--cap-add`, `--ulimit`, custom networks, etc.

--- a/libs/mngr/docs/concepts/docker_usage.md
+++ b/libs/mngr/docs/concepts/docker_usage.md
@@ -108,7 +108,7 @@ User-supplied bind mounts (`-s -v=...`) are independent of the host volume. They
 
 Three options, roughly in order of convenience for the local-Docker case.
 
-### Option A: Reach into the host volume
+### Option A: Read directly from the host volume
 
 When `is_host_volume_created = true` (the default), the agent's `host_dir` (and anything mngr puts under it, including worktree-mode work directories at `host_dir/worktrees/...`) lives on the shared Docker named volume. You can read it directly from the daemon host without any SSH:
 

--- a/libs/mngr/docs/concepts/docker_usage.md
+++ b/libs/mngr/docs/concepts/docker_usage.md
@@ -1,0 +1,195 @@
+# Using Docker
+
+Run coding agents in Docker containers. For general agent management, see [mngr create](../commands/primary/create.md). For the full list of Docker provider arguments, see the [Docker provider reference](../core_plugins/providers/docker.md).
+
+## Prerequisites
+
+- Docker installed and a reachable daemon (local Docker Desktop, a remote daemon via `DOCKER_HOST`, or a configured Docker context)
+- mngr installed and working locally
+
+The Docker client used by mngr resolves the daemon in the same order as the Docker CLI: `DOCKER_HOST`, then the active Docker context (from `~/.docker/config.json`), then the platform default. This means Docker Desktop on macOS works without extra configuration.
+
+## Creating a local agent
+
+From any git repo:
+
+```bash
+mngr create my-agent --provider docker
+```
+
+This builds a container, drops you into a tmux session, and gives you the same interactive experience as a local agent. Equivalently you can use the address form `mngr create my-agent@.docker`.
+
+If you do not pass an image or a Dockerfile, mngr builds a default image from `debian:bookworm-slim` with the packages it needs (`openssh-server`, `tmux`, `curl`, `rsync`, `git`, `jq`, `xxd`, `ca-certificates`). For faster startup on repeated creates, supply your own image (see below) so these packages are pre-installed alongside your project's dependencies.
+
+### Using a template
+
+If your project has a Docker template defined in `.mngr/settings.toml`, you can use `-t my-docker` instead of passing flags manually:
+
+```bash
+mngr create my-agent -t my-docker
+```
+
+Example template:
+
+```toml
+[create_templates.my-docker]
+provider = "docker"
+agent_args = ["--dangerously-skip-permissions"]
+pass_env = ["GH_TOKEN"]
+extra_window = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && git remote set-url origin https://github.com/<org>/<repo>.git && gh auth setup-git'"]
+```
+
+The container is an isolated environment, so `--dangerously-skip-permissions` is reasonable for the container itself -- but credentials forwarded via `pass_env` (e.g. `GH_TOKEN`) can still be used by the agent without confirmation. Note also that the container can read/write any bind-mounted host paths you pass via `-s -v=...`, so do not rely on the container as a strong sandbox if you mount sensitive host directories.
+
+See [Create Templates](../customization.md#create-templates) for the full set of template options.
+
+## Resource limits, GPUs, networking, and volumes
+
+Build arguments (`-b`) are passed to `docker build`. Start arguments (`-s`) are passed to `docker run`. Use start args for everything that affects how the container runs:
+
+```bash
+# CPU and memory limits
+mngr create my-agent --provider docker -s --cpus=4 -s --memory=16g
+
+# GPU access (requires the NVIDIA Container Toolkit)
+mngr create my-agent --provider docker -s --gpus=all
+
+# Bind-mount a host directory
+mngr create my-agent --provider docker -s -v=/host/data:/container/data
+
+# Attach to a Docker network
+mngr create my-agent --provider docker -s --network=my-network
+
+# Publish an extra port (the SSH port mngr uses is published automatically)
+mngr create my-agent --provider docker -s -p=8080:80
+```
+
+You can set defaults that apply to every container in your config:
+
+```toml
+[providers.docker]
+backend = "docker"
+default_start_args = ["--cpus=2", "--memory=4g"]
+```
+
+Per-create `-s` flags are appended to the defaults; Docker uses the last occurrence when a flag is repeated.
+
+## Custom images and Dockerfiles
+
+There are three ways to control the base image:
+
+1. **Use a pre-built image** -- set `default_image = "<ref>"` in your provider config. mngr pulls it on each create.
+2. **Build from a Dockerfile** -- pass build args:
+   ```bash
+   mngr create my-agent --provider docker -b --file=./Dockerfile -b .
+   ```
+   Everything after `-b` is appended to `docker build -t <generated-tag>`. The trailing `-b .` is the build context. Add `-b --no-cache`, `-b --build-arg=KEY=VAL`, etc. as needed.
+3. **Fall back to the mngr default Dockerfile** -- omit both. mngr warns and builds a minimal Debian image with the required packages.
+
+Whatever image you provide must include (or be able to install at runtime) `openssh-server`, `tmux`, `curl`, `rsync`, `git`, `jq`, `xxd`, and `ca-certificates`. If you are running fully offline, pre-install them so the runtime install step is a no-op.
+
+## Persistent host volume
+
+By default, each host's `host_dir` (e.g. `/mngr`) is symlinked to a sub-folder of a shared Docker named volume (`<prefix>docker-state-<user_id>`). This volume is mounted into both the host container and a small singleton "state container" that mngr uses as a file server. Two consequences:
+
+- **Offline access**: logs, agent data, and host metadata stay readable via `mngr events` and `mngr list` even after the container is stopped, because mngr reads them through the state container.
+- **Shared daemon, multiple clients**: multiple mngr clients pointing at the same Docker daemon see the same hosts and agents (provided they use the same profile `user_id`). Different `user_id`s are isolated by separate state volumes.
+
+You can disable this by setting `is_host_volume_created = false` in your provider config. The `host_dir` then lives on the container's overlay filesystem; it survives stop/start (Docker preserves the container filesystem) but is not accessible while the container is stopped.
+
+User-supplied bind mounts (`-s -v=...`) are independent of the host volume. They are **not** captured in snapshots -- only the container's filesystem layers are.
+
+## Getting changes back
+
+To retrieve changes from the agent's container, either **let the agent push via git** or **use `mngr pull`**.
+
+### Option A: Give the agent git credentials
+
+If the agent has `GH_TOKEN` (via `pass_env` in a template or `--pass-env` on the CLI), it can `git push` directly.
+
+### Option B: Use `mngr pull`
+
+`mngr pull` transfers changes from the agent to your local machine without needing git credentials on the agent. It supports two sync modes:
+
+**Pull git commits** (when the agent has committed its work):
+
+```bash
+mngr pull my-agent --sync-mode=git
+```
+
+This merges the agent's branch into your current local branch.
+
+**Pull files** (default -- works for uncommitted changes and non-git-tracked files):
+
+```bash
+mngr pull my-agent
+```
+
+This uses rsync over SSH to sync the agent's working directory to your current directory. To preview what would be transferred first:
+
+```bash
+mngr pull my-agent --dry-run
+```
+
+You can also pull a specific subdirectory:
+
+```bash
+mngr pull my-agent:src ./local-src
+```
+
+To push local changes to the agent (e.g. a config file you edited locally):
+
+```bash
+mngr push my-agent:config ./config
+```
+
+See [mngr pull](../commands/primary/pull.md) and [mngr push](../commands/primary/push.md) for all options.
+
+## Lifecycle and snapshots
+
+`mngr connect`, `mngr message`, `mngr stop`, `mngr start`, `mngr destroy`, and `mngr list` all work the same as for local and Modal agents. The Docker-specific behavior:
+
+- **Native stop/start.** Unlike Modal, Docker supports real `docker stop` / `docker start`. `mngr stop` stops the container (preserving its filesystem), and `mngr start` restarts the same container. `mngr destroy` removes the container permanently.
+- **Idle detection still applies.** The default idle timeout is 800 seconds. When idle detection fires, the host is stopped (not destroyed), so `mngr start` will resume it. `--idle-mode disabled` keeps the container running indefinitely.
+- **No forced lifetime cap.** Containers do not have a Modal-style maximum sandbox lifetime. They run until you stop them or idle detection stops them.
+- **Snapshot before stop.** By default, `mngr stop` takes a snapshot via `docker commit` before stopping. If the container is later removed (rather than just stopped), `mngr start` will recreate it from the most recent snapshot.
+
+You can also create named snapshots manually:
+
+```bash
+mngr snapshot create my-agent --name before-refactor
+```
+
+Snapshots are stored as Docker images (`mngr-snapshot:<host_id>-<name>`). They capture the container's filesystem layers but **not** the contents of any volumes -- bind mounts (`-s -v=...`), named volumes, or the shared host volume. When mngr restores a host from a snapshot, it re-mounts the same host volume sub-folder, so anything the agent wrote under `host_dir` (e.g. `/mngr`) reappears via the persistent volume rather than via the snapshot image itself. The snapshot image alone is therefore not a self-contained backup of agent state. If you need a portable filesystem snapshot of the host, also copy the contents of `host_dir` separately (e.g. with `mngr pull`).
+
+See [mngr snapshot](../commands/secondary/snapshot.md) for details.
+
+## Tags are immutable
+
+Docker stores tags as container labels, which Docker does not let you mutate after creation. Set tags at create time:
+
+```bash
+mngr create my-agent --provider docker --host-label env=test --host-label team=infra
+```
+
+`mngr` will refuse `set_host_tags` / `add_tags_to_host` / `remove_tags_from_host` after the container exists. If you need to change a tag, recreate the host (or restore from a snapshot with new labels).
+
+## Remote Docker daemons
+
+Point the provider at a remote daemon by setting `host` in the config or by exporting `DOCKER_HOST`:
+
+```toml
+[providers.docker]
+backend = "docker"
+host = "ssh://user@server"      # or "tcp://host:2376"
+```
+
+When `host` is unset, mngr resolves the daemon from `DOCKER_HOST`, then the active Docker context, then the platform default -- the same order the Docker CLI uses.
+
+For remote daemons, the SSH endpoint mngr uses to reach each container is the daemon's hostname (parsed out of `ssh://user@server` or `tcp://host:2376`); for local daemons, it is `127.0.0.1`. The SSH port for each container is auto-assigned by Docker via `-p :22`.
+
+The SSH hostname is derived only from the explicit `host` config field, not from `DOCKER_HOST` or the Docker context. If you point mngr at a remote daemon via `DOCKER_HOST`/context but leave `host` empty, the daemon connection will work but mngr will try to SSH to `127.0.0.1` -- which will fail. Set `host = "ssh://..."` (or `"tcp://..."`) in the provider config when the daemon is not local.
+
+## What else is possible
+
+The Docker provider passes `-b` flags through to `docker build` and `-s` flags through to `docker run`, so anything those CLIs support is available -- secrets via `--build-arg` / `--secret`, multi-stage builds, custom networks, devices via `--device`, ulimits, capabilities, etc. See `docker build --help` and `docker run --help` for the full set, and the [Docker provider reference](../core_plugins/providers/docker.md) for mngr-specific configuration.

--- a/libs/mngr/docs/concepts/modal_usage.md
+++ b/libs/mngr/docs/concepts/modal_usage.md
@@ -27,17 +27,19 @@ mngr create my-agent -t my-modal
 
 A typical Modal template includes `--dangerously-skip-permissions` since Modal sandboxes are disposable environments. This is safe for the sandbox itself, but be aware that any credentials you provide (e.g. `GH_TOKEN`) can be used by the agent without confirmation prompts.
 
-Example template:
+A typical Modal template builds the project's Dockerfile, mounts any volumes the agent needs, and points the agent at the path inside the sandbox where the source ends up:
 
 ```toml
 [create_templates.my-modal]
 provider = "modal"
+build_arg = ["file=path/to/Dockerfile", "context-dir=build/context/dir", "volume=my-cache:/cache"]
+target_path = "/code/my-project"
 agent_args = ["--dangerously-skip-permissions"]
 pass_env = ["GH_TOKEN"]
 extra_window = ["github_setup='ssh-keyscan github.com >> ~/.ssh/known_hosts && git remote set-url origin https://github.com/<org>/<repo>.git && gh auth setup-git'"]
 ```
 
-The `extra_window` creates a tmux window that trusts GitHub's host key, switches the remote to HTTPS (since the sandbox won't have your SSH keys), and configures git to authenticate via `gh` (which uses `GH_TOKEN`).
+`build_arg` entries are passed to the Modal sandbox builder as `key=value` pairs (see the [provider reference](../core_plugins/providers/modal.md#available-build-arguments) for the full list). `target_path` is where the agent runs commands -- if your Dockerfile copies the source to `/code/my-project`, set `target_path` to match. The `extra_window` creates a tmux window that trusts GitHub's host key, switches the remote to HTTPS (since the sandbox won't have your SSH keys), and configures git to authenticate via `gh` (which uses `GH_TOKEN`).
 
 See [Create Templates](../customization.md#create-templates) for the full set of template options.
 
@@ -49,7 +51,15 @@ Modal sandboxes have a default timeout of 15 minutes (900 seconds), after which 
 mngr create my-agent --provider modal -b timeout=3600
 ```
 
-The maximum is 86400 (24 hours).
+The maximum is 86400 (24 hours). To raise the default for every sandbox, set `default_sandbox_timeout` in your provider config:
+
+```toml
+[providers.modal]
+default_sandbox_timeout = 7200  # 2 hours
+default_cpu = 4
+default_memory = 8
+default_idle_timeout = 600
+```
 
 ## Getting changes back
 

--- a/libs/mngr/docs/concepts/modal_usage.md
+++ b/libs/mngr/docs/concepts/modal_usage.md
@@ -51,7 +51,7 @@ Modal sandboxes have a default timeout of 15 minutes (900 seconds), after which 
 mngr create my-agent --provider modal -b timeout=3600
 ```
 
-The maximum is 86400 (24 hours). To raise the default for every sandbox, set `default_sandbox_timeout` in your provider config:
+The maximum is 86400 (24 hours). To set the default for every sandbox, use `default_sandbox_timeout` in your provider config:
 
 ```toml
 [providers.modal]


### PR DESCRIPTION
## Summary
- New \`libs/mngr/docs/concepts/docker_usage.md\` mirroring \`concepts/modal_usage.md\` for the Docker provider.
- Covers Docker-specific material the Modal doc does not: daemon resolution order, three image options + required packages, \`-b\`/\`-s\` passthrough contract, persistent host volume + state container, snapshot semantics (image layers only, no volume contents), immutable tags, native stop/start, remote-daemon SSH-host footgun, and direct host-volume access as the fastest local option for getting changes back.
- Updates \`modal_usage.md\`: template now uses \`build_arg\` + \`target_path\` (matching how real templates are written), and adds a \`[providers.modal]\` config snippet showing \`default_sandbox_timeout\` / \`default_cpu\` / \`default_memory\` / \`default_idle_timeout\`.
- Claims verified against \`providers/docker/{instance,config,volume,host_store}.py\`, \`mngr_modal/config.py\`, and \`ssh_host_setup.REQUIRED_HOST_PACKAGES\`.

## Test plan
- [ ] Render the Markdown and skim for broken relative links
- [ ] Sanity-check the example commands actually work end-to-end against a local Docker daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)