### PR TITLE
Add productName `Minds`

### DIFF
--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,5 +1,6 @@
 {
   "name": "minds",
+  "productName": "Minds",
   "version": "0.1.0",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",


### PR DESCRIPTION
## Summary
Most macos product name is capital letter, with space, (e.g. Safari, Google Chrome. well, specific anti-example: iTerm) 

Adds `"productName": "Minds"` to `apps/minds/package.json` so the ToDesktop / Electron Builder pipeline emits `Minds.app` instead of `minds.app`, matching macOS app-naming conventions.

## Cross-platform behavior
`productName` is the standard Electron / Electron Builder field for the user-facing display name; `name` stays the npm identifier. Setting it affects all three platforms, and the capitalized form aligns with each platform's convention:

- **macOS**: bundle `Minds.app`, executable `Contents/MacOS/Minds`, menu bar / About / Dock all read "Minds". Driven entirely by `productName`.
- **Windows**: installer `Minds Setup.exe`, executable `Minds.exe`, Add/Remove Programs entry, Start Menu shortcut, and taskbar tooltip all read "Minds". Driven entirely by `productName`.
- **Linux**: AppImage / .deb / .rpm filename and the `.desktop` launcher's `Name=` field read "Minds" (what GNOME/KDE menus show). The binary on `$PATH` stays lowercase `minds` because Electron Builder defaults the Linux executable name to the npm `name`, not `productName` — which matches Linux convention (`firefox`, `code`, `slack` are all lowercase on PATH).

ToDesktop currently builds macOS and Windows; Linux is opt-in but would behave as above if enabled.

## MacOS userData migration note
On macOS's default case-insensitive APFS, `…/minds` and `…/Minds` resolve to the same directory, so existing dev installs are unaffected. On case-sensitive volumes existing users would appear freshly installed. 
This is probably fine as minds doesn't have shipped users yet. 

## Test plan
- [x] Trigger a ToDesktop build and confirm the artifact is `Minds.app`
- [x] Open the built app and confirm menu bar / Activity Monitor process name show "Minds"