### PR TITLE
Uniform wheel test-exclusion across all packages, enforced by meta ratchet

### DIFF
--- a/apps/minds/pyproject.toml
+++ b/apps/minds/pyproject.toml
@@ -44,7 +44,7 @@ imbue-common = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 # Shared pytest settings (markers, filterwarnings, coverage report config)
 # are centralized in:

--- a/apps/minds_workspace_server/pyproject.toml
+++ b/apps/minds_workspace_server/pyproject.toml
@@ -45,7 +45,7 @@ artifacts = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 # Shared pytest settings (markers, filterwarnings, coverage report config)
 # are centralized in:

--- a/apps/minds_workspace_server/pyproject.toml
+++ b/apps/minds_workspace_server/pyproject.toml
@@ -45,6 +45,7 @@ artifacts = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 # Shared pytest settings (markers, filterwarnings, coverage report config)
 # are centralized in:

--- a/apps/remote_service_connector/pyproject.toml
+++ b/apps/remote_service_connector/pyproject.toml
@@ -27,6 +27,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-common = { workspace = true }

--- a/apps/remote_service_connector/pyproject.toml
+++ b/apps/remote_service_connector/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-common = { workspace = true }

--- a/apps/slack_exporter/pyproject.toml
+++ b/apps/slack_exporter/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 concurrency-group = { workspace = true }

--- a/apps/slack_exporter/pyproject.toml
+++ b/apps/slack_exporter/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 concurrency-group = { workspace = true }

--- a/changelog/wz-ratchet-on-wheel-testing.md
+++ b/changelog/wz-ratchet-on-wheel-testing.md
@@ -1,0 +1,3 @@
+Add the `exclude = ["*_test.py", "test_*.py", "**/conftest.py"]` line under `[tool.hatch.build.targets.wheel]` to all remaining workspace packages that were missing it (18 packages across `apps/` and `libs/`). Without this, hatchling includes every `_test.py` and `conftest.py` in the published wheel.
+
+Add a meta ratchet (`test_every_project_excludes_tests_from_wheel` in `test_meta_ratchets.py`) that fails if any new project regresses on this hygiene rule.

--- a/changelog/wz-ratchet-on-wheel-testing.md
+++ b/changelog/wz-ratchet-on-wheel-testing.md
@@ -1,3 +1,3 @@
-Add the `exclude = ["*_test.py", "test_*.py", "**/conftest.py"]` line under `[tool.hatch.build.targets.wheel]` to all remaining workspace packages that were missing it (18 packages across `apps/` and `libs/`). Without this, hatchling includes every `_test.py` and `conftest.py` in the published wheel.
+Add the `exclude = ["*_test.py", "test_*.py", "**/conftest.py"]` line under `[tool.hatch.build.targets.wheel]` to all remaining workspace packages that were missing it (18 packages across `apps/` and `libs/`). Also exclude `**/testing.py` from packages that ship a `testing.py` helper (12 packages, including 3 leaking files in `libs/mngr` that the existing `**/utils/testing.py` pattern did not cover). Without these, hatchling includes test code in published wheels.
 
-Add a meta ratchet (`test_every_project_excludes_tests_from_wheel` in `test_meta_ratchets.py`) that fails if any new project regresses on this hygiene rule.
+Add a meta ratchet (`test_every_project_excludes_tests_from_wheel` in `test_meta_ratchets.py`) that requires both the baseline patterns and a glob-matching exclude for every `testing.py` file in a package's tree.

--- a/changelog/wz-ratchet-on-wheel-testing.md
+++ b/changelog/wz-ratchet-on-wheel-testing.md
@@ -1,10 +1,10 @@
-Every workspace package's wheel build now excludes test files uniformly via:
+Every workspace package's wheel build now excludes test files uniformly via the same canonical line:
 
 ```
 [tool.hatch.build.targets.wheel]
 exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 ```
 
-Previously, several packages were missing some or all of these patterns, so hatchling shipped `_test.py`, `conftest.py`, and `testing.py` files into the published wheels (e.g. `libs/mngr` was leaking `cli/testing.py`, `api/testing.py`, and `providers/docker/testing.py` because its existing pattern only covered `**/utils/testing.py`).
+Previously, several packages were missing some or all of these patterns and hatchling was shipping `_test.py`, `conftest.py`, and `testing.py` files into published wheels. Notably `libs/mngr` was leaking three test helpers (`cli/testing.py`, `api/testing.py`, `providers/docker/testing.py`) because its existing pattern only covered `**/utils/testing.py`.
 
 A new meta ratchet (`test_every_project_excludes_tests_from_wheel`) enforces the four-pattern rule on every project so this cannot regress.

