### PR TITLE
mngr_tmr: reuse one /opt/snapshotter checkout via git-worktree

### DIFF
--- a/libs/mngr/docs/commands/secondary/tmr.md
+++ b/libs/mngr/docs/commands/secondary/tmr.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr tmr [TEST_PATHS...] [-- TESTING_FLAGS...] [--provider <PROVIDER>] [--use-snapshot] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]
+mngr tmr [TEST_PATHS...] [-- TESTING_FLAGS...] [--provider <PROVIDER>] [--snapshot <ID>] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]
 ```
 
 Run and fix tests in parallel using agents (test map-reduce).
@@ -34,8 +34,10 @@ This discovers tests with `pytest --collect-only tests/e2e -m release` and runs
 each test with `pytest tests/e2e/test_foo.py::test_bar -m release`.
 
 Use --provider to run agents on a specific provider (e.g. docker, modal).
-Use --use-snapshot with remote providers to build and provision one host first,
-snapshot it, then launch all remaining agents from the snapshot (much faster).
+For remote providers that support snapshots, a snapshotter agent is built
+and snapshotted first, then all test agents launch from that snapshot and
+share its /opt/snapshotter checkout via git-worktree. Use --snapshot to
+reuse an existing snapshot instead.
 Use --env to pass environment variables and --label to tag all agents.
 Use --prompt-suffix to append custom instructions to the agent prompt.
 Use --max-agents to limit how many agents run simultaneously (0 = no limit).
@@ -84,8 +86,7 @@ mngr tmr [OPTIONS] [PYTEST_ARGS]...
 | `--env` | text | Environment variable KEY=VALUE to pass to agents [repeatable] | None |
 | `--label` | text | Agent label KEY=VALUE to attach to all launched agents [repeatable] | None |
 | `--prompt-suffix` | text | Additional text to append to the agent prompt | None |
-| `--use-snapshot` | boolean | Build one agent first, snapshot its host, then launch remaining agents from the snapshot (faster for remote providers) | `False` |
-| `--snapshot` | text | Use an existing snapshot/image ID for all agents (skips building; implies --use-snapshot behavior) | None |
+| `--snapshot` | text | Use an existing snapshot/image ID for all agents (skips building one). The snapshot must contain a /opt/snapshotter git checkout. | None |
 | `--max-parallel` | integer | Maximum number of agents to launch concurrently (launch-time parallelism) | `4` |
 | `--agents-per-host` | integer | Number of agents sharing each remote host (ignored for local provider) | `4` |
 | `--max-agents` | integer | Maximum number of agents running at any one time (0 = no limit). When set, agents are launched incrementally as earlier ones finish. | `0` |
@@ -130,10 +131,10 @@ $ mngr tmr tests/e2e -- -m release
 $ mngr tmr --provider docker tests/
 ```
 
