### PR TITLE
tests: mark known-flaky tests as @pytest.mark.flaky

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/conftest.py
+++ b/apps/minds/imbue/minds/desktop_client/conftest.py
@@ -178,7 +178,16 @@ class _FakeKeyHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture()
 def fake_key_server() -> Iterator[LiteLLMKeyClient]:
-    """Start a local HTTP server and return a LiteLLMKeyClient pointing to it."""
+    """Start a local HTTP server and return a LiteLLMKeyClient pointing to it.
+
+    Known intermittent failure mode: tests using this fixture sometimes fail
+    with "Connection reset by peer" before the first response arrives. The
+    `LiteLLMKeyClient` issues bare httpx calls (no retry wrapper), so adding
+    retry there just to mask a fixture race would pollute production code.
+    A proper fix belongs here -- e.g. a readiness probe before yielding or
+    using `ThreadingHTTPServer` -- but is deferred; the affected tests carry
+    `@pytest.mark.flaky` so offload retries them.
+    """
     server = HTTPServer(("127.0.0.1", 0), _FakeKeyHandler)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/apps/minds/imbue/minds/desktop_client/conftest.py
+++ b/apps/minds/imbue/minds/desktop_client/conftest.py
@@ -181,12 +181,7 @@ def fake_key_server() -> Iterator[LiteLLMKeyClient]:
     """Start a local HTTP server and return a LiteLLMKeyClient pointing to it.
 
     Known intermittent failure mode: tests using this fixture sometimes fail
-    with "Connection reset by peer" before the first response arrives. The
-    `LiteLLMKeyClient` issues bare httpx calls (no retry wrapper), so adding
-    retry there just to mask a fixture race would pollute production code.
-    A proper fix belongs here -- e.g. a readiness probe before yielding or
-    using `ThreadingHTTPServer` -- but is deferred; the affected tests carry
-    `@pytest.mark.flaky` so offload retries them.
+    with "Connection reset by peer" before the first response arrives.
     """
     server = HTTPServer(("127.0.0.1", 0), _FakeKeyHandler)
     port = server.server_address[1]

--- a/apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py
+++ b/apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py
@@ -83,6 +83,8 @@ def test_create_key_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     assert result.base_url == "https://litellm-proxy.modal.run/anthropic"
 
 
+# Flaky: ECONNRESET race against the in-process `fake_key_server`. See the
+# fixture in conftest.py for the deferred-fix rationale.
 @pytest.mark.flaky
 def test_create_key_without_optional_params(fake_key_server: LiteLLMKeyClient) -> None:
     result = fake_key_server.create_key(
@@ -114,6 +116,8 @@ def test_get_key_info_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     assert result.spend == 12.50
 
 
+# Flaky: ECONNRESET race against the in-process `fake_key_server`. See the
+# fixture in conftest.py for the deferred-fix rationale.
 @pytest.mark.flaky
 def test_update_budget_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     fake_key_server.update_budget(

--- a/apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py
+++ b/apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py
@@ -83,6 +83,7 @@ def test_create_key_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     assert result.base_url == "https://litellm-proxy.modal.run/anthropic"
 
 
+@pytest.mark.flaky
 def test_create_key_without_optional_params(fake_key_server: LiteLLMKeyClient) -> None:
     result = fake_key_server.create_key(
         access_token="test-token",
@@ -113,6 +114,7 @@ def test_get_key_info_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     assert result.spend == 12.50
 
 
+@pytest.mark.flaky
 def test_update_budget_happy_path(fake_key_server: LiteLLMKeyClient) -> None:
     fake_key_server.update_budget(
         access_token="test-token",


### PR DESCRIPTION
## Summary

Marks two known-flaky LiteLLM key client tests with `@pytest.mark.flaky` so offload retries them automatically on transient failure. The third test originally requested in the parent task (`test_post_attach_resize_delivers_sigwinch_to_pane_process`) is already marked flaky on `main` (commit `90e5cc562`), so no change there.

## Tests marked

### `apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py`

- `test_create_key_without_optional_params`
- `test_update_budget_happy_path`

**Failure mode:** `LiteLLMKeyError: Key creation request failed: [Errno 104] Connection reset by peer` (Linux) / `[Errno 54]` (macOS). The `fake_key_server` conftest fixture spins up a `BaseHTTPRequestHandler` on a daemon thread; httpx occasionally races the server's accept loop and the kernel resets the connection before any response bytes arrive. Reproduced locally during this change.

**CI runs that prompted marking:**
- https://github.com/imbue-ai/mngr/actions/runs/25224795818
- https://github.com/imbue-ai/mngr/actions/runs/25228133801 (most recent main run)

## Underlying-fix decision

`LiteLLMKeyClient` issues bare `httpx.{post,put,...}` calls with no retry wrapper. Adding retry logic to the production client purely to mask a fixture race would pollute the production code path. The proper fix belongs in the `fake_key_server` fixture (e.g. a readiness probe before yielding, or `ThreadingHTTPServer`), but is deferred from this PR. A docstring on the fixture and short pointer comments above the affected tests record the rationale.

## Test plan

- [x] Marker added immediately above each `def test_...`, matching the existing `@pytest.mark.flaky` precedent in `apps/minds/imbue/minds/desktop_client/host_pool_client_test.py:66`.
- [x] `flaky` marker is registered in `libs/imbue_common/imbue/imbue_common/conftest_hooks.py` (line 128 of `_SHARED_MARKERS`).
- [x] Local collection verified for the modified file: `PYTEST_MAX_DURATION_SECONDS=300 just test-quick "apps/minds/imbue/minds/desktop_client/litellm_key_client_test.py"` collects all 14 items; `test_update_budget_happy_path` actually flaked locally during verification with the same ECONNRESET symptom, confirming the marker is correctly placed.
- [ ] CI green via offload (relies on automatic flaky retry).
