### PR TITLE
Copy unclean files into git-worktree work dirs

### DIFF
--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2143,6 +2143,11 @@ class Host(BaseHost, OnlineHostInterface):
             # Track generated work directories at the host level
             self._add_generated_work_dir(work_dir_path)
 
+            # `git worktree add` only checks out the committed state of the base branch.
+            # Mirror the git-mirror codepath and copy over uncommitted (and optionally
+            # gitignored) files from the source so --include-unclean works in worktree mode.
+            self._transfer_extra_files(host, source_path, work_dir_path, options)
+
             self._apply_work_dir_extra_paths(
                 host, source_path, work_dir_path, self.mngr_ctx.config.work_dir_extra_paths
             )

--- a/libs/mngr/imbue/mngr/hosts/test_host.py
+++ b/libs/mngr/imbue/mngr/hosts/test_host.py
@@ -1910,6 +1910,119 @@ def test_create_work_dir_copy_with_renamed_file(
 
 
 @pytest.mark.rsync
+def test_create_work_dir_worktree_with_untracked_files(
+    host_with_temp_dir: tuple[Host, Path],
+    setup_git_config: None,
+) -> None:
+    """Worktree mode copies over untracked files when is_include_unclean is True.
+
+    `git worktree add` only checks out the committed state, so unclean files
+    must be rsynced separately for --no-ensure-clean / --include-unclean to
+    actually include them.
+    """
+    host, temp_dir = host_with_temp_dir
+
+    source_path = temp_dir / "source_wt_untracked"
+    source_path.mkdir()
+    (source_path / "tracked.txt").write_text("tracked")
+    _init_git_repo(source_path)
+    (source_path / "untracked.txt").write_text("untracked")
+    (source_path / ".gitignore").write_text("ignored.txt\n")
+    (source_path / "ignored.txt").write_text("ignored")
+
+    target_path = temp_dir / "target_wt_untracked"
+
+    options = CreateAgentOptions(
+        name=AgentName("wt-untracked"),
+        agent_type=AgentTypeName("generic"),
+        command=CommandString("sleep 1"),
+        target_path=target_path,
+        transfer_mode=TransferMode.GIT_WORKTREE,
+        git=AgentGitOptions(
+            new_branch_name="mngr/wt-untracked",
+            is_include_unclean=True,
+        ),
+    )
+
+    work_dir = host.create_agent_work_dir(host, source_path, options).path
+
+    assert work_dir == target_path
+    assert (work_dir / "tracked.txt").read_text() == "tracked"
+    assert (work_dir / "untracked.txt").read_text() == "untracked"
+    assert not (work_dir / "ignored.txt").exists()
+
+
+def test_create_work_dir_worktree_excludes_unclean_when_disabled(
+    host_with_temp_dir: tuple[Host, Path],
+    setup_git_config: None,
+) -> None:
+    """Worktree mode does not copy untracked files when is_include_unclean is False."""
+    host, temp_dir = host_with_temp_dir
+
+    source_path = temp_dir / "source_wt_clean"
+    source_path.mkdir()
+    (source_path / "tracked.txt").write_text("tracked")
+    _init_git_repo(source_path)
+    (source_path / "untracked.txt").write_text("untracked")
+
+    target_path = temp_dir / "target_wt_clean"
+
+    options = CreateAgentOptions(
+        name=AgentName("wt-clean"),
+        agent_type=AgentTypeName("generic"),
+        command=CommandString("sleep 1"),
+        target_path=target_path,
+        transfer_mode=TransferMode.GIT_WORKTREE,
+        git=AgentGitOptions(
+            new_branch_name="mngr/wt-clean",
+            is_include_unclean=False,
+        ),
+    )
+
+    work_dir = host.create_agent_work_dir(host, source_path, options).path
+
+    assert work_dir == target_path
+    assert (work_dir / "tracked.txt").read_text() == "tracked"
+    assert not (work_dir / "untracked.txt").exists()
+
+
+@pytest.mark.rsync
+def test_create_work_dir_worktree_with_gitignored_files(
+    host_with_temp_dir: tuple[Host, Path],
+    setup_git_config: None,
+) -> None:
+    """Worktree mode copies gitignored files when is_include_gitignored is True."""
+    host, temp_dir = host_with_temp_dir
+
+    source_path = temp_dir / "source_wt_gitignored"
+    source_path.mkdir()
+    (source_path / "tracked.txt").write_text("tracked")
+    (source_path / ".gitignore").write_text("*.log\n")
+    _init_git_repo(source_path)
+    (source_path / "debug.log").write_text("log content")
+
+    target_path = temp_dir / "target_wt_gitignored"
+
+    options = CreateAgentOptions(
+        name=AgentName("wt-gitignored"),
+        agent_type=AgentTypeName("generic"),
+        command=CommandString("sleep 1"),
+        target_path=target_path,
+        transfer_mode=TransferMode.GIT_WORKTREE,
+        git=AgentGitOptions(
+            new_branch_name="mngr/wt-gitignored",
+            is_include_gitignored=True,
+        ),
+    )
+
+    work_dir = host.create_agent_work_dir(host, source_path, options).path
+
+    assert work_dir == target_path
+    assert (work_dir / "tracked.txt").read_text() == "tracked"
+    assert (work_dir / "debug.log").read_text() == "log content"
+
+
+@pytest.mark.rsync
 def test_create_work_dir_generates_new_branch(
     host_with_temp_dir: tuple[Host, Path],
     setup_git_config: None,


### PR DESCRIPTION
## Summary

- `mngr create --no-ensure-clean` no longer included uncommitted/untracked files in the new agent's work_dir. The flag set `is_include_unclean=True` on the git options, but `_create_work_dir_as_git_worktree` only ran `git worktree add` (which checks out the committed base branch) and never called `_transfer_extra_files`. Only the GIT_MIRROR codepath did, so the (default) local-git path silently dropped the unclean files.
- Call `_transfer_extra_files` from the worktree path too, mirroring the git-mirror codepath. It uses `git status --porcelain` (and, for `--include-gitignored`, `git ls-files --others --ignored --exclude-standard`), so .gitignore is still respected -- this is not a "rsync the whole tree" approach.
- Added unit tests in `test_host.py` covering GIT_WORKTREE with `is_include_unclean=True` (untracked file copied, gitignored file not), `is_include_unclean=False` (untracked file skipped), and `is_include_gitignored=True` (gitignored file copied).

## Test plan

- [x] `just test-quick libs/mngr/imbue/mngr/hosts/test_host.py -k 'create_work_dir or worktree or transfer_extra'` (16 passed)
- [x] `just test-quick libs/mngr/imbue/mngr/cli/test_create.py -k 'ensure_clean or dirty'` (4 passed)
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (3634 passed)
- [x] Manual repro: created a local git repo with an untracked file, ran `mngr create --no-ensure-clean`, verified the untracked file appears in the worktree under `~/.mngr/worktrees/<name>-<uuid>/` and that gitignored files are still excluded unless `--include-gitignored` is passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)