-**Modal with snapshot**
+**Modal with explicit snapshot**
 
 ```bash
-$ mngr tmr --provider modal --use-snapshot tests/
+$ mngr tmr --provider modal --snapshot snap-abc tests/
 ```
 
 **Pass env vars and labels**

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -1536,14 +1536,6 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         Interactive and auto-approve runs skip these checks because
         provision() will handle them.
         """
-        if options.transfer_mode == TransferMode.GIT_WORKTREE:
-            if not host.is_local:
-                raise PluginMngrError(
-                    "Git worktree transfer mode is not supported on remote hosts.\n"
-                    "Claude trust extension requires local filesystem access. "
-                    "Use --transfer=git-mirror instead."
-                )
-
         config = self.agent_config
 
         # Validate dialogs for non-interactive local runs so we fail early with

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -1501,15 +1501,20 @@ def test_auto_dismiss_dialogs_defaults_to_false() -> None:
     assert config.auto_dismiss_dialogs is False
 
 
-def test_on_before_provisioning_raises_for_worktree_on_remote_host(
+def test_on_before_provisioning_allows_worktree_on_remote_host(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
-    """on_before_provisioning should raise PluginMngrError for worktree mode on remote hosts."""
+    """on_before_provisioning should accept worktree mode on remote hosts.
+
+    Remote claude trust comes from the work_dir entry in the synced .claude.json
+    (added by _build_claude_json when should_trust_work_dir is true), not from a
+    local trust check. The dialog-dismissed precheck below this branch is
+    already gated on host.is_local.
+    """
     agent, _ = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
 
     # Use SimpleNamespace to simulate a non-local host. Creating a real remote host
-    # requires SSH infrastructure not available in unit tests. The method only reads
-    # host.is_local before raising.
+    # requires SSH infrastructure not available in unit tests.
     non_local_host = cast(OnlineHostInterface, SimpleNamespace(is_local=False))
 
     options = CreateAgentOptions(
@@ -1517,8 +1522,7 @@ def test_on_before_provisioning_raises_for_worktree_on_remote_host(
         transfer_mode=TransferMode.GIT_WORKTREE,
     )
 
-    with pytest.raises(PluginMngrError, match="Git worktree transfer mode is not supported on remote hosts"):
-        agent.on_before_provisioning(host=non_local_host, options=options, mngr_ctx=temp_mngr_ctx)
+    agent.on_before_provisioning(host=non_local_host, options=options, mngr_ctx=temp_mngr_ctx)
 
 
 def test_on_before_provisioning_validates_trust_for_worktree(

--- a/libs/mngr_tmr/imbue/mngr_tmr/api.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api.py
@@ -28,9 +28,10 @@ from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
-from imbue.mngr_tmr.launching import launch_agents_up_to_limit
 
 # Re-export public API used by cli.py and tests
+from imbue.mngr_tmr.launching import ensure_snapshot as ensure_snapshot
+from imbue.mngr_tmr.launching import launch_agents_up_to_limit
 from imbue.mngr_tmr.launching import launch_all_test_agents as launch_all_test_agents
 from imbue.mngr_tmr.launching import launch_integrator_agent as launch_integrator_agent
 from imbue.mngr_tmr.launching import launch_test_agent as launch_test_agent

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -38,6 +38,7 @@ from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr_tmr.api import collect_tests
+from imbue.mngr_tmr.api import ensure_snapshot
 from imbue.mngr_tmr.api import gather_results
 from imbue.mngr_tmr.api import get_base_commit
 from imbue.mngr_tmr.api import launch_all_test_agents
@@ -74,7 +75,6 @@ class TmrCliOptions(CommonCliOptions):
     env: tuple[str, ...]
     label: tuple[str, ...]
     prompt_suffix: str | None
-    use_snapshot: bool
     snapshot: str | None
     max_parallel: int
     agents_per_host: int
@@ -416,15 +416,9 @@ def _run_integrator_phase(
     help="Additional text to append to the agent prompt",
 )
 @click.option(
-    "--use-snapshot",
-    is_flag=True,
-    default=False,
-    help="Build one agent first, snapshot its host, then launch remaining agents from the snapshot (faster for remote providers)",
-)
-@click.option(
     "--snapshot",
     default=None,
-    help="Use an existing snapshot/image ID for all agents (skips building; implies --use-snapshot behavior)",
+    help="Use an existing snapshot/image ID for all agents (skips building one). The snapshot must contain a /opt/snapshotter git checkout.",
 )
 @click.option(
     "--max-parallel",
@@ -580,7 +574,6 @@ def tmr(ctx: click.Context, **kwargs: object) -> None:
             source_host,
             label_options,
             test_node_ids,
-            provided_snapshot,
             env_options,
         )
     except KeyboardInterrupt:
@@ -602,7 +595,6 @@ def _run_tmr_pipeline(
     source_host: OnlineHostInterface,
     label_options: AgentLabelOptions,
     test_node_ids: list[str],
-    provided_snapshot: SnapshotName | None,
     env_options: AgentEnvironmentOptions,
 ) -> None:
     """Run the main TMR pipeline (launch, poll, gather, integrate, report)."""
@@ -615,26 +607,27 @@ def _run_tmr_pipeline(
         html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 7: Launch and poll agents
+    # Step 7: Build a snapshot up front (if the provider supports it). All
+    # subsequent test agents launch from this snapshot and reuse the
+    # /opt/snapshotter checkout via git-worktree, avoiding repeated repo uploads.
+    config = ensure_snapshot(config, mngr_ctx)
+
+    # Step 8: Launch and poll agents
     # When max_agents > 0, agents are launched incrementally as earlier ones finish.
     # Otherwise, all agents are launched up front and then polled via the same function.
     use_batched = opts.max_agents > 0 and opts.max_agents < len(test_node_ids)
 
     if use_batched:
-        if opts.use_snapshot:
-            write_human_line("WARNING: --use-snapshot is not supported with --max-agents and will be ignored")
         agent_infos: list[TestAgentInfo] = []
         agent_hosts: dict[str, OnlineHostInterface] = {}
         remaining_node_ids = test_node_ids
     else:
-        # When --snapshot is provided, all agents use it directly (no need for --use-snapshot)
         agent_infos, agent_hosts, _snapshot_name = launch_all_test_agents(
             test_node_ids=test_node_ids,
             config=config,
             mngr_ctx=mngr_ctx,
             pytest_flags=testing_flags,
             prompt_suffix=opts.prompt_suffix or "",
-            use_snapshot=opts.use_snapshot and provided_snapshot is None,
             max_parallel=opts.max_parallel,
             launch_delay_seconds=opts.launch_delay,
             agents_per_host=opts.agents_per_host,
@@ -731,7 +724,7 @@ def _print_run_commands(run_name: str, integrated_branch: str | None = None) -> 
 CommandHelpMetadata(
     key="tmr",
     one_line_description="Run and fix tests in parallel using agents (test map-reduce)",
-    synopsis="mngr tmr [TEST_PATHS...] [-- TESTING_FLAGS...] [--provider <PROVIDER>] [--use-snapshot] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]",
+    synopsis="mngr tmr [TEST_PATHS...] [-- TESTING_FLAGS...] [--provider <PROVIDER>] [--snapshot <ID>] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]",
     description="""This command implements a map-reduce pattern for tests:
 
 1. Collects tests using pytest --collect-only, passing through all arguments.
