### PR TITLE
Show code-guardian gate status in Claude Code status line

### DIFF
--- a/scripts/claude_code_guardian_status.sh
+++ b/scripts/claude_code_guardian_status.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Outputs a one-line summary of the imbue-code-guardian gate states, e.g.:
+#   code guardian: stop hook✓ autofix· conversation· architecture· ci·
+# Each gate is shown with a colored glyph: green check (done/on), yellow
+# ellipsis (pending), red cross (failed, CI only), dim dot (disabled).
+# Prints nothing if no .reviewer/settings*.json is present.
+
+# ANSI colors
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+DIM=$'\033[90m'
+RESET=$'\033[0m'
+
+WORK_DIR="${MNGR_AGENT_WORK_DIR:-.}"
+BASE_SETTINGS="$WORK_DIR/.reviewer/settings.json"
+LOCAL_SETTINGS="$WORK_DIR/.reviewer/settings.local.json"
+
+if [[ ! -f "$BASE_SETTINGS" && ! -f "$LOCAL_SETTINGS" ]]; then
+    exit 0
+fi
+
+# Mirrors the precedence used by the imbue-code-guardian plugin's
+# config_utils.sh: settings.local.json overrides settings.json.
+read_setting() {
+    local key="$1"
+    local default="$2"
+    local jq_path=".$key"
+    local val
+    if [[ -f "$LOCAL_SETTINGS" ]]; then
+        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$LOCAL_SETTINGS" 2>/dev/null || true)
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+    fi
+    if [[ -f "$BASE_SETTINGS" ]]; then
+        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$BASE_SETTINGS" 2>/dev/null || true)
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+    fi
+    echo "$default"
+}
+
+fmt_gate() {
+    local label="$1"
+    local color="$2"
+    local glyph="$3"
+    printf '%s%s%s%s' "$color" "$label" "$glyph" "$RESET"
+}
+
+HASH=$(git rev-parse HEAD 2>/dev/null || echo "")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+BRANCH_SANITIZED="${BRANCH//\//_}"
+
+PR_STATUS=""
+if [[ -f "$WORK_DIR/.reviewer/outputs/pr_status" ]]; then
+    PR_STATUS=$(cat "$WORK_DIR/.reviewer/outputs/pr_status" 2>/dev/null || echo "")
+fi
+
+# stop_hook: master switch. Evaluate the shell expression in enabled_when.
+STOP_EXPR=$(read_setting "stop_hook.enabled_when" "true")
+if eval "$STOP_EXPR" >/dev/null 2>&1; then
+    STOP_GATE=$(fmt_gate "stop hook" "$GREEN" "✓")
+else
+    STOP_GATE=$(fmt_gate "stop hook" "$DIM" "·")
+fi
+
+# autofix: per-commit completion file.
+AUTOFIX_ENABLED=$(read_setting "autofix.is_enabled" "true")
+if [[ "$AUTOFIX_ENABLED" != "true" ]]; then
+    AUTOFIX_GATE=$(fmt_gate "autofix" "$DIM" "·")
+elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/autofix/${HASH}_verified.md" ]]; then
+    AUTOFIX_GATE=$(fmt_gate "autofix" "$GREEN" "✓")
+else
+    AUTOFIX_GATE=$(fmt_gate "autofix" "$YELLOW" "⋯")
+fi
+
+# verify_conversation: per-commit completion file.
+CONV_ENABLED=$(read_setting "verify_conversation.is_enabled" "true")
+if [[ "$CONV_ENABLED" != "true" ]]; then
+    CONV_GATE=$(fmt_gate "conversation" "$DIM" "·")
+elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/conversation/${HASH}.json" ]]; then
+    CONV_GATE=$(fmt_gate "conversation" "$GREEN" "✓")
+else
+    CONV_GATE=$(fmt_gate "conversation" "$YELLOW" "⋯")
+fi
+
+# verify_architecture: per-branch completion file.
+ARCH_ENABLED=$(read_setting "verify_architecture.is_enabled" "true")
+if [[ "$ARCH_ENABLED" != "true" ]]; then
+    ARCH_GATE=$(fmt_gate "architecture" "$DIM" "·")
+elif [[ -n "$BRANCH_SANITIZED" && -f "$WORK_DIR/.reviewer/outputs/architecture/${BRANCH_SANITIZED}.md" ]]; then
+    ARCH_GATE=$(fmt_gate "architecture" "$GREEN" "✓")
+else
+    ARCH_GATE=$(fmt_gate "architecture" "$YELLOW" "⋯")
+fi
+
+# ci: state lives in .reviewer/outputs/pr_status.
+CI_ENABLED=$(read_setting "ci.is_enabled" "true")
+if [[ "$CI_ENABLED" != "true" ]]; then
+    CI_GATE=$(fmt_gate "ci" "$DIM" "·")
+else
+    case "$PR_STATUS" in
+        success) CI_GATE=$(fmt_gate "ci" "$GREEN" "✓") ;;
+        failure) CI_GATE=$(fmt_gate "ci" "$RED" "✗") ;;
+        *)       CI_GATE=$(fmt_gate "ci" "$YELLOW" "⋯") ;;
+    esac
+fi
+
+printf 'code guardian: %s %s %s %s %s' \
+    "$STOP_GATE" "$AUTOFIX_GATE" "$CONV_GATE" "$ARCH_GATE" "$CI_GATE"

