### PR TITLE
enable tab completion for agent names in various commands

### DIFF
--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -56,9 +56,9 @@ _POSITIONAL_COMPLETION_SUBCOMMAND_SPEC: Final[dict[str, list[list[str]]]] = {
     "config.get": [["config_keys"]],
     "config.set": [["config_keys"], ["config_value_for_key"]],
     "config.unset": [["config_keys"]],
-    "file.get": [["agent_names"], []],
-    "file.put": [["agent_names"], []],
-    "file.list": [["agent_names"], []],
+    "file.get": [["agent_names", "host_names"], []],
+    "file.put": [["agent_names", "host_names"], []],
+    "file.list": [["agent_names", "host_names"], []],
 }
 
 # Options (keyed as "command.--option") whose values should complete against

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -42,7 +42,7 @@ _POSITIONAL_COMPLETION_SPEC: Final[dict[str, list[list[str]]]] = {
     "rename": [["agent_names"], []],
     "start": [["agent_names"]],
     "stop": [["agent_names"]],
-    "transcript": [["agent_names"]],
+    "transcript": [["agent_names", "host_names"]],
 }
 
 # Per-position positional completion spec for group subcommands.

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -39,6 +39,7 @@ _POSITIONAL_COMPLETION_SPEC: Final[dict[str, list[list[str]]]] = {
     "rename": [["agent_names"], []],
     "start": [["agent_names"]],
     "stop": [["agent_names"]],
+    "transcript": [["agent_names"]],
 }
 
 # Per-position positional completion spec for group subcommands.

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -26,11 +26,14 @@ from imbue.mngr.utils.file_utils import atomic_write
 # For variadic commands (nargs=None), the last entry repeats.
 # Source identifiers: "agent_names", "host_names", "plugin_names", "config_keys"
 _POSITIONAL_COMPLETION_SPEC: Final[dict[str, list[list[str]]]] = {
+    "archive": [["agent_names"]],
+    "capture": [["agent_names"]],
     "connect": [["agent_names"]],
     "destroy": [["agent_names"]],
     "exec": [["agent_names"]],
     "limit": [["agent_names"]],
     "events": [["agent_names", "host_names"], []],
+    "label": [["agent_names"]],
     "message": [["agent_names"]],
     "pair": [["agent_names"]],
     "provision": [["agent_names"]],
@@ -53,6 +56,9 @@ _POSITIONAL_COMPLETION_SUBCOMMAND_SPEC: Final[dict[str, list[list[str]]]] = {
     "config.get": [["config_keys"]],
     "config.set": [["config_keys"], ["config_value_for_key"]],
     "config.unset": [["config_keys"]],
+    "file.get": [["agent_names"], []],
+    "file.put": [["agent_names"], []],
+    "file.list": [["agent_names"], []],
 }
 
 # Options (keyed as "command.--option") whose values should complete against


### PR DESCRIPTION
## Summary
- `mngr transcript <TAB>` now completes agent names, matching other agent-targeting commands (`connect`, `destroy`, `message`, etc.)

## Test plan
- [x] `just test-quick libs/mngr/imbue/mngr/config/completion_writer_test.py` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)