### PR TITLE
share filter options between list and kanpan

### DIFF
--- a/libs/mngr/docs/commands/primary/list.md
+++ b/libs/mngr/docs/commands/primary/list.md
@@ -31,14 +31,14 @@ mngr list [OPTIONS]
 | `--exclude` | text | Exclude agents matching CEL expression (repeatable) | None |
 | `--running` | boolean | Show only running agents (alias for --include 'state == "RUNNING"') | `False` |
 | `--stopped` | boolean | Show only stopped agents (alias for --include 'state == "STOPPED"') | `False` |
-| `--archived` | boolean | Show only stopped agents (alias for --include 'has(labels.archived_at)') | `False` |
-| `--active` | boolean | Show only stopped agents (anything not archived/destroyed/crashed/failed) | `False` |
+| `--archived` | boolean | Show only archived agents (alias for --include 'has(labels.archived_at)') | `False` |
+| `--active` | boolean | Show only active agents (anything not archived/destroyed/crashed/failed) | `False` |
 | `--local` | boolean | Show only local agents (alias for --include 'host.provider == "local"') | `False` |
 | `--remote` | boolean | Show only remote agents (alias for --exclude 'host.provider == "local"') | `False` |
-| `--provider` | text | Show only agents using specified provider (repeatable) | None |
 | `--project` | text | Show only agents with this project label (repeatable) | None |
 | `--label` | text | Show only agents with this label (format: KEY=VALUE, repeatable) [experimental] | None |
 | `--host-label` | text | Show only agents on hosts with this host label (format: KEY=VALUE, repeatable) | None |
+| `--provider` | text | Show only agents using specified provider (repeatable) | None |
 | `--stdin` | boolean | Read agent and host IDs or names from stdin (one per line) | `False` |
 
 ## Output Format

--- a/libs/mngr/docs/commands/secondary/kanpan.md
+++ b/libs/mngr/docs/commands/secondary/kanpan.md
@@ -20,7 +20,8 @@ including PR number, state (open/closed/merged), and CI check status.
 The display auto-refreshes every 10 minutes. Press 'r' to refresh manually,
 or 'q' to quit.
 
-Supports CEL filtering via --include/--exclude and a --project convenience flag.
+Filtering shares the flag set used by `mngr list` (--include/--exclude/--running/
+--stopped/--archived/--active/--local/--remote/--project/--label/--host-label).
 
 Requires the gh CLI to be installed and authenticated for GitHub PR information.
 
@@ -37,7 +38,15 @@ mngr kanpan [OPTIONS]
 | ---- | ---- | ----------- | ------- |
 | `--include` | text | Include agents matching CEL expression (repeatable) | None |
 | `--exclude` | text | Exclude agents matching CEL expression (repeatable) | None |
+| `--running` | boolean | Show only running agents (alias for --include 'state == "RUNNING"') | `False` |
+| `--stopped` | boolean | Show only stopped agents (alias for --include 'state == "STOPPED"') | `False` |
+| `--archived` | boolean | Show only archived agents (alias for --include 'has(labels.archived_at)') | `False` |
+| `--active` | boolean | Show only active agents (anything not archived/destroyed/crashed/failed) | `False` |
+| `--local` | boolean | Show only local agents (alias for --include 'host.provider == "local"') | `False` |
+| `--remote` | boolean | Show only remote agents (alias for --exclude 'host.provider == "local"') | `False` |
 | `--project` | text | Show only agents with this project label (repeatable) | None |
+| `--label` | text | Show only agents with this label (format: KEY=VALUE, repeatable) [experimental] | None |
+| `--host-label` | text | Show only agents on hosts with this host label (format: KEY=VALUE, repeatable) | None |
 
 ## Common
 
@@ -76,5 +85,5 @@ $ mngr kanpan --project mngr
 **Show only running agents**
 
 ```bash
-$ mngr kanpan --include 'state == "RUNNING"'
+$ mngr kanpan --running
 ```

--- a/libs/mngr/docs/commands/secondary/kanpan.md
+++ b/libs/mngr/docs/commands/secondary/kanpan.md
@@ -20,8 +20,10 @@ including PR number, state (open/closed/merged), and CI check status.
 The display auto-refreshes every 10 minutes. Press 'r' to refresh manually,
 or 'q' to quit.
 
-Filtering shares the flag set used by `mngr list` (--include/--exclude/--running/
---stopped/--archived/--active/--local/--remote/--project/--label/--host-label).
+Supports CEL filtering via --include/--exclude plus alias flags (--running,
+--stopped, --archived, --active, --local, --remote, --project, --label,
+--host-label). See `mngr list --help` for the full filter reference; the same
+flags work identically here.
 
 Requires the gh CLI to be installed and authenticated for GitHub PR information.
 
@@ -66,7 +68,7 @@ mngr kanpan [OPTIONS]
 
 ## See Also
 
-- [mngr list](../primary/list.md) - List agents
+- [mngr list](../primary/list.md) - List agents (see its Filtering section for the full flag reference)
 
 ## Examples
 
@@ -86,4 +88,10 @@ $ mngr kanpan --project mngr
 
 ```bash
 $ mngr kanpan --running
+```
+
+**Show running agents with a specific label**
+
+```bash
+$ mngr kanpan --running --label env=prod
 ```

--- a/libs/mngr/docs/commands/secondary/kanpan.md
+++ b/libs/mngr/docs/commands/secondary/kanpan.md
@@ -68,7 +68,7 @@ mngr kanpan [OPTIONS]
 
 ## See Also
 
