### PR TITLE
decrease retry counts for flaky and acceptance test groups

### DIFF
--- a/offload-modal-acceptance.toml
+++ b/offload-modal-acceptance.toml
@@ -35,7 +35,7 @@ command = "uv run pytest"
 run_args = "--no-cov -p no:xdist"
 
 [groups.all]
-retry_count = 4
+retry_count = 1
 # Exclude docker/docker_sdk tests -- they need a Docker daemon which Modal sandboxes don't have.
 # Those tests run in a separate GitHub runner job (test-docker) until offload Docker-in-Docker support lands.
 filters = "-m 'acceptance and not docker and not docker_sdk'"

--- a/offload-modal.toml
+++ b/offload-modal.toml
@@ -41,7 +41,7 @@ retry_count = 0
 filters = "-m 'not acceptance and not release and not flaky'"
 
 [groups.flaky]
-retry_count = 10
+retry_count = 4
 filters = "-m 'flaky and not acceptance and not release'"
 
 [report]


### PR DESCRIPTION
enough tests are marked flaky that we can really blow up modal right now

---

## Summary
- `[groups.flaky]` `retry_count` in `offload-modal.toml`: 10 → 4
- `[groups.all]` `retry_count` in `offload-modal-acceptance.toml`: 4 → 1

## Test plan
- [ ] CI passes
