### PR TITLE
make PRS_FAILED be "failed to get PRs", not "CI failed", in kanpan again

### DIFF
--- a/libs/mngr_kanpan/README.md
+++ b/libs/mngr_kanpan/README.md
@@ -146,7 +146,7 @@ Built-in column names: `name`, `state`. Data source field keys: `commits_ahead`,
 
 ## Section order
 
-By default, sections are displayed in this order: Done (PR merged), Cancelled (PR closed), In review (PR pending), In progress (draft PR), In progress (no PR yet), In progress (PRs failed), Muted. To customize:
+By default, sections are displayed in this order: Done (PR merged), Cancelled (PR closed), In review (PR pending), In progress (draft PR), In progress (no PR yet), In progress (PRs not loaded), Muted. To customize:
 
 ```toml
 [plugins.kanpan]

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -1,10 +1,12 @@
 from collections.abc import Sequence
 from typing import Any
+from typing import Literal
 from typing import Protocol
 from typing import runtime_checkable
 
 from loguru import logger
 from pydantic import Field
+from pydantic import TypeAdapter
 from pydantic import ValidationError
 
 from imbue.imbue_common.frozen_model import FrozenModel
@@ -51,6 +53,7 @@ class FieldValue(FrozenModel):
 class StringField(FieldValue):
     """Simple string field for shell data sources and similar."""
 
+    kind: Literal["string"] = Field(default="string", description="Discriminator tag")
     value: str = Field(description="The string value")
 
     def display(self) -> CellDisplay:
@@ -63,6 +66,7 @@ class StringField(FieldValue):
 class BoolField(FieldValue):
     """Boolean field (e.g. muted state)."""
 
+    kind: Literal["bool"] = Field(default="bool", description="Discriminator tag")
     value: bool = Field(description="The boolean value")
 
     def display(self) -> CellDisplay:
@@ -97,21 +101,21 @@ class KanpanDataSource(Protocol):
         ...
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        """Field key -> tuple of FieldValue subclasses that may appear in this slot.
+    def field_types(self) -> dict[str, "TypeAdapter[FieldValue]"]:
+        """Field key -> TypeAdapter that validates raw payloads for this slot.
 
         A "slot" (e.g. FIELD_PR) can be polymorphic: it may hold a real PrField,
-        or a sentinel like CreatePrUrlField / PrFetchFailedField. List every
-        concrete class that can land in the slot so the cache loader can
-        round-trip whichever one was last persisted.
+        or a sentinel like CreatePrUrlField / PrFetchFailedField. Build a
+        discriminated union for the slot using pydantic's standard pattern --
+        every FieldValue subclass declares ``kind: Literal["..."]`` and the
+        adapter is constructed as::
 
-        Tuple order is precedence for ambiguous payloads. ``deserialize_fields``
-        tries each class in order and keeps the first that validates. This works
-        unambiguously today because every FieldValue subclass uses pydantic's
-        ``extra="forbid"`` config (see imbue.imbue_common.frozen_model.FrozenModel),
-        so payload shapes are mutually exclusive. If you ever add two classes
-        whose required fields are subsets of each other, list the more
-        constrained one first.
+            TypeAdapter(Annotated[
+                PrField | CreatePrUrlField | PrFetchFailedField,
+                Field(discriminator="kind"),
+            ])
+
+        Single-class slots use ``TypeAdapter(SomeField)`` directly.
         """
         ...
 
@@ -142,34 +146,24 @@ FIELD_UNRESOLVED = "unresolved"
 
 def deserialize_fields(
     raw: dict[str, Any],
-    field_types: dict[str, tuple[type[FieldValue], ...]],
+    field_types: dict[str, TypeAdapter[FieldValue]],
 ) -> dict[str, FieldValue]:
     """Deserialize a dict of raw JSON dicts into typed FieldValue objects.
 
-    ``field_types`` matches the protocol's polymorphic shape: each slot lists
-    every concrete class that may land in it. This helper has no per-value
-    type tag to consult, so it tries each declared class in order and keeps
-    the first one that validates. For single-class slots that's just the
-    declared class; for polymorphic slots the order in the tuple defines
-    precedence. Keys not present in field_types are skipped.
+    ``field_types`` maps each slot to a pydantic ``TypeAdapter``. For
+    polymorphic slots the adapter wraps a discriminated union keyed on the
+    ``kind`` field; for single-class slots it wraps the class directly.
+    Pydantic picks the right concrete class via the discriminator (no
+    order-sensitive trial validation). Keys not present in field_types are
+    skipped; payloads that fail validation are logged and dropped.
     """
     result: dict[str, FieldValue] = {}
     for key, value in raw.items():
-        field_classes = field_types.get(key)
-        if field_classes is None:
+        adapter = field_types.get(key)
+        if adapter is None:
             continue
-        validated = False
-        for field_class in field_classes:
-            try:
-                result[key] = field_class.model_validate(value)
-                validated = True
-                break
-            except ValidationError:
-                continue
-        if not validated:
-            logger.debug(
-                "deserialize_fields: no class validated key {!r} against {}",
-                key,
-                [c.__name__ for c in field_classes],
-            )
+        try:
+            result[key] = adapter.validate_python(value)
+        except ValidationError as e:
+            logger.debug("deserialize_fields: validation failed for key {!r}: {}", key, e)
     return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -95,8 +95,14 @@ class KanpanDataSource(Protocol):
         ...
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        """Field key -> FieldValue subclass, for deserialization via model_validate()."""
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        """Field key -> tuple of FieldValue subclasses that may appear in this slot.
+
+        A "slot" (e.g. FIELD_PR) can be polymorphic: it may hold a real PrField,
+        or a sentinel like CreatePrUrlField / PrFetchFailedField. List every
+        concrete class that can land in the slot so the cache loader can
+        round-trip whichever one was last persisted.
+        """
         ...
 
     def compute(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -101,7 +101,7 @@ class KanpanDataSource(Protocol):
         ...
 
     @property
-    def field_types(self) -> dict[str, "TypeAdapter[FieldValue]"]:
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
         """Field key -> TypeAdapter that validates raw payloads for this slot.
 
         A "slot" (e.g. FIELD_PR) can be polymorphic: it may hold a real PrField,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -4,6 +4,7 @@ from typing import Protocol
 from typing import runtime_checkable
 
 from pydantic import Field
+from pydantic import ValidationError
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.mngr.config.data_types import MngrContext
@@ -132,16 +133,26 @@ FIELD_UNRESOLVED = "unresolved"
 
 def deserialize_fields(
     raw: dict[str, Any],
-    field_types: dict[str, type[FieldValue]],
+    field_types: dict[str, tuple[type[FieldValue], ...]],
 ) -> dict[str, FieldValue]:
     """Deserialize a dict of raw JSON dicts into typed FieldValue objects.
 
-    Keys not present in field_types are skipped.
+    ``field_types`` matches the protocol's polymorphic shape: each slot lists
+    every concrete class that may land in it. This helper has no per-value
+    type tag to consult, so it tries each declared class in order and keeps
+    the first one that validates. For single-class slots that's just the
+    declared class; for polymorphic slots the order in the tuple defines
+    precedence. Keys not present in field_types are skipped.
     """
     result: dict[str, FieldValue] = {}
     for key, value in raw.items():
-        field_type = field_types.get(key)
-        if field_type is None:
+        field_classes = field_types.get(key)
+        if field_classes is None:
             continue
-        result[key] = field_type.model_validate(value)
+        for field_class in field_classes:
+            try:
+                result[key] = field_class.model_validate(value)
+                break
+            except ValidationError:
+                continue
     return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Protocol
 from typing import runtime_checkable
 
+from loguru import logger
 from pydantic import Field
 from pydantic import ValidationError
 
@@ -103,6 +104,14 @@ class KanpanDataSource(Protocol):
         or a sentinel like CreatePrUrlField / PrFetchFailedField. List every
         concrete class that can land in the slot so the cache loader can
         round-trip whichever one was last persisted.
+
+        Tuple order is precedence for ambiguous payloads. ``deserialize_fields``
+        tries each class in order and keeps the first that validates. This works
+        unambiguously today because every FieldValue subclass uses pydantic's
+        ``extra="forbid"`` config (see imbue.imbue_common.frozen_model.FrozenModel),
+        so payload shapes are mutually exclusive. If you ever add two classes
+        whose required fields are subsets of each other, list the more
+        constrained one first.
         """
         ...
 
@@ -149,10 +158,18 @@ def deserialize_fields(
         field_classes = field_types.get(key)
         if field_classes is None:
             continue
+        validated = False
         for field_class in field_classes:
             try:
                 result[key] = field_class.model_validate(value)
+                validated = True
                 break
             except ValidationError:
                 continue
+        if not validated:
+            logger.debug(
+                "deserialize_fields: no class validated key {!r} against {}",
+                key,
+                [c.__name__ for c in field_classes],
+            )
     return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
@@ -245,3 +245,17 @@ def test_deserialize_fields_polymorphic_via_discriminator() -> None:
     assert pr_result["pr"].number == 7
     assert isinstance(create_result["pr"], CreatePrUrlField)
     assert create_result["pr"].url == "https://example.com/compare"
+
+
+def test_deserialize_fields_drops_invalid_payload_keeps_others() -> None:
+    """A payload that fails pydantic validation is logged and dropped, while
+    the rest of the dict still loads. Locks in the swallow path so a future
+    change can't quietly turn a bad cache row into a full-cache wipe.
+    """
+    types: dict[str, TypeAdapter[FieldValue]] = {"pr": TypeAdapter(PrField), "ci": TypeAdapter(CiField)}
+    # PrField requires number/url/title/state/head_branch/is_draft -- {} fails.
+    raw = {"pr": {}, "ci": {"kind": "ci", "status": "PASSING"}}
+    result = deserialize_fields(raw, types)
+    assert "pr" not in result
+    assert isinstance(result["ci"], CiField)
+    assert result["ci"].status == CiStatus.PASSING

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
@@ -1,3 +1,8 @@
+from typing import Annotated
+
+from pydantic import Field as PydanticField
+from pydantic import TypeAdapter
+
 from imbue.mngr_kanpan.data_source import BoolField
 from imbue.mngr_kanpan.data_source import CellDisplay
 from imbue.mngr_kanpan.data_source import FieldValue
@@ -177,6 +182,7 @@ def test_unresolved_field_display_no_unresolved() -> None:
 def test_deserialize_fields_basic() -> None:
     raw = {
         "pr": {
+            "kind": "pr",
             "number": 42,
             "url": "https://example.com/42",
             "is_draft": False,
@@ -184,9 +190,9 @@ def test_deserialize_fields_basic() -> None:
             "state": "OPEN",
             "head_branch": "b",
         },
-        "ci": {"status": "FAILING"},
+        "ci": {"kind": "ci", "status": "FAILING"},
     }
-    types: dict[str, tuple[type[FieldValue], ...]] = {"pr": (PrField,), "ci": (CiField,)}
+    types: dict[str, TypeAdapter[FieldValue]] = {"pr": TypeAdapter(PrField), "ci": TypeAdapter(CiField)}
     result = deserialize_fields(raw, types)
     assert isinstance(result["pr"], PrField)
     assert result["pr"].number == 42
@@ -196,7 +202,7 @@ def test_deserialize_fields_basic() -> None:
 
 def test_deserialize_fields_unknown_keys_skipped() -> None:
     raw = {"unknown_key": {"value": "test"}}
-    result = deserialize_fields(raw, {"pr": (PrField,)})
+    result = deserialize_fields(raw, {"pr": TypeAdapter(PrField)})
     assert result == {}
 
 
@@ -209,18 +215,19 @@ def test_deserialize_fields_round_trip() -> None:
         state=PrState.OPEN,
         head_branch="branch",
     )
-    dumped = {"pr": pr.model_dump()}
-    restored = deserialize_fields(dumped, {"pr": (PrField,)})
+    dumped = {"pr": pr.model_dump(mode="json")}
+    restored = deserialize_fields(dumped, {"pr": TypeAdapter(PrField)})
     assert restored["pr"] == pr
 
 
-def test_deserialize_fields_polymorphic_picks_first_validating_class() -> None:
-    """Each slot can list multiple classes; deserialize_fields keeps the first
-    one that validates the raw value. Tested with both shapes for the FIELD_PR
-    slot: a CreatePrUrlField payload and a PrField payload, both declared as
-    valid for the same key.
+def test_deserialize_fields_polymorphic_via_discriminator() -> None:
+    """A polymorphic slot is declared as a TypeAdapter wrapping a discriminated
+    union. Pydantic dispatches on the ``kind`` tag to pick the right class, so
+    the same slot accepts both PrField and CreatePrUrlField payloads.
     """
-    classes: tuple[type[FieldValue], ...] = (PrField, CreatePrUrlField)
+    pr_slot: TypeAdapter[FieldValue] = TypeAdapter(
+        Annotated[PrField | CreatePrUrlField, PydanticField(discriminator="kind")]
+    )
     pr_dump = PrField(
         number=7,
         url="https://example.com/7",
@@ -228,11 +235,11 @@ def test_deserialize_fields_polymorphic_picks_first_validating_class() -> None:
         title="t",
         state=PrState.OPEN,
         head_branch="b",
-    ).model_dump()
-    create_dump = CreatePrUrlField(url="https://example.com/compare").model_dump()
+    ).model_dump(mode="json")
+    create_dump = CreatePrUrlField(url="https://example.com/compare").model_dump(mode="json")
 
-    pr_result = deserialize_fields({"pr": pr_dump}, {"pr": classes})
-    create_result = deserialize_fields({"pr": create_dump}, {"pr": classes})
+    pr_result = deserialize_fields({"pr": pr_dump}, {"pr": pr_slot})
+    create_result = deserialize_fields({"pr": create_dump}, {"pr": pr_slot})
 
     assert isinstance(pr_result["pr"], PrField)
     assert pr_result["pr"].number == 7

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source_test.py
@@ -186,7 +186,7 @@ def test_deserialize_fields_basic() -> None:
         },
         "ci": {"status": "FAILING"},
     }
-    types: dict[str, type[FieldValue]] = {"pr": PrField, "ci": CiField}
+    types: dict[str, tuple[type[FieldValue], ...]] = {"pr": (PrField,), "ci": (CiField,)}
     result = deserialize_fields(raw, types)
     assert isinstance(result["pr"], PrField)
     assert result["pr"].number == 42
@@ -196,7 +196,7 @@ def test_deserialize_fields_basic() -> None:
 
 def test_deserialize_fields_unknown_keys_skipped() -> None:
     raw = {"unknown_key": {"value": "test"}}
-    result = deserialize_fields(raw, {"pr": PrField})
+    result = deserialize_fields(raw, {"pr": (PrField,)})
     assert result == {}
 
 
@@ -210,5 +210,31 @@ def test_deserialize_fields_round_trip() -> None:
         head_branch="branch",
     )
     dumped = {"pr": pr.model_dump()}
-    restored = deserialize_fields(dumped, {"pr": PrField})
+    restored = deserialize_fields(dumped, {"pr": (PrField,)})
     assert restored["pr"] == pr
+
+
+def test_deserialize_fields_polymorphic_picks_first_validating_class() -> None:
+    """Each slot can list multiple classes; deserialize_fields keeps the first
+    one that validates the raw value. Tested with both shapes for the FIELD_PR
+    slot: a CreatePrUrlField payload and a PrField payload, both declared as
+    valid for the same key.
+    """
+    classes: tuple[type[FieldValue], ...] = (PrField, CreatePrUrlField)
+    pr_dump = PrField(
+        number=7,
+        url="https://example.com/7",
+        is_draft=False,
+        title="t",
+        state=PrState.OPEN,
+        head_branch="b",
+    ).model_dump()
+    create_dump = CreatePrUrlField(url="https://example.com/compare").model_dump()
+
+    pr_result = deserialize_fields({"pr": pr_dump}, {"pr": classes})
+    create_result = deserialize_fields({"pr": create_dump}, {"pr": classes})
+
+    assert isinstance(pr_result["pr"], PrField)
+    assert pr_result["pr"].number == 7
+    assert isinstance(create_result["pr"], CreatePrUrlField)
+    assert create_result["pr"].url == "https://example.com/compare"

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
@@ -1,9 +1,11 @@
 from collections.abc import Sequence
 from pathlib import Path
 from subprocess import TimeoutExpired
+from typing import Literal
 
 from loguru import logger
 from pydantic import Field
+from pydantic import TypeAdapter
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ConcurrencyGroupError
@@ -21,6 +23,7 @@ from imbue.mngr_kanpan.data_source import FieldValue
 class CommitsAheadField(FieldValue):
     """Number of commits ahead of the remote tracking branch."""
 
+    kind: Literal["commits_ahead"] = Field(default="commits_ahead", description="Discriminator tag")
     count: int | None = Field(description="Commits ahead count, None if unknown")
     has_work_dir: bool = Field(default=True, description="Whether the agent has a local work directory")
 
@@ -50,8 +53,8 @@ class GitInfoDataSource(FrozenModel):
         return {FIELD_COMMITS_AHEAD: "GIT"}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        return {FIELD_COMMITS_AHEAD: (CommitsAheadField,)}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {FIELD_COMMITS_AHEAD: TypeAdapter(CommitsAheadField)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
@@ -37,6 +37,9 @@ class CommitsAheadField(FieldValue):
         return CellDisplay(text=f"[{self.count} unpushed]")
 
 
+_COMMITS_AHEAD_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(CommitsAheadField)
+
+
 class GitInfoDataSource(FrozenModel):
     """Computes commits_ahead field from git rev-list --count."""
 
@@ -54,7 +57,7 @@ class GitInfoDataSource(FrozenModel):
 
     @property
     def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
-        return {FIELD_COMMITS_AHEAD: TypeAdapter(CommitsAheadField)}
+        return {FIELD_COMMITS_AHEAD: _COMMITS_AHEAD_ADAPTER}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/git_info.py
@@ -50,8 +50,8 @@ class GitInfoDataSource(FrozenModel):
         return {FIELD_COMMITS_AHEAD: "GIT"}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        return {FIELD_COMMITS_AHEAD: CommitsAheadField}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        return {FIELD_COMMITS_AHEAD: (CommitsAheadField,)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -101,6 +101,21 @@ class CreatePrUrlField(FieldValue):
         return CellDisplay(text="+PR", url=self.url)
 
 
+class PrFetchFailedField(FieldValue):
+    """Sentinel placed in the FIELD_PR slot when the repo's PR fetch failed
+    and no historical PR data is available to fall back to.
+
+    Routes the agent into BoardSection.PRS_FAILED. If a previous cycle
+    successfully fetched a PrField, that cached PrField is used instead of
+    emitting this sentinel (silent fallback).
+    """
+
+    repo: str = Field(description="Repo path that failed to load (e.g. 'org/repo')")
+
+    def display(self) -> CellDisplay:
+        return CellDisplay(text="?", color="light red")
+
+
 class ConflictsField(FieldValue):
     """Merge conflict status for a PR."""
 
@@ -406,9 +421,23 @@ class GitHubDataSource(FrozenModel):
                         agent_fields[FIELD_PR] = pr
                     if self.config.ci:
                         agent_fields[FIELD_CI] = CiField(status=pr.internal_check_status)
+                elif agent_prs_loaded:
+                    agent_fields[FIELD_PR] = CreatePrUrlField(url=_build_create_pr_url(agent_repo, branch))
                 else:
-                    if agent_prs_loaded:
-                        agent_fields[FIELD_PR] = CreatePrUrlField(url=_build_create_pr_url(agent_repo, branch))
+                    # Fetch failed for this repo: silently fall back to cached PrField/CiField
+                    # if available; otherwise emit a PrFetchFailedField so the agent shows up
+                    # under "PRs not loaded" instead of being misclassified as "no PR yet".
+                    cached_agent = cached_fields.get(agent.name, {})
+                    cached_pr = cached_agent.get(FIELD_PR)
+                    if isinstance(cached_pr, PrField):
+                        if self.config.pr:
+                            agent_fields[FIELD_PR] = cached_pr
+                        if self.config.ci:
+                            cached_ci = cached_agent.get(FIELD_CI)
+                            if isinstance(cached_ci, CiField):
+                                agent_fields[FIELD_CI] = cached_ci
+                    elif self.config.pr:
+                        agent_fields[FIELD_PR] = PrFetchFailedField(repo=agent_repo)
 
             if agent_fields:
                 fields[agent.name] = agent_fields

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -112,11 +112,14 @@ class CreatePrUrlField(FieldValue):
 
 class PrFetchFailedField(FieldValue):
     """Sentinel placed in the FIELD_PR slot when the repo's PR fetch failed
-    and no historical PR data is available to fall back to.
+    and no usable historical PR data is available to fall back to.
 
     Routes the agent into BoardSection.PRS_FAILED. If a previous cycle
-    successfully fetched a PrField, that cached PrField is used instead of
-    emitting this sentinel (silent fallback).
+    cached a PrField whose ``head_branch`` matches the agent's current
+    branch, that cached PrField is used instead of emitting this sentinel
+    (silent fallback). A cached PrField for a different branch is treated
+    as unusable -- the agent has moved on and the old PR would be
+    misattributed -- so this sentinel is emitted in that case too.
     """
 
     kind: Literal["pr_fetch_failed"] = Field(default="pr_fetch_failed", description="Discriminator tag")

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -431,6 +431,13 @@ class GitHubDataSource(FrozenModel):
                     # Fetch failed for this repo: silently fall back to cached PrField/CiField
                     # if available; otherwise emit a PrFetchFailedField so the agent shows up
                     # under "PRs not loaded" instead of being misclassified as "no PR yet".
+                    #
+                    # Staleness: there is no TTL on the cached PR. If `gh pr list` keeps failing
+                    # for hours, we will keep showing the last-known PR row (number, state, CI).
+                    # That is the intentional trade-off -- a stale row is more useful than a
+                    # blank one and the failure is reported via `errors`. Re-evaluate if
+                    # auth/rate-limit failures become long-lived enough that a stale PR could
+                    # mislead the user (e.g. PR shown OPEN after it was merged days ago).
                     cached_agent = cached_fields.get(agent.name, {})
                     cached_pr = cached_agent.get(FIELD_PR)
                     if isinstance(cached_pr, PrField):

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -97,6 +97,9 @@ class CiField(FieldValue):
         return {"MNGR_FIELD_CI_STATUS": str(self.status)}
 
 
+_CI_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(CiField)
+
+
 class CreatePrUrlField(FieldValue):
     """URL to create a new PR for a branch."""
 
@@ -135,6 +138,9 @@ class ConflictsField(FieldValue):
         return CellDisplay(text="no", color="light green")
 
 
+_CONFLICTS_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(ConflictsField)
+
+
 class UnresolvedField(FieldValue):
     """Unresolved review comment status for a PR."""
 
@@ -145,6 +151,9 @@ class UnresolvedField(FieldValue):
         if self.has_unresolved:
             return CellDisplay(text="YES", color="light red")
         return CellDisplay(text="no", color="light green")
+
+
+_UNRESOLVED_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(UnresolvedField)
 
 
 class PrInfo(FrozenModel):
@@ -381,11 +390,11 @@ class GitHubDataSource(FrozenModel):
         if self.config.pr:
             types[FIELD_PR] = _PR_SLOT_ADAPTER
         if self.config.ci:
-            types[FIELD_CI] = TypeAdapter(CiField)
+            types[FIELD_CI] = _CI_ADAPTER
         if self.config.conflicts:
-            types[FIELD_CONFLICTS] = TypeAdapter(ConflictsField)
+            types[FIELD_CONFLICTS] = _CONFLICTS_ADAPTER
         if self.config.unresolved:
-            types[FIELD_UNRESOLVED] = TypeAdapter(UnresolvedField)
+            types[FIELD_UNRESOLVED] = _UNRESOLVED_ADAPTER
         return types
 
     def compute(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -358,13 +358,11 @@ class GitHubDataSource(FrozenModel):
     def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
         types: dict[str, tuple[type[FieldValue], ...]] = {}
         if self.config.pr:
-            # FIELD_PR is polymorphic: a real PR -> _PrFieldInternal (PrField
-            # subclass that carries the fetched check_status); pushed branch with
+            # FIELD_PR is polymorphic: a real PR -> PrField; pushed branch with
             # no PR -> CreatePrUrlField; repo fetch failed and no cached PR ->
-            # PrFetchFailedField. All four classes (including the public PrField
-            # base) need to round-trip through the cache so a previously-saved
-            # entry is re-typed correctly on load.
-            types[FIELD_PR] = (_PrFieldInternal, PrField, CreatePrUrlField, PrFetchFailedField)
+            # PrFetchFailedField. All three classes need to round-trip through
+            # the cache so a previously-saved entry is re-typed correctly on load.
+            types[FIELD_PR] = (PrField, CreatePrUrlField, PrFetchFailedField)
         if self.config.ci:
             types[FIELD_CI] = (CiField,)
         if self.config.conflicts:
@@ -397,7 +395,7 @@ class GitHubDataSource(FrozenModel):
             return {}, errors
 
         # Fetch PRs for all unique repos in parallel
-        pr_by_repo_branch: dict[str, dict[str, _PrFieldInternal]] = {}
+        pr_by_repo_branch: dict[str, dict[str, _PrLookup]] = {}
         repo_pr_loaded: dict[str, bool] = {}
 
         with ThreadPoolExecutor(max_workers=min(len(all_repos), 8)) as executor:
@@ -419,14 +417,14 @@ class GitHubDataSource(FrozenModel):
             agent_fields: dict[str, FieldValue] = {}
 
             if agent_repo is not None and branch is not None:
-                pr = _lookup_pr(pr_by_repo_branch, agent_repo, branch)
+                lookup = _lookup_pr(pr_by_repo_branch, agent_repo, branch)
                 agent_prs_loaded = repo_pr_loaded.get(agent_repo) is True
 
-                if pr is not None:
+                if lookup is not None:
                     if self.config.pr:
-                        agent_fields[FIELD_PR] = pr
+                        agent_fields[FIELD_PR] = lookup.pr
                     if self.config.ci:
-                        agent_fields[FIELD_CI] = CiField(status=pr.internal_check_status)
+                        agent_fields[FIELD_CI] = CiField(status=lookup.check_status)
                 elif agent_prs_loaded:
                     agent_fields[FIELD_PR] = CreatePrUrlField(url=_build_create_pr_url(agent_repo, branch))
                 else:
@@ -461,16 +459,22 @@ class GitHubDataSource(FrozenModel):
         return fields, errors
 
 
-class _PrFieldInternal(PrField):
-    """Internal PR field with check_status for CI field extraction."""
+class _PrLookup(FrozenModel):
+    """Internal record bundling a fetched PR with its CI status.
 
-    internal_check_status: CiStatus = Field(default=CiStatus.UNKNOWN, description="CI check status for internal use")
+    Used while building the per-repo PR index so the public PrField stays a
+    pure board-display value -- the CiStatus rides alongside instead of being
+    smuggled in as an extra PrField subclass field.
+    """
+
+    pr: PrField = Field(description="The fetched PR (canonical FIELD_PR value)")
+    check_status: CiStatus = Field(description="Aggregate CI check status from the same fetch")
 
 
 class _FetchPrsResult(FrozenModel):
-    """Result of fetching PRs from GitHub, using PrField."""
+    """Result of fetching PRs from GitHub."""
 
-    prs: tuple[_PrFieldInternal, ...] = Field(description="Fetched PRs as PrField objects")
+    prs: tuple[_PrLookup, ...] = Field(description="Fetched PRs paired with their CI status")
     error: str | None = Field(default=None, description="Error message if fetch failed")
 
 
@@ -488,34 +492,35 @@ def _get_cached_repo_path(cached_fields: dict[AgentName, dict[str, FieldValue]],
 def _fetch_repo_prs(cg: ConcurrencyGroup, repo_path: str) -> tuple[str, _FetchPrsResult]:
     """Fetch PRs for a single repo."""
     result = fetch_all_prs(cg, repo=repo_path)
-    # Convert PrInfo objects to PrField objects
-    pr_fields: list[_PrFieldInternal] = []
+    lookups: list[_PrLookup] = []
     for pr_info in result.prs:
-        pr_fields.append(
-            _PrFieldInternal(
-                number=pr_info.number,
-                url=pr_info.url,
-                is_draft=pr_info.is_draft,
-                title=pr_info.title,
-                state=PrState(str(pr_info.state)),
-                head_branch=pr_info.head_branch,
-                internal_check_status=CiStatus(str(pr_info.check_status)),
+        lookups.append(
+            _PrLookup(
+                pr=PrField(
+                    number=pr_info.number,
+                    url=pr_info.url,
+                    is_draft=pr_info.is_draft,
+                    title=pr_info.title,
+                    state=PrState(str(pr_info.state)),
+                    head_branch=pr_info.head_branch,
+                ),
+                check_status=CiStatus(str(pr_info.check_status)),
             )
         )
-    return repo_path, _FetchPrsResult(prs=tuple(pr_fields), error=result.error)
+    return repo_path, _FetchPrsResult(prs=tuple(lookups), error=result.error)
 
 
 @pure
-def _build_pr_branch_index(prs: tuple[_PrFieldInternal, ...]) -> dict[str, _PrFieldInternal]:
+def _build_pr_branch_index(prs: tuple[_PrLookup, ...]) -> dict[str, _PrLookup]:
     """Build a lookup dict from branch name to the most relevant PR.
 
     If multiple PRs share the same branch, prefers OPEN > MERGED > CLOSED.
     """
-    result: dict[str, _PrFieldInternal] = {}
-    for pr in prs:
-        existing = result.get(pr.head_branch)
-        if existing is None or _pr_priority(pr) > _pr_priority(existing):
-            result[pr.head_branch] = pr
+    result: dict[str, _PrLookup] = {}
+    for lookup in prs:
+        existing = result.get(lookup.pr.head_branch)
+        if existing is None or _pr_priority(lookup.pr) > _pr_priority(existing.pr):
+            result[lookup.pr.head_branch] = lookup
     return result
 
 
@@ -531,10 +536,10 @@ def _pr_priority(pr: PrField) -> int:
 
 @pure
 def _lookup_pr(
-    pr_by_repo_branch: dict[str, dict[str, _PrFieldInternal]],
+    pr_by_repo_branch: dict[str, dict[str, _PrLookup]],
     agent_repo: str,
     branch: str,
-) -> _PrFieldInternal | None:
+) -> _PrLookup | None:
     """Look up the PR for an agent by its repo and branch."""
     repo_prs = pr_by_repo_branch.get(agent_repo)
     return repo_prs.get(branch) if repo_prs is not None else None

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -355,16 +355,22 @@ class GitHubDataSource(FrozenModel):
         return cols
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        types: dict[str, type[FieldValue]] = {}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        types: dict[str, tuple[type[FieldValue], ...]] = {}
         if self.config.pr:
-            types[FIELD_PR] = PrField
+            # FIELD_PR is polymorphic: a real PR -> _PrFieldInternal (PrField
+            # subclass that carries the fetched check_status); pushed branch with
+            # no PR -> CreatePrUrlField; repo fetch failed and no cached PR ->
+            # PrFetchFailedField. All four classes (including the public PrField
+            # base) need to round-trip through the cache so a previously-saved
+            # entry is re-typed correctly on load.
+            types[FIELD_PR] = (_PrFieldInternal, PrField, CreatePrUrlField, PrFetchFailedField)
         if self.config.ci:
-            types[FIELD_CI] = CiField
+            types[FIELD_CI] = (CiField,)
         if self.config.conflicts:
-            types[FIELD_CONFLICTS] = ConflictsField
+            types[FIELD_CONFLICTS] = (ConflictsField,)
         if self.config.unresolved:
-            types[FIELD_UNRESOLVED] = UnresolvedField
+            types[FIELD_UNRESOLVED] = (UnresolvedField,)
         return types
 
     def compute(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -3,10 +3,13 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from enum import auto
 from pathlib import Path
+from typing import Annotated
 from typing import Any
+from typing import Literal
 
 from loguru import logger
 from pydantic import Field
+from pydantic import TypeAdapter
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ProcessError
@@ -60,6 +63,7 @@ class CiStatus(UpperCaseStrEnum):
 class PrField(FieldValue):
     """GitHub pull request field value."""
 
+    kind: Literal["pr"] = Field(default="pr", description="Discriminator tag")
     number: int = Field(description="PR number")
     url: str = Field(description="PR URL")
     is_draft: bool = Field(description="Whether the PR is a draft")
@@ -81,6 +85,7 @@ class PrField(FieldValue):
 class CiField(FieldValue):
     """CI check status field value."""
 
+    kind: Literal["ci"] = Field(default="ci", description="Discriminator tag")
     status: CiStatus = Field(description="Aggregate CI check status")
 
     def display(self) -> CellDisplay:
@@ -95,6 +100,7 @@ class CiField(FieldValue):
 class CreatePrUrlField(FieldValue):
     """URL to create a new PR for a branch."""
 
+    kind: Literal["create_pr_url"] = Field(default="create_pr_url", description="Discriminator tag")
     url: str = Field(description="URL to create a PR")
 
     def display(self) -> CellDisplay:
@@ -110,6 +116,7 @@ class PrFetchFailedField(FieldValue):
     emitting this sentinel (silent fallback).
     """
 
+    kind: Literal["pr_fetch_failed"] = Field(default="pr_fetch_failed", description="Discriminator tag")
     repo: str = Field(description="Repo path that failed to load (e.g. 'org/repo')")
 
     def display(self) -> CellDisplay:
@@ -119,6 +126,7 @@ class PrFetchFailedField(FieldValue):
 class ConflictsField(FieldValue):
     """Merge conflict status for a PR."""
 
+    kind: Literal["conflicts"] = Field(default="conflicts", description="Discriminator tag")
     has_conflicts: bool = Field(description="Whether the PR has merge conflicts")
 
     def display(self) -> CellDisplay:
@@ -130,6 +138,7 @@ class ConflictsField(FieldValue):
 class UnresolvedField(FieldValue):
     """Unresolved review comment status for a PR."""
 
+    kind: Literal["unresolved"] = Field(default="unresolved", description="Discriminator tag")
     has_unresolved: bool = Field(description="Whether the PR has unresolved review comments")
 
     def display(self) -> CellDisplay:
@@ -310,6 +319,18 @@ def _parse_check_status(rollup: list[dict[str, Any]] | None) -> CiStatus:
     return CiStatus.PASSING
 
 
+# Discriminated-union adapter for the FIELD_PR slot. The slot is polymorphic --
+# a real PR is a PrField, a pushed-but-no-PR branch is a CreatePrUrlField, and
+# a fetch failure with no cached fallback is a PrFetchFailedField. The
+# `kind` Literal on each subclass is the discriminator, so pydantic picks the
+# right concrete class without order-sensitive trial validation.
+PrSlotField = Annotated[
+    PrField | CreatePrUrlField | PrFetchFailedField,
+    Field(discriminator="kind"),
+]
+_PR_SLOT_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(PrSlotField)
+
+
 class GitHubDataSourceConfig(DataSourceConfig):
     """Configuration for the GitHub data source."""
 
@@ -355,20 +376,16 @@ class GitHubDataSource(FrozenModel):
         return cols
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        types: dict[str, tuple[type[FieldValue], ...]] = {}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        types: dict[str, TypeAdapter[FieldValue]] = {}
         if self.config.pr:
-            # FIELD_PR is polymorphic: a real PR -> PrField; pushed branch with
-            # no PR -> CreatePrUrlField; repo fetch failed and no cached PR ->
-            # PrFetchFailedField. All three classes need to round-trip through
-            # the cache so a previously-saved entry is re-typed correctly on load.
-            types[FIELD_PR] = (PrField, CreatePrUrlField, PrFetchFailedField)
+            types[FIELD_PR] = _PR_SLOT_ADAPTER
         if self.config.ci:
-            types[FIELD_CI] = (CiField,)
+            types[FIELD_CI] = TypeAdapter(CiField)
         if self.config.conflicts:
-            types[FIELD_CONFLICTS] = (ConflictsField,)
+            types[FIELD_CONFLICTS] = TypeAdapter(ConflictsField)
         if self.config.unresolved:
-            types[FIELD_UNRESOLVED] = (UnresolvedField,)
+            types[FIELD_UNRESOLVED] = TypeAdapter(UnresolvedField)
         return types
 
     def compute(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -457,32 +457,9 @@ class GitHubDataSource(FrozenModel):
                 elif agent_prs_loaded:
                     agent_fields[FIELD_PR] = CreatePrUrlField(url=_build_create_pr_url(agent_repo, branch))
                 else:
-                    # Fetch failed for this repo: silently fall back to cached PrField/CiField
-                    # if available; otherwise emit a PrFetchFailedField so the agent shows up
-                    # under "PRs not loaded" instead of being misclassified as "no PR yet".
-                    #
-                    # Branch match: only reuse the cache when the cached PR's head_branch
-                    # equals the agent's current branch. Otherwise the agent has moved on to
-                    # a different branch since the cache was written, and showing the old
-                    # PR would misattribute it to the wrong branch.
-                    #
-                    # Staleness: there is no TTL on the cached PR. If `gh pr list` keeps failing
-                    # for hours, we will keep showing the last-known PR row (number, state, CI).
-                    # That is the intentional trade-off -- a stale row is more useful than a
-                    # blank one and the failure is reported via `errors`. Re-evaluate if
-                    # auth/rate-limit failures become long-lived enough that a stale PR could
-                    # mislead the user (e.g. PR shown OPEN after it was merged days ago).
-                    cached_agent = cached_fields.get(agent.name, {})
-                    cached_pr = cached_agent.get(FIELD_PR)
-                    if isinstance(cached_pr, PrField) and cached_pr.head_branch == branch:
-                        if self.config.pr:
-                            agent_fields[FIELD_PR] = cached_pr
-                        if self.config.ci:
-                            cached_ci = cached_agent.get(FIELD_CI)
-                            if isinstance(cached_ci, CiField):
-                                agent_fields[FIELD_CI] = cached_ci
-                    elif self.config.pr:
-                        agent_fields[FIELD_PR] = PrFetchFailedField(repo=agent_repo)
+                    agent_fields.update(
+                        _compute_failed_fetch_fields(cached_fields, agent.name, branch, agent_repo, self.config)
+                    )
 
             if agent_fields:
                 fields[agent.name] = agent_fields
@@ -590,6 +567,48 @@ def _lookup_pr(
 def _build_create_pr_url(repo_path: str, branch: str) -> str:
     """Build a GitHub URL for creating a new PR from the given branch."""
     return f"https://github.com/{repo_path}/compare/{branch}?expand=1"
+
+
+@pure
+def _compute_failed_fetch_fields(
+    cached_fields: dict[AgentName, dict[str, FieldValue]],
+    agent_name: AgentName,
+    branch: str,
+    agent_repo: str,
+    config: GitHubDataSourceConfig,
+) -> dict[str, FieldValue]:
+    """Build the FIELD_PR / FIELD_CI fields for an agent whose repo PR fetch failed.
+
+    Silently falls back to a cached PrField/CiField if available; otherwise
+    emits a PrFetchFailedField so the agent shows up under "PRs not loaded"
+    instead of being misclassified as "no PR yet".
+
+    Branch match: only reuse the cache when the cached PR's head_branch
+    equals the agent's current branch. Otherwise the agent has moved on to
+    a different branch since the cache was written, and showing the old
+    PR would misattribute it to the wrong branch.
+
+    Staleness: there is no TTL on the cached PR. If ``gh pr list`` keeps
+    failing for hours, we will keep showing the last-known PR row (number,
+    state, CI). That is the intentional trade-off -- a stale row is more
+    useful than a blank one and the failure is reported via ``errors``.
+    Re-evaluate if auth/rate-limit failures become long-lived enough that
+    a stale PR could mislead the user (e.g. PR shown OPEN after it was
+    merged days ago).
+    """
+    agent_fields: dict[str, FieldValue] = {}
+    cached_agent = cached_fields.get(agent_name, {})
+    cached_pr = cached_agent.get(FIELD_PR)
+    if isinstance(cached_pr, PrField) and cached_pr.head_branch == branch:
+        if config.pr:
+            agent_fields[FIELD_PR] = cached_pr
+        if config.ci:
+            cached_ci = cached_agent.get(FIELD_CI)
+            if isinstance(cached_ci, CiField):
+                agent_fields[FIELD_CI] = cached_ci
+    elif config.pr:
+        agent_fields[FIELD_PR] = PrFetchFailedField(repo=agent_repo)
+    return agent_fields
 
 
 def _fetch_pr_metadata(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -432,6 +432,11 @@ class GitHubDataSource(FrozenModel):
                     # if available; otherwise emit a PrFetchFailedField so the agent shows up
                     # under "PRs not loaded" instead of being misclassified as "no PR yet".
                     #
+                    # Branch match: only reuse the cache when the cached PR's head_branch
+                    # equals the agent's current branch. Otherwise the agent has moved on to
+                    # a different branch since the cache was written, and showing the old
+                    # PR would misattribute it to the wrong branch.
+                    #
                     # Staleness: there is no TTL on the cached PR. If `gh pr list` keeps failing
                     # for hours, we will keep showing the last-known PR row (number, state, CI).
                     # That is the intentional trade-off -- a stale row is more useful than a
@@ -440,7 +445,7 @@ class GitHubDataSource(FrozenModel):
                     # mislead the user (e.g. PR shown OPEN after it was merged days ago).
                     cached_agent = cached_fields.get(agent.name, {})
                     cached_pr = cached_agent.get(FIELD_PR)
-                    if isinstance(cached_pr, PrField):
+                    if isinstance(cached_pr, PrField) and cached_pr.head_branch == branch:
                         if self.config.pr:
                             agent_fields[FIELD_PR] = cached_pr
                         if self.config.ci:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -322,6 +322,22 @@ def _make_fetch_cg(open_json: str, all_json: str) -> MagicMock:
     return cg
 
 
+def _make_failing_fetch_cg(stderr: str = "HTTP 504") -> MagicMock:
+    """Build a mock ConcurrencyGroup whose two PR fetches both fail with the given stderr.
+
+    Mirrors the failure shape used by tests that exercise the PR-fetch-failed code
+    paths (returncode=1, empty stdout). The two-process side_effect matches
+    fetch_all_prs's open + all queries.
+    """
+    fail_proc = MagicMock()
+    fail_proc.read_stdout.return_value = ""
+    fail_proc.read_stderr.return_value = stderr
+    fail_proc.returncode = 1
+    cg = MagicMock()
+    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
+    return cg
+
+
 def _make_open_pr_json(number: int = 1, branch: str = "test-branch") -> str:
     return json.dumps(
         [
@@ -418,13 +434,7 @@ def test_compute_no_pr_for_branch_generates_create_url_in_pr_slot() -> None:
 def test_compute_pr_fetch_error_adds_error() -> None:
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
-    cg = MagicMock()
-    fail_proc = MagicMock()
-    fail_proc.read_stdout.return_value = ""
-    fail_proc.read_stderr.return_value = "HTTP 504"
-    fail_proc.returncode = 1
-    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
-    ctx = make_mngr_ctx_with_cg(cg)
+    ctx = make_mngr_ctx_with_cg(_make_failing_fetch_cg())
     fields, errors = ds.compute(agents=(agent,), cached_fields={}, mngr_ctx=ctx)
     assert len(errors) > 0
 
@@ -435,13 +445,7 @@ def test_compute_pr_fetch_failed_no_cache_emits_fetch_failed_field() -> None:
     """
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
-    cg = MagicMock()
-    fail_proc = MagicMock()
-    fail_proc.read_stdout.return_value = ""
-    fail_proc.read_stderr.return_value = "HTTP 504"
-    fail_proc.returncode = 1
-    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
-    ctx = make_mngr_ctx_with_cg(cg)
+    ctx = make_mngr_ctx_with_cg(_make_failing_fetch_cg())
     fields, _errors = ds.compute(agents=(agent,), cached_fields={}, mngr_ctx=ctx)
     assert agent.name in fields
     pr_field = fields[agent.name].get(FIELD_PR)
@@ -460,13 +464,7 @@ def test_compute_pr_fetch_failed_with_cached_pr_uses_cache() -> None:
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: cached_pr, FIELD_CI: cached_ci},
     }
-    cg = MagicMock()
-    fail_proc = MagicMock()
-    fail_proc.read_stdout.return_value = ""
-    fail_proc.read_stderr.return_value = "HTTP 504"
-    fail_proc.returncode = 1
-    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
-    ctx = make_mngr_ctx_with_cg(cg)
+    ctx = make_mngr_ctx_with_cg(_make_failing_fetch_cg())
     fields, _errors = ds.compute(agents=(agent,), cached_fields=cached, mngr_ctx=ctx)
     assert agent.name in fields
     pr_field = fields[agent.name].get(FIELD_PR)
@@ -488,13 +486,7 @@ def test_compute_pr_fetch_failed_with_cached_pr_for_different_branch_emits_fetch
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: stale_cached_pr, FIELD_CI: cached_ci},
     }
-    cg = MagicMock()
-    fail_proc = MagicMock()
-    fail_proc.read_stdout.return_value = ""
-    fail_proc.read_stderr.return_value = "HTTP 504"
-    fail_proc.returncode = 1
-    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
-    ctx = make_mngr_ctx_with_cg(cg)
+    ctx = make_mngr_ctx_with_cg(_make_failing_fetch_cg())
     fields, _errors = ds.compute(agents=(agent,), cached_fields=cached, mngr_ctx=ctx)
     assert agent.name in fields
     pr_field = fields[agent.name].get(FIELD_PR)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -8,11 +8,13 @@ from imbue.mngr_kanpan.data_source import FIELD_CONFLICTS
 from imbue.mngr_kanpan.data_source import FIELD_PR
 from imbue.mngr_kanpan.data_source import FIELD_UNRESOLVED
 from imbue.mngr_kanpan.data_source import FieldValue
+from imbue.mngr_kanpan.data_sources.github import CiField
 from imbue.mngr_kanpan.data_sources.github import CiStatus
 from imbue.mngr_kanpan.data_sources.github import ConflictsField
 from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSource
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
+from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_sources.github import UnresolvedField
 from imbue.mngr_kanpan.data_sources.github import _PrFieldInternal
@@ -417,6 +419,52 @@ def test_compute_pr_fetch_error_adds_error() -> None:
     ctx = make_mngr_ctx_with_cg(cg)
     fields, errors = ds.compute(agents=(agent,), cached_fields={}, mngr_ctx=ctx)
     assert len(errors) > 0
+
+
+def test_compute_pr_fetch_failed_no_cache_emits_fetch_failed_field() -> None:
+    """When the repo's PR fetch fails and no cached PrField exists, the agent
+    gets a PrFetchFailedField in the FIELD_PR slot so it routes into PRS_FAILED.
+    """
+    ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
+    agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
+    cg = MagicMock()
+    fail_proc = MagicMock()
+    fail_proc.read_stdout.return_value = ""
+    fail_proc.read_stderr.return_value = "HTTP 504"
+    fail_proc.returncode = 1
+    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
+    ctx = make_mngr_ctx_with_cg(cg)
+    fields, _errors = ds.compute(agents=(agent,), cached_fields={}, mngr_ctx=ctx)
+    assert agent.name in fields
+    pr_field = fields[agent.name].get(FIELD_PR)
+    assert isinstance(pr_field, PrFetchFailedField)
+    assert pr_field.repo == "org/repo"
+
+
+def test_compute_pr_fetch_failed_with_cached_pr_uses_cache() -> None:
+    """When the repo's PR fetch fails but a cached PrField exists, fall back to
+    the cached field silently (no PrFetchFailedField, no agent flagged in PRS_FAILED).
+    """
+    ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
+    agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
+    cached_pr = _make_internal_pr(number=42, branch="branch-1", check_status=CiStatus.PASSING)
+    cached_ci = CiField(status=CiStatus.PASSING)
+    cached: dict[AgentName, dict[str, FieldValue]] = {
+        agent.name: {FIELD_PR: cached_pr, FIELD_CI: cached_ci},
+    }
+    cg = MagicMock()
+    fail_proc = MagicMock()
+    fail_proc.read_stdout.return_value = ""
+    fail_proc.read_stderr.return_value = "HTTP 504"
+    fail_proc.returncode = 1
+    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
+    ctx = make_mngr_ctx_with_cg(cg)
+    fields, _errors = ds.compute(agents=(agent,), cached_fields=cached, mngr_ctx=ctx)
+    assert agent.name in fields
+    pr_field = fields[agent.name].get(FIELD_PR)
+    assert not isinstance(pr_field, PrFetchFailedField)
+    assert pr_field == cached_pr
+    assert fields[agent.name].get(FIELD_CI) == cached_ci
 
 
 def test_compute_with_conflicts_and_unresolved() -> None:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -15,7 +15,6 @@ from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSource
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
-from imbue.mngr_kanpan.data_sources.github import PrField
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_sources.github import UnresolvedField
 from imbue.mngr_kanpan.data_sources.github import _PrLookup
@@ -36,21 +35,7 @@ from imbue.mngr_kanpan.data_sources.github import fetch_all_prs
 from imbue.mngr_kanpan.data_sources.repo_paths import RepoPathField
 from imbue.mngr_kanpan.testing import make_agent_details
 from imbue.mngr_kanpan.testing import make_mngr_ctx_with_cg
-
-
-def _make_pr(
-    number: int = 1,
-    branch: str = "test-branch",
-    state: PrState = PrState.OPEN,
-) -> PrField:
-    return PrField(
-        number=number,
-        title=f"PR {number}",
-        state=state,
-        url=f"https://github.com/org/repo/pull/{number}",
-        head_branch=branch,
-        is_draft=False,
-    )
+from imbue.mngr_kanpan.testing import make_pr_field
 
 
 def _make_pr_lookup(
@@ -59,7 +44,10 @@ def _make_pr_lookup(
     state: PrState = PrState.OPEN,
     check_status: CiStatus = CiStatus.PASSING,
 ) -> _PrLookup:
-    return _PrLookup(pr=_make_pr(number=number, branch=branch, state=state), check_status=check_status)
+    return _PrLookup(
+        pr=make_pr_field(number=number, head_branch=branch, state=state),
+        check_status=check_status,
+    )
 
 
 # === GitHubDataSource properties ===
@@ -106,7 +94,7 @@ def test_get_cached_repo_path_not_found() -> None:
 
 def test_get_cached_repo_path_wrong_type() -> None:
     cached: dict[AgentName, dict[str, FieldValue]] = {
-        AgentName("a1"): {"repo_path": _make_pr()},
+        AgentName("a1"): {"repo_path": make_pr_field()},
     }
     assert _get_cached_repo_path(cached, AgentName("a1")) is None
 
@@ -115,15 +103,15 @@ def test_get_cached_repo_path_wrong_type() -> None:
 
 
 def test_pr_priority_open() -> None:
-    assert _pr_priority(_make_pr(state=PrState.OPEN)) == 2
+    assert _pr_priority(make_pr_field(state=PrState.OPEN)) == 2
 
 
 def test_pr_priority_merged() -> None:
-    assert _pr_priority(_make_pr(state=PrState.MERGED)) == 1
+    assert _pr_priority(make_pr_field(state=PrState.MERGED)) == 1
 
 
 def test_pr_priority_closed() -> None:
-    assert _pr_priority(_make_pr(state=PrState.CLOSED)) == 0
+    assert _pr_priority(make_pr_field(state=PrState.CLOSED)) == 0
 
 
 # === _build_pr_branch_index ===
@@ -459,7 +447,7 @@ def test_compute_pr_fetch_failed_with_cached_pr_uses_cache() -> None:
     """
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
-    cached_pr = _make_pr(number=42, branch="branch-1")
+    cached_pr = make_pr_field(number=42, head_branch="branch-1")
     cached_ci = CiField(status=CiStatus.PASSING)
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: cached_pr, FIELD_CI: cached_ci},
@@ -482,7 +470,7 @@ def test_compute_pr_fetch_failed_with_cached_pr_for_different_branch_emits_fetch
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-2", labels={"remote": "git@github.com:org/repo.git"})
     # The cached PR's head_branch ("branch-1") differs from the agent's current branch.
-    stale_cached_pr = _make_pr(number=42, branch="branch-1")
+    stale_cached_pr = make_pr_field(number=42, head_branch="branch-1")
     cached_ci = CiField(status=CiStatus.PASSING)
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: stale_cached_pr, FIELD_CI: cached_ci},

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -475,6 +475,35 @@ def test_compute_pr_fetch_failed_with_cached_pr_uses_cache() -> None:
     assert fields[agent.name].get(FIELD_CI) == cached_ci
 
 
+def test_compute_pr_fetch_failed_with_cached_pr_for_different_branch_emits_fetch_failed_field() -> None:
+    """When the repo's PR fetch fails and the cached PrField is for a different
+    branch than the agent's current one, the cache must NOT be reused -- otherwise
+    we would attribute the old branch's PR to the new branch. We should fall through
+    to PrFetchFailedField, the same as the no-cache case.
+    """
+    ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
+    agent = make_agent_details(name="a1", initial_branch="branch-2", labels={"remote": "git@github.com:org/repo.git"})
+    stale_cached_pr = _make_pr(number=42, branch="branch-1")  # different branch
+    cached_ci = CiField(status=CiStatus.PASSING)
+    cached: dict[AgentName, dict[str, FieldValue]] = {
+        agent.name: {FIELD_PR: stale_cached_pr, FIELD_CI: cached_ci},
+    }
+    cg = MagicMock()
+    fail_proc = MagicMock()
+    fail_proc.read_stdout.return_value = ""
+    fail_proc.read_stderr.return_value = "HTTP 504"
+    fail_proc.returncode = 1
+    cg.run_process_in_background.side_effect = [fail_proc, fail_proc]
+    ctx = make_mngr_ctx_with_cg(cg)
+    fields, _errors = ds.compute(agents=(agent,), cached_fields=cached, mngr_ctx=ctx)
+    assert agent.name in fields
+    pr_field = fields[agent.name].get(FIELD_PR)
+    assert isinstance(pr_field, PrFetchFailedField)
+    assert pr_field.repo == "org/repo"
+    # Stale CI must not leak through either.
+    assert FIELD_CI not in fields[agent.name]
+
+
 def test_compute_with_conflicts_and_unresolved() -> None:
     """Full compute with conflicts and unresolved metadata fetching."""
     ds = GitHubDataSource(config=GitHubDataSourceConfig(pr=True, ci=True, conflicts=True, unresolved=True))

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -481,7 +481,8 @@ def test_compute_pr_fetch_failed_with_cached_pr_for_different_branch_emits_fetch
     """
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-2", labels={"remote": "git@github.com:org/repo.git"})
-    stale_cached_pr = _make_pr(number=42, branch="branch-1")  # different branch
+    # The cached PR's head_branch ("branch-1") differs from the agent's current branch.
+    stale_cached_pr = _make_pr(number=42, branch="branch-1")
     cached_ci = CiField(status=CiStatus.PASSING)
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: stale_cached_pr, FIELD_CI: cached_ci},

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github_test.py
@@ -15,9 +15,10 @@ from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSource
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
+from imbue.mngr_kanpan.data_sources.github import PrField
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_sources.github import UnresolvedField
-from imbue.mngr_kanpan.data_sources.github import _PrFieldInternal
+from imbue.mngr_kanpan.data_sources.github import _PrLookup
 from imbue.mngr_kanpan.data_sources.github import _build_create_pr_url
 from imbue.mngr_kanpan.data_sources.github import _build_pr_branch_index
 from imbue.mngr_kanpan.data_sources.github import _build_unresolved_query
@@ -37,21 +38,28 @@ from imbue.mngr_kanpan.testing import make_agent_details
 from imbue.mngr_kanpan.testing import make_mngr_ctx_with_cg
 
 
-def _make_internal_pr(
+def _make_pr(
     number: int = 1,
     branch: str = "test-branch",
     state: PrState = PrState.OPEN,
-    check_status: CiStatus = CiStatus.PASSING,
-) -> _PrFieldInternal:
-    return _PrFieldInternal(
+) -> PrField:
+    return PrField(
         number=number,
         title=f"PR {number}",
         state=state,
         url=f"https://github.com/org/repo/pull/{number}",
         head_branch=branch,
         is_draft=False,
-        internal_check_status=check_status,
     )
+
+
+def _make_pr_lookup(
+    number: int = 1,
+    branch: str = "test-branch",
+    state: PrState = PrState.OPEN,
+    check_status: CiStatus = CiStatus.PASSING,
+) -> _PrLookup:
+    return _PrLookup(pr=_make_pr(number=number, branch=branch, state=state), check_status=check_status)
 
 
 # === GitHubDataSource properties ===
@@ -98,7 +106,7 @@ def test_get_cached_repo_path_not_found() -> None:
 
 def test_get_cached_repo_path_wrong_type() -> None:
     cached: dict[AgentName, dict[str, FieldValue]] = {
-        AgentName("a1"): {"repo_path": _make_internal_pr()},
+        AgentName("a1"): {"repo_path": _make_pr()},
     }
     assert _get_cached_repo_path(cached, AgentName("a1")) is None
 
@@ -107,15 +115,15 @@ def test_get_cached_repo_path_wrong_type() -> None:
 
 
 def test_pr_priority_open() -> None:
-    assert _pr_priority(_make_internal_pr(state=PrState.OPEN)) == 2
+    assert _pr_priority(_make_pr(state=PrState.OPEN)) == 2
 
 
 def test_pr_priority_merged() -> None:
-    assert _pr_priority(_make_internal_pr(state=PrState.MERGED)) == 1
+    assert _pr_priority(_make_pr(state=PrState.MERGED)) == 1
 
 
 def test_pr_priority_closed() -> None:
-    assert _pr_priority(_make_internal_pr(state=PrState.CLOSED)) == 0
+    assert _pr_priority(_make_pr(state=PrState.CLOSED)) == 0
 
 
 # === _build_pr_branch_index ===
@@ -126,26 +134,26 @@ def test_build_pr_branch_index_empty() -> None:
 
 
 def test_build_pr_branch_index_single() -> None:
-    pr = _make_internal_pr(branch="branch-1")
-    result = _build_pr_branch_index((pr,))
+    lookup = _make_pr_lookup(branch="branch-1")
+    result = _build_pr_branch_index((lookup,))
     assert "branch-1" in result
-    assert result["branch-1"].number == 1
+    assert result["branch-1"].pr.number == 1
 
 
 def test_build_pr_branch_index_prefers_open() -> None:
-    closed = _make_internal_pr(number=1, branch="b", state=PrState.CLOSED)
-    open_pr = _make_internal_pr(number=2, branch="b", state=PrState.OPEN)
+    closed = _make_pr_lookup(number=1, branch="b", state=PrState.CLOSED)
+    open_pr = _make_pr_lookup(number=2, branch="b", state=PrState.OPEN)
     result = _build_pr_branch_index((closed, open_pr))
-    assert result["b"].number == 2
+    assert result["b"].pr.number == 2
 
 
 # === _lookup_pr ===
 
 
 def test_lookup_pr_found() -> None:
-    pr = _make_internal_pr(branch="b")
-    index = {"repo": {"b": pr}}
-    assert _lookup_pr(index, "repo", "b") == pr
+    lookup = _make_pr_lookup(branch="b")
+    index = {"repo": {"b": lookup}}
+    assert _lookup_pr(index, "repo", "b") == lookup
 
 
 def test_lookup_pr_not_found() -> None:
@@ -153,8 +161,8 @@ def test_lookup_pr_not_found() -> None:
 
 
 def test_lookup_pr_no_repo() -> None:
-    pr = _make_internal_pr(branch="b")
-    assert _lookup_pr({"other": {"b": pr}}, "repo", "b") is None
+    lookup = _make_pr_lookup(branch="b")
+    assert _lookup_pr({"other": {"b": lookup}}, "repo", "b") is None
 
 
 # === _build_create_pr_url ===
@@ -336,8 +344,8 @@ def test_fetch_repo_prs_success() -> None:
     assert repo_path == "org/repo"
     assert result.error is None
     assert len(result.prs) == 1
-    assert result.prs[0].number == 1
-    assert result.prs[0].head_branch == "branch-1"
+    assert result.prs[0].pr.number == 1
+    assert result.prs[0].pr.head_branch == "branch-1"
 
 
 def test_fetch_repo_prs_error() -> None:
@@ -447,7 +455,7 @@ def test_compute_pr_fetch_failed_with_cached_pr_uses_cache() -> None:
     """
     ds = GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))
     agent = make_agent_details(name="a1", initial_branch="branch-1", labels={"remote": "git@github.com:org/repo.git"})
-    cached_pr = _make_internal_pr(number=42, branch="branch-1", check_status=CiStatus.PASSING)
+    cached_pr = _make_pr(number=42, branch="branch-1")
     cached_ci = CiField(status=CiStatus.PASSING)
     cached: dict[AgentName, dict[str, FieldValue]] = {
         agent.name: {FIELD_PR: cached_pr, FIELD_CI: cached_ci},

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
@@ -31,6 +31,9 @@ class _ColoredStringField(FieldValue):
         return CellDisplay(text=self.value, color=self.color)
 
 
+_COLORED_STRING_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(_ColoredStringField)
+
+
 class LabelsDataSource(FrozenModel):
     """Reads agent labels and produces colored string fields.
 
@@ -55,7 +58,7 @@ class LabelsDataSource(FrozenModel):
 
     @property
     def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
-        return {self.field_key: TypeAdapter(_ColoredStringField)}
+        return {self.field_key: _COLORED_STRING_ADAPTER}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
+from typing import Literal
 
 from pydantic import Field
+from pydantic import TypeAdapter
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.mngr.config.data_types import MngrContext
@@ -21,6 +23,7 @@ class LabelColumnConfig(FrozenModel):
 class _ColoredStringField(FieldValue):
     """String field with an optional color from a color map."""
 
+    kind: Literal["colored_string"] = Field(default="colored_string", description="Discriminator tag")
     value: str = Field(description="The string value")
     color: str | None = Field(default=None, description="Optional urwid color name")
 
@@ -51,8 +54,8 @@ class LabelsDataSource(FrozenModel):
         return {self.field_key: self.config.header}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        return {self.field_key: (_ColoredStringField,)}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {self.field_key: TypeAdapter(_ColoredStringField)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/labels.py
@@ -51,8 +51,8 @@ class LabelsDataSource(FrozenModel):
         return {self.field_key: self.config.header}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        return {self.field_key: _ColoredStringField}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        return {self.field_key: (_ColoredStringField,)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
+from typing import Literal
 from urllib.parse import urlparse
 
 from pydantic import Field
+from pydantic import TypeAdapter
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
@@ -16,6 +18,7 @@ from imbue.mngr_kanpan.data_source import FieldValue
 class RepoPathField(FieldValue):
     """GitHub repository path (owner/repo) for an agent."""
 
+    kind: Literal["repo_path"] = Field(default="repo_path", description="Discriminator tag")
     path: str = Field(description="GitHub owner/repo path")
 
     def display(self) -> CellDisplay:
@@ -76,8 +79,8 @@ class RepoPathsDataSource(FrozenModel):
         return {FIELD_REPO_PATH: "REPO"}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        return {FIELD_REPO_PATH: (RepoPathField,)}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {FIELD_REPO_PATH: TypeAdapter(RepoPathField)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
@@ -59,6 +59,9 @@ def repo_path_from_labels(labels: dict[str, str]) -> str | None:
     return _parse_github_repo_path(remote_url)
 
 
+_REPO_PATH_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(RepoPathField)
+
+
 class RepoPathsDataSource(FrozenModel):
     """Computes repo_path field from agent remote labels.
 
@@ -80,7 +83,7 @@ class RepoPathsDataSource(FrozenModel):
 
     @property
     def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
-        return {FIELD_REPO_PATH: TypeAdapter(RepoPathField)}
+        return {FIELD_REPO_PATH: _REPO_PATH_ADAPTER}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
@@ -76,8 +76,8 @@ class RepoPathsDataSource(FrozenModel):
         return {FIELD_REPO_PATH: "REPO"}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        return {FIELD_REPO_PATH: RepoPathField}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        return {FIELD_REPO_PATH: (RepoPathField,)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
@@ -25,6 +25,9 @@ class ShellCommandConfig(FrozenModel):
     command: str = Field(description="Shell command to run per agent")
 
 
+_STRING_ADAPTER: TypeAdapter[FieldValue] = TypeAdapter(StringField)
+
+
 class ShellCommandDataSource(FrozenModel):
     """Runs user-defined shell commands per agent and produces StringField values.
 
@@ -51,7 +54,7 @@ class ShellCommandDataSource(FrozenModel):
 
     @property
     def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
-        return {self.field_key: TypeAdapter(StringField)}
+        return {self.field_key: _STRING_ADAPTER}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
@@ -49,8 +49,8 @@ class ShellCommandDataSource(FrozenModel):
         return {self.field_key: self.config.header}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        return {self.field_key: StringField}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        return {self.field_key: (StringField,)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/shell.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 from loguru import logger
 from pydantic import Field
+from pydantic import TypeAdapter
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
 from imbue.concurrency_group.local_process import RunningProcess
@@ -49,8 +50,8 @@ class ShellCommandDataSource(FrozenModel):
         return {self.field_key: self.config.header}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        return {self.field_key: (StringField,)}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {self.field_key: TypeAdapter(StringField)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
@@ -17,19 +17,10 @@ from imbue.mngr_kanpan.data_source import FieldValue
 
 
 class BoardSection(UpperCaseStrEnum):
-    """Sections for grouping agents on the board, based on PR state.
-
-    ``PRS_FAILED`` historically meant "open PR with failing CI"; it now means
-    "PR data could not be loaded (gh fetch failed and there is no usable cached
-    fallback)" -- the displayed label is "PRs not loaded". The enum value name
-    is preserved so users' existing ``section_order`` TOML configs keep working.
-    """
+    """Sections for grouping agents on the board, based on PR state."""
 
     STILL_COOKING = auto()
     PR_DRAFT = auto()
-    # "PR data not loaded" -- emitted when the gh PR fetch fails and no cached
-    # PrField is available to fall back to. Not "open PR with failing CI"; that
-    # case lives under PR_BEING_REVIEWED.
     PRS_FAILED = auto()
     PR_BEING_REVIEWED = auto()
     PR_MERGED = auto()

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_types.py
@@ -17,10 +17,19 @@ from imbue.mngr_kanpan.data_source import FieldValue
 
 
 class BoardSection(UpperCaseStrEnum):
-    """Sections for grouping agents on the board, based on PR state."""
+    """Sections for grouping agents on the board, based on PR state.
+
+    ``PRS_FAILED`` historically meant "open PR with failing CI"; it now means
+    "PR data could not be loaded (gh fetch failed and there is no usable cached
+    fallback)" -- the displayed label is "PRs not loaded". The enum value name
+    is preserved so users' existing ``section_order`` TOML configs keep working.
+    """
 
     STILL_COOKING = auto()
     PR_DRAFT = auto()
+    # "PR data not loaded" -- emitted when the gh PR fetch fails and no cached
+    # PrField is available to fall back to. Not "open PR with failing CI"; that
+    # case lives under PR_BEING_REVIEWED.
     PRS_FAILED = auto()
     PR_BEING_REVIEWED = auto()
     PR_MERGED = auto()

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -329,16 +329,15 @@ def load_field_cache(
 
     try:
         raw = json.loads(cache_path.read_text())
+        result: dict[AgentName, dict[str, FieldValue]] = {}
+        for agent_name_str, agent_data in raw.items():
+            agent_fields = deserialize_fields(agent_data, adapters)
+            if agent_fields:
+                result[AgentName(agent_name_str)] = agent_fields
+        return result
     except Exception as e:
         logger.debug("Failed to load field cache: {}", e)
         return {}
-
-    result: dict[AgentName, dict[str, FieldValue]] = {}
-    for agent_name_str, agent_data in raw.items():
-        agent_fields = deserialize_fields(agent_data, adapters)
-        if agent_fields:
-            result[AgentName(agent_name_str)] = agent_fields
-    return result
 
 
 def collect_data_sources(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from loguru import logger
 from pydantic import Field
+from pydantic import TypeAdapter
+from pydantic import ValidationError
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
@@ -284,10 +286,9 @@ def save_field_cache(
         for agent_name, agent_fields in cached_fields.items():
             agent_data: dict[str, Any] = {}
             for key, field in agent_fields.items():
-                agent_data[key] = {
-                    "type": type(field).__name__,
-                    "data": field.model_dump(),
-                }
+                # mode="json" so non-string keys / enums / etc. survive json.dump.
+                # The dump includes the kind discriminator -- no separate envelope needed.
+                agent_data[key] = field.model_dump(mode="json")
             serialized[str(agent_name)] = agent_data
 
         cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -309,51 +310,50 @@ def load_field_cache(
 ) -> dict[AgentName, dict[str, FieldValue]]:
     """Load cached fields from the local JSON file.
 
-    Uses field_types from data sources to deserialize each field value.
-    Returns an empty dict if the cache file doesn't exist or is corrupt.
+    Each slot's TypeAdapter (from ``KanpanDataSource.field_types``) validates
+    the raw payload. For polymorphic slots the adapter wraps a discriminated
+    union and dispatches on the ``kind`` tag in the payload. Returns an empty
+    dict if the cache file doesn't exist or is corrupt; per-key validation
+    failures are logged at debug and the offending key is dropped.
     """
     cache_path = _cache_file_path(mngr_ctx)
     if not cache_path.exists():
         return {}
 
-    # Build type registry from all data sources. Each slot may have multiple
-    # concrete classes (e.g. FIELD_PR can hold PrField, CreatePrUrlField, or
-    # PrFetchFailedField); register every class by name so the cache can
-    # round-trip whichever class the source last persisted into the slot.
-    type_registry: dict[str, type[FieldValue]] = {}
+    adapters: dict[str, TypeAdapter[FieldValue]] = {}
     for source in data_sources:
-        for _key, field_classes in source.field_types.items():
-            for field_class in field_classes:
-                type_registry[field_class.__name__] = field_class
+        adapters.update(source.field_types)
 
     try:
         raw = json.loads(cache_path.read_text())
-        result: dict[AgentName, dict[str, FieldValue]] = {}
-        for agent_name_str, agent_data in raw.items():
-            agent_fields: dict[str, FieldValue] = {}
-            for key, field_info in agent_data.items():
-                type_name = field_info.get("type")
-                data = field_info.get("data")
-                field_type = type_registry.get(type_name or "")
-                if field_type is None:
-                    logger.debug(
-                        "load_field_cache: unknown FieldValue type {!r} for agent {} key {!r}; "
-                        "the field will be dropped (registered classes: {})",
-                        type_name,
-                        agent_name_str,
-                        key,
-                        sorted(type_registry.keys()),
-                    )
-                    continue
-                if data is None:
-                    continue
-                agent_fields[key] = field_type.model_validate(data)
-            if agent_fields:
-                result[AgentName(agent_name_str)] = agent_fields
-        return result
     except Exception as e:
         logger.debug("Failed to load field cache: {}", e)
         return {}
+
+    result: dict[AgentName, dict[str, FieldValue]] = {}
+    for agent_name_str, agent_data in raw.items():
+        agent_fields: dict[str, FieldValue] = {}
+        for key, payload in agent_data.items():
+            adapter = adapters.get(key)
+            if adapter is None:
+                logger.debug(
+                    "load_field_cache: no adapter registered for agent {} key {!r}; dropping",
+                    agent_name_str,
+                    key,
+                )
+                continue
+            try:
+                agent_fields[key] = adapter.validate_python(payload)
+            except ValidationError as e:
+                logger.debug(
+                    "load_field_cache: validation failed for agent {} key {!r}: {}",
+                    agent_name_str,
+                    key,
+                    e,
+                )
+        if agent_fields:
+            result[AgentName(agent_name_str)] = agent_fields
+    return result
 
 
 def collect_data_sources(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -28,8 +28,8 @@ from imbue.mngr_kanpan.data_source import FieldValue
 from imbue.mngr_kanpan.data_source import KanpanDataSource
 from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
 from imbue.mngr_kanpan.data_sources.github import CiField
-from imbue.mngr_kanpan.data_sources.github import CiStatus
 from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
+from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrField
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_types import AgentBoardEntry
@@ -198,8 +198,19 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
     if isinstance(pr, CreatePrUrlField):
         # CreatePrUrlField in the pr slot means no real PR exists yet
         return BoardSection.STILL_COOKING
+    if isinstance(pr, PrFetchFailedField):
+        # The repo's PR fetch failed and no cached PrField was available to
+        # fall back to, so we genuinely have no PR data for this agent.
+        return BoardSection.PRS_FAILED
     if not isinstance(pr, PrField):
         raise KanpanFieldTypeError(f"Expected PrField for 'pr', got {type(pr).__name__}")
+
+    # CiField is still type-validated below for any open PR that has a ci field,
+    # even though CI status no longer affects section assignment, so type errors
+    # in the cache are caught early.
+    ci = fields.get(FIELD_CI)
+    if ci is not None and not isinstance(ci, CiField):
+        raise KanpanFieldTypeError(f"Expected CiField for 'ci', got {type(ci).__name__}")
 
     match pr.state:
         case PrState.MERGED:
@@ -209,20 +220,7 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
         case PrState.OPEN:
             if pr.is_draft:
                 return BoardSection.PR_DRAFT
-            ci = fields.get(FIELD_CI)
-            match ci:
-                case None:
-                    return BoardSection.PR_BEING_REVIEWED
-                case CiField():
-                    pass
-                case _:
-                    raise KanpanFieldTypeError(f"Expected CiField for 'ci', got {type(ci).__name__}")
-            match ci.status:
-                case CiStatus.FAILING:
-                    return BoardSection.PRS_FAILED
-                case CiStatus.PASSING | CiStatus.PENDING | CiStatus.UNKNOWN:
-                    return BoardSection.PR_BEING_REVIEWED
-            raise AssertionError(f"Unhandled CI status: {ci.status}")
+            return BoardSection.PR_BEING_REVIEWED
     raise AssertionError(f"Unhandled PR state: {pr.state}")
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -10,7 +10,6 @@ from typing import Any
 from loguru import logger
 from pydantic import Field
 from pydantic import TypeAdapter
-from pydantic import ValidationError
 
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
@@ -28,6 +27,7 @@ from imbue.mngr_kanpan.data_source import FIELD_PR
 from imbue.mngr_kanpan.data_source import FieldValue
 from imbue.mngr_kanpan.data_source import KanpanDataSource
 from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
+from imbue.mngr_kanpan.data_source import deserialize_fields
 from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrField
@@ -316,7 +316,8 @@ def load_field_cache(
     the raw payload. For polymorphic slots the adapter wraps a discriminated
     union and dispatches on the ``kind`` tag in the payload. Returns an empty
     dict if the cache file doesn't exist or is corrupt; per-key validation
-    failures are logged at debug and the offending key is dropped.
+    failures are logged at debug and the offending key is dropped (see
+    ``deserialize_fields``).
     """
     cache_path = _cache_file_path(mngr_ctx)
     if not cache_path.exists():
@@ -334,25 +335,7 @@ def load_field_cache(
 
     result: dict[AgentName, dict[str, FieldValue]] = {}
     for agent_name_str, agent_data in raw.items():
-        agent_fields: dict[str, FieldValue] = {}
-        for key, payload in agent_data.items():
-            adapter = adapters.get(key)
-            if adapter is None:
-                logger.debug(
-                    "load_field_cache: no adapter registered for agent {} key {!r}; dropping",
-                    agent_name_str,
-                    key,
-                )
-                continue
-            try:
-                agent_fields[key] = adapter.validate_python(payload)
-            except ValidationError as e:
-                logger.debug(
-                    "load_field_cache: validation failed for agent {} key {!r}: {}",
-                    agent_name_str,
-                    key,
-                    e,
-                )
+        agent_fields = deserialize_fields(agent_data, adapters)
         if agent_fields:
             result[AgentName(agent_name_str)] = agent_fields
     return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -277,7 +277,9 @@ def save_field_cache(
     """Persist cached fields to a local JSON file atomically.
 
     Writes a temporary file then renames it to avoid partial reads.
-    Each field is stored as {field_key: {type: class_name, data: model_dump}}.
+    Each field is stored as ``{field_key: model_dump}`` -- the dump
+    includes the FieldValue subclass's ``kind`` discriminator, so no
+    separate type envelope is needed.
     """
     cache_path = _cache_file_path(mngr_ctx)
     tmp_path: str | None = None

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -21,13 +21,11 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr_kanpan.data_source import BoolField
-from imbue.mngr_kanpan.data_source import FIELD_CI
 from imbue.mngr_kanpan.data_source import FIELD_MUTED
 from imbue.mngr_kanpan.data_source import FIELD_PR
 from imbue.mngr_kanpan.data_source import FieldValue
 from imbue.mngr_kanpan.data_source import KanpanDataSource
 from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
-from imbue.mngr_kanpan.data_sources.github import CiField
 from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrField
@@ -205,13 +203,6 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
     if not isinstance(pr, PrField):
         raise KanpanFieldTypeError(f"Expected PrField for 'pr', got {type(pr).__name__}")
 
-    # CiField is still type-validated below for any open PR that has a ci field,
-    # even though CI status no longer affects section assignment, so type errors
-    # in the cache are caught early.
-    ci = fields.get(FIELD_CI)
-    if ci is not None and not isinstance(ci, CiField):
-        raise KanpanFieldTypeError(f"Expected CiField for 'ci', got {type(ci).__name__}")
-
     match pr.state:
         case PrState.MERGED:
             return BoardSection.PR_MERGED
@@ -344,8 +335,19 @@ def load_field_cache(
                 type_name = field_info.get("type")
                 data = field_info.get("data")
                 field_type = type_registry.get(type_name or "")
-                if field_type is not None and data is not None:
-                    agent_fields[key] = field_type.model_validate(data)
+                if field_type is None:
+                    logger.debug(
+                        "load_field_cache: unknown FieldValue type {!r} for agent {} key {!r}; "
+                        "the field will be dropped (registered classes: {})",
+                        type_name,
+                        agent_name_str,
+                        key,
+                        sorted(type_registry.keys()),
+                    )
+                    continue
+                if data is None:
+                    continue
+                agent_fields[key] = field_type.model_validate(data)
             if agent_fields:
                 result[AgentName(agent_name_str)] = agent_fields
         return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -325,11 +325,15 @@ def load_field_cache(
     if not cache_path.exists():
         return {}
 
-    # Build type registry from all data sources
+    # Build type registry from all data sources. Each slot may have multiple
+    # concrete classes (e.g. FIELD_PR can hold PrField, CreatePrUrlField, or
+    # PrFetchFailedField); register every class by name so the cache can
+    # round-trip whichever class the source last persisted into the slot.
     type_registry: dict[str, type[FieldValue]] = {}
     for source in data_sources:
-        for _key, field_type in source.field_types.items():
-            type_registry[field_type.__name__] = field_type
+        for _key, field_classes in source.field_types.items():
+            for field_class in field_classes:
+                type_registry[field_class.__name__] = field_class
 
     try:
         raw = json.loads(cache_path.read_text())

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -110,12 +110,18 @@ def test_compute_section_open_pr_no_ci() -> None:
     assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
 
 
-def test_compute_section_open_pr_ci_failing() -> None:
-    # Failing CI does NOT route to PRS_FAILED. PRS_FAILED is reserved for the
-    # "could not load PR data" case. A real PR with red CI is still in review.
+@pytest.mark.parametrize(
+    "ci_status",
+    [CiStatus.PASSING, CiStatus.FAILING, CiStatus.PENDING, CiStatus.UNKNOWN],
+)
+def test_compute_section_open_pr_ignores_ci(ci_status: CiStatus) -> None:
+    # Regression: compute_section no longer dispatches on FIELD_CI for open PRs.
+    # An open, non-draft PR is always PR_BEING_REVIEWED regardless of CI status;
+    # PRS_FAILED is reserved for the "could not load PR data" case (see
+    # test_compute_section_pr_fetch_failed below).
     fields: dict[str, FieldValue] = {
         FIELD_PR: make_pr_field(),
-        FIELD_CI: CiField(status=CiStatus.FAILING),
+        FIELD_CI: CiField(status=ci_status),
     }
     assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
 
@@ -123,30 +129,6 @@ def test_compute_section_open_pr_ci_failing() -> None:
 def test_compute_section_pr_fetch_failed() -> None:
     fields: dict[str, FieldValue] = {FIELD_PR: PrFetchFailedField(repo="org/repo")}
     assert compute_section(fields) == BoardSection.PRS_FAILED
-
-
-def test_compute_section_open_pr_ci_passing() -> None:
-    fields: dict[str, FieldValue] = {
-        FIELD_PR: make_pr_field(),
-        FIELD_CI: CiField(status=CiStatus.PASSING),
-    }
-    assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
-
-
-def test_compute_section_open_pr_ci_pending() -> None:
-    fields: dict[str, FieldValue] = {
-        FIELD_PR: make_pr_field(),
-        FIELD_CI: CiField(status=CiStatus.PENDING),
-    }
-    assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
-
-
-def test_compute_section_open_pr_ci_unknown() -> None:
-    fields: dict[str, FieldValue] = {
-        FIELD_PR: make_pr_field(),
-        FIELD_CI: CiField(status=CiStatus.UNKNOWN),
-    }
-    assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
 
 
 def test_compute_section_wrong_muted_type() -> None:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -15,8 +15,12 @@ from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
 from imbue.mngr_kanpan.data_source import StringField
 from imbue.mngr_kanpan.data_sources.github import CiField
 from imbue.mngr_kanpan.data_sources.github import CiStatus
+from imbue.mngr_kanpan.data_sources.github import CreatePrUrlField
+from imbue.mngr_kanpan.data_sources.github import GitHubDataSource
+from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrState
+from imbue.mngr_kanpan.data_sources.github import _PrFieldInternal
 from imbue.mngr_kanpan.data_sources.repo_paths import _parse_github_repo_path
 from imbue.mngr_kanpan.data_sources.repo_paths import repo_path_from_labels
 from imbue.mngr_kanpan.data_types import BoardSection
@@ -216,7 +220,7 @@ class _MockDataSource:
         return {}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
         return {}
 
     def compute(
@@ -242,7 +246,7 @@ class _FailingDataSource:
         return {}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
         return {}
 
     def compute(
@@ -437,7 +441,7 @@ def test_plugin_kanpan_data_sources_from_loader_path() -> None:
 
 def _make_mock_data_source(field_key: str, field_type: type[FieldValue]) -> KanpanDataSource:
     return SimpleNamespace(  # ty: ignore[invalid-return-type]
-        field_types={field_key: field_type},
+        field_types={field_key: (field_type,)},
     )
 
 
@@ -474,6 +478,46 @@ def test_save_load_field_cache_roundtrip(tmp_path: Path) -> None:
     field = loaded[agent_name]["status"]
     assert isinstance(field, StringField)
     assert field.value == "hello"
+
+
+def test_save_load_field_cache_polymorphic_slot_roundtrip(tmp_path: Path) -> None:
+    """A slot can hold any of several FieldValue subclasses (e.g. FIELD_PR can hold
+    PrField, CreatePrUrlField, or PrFetchFailedField). All declared classes for a
+    slot must round-trip through the cache, regardless of which one was last persisted.
+    """
+    ctx = make_mngr_ctx_with_profile_dir(tmp_path)
+    a1 = AgentName("a1")
+    a2 = AgentName("a2")
+    a3 = AgentName("a3")
+    a4 = AgentName("a4")
+    pr_internal = _PrFieldInternal(
+        number=99,
+        url="https://example.com/99",
+        is_draft=False,
+        title="t",
+        state=PrState.OPEN,
+        head_branch="b",
+        internal_check_status=CiStatus.PASSING,
+    )
+    original: dict[AgentName, dict[str, FieldValue]] = {
+        a1: {FIELD_PR: make_pr_field(number=42)},
+        a2: {FIELD_PR: CreatePrUrlField(url="https://example.com/compare")},
+        a3: {FIELD_PR: PrFetchFailedField(repo="org/repo")},
+        a4: {FIELD_PR: pr_internal},
+    }
+    save_field_cache(ctx, original)
+
+    data_sources = [GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))]
+    loaded = load_field_cache(ctx, data_sources)
+
+    assert isinstance(loaded[a1][FIELD_PR], type(original[a1][FIELD_PR]))
+    assert isinstance(loaded[a2][FIELD_PR], CreatePrUrlField)
+    assert isinstance(loaded[a3][FIELD_PR], PrFetchFailedField)
+    assert loaded[a3][FIELD_PR] == original[a3][FIELD_PR]
+    assert isinstance(loaded[a4][FIELD_PR], _PrFieldInternal)
+    loaded_internal = loaded[a4][FIELD_PR]
+    assert isinstance(loaded_internal, _PrFieldInternal)
+    assert loaded_internal.internal_check_status == CiStatus.PASSING
 
 
 def test_load_field_cache_returns_empty_on_corrupt_json(tmp_path: Path) -> None:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from pydantic import TypeAdapter
 
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentName
@@ -210,7 +211,7 @@ class _MockDataSource:
         return {}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
         return {}
 
     def compute(
@@ -236,7 +237,7 @@ class _FailingDataSource:
         return {}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
         return {}
 
     def compute(
@@ -431,7 +432,7 @@ def test_plugin_kanpan_data_sources_from_loader_path() -> None:
 
 def _make_mock_data_source(field_key: str, field_type: type[FieldValue]) -> KanpanDataSource:
     return SimpleNamespace(  # ty: ignore[invalid-return-type]
-        field_types={field_key: (field_type,)},
+        field_types={field_key: TypeAdapter(field_type)},
     )
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -508,6 +508,32 @@ def test_load_field_cache_returns_empty_on_corrupt_json(tmp_path: Path) -> None:
     assert result == {}
 
 
+def test_load_field_cache_returns_empty_on_top_level_non_dict_json(tmp_path: Path) -> None:
+    """load_field_cache returns empty dict when the cache JSON parses but isn't a dict at the top level."""
+    cache_dir = tmp_path / "kanpan"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "field_cache.json").write_text("[]")
+    ctx = make_mngr_ctx_with_profile_dir(tmp_path)
+    result = load_field_cache(ctx, [])
+    assert result == {}
+
+
+def test_load_field_cache_returns_empty_on_invalid_agent_name(tmp_path: Path) -> None:
+    """load_field_cache returns empty dict when a top-level key is not a valid AgentName.
+
+    The cache file may have been hand-edited or written by an older incompatible
+    version. AgentName construction enforces SafeName's regex and would otherwise
+    raise InvalidName; load_field_cache must swallow that and return {}.
+    """
+    cache_dir = tmp_path / "kanpan"
+    cache_dir.mkdir(parents=True)
+    # 'a1/x' contains '/', which violates SafeName's regex.
+    (cache_dir / "field_cache.json").write_text('{"a1/x": {}}')
+    ctx = make_mngr_ctx_with_profile_dir(tmp_path)
+    result = load_field_cache(ctx, [])
+    assert result == {}
+
+
 def test_load_field_cache_skips_unknown_types(tmp_path: Path) -> None:
     """load_field_cache skips field entries whose type is not in the type registry."""
     ctx = make_mngr_ctx_with_profile_dir(tmp_path)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -524,13 +525,23 @@ def test_load_field_cache_returns_empty_on_invalid_agent_name(tmp_path: Path) ->
     The cache file may have been hand-edited or written by an older incompatible
     version. AgentName construction enforces SafeName's regex and would otherwise
     raise InvalidName; load_field_cache must swallow that and return {}.
+
+    The payload here must be non-empty and validate against the supplied
+    adapters -- otherwise deserialize_fields returns {} and the
+    ``if agent_fields:`` guard short-circuits before AgentName(...) is
+    even called, which would not exercise the swallow path.
     """
     cache_dir = tmp_path / "kanpan"
     cache_dir.mkdir(parents=True)
-    # 'a1/x' contains '/', which violates SafeName's regex.
-    (cache_dir / "field_cache.json").write_text('{"a1/x": {}}')
+    pr_payload = make_pr_field().model_dump(mode="json")
+    # 'a1/x' contains '/', which violates SafeName's regex. The PR payload
+    # makes deserialize_fields return a non-empty dict so that the
+    # AgentName(\"a1/x\") constructor is actually reached.
+    cache_data = {"a1/x": {FIELD_PR: pr_payload}}
+    (cache_dir / "field_cache.json").write_text(json.dumps(cache_data))
     ctx = make_mngr_ctx_with_profile_dir(tmp_path)
-    result = load_field_cache(ctx, [])
+    data_sources = [GitHubDataSource(config=GitHubDataSourceConfig(conflicts=False, unresolved=False))]
+    result = load_field_cache(ctx, data_sources)
     assert result == {}
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -15,6 +15,7 @@ from imbue.mngr_kanpan.data_source import KanpanFieldTypeError
 from imbue.mngr_kanpan.data_source import StringField
 from imbue.mngr_kanpan.data_sources.github import CiField
 from imbue.mngr_kanpan.data_sources.github import CiStatus
+from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrState
 from imbue.mngr_kanpan.data_sources.repo_paths import _parse_github_repo_path
 from imbue.mngr_kanpan.data_sources.repo_paths import repo_path_from_labels
@@ -105,10 +106,17 @@ def test_compute_section_open_pr_no_ci() -> None:
 
 
 def test_compute_section_open_pr_ci_failing() -> None:
+    # Failing CI does NOT route to PRS_FAILED. PRS_FAILED is reserved for the
+    # "could not load PR data" case. A real PR with red CI is still in review.
     fields: dict[str, FieldValue] = {
         FIELD_PR: make_pr_field(),
         FIELD_CI: CiField(status=CiStatus.FAILING),
     }
+    assert compute_section(fields) == BoardSection.PR_BEING_REVIEWED
+
+
+def test_compute_section_pr_fetch_failed() -> None:
+    fields: dict[str, FieldValue] = {FIELD_PR: PrFetchFailedField(repo="org/repo")}
     assert compute_section(fields) == BoardSection.PRS_FAILED
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -20,7 +20,6 @@ from imbue.mngr_kanpan.data_sources.github import GitHubDataSource
 from imbue.mngr_kanpan.data_sources.github import GitHubDataSourceConfig
 from imbue.mngr_kanpan.data_sources.github import PrFetchFailedField
 from imbue.mngr_kanpan.data_sources.github import PrState
-from imbue.mngr_kanpan.data_sources.github import _PrFieldInternal
 from imbue.mngr_kanpan.data_sources.repo_paths import _parse_github_repo_path
 from imbue.mngr_kanpan.data_sources.repo_paths import repo_path_from_labels
 from imbue.mngr_kanpan.data_types import BoardSection
@@ -489,21 +488,10 @@ def test_save_load_field_cache_polymorphic_slot_roundtrip(tmp_path: Path) -> Non
     a1 = AgentName("a1")
     a2 = AgentName("a2")
     a3 = AgentName("a3")
-    a4 = AgentName("a4")
-    pr_internal = _PrFieldInternal(
-        number=99,
-        url="https://example.com/99",
-        is_draft=False,
-        title="t",
-        state=PrState.OPEN,
-        head_branch="b",
-        internal_check_status=CiStatus.PASSING,
-    )
     original: dict[AgentName, dict[str, FieldValue]] = {
         a1: {FIELD_PR: make_pr_field(number=42)},
         a2: {FIELD_PR: CreatePrUrlField(url="https://example.com/compare")},
         a3: {FIELD_PR: PrFetchFailedField(repo="org/repo")},
-        a4: {FIELD_PR: pr_internal},
     }
     save_field_cache(ctx, original)
 
@@ -511,13 +499,11 @@ def test_save_load_field_cache_polymorphic_slot_roundtrip(tmp_path: Path) -> Non
     loaded = load_field_cache(ctx, data_sources)
 
     assert isinstance(loaded[a1][FIELD_PR], type(original[a1][FIELD_PR]))
+    assert loaded[a1][FIELD_PR] == original[a1][FIELD_PR]
     assert isinstance(loaded[a2][FIELD_PR], CreatePrUrlField)
+    assert loaded[a2][FIELD_PR] == original[a2][FIELD_PR]
     assert isinstance(loaded[a3][FIELD_PR], PrFetchFailedField)
     assert loaded[a3][FIELD_PR] == original[a3][FIELD_PR]
-    assert isinstance(loaded[a4][FIELD_PR], _PrFieldInternal)
-    loaded_internal = loaded[a4][FIELD_PR]
-    assert isinstance(loaded_internal, _PrFieldInternal)
-    assert loaded_internal.internal_check_status == CiStatus.PASSING
 
 
 def test_load_field_cache_returns_empty_on_corrupt_json(tmp_path: Path) -> None:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -546,14 +546,17 @@ def test_load_field_cache_returns_empty_on_invalid_agent_name(tmp_path: Path) ->
 
 
 def test_load_field_cache_skips_unknown_types(tmp_path: Path) -> None:
-    """load_field_cache skips field entries whose type is not in the type registry."""
+    """load_field_cache drops cache entries whose field key is not declared by any
+    data source's ``field_types`` adapter map. With no data sources passed in there
+    are no adapters, so every saved field key is unknown and the result is empty.
+    """
     ctx = make_mngr_ctx_with_profile_dir(tmp_path)
     agent_name = AgentName("agent-1")
     original: dict[AgentName, dict[str, FieldValue]] = {
         agent_name: {"status": StringField(value="hello")},
     }
     save_field_cache(ctx, original)
-    # Load with no data sources (empty type registry) -- field should be skipped
+    # No data sources -> no field-key adapters, so every saved key is unknown and dropped.
     loaded = load_field_cache(ctx, [])
     assert loaded == {}
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -518,7 +518,7 @@ def test_load_field_cache_returns_empty_on_invalid_agent_name(tmp_path: Path) ->
     pr_payload = make_pr_field().model_dump(mode="json")
     # 'a1/x' contains '/', which violates SafeName's regex. The PR payload
     # makes deserialize_fields return a non-empty dict so that the
-    # AgentName(\"a1/x\") constructor is actually reached.
+    # AgentName("a1/x") constructor is actually reached.
     cache_data = {"a1/x": {FIELD_PR: pr_payload}}
     (cache_dir / "field_cache.json").write_text(json.dumps(cache_data))
     ctx = make_mngr_ctx_with_profile_dir(tmp_path)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -159,15 +159,6 @@ def test_compute_section_wrong_pr_type() -> None:
         compute_section(fields)
 
 
-def test_compute_section_wrong_ci_type() -> None:
-    fields: dict[str, FieldValue] = {
-        FIELD_PR: make_pr_field(),
-        FIELD_CI: StringField(value="oops"),
-    }
-    with pytest.raises(KanpanFieldTypeError, match="Expected CiField"):
-        compute_section(fields)
-
-
 # === _is_agent_muted ===
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
@@ -55,8 +55,8 @@ class _FakeRemoteDataSource:
         return {FIELD_REPO_PATH: "FAKE"}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
-        return {FIELD_REPO_PATH: RepoPathField}
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+        return {FIELD_REPO_PATH: (RepoPathField,)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
@@ -11,6 +11,7 @@ To run these tests locally:
 from pathlib import Path
 
 import pytest
+from pydantic import TypeAdapter
 
 from imbue.mngr.cli.testing import create_test_agent_state
 from imbue.mngr.config.data_types import MngrContext
@@ -55,8 +56,8 @@ class _FakeRemoteDataSource:
         return {FIELD_REPO_PATH: "FAKE"}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
-        return {FIELD_REPO_PATH: (RepoPathField,)}
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {FIELD_REPO_PATH: TypeAdapter(RepoPathField)}
 
     def compute(
         self,

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
@@ -131,7 +131,7 @@ _SECTION_SUFFIX: dict[BoardSection, str] = {
     BoardSection.PR_BEING_REVIEWED: "PR pending",
     BoardSection.PR_DRAFT: "draft PR",
     BoardSection.STILL_COOKING: "no PR yet",
-    BoardSection.PRS_FAILED: "PRs failed",
+    BoardSection.PRS_FAILED: "PRs not loaded",
     BoardSection.MUTED: "",
 }
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -499,7 +499,7 @@ class _MockDataSource:
         return {"mock_field": "MOCK", "another_field": "ANOTHER"}
 
     @property
-    def field_types(self) -> dict[str, type[FieldValue]]:
+    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
         return {}
 
     def compute(

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import TypeAdapter
 from pydantic import ValidationError
 from urwid.event_loop.abstract_loop import ExitMainLoop
 from urwid.widget.attr_map import AttrMap
@@ -499,7 +500,7 @@ class _MockDataSource:
         return {"mock_field": "MOCK", "another_field": "ANOTHER"}
 
     @property
-    def field_types(self) -> dict[str, tuple[type[FieldValue], ...]]:
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
         return {}
 
     def compute(


### PR DESCRIPTION
my claude that redid a bunch of kanpan logic made this mistake and i didn't catch it, rip

---

## Summary

Restores the original meaning of `BoardSection.PRS_FAILED` ("PR data could not be loaded and there is no historical fallback") that was silently broken by the pluggable-data-sources refactor (`a6f34c2f3`), which re-purposed the section to mean "open PR with failing CI". Along the way also fixes a few related architecture issues in the data-source / cache layer.

### Behavior change (the user-visible fix)

- A new `PrFetchFailedField` sentinel goes in the `FIELD_PR` slot when a repo's PR fetch fails AND no cached `PrField` exists. Routes the agent into `PRS_FAILED`.
- When fetch fails but the previous cycle cached a `PrField`, the source silently reuses the cached field (and `CiField`) instead of dropping the PR column. Gated on `cached_pr.head_branch == agent.initial_branch` so a branch switch doesn't misattribute the previous branch's PR.
- `compute_section` no longer routes `CiStatus.FAILING` into `PRS_FAILED`; open non-draft PRs all go to `PR_BEING_REVIEWED` regardless of CI status.
- Section suffix renamed `"PRs failed"` → `"PRs not loaded"` to match the original wording from `87ae40556`.

### Architecture cleanups (related, but the diff grew)

- `KanpanDataSource.field_types` shape changed from `dict[str, type[FieldValue]]` to `dict[str, TypeAdapter[FieldValue]]`. Polymorphic slots use `TypeAdapter(Annotated[Union[...], Field(discriminator="kind")])` — pydantic dispatches on the `kind` tag, no more order-sensitive trial validation. Matches the existing `KanpanCommand` discriminator pattern in `data_types.py`.
- Every `FieldValue` subclass now has a `kind: Literal["..."]` discriminator (11 subclasses).
- `_PrFieldInternal` (a `PrField` subclass that smuggled `internal_check_status`) replaced with `_PrLookup`, a small `FrozenModel` pairing `pr: PrField` and `check_status: CiStatus`. Keeps `PrField` clean and the `FIELD_PR` slot only ever contains canonical types.
- `data_source.deserialize_fields` aligned with the new shape (one `adapter.validate_python(value)` call per slot).
- `fetcher.save_field_cache` drops the `{type, data}` envelope and stores `field.model_dump(mode="json")` directly. Discriminator is inside the dump.
- `fetcher.load_field_cache` dispatches via `adapter.validate_python`. `ValidationError` on a single key is logged at debug and the key is dropped; the cache as a whole survives.
- Removed dead defensive `ci`-type-check from `compute_section` (it was never load-bearing after the routing change).
- Documented the cached-fallback staleness trade-off in `github.compute()` (no TTL — intentional, but flagged in the comment).

### Test plan

- [x] `just test-quick libs/mngr_kanpan` — **378 passed**, 0 failed. New tests cover: PRS_FAILED routing for `PrFetchFailedField`, cached-fallback hit / miss / branch-mismatch, polymorphic-slot cache round-trip, discriminator-based deserialization.
- [x] Manual: `uv run mngr kanpan --project mngr --exclude 'labels.mngr_subagent_proxy == "child"'` after the semantics fix — the 8 agents previously parked in "PRs failed" now appear under "In review - PR pending" with their `failing` CI badge intact; "PRs not loaded" is empty (no genuine fetch failures this run).
- [x] `/verify-architecture` — all raised concerns addressed.
- [x] `/verify-conversation` (haiku) — clean, no behavioral issues.
- [x] `/autofix` — 3 fix commits, all kept by user (branch-match guard for cached fallback, test helper extraction, ratchet hygiene).
- [ ] CI offload (acceptance + release) — runs automatically.

### Cache wire-format note

Old cache files written with the previous `{type, data}` envelope will fail validation on the first load after this lands (logged at debug, key dropped) and get rebuilt on the next refresh. Cache is per-user and refreshes every 10 minutes, so this is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
