### PR TITLE
Also enable code-guardian stop hook in Sculptor sessions

### DIFF
--- a/.reviewer/settings.json
+++ b/.reviewer/settings.json
@@ -1,6 +1,6 @@
 {
     "stop_hook": {
-        "enabled_when": "test -n \"${MNGR_AGENT_STATE_DIR:-}\""
+        "enabled_when": "test -n \"${MNGR_AGENT_STATE_DIR:-}\" || test -n \"${SCULPTOR_API_PORT:-}\""
     },
     "autofix": {
         "is_enabled": true,


### PR DESCRIPTION
The hook was previously gated on $MNGR_AGENT_STATE_DIR, which is only set by mngr. Sculptor sets $SCULPTOR_API_PORT (see sculptor/cli/main.py: it's exported unconditionally at backend startup and inherited by every spawned claude child via local_environment.py's os.environ merge), so we can OR that into enabled_when to get the same stop-hook behavior in Sculptor without affecting mngr.

In the future Sculptor will set a better well-known env var that we can switch to for this gate.