### PR TITLE
add plugin install hints to various errors, checked against catalog of first-party plugins

### DIFF
--- a/libs/mngr/imbue/mngr/api/providers_test.py
+++ b/libs/mngr/imbue/mngr/api/providers_test.py
@@ -37,13 +37,21 @@ def test_get_unknown_backend_raises() -> None:
     assert "nonexistent" in str(exc_info.value)
 
 
-def test_get_unknown_backend_includes_plugin_install_hint() -> None:
-    """Unknown backend errors should suggest installing the matching plugin."""
+def test_get_unknown_backend_includes_plugin_install_hint_for_cataloged_backend() -> None:
+    """Unknown backend errors should name the actual package for cataloged plugins."""
     with pytest.raises(UnknownBackendError) as exc_info:
-        get_backend("lima")
+        get_backend("modal")
     formatted = exc_info.value.format_message()
-    assert "imbue-mngr-lima" in formatted
-    assert "plugin" in formatted
+    assert "imbue-mngr-modal" in formatted
+
+
+def test_get_unknown_backend_uses_generic_hint_for_uncataloged_backend() -> None:
+    """Unknown backend errors for uncataloged names should not fabricate a package name."""
+    with pytest.raises(UnknownBackendError) as exc_info:
+        get_backend("xyzzy")
+    formatted = exc_info.value.format_message()
+    assert "imbue-mngr-xyzzy" not in formatted
+    assert "not a known mngr plugin" in formatted
 
 
 def test_get_local_provider_instance(temp_mngr_ctx: MngrContext) -> None:

--- a/libs/mngr/imbue/mngr/api/providers_test.py
+++ b/libs/mngr/imbue/mngr/api/providers_test.py
@@ -37,6 +37,15 @@ def test_get_unknown_backend_raises() -> None:
     assert "nonexistent" in str(exc_info.value)
 
 
+def test_get_unknown_backend_includes_plugin_install_hint() -> None:
+    """Unknown backend errors should suggest installing the matching plugin."""
+    with pytest.raises(UnknownBackendError) as exc_info:
+        get_backend("lima")
+    formatted = exc_info.value.format_message()
+    assert "imbue-mngr-lima" in formatted
+    assert "plugin" in formatted
+
+
 def test_get_local_provider_instance(temp_mngr_ctx: MngrContext) -> None:
     """Test getting a local provider instance."""
     provider = get_provider_instance(LOCAL_PROVIDER_NAME, temp_mngr_ctx)

--- a/libs/mngr/imbue/mngr/api/providers_test.py
+++ b/libs/mngr/imbue/mngr/api/providers_test.py
@@ -51,7 +51,8 @@ def test_get_unknown_backend_uses_generic_hint_for_uncataloged_backend() -> None
         get_backend("xyzzy")
     formatted = exc_info.value.format_message()
     assert "imbue-mngr-xyzzy" not in formatted
-    assert "not a known mngr plugin" in formatted
+    assert "do not recognize 'xyzzy'" in formatted
+    assert "third-party plugin" in formatted
 
 
 def test_get_local_provider_instance(temp_mngr_ctx: MngrContext) -> None:

--- a/libs/mngr/imbue/mngr/cli/default_command_group.py
+++ b/libs/mngr/imbue/mngr/cli/default_command_group.py
@@ -3,6 +3,7 @@ from typing import Any
 import click
 
 from imbue.mngr.config.pre_readers import read_default_command
+from imbue.mngr.plugin_catalog import get_install_hint_for_cli_command
 
 
 class DefaultCommandGroup(click.Group):
@@ -50,4 +51,8 @@ class DefaultCommandGroup(click.Group):
             cmd = self.get_command(ctx, args[0])
             if cmd is None and self._default_command:
                 return super().resolve_command(ctx, [self._default_command] + args)