@@ -755,8 +748,10 @@ This discovers tests with `pytest --collect-only tests/e2e -m release` and runs
 each test with `pytest tests/e2e/test_foo.py::test_bar -m release`.
 
 Use --provider to run agents on a specific provider (e.g. docker, modal).
-Use --use-snapshot with remote providers to build and provision one host first,
-snapshot it, then launch all remaining agents from the snapshot (much faster).
+For remote providers that support snapshots, a snapshotter agent is built
+and snapshotted first, then all test agents launch from that snapshot and
+share its /opt/snapshotter checkout via git-worktree. Use --snapshot to
+reuse an existing snapshot instead.
 Use --env to pass environment variables and --label to tag all agents.
 Use --prompt-suffix to append custom instructions to the agent prompt.
 Use --max-agents to limit how many agents run simultaneously (0 = no limit).
@@ -769,7 +764,7 @@ tests_passing_before/after booleans, and a markdown summary.""",
         ("Run tests in a specific file", "mngr tmr tests/test_foo.py"),
         ("Run tests with a marker", "mngr tmr tests/e2e -- -m release"),
         ("Use Docker provider", "mngr tmr --provider docker tests/"),
-        ("Modal with snapshot", "mngr tmr --provider modal --use-snapshot tests/"),
+        ("Modal with explicit snapshot", "mngr tmr --provider modal --snapshot snap-abc tests/"),
         ("Pass env vars and labels", "mngr tmr --env API_KEY=xxx --label batch=run1"),
         ("Limit to 4 concurrent agents", "mngr tmr --max-agents 4 tests/"),
         ("Custom poll interval", "mngr tmr --poll-interval 30"),

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -24,8 +24,7 @@ from imbue.mngr.cli.output_helpers import emit_event
 from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
-from imbue.mngr.errors import HostError
-from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import BaseMngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import AgentEnvironmentOptions
 from imbue.mngr.interfaces.host import AgentLabelOptions
@@ -220,7 +219,7 @@ def _run_reintegrate(
                     host_ref = host_provider.get_host(HostName(detail.host.name))
                     host, _ = ensure_host_started(host_ref, is_start_desired=True, provider=host_provider)
                     agent_hosts[agent_id_str] = host
-                except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+                except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
                     logger.warning("Could not connect to host for agent '{}': {}", detail.name, exc)
 
     # Compute output directory
@@ -319,7 +318,7 @@ def _run_integrator_phase(
             config=config,
             mngr_ctx=mngr_ctx,
         )
-    except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+    except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
         logger.warning("Failed to launch integrator agent: {}", exc)
         return None
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -658,7 +658,7 @@ def _run_tmr_pipeline(
     if use_batched:
         _emit_agents_launched(len(agent_infos), output_opts)
 
-    # Step 8: Gather final results (branches already pulled during polling for
+    # Step 9: Gather final results (branches already pulled during polling for
     # remote providers; gather_results re-attempts for any that were missed)
     results = gather_results(
         agents=agent_infos,
@@ -671,10 +671,10 @@ def _run_tmr_pipeline(
         cached_results=cached_results,
     )
 
-    # Step 9: Write report with final results (artifacts already pulled during polling)
+    # Step 10: Write report with final results (artifacts already pulled during polling)
     generate_html_report(results, html_path, test_artifacts_dir=output_dir)
 
-    # Step 10: Build integrator config (defaults to local provider) and integrate
+    # Step 11: Build integrator config (defaults to local provider) and integrate
     integrator_agent_type = opts.integrator_type if opts.integrator_type is not None else opts.agent_type
     integrator_templates = opts.integrator_template if opts.integrator_template else opts.agent_template
     integrator_config = TmrLaunchConfig(

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
@@ -36,7 +36,7 @@ def test_cli_help_contains_provider_env_label_options(cli_runner: CliRunner) -> 
     assert "--env" in result.output
     assert "--label" in result.output
     assert "--prompt-suffix" in result.output
-    assert "--use-snapshot" in result.output
+    assert "--snapshot" in result.output
 
 
 def test_cli_help_contains_timeout_options(cli_runner: CliRunner) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -170,6 +170,9 @@ def launch_test_agent(
         source_location: HostLocation | None = None
         transfer_mode: TransferMode | None = None
         resolved_existing_host = existing_host
+        # host_name is only consulted by _create_tmr_agent when existing_host
+        # is None, so forward it for the fall-back branch.
+        effective_host_name: HostName | None = host_name
     else:
         # Remote provider with a snapshot: pre-resolve the target host (from
         # the snapshot) and source the test agent's worktree from
@@ -183,6 +186,9 @@ def launch_test_agent(
             resolved_existing_host = resolve_target_host(new_host_opts, mngr_ctx)
         source_location = HostLocation(host=resolved_existing_host, path=SNAPSHOTTER_CHECKOUT_PATH)
         transfer_mode = TransferMode.GIT_WORKTREE
+        # The host has already been materialised, so host_name is irrelevant
+        # for the downstream _create_tmr_agent call.
+        effective_host_name = None
 
     create_result = _create_tmr_agent(
         agent_name=agent_name,
@@ -191,7 +197,7 @@ def launch_test_agent(
         mngr_ctx=mngr_ctx,
         initial_message=build_test_agent_prompt(test_node_id, pytest_flags, prompt_suffix),
         existing_host=resolved_existing_host,
-        host_name=host_name,
+        host_name=effective_host_name,
         source_location=source_location,
         transfer_mode=transfer_mode,
     )

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -318,14 +318,12 @@ def launch_all_test_agents(
     agents: list[TestAgentInfo] = []
     agent_hosts: dict[str, OnlineHostInterface] = {}
 
-    launch_config = config
-
-    is_local = launch_config.provider_name.lower() == LOCAL_PROVIDER_NAME
+    is_local = config.provider_name.lower() == LOCAL_PROVIDER_NAME
     host_pool: list[OnlineHostInterface] = []
     if not is_local and agents_per_host > 0:
         host_count = math.ceil(len(test_node_ids) / agents_per_host)
         if host_count > 0:
-            host_pool = _create_host_pool(host_count, launch_config, mngr_ctx, run_name, max_parallel)
+            host_pool = _create_host_pool(host_count, config, mngr_ctx, run_name, max_parallel)
 
     with ConcurrencyGroupExecutor(
         parent_cg=mngr_ctx.concurrency_group,
@@ -342,7 +340,7 @@ def launch_all_test_agents(
                 executor.submit(
                     launch_test_agent,
                     test_node_id,
-                    launch_config,
+                    config,
                     mngr_ctx,
                     pytest_flags,
                     prompt_suffix,
@@ -359,7 +357,7 @@ def launch_all_test_agents(
                 logger.warning("Failed to launch agent: {}", exc)
 
     logger.info("Launched {} agent(s)", len(agents))
-    return agents, agent_hosts, launch_config.snapshot
+    return agents, agent_hosts, config.snapshot
 
 
 def launch_with_timeout(

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -2,6 +2,7 @@
 
 import math
 import time
+from pathlib import Path
 
 from loguru import logger
 
@@ -26,6 +27,7 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import SnapshotName
+from imbue.mngr.primitives import TransferMode
 from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.prompts import build_integrator_prompt
@@ -36,6 +38,8 @@ from imbue.mngr_tmr.utils import short_random_id
 from imbue.mngr_tmr.utils import transfer_mode_for_provider
 
 _AGENT_CREATION_TIMEOUT_SECONDS = 600.0
+
+SNAPSHOTTER_CHECKOUT_PATH = Path("/opt/snapshotter")
 
 
 def _resolve_build_options(config: TmrLaunchConfig, mngr_ctx: MngrContext) -> NewHostBuildOptions:
@@ -53,15 +57,24 @@ def build_agent_options(
     branch_name: str,
     config: TmrLaunchConfig,
     initial_message: str | None = None,
+    transfer_mode: TransferMode | None = None,
+    target_path: Path | None = None,
 ) -> CreateAgentOptions:
-    """Build CreateAgentOptions for a tmr agent."""
-    transfer_mode = transfer_mode_for_provider(config.provider_name)
+    """Build CreateAgentOptions for a tmr agent.
+
+    If transfer_mode is None, defaults to the natural mode for the provider
+    (git-worktree for local, git-mirror for remote).
+    """
+    resolved_transfer_mode = (
+        transfer_mode if transfer_mode is not None else transfer_mode_for_provider(config.provider_name)
+    )
     is_remote = config.provider_name.lower() != LOCAL_PROVIDER_NAME
     return CreateAgentOptions(
         agent_type=config.agent_type,
         name=agent_name,
         initial_message=initial_message,
-        transfer_mode=transfer_mode,
+        transfer_mode=resolved_transfer_mode,
+        target_path=target_path,
         git=AgentGitOptions(
             new_branch_name=branch_name,
         ),
@@ -80,14 +93,31 @@ def _create_tmr_agent(
     initial_message: str | None = None,
     existing_host: OnlineHostInterface | None = None,
     host_name: HostName | None = None,
+    source_location: HostLocation | None = None,
+    transfer_mode: TransferMode | None = None,
+    target_path: Path | None = None,
 ) -> CreateAgentResult:
     """Create an agent on the configured provider with an optional initial message.
 
     If existing_host is provided, the agent is placed on that host instead of
     creating a new one (used for host sharing in remote providers).
