### PR TITLE
Improve TMR reliability against Modal provider

### DIFF
--- a/changelog/mngr-run-tmr.md
+++ b/changelog/mngr-run-tmr.md
@@ -22,6 +22,16 @@
   debugging. The `mngr create -vv` log span around `_execute_agent_file_transfers`
   now wraps the early-return path too, so the span is emitted (with
   `count=0`) even when the agent declared no file transfers.
+- Stop the `claude plugin update` SessionStart hook from hanging Modal-launched
+  agents at an `ssh` first-contact (TOFU) prompt for github.com. The plugin
+  updater shells out to `git pull`, which uses `ssh` -- on a fresh sandbox
+  with no `~/.ssh/known_hosts` entry, ssh blocks on a "Are you sure you
+  want to continue connecting" prompt that Claude Code's bypass-permissions
+  setting does not cover. `scripts/claude_update_plugin.sh` now prefixes
+  the update with `GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new
+  -o BatchMode=yes'`, which writes the first-seen host key to known_hosts
+  and exits non-interactively if anything goes wrong (matching the
+  script's existing `2>/dev/null || true` failure tolerance).
 - `mngr tmr` HTML reports now have a dedicated "Failed" section,
   separate from "Blocked". The two represent different failure modes:
   Blocked means the coding agent reported every change as BLOCKED

--- a/changelog/mngr-run-tmr.md
+++ b/changelog/mngr-run-tmr.md
@@ -14,3 +14,6 @@
   ("localhost"), so the new-host path can never find a free name; TMR now
   reuses the existing local host when the target provider is `local`,
   matching what `mngr create` already does.
+- `mngr tmr` HTML reports now include rows for tests whose agent failed to
+  launch (e.g. `SendMessageError` from a paste-detection timeout). They are
+  rendered as errored entries instead of being silently dropped.

--- a/changelog/mngr-run-tmr.md
+++ b/changelog/mngr-run-tmr.md
@@ -1,0 +1,10 @@
+- `mngr create -vv` now emits a `Transferring agent files` log span around the
+  per-file `write_file` loop in agent provisioning, so the total time spent
+  pushing plugin-declared files (e.g. Claude Code config) is visible in timing
+  output.
+- `mngr tmr` no longer crashes the whole orchestrator when a single agent
+  fails its initial-message send (e.g. `SendMessageError` from the tmux
+  paste-detection timeout). The launching loops now also catch `AgentError`
+  alongside `MngrError` / `HostError`, log a warning, and continue with the
+  remaining agents. This applies to test-agent launching (both batched and
+  pre-launched modes) and to the integrator launch.

--- a/changelog/mngr-run-tmr.md
+++ b/changelog/mngr-run-tmr.md
@@ -16,4 +16,16 @@
   matching what `mngr create` already does.
 - `mngr tmr` HTML reports now include rows for tests whose agent failed to
   launch (e.g. `SendMessageError` from a paste-detection timeout). They are
-  rendered as errored entries instead of being silently dropped.
+  rendered as errored entries instead of being silently dropped, and carry
+  the actual agent name that was used for the failed launch attempt -- so
+  the report row matches the host/tmux session if the user kept it for
+  debugging. The `mngr create -vv` log span around `_execute_agent_file_transfers`
+  now wraps the early-return path too, so the span is emitted (with
+  `count=0`) even when the agent declared no file transfers.
+- `mngr tmr` HTML reports now have a dedicated "Failed" section,
+  separate from "Blocked". The two represent different failure modes:
+  Blocked means the coding agent reported every change as BLOCKED
+  (i.e. it considered the work too complex), while Failed means an
+  infrastructure failure prevented the agent from producing a verdict
+  (launch failed, agent timed out, agent details missing). Errored
+  results that previously fell into "Blocked" now route to "Failed".

--- a/changelog/mngr-run-tmr.md
+++ b/changelog/mngr-run-tmr.md
@@ -8,3 +8,9 @@
   alongside `MngrError` / `HostError`, log a warning, and continue with the
   remaining agents. This applies to test-agent launching (both batched and
   pre-launched modes) and to the integrator launch.
+- Fix `mngr tmr` integrator launch (and any local-provider test-agent
+  launch), which always failed with `Failed to generate a unique host name
+  after 100 attempts`. The local provider has a single fixed host
+  ("localhost"), so the new-host path can never find a free name; TMR now
+  reuses the existing local host when the target provider is `local`,
+  matching what `mngr create` already does.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2574,18 +2574,19 @@ class Host(BaseHost, OnlineHostInterface):
             raise MngrError(f"Required files for provisioning not found: {missing_str}")
 
         # Execute transfers
-        for transfer in transfers:
-            if not transfer.local_path.exists():
-                # Optional file doesn't exist, skip it
-                logger.trace("Skipped optional file transfer (file not found): {}", transfer.local_path)
-                continue
+        with log_span("Transferring agent files", count=len(transfers)):
+            for transfer in transfers:
+                if not transfer.local_path.exists():
+                    # Optional file doesn't exist, skip it
+                    logger.trace("Skipped optional file transfer (file not found): {}", transfer.local_path)
+                    continue
 
-            # Resolve relative remote paths to work_dir
-            remote_path = agent.work_dir / transfer.agent_path
+                # Resolve relative remote paths to work_dir
+                remote_path = agent.work_dir / transfer.agent_path
 
-            local_content = transfer.local_path.read_bytes()
-            self.write_file(remote_path, local_content)
-            logger.trace("Transferred agent file: {} -> {}", transfer.local_path, remote_path)
+                local_content = transfer.local_path.read_bytes()
+                self.write_file(remote_path, local_content)
+                logger.trace("Transferred agent file: {} -> {}", transfer.local_path, remote_path)
 
     def rename_agent(self, agent: AgentInterface, new_name: AgentName) -> AgentInterface:
         """Rename an agent and return the updated agent object.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2559,22 +2559,23 @@ class Host(BaseHost, OnlineHostInterface):
         """Validate and execute file transfers from the agent.
 
         First validates that all required files exist, then executes transfers.
+        Always emits a "Transferring agent files" log_span (with count=0 when
+        the agent declared no transfers) so timing is visible at -vv.
         """
-        if not transfers:
-            return
-
-        # Validate required files first
-        missing_required: list[Path] = []
-        for transfer in transfers:
-            if transfer.is_required and not transfer.local_path.exists():
-                missing_required.append(transfer.local_path)
-
-        if missing_required:
-            missing_str = ", ".join(str(p) for p in missing_required)
-            raise MngrError(f"Required files for provisioning not found: {missing_str}")
-
-        # Execute transfers
         with log_span("Transferring agent files", count=len(transfers)):
+            if not transfers:
+                return
+
+            # Validate required files first
+            missing_required: list[Path] = []
+            for transfer in transfers:
+                if transfer.is_required and not transfer.local_path.exists():
+                    missing_required.append(transfer.local_path)
+
+            if missing_required:
+                missing_str = ", ".join(str(p) for p in missing_required)
+                raise MngrError(f"Required files for provisioning not found: {missing_str}")
+
             for transfer in transfers:
                 if not transfer.local_path.exists():
                     # Optional file doesn't exist, skip it

--- a/libs/mngr_tmr/imbue/mngr_tmr/api.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api.py
@@ -10,6 +10,7 @@ Sub-modules:
 """
 
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 from loguru import logger
@@ -112,6 +113,7 @@ def launch_and_poll_agents(
     report_path: Path | None,
     all_agents: list[TestAgentInfo],
     all_hosts: dict[str, OnlineHostInterface],
+    launch_failures: list[TestMapReduceResult],
     artifact_output_dir: Path | None = None,
     source_dir: Path | None = None,
     base_commit: str | None = None,
@@ -125,9 +127,9 @@ def launch_and_poll_agents(
     2. Pre-launched polling (test_node_ids empty, all_agents pre-populated):
        polls the already-launched agents without launching any new ones.
 
-    all_agents and all_hosts are input/output parameters: pre-existing entries
-    are tracked from the start, and newly launched agents are appended during
-    execution.
+    all_agents, all_hosts, and launch_failures are input/output parameters:
+    pre-existing entries are tracked from the start, and newly launched
+    agents (or new launch failures) are appended during execution.
 
     Returns (final_details, timed_out_ids, cached_results).
     """
@@ -157,6 +159,7 @@ def launch_and_poll_agents(
         "all_agents": all_agents,
         "all_hosts": all_hosts,
         "agent_id_to_info": agent_id_to_info,
+        "launch_failures": launch_failures,
     }
 
     launch_agents_up_to_limit(**launch_kwargs)
@@ -165,7 +168,7 @@ def launch_and_poll_agents(
             last_result_check[aid] = agent_id_to_info[aid].created_at
 
     if report_path is not None:
-        current_results = build_current_results(all_agents, final_details, timed_out_ids, all_hosts)
+        current_results = build_current_results(all_agents, final_details, timed_out_ids, all_hosts, launch_failures)
         generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
     while pending_ids or remaining_tests:
@@ -194,7 +197,9 @@ def launch_and_poll_agents(
                 last_result_check[aid] = agent_id_to_info[aid].created_at
 
         if timed_out_this_round and report_path is not None:
-            current_results = build_current_results(all_agents, final_details, timed_out_ids, all_hosts)
+            current_results = build_current_results(
+                all_agents, final_details, timed_out_ids, all_hosts, launch_failures
+            )
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
         if not pending_ids and not remaining_tests:
@@ -305,7 +310,9 @@ def launch_and_poll_agents(
                     changed = True
 
         if (changed or timed_out_this_round) and report_path is not None:
-            current_results = build_current_results(all_agents, final_details, timed_out_ids, all_hosts)
+            current_results = build_current_results(
+                all_agents, final_details, timed_out_ids, all_hosts, launch_failures
+            )
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
         if pending_ids or remaining_tests:
@@ -413,8 +420,13 @@ def gather_results(
     cg: ConcurrencyGroup,
     base_commit: str | None = None,
     cached_results: dict[str, TestResult] | None = None,
+    launch_failures: Sequence[TestMapReduceResult] = (),
 ) -> list[TestMapReduceResult]:
-    """Gather results from all finished agents, pulling branches where appropriate."""
+    """Gather results from all finished agents, pulling branches where appropriate.
+
+    ``launch_failures`` are prepended to the returned list so agents that
+    failed to launch still appear in the report.
+    """
     results = _collect_agent_results(
         agents=agents,
         final_details=final_details,
@@ -444,7 +456,7 @@ def gather_results(
                         base_commit=base_commit,
                     )
 
-    return results
+    return [*launch_failures, *results]
 
 
 def build_current_results(
@@ -452,16 +464,24 @@ def build_current_results(
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
     hosts: dict[str, OnlineHostInterface],
+    launch_failures: Sequence[TestMapReduceResult] = (),
 ) -> list[TestMapReduceResult]:
-    """Build current results without pulling branches, for intermediate reports."""
-    return _collect_agent_results(
-        agents=agents,
-        final_details=final_details,
-        timed_out_ids=timed_out_ids,
-        hosts=hosts,
-        missing_detail_errored=False,
-        missing_detail_summary="Agent is still running...",
-    )
+    """Build current results without pulling branches, for intermediate reports.
+
+    ``launch_failures`` are prepended so agents that failed to launch still
+    appear in the report.
+    """
+    return [
+        *launch_failures,
+        *_collect_agent_results(
+            agents=agents,
+            final_details=final_details,
+            timed_out_ids=timed_out_ids,
+            hosts=hosts,
+            missing_detail_errored=False,
+            missing_detail_summary="Agent is still running...",
+        ),
+    ]
 
 
 def wait_for_integrator(

--- a/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
@@ -308,7 +308,7 @@ def test_build_current_results_timed_out_agents() -> None:
     results = build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)}, hosts={})
     assert len(results) == 1
     assert results[0].errored is True
-    assert report_section_of(results[0]) == ReportSection.BLOCKED
+    assert report_section_of(results[0]) == ReportSection.FAILED
 
 
 def test_build_current_results_includes_launch_failures() -> None:
@@ -330,7 +330,7 @@ def test_build_current_results_includes_launch_failures() -> None:
     assert results[0].test_node_id == "tests/test_a.py::test_one"
     assert results[0].errored is True
     assert "Failed to launch agent: boom" in results[0].summary_markdown
-    assert report_section_of(results[0]) == ReportSection.BLOCKED
+    assert report_section_of(results[0]) == ReportSection.FAILED
 
 
 def test_build_current_results_launch_failures_come_before_running_agents() -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
@@ -30,6 +30,7 @@ from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
 from imbue.mngr_tmr.data_types import ReportSection
 from imbue.mngr_tmr.data_types import TestAgentInfo
+from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import build_agent_options as _build_agent_options
 from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
@@ -308,6 +309,55 @@ def test_build_current_results_timed_out_agents() -> None:
     assert len(results) == 1
     assert results[0].errored is True
     assert report_section_of(results[0]) == ReportSection.BLOCKED
+
+
+def test_build_current_results_includes_launch_failures() -> None:
+    """Agents that failed to launch should appear in the results as ERRORED."""
+    failure = TestMapReduceResult(
+        test_node_id="tests/test_a.py::test_one",
+        agent_name=AgentName("tmr-test-one-launch-failed"),
+        errored=True,
+        summary_markdown="Failed to launch agent: boom",
+    )
+    results = build_current_results(
+        agents=[],
+        final_details={},
+        timed_out_ids=set(),
+        hosts={},
+        launch_failures=[failure],
+    )
+    assert len(results) == 1
+    assert results[0].test_node_id == "tests/test_a.py::test_one"
+    assert results[0].errored is True
+    assert "Failed to launch agent: boom" in results[0].summary_markdown
+    assert report_section_of(results[0]) == ReportSection.BLOCKED
+
+
+def test_build_current_results_launch_failures_come_before_running_agents() -> None:
+    """Launch failures should be ordered before live-agent results in the report."""
+    failure = TestMapReduceResult(
+        test_node_id="tests/test_failed.py::test_one",
+        agent_name=AgentName("tmr-test-one-launch-failed"),
+        errored=True,
+        summary_markdown="Failed to launch agent: boom",
+    )
+    agent = TestAgentInfo(
+        test_node_id="tests/test_running.py::test_two",
+        agent_id=AgentId.generate(),
+        agent_name=AgentName("tmr-test-two-abc123"),
+        work_dir=Path("/tmp/work"),
+        created_at=0.0,
+    )
+    results = build_current_results(
+        agents=[agent],
+        final_details={},
+        timed_out_ids=set(),
+        hosts={},
+        launch_failures=[failure],
+    )
+    assert len(results) == 2
+    assert results[0].test_node_id == "tests/test_failed.py::test_one"
+    assert results[1].test_node_id == "tests/test_running.py::test_two"
 
 
 # --- _read_local_result / read_integrator_result tests ---

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -24,6 +24,7 @@ from imbue.mngr.cli.output_helpers import emit_event
 from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import HostError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
@@ -319,7 +320,7 @@ def _run_integrator_phase(
             config=config,
             mngr_ctx=mngr_ctx,
         )
-    except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+    except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
         logger.warning("Failed to launch integrator agent: {}", exc)
         return None
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -621,6 +621,8 @@ def _run_tmr_pipeline(
     # Otherwise, all agents are launched up front and then polled via the same function.
     use_batched = opts.max_agents > 0 and opts.max_agents < len(test_node_ids)
 
+    launch_failures: list[TestMapReduceResult] = []
+
     if use_batched:
         if opts.use_snapshot:
             write_human_line("WARNING: --use-snapshot is not supported with --max-agents and will be ignored")
@@ -634,6 +636,7 @@ def _run_tmr_pipeline(
             config=config,
             mngr_ctx=mngr_ctx,
             pytest_flags=testing_flags,
+            launch_failures=launch_failures,
             prompt_suffix=opts.prompt_suffix or "",
             use_snapshot=opts.use_snapshot and provided_snapshot is None,
             max_parallel=opts.max_parallel,
@@ -658,6 +661,7 @@ def _run_tmr_pipeline(
         report_path=html_path,
         all_agents=agent_infos,
         all_hosts=agent_hosts,
+        launch_failures=launch_failures,
         artifact_output_dir=output_dir,
         source_dir=source_dir,
         base_commit=base_commit if is_remote_provider else None,
@@ -677,6 +681,7 @@ def _run_tmr_pipeline(
         cg=mngr_ctx.concurrency_group,
         base_commit=base_commit if is_remote_provider else None,
         cached_results=cached_results,
+        launch_failures=launch_failures,
     )
 
     # Step 9: Write report with final results (artifacts already pulled during polling)

--- a/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
@@ -42,11 +42,19 @@ class Change(FrozenModel):
 
 
 class ReportSection(UpperCaseStrEnum):
-    """Derived section for HTML report grouping and coloring."""
+    """Derived section for HTML report grouping and coloring.
+
+    BLOCKED is reserved for results where the coding agent itself decided
+    the work was too complex (i.e. produced changes whose status is BLOCKED).
+    FAILED is reserved for infrastructure failures: launch failures, agent
+    timeouts, missing details, etc. -- cases where the agent never had a
+    chance to produce a real verdict.
+    """
 
     NON_IMPL_FIXES = auto()
     IMPL_FIXES = auto()
     BLOCKED = auto()
+    FAILED = auto()
     CLEAN_PASS = auto()
     RUNNING = auto()
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -12,6 +12,7 @@ from imbue.mngr.api.create import resolve_target_host
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import HostError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.hosts.host import HostLocation
@@ -284,7 +285,7 @@ def launch_all_test_agents(
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
-            except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+            except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to launch agent: {}", exc)
 
     logger.info("Launched {} agent(s)", len(agents))
@@ -328,7 +329,7 @@ def launch_agents_up_to_limit(
         except TimeoutError:
             logger.warning("Agent creation timed out after {}s for {}", _AGENT_CREATION_TIMEOUT_SECONDS, test_node_id)
             continue
-        except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
+        except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
             continue
         all_agents.append(info)

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -41,15 +41,32 @@ from imbue.mngr_tmr.utils import transfer_mode_for_provider
 _AGENT_CREATION_TIMEOUT_SECONDS = 600.0
 
 
-def _make_launch_failure_result(test_node_id: str, error: object) -> TestMapReduceResult:
+def make_test_agent_identity(test_node_id: str) -> tuple[AgentName, str]:
+    """Generate (agent_name, branch_name) for a test agent.
+
+    Both share a fresh random short_id so they identify the same launch
+    attempt. Callers should generate these once per test and reuse them
+    for both the launch attempt and any failure reporting, so that a
+    failed-launch entry in the report carries the same name the agent
+    would have had if it had succeeded.
+    """
+    name_suffix = sanitize_test_name_for_agent(test_node_id)
+    short_id = short_random_id()
+    return AgentName(f"tmr-{name_suffix}-{short_id}"), f"mngr-tmr/{name_suffix}-{short_id}"
+
+
+def _make_launch_failure_result(test_node_id: str, agent_name: AgentName, error: object) -> TestMapReduceResult:
     """Build a TestMapReduceResult marking that an agent failed to launch.
 
     Used so launch failures still appear in the HTML report (as errored
-    entries in the BLOCKED section) instead of silently disappearing.
+    entries in the FAILED section) instead of silently disappearing.
+    ``agent_name`` should be the name that was used for the launch
+    attempt, so the report row matches the host/tmux session if the
+    user retained it for debugging.
     """
     return TestMapReduceResult(
         test_node_id=test_node_id,
-        agent_name=AgentName(f"tmr-{sanitize_test_name_for_agent(test_node_id)}-launch-failed"),
+        agent_name=agent_name,
         errored=True,
         summary_markdown=f"Failed to launch agent: {error}",
     )
@@ -129,6 +146,8 @@ def _create_tmr_agent(
 
 def launch_test_agent(
     test_node_id: str,
+    agent_name: AgentName,
+    branch_name: str,
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     pytest_flags: tuple[str, ...],
@@ -136,15 +155,16 @@ def launch_test_agent(
     existing_host: OnlineHostInterface | None = None,
     host_name: HostName | None = None,
 ) -> tuple[TestAgentInfo, OnlineHostInterface]:
-    """Launch a single agent to run and optionally fix one test."""
-    agent_name_suffix = sanitize_test_name_for_agent(test_node_id)
-    short_id = short_random_id()
-    agent_name = AgentName(f"tmr-{agent_name_suffix}-{short_id}")
+    """Launch a single agent to run and optionally fix one test.
 
+    ``agent_name`` and ``branch_name`` are passed in (rather than derived
+    from ``test_node_id`` here) so the caller can reuse the same identity
+    when reporting a launch failure.
+    """
     logger.info("Launching agent '{}' for test: {}", agent_name, test_node_id)
     create_result = _create_tmr_agent(
         agent_name=agent_name,
-        branch_name=f"mngr-tmr/{agent_name_suffix}-{short_id}",
+        branch_name=branch_name,
         config=config,
         mngr_ctx=mngr_ctx,
         initial_message=build_test_agent_prompt(test_node_id, pytest_flags, prompt_suffix),
@@ -152,14 +172,13 @@ def launch_test_agent(
         host_name=host_name,
     )
 
-    branch = f"mngr-tmr/{agent_name_suffix}-{short_id}"
     return (
         TestAgentInfo(
             test_node_id=test_node_id,
             agent_id=create_result.agent.id,
             agent_name=create_result.agent.name,
             work_dir=create_result.agent.work_dir,
-            branch_name=branch,
+            branch_name=branch_name,
             created_at=time.monotonic(),
         ),
         create_result.host,
@@ -287,17 +306,20 @@ def launch_all_test_agents(
         name="tmr_launch",
         max_workers=max_parallel,
     ) as executor:
-        futures: list[tuple[Future[tuple[TestAgentInfo, OnlineHostInterface]], str]] = []
+        futures: list[tuple[Future[tuple[TestAgentInfo, OnlineHostInterface]], str, AgentName]] = []
         for i, test_node_id in enumerate(test_node_ids):
             if i > 0 and launch_delay_seconds > 0:
                 time.sleep(launch_delay_seconds)
             existing_host = host_pool[i % len(host_pool)] if host_pool else None
             h_name = HostName(f"{run_name}-host-{i}") if not is_local and not host_pool else None
+            agent_name, branch_name = make_test_agent_identity(test_node_id)
             futures.append(
                 (
                     executor.submit(
                         launch_test_agent,
                         test_node_id,
+                        agent_name,
+                        branch_name,
                         launch_config,
                         mngr_ctx,
                         pytest_flags,
@@ -306,16 +328,17 @@ def launch_all_test_agents(
                         h_name,
                     ),
                     test_node_id,
+                    agent_name,
                 )
             )
-        for future, test_node_id in futures:
+        for future, test_node_id, agent_name in futures:
             try:
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
             except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
-                launch_failures.append(_make_launch_failure_result(test_node_id, exc))
+                launch_failures.append(_make_launch_failure_result(test_node_id, agent_name, exc))
 
     logger.info("Launched {} agent(s)", len(agents))
     return agents, agent_hosts, launch_config.snapshot
@@ -323,6 +346,8 @@ def launch_all_test_agents(
 
 def launch_with_timeout(
     test_node_id: str,
+    agent_name: AgentName,
+    branch_name: str,
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     pytest_flags: tuple[str, ...],
@@ -330,7 +355,9 @@ def launch_with_timeout(
 ) -> tuple[TestAgentInfo, OnlineHostInterface]:
     """Launch a test agent with a timeout. Raises TimeoutError if creation takes too long."""
     with ConcurrencyGroupExecutor(mngr_ctx.concurrency_group, name="launch-agent", max_workers=1) as executor:
-        future = executor.submit(launch_test_agent, test_node_id, config, mngr_ctx, pytest_flags, prompt_suffix)
+        future = executor.submit(
+            launch_test_agent, test_node_id, agent_name, branch_name, config, mngr_ctx, pytest_flags, prompt_suffix
+        )
         return future.result(timeout=_AGENT_CREATION_TIMEOUT_SECONDS)
 
 
@@ -356,19 +383,22 @@ def launch_agents_up_to_limit(
     """
     while remaining_tests and (max_agents <= 0 or len(pending_ids) < max_agents):
         test_node_id = remaining_tests.pop(0)
+        agent_name, branch_name = make_test_agent_identity(test_node_id)
         try:
-            info, host = launch_with_timeout(test_node_id, config, mngr_ctx, pytest_flags, prompt_suffix)
+            info, host = launch_with_timeout(
+                test_node_id, agent_name, branch_name, config, mngr_ctx, pytest_flags, prompt_suffix
+            )
         except TimeoutError:
             logger.warning("Agent creation timed out after {}s for {}", _AGENT_CREATION_TIMEOUT_SECONDS, test_node_id)
             launch_failures.append(
                 _make_launch_failure_result(
-                    test_node_id, f"creation timed out after {_AGENT_CREATION_TIMEOUT_SECONDS}s"
+                    test_node_id, agent_name, f"creation timed out after {_AGENT_CREATION_TIMEOUT_SECONDS}s"
                 )
             )
             continue
         except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
-            launch_failures.append(_make_launch_failure_result(test_node_id, exc))
+            launch_failures.append(_make_launch_failure_result(test_node_id, agent_name, exc))
             continue
         all_agents.append(info)
         all_hosts[str(info.agent_id)] = host

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -2,6 +2,7 @@
 
 import math
 import time
+from concurrent.futures import Future
 
 from loguru import logger
 
@@ -28,6 +29,7 @@ from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr_tmr.data_types import TestAgentInfo
+from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.prompts import build_integrator_prompt
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
@@ -37,6 +39,20 @@ from imbue.mngr_tmr.utils import short_random_id
 from imbue.mngr_tmr.utils import transfer_mode_for_provider
 
 _AGENT_CREATION_TIMEOUT_SECONDS = 600.0
+
+
+def _make_launch_failure_result(test_node_id: str, error: object) -> TestMapReduceResult:
+    """Build a TestMapReduceResult marking that an agent failed to launch.
+
+    Used so launch failures still appear in the HTML report (as errored
+    entries in the BLOCKED section) instead of silently disappearing.
+    """
+    return TestMapReduceResult(
+        test_node_id=test_node_id,
+        agent_name=AgentName(f"tmr-{sanitize_test_name_for_agent(test_node_id)}-launch-failed"),
+        errored=True,
+        summary_markdown=f"Failed to launch agent: {error}",
+    )
 
 
 def _resolve_build_options(config: TmrLaunchConfig, mngr_ctx: MngrContext) -> NewHostBuildOptions:
@@ -224,6 +240,7 @@ def launch_all_test_agents(
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     pytest_flags: tuple[str, ...],
+    launch_failures: list[TestMapReduceResult],
     prompt_suffix: str = "",
     use_snapshot: bool = False,
     max_parallel: int = 4,
@@ -236,6 +253,9 @@ def launch_all_test_agents(
     For remote providers, agents_per_host controls how many agents share a single
     host. Hosts are pre-created in a pool and agents are assigned round-robin.
     For local providers, this setting is ignored (all agents share localhost).
+
+    Per-test launch failures are appended (in place) to ``launch_failures`` so
+    they can be surfaced in the report.
     """
     agents: list[TestAgentInfo] = []
     agent_hosts: dict[str, OnlineHostInterface] = {}
@@ -267,31 +287,35 @@ def launch_all_test_agents(
         name="tmr_launch",
         max_workers=max_parallel,
     ) as executor:
-        futures = []
+        futures: list[tuple[Future[tuple[TestAgentInfo, OnlineHostInterface]], str]] = []
         for i, test_node_id in enumerate(test_node_ids):
             if i > 0 and launch_delay_seconds > 0:
                 time.sleep(launch_delay_seconds)
             existing_host = host_pool[i % len(host_pool)] if host_pool else None
             h_name = HostName(f"{run_name}-host-{i}") if not is_local and not host_pool else None
             futures.append(
-                executor.submit(
-                    launch_test_agent,
+                (
+                    executor.submit(
+                        launch_test_agent,
+                        test_node_id,
+                        launch_config,
+                        mngr_ctx,
+                        pytest_flags,
+                        prompt_suffix,
+                        existing_host,
+                        h_name,
+                    ),
                     test_node_id,
-                    launch_config,
-                    mngr_ctx,
-                    pytest_flags,
-                    prompt_suffix,
-                    existing_host,
-                    h_name,
                 )
             )
-        for future in futures:
+        for future, test_node_id in futures:
             try:
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
             except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
-                logger.warning("Failed to launch agent: {}", exc)
+                logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
+                launch_failures.append(_make_launch_failure_result(test_node_id, exc))
 
     logger.info("Launched {} agent(s)", len(agents))
     return agents, agent_hosts, launch_config.snapshot
@@ -321,11 +345,14 @@ def launch_agents_up_to_limit(
     all_agents: list[TestAgentInfo],
     all_hosts: dict[str, OnlineHostInterface],
     agent_id_to_info: dict[str, TestAgentInfo],
+    launch_failures: list[TestMapReduceResult],
 ) -> None:
     """Launch agents from remaining_tests until we hit max_agents running.
 
     Mutates remaining_tests (pops from front), pending_ids, all_agents,
-    all_hosts, and agent_id_to_info in place.
+    all_hosts, agent_id_to_info, and launch_failures in place. Per-test
+    launch failures are appended to ``launch_failures`` so they can be
+    surfaced in the report.
     """
     while remaining_tests and (max_agents <= 0 or len(pending_ids) < max_agents):
         test_node_id = remaining_tests.pop(0)
@@ -333,9 +360,15 @@ def launch_agents_up_to_limit(
             info, host = launch_with_timeout(test_node_id, config, mngr_ctx, pytest_flags, prompt_suffix)
         except TimeoutError:
             logger.warning("Agent creation timed out after {}s for {}", _AGENT_CREATION_TIMEOUT_SECONDS, test_node_id)
+            launch_failures.append(
+                _make_launch_failure_result(
+                    test_node_id, f"creation timed out after {_AGENT_CREATION_TIMEOUT_SECONDS}s"
+                )
+            )
             continue
         except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
+            launch_failures.append(_make_launch_failure_result(test_node_id, exc))
             continue
         all_agents.append(info)
         all_hosts[str(info.agent_id)] = host

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -92,11 +92,16 @@ def _create_tmr_agent(
 
     if existing_host is not None:
         target_host: OnlineHostInterface | NewHostOptions = existing_host
+    elif config.provider_name.lower() == LOCAL_PROVIDER_NAME:
+        # The local provider has a single fixed host ("localhost"); reuse the
+        # source_host (already the local host) instead of the new-host path.
+        # That path would call _generate_unique_host_name, which never finds
+        # a free name because the local provider's get_host_name always
+        # returns "localhost" and discover_hosts always reports it as taken.
+        target_host = config.source_host
     else:
         build = _resolve_build_options(config, mngr_ctx)
-        is_local = config.provider_name.lower() == LOCAL_PROVIDER_NAME
-        resolved_host_name = None if is_local else host_name
-        target_host = NewHostOptions(provider=config.provider_name, name=resolved_host_name, build=build)
+        target_host = NewHostOptions(provider=config.provider_name, name=host_name, build=build)
 
     return api_create(
         source_location=source_location,

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -27,6 +27,7 @@ _SECTION_ORDER: list[ReportSection] = [
     ReportSection.NON_IMPL_FIXES,
     ReportSection.IMPL_FIXES,
     ReportSection.BLOCKED,
+    ReportSection.FAILED,
     ReportSection.CLEAN_PASS,
     ReportSection.RUNNING,
 ]
@@ -35,6 +36,7 @@ _SECTION_LABELS: dict[ReportSection, str] = {
     ReportSection.NON_IMPL_FIXES: "Non-implementation fixes",
     ReportSection.IMPL_FIXES: "Implementation fixes",
     ReportSection.BLOCKED: "Blocked",
+    ReportSection.FAILED: "Failed",
     ReportSection.CLEAN_PASS: "Clean pass",
     ReportSection.RUNNING: "Running",
 }
@@ -43,6 +45,7 @@ _SECTION_COLORS: dict[ReportSection, str] = {
     ReportSection.NON_IMPL_FIXES: "rgb(33, 150, 243)",
     ReportSection.IMPL_FIXES: "rgb(76, 175, 80)",
     ReportSection.BLOCKED: "rgb(244, 67, 54)",
+    ReportSection.FAILED: "rgb(255, 152, 0)",
     ReportSection.CLEAN_PASS: "rgb(158, 158, 158)",
     ReportSection.RUNNING: "rgb(3, 169, 244)",
 }
@@ -53,9 +56,15 @@ _NON_IMPL_CHANGE_KINDS = frozenset({ChangeKind.FIX_TEST, ChangeKind.IMPROVE_TEST
 
 
 def report_section_of(result: TestMapReduceResult) -> ReportSection:
-    """Derive a report section from a result for report grouping/coloring."""
+    """Derive a report section from a result for report grouping/coloring.
+
+    ``errored=True`` indicates an infrastructure failure (launch failed,
+    agent timed out, details missing) and is rendered in the FAILED section.
+    The BLOCKED section is reserved for results where the coding agent
+    itself reported every change as BLOCKED.
+    """
     if result.errored:
-        return ReportSection.BLOCKED
+        return ReportSection.FAILED
     if result.tests_passing_before is None and result.tests_passing_after is None and not result.changes:
         return ReportSection.RUNNING
     if result.changes and all(c.status == ChangeStatus.BLOCKED for c in result.changes.values()):

--- a/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
@@ -23,7 +23,7 @@ from imbue.mngr_tmr.testing import make_test_result
 
 
 def test_report_section_errored() -> None:
-    assert report_section_of(make_test_result(errored=True)) == ReportSection.BLOCKED
+    assert report_section_of(make_test_result(errored=True)) == ReportSection.FAILED
 
 
 def test_report_section_running() -> None:
@@ -332,6 +332,7 @@ def test_generate_html_report_all_report_sections(tmp_path: Path) -> None:
             ReportSection.NON_IMPL_FIXES: "Non-implementation fixes",
             ReportSection.IMPL_FIXES: "Implementation fixes",
             ReportSection.BLOCKED: "Blocked",
+            ReportSection.FAILED: "Failed",
             ReportSection.CLEAN_PASS: "Clean pass",
             ReportSection.RUNNING: "Running",
         }[sec]

--- a/scripts/claude_update_plugin.sh
+++ b/scripts/claude_update_plugin.sh
@@ -15,4 +15,5 @@ rm -rf "$CACHE_DIR/imbue-mngr" "$CACHE_DIR/imbue-code-guardian" 2>/dev/null || t
 # The plugin and marketplace are configured at project scope in
 # .claude/settings.json (extraKnownMarketplaces + enabledPlugins),
 # so Claude Code handles installation automatically. Just update.
-claude plugin update "$PLUGIN_ID" 2>/dev/null || true
+GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes' \
+  claude plugin update "$PLUGIN_ID" 2>/dev/null || true


### PR DESCRIPTION
## Summary

A grab-bag of TMR / Modal-provider reliability fixes, plus visibility tweaks for the HTML report and `-vv` timing logs.

### TMR orchestrator no longer crashes on partial agent failures
- Catch `AgentError` (e.g. `SendMessageError` from the tmux paste-detection timeout) when launching test agents and the integrator. Previously the whole orchestrator died because `SendMessageError` is `AgentError → BaseMngrError`, not `MngrError`, so the existing `(MngrError, HostError, OSError, BaseExceptionGroup)` clauses didn't catch it.
- Tests whose agent failed to launch now appear in the HTML report (with the actual agent name that was used for the launch attempt, so the row matches any surviving host/tmux session) instead of being silently dropped.

### TMR HTML report
- New dedicated **Failed** section, separate from **Blocked**. Errored results (launch failure, agent timeout, missing details) used to be lumped into Blocked, but Blocked is supposed to mean the coding agent itself reported every change as BLOCKED -- those are different failure patterns and now have separate sections + colors.

### TMR integrator launch (and any local-provider TMR run)
- Fix `Failed to generate a unique host name after 100 attempts`. The local provider has a single fixed host (`localhost`), so the new-host path can never find a free name; TMR now reuses the existing local host when the target provider is `local`, mirroring what `mngr create` already does. This consistently broke the integrator (which defaults to `--integrator-provider local`).

### Modal-launched agents no longer hang at SSH TOFU prompt
- The `claude plugin update` SessionStart hook script shells out to `git pull`, which uses `ssh`. On a fresh Modal sandbox `~/.ssh/known_hosts` is empty, so ssh blocks on a "Are you sure you want to continue connecting" prompt that Claude Code's bypass-permissions setting does NOT cover -- breaking TUI-driving tests like TMR's send-enter-and-wait.
- Prefix the update with `GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes'`. `accept-new` writes the first-seen host key to known_hosts (so subsequent ssh-via-git calls in the same sandbox don't re-prompt), and `BatchMode=yes` exits non-interactively on failure.

### `-vv` timing visibility
- `mngr create -vv` now emits a `Transferring agent files` log_span around `_execute_agent_file_transfers`, with `count=N` (including `count=0` when the agent declared no transfers). Previously the per-file `write_file` calls were only logged at `trace` and the aggregate cost was invisible.

## Test plan

- [x] `just test-quick libs/mngr_tmr` — 175 passed
- [x] `just test-quick libs/mngr` — 3797 passed
- [x] `just test-quick libs/mngr_claude` — 458 passed
- [x] Run `mngr tmr --provider modal` end-to-end with at least one test whose agent will fail to receive its initial message; confirm:
  - the orchestrator does not crash
  - the failed test shows up in the HTML report under the new **Failed** section
  - its row in the report shows the actual agent name (e.g. `tmr-test-foo-f95667`), not a `-launch-failed` placeholder
  - other agents continue normally
- [x] Run `mngr tmr --provider local` end-to-end and verify the integrator launches successfully (no `Failed to generate a unique host name` error). Test agents should also work locally.
- [x] Run `mngr create -vv` against a Modal host and confirm `Transferring agent files [done in X sec]` appears in the timing output.
- [x] On a fresh Modal sandbox, confirm Claude Code starts cleanly without the github.com SSH TOFU prompt sitting in the tmux pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)