--- a/scripts/claude_code_guardian_status.sh
+++ b/scripts/claude_code_guardian_status.sh
@@ -69,14 +69,21 @@ else
     STOP_GATE=$(fmt_gate "stop hook" "$DIM" "·")
 fi
 
-# autofix: per-commit completion file.
+# autofix: per-commit completion file. Append "(major+critical)" when
+# configured to ignore minor issues; detected via the unique marker phrase
+# the reviewer-autofix-ignore-minor-issues skill writes into append_to_prompt.
 AUTOFIX_ENABLED=$(read_setting "autofix.is_enabled" "true")
+AUTOFIX_PROMPT=$(read_setting "autofix.append_to_prompt" "")
+AUTOFIX_LABEL="autofix"
+if [[ "$AUTOFIX_PROMPT" == *"MAJOR and CRITICAL"* ]]; then
+    AUTOFIX_LABEL="autofix(major+critical)"
+fi
 if [[ "$AUTOFIX_ENABLED" != "true" ]]; then
-    AUTOFIX_GATE=$(fmt_gate "autofix" "$DIM" "·")
+    AUTOFIX_GATE=$(fmt_gate "$AUTOFIX_LABEL" "$DIM" "·")
 elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/autofix/${HASH}_verified.md" ]]; then
-    AUTOFIX_GATE=$(fmt_gate "autofix" "$GREEN" "✓")
+    AUTOFIX_GATE=$(fmt_gate "$AUTOFIX_LABEL" "$GREEN" "✓")
 else
-    AUTOFIX_GATE=$(fmt_gate "autofix" "$YELLOW" "⋯")
+    AUTOFIX_GATE=$(fmt_gate "$AUTOFIX_LABEL" "$YELLOW" "⋯")
 fi
 
 # verify_conversation: per-commit completion file.

--- a/scripts/claude_code_guardian_status.sh
+++ b/scripts/claude_code_guardian_status.sh
@@ -22,12 +22,23 @@ if [[ ! -f "$BASE_SETTINGS" && ! -f "$LOCAL_SETTINGS" ]]; then
 fi
 
 # Mirrors the precedence used by the imbue-code-guardian plugin's