+            if cmd is None:
+                hint = get_install_hint_for_cli_command(args[0])
+                if hint is not None:
+                    raise click.UsageError(f"No such command '{args[0]}'. {hint}", ctx)
         return super().resolve_command(ctx, args)

--- a/libs/mngr/imbue/mngr/config/agent_class_registry.py
+++ b/libs/mngr/imbue/mngr/config/agent_class_registry.py
@@ -1,4 +1,4 @@
-from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import UnknownAgentTypeError
 from imbue.mngr.primitives import AgentTypeName
 
 # =============================================================================
@@ -31,14 +31,14 @@ def get_agent_class(agent_type: str) -> type:
     """Get the agent class for an agent type.
 
     Returns the default agent class if no specific type is registered.
-    Raises MngrError if no default has been set.
+    Raises UnknownAgentTypeError if no default has been set.
     """
     key = AgentTypeName(agent_type)
     if key in _agent_class_registry:
         return _agent_class_registry[key]
     if _default_agent_class is not None:
         return _default_agent_class
-    raise MngrError(f"Unknown agent type '{agent_type}' and no default agent class set.")
+    raise UnknownAgentTypeError(agent_type)
 
 
 def is_agent_class_registered(agent_type: str) -> bool:

--- a/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
+++ b/libs/mngr/imbue/mngr/config/agent_config_registry_test.py
@@ -195,6 +195,15 @@ def test_get_agent_class_raises_when_unknown_and_no_default() -> None:
         get_agent_class("nonexistent")
 
 
+def test_get_agent_class_unknown_includes_install_hint_for_known_plugin() -> None:
+    """Unknown agent types that match a cataloged plugin should suggest installing it."""
+    reset_agent_class_registry()
+    with pytest.raises(MngrError) as exc_info:
+        get_agent_class("claude")
+    formatted = exc_info.value.format_message()
+    assert "imbue-mngr-claude" in formatted
+
+
 # =============================================================================
 # resolve_agent_type tests
 # =============================================================================

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -39,6 +39,7 @@ from imbue.mngr.config.provider_config_registry import list_registered_provider_
 from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.errors import UnknownBackendError
 from imbue.mngr.errors import UserInputError
+from imbue.mngr.plugin_catalog import get_plugin_install_hint
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import PluginName
 from imbue.mngr.primitives import ProviderInstanceName
@@ -358,12 +359,7 @@ def _parse_providers(
                     f" block. Currently disabled plugins: {', '.join(sorted(disabled_plugins))}"
                 )
             else:
-                msg += (
-                    f" The plugin package that provides the"
-                    f" '{backend}' backend may not be installed. If you installed mngr"
-                    f" as a tool, try reinstalling with the plugin package"
-                    f" (e.g. --with 'imbue-mngr-{backend}')."
-                )
+                msg += f" {get_plugin_install_hint(backend)}"
             if strict:
                 raise ConfigParseError(msg) from e
             else:

--- a/libs/mngr/imbue/mngr/config/provider_config_registry.py
+++ b/libs/mngr/imbue/mngr/config/provider_config_registry.py
@@ -24,8 +24,8 @@ def get_provider_config_class(backend_name: str) -> type[ProviderInstanceConfig]
     """
     key = ProviderBackendName(backend_name)
     if key not in _provider_config_registry:
-        registered = ", ".join(sorted(str(k) for k in _provider_config_registry.keys()))
-        raise UnknownBackendError(f"Unknown provider backend: {key}. Registered backends: {registered or '(none)'}")
+        registered = sorted(str(k) for k in _provider_config_registry.keys())
+        raise UnknownBackendError(str(key), registered)
     return _provider_config_registry[key]
 
 

--- a/libs/mngr/imbue/mngr/default_command_group_test.py
+++ b/libs/mngr/imbue/mngr/default_command_group_test.py
@@ -76,6 +76,26 @@ def test_unrecognized_command_errors_by_default() -> None:
     assert "No such command" in result.output
 
 
+def test_unrecognized_command_for_known_plugin_includes_install_hint() -> None:
+    """Unknown command names that match a cataloged plugin should suggest installing it."""
+    record: dict[str, str | None] = {}
+    group = _make_test_group(record)
+    runner = CliRunner()
+    result = runner.invoke(group, ["wait"])
+    assert result.exit_code != 0
+    assert "imbue-mngr-wait" in result.output
+
+
+def test_unrecognized_command_for_aliased_plugin_includes_install_hint() -> None:
+    """Plugins whose CLI command name differs from the entry-point name should still match."""
+    record: dict[str, str | None] = {}
+    group = _make_test_group(record)
+    runner = CliRunner()
+    result = runner.invoke(group, ["notify"])
+    assert result.exit_code != 0
+    assert "imbue-mngr-notifications" in result.output
+
+
 def test_unrecognized_command_forwards_when_configured() -> None:
     """Running the group with an unrecognized command should forward to the configured default."""
     record: dict[str, str | None] = {}

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -370,6 +370,15 @@ class ConfigStructureError(ConfigError, TypeError):
     """Invalid configuration structure."""
 
 
+class UnknownAgentTypeError(ConfigError):
+    """Unknown agent type."""
+
+    def __init__(self, agent_type: str) -> None:
+        self.agent_type = agent_type
+        super().__init__(f"Unknown agent type '{agent_type}' and no default agent class set.")
+        self.user_help_text = get_plugin_install_hint(agent_type)
+
+
 class UnknownBackendError(ConfigError):
     """Unknown provider backend."""
 

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -373,13 +373,13 @@ class ConfigStructureError(ConfigError, TypeError):
 class UnknownBackendError(ConfigError):
     """Unknown provider backend."""
 
-    def __init__(self, key: str, registered: list[str] | None = None) -> None:
-        self.key = key
+    def __init__(self, backend_name: str, registered: list[str] | None = None) -> None:
+        self.backend_name = backend_name
         self.registered = list(registered) if registered is not None else []
         registered_str = ", ".join(self.registered) or "(none)"
-        message = f"Unknown provider backend: {key}. Registered backends: {registered_str}"
+        message = f"Unknown provider backend: {backend_name}. Registered backends: {registered_str}"
         super().__init__(message)
-        self.user_help_text = get_plugin_install_hint(key)
+        self.user_help_text = get_plugin_install_hint(backend_name)
 
 
 class NestedTmuxError(MngrError):

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from click import ClickException
 
+from imbue.mngr.plugin_catalog import get_plugin_install_hint
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import HostId
@@ -378,12 +379,7 @@ class UnknownBackendError(ConfigError):
         registered_str = ", ".join(self.registered) or "(none)"
         message = f"Unknown provider backend: {key}. Registered backends: {registered_str}"
         super().__init__(message)
-        self.user_help_text = (
-            f"If '{key}' is provided by a plugin, install the package that"
-            f" registers it (e.g. 'imbue-mngr-{key}') and ensure the plugin is"
-            " enabled. If you installed mngr as a uv tool, reinstall it with"
-            f" '--with imbue-mngr-{key}'."
-        )
+        self.user_help_text = get_plugin_install_hint(key)
 
 
 class NestedTmuxError(MngrError):

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -372,6 +372,19 @@ class ConfigStructureError(ConfigError, TypeError):
 class UnknownBackendError(ConfigError):
     """Unknown provider backend."""
 
+    def __init__(self, key: str, registered: list[str] | None = None) -> None:
+        self.key = key
+        self.registered = list(registered) if registered is not None else []
+        registered_str = ", ".join(self.registered) or "(none)"
+        message = f"Unknown provider backend: {key}. Registered backends: {registered_str}"
+        super().__init__(message)
+        self.user_help_text = (
+            f"If '{key}' is provided by a plugin, install the package that"
+            f" registers it (e.g. 'imbue-mngr-{key}') and ensure the plugin is"
+            " enabled. If you installed mngr as a uv tool, reinstall it with"
+            f" '--with imbue-mngr-{key}'."
+        )
+
 
 class NestedTmuxError(MngrError):
     """Cannot attach to tmux session from inside another tmux session."""

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -373,9 +373,9 @@ class ConfigStructureError(ConfigError, TypeError):
 class UnknownBackendError(ConfigError):
     """Unknown provider backend."""
 
-    def __init__(self, backend_name: str, registered: list[str] | None = None) -> None:
+    def __init__(self, backend_name: str, registered: list[str]) -> None:
         self.backend_name = backend_name
-        self.registered = list(registered) if registered is not None else []
+        self.registered = list(registered)
         registered_str = ", ".join(self.registered) or "(none)"
         message = f"Unknown provider backend: {backend_name}. Registered backends: {registered_str}"
         super().__init__(message)

--- a/libs/mngr/imbue/mngr/plugin_catalog.py
+++ b/libs/mngr/imbue/mngr/plugin_catalog.py
@@ -75,6 +75,10 @@ class CatalogEntry(FrozenModel):
     tier: PluginTier = Field(description="INDEPENDENT (works alone) or DEPENDENT (needs another plugin's signal)")
     signal: SignalCheck | None = Field(default=None, description="Signal check, or None")
     is_recommended: bool = Field(default=False, description="Whether this plugin is recommended for most users")
+    cli_command_names: tuple[str, ...] = Field(
+        default=(),
+        description="Top-level CLI command names this plugin registers, when different from entry_point_name",
+    )
 
 
 # Descriptions sourced from each plugin's pyproject.toml.
@@ -164,6 +168,7 @@ PLUGIN_CATALOG: Final[tuple[CatalogEntry, ...]] = (
         package_name="imbue-mngr-notifications",
         description="Notification plugin for mngr - alerts when agents transition to WAITING state",
         tier=PluginTier.INDEPENDENT,
+        cli_command_names=("notify",),
     ),
     CatalogEntry(
         entry_point_name="pair",
@@ -202,6 +207,18 @@ PLUGIN_CATALOG: Final[tuple[CatalogEntry, ...]] = (
 _CATALOG_BY_ENTRY_POINT: Final[dict[str, CatalogEntry]] = {e.entry_point_name: e for e in PLUGIN_CATALOG}
 
 
+def _build_catalog_by_cli_command() -> dict[str, CatalogEntry]:
+    index: dict[str, CatalogEntry] = {}
+    for entry in PLUGIN_CATALOG:
+        names = entry.cli_command_names or (entry.entry_point_name,)
+        for name in names:
+            index.setdefault(name, entry)
+    return index
+
+
+_CATALOG_BY_CLI_COMMAND: Final[dict[str, CatalogEntry]] = _build_catalog_by_cli_command()
+
+
 def get_catalog_entry(entry_point_name: str) -> CatalogEntry | None:
     """Look up a catalog entry by its pluggy entry point name.
 
