### PR TITLE
Protect .claude/settings.local.json from propagate_changes rsync --delete

### DIFF
--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -171,7 +171,7 @@ If this chain breaks (orphaned `mngr observe`/`mngr event` processes appear), so
 Both syncs (mngr->vendor/mngr and template->container) exclude:
 `.git`, `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `uv.lock`, `.external_worktrees`
 
-The template->container sync also protects `runtime/`, `.mngr/`, and `.claude/settings.local.json` from deletion. The latter holds the per-agent `UserPromptSubmit` hook (`tmux wait-for -S "mngr-submit-..."`) that mngr writes during agent creation; without it, every `send_message` hangs the 90s submission-signal timeout while Claude responds normally in the UI.
+The template->container sync also protects `runtime/`, `.mngr/`, and `.claude/settings.local.json` from deletion.
 
 ### Editable installs
 

--- a/.claude/skills/minds-dev-iterate/SKILL.md
+++ b/.claude/skills/minds-dev-iterate/SKILL.md
@@ -171,7 +171,7 @@ If this chain breaks (orphaned `mngr observe`/`mngr event` processes appear), so
 Both syncs (mngr->vendor/mngr and template->container) exclude:
 `.git`, `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `uv.lock`, `.external_worktrees`
 
-The template->container sync also protects `runtime/` and `.mngr/` from deletion.
+The template->container sync also protects `runtime/`, `.mngr/`, and `.claude/settings.local.json` from deletion. The latter holds the per-agent `UserPromptSubmit` hook (`tmux wait-for -S "mngr-submit-..."`) that mngr writes during agent creation; without it, every `send_message` hangs the 90s submission-signal timeout while Claude responds normally in the UI.
 
 ### Editable installs
 

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -168,12 +168,18 @@ agent_update() {
         return 1
     fi
 
+    # Protect .claude/settings.local.json: it is generated per-agent at create
+    # time by mngr's _configure_agent_hooks (writes UserPromptSubmit hooks that
+    # signal `tmux wait-for -S "mngr-submit-..."`). Without it, every send_message
+    # hangs the 90s submission-signal timeout. The template doesn't ship this
+    # file, so without protection, --delete blows it away on every iteration.
     echo "[3/4] Syncing template into agent work_dir..."
     if [[ "${MODE}" == "remote" ]]; then
         rsync -avz --delete \
             "${RSYNC_EXCLUDES[@]}" \
             --filter='protect runtime/' \
             --filter='protect .mngr/' \
+            --filter='protect .claude/settings.local.json' \
             -e "ssh -p ${SSH_PORT} -i ${SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
             "${TEMPLATE_DIR}/" "${SSH_USER}@${SSH_HOST}:/code/"
     else
@@ -181,6 +187,7 @@ agent_update() {
             "${RSYNC_EXCLUDES[@]}" \
             --filter='protect runtime/' \
             --filter='protect .mngr/' \
+            --filter='protect .claude/settings.local.json' \
             "${TEMPLATE_DIR}/" "${LOCAL_TARGET}/"
     fi
     echo "      Done."

--- a/apps/minds/scripts/propagate_changes
+++ b/apps/minds/scripts/propagate_changes
@@ -168,11 +168,9 @@ agent_update() {
         return 1
     fi
 
-    # Protect .claude/settings.local.json: it is generated per-agent at create
-    # time by mngr's _configure_agent_hooks (writes UserPromptSubmit hooks that
-    # signal `tmux wait-for -S "mngr-submit-..."`). Without it, every send_message
-    # hangs the 90s submission-signal timeout. The template doesn't ship this
-    # file, so without protection, --delete blows it away on every iteration.
+    # .claude/settings.local.json is generated per-agent at create time and
+    # holds mngr's UserPromptSubmit hook; without protection, --delete removes
+    # it and send_message then hangs the 90s submission-signal timeout.
     echo "[3/4] Syncing template into agent work_dir..."
     if [[ "${MODE}" == "remote" ]]; then
         rsync -avz --delete \

--- a/changelog/gabriel-fix-propagate-changes-claude-settings.md
+++ b/changelog/gabriel-fix-propagate-changes-claude-settings.md
@@ -1,0 +1,5 @@
+`apps/minds/scripts/propagate_changes` now protects `.claude/settings.local.json` from `rsync --delete` when syncing the template into an agent's work_dir.
+
+That file is generated per-agent at create time by mngr's `_configure_agent_hooks` and holds the `UserPromptSubmit` hook that signals `tmux wait-for -S "mngr-submit-..."`. Without it, every `send_message` hangs the 90-second submission-signal timeout while the prompt is actually delivered to Claude (so the UI shows the message and Claude responds normally, but the HTTP `/message` request times out).
+
+Previously the script only protected `runtime/` and `.mngr/`, so iterating with `propagate_changes` reliably reproduced the hang -- and there was no easy way to recover short of recreating the agent.

--- a/specs/minds-dev-iteration-loop/spec.md
+++ b/specs/minds-dev-iteration-loop/spec.md
@@ -98,7 +98,7 @@ This ensures that `vendor/mngr/` in the template on disk always reflects the cur
 * Source: `${TEMPLATE_DIR}/` (trailing slash = copy contents)
 * Destination: `/code/` (remote) or `${TARGET}/` (local)
 * Flags: `-a --delete` (add `-vz` for remote)
-* Exclusions: same as above, plus `--filter='protect runtime/'` and `--filter='protect .mngr/'` to prevent `--delete` from removing container runtime state
+* Exclusions: same as above, plus `--filter='protect runtime/'`, `--filter='protect .mngr/'`, and `--filter='protect .claude/settings.local.json'` to prevent `--delete` from removing container runtime state and the per-agent UserPromptSubmit hook config
 
 ## Implementation Phases
 


### PR DESCRIPTION
## Summary

`apps/minds/scripts/propagate_changes` now protects `.claude/settings.local.json` from `rsync --delete` when syncing the template into an agent's work_dir.

That file is generated per-agent at create time by mngr's `_configure_agent_hooks` (see `libs/mngr_claude/imbue/mngr_claude/plugin.py:_configure_agent_hooks`) and holds the `UserPromptSubmit` hook that signals `tmux wait-for -S "mngr-submit-..."` (built by `build_readiness_hooks_config` in `libs/mngr_claude/imbue/mngr_claude/claude_config.py`). Mngr's `_send_enter_and_wait_for_signal` waits on that signal to confirm prompt submission.

Without the file, every `send_message` hangs the 90-second submission-signal timeout. The prompt is actually delivered to Claude — the chat UI shows the message and Claude responds normally — but the HTTP `/message` request blocks until the wait-for times out.

Previously the script protected only `runtime/` and `.mngr/`, so iterating with `propagate_changes` reliably reproduced this hang and the only recovery was to recreate the agent.

Also updates the `minds-dev-iterate` skill (`.claude/skills/minds-dev-iterate/SKILL.md`) and the dev-iteration-loop spec (`specs/minds-dev-iteration-loop/spec.md`) to document the new protect filter and the failure mode it prevents.

## Test plan

- [x] Reproduced the hang on mindtest-3 after a normal `propagate_changes` run: the file was missing in `/code/.claude/`, sends hung 90s while Claude responded normally
- [x] Manually restored the file via `build_readiness_hooks_config()`, restarted the agent — sends complete in <1s
- [x] Re-ran `propagate_changes` with the fix in place — `/code/.claude/settings.local.json` survives the rsync
- [ ] CI green