+
+    If source_location is None, the local user checkout (config.source_host,
+    config.source_dir) is used.
     """
-    agent_options = build_agent_options(agent_name, branch_name, config, initial_message=initial_message)
-    source_location = HostLocation(host=config.source_host, path=config.source_dir)
+    agent_options = build_agent_options(
+        agent_name,
+        branch_name,
+        config,
+        initial_message=initial_message,
+        transfer_mode=transfer_mode,
+        target_path=target_path,
+    )
+    resolved_source = (
+        source_location
+        if source_location is not None
+        else HostLocation(host=config.source_host, path=config.source_dir)
+    )
 
     if existing_host is not None:
         target_host: OnlineHostInterface | NewHostOptions = existing_host
@@ -98,7 +128,7 @@ def _create_tmr_agent(
         target_host = NewHostOptions(provider=config.provider_name, name=resolved_host_name, build=build)
 
     return api_create(
-        source_location=source_location,
+        source_location=resolved_source,
         target_host=target_host,
         agent_options=agent_options,
         mngr_ctx=mngr_ctx,
@@ -114,23 +144,51 @@ def launch_test_agent(
     existing_host: OnlineHostInterface | None = None,
     host_name: HostName | None = None,
 ) -> tuple[TestAgentInfo, OnlineHostInterface]:
-    """Launch a single agent to run and optionally fix one test."""
+    """Launch a single agent to run and optionally fix one test.
+
+    For remote providers, the test agent's host is pre-resolved (creating a new
+    host from the snapshot if needed) and used as both the source and target,
+    transferring via git-worktree from /opt/snapshotter (which is baked into
+    the snapshot by the snapshotter agent).
+    """
     agent_name_suffix = sanitize_test_name_for_agent(test_node_id)
     short_id = short_random_id()
     agent_name = AgentName(f"tmr-{agent_name_suffix}-{short_id}")
+    branch = f"mngr-tmr/{agent_name_suffix}-{short_id}"
 
     logger.info("Launching agent '{}' for test: {}", agent_name, test_node_id)
+
+    is_local = config.provider_name.lower() == LOCAL_PROVIDER_NAME
+    if is_local:
+        # Local provider: use the natural git-worktree from the local user checkout.
+        source_location: HostLocation | None = None
+        transfer_mode: TransferMode | None = None
+        resolved_existing_host = existing_host
+    else:
+        # Remote provider: pre-resolve the target host (from the snapshot) and
+        # source the test agent's worktree from /opt/snapshotter on the same
+        # host. This avoids re-uploading the git repo for every agent.
+        if existing_host is not None:
+            resolved_existing_host = existing_host
+        else:
+            build = _resolve_build_options(config, mngr_ctx)
+            new_host_opts = NewHostOptions(provider=config.provider_name, name=host_name, build=build)
+            resolved_existing_host = resolve_target_host(new_host_opts, mngr_ctx)
+        source_location = HostLocation(host=resolved_existing_host, path=SNAPSHOTTER_CHECKOUT_PATH)
+        transfer_mode = TransferMode.GIT_WORKTREE
+
     create_result = _create_tmr_agent(
         agent_name=agent_name,
-        branch_name=f"mngr-tmr/{agent_name_suffix}-{short_id}",
+        branch_name=branch,
         config=config,
         mngr_ctx=mngr_ctx,
         initial_message=build_test_agent_prompt(test_node_id, pytest_flags, prompt_suffix),
-        existing_host=existing_host,
+        existing_host=resolved_existing_host,
         host_name=host_name,
+        source_location=source_location,
+        transfer_mode=transfer_mode,
     )
 
-    branch = f"mngr-tmr/{agent_name_suffix}-{short_id}"
     return (
         TestAgentInfo(
             test_node_id=test_node_id,
@@ -148,7 +206,12 @@ def _create_snapshot_host(
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
 ) -> SnapshotName:
-    """Launch a dedicated snapshotter agent, snapshot its host, then stop it."""
+    """Launch a dedicated snapshotter agent, snapshot its host, then stop it.
+
+    The snapshotter's git checkout is placed at /opt/snapshotter so that
+    test agents launched from the snapshot can create git worktrees from it
+    without re-uploading the repo.
+    """
     short_id = short_random_id()
     agent_name = AgentName(f"tmr-snapshotter-{short_id}")
 
@@ -158,6 +221,7 @@ def _create_snapshot_host(
         branch_name=f"mngr-tmr/snapshotter-{short_id}",
         config=config,
         mngr_ctx=mngr_ctx,
+        target_path=SNAPSHOTTER_CHECKOUT_PATH,
     )
 
     snapshotter_host = create_result.host
@@ -213,13 +277,31 @@ def _create_host_pool(
     return hosts
 
 
+def ensure_snapshot(config: TmrLaunchConfig, mngr_ctx: MngrContext) -> TmrLaunchConfig:
+    """Build a snapshot host if the provider supports it and one is not already set.
+
+    Returns the (possibly updated) config. For providers that don't support
+    snapshots (e.g. local), returns the config unchanged.
+    """
+    if config.snapshot is not None:
+        return config
+    provider = get_provider_instance(config.provider_name, mngr_ctx)
+    if not provider.supports_snapshots:
+        return config
+    try:
+        snapshot_name = _create_snapshot_host(config, mngr_ctx)
+    except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+        logger.warning("Failed to create snapshot, launching agents without snapshot: {}", exc)
+        return config
+    return config.model_copy_update(to_update(config.field_ref().snapshot, snapshot_name))
+
+
 def launch_all_test_agents(
     test_node_ids: list[str],
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     pytest_flags: tuple[str, ...],
     prompt_suffix: str = "",
-    use_snapshot: bool = False,
     max_parallel: int = 4,
     launch_delay_seconds: float = 2.0,
     agents_per_host: int = 4,
@@ -227,27 +309,16 @@ def launch_all_test_agents(
 ) -> tuple[list[TestAgentInfo], dict[str, OnlineHostInterface], SnapshotName | None]:
     """Launch agents for all collected tests.
 