-# config_utils.sh: settings.local.json overrides settings.json.
+# config_utils.sh: env var override (CODE_GUARDIAN_<KEY uppercased, dots
+# -> __>) > settings.local.json > settings.json > default.
 read_setting() {
     local key="$1"
     local default="$2"
     local jq_path=".$key"
     local val
+
+    # Env-var override: matches read_json_config in the upstream plugin so
+    # users who configure gates via env vars see consistent state here.
+    local env_var
+    env_var="CODE_GUARDIAN_$(echo "$key" | tr '[:lower:]' '[:upper:]' | sed 's/\./__/g')"
+    if [[ -n "${!env_var:-}" ]]; then
+        echo "${!env_var}"
+        return
+    fi
+
     if [[ -f "$LOCAL_SETTINGS" ]]; then
         val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$LOCAL_SETTINGS" 2>/dev/null || true)
         if [[ -n "$val" ]]; then

--- a/scripts/claude_status_line.sh
+++ b/scripts/claude_status_line.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Status line script for Claude Code
-# Outputs two lines:
-#   1. [time user@host dir] branch | PR: url (status)
-#   2. reviewer: stop<g> autofix<g> conv<g> arch<g> ci<g>
-# where each <g> is a colored glyph: green check (done/on),
-# yellow ellipsis (pending), red cross (failed), dim dot (off).
-
-# ANSI colors
-GREEN=$'\033[32m'
-YELLOW=$'\033[33m'
-RED=$'\033[31m'
-DIM=$'\033[90m'
-RESET=$'\033[0m'
+# Outputs: [time user@host dir] branch | PR: url (status)
 
 # Get basic info
 TIME=$(date +%H:%M:%S)
@@ -26,130 +15,39 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 fi
 
-WORK_DIR="${MNGR_AGENT_WORK_DIR:-.}"
-
 # Get PR URL from .reviewer/outputs/pr_url (if exists)
 PR_URL=""
-if [[ -f "$WORK_DIR/.reviewer/outputs/pr_url" ]]; then
-    PR_URL=$(cat "$WORK_DIR/.reviewer/outputs/pr_url" 2>/dev/null || echo "")
+if [[ -f "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_url" ]]; then
+    PR_URL=$(cat "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_url" 2>/dev/null || echo "")
 fi
 
 # Get PR status from .reviewer/outputs/pr_status (if exists)
 PR_STATUS=""
-if [[ -f "$WORK_DIR/.reviewer/outputs/pr_status" ]]; then
-    PR_STATUS=$(cat "$WORK_DIR/.reviewer/outputs/pr_status" 2>/dev/null || echo "")
+if [[ -f "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_status" ]]; then
+    PR_STATUS=$(cat "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_status" 2>/dev/null || echo "")
 fi
 
-# Build the first status line
-LINE1="[$TIME $USER@$HOST $DIR]"
+# Build the status line
+STATUS_LINE="[$TIME $USER@$HOST $DIR]"
 
+# Add branch info
 if [[ -n "$BRANCH" ]]; then
-    LINE1="$LINE1 $BRANCH"
+    STATUS_LINE="$STATUS_LINE $BRANCH"
 fi
 
+# Add PR info if available
 if [[ -n "$PR_URL" ]]; then
     if [[ -n "$PR_STATUS" ]]; then
-        LINE1="$LINE1 | PR: $PR_URL ($PR_STATUS)"
+        STATUS_LINE="$STATUS_LINE | PR: $PR_URL ($PR_STATUS)"
     else
-        LINE1="$LINE1 | PR: $PR_URL"
+        STATUS_LINE="$STATUS_LINE | PR: $PR_URL"
     fi
 fi
 
-# --- Reviewer gates line ---
-# Mirrors the precedence used by the imbue-code-guardian plugin's
-# config_utils.sh: settings.local.json overrides settings.json.
-BASE_SETTINGS="$WORK_DIR/.reviewer/settings.json"
-LOCAL_SETTINGS="$WORK_DIR/.reviewer/settings.local.json"
-
-read_setting() {
-    local key="$1"
-    local default="$2"
-    local jq_path=".$key"
-    local val
-    if [[ -f "$LOCAL_SETTINGS" ]]; then
-        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$LOCAL_SETTINGS" 2>/dev/null || true)
-        if [[ -n "$val" ]]; then
-            echo "$val"
-            return
-        fi
-    fi
-    if [[ -f "$BASE_SETTINGS" ]]; then
-        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$BASE_SETTINGS" 2>/dev/null || true)
-        if [[ -n "$val" ]]; then
-            echo "$val"
-            return
-        fi
-    fi
-    echo "$default"
-}
-
-fmt_gate() {
-    local label="$1"
-    local color="$2"
-    local glyph="$3"
-    printf '%s%s%s%s' "$color" "$label" "$glyph" "$RESET"
-}
-
-LINE2=""
-if [[ -f "$BASE_SETTINGS" || -f "$LOCAL_SETTINGS" ]]; then
-    HASH=$(git rev-parse HEAD 2>/dev/null || echo "")
-    BRANCH_SANITIZED="${BRANCH//\//_}"
-
-    # stop_hook: master switch. Evaluate the shell expression in enabled_when.
-    STOP_EXPR=$(read_setting "stop_hook.enabled_when" "true")
-    if eval "$STOP_EXPR" >/dev/null 2>&1; then
-        STOP_GATE=$(fmt_gate "stop" "$GREEN" "✓")
-    else
-        STOP_GATE=$(fmt_gate "stop" "$DIM" "·")
-    fi
-
-    # autofix: per-commit completion file.
-    AUTOFIX_ENABLED=$(read_setting "autofix.is_enabled" "true")
-    if [[ "$AUTOFIX_ENABLED" != "true" ]]; then
-        AUTOFIX_GATE=$(fmt_gate "autofix" "$DIM" "·")
-    elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/autofix/${HASH}_verified.md" ]]; then
-        AUTOFIX_GATE=$(fmt_gate "autofix" "$GREEN" "✓")
-    else
-        AUTOFIX_GATE=$(fmt_gate "autofix" "$YELLOW" "⋯")
-    fi
-
-    # verify_conversation: per-commit completion file.
-    CONV_ENABLED=$(read_setting "verify_conversation.is_enabled" "true")
-    if [[ "$CONV_ENABLED" != "true" ]]; then
-        CONV_GATE=$(fmt_gate "conv" "$DIM" "·")
-    elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/conversation/${HASH}.json" ]]; then
-        CONV_GATE=$(fmt_gate "conv" "$GREEN" "✓")
-    else
-        CONV_GATE=$(fmt_gate "conv" "$YELLOW" "⋯")
-    fi
-
-    # verify_architecture: per-branch completion file.
-    ARCH_ENABLED=$(read_setting "verify_architecture.is_enabled" "true")
-    if [[ "$ARCH_ENABLED" != "true" ]]; then
-        ARCH_GATE=$(fmt_gate "arch" "$DIM" "·")
-    elif [[ -n "$BRANCH_SANITIZED" && -f "$WORK_DIR/.reviewer/outputs/architecture/${BRANCH_SANITIZED}.md" ]]; then
-        ARCH_GATE=$(fmt_gate "arch" "$GREEN" "✓")
-    else
-        ARCH_GATE=$(fmt_gate "arch" "$YELLOW" "⋯")
-    fi
-
-    # ci: state lives in .reviewer/outputs/pr_status.
-    CI_ENABLED=$(read_setting "ci.is_enabled" "true")
-    if [[ "$CI_ENABLED" != "true" ]]; then
-        CI_GATE=$(fmt_gate "ci" "$DIM" "·")
-    else
-        case "$PR_STATUS" in
-            success) CI_GATE=$(fmt_gate "ci" "$GREEN" "✓") ;;
-            failure) CI_GATE=$(fmt_gate "ci" "$RED" "✗") ;;
-            *)       CI_GATE=$(fmt_gate "ci" "$YELLOW" "⋯") ;;
-        esac
-    fi
-
-    LINE2="reviewer: $STOP_GATE $AUTOFIX_GATE $CONV_GATE $ARCH_GATE $CI_GATE"
+# Append code-guardian gate status on a second line if produced.
+GUARDIAN_LINE=$("${MNGR_AGENT_WORK_DIR:-.}/scripts/claude_code_guardian_status.sh" 2>/dev/null || true)
+if [[ -n "$GUARDIAN_LINE" ]]; then
+    STATUS_LINE="$STATUS_LINE"$'\n'"$GUARDIAN_LINE"
 fi
 