--- a/changelog/wz-ratchet-on-wheel-testing.md
+++ b/changelog/wz-ratchet-on-wheel-testing.md
@@ -1,3 +1,10 @@
-Add the `exclude = ["*_test.py", "test_*.py", "**/conftest.py"]` line under `[tool.hatch.build.targets.wheel]` to all remaining workspace packages that were missing it (18 packages across `apps/` and `libs/`). Also exclude `**/testing.py` from packages that ship a `testing.py` helper (12 packages, including 3 leaking files in `libs/mngr` that the existing `**/utils/testing.py` pattern did not cover). Without these, hatchling includes test code in published wheels.
+Every workspace package's wheel build now excludes test files uniformly via:
 
-Add a meta ratchet (`test_every_project_excludes_tests_from_wheel` in `test_meta_ratchets.py`) that requires both the baseline patterns and a glob-matching exclude for every `testing.py` file in a package's tree.
+```
+[tool.hatch.build.targets.wheel]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
+```
+
+Previously, several packages were missing some or all of these patterns, so hatchling shipped `_test.py`, `conftest.py`, and `testing.py` files into the published wheels (e.g. `libs/mngr` was leaking `cli/testing.py`, `api/testing.py`, and `providers/docker/testing.py` because its existing pattern only covered `**/utils/testing.py`).
+
+A new meta ratchet (`test_every_project_excludes_tests_from_wheel`) enforces the four-pattern rule on every project so this cannot regress.

--- a/libs/concurrency_group/pyproject.toml
+++ b/libs/concurrency_group/pyproject.toml
@@ -32,7 +32,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/utils/testing.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-common = { workspace = true }

--- a/libs/imbue_common/pyproject.toml
+++ b/libs/imbue_common/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/conftest_hooks.py", "**/pytest_utils.py", "**/utils/testing.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py", "**/conftest_hooks.py", "**/pytest_utils.py"]
 
 # Shared pytest settings (markers, filterwarnings, coverage report config)
 # are centralized in:

--- a/libs/mngr/pyproject.toml
+++ b/libs/mngr/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/utils/testing.py", "**/utils/plugin_testing.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py", "**/utils/plugin_testing.py"]
 
 [tool.uv.sources]
 imbue-common = { workspace = true }

--- a/libs/mngr_claude/pyproject.toml
+++ b/libs/mngr_claude/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_file/pyproject.toml
+++ b/libs/mngr_file/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_file/pyproject.toml
+++ b/libs/mngr_file/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_kanpan/pyproject.toml
+++ b/libs/mngr_kanpan/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_kanpan/pyproject.toml
+++ b/libs/mngr_kanpan/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_lima/pyproject.toml
+++ b/libs/mngr_lima/pyproject.toml
@@ -21,6 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_lima/pyproject.toml
+++ b/libs/mngr_lima/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_modal/pyproject.toml
+++ b/libs/mngr_modal/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_notifications/pyproject.toml
+++ b/libs/mngr_notifications/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_notifications/pyproject.toml
+++ b/libs/mngr_notifications/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_opencode/pyproject.toml
+++ b/libs/mngr_opencode/pyproject.toml
@@ -17,6 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_opencode/pyproject.toml
+++ b/libs/mngr_opencode/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_pair/pyproject.toml
+++ b/libs/mngr_pair/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_pair/pyproject.toml
+++ b/libs/mngr_pair/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_pi_coding/pyproject.toml
+++ b/libs/mngr_pi_coding/pyproject.toml
@@ -17,6 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_pi_coding/pyproject.toml
+++ b/libs/mngr_pi_coding/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_recursive/pyproject.toml
+++ b/libs/mngr_recursive/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_recursive/pyproject.toml
+++ b/libs/mngr_recursive/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_schedule/pyproject.toml
+++ b/libs/mngr_schedule/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_schedule/pyproject.toml
+++ b/libs/mngr_schedule/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_tmr/pyproject.toml
+++ b/libs/mngr_tmr/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_tmr/pyproject.toml
+++ b/libs/mngr_tmr/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_ttyd/pyproject.toml
+++ b/libs/mngr_ttyd/pyproject.toml
@@ -17,6 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_ttyd/pyproject.toml
+++ b/libs/mngr_ttyd/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_tutor/pyproject.toml
+++ b/libs/mngr_tutor/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_tutor/pyproject.toml
+++ b/libs/mngr_tutor/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_vps_docker/pyproject.toml
+++ b/libs/mngr_vps_docker/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_vps_docker/pyproject.toml
+++ b/libs/mngr_vps_docker/pyproject.toml
@@ -14,6 +14,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_vultr/pyproject.toml
+++ b/libs/mngr_vultr/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_vultr/pyproject.toml
+++ b/libs/mngr_vultr/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_wait/pyproject.toml
+++ b/libs/mngr_wait/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/mngr_wait/pyproject.toml
+++ b/libs/mngr_wait/pyproject.toml
@@ -18,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/libs/modal_proxy/pyproject.toml
+++ b/libs/modal_proxy/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 concurrency-group = { workspace = true }