@@ -233,6 +250,14 @@ def check_signal(signal: SignalCheck) -> bool:
             return False
 
 
+def _format_install_hint(entry: CatalogEntry) -> str:
+    return (
+        f"This plugin is provided by '{entry.package_name}' ({entry.description})."
+        f" Install it (e.g. reinstall the mngr uv tool with '--with {entry.package_name}')"
+        " and ensure the plugin is enabled."
+    )
+
+
 def get_plugin_install_hint(name: str) -> str:
     """Return user-facing help text for a missing plugin entry point.
 
@@ -243,16 +268,25 @@ def get_plugin_install_hint(name: str) -> str:
     """
     entry = get_catalog_entry(name)
     if entry is not None:
-        return (
-            f"If you want the '{name}' plugin ({entry.description}),"
-            f" install '{entry.package_name}'. If you installed mngr as a uv"
-            f" tool, reinstall it with '--with {entry.package_name}'."
-        )
+        return _format_install_hint(entry)
     return (
         f"'{name}' is not a known mngr plugin. If it is provided by a"
         " third-party plugin, install that package and ensure the plugin is"
         " enabled. Run 'mngr extras' to see installable plugins."
     )
+
+
+def get_install_hint_for_cli_command(command_name: str) -> str | None:
+    """Return install help for a CLI command provided by a known plugin, or None.
+
+    Returns None when the command name is not registered by any cataloged
+    plugin, so callers can fall back to the default click "no such command"
+    error without fabricating advice.
+    """
+    entry = _CATALOG_BY_CLI_COMMAND.get(command_name)
+    if entry is None:
+        return None
+    return _format_install_hint(entry)
 
 
 def get_installable_packages() -> tuple[CatalogEntry, ...]:

--- a/libs/mngr/imbue/mngr/plugin_catalog.py
+++ b/libs/mngr/imbue/mngr/plugin_catalog.py
@@ -233,6 +233,28 @@ def check_signal(signal: SignalCheck) -> bool:
             return False
 
 
+def get_plugin_install_hint(name: str) -> str:
+    """Return user-facing help text for a missing plugin entry point.
+
+    If the name appears in the catalog, names the actual PyPI package and
+    description. Otherwise returns a generic prompt to check installed
+    plugins, since fabricating a package name for an unknown name would be
+    misleading.
+    """
+    entry = get_catalog_entry(name)
+    if entry is not None:
+        return (
+            f"If you want the '{name}' plugin ({entry.description}),"
+            f" install '{entry.package_name}'. If you installed mngr as a uv"
+            f" tool, reinstall it with '--with {entry.package_name}'."
+        )
+    return (
+        f"'{name}' is not a known mngr plugin. If it is provided by a"
+        " third-party plugin, install that package and ensure the plugin is"
+        " enabled. Run 'mngr extras' to see installable plugins."
+    )
+
+
 def get_installable_packages() -> tuple[CatalogEntry, ...]:
     """Return one representative CatalogEntry per unique package.
 

--- a/libs/mngr/imbue/mngr/plugin_catalog.py
+++ b/libs/mngr/imbue/mngr/plugin_catalog.py
@@ -59,11 +59,18 @@ class ModalSignalCheck(SignalCheck):
     command: tuple[str, ...] = ("sh", "-c", "test -f ~/.modal.toml")
 
 
+class LimaSignalCheck(SignalCheck):
+    """Detects whether the limactl CLI is installed."""
+
+    command: tuple[str, ...] = ("limactl", "--version")
+
+
 # Shared instances for use across catalog entries.
 _CLAUDE_SIGNAL: Final[ClaudeSignalCheck] = ClaudeSignalCheck()
 _OPENCODE_SIGNAL: Final[OpenCodeSignalCheck] = OpenCodeSignalCheck()
 _PI_SIGNAL: Final[PiSignalCheck] = PiSignalCheck()
 _MODAL_SIGNAL: Final[ModalSignalCheck] = ModalSignalCheck()
+_LIMA_SIGNAL: Final[LimaSignalCheck] = LimaSignalCheck()
 
 
 class CatalogEntry(FrozenModel):
@@ -114,6 +121,19 @@ PLUGIN_CATALOG: Final[tuple[CatalogEntry, ...]] = (
         tier=PluginTier.INDEPENDENT,
         signal=_MODAL_SIGNAL,
         is_recommended=True,
+    ),
+    CatalogEntry(
+        entry_point_name="lima",
+        package_name="imbue-mngr-lima",
+        description="Lima VM provider backend plugin for mngr",
+        tier=PluginTier.INDEPENDENT,
+        signal=_LIMA_SIGNAL,
+    ),
+    CatalogEntry(
+        entry_point_name="vultr",
+        package_name="imbue-mngr-vultr",
+        description="Vultr provider backend plugin for mngr",
+        tier=PluginTier.INDEPENDENT,
     ),
     CatalogEntry(
         entry_point_name="tutor",

--- a/libs/mngr/imbue/mngr/plugin_catalog.py
+++ b/libs/mngr/imbue/mngr/plugin_catalog.py
@@ -290,9 +290,8 @@ def get_plugin_install_hint(name: str) -> str:
     if entry is not None:
         return _format_install_hint(entry)
     return (
-        f"'{name}' is not a known mngr plugin. If it is provided by a"
-        " third-party plugin, install that package and ensure the plugin is"
-        " enabled. Run 'mngr extras' to see installable plugins."
+        f"We do not recognize '{name}'. If it is provided by a third-party"
+        " plugin, install that package and ensure the plugin is enabled."
     )
 
 

--- a/libs/mngr/imbue/mngr/providers/registry.py
+++ b/libs/mngr/imbue/mngr/providers/registry.py
@@ -44,12 +44,19 @@ def reset_backend_registry() -> None:
     _registry_state["backends_loaded"] = False
 
 
-def _load_backends(pm: pluggy.PluginManager, *, include_modal: bool, include_docker: bool) -> None:
+# Provider backends that talk to external services (cloud APIs, daemons,
+# VMs). Tests use ``load_local_backend_only`` to skip these, since they
+# require credentials or system binaries.
+_REMOTE_BACKEND_NAMES: frozenset[str] = frozenset({"modal", "lima", "vultr"})
+
+
+def _load_backends(pm: pluggy.PluginManager, *, include_docker: bool, include_remote: bool) -> None:
     """Load provider backends from the specified modules.
 
