### PR TITLE
add provider plugins lima, vultr, and vps-docker to the release list

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -50,6 +50,13 @@ PACKAGES: Final[tuple[PackageInfo, ...]] = (
     PackageInfo(dir_name="mngr_recursive", pypi_name="imbue-mngr-recursive", internal_deps=("imbue-mngr",)),
     PackageInfo(dir_name="mngr_ttyd", pypi_name="imbue-mngr-ttyd", internal_deps=("imbue-mngr",)),
     PackageInfo(dir_name="mngr_wait", pypi_name="imbue-mngr-wait", internal_deps=("imbue-mngr",)),
+    PackageInfo(dir_name="mngr_vps_docker", pypi_name="imbue-mngr-vps-docker", internal_deps=("imbue-mngr",)),
+    PackageInfo(dir_name="mngr_lima", pypi_name="imbue-mngr-lima", internal_deps=("imbue-mngr",)),
+    PackageInfo(
+        dir_name="mngr_vultr",
+        pypi_name="imbue-mngr-vultr",
+        internal_deps=("imbue-mngr", "imbue-mngr-vps-docker"),
+    ),
 )
 
 PACKAGE_BY_PYPI_NAME: Final[dict[str, PackageInfo]] = {pkg.pypi_name: pkg for pkg in PACKAGES}


### PR DESCRIPTION
## Summary
- Adds `mngr_lima`, `mngr_vultr`, and `mngr_vps_docker` to the `PACKAGES` tuple in `scripts/utils.py`
- These provider plugin libraries existed under `libs/` but were never bumped or published by the release script
- `mngr_vultr` declares `imbue-mngr-vps-docker` as an internal dep, matching its pyproject.toml

## Test plan
- [ ] CI passes (utils tests validate the dependency graph against pyproject.toml)
- [ ] Next release run publishes the three new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)