-if [[ -n "$LINE2" ]]; then
-    printf '%s\n%s' "$LINE1" "$LINE2"
-else
-    printf '%s' "$LINE1"
-fi
+printf '%s' "$STATUS_LINE"

--- a/scripts/claude_status_line.sh
+++ b/scripts/claude_status_line.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Status line script for Claude Code
-# Outputs: [time user@host dir] branch | PR: url (status)
+# Outputs two lines:
+#   1. [time user@host dir] branch | PR: url (status)
+#   2. reviewer: stop<g> autofix<g> conv<g> arch<g> ci<g>
+# where each <g> is a colored glyph: green check (done/on),
+# yellow ellipsis (pending), red cross (failed), dim dot (off).
+
+# ANSI colors
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+DIM=$'\033[90m'
+RESET=$'\033[0m'
 
 # Get basic info
 TIME=$(date +%H:%M:%S)
@@ -15,33 +26,130 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 fi
 
+WORK_DIR="${MNGR_AGENT_WORK_DIR:-.}"
+
 # Get PR URL from .reviewer/outputs/pr_url (if exists)
 PR_URL=""
-if [[ -f "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_url" ]]; then
-    PR_URL=$(cat "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_url" 2>/dev/null || echo "")
+if [[ -f "$WORK_DIR/.reviewer/outputs/pr_url" ]]; then
+    PR_URL=$(cat "$WORK_DIR/.reviewer/outputs/pr_url" 2>/dev/null || echo "")
 fi
 
 # Get PR status from .reviewer/outputs/pr_status (if exists)
 PR_STATUS=""