-    For remote providers, agents_per_host controls how many agents share a single
-    host. Hosts are pre-created in a pool and agents are assigned round-robin.
-    For local providers, this setting is ignored (all agents share localhost).
+    Assumes a snapshot has already been built (or is impossible for the
+    provider). For remote providers, agents_per_host controls how many agents
+    share a single host. Hosts are pre-created in a pool and agents are assigned
+    round-robin. For local providers, this setting is ignored (all agents share
+    localhost).
     """
     agents: list[TestAgentInfo] = []
     agent_hosts: dict[str, OnlineHostInterface] = {}
 
     launch_config = config
-    if use_snapshot:
-        provider = get_provider_instance(config.provider_name, mngr_ctx)
-        if provider.supports_snapshots:
-            try:
-                snapshot_name = _create_snapshot_host(config, mngr_ctx)
-                launch_config = config.model_copy_update(to_update(config.field_ref().snapshot, snapshot_name))
-            except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
-                logger.warning("Failed to create snapshot, launching agents without snapshot: {}", exc)
-        else:
-            logger.warning(
-                "Provider '{}' does not support snapshots, launching all agents without snapshot",
-                config.provider_name,
-            )
 
     is_local = launch_config.provider_name.lower() == LOCAL_PROVIDER_NAME
     host_pool: list[OnlineHostInterface] = []

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -13,8 +13,7 @@ from imbue.mngr.api.create import resolve_target_host
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import HostError
-from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import BaseMngrError
 from imbue.mngr.hosts.host import HostLocation
 from imbue.mngr.interfaces.host import AgentDataOptions
 from imbue.mngr.interfaces.host import AgentGitOptions
@@ -255,7 +254,7 @@ def stop_agent_on_host(host: OnlineHostInterface, agent_id: AgentId, agent_name:
     try:
         host.stop_agents([agent_id])
         logger.info("Stopped agent '{}'", agent_name)
-    except (MngrError, HostError) as exc:
+    except BaseMngrError as exc:
         logger.warning("Failed to stop agent '{}': {}", agent_name, exc)
 
 
@@ -283,7 +282,7 @@ def _create_host_pool(
         for future in futures:
             try:
                 hosts.append(future.result())
-            except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+            except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to create host: {}", exc)
 
     logger.info("Created {} host(s) for agent placement", len(hosts))
@@ -303,7 +302,7 @@ def ensure_snapshot(config: TmrLaunchConfig, mngr_ctx: MngrContext) -> TmrLaunch
         return config
     try:
         snapshot_name = _create_snapshot_host(config, mngr_ctx)
-    except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+    except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
         logger.warning("Failed to create snapshot, launching agents without snapshot: {}", exc)
         return config
     return config.model_copy_update(to_update(config.field_ref().snapshot, snapshot_name))
@@ -366,7 +365,7 @@ def launch_all_test_agents(
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
-            except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+            except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to launch agent: {}", exc)
 
     logger.info("Launched {} agent(s)", len(agents))
@@ -410,7 +409,7 @@ def launch_agents_up_to_limit(
         except TimeoutError:
             logger.warning("Agent creation timed out after {}s for {}", _AGENT_CREATION_TIMEOUT_SECONDS, test_node_id)
             continue
-        except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+        except (BaseMngrError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
             continue
         all_agents.append(info)

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -146,10 +146,13 @@ def launch_test_agent(
 ) -> tuple[TestAgentInfo, OnlineHostInterface]:
     """Launch a single agent to run and optionally fix one test.
 
