### PR TITLE
Reopen primary agent chat when last minds tab closes

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -1516,6 +1516,8 @@ def test_subdomain_forward_websocket_loopback_url_without_tunnel_closes_with_101
 
     assert exc_info.value.code == 1013
     assert "loopback" in (exc_info.value.reason or "")
+
+
 def _create_pending_subdomain_test_client(tmp_path: Path, agent_id: AgentId) -> tuple[TestClient, FileAuthStore]:
     """Build a desktop client where the given agent is a known workspace whose
     workspace_server URL has not yet been registered (service_logs is empty).

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -457,6 +457,14 @@ function addChatPanel(chatAgentId: string, chatAgentName: string): void {
   });
 }
 
+function openPrimaryAgentChat(): void {
+  const primaryId = getPrimaryAgentId();
+  if (!primaryId) return;
+  const agent = getAgentById(primaryId);
+  const agentName = agent?.name ?? "Chat";
+  addChatPanel(primaryId, agentName);
+}
+
 function openIframeTab(url: string, title: string, panelType: PanelType = "iframe", serviceName?: string): void {
   if (!dockview) return;
   const primaryId = getPrimaryAgentId();
@@ -682,9 +690,14 @@ function initializeDockview(parentElement: HTMLElement): void {
     scheduleSave();
   });
 
-  // Listen for panel removal to clean up params
+  // Listen for panel removal to clean up params. If the user closes the
+  // last remaining tab the dockview would otherwise be a blank screen with
+  // no recovery path, so reopen the primary agent's chat tab.
   dv.api.onDidRemovePanel((panel) => {
     panelParams.delete(panel.id);
+    if (dv.panels.length === 0) {
+      openPrimaryAgentChat();
+    }
   });
 
   // Agent-triggered refresh: reload every open iframe tab whose
@@ -704,18 +717,15 @@ function initializeDockview(parentElement: HTMLElement): void {
       }
       try {
         dv.fromJSON(saved.dockview);
-        return;
       } catch {
         panelParams.clear();
       }
     }
 
-    // Default: open primary agent's chat tab
-    const primaryId = getPrimaryAgentId();
-    if (primaryId) {
-      const agent = getAgentById(primaryId);
-      const agentName = agent?.name ?? "Chat";
-      addChatPanel(primaryId, agentName);
+    // Open primary agent's chat tab if no panels were restored (no saved
+    // layout, restore failed, or the saved layout was empty).
+    if (dv.panels.length === 0) {
+      openPrimaryAgentChat();
     }
   });
 }

--- a/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
+++ b/apps/minds_workspace_server/frontend/src/views/DockviewWorkspace.ts
@@ -91,7 +91,6 @@ let dockview: DockviewComponent | null = null;
 let dockviewContainer: HTMLElement | null = null;
 const panelParams = new Map<string, PanelParams>();
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
-let _layoutChangeDisposable: { dispose: () => void } | null = null;
 let _refreshServiceListener: RefreshServiceListener | null = null;
 let initialized = false;
 
@@ -686,17 +685,28 @@ function initializeDockview(parentElement: HTMLElement): void {
   dockview = dv;
 
   // Listen for layout changes and auto-save
-  _layoutChangeDisposable = dv.api.onDidLayoutChange(() => {
+  dv.api.onDidLayoutChange(() => {
     scheduleSave();
   });
 
   // Listen for panel removal to clean up params. If the user closes the
   // last remaining tab the dockview would otherwise be a blank screen with
   // no recovery path, so reopen the primary agent's chat tab.
+  //
+  // The re-add is deferred to a microtask: when the user closes the primary
+  // chat itself, adding a panel with the same id synchronously inside the
+  // remove listener races with dockview's own teardown of the just-removed
+  // panel and produces a tab that appears to "stay open" but with a blank
+  // (white) content area. Deferring lets dockview finish disposing before we
+  // add the replacement.
   dv.api.onDidRemovePanel((panel) => {
     panelParams.delete(panel.id);
     if (dv.panels.length === 0) {
-      openPrimaryAgentChat();
+      queueMicrotask(() => {
+        if (dv.panels.length === 0) {
+          openPrimaryAgentChat();
+        }
+      });
     }
   });
 

--- a/changelog/gabriel-space-eel.md
+++ b/changelog/gabriel-space-eel.md
@@ -3,3 +3,4 @@
   - WebSocket upgrades close with code `1013` (Try Again Later).
   - Refresh broadcasts are dropped instead of being POSTed to the host.
   - Non-loopback registered URLs (real hostnames, container DNS names, public IPs) are unaffected.
+- Fixed: closing the last tab in a minds workspace no longer leaves a blank screen with no recovery path. The primary agent's chat tab is automatically reopened when the dockview becomes empty (whether by closing all tabs at runtime or restoring an empty saved layout).


### PR DESCRIPTION
## Summary
- Closing the last dockview tab in a minds workspace previously left a blank screen with no way to recover. Now the primary agent's chat tab is reopened automatically when the dockview becomes empty.
- The fix runs both at runtime (after a panel is removed via `onDidRemovePanel`) and after restoring a saved layout that has no panels.

This branch also carries the previously-staged `Bypass pyinfra/loopback dial` work; only the new commit is the dockview fix.

## Test plan
- [ ] Open the minds workspace, close every tab one by one, and confirm the primary agent chat reopens automatically once the last tab closes.
- [ ] Reload the app with a saved layout that has zero panels (or after the layout fails to restore) and confirm the primary chat is opened.
- [ ] Verify destroying a non-primary agent that owned the only remaining tab also reopens the primary chat.
- [ ] `npm run lint` and `npm run build` in `apps/minds_workspace_server/frontend` pass.