-    The pm parameter is the pluggy plugin manager. If include_modal is True,
-    the Modal backend is included (requires Modal credentials). If include_docker
-    is True, the Docker backend is included (requires a Docker daemon).
+    The pm parameter is the pluggy plugin manager. If include_docker is True,
+    the Docker backend is included (requires a Docker daemon). If include_remote
+    is True, plugin-provided backends that require external services
+    (Modal, Lima, Vultr, ...) are included.
     """
     if _registry_state["backends_loaded"]:
         return
@@ -58,7 +65,7 @@ def _load_backends(pm: pluggy.PluginManager, *, include_modal: bool, include_doc
     pm.register(ssh_backend_module, name="ssh")
     if include_docker:
         pm.register(docker_backend_module, name="docker")
-    # Note: modal backend is loaded via the mngr_modal plugin entry point
+    # Note: remote backends (modal, lima, vultr, ...) are loaded via plugin entry points
 
     registrations = pm.hook.register_provider_backend()
 
@@ -66,7 +73,7 @@ def _load_backends(pm: pluggy.PluginManager, *, include_modal: bool, include_doc
         if registration is not None:
             backend_class, config_class = registration
             backend_name = backend_class.get_name()
-            if not include_modal and str(backend_name) == "modal":
+            if not include_remote and str(backend_name) in _REMOTE_BACKEND_NAMES:
                 continue
             _backend_registry[backend_name] = backend_class
             register_provider_config(str(backend_name), config_class)
@@ -79,14 +86,14 @@ def load_local_backend_only(pm: pluggy.PluginManager) -> None:
 
     This is used by tests to avoid depending on external services.
     Unlike load_backends_from_plugins, this only registers the local and SSH backends
-    (not Modal or Docker which require external daemons/credentials).
+    (not Docker or any remote backends which require external daemons/credentials).
     """
-    _load_backends(pm, include_modal=False, include_docker=False)
+    _load_backends(pm, include_docker=False, include_remote=False)
 
 
 def load_backends_from_plugins(pm: pluggy.PluginManager) -> None:
     """Load all provider backends from plugins."""