--- a/libs/resource_guards/pyproject.toml
+++ b/libs/resource_guards/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.pytest.ini_options]
 timeout_func_only = true

--- a/libs/skitwright/pyproject.toml
+++ b/libs/skitwright/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
-exclude = ["*_test.py", "test_*.py", "**/conftest.py"]
+exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-common = { workspace = true }

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -264,59 +264,45 @@ def test_every_project_has_pypi_readme() -> None:
     assert len(errors) == 0, "Projects with PyPI readme issues:\n" + "\n".join(f"  - {e}" for e in errors)
 
 
-_REQUIRED_WHEEL_EXCLUDE_PATTERNS: tuple[str, ...] = ("*_test.py", "test_*.py", "**/conftest.py")
+_REQUIRED_WHEEL_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    "*_test.py",
+    "test_*.py",
+    "**/conftest.py",
+    "**/testing.py",
+)
 
 
 def test_every_project_excludes_tests_from_wheel() -> None:
-    """Ensure each project's wheel build excludes test files from the published artifact.
+    """Ensure each project's wheel build excludes test code from the published artifact.
 
-    Without this, hatchling bundles every `_test.py`, `conftest.py`, and `testing.py`
-    helper into the wheel, so any consumer that pip-installs the package ships our
+    Without this, hatchling bundles `_test.py`, `conftest.py`, and `testing.py`
+    helpers into the wheel, so any consumer that pip-installs the package ships our
     test code in their `site-packages/`.
 
