### PR TITLE
fix implicit conflict from merges that broke ci

### DIFF
--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -1135,12 +1135,12 @@ def test_setup_command_context_raises_on_unknown_command_param_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Without MNGR_ALLOW_UNKNOWN_CONFIG, a typo in [commands.create] must raise."""
-    # MNGR_PROJECT_DIR points directly at the directory containing settings.toml
+    # MNGR_PROJECT_CONFIG_DIR points directly at the directory containing settings.toml
     # (see resolve_project_config_dir in config/pre_readers.py).
     (tmp_path / "settings.toml").write_text('[commands.create]\nbogus_typo_param = "x"\n')
 
     monkeypatch.delenv("MNGR_ALLOW_UNKNOWN_CONFIG", raising=False)
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
 
     cmd = _make_strict_test_command()
 
@@ -1164,7 +1164,7 @@ def test_setup_command_context_warns_on_unknown_command_param_when_lax(
     (tmp_path / "settings.toml").write_text('[commands.create]\nbogus_typo_param = "x"\n')
 
     monkeypatch.setenv("MNGR_ALLOW_UNKNOWN_CONFIG", "1")
-    monkeypatch.setenv("MNGR_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
 
     cmd = _make_strict_test_command()
 


### PR DESCRIPTION
## Summary

Two new strict-mode integration tests for `setup_command_context` (added in #1429) fail on `main` because they set `MNGR_PROJECT_DIR`, an env var that was concurrently renamed to `MNGR_PROJECT_CONFIG_DIR` in 40926d883. The rename PR only updated existing references; the in-flight tests in #1429 slipped through.

Without the right env var, `resolve_project_config_dir` falls back to the worktree's git root (which has no `bogus_typo_param`), so:
- `test_setup_command_context_raises_on_unknown_command_param_by_default` exits 0 instead of non-zero
- `test_setup_command_context_warns_on_unknown_command_param_when_lax` produces no warning containing `bogus_typo_param`

Fix: rename both `monkeypatch.setenv` calls and the explanatory comment to `MNGR_PROJECT_CONFIG_DIR`.

## Test plan
- [x] `just test-quick` for the two affected tests passes (was 2 failed, now 2 passed)
- [ ] CI offload suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
