### PR TITLE
configure git so offload can write image-cache notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Fetch offload image-cache git notes
         run: git fetch origin 'refs/notes/*:refs/notes/*' || true
 
+      - name: Configure git identity for image-cache note writes
+        run: |
+          git config user.email "ci@imbue.ai"
+          git config user.name "imbue-ci"
+
       - name: Run tests via offload
         id: tests
         run: just test-offload
@@ -262,6 +267,11 @@ jobs:
 
       - name: Fetch offload image-cache git notes
         run: git fetch origin 'refs/notes/*:refs/notes/*' || true
+
+      - name: Configure git identity for image-cache note writes
+        run: |
+          git config user.email "ci@imbue.ai"
+          git config user.name "imbue-ci"
 
       - name: Run acceptance tests via offload
         id: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Configure git identity for image-cache note writes
         run: |
-          git config user.email "ci@imbue.ai"
-          git config user.name "imbue-ci"
+          git config user.email "dev@imbue.com"
+          git config user.name "imbue-dev"
 
       - name: Run tests via offload
         id: tests
@@ -270,8 +270,8 @@ jobs:
 
       - name: Configure git identity for image-cache note writes
         run: |
-          git config user.email "ci@imbue.ai"
-          git config user.name "imbue-ci"
+          git config user.email "dev@imbue.com"
+          git config user.name "imbue-dev"
 
       - name: Run acceptance tests via offload
         id: tests

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -1135,12 +1135,12 @@ def test_setup_command_context_raises_on_unknown_command_param_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Without MNGR_ALLOW_UNKNOWN_CONFIG, a typo in [commands.create] must raise."""
-    # MNGR_PROJECT_DIR points directly at the directory containing settings.toml
+    # MNGR_PROJECT_CONFIG_DIR points directly at the directory containing settings.toml
     # (see resolve_project_config_dir in config/pre_readers.py).
     (tmp_path / "settings.toml").write_text('[commands.create]\nbogus_typo_param = "x"\n')
 
     monkeypatch.delenv("MNGR_ALLOW_UNKNOWN_CONFIG", raising=False)
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
 
     cmd = _make_strict_test_command()
 
@@ -1164,7 +1164,7 @@ def test_setup_command_context_warns_on_unknown_command_param_when_lax(
     (tmp_path / "settings.toml").write_text('[commands.create]\nbogus_typo_param = "x"\n')
 
     monkeypatch.setenv("MNGR_ALLOW_UNKNOWN_CONFIG", "1")
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
 
     cmd = _make_strict_test_command()
 


### PR DESCRIPTION
## Summary
- Offload writes a git note per built image so the next run can reuse the cached image instead of rebuilding.
- Without git identity on the runner, the write fails with \`WARN Failed to write note: git notes add failed: Author identity unknown\` (seen on run 25128509066).
- Configure \`user.email\`/\`user.name\` on the runner before \`just test-offload\` and \`just test-offload-acceptance\` so the cache actually persists.

## Test plan
- [ ] CI run no longer emits the \"Author identity unknown\" warning during offload prepare.
- [ ] Subsequent CI run reuses the cached image instead of rebuilding from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)