-    Each project's `[tool.hatch.build.targets.wheel]` must:
-    1. Set `exclude` to literally include `*_test.py`, `test_*.py`, and `**/conftest.py`.
-    2. Cover every `testing.py` file in the package tree with at least one exclude
-       pattern (the canonical form is `**/testing.py`).
+    Each project's `[tool.hatch.build.targets.wheel].exclude` must literally contain all
+    of `*_test.py`, `test_*.py`, `**/conftest.py`, and `**/testing.py`. The patterns are
+    required uniformly even for projects that do not currently have a matching file --
+    that way, adding a new `testing.py` (or similar) tomorrow needs no second PR.
 
     Projects with `only-include` (an explicit whitelist) are exempt.
     """
-    missing_baseline: list[str] = []
-    leaking_testing_helpers: list[str] = []
+    missing: list[str] = []
     for project_dir in _get_all_project_dirs():
         pyproject = tomlkit.parse((project_dir / "pyproject.toml").read_text())
         wheel = pyproject.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {}).get("wheel", {})
         if "only-include" in wheel:
             continue
         exclude_patterns = [str(x) for x in wheel.get("exclude", [])]
-
         absent = [pat for pat in _REQUIRED_WHEEL_EXCLUDE_PATTERNS if pat not in exclude_patterns]
         if absent:
-            missing_baseline.append(f"{project_dir.name} (missing: {absent})")
+            missing.append(f"{project_dir.name} (missing: {absent})")
 
-        package_root = project_dir / "imbue" / project_dir.name
-        if not package_root.exists():
-            continue
-        for testing_file in package_root.rglob("testing.py"):
-            rel = str(testing_file.relative_to(project_dir))
-            if not any(fnmatch.fnmatch(rel, pat) for pat in exclude_patterns):
-                leaking_testing_helpers.append(f"{project_dir.name}: {rel}")
-
-    errors: list[str] = []
-    if missing_baseline:
-        errors.append(
-            "Missing baseline test exclusions. Add to [tool.hatch.build.targets.wheel]:\n"
-            '    exclude = ["*_test.py", "test_*.py", "**/conftest.py"]\n\n'
-            "Offending projects:\n" + "\n".join(f"  - {m}" for m in missing_baseline)
-        )
-    if leaking_testing_helpers:
-        errors.append(
-            "`testing.py` helper files would ship in the wheel. Add `**/testing.py` to "
-            "[tool.hatch.build.targets.wheel].exclude (or a more specific pattern that "
-            "matches the file).\n\nOffending files:\n" + "\n".join(f"  - {m}" for m in leaking_testing_helpers)
-        )
-
-    assert len(errors) == 0, "Wheel test-exclusion check failed:\n\n" + "\n\n".join(errors)
+    assert len(missing) == 0, (
+        "Projects must exclude test files from their wheel build. Add to "
+        "[tool.hatch.build.targets.wheel]:\n"
+        '    exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]\n\n'
+        "Offending projects:\n" + "\n".join(f"  - {m}" for m in missing)
+    )
 
 
 def _has_test_files(project_dir: Path) -> bool:

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -264,6 +264,37 @@ def test_every_project_has_pypi_readme() -> None:
     assert len(errors) == 0, "Projects with PyPI readme issues:\n" + "\n".join(f"  - {e}" for e in errors)
 
 
+_REQUIRED_WHEEL_EXCLUDE_PATTERNS: tuple[str, ...] = ("*_test.py", "test_*.py", "**/conftest.py")
+
+
+def test_every_project_excludes_tests_from_wheel() -> None:
+    """Ensure each project's wheel build excludes test files from the published artifact.
+
+    Without this, hatchling bundles every `_test.py` and `conftest.py` into the wheel,
+    so any consumer that pip-installs the package ships our unit tests in their
+    `site-packages/`. Each project's `[tool.hatch.build.targets.wheel]` must either:
+    1. Set `exclude` to include all of `*_test.py`, `test_*.py`, and `**/conftest.py`, or
+    2. Set `only-include` (an explicit whitelist makes a leaking exclude unnecessary).
+    """
+    missing: list[str] = []
+    for project_dir in _get_all_project_dirs():
+        pyproject = tomlkit.parse((project_dir / "pyproject.toml").read_text())
+        wheel = pyproject.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {}).get("wheel", {})
+        if "only-include" in wheel:
+            continue
+        exclude = [str(x) for x in wheel.get("exclude", [])]
+        absent = [pat for pat in _REQUIRED_WHEEL_EXCLUDE_PATTERNS if pat not in exclude]
+        if absent:
+            missing.append(f"{project_dir.name} (missing: {absent})")
+
+    assert len(missing) == 0, (
+        "Projects must exclude test files from their wheel build. Add to "
+        "[tool.hatch.build.targets.wheel]:\n"
+        '    exclude = ["*_test.py", "test_*.py", "**/conftest.py"]\n\n'
+        "Offending projects:\n" + "\n".join(f"  - {m}" for m in missing)
+    )
+
+
 def _has_test_files(project_dir: Path) -> bool:
     """Return True if the project contains any test files."""
     for pattern in ["*_test.py", "test_*.py"]:

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -270,29 +270,53 @@ _REQUIRED_WHEEL_EXCLUDE_PATTERNS: tuple[str, ...] = ("*_test.py", "test_*.py", "
 def test_every_project_excludes_tests_from_wheel() -> None:
     """Ensure each project's wheel build excludes test files from the published artifact.
 