-    _load_backends(pm, include_modal=True, include_docker=True)
+    _load_backends(pm, include_docker=True, include_remote=True)
 
 
 def get_backend(name: str | ProviderBackendName) -> type[ProviderBackendInterface]:

--- a/libs/mngr/imbue/mngr/providers/registry.py
+++ b/libs/mngr/imbue/mngr/providers/registry.py
@@ -44,10 +44,12 @@ def reset_backend_registry() -> None:
     _registry_state["backends_loaded"] = False
 
 
-# Provider backends that talk to external services (cloud APIs, daemons,
-# VMs). Tests use ``load_local_backend_only`` to skip these, since they
-# require credentials or system binaries.
-_REMOTE_BACKEND_NAMES: frozenset[str] = frozenset({"modal", "lima", "vultr"})
+# Provider backends that require credentials at registration time (e.g.
+# Modal SDK auth, Vultr API key). Tests use ``load_local_backend_only`` to
+# skip these. Lima is intentionally excluded: its backend defers limactl
+# checks to first use, so registering it is safe even without limactl
+# installed.
+_REMOTE_BACKEND_NAMES: frozenset[str] = frozenset({"modal", "vultr"})
 
 
 def _load_backends(pm: pluggy.PluginManager, *, include_docker: bool, include_remote: bool) -> None:

--- a/libs/mngr/imbue/mngr/providers/registry.py
+++ b/libs/mngr/imbue/mngr/providers/registry.py
@@ -97,9 +97,7 @@ def get_backend(name: str | ProviderBackendName) -> type[ProviderBackendInterfac
     key = ProviderBackendName(name) if isinstance(name, str) else name
     if key not in _backend_registry:
         available = sorted(str(k) for k in _backend_registry.keys())
-        raise UnknownBackendError(
-            f"Unknown provider backend: {key}. Registered backends: {', '.join(available) or '(none)'}"
-        )
+        raise UnknownBackendError(str(key), available)
     return _backend_registry[key]
 
 


### PR DESCRIPTION
implementation is a little weird but seems low-stakes

---

## Summary

When a user references a name that isn't registered locally — e.g. `mngr create --provider lima`, `mngr wait` without `imbue-mngr-wait` installed, or `mngr create --agent claude` without `imbue-mngr-claude` installed — the CLI used to surface a bare "unknown ..." error with no actionable next step. This PR routes those error paths through `plugin_catalog.get_plugin_install_hint`, so the message names the actual `imbue-mngr-<name>` package to install when the missing name matches a cataloged plugin, and falls back to a generic "not a known mngr plugin" prompt otherwise (so we don't fabricate package names).

Three call sites covered:
- `UnknownBackendError` (provider backends, e.g. `--provider lima`)
- `UnknownAgentTypeError` (new — agent types resolved via `get_agent_class`, e.g. `--agent claude`)
- `DefaultCommandGroup.resolve_command` (top-level CLI commands, e.g. `mngr wait`)

Other changes:
- Catalog now contains `lima` and `vultr` rows so provider hints work for them. New `LimaSignalCheck` (`limactl --version`).
- `CatalogEntry.cli_command_names` lets `notifications` (entry-point) map to the `notify` CLI command for the unknown-command hint path.
- `_load_backends`'s prior modal-only filter is generalized into `_REMOTE_BACKEND_NAMES = {"modal", "vultr"}` so test harnesses keep skipping credential-dependent backends. Lima is intentionally excluded because its registration is side-effect free (limactl checks deferred to first use).
- The existing duplicate hint in `config/loader.py` now delegates to `get_plugin_install_hint` so the two paths agree.

## Test plan
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 3636 passed
- [x] `just test-quick "libs/mngr_modal libs/mngr_lima libs/mngr_vultr libs/mngr_vps_docker -m 'not modal and not docker and not docker_sdk and not acceptance and not release and not tmux'"` — 696 passed
- [ ] Offload + acceptance via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)