### PR TITLE
Rename --attach-command flag to --session-command

### DIFF
--- a/changelog/mngr-rename-attach-cmd-take-2.md
+++ b/changelog/mngr-rename-attach-cmd-take-2.md
@@ -1,0 +1,1 @@
+Renamed the `--attach-command` flag on `mngr create` and `mngr connect` to `--session-command`.

--- a/libs/mngr/analysis/raw-types-2026-01-19.md
+++ b/libs/mngr/analysis/raw-types-2026-01-19.md
@@ -97,11 +97,11 @@ Recommendation: Change to `command: CommandString = Field(...)`. Commands should
 
 Decision: Accept
 
-## 11. ConnectionOptions.attach_command uses plain str instead of CommandString
+## 11. ConnectionOptions.session_command uses plain str instead of CommandString
 
-Description: In `libs/mngr/imbue/mngr/api/data_types.py:172-175`, `attach_command` is declared as `attach_command: str | None = Field(...)`.
+Description: In `libs/mngr/imbue/mngr/api/data_types.py:172-175`, `session_command` is declared as `session_command: str | None = Field(...)`.
 
-Recommendation: Change to `attach_command: CommandString | None`. When specified, attach commands should be non-empty.
+Recommendation: Change to `session_command: CommandString | None`. When specified, session commands should be non-empty.
 
 Decision: Accept
 

--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -53,7 +53,7 @@ mngr connect [OPTIONS] [AGENT]
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--reconnect`, `--no-reconnect` | boolean | Automatically reconnect if dropped [future] | `True` |
-| `--attach-command` | text | Command to run instead of attaching to main session [future] | None |
+| `--session-command` | text | Command to run instead of attaching to main session [future] | None |
 | `--allow-unknown-host`, `--no-allow-unknown-host` | boolean | Allow connecting to hosts without a known_hosts file (disables SSH host key verification) | `False` |
 
 ## Filtering

--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -174,7 +174,7 @@ See [connect options](./connect.md) for full details (only applies if `--connect
 | `--message` | text | Initial message to send after the agent starts | None |
 | `--message-file` | path | File containing initial message to send | None |
 | `--edit-message` | boolean | Open an editor to compose the initial message (uses $EDITOR). Editor runs in parallel with agent creation. If --message or --message-file is provided, their content is used as initial editor content. | `False` |
-| `--attach-command` | text | Command to run instead of attaching to main session | None |
+| `--session-command` | text | Command to run instead of attaching to main session | None |
 | `--connect-command` | text | Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set. | None |
 
 ## Automation

--- a/libs/mngr/imbue/mngr/api/data_types.py
+++ b/libs/mngr/imbue/mngr/api/data_types.py
@@ -41,7 +41,7 @@ class ConnectionOptions(FrozenModel):
         default="5s",
         description="Delay between retries (e.g., 5s, 1m)",
     )
-    attach_command: str | None = Field(
+    session_command: str | None = Field(
         default=None,
         description="Command to run instead of attaching to main session",
     )

--- a/libs/mngr/imbue/mngr/cli/conftest.py
+++ b/libs/mngr/imbue/mngr/cli/conftest.py
@@ -94,7 +94,7 @@ def default_create_cli_opts() -> CreateCliOptions:
         message=None,
         message_file=None,
         edit_message=False,
-        attach_command=None,
+        session_command=None,
         connect_command=None,
         idle_timeout=None,
         idle_mode=None,
@@ -129,7 +129,7 @@ def default_connect_cli_opts() -> ConnectCliOptions:
         agent=None,
         start=True,
         reconnect=True,
-        attach_command=None,
+        session_command=None,
         allow_unknown_host=False,
     )
 

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -51,7 +51,7 @@ class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
     agent: str | None
     start: bool
     reconnect: bool
-    attach_command: str | None
+    session_command: str | None
     allow_unknown_host: bool
 
 
@@ -328,7 +328,7 @@ def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) ->
         is_reconnect=opts.reconnect,
         retry_count=mngr_ctx.config.retry.connect_retry_times,
         retry_delay=mngr_ctx.config.retry.connect_retry_delay,
-        attach_command=opts.attach_command,
+        session_command=opts.session_command,
         is_unknown_host_allowed=opts.allow_unknown_host,
     )
 
@@ -350,7 +350,7 @@ def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) ->
     show_default=True,
     help="Automatically reconnect if dropped [future]",
 )
