### PR TITLE
Exclude tests from wheel builds for 4 workspace packages

### DIFF
--- a/apps/minds/pyproject.toml
+++ b/apps/minds/pyproject.toml
@@ -44,6 +44,7 @@ imbue-common = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 # Shared pytest settings (markers, filterwarnings, coverage report config)
 # are centralized in:

--- a/libs/mngr_claude/pyproject.toml
+++ b/libs/mngr_claude/pyproject.toml
@@ -25,6 +25,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_modal/pyproject.toml
+++ b/libs/mngr_modal/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/modal_proxy/pyproject.toml
+++ b/libs/modal_proxy/pyproject.toml
@@ -21,6 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 concurrency-group = { workspace = true }


### PR DESCRIPTION
## Summary
Tiny packaging-hygiene fix. Add \`exclude = [\"*_test.py\", \"test_*.py\", \"**/conftest.py\"]\` under \`[tool.hatch.build.targets.wheel]\` for the four workspace packages that were missing it: \`minds\`, \`mngr_claude\`, \`mngr_modal\`, \`modal_proxy\`.

Without this, hatchling includes every \`_test.py\` and \`conftest.py\` in the wheel — any consumer that pip-installs one of these packages ships unit tests in their \`site-packages/\`. The other workspace packages (\`mngr\`, \`mngr_lima\`, etc.) already have this exclusion; this PR just brings the four stragglers in line.

Originally part of a larger \`Lima mode, wheel bundling, cross-platform builds, minds cleanup\` commit on \`wz/minds_onboard\`; extracted as a standalone PR per the splitting plan.

## Test plan
- [x] \`uv build --wheel\` succeeds for all 4 packages
- [x] \`unzip -l\` on each resulting wheel shows zero \`*_test.py\` / \`conftest.py\` entries
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)