-if [[ -f "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_status" ]]; then
-    PR_STATUS=$(cat "${MNGR_AGENT_WORK_DIR:-.}/.reviewer/outputs/pr_status" 2>/dev/null || echo "")
+if [[ -f "$WORK_DIR/.reviewer/outputs/pr_status" ]]; then
+    PR_STATUS=$(cat "$WORK_DIR/.reviewer/outputs/pr_status" 2>/dev/null || echo "")
 fi
 
-# Build the status line
-STATUS_LINE="[$TIME $USER@$HOST $DIR]"
+# Build the first status line
+LINE1="[$TIME $USER@$HOST $DIR]"
 
-# Add branch info
 if [[ -n "$BRANCH" ]]; then
-    STATUS_LINE="$STATUS_LINE $BRANCH"
+    LINE1="$LINE1 $BRANCH"
 fi
 
-# Add PR info if available
 if [[ -n "$PR_URL" ]]; then
     if [[ -n "$PR_STATUS" ]]; then
-        STATUS_LINE="$STATUS_LINE | PR: $PR_URL ($PR_STATUS)"
+        LINE1="$LINE1 | PR: $PR_URL ($PR_STATUS)"
     else
-        STATUS_LINE="$STATUS_LINE | PR: $PR_URL"
+        LINE1="$LINE1 | PR: $PR_URL"
     fi
 fi
 