-    For remote providers, the test agent's host is pre-resolved (creating a new
-    host from the snapshot if needed) and used as both the source and target,
-    transferring via git-worktree from /opt/snapshotter (which is baked into
-    the snapshot by the snapshotter agent).
+    When a snapshot is available for a remote provider, the test agent's host
+    is pre-resolved (creating a new host from the snapshot if needed) and used
+    as both the source and target, transferring via git-worktree from
+    /opt/snapshotter (which is baked into the snapshot by the snapshotter
+    agent). Without a snapshot we fall back to the natural transfer mode for
+    the provider (git-mirror from the local user checkout for remote, or
+    git-worktree from the local user checkout for local).
     """
     agent_name_suffix = sanitize_test_name_for_agent(test_node_id)
     short_id = short_random_id()
@@ -159,15 +162,19 @@ def launch_test_agent(
     logger.info("Launching agent '{}' for test: {}", agent_name, test_node_id)
 
     is_local = config.provider_name.lower() == LOCAL_PROVIDER_NAME
-    if is_local:
-        # Local provider: use the natural git-worktree from the local user checkout.
+    # The /opt/snapshotter fast path requires the host to have been built from
+    # a snapshot containing that checkout. If we have no snapshot (local
+    # provider, snapshot-incapable provider, or snapshot creation failed), we
+    # must fall back to transferring from the local user checkout.
+    if is_local or config.snapshot is None:
         source_location: HostLocation | None = None
         transfer_mode: TransferMode | None = None
         resolved_existing_host = existing_host
     else:
-        # Remote provider: pre-resolve the target host (from the snapshot) and
-        # source the test agent's worktree from /opt/snapshotter on the same
-        # host. This avoids re-uploading the git repo for every agent.
+        # Remote provider with a snapshot: pre-resolve the target host (from
+        # the snapshot) and source the test agent's worktree from
+        # /opt/snapshotter on the same host. This avoids re-uploading the git
+        # repo for every agent.
         if existing_host is not None:
             resolved_existing_host = existing_host
         else:

--- a/libs/mngr_tmr/imbue/mngr_tmr/utils.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/utils.py
@@ -103,11 +103,14 @@ def sanitize_test_name_for_agent(test_node_id: str) -> str:
 
 
 def transfer_mode_for_provider(provider_name: ProviderInstanceName) -> TransferMode:
-    """Determine the transfer mode based on the provider.
+    """Pick a default transfer mode for the user's local checkout.
 
-    GIT_WORKTREE only works when source and target are on the same host, so it is
-    only usable with the local provider. Remote providers (docker, modal, etc.)
-    use GIT_MIRROR to transfer git history efficiently.
+    GIT_WORKTREE only works when source and target are on the same host. With the
+    local provider both source and target are local, so GIT_WORKTREE is the
+    natural default. With remote providers (docker, modal, etc.) the source
+    (local user checkout) and target (remote host) differ, so we fall back to
+    GIT_MIRROR. Callers that have arranged source and target to be on the same
+    remote host can pass GIT_WORKTREE explicitly.
     """
     is_local = provider_name.lower() == LOCAL_PROVIDER_NAME
     return TransferMode.GIT_WORKTREE if is_local else TransferMode.GIT_MIRROR