-- [mngr list](../primary/list.md) - List agents (see its Filtering section for the full flag reference)
+- [mngr list](../primary/list.md#filtering) - List agents (see its Filtering section for the full flag reference)
 
 ## Examples
 
@@ -90,8 +90,8 @@ $ mngr kanpan --project mngr
 $ mngr kanpan --running
 ```
 
-**Show running agents with a specific label**
+**Show stopped agents with a specific label**
 
 ```bash
-$ mngr kanpan --running --label env=prod
+$ mngr kanpan --stopped --label env=prod
 ```

--- a/libs/mngr/imbue/mngr/cli/filter_opts.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts.py
@@ -28,6 +28,7 @@ from click_option_group import optgroup
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import HostState
+from imbue.mngr.utils.cel_utils import compile_cel_filters
 
 TDecorated = TypeVar("TDecorated", bound=Callable[..., Any])
 
@@ -130,7 +131,12 @@ def _key_value_filter(specs: tuple[str, ...], cel_prefix: str, flag_name: str) -
 def build_agent_filter_cel(
     opts: AgentFilterCliOptions,
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Translate parsed filter flags into ``(include_filters, exclude_filters)`` CEL tuples."""
+    """Translate parsed filter flags into ``(include_filters, exclude_filters)`` CEL tuples.
+
+    Compiles the result with ``compile_cel_filters`` to fail fast on syntactically
+    invalid ``--include``/``--exclude`` expressions before any consumer (list,
+    kanpan, ...) starts work.
+    """
     include: list[str] = list(opts.include)
     exclude: list[str] = list(opts.exclude)
 
@@ -156,4 +162,8 @@ def build_agent_filter_cel(
     if opts.host_label:
         include.append(_key_value_filter(opts.host_label, "host.tags", "--host-label"))
 
-    return tuple(include), tuple(exclude)
+    include_tuple = tuple(include)
+    exclude_tuple = tuple(exclude)
+    if include_tuple or exclude_tuple:
+        compile_cel_filters(include_tuple, exclude_tuple)
+    return include_tuple, exclude_tuple

--- a/libs/mngr/imbue/mngr/cli/filter_opts.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts.py
@@ -1,0 +1,159 @@
+"""Shared agent filter CLI options.
+
+Commands that operate on a filtered set of agents (`mngr list`, `mngr kanpan`, ...)
+share three pieces:
+
+1. ``AgentFilterCliOptions`` -- a ``FrozenModel`` mixin holding the parsed flag
+   values. Mix it into a command's options class alongside ``CommonCliOptions``.
+2. ``add_agent_filter_options`` -- a click decorator that adds the matching
+   ``--include/--exclude`` flags plus alias flags (``--running``, ``--stopped``,
+   etc.) under a "Filtering" option group.
+3. ``build_agent_filter_cel`` -- translates an ``AgentFilterCliOptions`` instance
+   into a ``(include_filters, exclude_filters)`` pair of CEL string tuples,
+   suitable for passing directly to ``list_agents()`` /
+   ``fetch_board_snapshot()`` and any other API that accepts CEL filters.
+
+To add a new filter flag, edit all three pieces in this module and every command
+using ``add_agent_filter_options`` inherits the new flag with no per-command
+glue.
+"""
+
+from collections.abc import Callable
+from typing import Any
+from typing import TypeVar
+
+import click
+from click_option_group import optgroup
+
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.mngr.primitives import AgentLifecycleState
+from imbue.mngr.primitives import HostState
+
+TDecorated = TypeVar("TDecorated", bound=Callable[..., Any])
+
+FILTER_OPTIONS_GROUP_NAME = "Filtering"
+
+
+class AgentFilterCliOptions(FrozenModel):
+    """Filter options shared by commands operating on a filtered set of agents.
+
+    Field names and types intentionally mirror the ``add_agent_filter_options``
+    decorator so ``command_class(**click_kwargs)`` works without per-command glue.
+    """
+
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    running: bool = False
+    stopped: bool = False
+    archived: bool = False
+    active: bool = False
+    local: bool = False
+    remote: bool = False
+    project: tuple[str, ...] = ()
+    label: tuple[str, ...] = ()
+    host_label: tuple[str, ...] = ()
+
+
+def add_agent_filter_options(command: TDecorated) -> TDecorated:
+    """Add the shared agent filter flags under a "Filtering" option group."""
+    # Decorators apply bottom-up, so the visible help order matches reverse order here.
+    command = optgroup.option(
+        "--host-label",
+        multiple=True,
+        help="Show only agents on hosts with this host label (format: KEY=VALUE, repeatable)",
+    )(command)
+    command = optgroup.option(
+        "--label",
+        multiple=True,
+        help="Show only agents with this label (format: KEY=VALUE, repeatable) [experimental]",
+    )(command)
+    command = optgroup.option(
+        "--project",
+        multiple=True,
+        help="Show only agents with this project label (repeatable)",
+    )(command)
+    command = optgroup.option(
+        "--remote",
+        is_flag=True,
+        help="Show only remote agents (alias for --exclude 'host.provider == \"local\"')",
+    )(command)
+    command = optgroup.option(
+        "--local",
+        is_flag=True,
+        help="Show only local agents (alias for --include 'host.provider == \"local\"')",
+    )(command)
+    command = optgroup.option(
+        "--active",
+        is_flag=True,
+        help="Show only active agents (anything not archived/destroyed/crashed/failed)",
+    )(command)
+    command = optgroup.option(
+        "--archived",
+        is_flag=True,
+        help="Show only archived agents (alias for --include 'has(labels.archived_at)')",
+    )(command)
+    command = optgroup.option(
+        "--stopped",
+        is_flag=True,
+        help="Show only stopped agents (alias for --include 'state == \"STOPPED\"')",
+    )(command)
+    command = optgroup.option(
+        "--running",
+        is_flag=True,
+        help="Show only running agents (alias for --include 'state == \"RUNNING\"')",
+    )(command)
+    command = optgroup.option(
+        "--exclude",
+        multiple=True,
+        help="Exclude agents matching CEL expression (repeatable)",
+    )(command)
+    command = optgroup.option(
+        "--include",
+        multiple=True,
+        help="Include agents matching CEL expression (repeatable)",
+    )(command)
+    command = optgroup.group(FILTER_OPTIONS_GROUP_NAME)(command)
+    return command
+
+
+def _key_value_filter(specs: tuple[str, ...], cel_prefix: str, flag_name: str) -> str:
+    """Build an OR-joined CEL fragment from KEY=VALUE specs against ``cel_prefix.KEY``."""
+    parts: list[str] = []
+    for spec in specs:
+        if "=" not in spec:
+            raise click.BadParameter(f"Label must be in KEY=VALUE format, got: {spec}", param_hint=flag_name)
+        key, value = spec.split("=", 1)
+        parts.append(f'{cel_prefix}.{key} == "{value}"')
+    return " || ".join(parts)
+
+
+def build_agent_filter_cel(
+    opts: AgentFilterCliOptions,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Translate parsed filter flags into ``(include_filters, exclude_filters)`` CEL tuples."""
+    include: list[str] = list(opts.include)
+    exclude: list[str] = list(opts.exclude)
+
+    if opts.running:
+        include.append(f'state == "{AgentLifecycleState.RUNNING.value}"')
+    if opts.stopped:
+        include.append(f'state == "{AgentLifecycleState.STOPPED.value}"')
+    if opts.archived:
+        include.append("has(labels.archived_at)")
+    if opts.local:
+        include.append('host.provider == "local"')
+    if opts.remote:
+        exclude.append('host.provider == "local"')
+    if opts.active:
+        exclude.append("has(labels.archived_at)")
+        include.append(f'host.state != "{HostState.CRASHED.value}"')
+        include.append(f'host.state != "{HostState.FAILED.value}"')
+        include.append(f'host.state != "{HostState.DESTROYED.value}"')
+    if opts.project:
+        include.append(" || ".join(f'labels.project == "{p}"' for p in opts.project))
+    if opts.label:
+        include.append(_key_value_filter(opts.label, "labels", "--label"))
+    if opts.host_label:
+        include.append(_key_value_filter(opts.host_label, "host.tags", "--host-label"))
+
+    return tuple(include), tuple(exclude)

--- a/libs/mngr/imbue/mngr/cli/filter_opts.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts.py
@@ -117,12 +117,12 @@ def add_agent_filter_options(command: TDecorated) -> TDecorated:
     return command
 
 
-def _key_value_filter(specs: tuple[str, ...], cel_prefix: str, flag_name: str) -> str:
+def _key_value_filter(specs: tuple[str, ...], cel_prefix: str, flag_name: str, error_noun: str) -> str:
     """Build an OR-joined CEL fragment from KEY=VALUE specs against ``cel_prefix.KEY``."""
     parts: list[str] = []
     for spec in specs:
         if "=" not in spec:
-            raise click.BadParameter(f"Label must be in KEY=VALUE format, got: {spec}", param_hint=flag_name)
+            raise click.BadParameter(f"{error_noun} must be in KEY=VALUE format, got: {spec}", param_hint=flag_name)
         key, value = spec.split("=", 1)
         parts.append(f'{cel_prefix}.{key} == "{value}"')
     return " || ".join(parts)
@@ -158,9 +158,9 @@ def build_agent_filter_cel(
     if opts.project:
         include.append(" || ".join(f'labels.project == "{p}"' for p in opts.project))
     if opts.label:
-        include.append(_key_value_filter(opts.label, "labels", "--label"))
+        include.append(_key_value_filter(opts.label, "labels", "--label", "Label"))
     if opts.host_label:
-        include.append(_key_value_filter(opts.host_label, "host.tags", "--host-label"))
+        include.append(_key_value_filter(opts.host_label, "host.tags", "--host-label", "Host label"))
 
     include_tuple = tuple(include)
     exclude_tuple = tuple(exclude)

--- a/libs/mngr/imbue/mngr/cli/filter_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts_test.py
@@ -7,53 +7,50 @@ from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
 from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 
 
-def _opts(**overrides: object) -> AgentFilterCliOptions:
-    """Build an AgentFilterCliOptions with explicit overrides over the field defaults."""
-    return AgentFilterCliOptions(**overrides)  # type: ignore[arg-type]
-
-
 def test_empty_options_produces_empty_filters() -> None:
-    include, exclude = build_agent_filter_cel(_opts())
+    include, exclude = build_agent_filter_cel(AgentFilterCliOptions())
     assert include == ()
     assert exclude == ()
 
 
 def test_passthrough_include_and_exclude() -> None:
-    include, exclude = build_agent_filter_cel(_opts(include=('state == "RUNNING"',), exclude=('state == "DONE"',)))
+    include, exclude = build_agent_filter_cel(
+        AgentFilterCliOptions(include=('state == "RUNNING"',), exclude=('state == "DONE"',))
+    )
     assert include == ('state == "RUNNING"',)
     assert exclude == ('state == "DONE"',)
 
 
 def test_running_alias() -> None:
-    include, exclude = build_agent_filter_cel(_opts(running=True))
+    include, exclude = build_agent_filter_cel(AgentFilterCliOptions(running=True))
     assert include == ('state == "RUNNING"',)
     assert exclude == ()
 
 
 def test_stopped_alias() -> None:
-    include, _ = build_agent_filter_cel(_opts(stopped=True))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(stopped=True))
     assert include == ('state == "STOPPED"',)
 
 
 def test_archived_alias() -> None:
-    include, _ = build_agent_filter_cel(_opts(archived=True))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(archived=True))
     assert include == ("has(labels.archived_at)",)
 
 
 def test_local_alias() -> None:
-    include, exclude = build_agent_filter_cel(_opts(local=True))
+    include, exclude = build_agent_filter_cel(AgentFilterCliOptions(local=True))
     assert include == ('host.provider == "local"',)
     assert exclude == ()
 
 
 def test_remote_alias_goes_into_exclude() -> None:
-    include, exclude = build_agent_filter_cel(_opts(remote=True))
+    include, exclude = build_agent_filter_cel(AgentFilterCliOptions(remote=True))
     assert include == ()
     assert exclude == ('host.provider == "local"',)
 
 
 def test_active_alias_excludes_archived_and_unhealthy_hosts() -> None:
-    include, exclude = build_agent_filter_cel(_opts(active=True))
+    include, exclude = build_agent_filter_cel(AgentFilterCliOptions(active=True))
     assert exclude == ("has(labels.archived_at)",)
     assert include == (
         'host.state != "CRASHED"',
@@ -63,38 +60,38 @@ def test_active_alias_excludes_archived_and_unhealthy_hosts() -> None:
 
 
 def test_project_single() -> None:
-    include, _ = build_agent_filter_cel(_opts(project=("mngr",)))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(project=("mngr",)))
     assert include == ('labels.project == "mngr"',)
 
 
 def test_project_multiple_ors_into_one_filter() -> None:
-    include, _ = build_agent_filter_cel(_opts(project=("mngr", "other")))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(project=("mngr", "other")))
     assert include == ('labels.project == "mngr" || labels.project == "other"',)
 
 
 def test_label_kv() -> None:
-    include, _ = build_agent_filter_cel(_opts(label=("env=prod",)))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(label=("env=prod",)))
     assert include == ('labels.env == "prod"',)
 
 
 def test_host_label_kv() -> None:
-    include, _ = build_agent_filter_cel(_opts(host_label=("region=us-east",)))
+    include, _ = build_agent_filter_cel(AgentFilterCliOptions(host_label=("region=us-east",)))
     assert include == ('host.tags.region == "us-east"',)
 
 
 def test_label_without_equals_raises() -> None:
     with pytest.raises(click.BadParameter):
-        build_agent_filter_cel(_opts(label=("noequals",)))
+        build_agent_filter_cel(AgentFilterCliOptions(label=("noequals",)))
 
 
 def test_host_label_without_equals_raises() -> None:
     with pytest.raises(click.BadParameter):
-        build_agent_filter_cel(_opts(host_label=("noequals",)))
+        build_agent_filter_cel(AgentFilterCliOptions(host_label=("noequals",)))
 
 
 def test_combined_aliases_compose() -> None:
     include, exclude = build_agent_filter_cel(
-        _opts(
+        AgentFilterCliOptions(
             include=('name == "foo"',),
             exclude=('id == "bar"',),
             running=True,

--- a/libs/mngr/imbue/mngr/cli/filter_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts_test.py
@@ -1,0 +1,113 @@
+"""Tests for filter_opts module."""
+
+import click
+import pytest
+
+from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
+from imbue.mngr.cli.filter_opts import build_agent_filter_cel
+
+
+def _opts(**overrides: object) -> AgentFilterCliOptions:
+    """Build an AgentFilterCliOptions with explicit overrides over the field defaults."""
+    return AgentFilterCliOptions(**overrides)  # type: ignore[arg-type]
+
+
+def test_empty_options_produces_empty_filters() -> None:
+    include, exclude = build_agent_filter_cel(_opts())
+    assert include == ()
+    assert exclude == ()
+
+
+def test_passthrough_include_and_exclude() -> None:
+    include, exclude = build_agent_filter_cel(_opts(include=('state == "RUNNING"',), exclude=('state == "DONE"',)))
+    assert include == ('state == "RUNNING"',)
+    assert exclude == ('state == "DONE"',)
+
+
+def test_running_alias() -> None:
+    include, exclude = build_agent_filter_cel(_opts(running=True))
+    assert include == ('state == "RUNNING"',)
+    assert exclude == ()
+
+
+def test_stopped_alias() -> None:
+    include, _ = build_agent_filter_cel(_opts(stopped=True))
+    assert include == ('state == "STOPPED"',)
+
+
+def test_archived_alias() -> None:
+    include, _ = build_agent_filter_cel(_opts(archived=True))
+    assert include == ("has(labels.archived_at)",)
+
+
+def test_local_alias() -> None:
+    include, exclude = build_agent_filter_cel(_opts(local=True))
+    assert include == ('host.provider == "local"',)
+    assert exclude == ()
+
+
+def test_remote_alias_goes_into_exclude() -> None:
+    include, exclude = build_agent_filter_cel(_opts(remote=True))
+    assert include == ()
+    assert exclude == ('host.provider == "local"',)
+
+
+def test_active_alias_excludes_archived_and_unhealthy_hosts() -> None:
+    include, exclude = build_agent_filter_cel(_opts(active=True))
+    assert exclude == ("has(labels.archived_at)",)
+    assert include == (
+        'host.state != "CRASHED"',
+        'host.state != "FAILED"',
+        'host.state != "DESTROYED"',
+    )
+
+
+def test_project_single() -> None:
+    include, _ = build_agent_filter_cel(_opts(project=("mngr",)))
+    assert include == ('labels.project == "mngr"',)
+
+
+def test_project_multiple_ors_into_one_filter() -> None:
+    include, _ = build_agent_filter_cel(_opts(project=("mngr", "other")))
+    assert include == ('labels.project == "mngr" || labels.project == "other"',)
+
+
+def test_label_kv() -> None:
+    include, _ = build_agent_filter_cel(_opts(label=("env=prod",)))
+    assert include == ('labels.env == "prod"',)
+
+
+def test_host_label_kv() -> None:
+    include, _ = build_agent_filter_cel(_opts(host_label=("region=us-east",)))
+    assert include == ('host.tags.region == "us-east"',)
+
+
+def test_label_without_equals_raises() -> None:
+    with pytest.raises(click.BadParameter):
+        build_agent_filter_cel(_opts(label=("noequals",)))
+
+
+def test_host_label_without_equals_raises() -> None:
+    with pytest.raises(click.BadParameter):
+        build_agent_filter_cel(_opts(host_label=("noequals",)))
+
+
+def test_combined_aliases_compose() -> None:
+    include, exclude = build_agent_filter_cel(
+        _opts(
+            include=('name == "foo"',),
+            exclude=('id == "bar"',),
+            running=True,
+            remote=True,
+            project=("mngr",),
+        )
+    )
+    assert include == (
+        'name == "foo"',
+        'state == "RUNNING"',
+        'labels.project == "mngr"',
+    )
+    assert exclude == (
+        'id == "bar"',
+        'host.provider == "local"',
+    )

--- a/libs/mngr/imbue/mngr/cli/filter_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts_test.py
@@ -81,12 +81,12 @@ def test_host_label_kv() -> None:
 
 
 def test_label_without_equals_raises() -> None:
-    with pytest.raises(click.BadParameter):
+    with pytest.raises(click.BadParameter, match="Label must be in KEY=VALUE format"):
         build_agent_filter_cel(AgentFilterCliOptions(label=("noequals",)))
 
 
-def test_host_label_without_equals_raises() -> None:
-    with pytest.raises(click.BadParameter):
+def test_host_label_without_equals_raises_with_host_label_wording() -> None:
+    with pytest.raises(click.BadParameter, match="Host label must be in KEY=VALUE format"):
         build_agent_filter_cel(AgentFilterCliOptions(host_label=("noequals",)))
 
 

--- a/libs/mngr/imbue/mngr/cli/filter_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/filter_opts_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
 from imbue.mngr.cli.filter_opts import build_agent_filter_cel
+from imbue.mngr.errors import MngrError
 
 
 def test_empty_options_produces_empty_filters() -> None:
@@ -87,6 +88,16 @@ def test_label_without_equals_raises() -> None:
 def test_host_label_without_equals_raises() -> None:
     with pytest.raises(click.BadParameter):
         build_agent_filter_cel(AgentFilterCliOptions(host_label=("noequals",)))
+
+
+def test_invalid_cel_in_include_fails_fast() -> None:
+    with pytest.raises(MngrError):
+        build_agent_filter_cel(AgentFilterCliOptions(include=("invalid(",)))
+
+
+def test_invalid_cel_in_exclude_fails_fast() -> None:
+    with pytest.raises(MngrError):
+        build_agent_filter_cel(AgentFilterCliOptions(exclude=("invalid(",)))
 
 
 def test_combined_aliases_compose() -> None:

--- a/libs/mngr/imbue/mngr/cli/help_formatter.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter.py
@@ -299,7 +299,9 @@ def _write_git_style_help(
     if metadata.see_also:
         output.write(f"{_format_section_title('See Also')}\n")
         for ref_name, description in metadata.see_also:
-            output.write(f"       mngr help {ref_name} - {description}\n")
+            # Strip "#anchor" suffix; anchors are only meaningful for the markdown renderer.
+            bare_name = ref_name.partition("#")[0]
+            output.write(f"       mngr help {bare_name} - {description}\n")
         output.write("\n")
 
     # EXAMPLES section (if provided)

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -128,6 +128,10 @@ class ListCliOptions(AgentFilterCliOptions, CommonCliOptions):
 
 @click.command(name="list")
 @add_agent_filter_options
+# --provider and --stdin are intentionally NOT in add_agent_filter_options:
+# --provider selects which providers to query (a fan-out control passed
+# through to api_list_agents as provider_names, not a CEL filter on results),
+# and --stdin reads refs from stdin which only makes sense for batch list.
 @optgroup.option(
     "--provider",
     multiple=True,

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -27,6 +27,9 @@ from imbue.mngr.api.list import agent_details_to_cel_context
 from imbue.mngr.api.list import list_agents as api_list_agents
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
+from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
+from imbue.mngr.cli.filter_opts import add_agent_filter_options
+from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
@@ -39,9 +42,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
-from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import ErrorBehavior
-from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.utils.cel_utils import build_cel_context
 from imbue.mngr.utils.cel_utils import compile_cel_sort_keys
@@ -100,30 +101,20 @@ def _should_use_streaming_mode(
     )
 
 
-class ListCliOptions(CommonCliOptions):
+class ListCliOptions(AgentFilterCliOptions, CommonCliOptions):
     """Options passed from the CLI to the list command.
 
     This captures all the click parameters so we can pass them as a single object
     to helper functions instead of passing dozens of individual parameters.
 
-    Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
+    Inherits filter options (include, exclude, running, ...) from AgentFilterCliOptions
+    and common options (output_format, quiet, verbose, ...) from CommonCliOptions.
 
     Note that this class VERY INTENTIONALLY DOES NOT use Field() decorators with descriptions, defaults, etc.
     For that information, see the click.option() and click.argument() decorators on the list() function itself.
     """
 
-    include: tuple[str, ...]
-    exclude: tuple[str, ...]
-    running: bool
-    stopped: bool
-    archived: bool
-    active: bool
-    local: bool
-    remote: bool
     provider: tuple[str, ...]
-    project: tuple[str, ...]
-    label: tuple[str, ...]
-    host_label: tuple[str, ...]
     stdin: bool
     fields: str | None
     header: tuple[str, ...]
@@ -136,66 +127,11 @@ class ListCliOptions(CommonCliOptions):
 
 
 @click.command(name="list")
-@optgroup.group("Filtering")
-@optgroup.option(
-    "--include",
-    multiple=True,
-    help="Include agents matching CEL expression (repeatable)",
-)
-@optgroup.option(
-    "--exclude",
-    multiple=True,
-    help="Exclude agents matching CEL expression (repeatable)",
-)
-@optgroup.option(
-    "--running",
-    is_flag=True,
-    help="Show only running agents (alias for --include 'state == \"RUNNING\"')",
-)
-@optgroup.option(
-    "--stopped",
-    is_flag=True,
-    help="Show only stopped agents (alias for --include 'state == \"STOPPED\"')",
-)
-@optgroup.option(
-    "--archived",
-    is_flag=True,
-    help="Show only stopped agents (alias for --include 'has(labels.archived_at)')",
-)
-@optgroup.option(
-    "--active",
-    is_flag=True,
-    help="Show only stopped agents (anything not archived/destroyed/crashed/failed)",
-)
-@optgroup.option(
-    "--local",
-    is_flag=True,
-    help="Show only local agents (alias for --include 'host.provider == \"local\"')",
-)
-@optgroup.option(
-    "--remote",
-    is_flag=True,
-    help="Show only remote agents (alias for --exclude 'host.provider == \"local\"')",
-)
+@add_agent_filter_options
 @optgroup.option(
     "--provider",
     multiple=True,
     help="Show only agents using specified provider (repeatable)",
-)
-@optgroup.option(
-    "--project",
-    multiple=True,
-    help="Show only agents with this project label (repeatable)",
-)
-@optgroup.option(
-    "--label",
-    multiple=True,
-    help="Show only agents with this label (format: KEY=VALUE, repeatable) [experimental]",
-)
-@optgroup.option(
-    "--host-label",
-    multiple=True,
-    help="Show only agents on hosts with this host label (format: KEY=VALUE, repeatable)",
 )
 @optgroup.option(
     "--stdin",
@@ -323,75 +259,19 @@ def _list_impl(ctx: click.Context, **kwargs) -> None:
             field_name, label = header_spec.split("=", 1)
             custom_headers[field_name.strip()] = label.strip()
 
-    # Build list of include filters
-    include_filters = list(opts.include)
+    # Translate filter aliases (--running, --project, etc.) into CEL strings.
+    include_filters_tuple, exclude_filters_tuple = build_agent_filter_cel(opts)
 
-    # Handle stdin input by converting to CEL filters
+    # --stdin: read agent/host refs from stdin and add as an OR'd include filter.
+    # List-specific because kanpan and other commands don't take stdin input.
     if opts.stdin:
         stdin_refs = [line.strip() for line in sys.stdin if line.strip()]
         if stdin_refs:
-            # Create a CEL filter that matches any of the provided refs against
-            # host.name, host.id, name, or id (using dot notation for nested fields)
-            ref_filters = []
-            for ref in stdin_refs:
-                ref_filter = f'(name == "{ref}" || id == "{ref}" || host.name == "{ref}" || host.id == "{ref}")'
-                ref_filters.append(ref_filter)
-            # Combine all ref filters with OR
-            combined_filter = " || ".join(ref_filters)
-            include_filters.append(combined_filter)
-
-    # --running: alias for --include 'state == "RUNNING"'
-    # --stopped: alias for --include 'state == "STOPPED"'
-    # --local: alias for --include 'host.provider == "local"'
-    # --remote: alias for --exclude 'host.provider == "local"'
-    if opts.running:
-        include_filters.append(f'state == "{AgentLifecycleState.RUNNING.value}"')
-    if opts.stopped:
-        include_filters.append(f'state == "{AgentLifecycleState.STOPPED.value}"')
-    if opts.local:
-        include_filters.append('host.provider == "local"')
-    if opts.archived:
-        include_filters.append("has(labels.archived_at)")
-
-    # --project X: alias for --include 'labels.project == "X"'
-    # Multiple values are OR'd together
-    if opts.project:
-        project_parts = [f'labels.project == "{p}"' for p in opts.project]
-        include_filters.append(" || ".join(project_parts))
-
-    # --label K=V: alias for --include 'labels.K == "V"'
-    # Multiple values are OR'd together
-    if opts.label:
-        label_parts = []
-        for label_spec in opts.label:
-            if "=" not in label_spec:
-                raise click.BadParameter(f"Label must be in KEY=VALUE format, got: {label_spec}", param_hint="--label")
-            key, value = label_spec.split("=", 1)
-            label_parts.append(f'labels.{key} == "{value}"')
-        include_filters.append(" || ".join(label_parts))
-
-    # --host-label K=V: alias for --include 'host.tags.K == "V"'
-    # Multiple values are OR'd together
-    if opts.host_label:
-        host_label_parts = []
-        for label_spec in opts.host_label:
-            if "=" not in label_spec:
-                raise click.BadParameter(
-                    f"Host label must be in KEY=VALUE format, got: {label_spec}", param_hint="--host-label"
-                )
-            key, value = label_spec.split("=", 1)
-            host_label_parts.append(f'host.tags.{key} == "{value}"')
-        include_filters.append(" || ".join(host_label_parts))
-
-    # Build list of exclude filters
-    exclude_filters = list(opts.exclude)
-    if opts.remote:
-        exclude_filters.append('host.provider == "local"')
-    if opts.active:
-        exclude_filters.append("has(labels.archived_at)")
-        include_filters.append(f'host.state != "{HostState.CRASHED.value}"')
-        include_filters.append(f'host.state != "{HostState.FAILED.value}"')
-        include_filters.append(f'host.state != "{HostState.DESTROYED.value}"')
+            ref_filters = [
+                f'(name == "{ref}" || id == "{ref}" || host.name == "{ref}" || host.id == "{ref}")'
+                for ref in stdin_refs
+            ]
+            include_filters_tuple = (*include_filters_tuple, " || ".join(ref_filters))
 
     # --sort EXPR: CEL expression(s) with optional direction, e.g. "name asc, create_time desc"
     compiled_sort_keys = compile_cel_sort_keys(opts.sort)
@@ -404,8 +284,6 @@ def _list_impl(ctx: click.Context, **kwargs) -> None:
 
     error_behavior = ErrorBehavior(opts.on_error.upper())
 
-    include_filters_tuple = tuple(include_filters)
-    exclude_filters_tuple = tuple(exclude_filters)
     provider_names = opts.provider if opts.provider else None
 
     # Dispatch to the appropriate output path

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
@@ -1,10 +1,12 @@
 from typing import Any
 
 import click
-from click_option_group import optgroup
 
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
+from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
+from imbue.mngr.cli.filter_opts import add_agent_filter_options
+from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -12,49 +14,22 @@ from imbue.mngr.utils.cel_utils import compile_cel_filters
 from imbue.mngr_kanpan.tui import run_kanpan
 
 
-class KanpanCliOptions(CommonCliOptions):
+class KanpanCliOptions(AgentFilterCliOptions, CommonCliOptions):
     """Options for the kanpan command."""
-
-    include: tuple[str, ...]
-    exclude: tuple[str, ...]
-    project: tuple[str, ...]
 
 
 @click.command()
-@optgroup.group("Filtering")
-@optgroup.option(
-    "--include",
-    multiple=True,
-    help="Include agents matching CEL expression (repeatable)",
-)
-@optgroup.option(
-    "--exclude",
-    multiple=True,
-    help="Exclude agents matching CEL expression (repeatable)",
-)
-@optgroup.option(
-    "--project",
-    multiple=True,
-    help="Show only agents with this project label (repeatable)",
-)
+@add_agent_filter_options
 @add_common_options
 @click.pass_context
 def kanpan(ctx: click.Context, **kwargs: Any) -> None:
-    mngr_ctx, output_opts, opts = setup_command_context(
+    mngr_ctx, _output_opts, opts = setup_command_context(
         ctx=ctx,
         command_name="kanpan",
         command_class=KanpanCliOptions,
     )
 
-    # Build include/exclude filter tuples from CLI options
-    include_filters = list(opts.include)
-    if opts.project:
-        project_parts = [f'labels.project == "{p}"' for p in opts.project]
-        include_filters.append(" || ".join(project_parts))
-    exclude_filters = list(opts.exclude)
-
-    include_tuple = tuple(include_filters)
-    exclude_tuple = tuple(exclude_filters)
+    include_tuple, exclude_tuple = build_agent_filter_cel(opts)
 
     # Fail fast on invalid CEL expressions before launching the TUI
     if include_tuple or exclude_tuple:
@@ -76,13 +51,14 @@ including PR number, state (open/closed/merged), and CI check status.
 The display auto-refreshes every 10 minutes. Press 'r' to refresh manually,
 or 'q' to quit.
 
-Supports CEL filtering via --include/--exclude and a --project convenience flag.
+Filtering shares the flag set used by `mngr list` (--include/--exclude/--running/
+--stopped/--archived/--active/--local/--remote/--project/--label/--host-label).
 
 Requires the gh CLI to be installed and authenticated for GitHub PR information.""",
     examples=(
         ("Launch the kanpan board", "mngr kanpan"),
         ("Show only agents for a specific project", "mngr kanpan --project mngr"),
-        ("Show only running agents", "mngr kanpan --include 'state == \"RUNNING\"'"),
+        ("Show only running agents", "mngr kanpan --running"),
     ),
     see_also=(("list", "List agents"),),
 ).register()

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
@@ -56,9 +56,9 @@ Requires the gh CLI to be installed and authenticated for GitHub PR information.
         ("Launch the kanpan board", "mngr kanpan"),
         ("Show only agents for a specific project", "mngr kanpan --project mngr"),
         ("Show only running agents", "mngr kanpan --running"),
-        ("Show running agents with a specific label", "mngr kanpan --running --label env=prod"),
+        ("Show stopped agents with a specific label", "mngr kanpan --stopped --label env=prod"),
     ),
-    see_also=(("list", "List agents (see its Filtering section for the full flag reference)"),),
+    see_also=(("list#filtering", "List agents (see its Filtering section for the full flag reference)"),),
 ).register()
 
 add_pager_help_option(kanpan)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/cli.py
@@ -10,7 +10,6 @@ from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.config.data_types import CommonCliOptions
-from imbue.mngr.utils.cel_utils import compile_cel_filters
 from imbue.mngr_kanpan.tui import run_kanpan
 
 
@@ -31,10 +30,6 @@ def kanpan(ctx: click.Context, **kwargs: Any) -> None:
 
     include_tuple, exclude_tuple = build_agent_filter_cel(opts)
 
-    # Fail fast on invalid CEL expressions before launching the TUI
-    if include_tuple or exclude_tuple:
-        compile_cel_filters(include_tuple, exclude_tuple)
-
     run_kanpan(mngr_ctx, include_filters=include_tuple, exclude_filters=exclude_tuple)
 
 
@@ -51,16 +46,19 @@ including PR number, state (open/closed/merged), and CI check status.
 The display auto-refreshes every 10 minutes. Press 'r' to refresh manually,
 or 'q' to quit.
 
-Filtering shares the flag set used by `mngr list` (--include/--exclude/--running/
---stopped/--archived/--active/--local/--remote/--project/--label/--host-label).
+Supports CEL filtering via --include/--exclude plus alias flags (--running,
+--stopped, --archived, --active, --local, --remote, --project, --label,
+--host-label). See `mngr list --help` for the full filter reference; the same
+flags work identically here.
 
 Requires the gh CLI to be installed and authenticated for GitHub PR information.""",
     examples=(
         ("Launch the kanpan board", "mngr kanpan"),
         ("Show only agents for a specific project", "mngr kanpan --project mngr"),
         ("Show only running agents", "mngr kanpan --running"),
+        ("Show running agents with a specific label", "mngr kanpan --running --label env=prod"),
     ),
-    see_also=(("list", "List agents"),),
+    see_also=(("list", "List agents (see its Filtering section for the full flag reference)"),),
 ).register()
 
 add_pager_help_option(kanpan)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/cli_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/cli_test.py
@@ -73,18 +73,6 @@ def test_kanpan_command_converts_project_to_include_filter(
     assert patched_run_kanpan[0]["include_filters"] == ('labels.project == "mngr"',)
 
 
-def test_kanpan_command_ors_multiple_projects(
-    cli_runner: CliRunner,
-    plugin_manager: pluggy.PluginManager,
-    patched_run_kanpan: list[dict[str, Any]],
-) -> None:
-    result = cli_runner.invoke(
-        kanpan, ["--project", "mngr", "--project", "other"], obj=plugin_manager, catch_exceptions=False
-    )
-    assert result.exit_code == 0
-    assert patched_run_kanpan[0]["include_filters"] == ('labels.project == "mngr" || labels.project == "other"',)
-
-
 def test_kanpan_command_fails_fast_on_invalid_cel(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,

--- a/scripts/make_cli_docs.py
+++ b/scripts/make_cli_docs.py
@@ -404,18 +404,25 @@ def get_relative_link(from_command: str, to_name: str) -> str:
 
 
 def format_see_also_section(command_name: str, metadata: CommandHelpMetadata) -> str:
-    """Format the See Also section from metadata with markdown links."""
+    """Format the See Also section from metadata with markdown links.
+
+    A ``ref_name`` of the form ``"list#filtering"`` links to ``list.md#filtering``;
+    the bare command name is used for category lookup and link text.
+    """
     if not metadata.see_also:
         return ""
 
     lines = ["", "## See Also", ""]
     for ref_name, description in metadata.see_also:
-        link = get_relative_link(command_name, ref_name)
+        bare_name, _, anchor = ref_name.partition("#")
+        link = get_relative_link(command_name, bare_name)
+        if anchor:
+            link = f"{link}#{anchor}"
         # Use "mngr <name>" for commands, "mngr help <name>" for topics
-        if get_command_category(ref_name) is not None:
-            link_text = f"mngr {ref_name}"
+        if get_command_category(bare_name) is not None:
+            link_text = f"mngr {bare_name}"
         else:
-            link_text = f"mngr help {ref_name}"
+            link_text = f"mngr help {bare_name}"
         lines.append(f"- [{link_text}]({link}) - {description}")
 
     lines.append("")


### PR DESCRIPTION
## Summary

- Extract the agent filter flag set (`--include/--exclude/--running/--stopped/--archived/--active/--local/--remote/--project/--label/--host-label`) into `libs/mngr/imbue/mngr/cli/filter_opts.py` so `mngr list` and `mngr kanpan` share one decorator (`add_agent_filter_options`), one options model (`AgentFilterCliOptions`), and one CEL translator (`build_agent_filter_cel`).
- New filters now live in one place; both commands inherit them automatically. Adding a flag = add a field to `AgentFilterCliOptions`, an `optgroup.option` line in `add_agent_filter_options`, and a branch in `build_agent_filter_cel`.
- `mngr kanpan` gains all of list's alias flags (previously only `--include/--exclude/--project`) and drops the duplicated `--project` translation.
- `--provider` and `--stdin` stay list-specific since they are not CEL filter inputs.

## Test plan

- [x] `just test-quick` for `libs/mngr` (3646 passed) and `libs/mngr_kanpan` (370 passed)
- [x] New `filter_opts_test.py` covers each alias-to-CEL translation (15 tests)
- [x] `mngr list --help` and `mngr kanpan --help` render the same Filtering group
- [ ] CI offload (acceptance + release tests)

Branch base: main