### PR TITLE
add filters to mngr connect

### DIFF
--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -91,7 +91,7 @@ mngr connect [OPTIONS] [AGENT]
 ## See Also
 
 - [mngr create](./create.md) - Create and connect to a new agent
-- [mngr list](./list.md#filtering) - List agents (see its Filtering section for the full flag reference)
+- [mngr list](./list.md) - List agents (full filter flag reference lives here)
 
 ## Examples
 

--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -116,5 +116,5 @@ $ mngr connect
 **Selector limited to running agents on a project**
 
 ```bash
-$ mngr connect --running --project mngr
+$ mngr connect --running --project my-project
 ```

--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -22,6 +22,12 @@ The agent can be specified as a positional argument or via --agent:
   mngr connect my-agent
   mngr connect --agent my-agent
 
+Filter flags (--include/--exclude plus aliases like --running, --project,
+--label, ...) narrow the candidate pool used by the interactive selector
+and the non-interactive most-recent fallback. They are ignored when an
+explicit agent is given. See `mngr list --help` for the full filter
+reference; the same flags work identically here.
+
 Alias: conn
 
 **Usage:**
@@ -50,6 +56,22 @@ mngr connect [OPTIONS] [AGENT]
 | `--attach-command` | text | Command to run instead of attaching to main session [future] | None |
 | `--allow-unknown-host`, `--no-allow-unknown-host` | boolean | Allow connecting to hosts without a known_hosts file (disables SSH host key verification) | `False` |
 
+## Filtering
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--include` | text | Include agents matching CEL expression (repeatable) | None |
+| `--exclude` | text | Exclude agents matching CEL expression (repeatable) | None |
+| `--running` | boolean | Show only running agents (alias for --include 'state == "RUNNING"') | `False` |
+| `--stopped` | boolean | Show only stopped agents (alias for --include 'state == "STOPPED"') | `False` |
+| `--archived` | boolean | Show only archived agents (alias for --include 'has(labels.archived_at)') | `False` |
+| `--active` | boolean | Show only active agents (anything not archived/destroyed/crashed/failed) | `False` |
+| `--local` | boolean | Show only local agents (alias for --include 'host.provider == "local"') | `False` |
+| `--remote` | boolean | Show only remote agents (alias for --exclude 'host.provider == "local"') | `False` |
+| `--project` | text | Show only agents with this project label (repeatable) | None |
+| `--label` | text | Show only agents with this label (format: KEY=VALUE, repeatable) [experimental] | None |
+| `--host-label` | text | Show only agents on hosts with this host label (format: KEY=VALUE, repeatable) | None |
+
 ## Common
 
 | Name | Type | Description | Default |
@@ -69,7 +91,7 @@ mngr connect [OPTIONS] [AGENT]
 ## See Also
 
 - [mngr create](./create.md) - Create and connect to a new agent
-- [mngr list](./list.md) - List available agents
+- [mngr list](./list.md#filtering) - List agents (see its Filtering section for the full flag reference)
 
 ## Examples
 
@@ -89,4 +111,10 @@ $ mngr connect my-agent --no-start
 
 ```bash
 $ mngr connect
+```
+
+**Selector limited to running agents on a project**
+
+```bash
+$ mngr connect --running --project mngr
 ```

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -468,7 +468,7 @@ reference; the same flags work identically here.""",
         ("Connect to an agent by name", "mngr connect my-agent"),
         ("Connect without auto-starting if stopped", "mngr connect my-agent --no-start"),
         ("Show interactive agent selector", "mngr connect"),
-        ("Selector limited to running agents on a project", "mngr connect --running --project mngr"),
+        ("Selector limited to running agents on a project", "mngr connect --running --project my-project"),
     ),
     see_also=(
         ("create", "Create and connect to a new agent"),

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -472,7 +472,7 @@ reference; the same flags work identically here.""",
     ),
     see_also=(
         ("create", "Create and connect to a new agent"),
-        ("list#filtering", "List agents (see its Filtering section for the full flag reference)"),
+        ("list", "List agents (full filter flag reference lives here)"),
     ),
 ).register()
 

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -24,6 +24,9 @@ from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.list import list_agents
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
+from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
+from imbue.mngr.cli.filter_opts import add_agent_filter_options
+from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.urwid_utils import create_urwid_screen_preserving_terminal
@@ -36,10 +39,13 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentLifecycleState
 
 
-class ConnectCliOptions(CommonCliOptions):
+class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
     """Options passed from the CLI to the connect command.
 
-    Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
+    Inherits common options from CommonCliOptions and the shared agent filter
+    flags from AgentFilterCliOptions. Filter flags only narrow the candidate
+    pool when no explicit agent is given (interactive selector and the
+    non-interactive most-recent fallback); they are ignored otherwise.
     """
 
     agent: str | None
@@ -352,6 +358,7 @@ def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) ->
     show_default=True,
     help="Allow connecting to hosts without a known_hosts file (disables SSH host key verification)",
 )
+@add_agent_filter_options
 @add_common_options
 @click.pass_context
 def connect(ctx: click.Context, **kwargs: Any) -> None:
@@ -385,7 +392,13 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
         )
     elif not mngr_ctx.is_interactive:
         # Default to most recently created agent when running non-interactively
-        list_result = list_agents(mngr_ctx, is_streaming=False)
+        include_filters, exclude_filters = build_agent_filter_cel(opts)
+        list_result = list_agents(
+            mngr_ctx,
+            is_streaming=False,
+            include_filters=include_filters,
+            exclude_filters=exclude_filters,
+        )
         if not list_result.agents:
             raise UserInputError("No agents found")
 
@@ -400,7 +413,13 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
             is_start_desired=opts.start,
         )
     else:
-        list_result = list_agents(mngr_ctx, is_streaming=False)
+        include_filters, exclude_filters = build_agent_filter_cel(opts)
+        list_result = list_agents(
+            mngr_ctx,
+            is_streaming=False,
+            include_filters=include_filters,
+            exclude_filters=exclude_filters,
+        )
         if not list_result.agents:
             raise UserInputError("No agents found")
 
@@ -437,16 +456,23 @@ by name.
 
 The agent can be specified as a positional argument or via --agent:
   mngr connect my-agent
-  mngr connect --agent my-agent""",
+  mngr connect --agent my-agent
+
+Filter flags (--include/--exclude plus aliases like --running, --project,
+--label, ...) narrow the candidate pool used by the interactive selector
+and the non-interactive most-recent fallback. They are ignored when an
+explicit agent is given. See `mngr list --help` for the full filter
+reference; the same flags work identically here.""",
     aliases=("conn",),
     examples=(
         ("Connect to an agent by name", "mngr connect my-agent"),
         ("Connect without auto-starting if stopped", "mngr connect my-agent --no-start"),
         ("Show interactive agent selector", "mngr connect"),
+        ("Selector limited to running agents on a project", "mngr connect --running --project mngr"),
     ),
     see_also=(
         ("create", "Create and connect to a new agent"),
-        ("list", "List available agents"),
+        ("list#filtering", "List agents (see its Filtering section for the full flag reference)"),
     ),
 ).register()
 


### PR DESCRIPTION
addresses https://github.com/imbue-ai/mngr/issues/473 point 27

---

## Summary

- Add the unified agent filter flag set (`--include`, `--exclude`, `--running`, `--stopped`, `--archived`, `--active`, `--local`, `--remote`, `--project`, `--label`, `--host-label`) to `mngr connect`.
- Mix `AgentFilterCliOptions` into `ConnectCliOptions`, decorate the command with `@add_agent_filter_options`, and feed the resulting CEL tuples into both `list_agents` calls (interactive selector and the non-interactive most-recent fallback).
- Filter flags only narrow the candidate pool when no explicit agent is given; they are ignored when an agent is specified positionally or via `--agent`.
- Help metadata + examples updated; `see_also` points at `list#filtering` for the full filter reference.

## Test plan

- [x] `just test-quick libs/mngr/imbue/mngr/cli/connect_test.py` (17 passed)
- [x] `just test-quick "libs/mngr/imbue/mngr/cli -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (1289 passed)
- [x] `mngr connect --help` renders the shared Filtering group with all 11 flags
- [ ] CI offload (acceptance + release tests)