-    Without this, hatchling bundles every `_test.py` and `conftest.py` into the wheel,
-    so any consumer that pip-installs the package ships our unit tests in their
-    `site-packages/`. Each project's `[tool.hatch.build.targets.wheel]` must either:
-    1. Set `exclude` to include all of `*_test.py`, `test_*.py`, and `**/conftest.py`, or
-    2. Set `only-include` (an explicit whitelist makes a leaking exclude unnecessary).
+    Without this, hatchling bundles every `_test.py`, `conftest.py`, and `testing.py`
+    helper into the wheel, so any consumer that pip-installs the package ships our
+    test code in their `site-packages/`.
+
+    Each project's `[tool.hatch.build.targets.wheel]` must:
+    1. Set `exclude` to literally include `*_test.py`, `test_*.py`, and `**/conftest.py`.
+    2. Cover every `testing.py` file in the package tree with at least one exclude
+       pattern (the canonical form is `**/testing.py`).
+
+    Projects with `only-include` (an explicit whitelist) are exempt.
     """
-    missing: list[str] = []
+    missing_baseline: list[str] = []
+    leaking_testing_helpers: list[str] = []
     for project_dir in _get_all_project_dirs():
         pyproject = tomlkit.parse((project_dir / "pyproject.toml").read_text())
         wheel = pyproject.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {}).get("wheel", {})
         if "only-include" in wheel:
             continue
-        exclude = [str(x) for x in wheel.get("exclude", [])]
-        absent = [pat for pat in _REQUIRED_WHEEL_EXCLUDE_PATTERNS if pat not in exclude]
-        if absent:
-            missing.append(f"{project_dir.name} (missing: {absent})")
+        exclude_patterns = [str(x) for x in wheel.get("exclude", [])]
 
-    assert len(missing) == 0, (
-        "Projects must exclude test files from their wheel build. Add to "
-        "[tool.hatch.build.targets.wheel]:\n"
-        '    exclude = ["*_test.py", "test_*.py", "**/conftest.py"]\n\n'
-        "Offending projects:\n" + "\n".join(f"  - {m}" for m in missing)
-    )
+        absent = [pat for pat in _REQUIRED_WHEEL_EXCLUDE_PATTERNS if pat not in exclude_patterns]
+        if absent:
+            missing_baseline.append(f"{project_dir.name} (missing: {absent})")
+
+        package_root = project_dir / "imbue" / project_dir.name
+        if not package_root.exists():
+            continue
+        for testing_file in package_root.rglob("testing.py"):
+            rel = str(testing_file.relative_to(project_dir))
+            if not any(fnmatch.fnmatch(rel, pat) for pat in exclude_patterns):
+                leaking_testing_helpers.append(f"{project_dir.name}: {rel}")
+
+    errors: list[str] = []
+    if missing_baseline:
+        errors.append(
+            "Missing baseline test exclusions. Add to [tool.hatch.build.targets.wheel]:\n"
+            '    exclude = ["*_test.py", "test_*.py", "**/conftest.py"]\n\n'
+            "Offending projects:\n" + "\n".join(f"  - {m}" for m in missing_baseline)
+        )
+    if leaking_testing_helpers:
+        errors.append(
+            "`testing.py` helper files would ship in the wheel. Add `**/testing.py` to "
+            "[tool.hatch.build.targets.wheel].exclude (or a more specific pattern that "
+            "matches the file).\n\nOffending files:\n" + "\n".join(f"  - {m}" for m in leaking_testing_helpers)
+        )
+
+    assert len(errors) == 0, "Wheel test-exclusion check failed:\n\n" + "\n\n".join(errors)
 
 
 def _has_test_files(project_dir: Path) -> bool:


### PR DESCRIPTION
## Summary

Every workspace package's wheel build now excludes test files uniformly via the same canonical line:

```
[tool.hatch.build.targets.wheel]
exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
```

Previously, several packages were missing some or all of these patterns, so hatchling was shipping `_test.py`, `conftest.py`, and `testing.py` files into published wheels — meaning any consumer that pip-installed one of these packages got our test code in their `site-packages/`. Notably `libs/mngr` was leaking `imbue/mngr/cli/testing.py`, `imbue/mngr/api/testing.py`, and `imbue/mngr/providers/docker/testing.py` because its existing exclude (`**/utils/testing.py`) only covered the one in `utils/`.

A new meta ratchet (`test_every_project_excludes_tests_from_wheel` in `test_meta_ratchets.py`) enforces the four-pattern rule on every project so the same regression cannot happen again. The check is a simple literal-string membership test against `[tool.hatch.build.targets.wheel].exclude`. Projects with `only-include` (an explicit whitelist) are exempt; `flexmux` is exempt via the existing `_EXCLUDED_PROJECTS` set.

The four patterns are required uniformly, even on packages that don't currently have a matching file. That's deliberate — it's the same convention `**/conftest.py` already followed (11 packages carry it without a current `conftest.py`) and means adding a new `testing.py` later doesn't need a second config-only PR. Trade-off: ~15 packages carry `**/testing.py` as no-op config today; benefit: the ratchet stays a 5-line literal check with no file-walking, no glob semantics, and no two-step trap.

Extends the original fix in #1500 (which added the exclude to 4 packages); this PR brings every remaining package in line and adds the enforcement.

## Test plan
- [x] `just test-quick test_meta_ratchets.py` -> 14 passed
- [x] Verified the ratchet fails on regression (manually removed `**/testing.py` from one project; got a clean per-project diagnostic)
- [x] Verified the ratchet catches mngr's previously-leaking `cli/`, `api/`, `providers/docker/testing.py` files when reverted to the old `**/utils/testing.py` pattern
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)