### PR TITLE
include hidden files in ci artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,4 +441,5 @@ jobs:
         with:
           name: test-durations-release-${{ matrix.os }}-${{ matrix.group }}
           path: .test_output/test_durations_*.json
+          include-hidden-files: true
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,9 @@ jobs:
         with:
           name: test-results-offload-acceptance
           path: test-results/
+          # Same rationale as the test-offload upload step above: offload's
+          # per-sandbox flaky_tests_*.txt manifests live under hidden
+          # test-results/<sb>/.test_output/ subdirs.
           include-hidden-files: true
           retention-days: 30
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,11 @@ jobs:
         with:
           name: test-results-offload
           path: test-results/
+          # Offload pulls per-sandbox files into test-results/<sb>/.test_output/,
+          # which holds the flaky_tests_*.txt manifests used by the summary check.
+          # Default upload-artifact behavior strips hidden paths, making post-hoc
+          # debugging of the @flaky column impossible.
+          include-hidden-files: true
           retention-days: 30
 
   # Clean up old Modal test environments - runs on all branches including release,
@@ -289,6 +294,7 @@ jobs:
         with:
           name: test-results-offload-acceptance
           path: test-results/
+          include-hidden-files: true
           retention-days: 30
 
   # Docker acceptance tests - runs on a GitHub runner with a real Docker daemon.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,5 +444,7 @@ jobs:
         with:
           name: test-durations-release-${{ matrix.os }}-${{ matrix.group }}
           path: .test_output/test_durations_*.json
+          # The .test_output/ parent is hidden, so upload-artifact's default
+          # of stripping hidden paths would drop the entire glob match.
           include-hidden-files: true
           retention-days: 30


### PR DESCRIPTION
## Summary
- Investigation of recent CI flakiness identified that the @flaky column in the test-results check-run renders correctly on the runner but the underlying flaky_tests_*.txt manifests are stripped from the uploaded artifact, blocking post-hoc debugging.
- Cause: actions/upload-artifact@v4 defaults `include-hidden-files: false`, and offload places the manifests under hidden `.test_output/` subdirs.
- Enable `include-hidden-files: true` on both the unit/integration and acceptance test-results uploads.

This is the first commit on a broader CI-flakes investigation branch. Larger items (real-bug regressions on main, an upstream offload dead-sandbox-retry fix, marking known-flaky tests) are tracked separately.

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, download a `test-results-offload` artifact from any subsequent run and confirm `flaky_tests_*.txt` files are present under per-sandbox `.test_output/` paths
