### PR TITLE
Baseline timing measurement (throwaway)

### DIFF
--- a/changelog/danver-offload-baseline-timing.md
+++ b/changelog/danver-offload-baseline-timing.md
@@ -1,0 +1,1 @@
+No user-visible changes (baseline timing measurement).


### PR DESCRIPTION
Throwaway branch to measure offload 0.8.1 test-offload step timing.