-@optgroup.option("--attach-command", help="Command to run instead of attaching to main session [future]")
+@optgroup.option("--session-command", help="Command to run instead of attaching to main session [future]")
 @optgroup.option(
     "--allow-unknown-host/--no-allow-unknown-host",
     "allow_unknown_host",
@@ -370,8 +370,8 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
 
     # Run this command instead of the default tmux attach
     # Useful for running a different shell or command in the agent's environment
-    if opts.attach_command is not None:
-        raise NotImplementedError("--attach-command is not implemented yet")
+    if opts.session_command is not None:
+        raise NotImplementedError("--session-command is not implemented yet")
 
     # Disable automatic reconnection if the connection is dropped
     # Default behavior (--reconnect) should automatically reconnect

--- a/libs/mngr/imbue/mngr/cli/connect_test.py
+++ b/libs/mngr/imbue/mngr/cli/connect_test.py
@@ -19,7 +19,7 @@ def _make_connect_opts(
     agent: str | None = "my-agent",
     start: bool = True,
     reconnect: bool = True,
-    attach_command: str | None = None,
+    session_command: str | None = None,
     allow_unknown_host: bool = False,
     output_format: str = "human",
     quiet: bool = False,
@@ -34,7 +34,7 @@ def _make_connect_opts(
         agent=agent,
         start=start,
         reconnect=reconnect,
-        attach_command=attach_command,
+        session_command=session_command,
         allow_unknown_host=allow_unknown_host,
         output_format=output_format,
         quiet=quiet,
@@ -204,7 +204,7 @@ def test_build_connection_options_default_values(temp_mngr_ctx: MngrContext) -> 
     assert conn_opts.is_reconnect is True
     assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
     assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert conn_opts.attach_command is None
+    assert conn_opts.session_command is None
     assert conn_opts.is_unknown_host_allowed is False
 
 
@@ -212,14 +212,14 @@ def test_build_connection_options_custom_values(temp_mngr_ctx: MngrContext) -> N
     """_build_connection_options should map custom CLI values correctly."""
     opts = _make_connect_opts(
         reconnect=False,
-        attach_command="ssh user@host",
+        session_command="ssh user@host",
         allow_unknown_host=True,
     )
     conn_opts = _build_connection_options(opts, temp_mngr_ctx)
     assert conn_opts.is_reconnect is False
     assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
     assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert conn_opts.attach_command == "ssh user@host"
+    assert conn_opts.session_command == "ssh user@host"
     assert conn_opts.is_unknown_host_allowed is True
 
 

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -187,7 +187,7 @@ def _resolve_or_generate_agent_name(address: AgentAddress, opts: CreateCliOption
 # ``_reject_incompatible_headless_flags`` for rationale.
 _HEADLESS_INCOMPATIBLE_FLAGS: tuple[tuple[str, str], ...] = (
     ("edit_message", "--edit-message"),
-    ("attach_command", "--attach-command"),
+    ("session_command", "--session-command"),
     ("connect_command", "--connect-command"),
 )
 
@@ -239,7 +239,7 @@ def _reject_incompatible_headless_flags(
         raise UserInputError(
             f"Headless agent type '{agent_type_name}' does not support: {flags_str}. "
             f"The headless flow streams output and auto-destroys, so flags for the "
-            f"post-create connect/attach phase (e.g. --reconnect, --attach-command), "
+            f"post-create connect/attach phase (e.g. --reconnect, --session-command), "
             f"for send-message-based delivery (--edit-message), and for long-lived "
             f"agents (--reuse, --update, --start-on-boot) do not apply."
         )
@@ -522,7 +522,7 @@ class _CreateCommand(click.Command):
     is_flag=True,
     help="Open an editor to compose the initial message (uses $EDITOR). Editor runs in parallel with agent creation. If --message or --message-file is provided, their content is used as initial editor content.",
 )
-@optgroup.option("--attach-command", help="Command to run instead of attaching to main session")
+@optgroup.option("--session-command", help="Command to run instead of attaching to main session")
 @optgroup.option(
     "--connect-command",
     help="Command to run instead of the builtin connect. MNGR_AGENT_NAME and MNGR_SESSION_NAME env vars are set.",
@@ -817,7 +817,7 @@ def _create_agent(
         message=None,
         retry_count=mngr_ctx.config.retry.connect_retry_times,
         retry_delay=mngr_ctx.config.retry.connect_retry_delay,
-        attach_command=opts.attach_command,
+        session_command=opts.session_command,
     )
 
     # If --reuse is set, try to find and reuse an existing agent with the same name

--- a/libs/mngr/imbue/mngr/cli/create_test.py
+++ b/libs/mngr/imbue/mngr/cli/create_test.py
@@ -1022,7 +1022,7 @@ def test_create_headless_allows_no_forms_of_boolean_pair_flags(
     Matches the --no-connect treatment: headless already does not
     connect/reconnect/reuse/update/start-on-boot, so the --no-* form is a
     redundant-but-compatible assertion, not a conflict. Pairs each
-    allowed flag with --attach-command (still rejected) so the validator
+    allowed flag with --session-command (still rejected) so the validator
     runs and we can confirm the allowed flag is not in the error listing.
     """
     result = cli_runner.invoke(
@@ -1032,14 +1032,14 @@ def test_create_headless_allows_no_forms_of_boolean_pair_flags(
             "headless_command",
             "--foreground",
             no_form_flag,
-            "--attach-command",
+            "--session-command",
             "tmux attach",
         ],
         obj=plugin_manager,
     )
 
     assert result.exit_code != 0
-    assert "--attach-command" in result.output
+    assert "--session-command" in result.output
     assert no_form_flag not in result.output
 
 

--- a/libs/mngr/imbue/mngr/cli/help_formatter_test.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter_test.py
@@ -580,7 +580,7 @@ _SYNOPSIS_OPTOUT_FLAGS: dict[str, frozenset[str]] = {
             "--pass-host-env",
             "--activity-sources",
             "--reconnect",
-            "--attach-command",
+            "--session-command",
             "--connect-command",
         }
     ),

--- a/libs/mngr/imbue/mngr/cli/start.py
+++ b/libs/mngr/imbue/mngr/cli/start.py
@@ -221,7 +221,7 @@ def start(ctx: click.Context, **kwargs: Any) -> None:
                 is_reconnect=True,
                 retry_count=mngr_ctx.config.retry.connect_retry_times,
                 retry_delay=mngr_ctx.config.retry.connect_retry_delay,
-                attach_command=None,
+                session_command=None,
                 is_unknown_host_allowed=False,
             )
             logger.info("Connecting to agent: {}", last_started_agent.name)

--- a/libs/mngr/imbue/mngr/cli/test_connect.py
+++ b/libs/mngr/imbue/mngr/cli/test_connect.py
@@ -325,7 +325,7 @@ def test_build_connection_options_maps_all_fields(
     """Test that all ConnectCliOptions fields are correctly mapped to ConnectionOptions."""
     opts = default_connect_cli_opts.model_copy_update(
         to_update(default_connect_cli_opts.field_ref().reconnect, False),
-        to_update(default_connect_cli_opts.field_ref().attach_command, "bash"),
+        to_update(default_connect_cli_opts.field_ref().session_command, "bash"),
         to_update(default_connect_cli_opts.field_ref().allow_unknown_host, True),
     )
 
@@ -334,7 +334,7 @@ def test_build_connection_options_maps_all_fields(
     assert connection_opts.is_reconnect is False
     assert connection_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
     assert connection_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert connection_opts.attach_command == "bash"
+    assert connection_opts.session_command == "bash"
     assert connection_opts.is_unknown_host_allowed is True
 
 

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -918,7 +918,7 @@ class CreateCliOptions(CommonCliOptions):
     message: str | None
     message_file: str | None
     edit_message: bool
-    attach_command: str | None
+    session_command: str | None
     idle_timeout: str | None
     idle_mode: str | None
     activity_sources: str | None


### PR DESCRIPTION
## Summary
- Renames the `--attach-command` CLI flag on `mngr create` and `mngr connect` to `--session-command`, along with the underlying `attach_command` field on `ConnectionOptions`, `CreateCliOptions`, and `ConnectCliOptions`.
- Updates all call sites, default-value sites, public docs, and the historical analysis doc entry.
- Take 2: the original rename PR (`mngr/rename-attach-cmd`) landed before `_HEADLESS_INCOMPATIBLE_FLAGS`, the headless flag-rejection error message, and `help_formatter_test.py`'s flag list referenced the flag, so this PR re-applies the rename and covers those new sites.

## Test plan
- [x] `just test-quick` over the affected CLI test files (242 passed)
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` (3797 passed)
- [ ] CI runs full offload + acceptance suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)