-printf '%s' "$STATUS_LINE"
+# --- Reviewer gates line ---
+# Mirrors the precedence used by the imbue-code-guardian plugin's
+# config_utils.sh: settings.local.json overrides settings.json.
+BASE_SETTINGS="$WORK_DIR/.reviewer/settings.json"
+LOCAL_SETTINGS="$WORK_DIR/.reviewer/settings.local.json"
+
+read_setting() {
+    local key="$1"
+    local default="$2"
+    local jq_path=".$key"
+    local val
+    if [[ -f "$LOCAL_SETTINGS" ]]; then
+        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$LOCAL_SETTINGS" 2>/dev/null || true)
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+    fi
+    if [[ -f "$BASE_SETTINGS" ]]; then
+        val=$(jq -r "if $jq_path == null then empty else $jq_path end" "$BASE_SETTINGS" 2>/dev/null || true)
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+    fi
+    echo "$default"
+}
+
+fmt_gate() {
+    local label="$1"
+    local color="$2"
+    local glyph="$3"
+    printf '%s%s%s%s' "$color" "$label" "$glyph" "$RESET"
+}
+
+LINE2=""
+if [[ -f "$BASE_SETTINGS" || -f "$LOCAL_SETTINGS" ]]; then
+    HASH=$(git rev-parse HEAD 2>/dev/null || echo "")
+    BRANCH_SANITIZED="${BRANCH//\//_}"
+
+    # stop_hook: master switch. Evaluate the shell expression in enabled_when.
+    STOP_EXPR=$(read_setting "stop_hook.enabled_when" "true")
+    if eval "$STOP_EXPR" >/dev/null 2>&1; then
+        STOP_GATE=$(fmt_gate "stop" "$GREEN" "✓")
+    else
+        STOP_GATE=$(fmt_gate "stop" "$DIM" "·")
+    fi
+
+    # autofix: per-commit completion file.
+    AUTOFIX_ENABLED=$(read_setting "autofix.is_enabled" "true")
+    if [[ "$AUTOFIX_ENABLED" != "true" ]]; then
+        AUTOFIX_GATE=$(fmt_gate "autofix" "$DIM" "·")
+    elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/autofix/${HASH}_verified.md" ]]; then
+        AUTOFIX_GATE=$(fmt_gate "autofix" "$GREEN" "✓")
+    else
+        AUTOFIX_GATE=$(fmt_gate "autofix" "$YELLOW" "⋯")
+    fi
+
+    # verify_conversation: per-commit completion file.
+    CONV_ENABLED=$(read_setting "verify_conversation.is_enabled" "true")
+    if [[ "$CONV_ENABLED" != "true" ]]; then
+        CONV_GATE=$(fmt_gate "conv" "$DIM" "·")
+    elif [[ -n "$HASH" && -f "$WORK_DIR/.reviewer/outputs/conversation/${HASH}.json" ]]; then
+        CONV_GATE=$(fmt_gate "conv" "$GREEN" "✓")
+    else
+        CONV_GATE=$(fmt_gate "conv" "$YELLOW" "⋯")
+    fi
+
+    # verify_architecture: per-branch completion file.
+    ARCH_ENABLED=$(read_setting "verify_architecture.is_enabled" "true")
+    if [[ "$ARCH_ENABLED" != "true" ]]; then
+        ARCH_GATE=$(fmt_gate "arch" "$DIM" "·")
+    elif [[ -n "$BRANCH_SANITIZED" && -f "$WORK_DIR/.reviewer/outputs/architecture/${BRANCH_SANITIZED}.md" ]]; then
+        ARCH_GATE=$(fmt_gate "arch" "$GREEN" "✓")
+    else
+        ARCH_GATE=$(fmt_gate "arch" "$YELLOW" "⋯")
+    fi
+
+    # ci: state lives in .reviewer/outputs/pr_status.
+    CI_ENABLED=$(read_setting "ci.is_enabled" "true")
+    if [[ "$CI_ENABLED" != "true" ]]; then
+        CI_GATE=$(fmt_gate "ci" "$DIM" "·")
+    else
+        case "$PR_STATUS" in
+            success) CI_GATE=$(fmt_gate "ci" "$GREEN" "✓") ;;
+            failure) CI_GATE=$(fmt_gate "ci" "$RED" "✗") ;;
+            *)       CI_GATE=$(fmt_gate "ci" "$YELLOW" "⋯") ;;
+        esac
+    fi
+
+    LINE2="reviewer: $STOP_GATE $AUTOFIX_GATE $CONV_GATE $ARCH_GATE $CI_GATE"
+fi
+
+if [[ -n "$LINE2" ]]; then
+    printf '%s\n%s' "$LINE1" "$LINE2"
+else
+    printf '%s' "$LINE1"
+fi


### PR DESCRIPTION
## Summary
- Add a second line to the Claude Code status line showing the state of each imbue-code-guardian gate (stop hook, autofix, conversation, architecture, ci) with a colored glyph: green check (done/on), yellow ellipsis (pending), red cross (CI failed), dim dot (disabled).
- Move the gate-status logic into a new `scripts/claude_code_guardian_status.sh` and keep the change to `scripts/claude_status_line.sh` minimal (just appends the new script's output as a second line).
- When `autofix.append_to_prompt` is set to the "ignore minor issues" variant (detected via the literal "MAJOR and CRITICAL" phrase the skill writes), append a "(major+critical)" marker to the autofix label.

## Test plan
- [ ] Verify the status line renders two lines with correct gate states given the current `.reviewer/settings.json` and `.reviewer/settings.local.json`
- [ ] Toggle a gate's `is_enabled` and confirm the corresponding label color changes from dim to green/yellow
- [ ] Set `autofix.append_to_prompt` to the all-issues variant and confirm the "(major+critical)" marker disappears
- [ ] Confirm the status line still works when `.reviewer/settings*.json` is absent (second line should be omitted)