### PR TITLE
Fix CI failures: ratchets and dep pins

### DIFF
--- a/apps/modal_litellm/test_ratchets.py
+++ b/apps/modal_litellm/test_ratchets.py
@@ -192,6 +192,10 @@ def test_prevent_fstring_logging() -> None:
     rc.check_fstring_logging(_DIR, snapshot(0))
 
 
+def test_prevent_logger_exception() -> None:
+    rc.check_logger_exception(_DIR, snapshot(0))
+
+
 def test_prevent_click_echo() -> None:
     rc.check_click_echo(_DIR, snapshot(0))
 

--- a/libs/mngr/imbue/mngr/api/discovery_events.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events.py
@@ -690,8 +690,8 @@ def _discovery_stream_tail_events_file(
                         if stop_event.is_set():
                             break
                         _discovery_stream_emit_line(file_line, emitted_event_ids, emit_lock, on_line)
-        except Exception:
-            logger.exception("Error while tailing discovery events file")
+        except Exception as e:
+            logger.opt(exception=e).error("Error while tailing discovery events file")
         stop_event.wait(timeout=1.0)
 
 
@@ -717,7 +717,7 @@ def _write_unfiltered_full_snapshot_logged(mngr_ctx: MngrContext, error_behavior
     try:
         _write_unfiltered_full_snapshot(mngr_ctx, error_behavior)
     except Exception as e:
-        logger.exception("Failed to write discovery snapshot")
+        logger.opt(exception=e).error("Failed to write discovery snapshot")
         try:
             emit_discovery_error_event(
                 mngr_ctx.config,
@@ -803,7 +803,7 @@ def run_discovery_stream(
                 _write_unfiltered_full_snapshot(mngr_ctx, error_behavior)
                 # The tail thread will pick up the new snapshot and emit it
             except Exception as e:
-                logger.exception("Discovery stream poll failed (continuing)")
+                logger.opt(exception=e).error("Discovery stream poll failed (continuing)")
                 try:
                     emit_discovery_error_event(
                         mngr_ctx.config,

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -381,7 +381,7 @@ def _discover_and_emit_details_for_provider(
             if isinstance(e, MngrError):
                 raise
             raise MngrError(str(e)) from e
-        logger.exception("Error discovering agents for provider {}", provider.name)
+        logger.opt(exception=e).error("Error discovering agents for provider {}", provider.name)
         emit_discovery_error_to_stdout(
             error_type=type(e).__name__,
             error_message=str(e),
@@ -467,7 +467,7 @@ def _process_host_with_error_handling(
             if isinstance(e, (MngrError, BaseMngrError)):
                 raise
             raise MngrError(str(e)) from e
-        logger.exception("Error processing host {}", host_ref.host_id)
+        logger.opt(exception=e).error("Error processing host {}", host_ref.host_id)
         emit_discovery_error_to_stdout(
             error_type=type(e).__name__,
             error_message=str(e),

--- a/libs/mngr_lima/pyproject.toml
+++ b/libs/mngr_lima/pyproject.toml
@@ -5,7 +5,7 @@ description = "Lima VM provider backend plugin for mngr"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "imbue-mngr==0.2.2",
+    "imbue-mngr==0.2.5",
     "pyyaml>=6.0",
 ]
 

--- a/libs/mngr_vps_docker/pyproject.toml
+++ b/libs/mngr_vps_docker/pyproject.toml
@@ -5,7 +5,7 @@ description = "VPS Docker provider base classes for mngr"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "imbue-mngr==0.2.1",
+    "imbue-mngr==0.2.5",
 ]
 
 [build-system]

--- a/libs/mngr_vultr/pyproject.toml
+++ b/libs/mngr_vultr/pyproject.toml
@@ -5,7 +5,7 @@ description = "Vultr provider backend plugin for mngr"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "imbue-mngr==0.2.1",
+    "imbue-mngr==0.2.5",
     "imbue-mngr-vps-docker==0.2.1",
     "requests>=2.31.0",
 ]


### PR DESCRIPTION
## Summary
- Add missing `test_prevent_logger_exception` to `apps/modal_litellm/test_ratchets.py`
- Bump `imbue-mngr` pin to `0.2.5` in `mngr_vps_docker`, `mngr_lima`, `mngr_vultr` pyproject.toml
- Replace 5 `logger.exception()` calls in `libs/mngr` with `logger.opt(exception=e).error(...)` (discovery_events.py, list.py)

## Test plan
- [x] `test_meta_ratchets.py::test_all_test_ratchets_files_have_same_tests` passes
- [x] `scripts/version_sync_test.py::test_internal_dep_pins_are_consistent` passes
- [x] `libs/mngr/imbue/mngr/utils/test_ratchets.py::test_prevent_logger_exception` passes
- [x] `apps/modal_litellm/test_ratchets.py::test_prevent_logger_exception` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)