### PR DESCRIPTION
## Summary
- Remove `--use-snapshot`; the snapshotter is now the only mode for remote providers (`--snapshot` still lets you reuse an existing one).
- Pin the snapshotter agent's work_dir to `/opt/snapshotter` so every host launched from the snapshot has a ready-to-use checkout.
- Each test agent now sources its work_dir via git-worktree from `/opt/snapshotter` on its own host, instead of doing a fresh git-mirror push from the user's local checkout. This removes the redundant per-agent repo upload.
- Extract `ensure_snapshot` so the up-front snapshot build also runs on the `--max-agents` (incremental) path, which previously skipped it.

The git-worktree codepath in `Host._create_work_dir_as_git_worktree` only requires source and target to be the same host (`host.id == self.id`), not local-only — the CLI's `local-only` rejection is just a UI guard that we bypass by calling `api_create` directly.

## Test plan
- [x] `just test-quick libs/mngr_tmr` — 172 passed
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 3700 passed
- [x] `uv run pytest libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py::test_no_type_errors` — passed
- [x] `uv run pytest libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py::test_no_ruff_errors` — passed
- [ ] Run a real `mngr tmr --provider modal ...` end to end to confirm same-remote-host git-worktree works in practice (CLI rejects this combo so it's not exercised by the existing test matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)