### PR TITLE
Reset mngr_vps_docker and mngr_vultr versions to 0.1.0

### DIFF
--- a/libs/mngr_vps_docker/pyproject.toml
+++ b/libs/mngr_vps_docker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbue-mngr-vps-docker"
-version = "0.2.1"
+version = "0.1.0"
 description = "VPS Docker provider base classes for mngr"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/libs/mngr_vultr/pyproject.toml
+++ b/libs/mngr_vultr/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "imbue-mngr-vultr"
-version = "0.2.1"
+version = "0.1.0"
 description = "Vultr provider backend plugin for mngr"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "imbue-mngr==0.2.5",
-    "imbue-mngr-vps-docker==0.2.1",
+    "imbue-mngr-vps-docker==0.1.0",
     "requests>=2.31.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1950,7 +1950,7 @@ requires-dist = [
 
 [[package]]
 name = "imbue-mngr-vps-docker"
-version = "0.2.1"
+version = "0.1.0"
 source = { editable = "libs/mngr_vps_docker" }
 dependencies = [
     { name = "imbue-mngr" },
@@ -1961,7 +1961,7 @@ requires-dist = [{ name = "imbue-mngr", editable = "libs/mngr" }]
 
 [[package]]
 name = "imbue-mngr-vultr"
-version = "0.2.1"
+version = "0.1.0"
 source = { editable = "libs/mngr_vultr" }
 dependencies = [
     { name = "imbue-mngr" },


### PR DESCRIPTION
## Summary
- `mngr_vps_docker` and `mngr_vultr` were created at version `0.2.1` in `c3ed726b0` with no rationale in the commit message.
- Sister provider plugin `mngr_lima` (same era, same plugin pattern) is at `0.1.0`, matching the convention for new packages.
- Reset both to `0.1.0` (and the internal `imbue-mngr-vps-docker` pin in `mngr_vultr`) before first release so version history starts cleanly.

## Test plan
- [ ] CI passes (no code changed; only package versions and lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)