### PR TITLE
mngr list: route per-provider errors through events file (fixes --format json validity)

### DIFF
--- a/libs/mngr/imbue/mngr/api/discovery_events.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events.py
@@ -403,32 +403,6 @@ def emit_discovery_error_event(
     logger.trace("Emitted discovery_error event: {} from {}", error_type, source_name)
 
 
-def emit_discovery_error_to_stdout(
-    error_type: str,
-    error_message: str,
-    source_name: str,
-    provider_name: str | None = None,
-) -> None:
-    """Write a discovery error event as a JSONL line to stdout.
-
-    Used in contexts where the events_base_dir is not available (e.g. list.py).
-    The discovery stream tail thread will pick it up from stdout.
-    """
-    timestamp, event_id = _make_envelope_fields()
-    event = DiscoveryErrorEvent(
-        timestamp=timestamp,
-        event_id=event_id,
-        source=DISCOVERY_EVENT_SOURCE,
-        error_type=error_type,
-        error_message=error_message,
-        source_name=source_name,
-        provider_name=provider_name,
-    )
-    line = json.dumps(event.model_dump(mode="json"), separators=(",", ":"))
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
-
-
 def emit_discovery_events_for_host(
     config: MngrConfig,
     host: OnlineHostInterface,

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -15,7 +15,7 @@ from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.discover import warn_on_duplicate_host_names
-from imbue.mngr.api.discovery_events import emit_discovery_error_to_stdout
+from imbue.mngr.api.discovery_events import emit_discovery_error_event
 from imbue.mngr.api.discovery_events import emit_host_ssh_info
 from imbue.mngr.api.discovery_events import extract_agents_and_hosts_from_full_listing
 from imbue.mngr.api.discovery_events import write_full_discovery_snapshot
@@ -263,10 +263,12 @@ def _construct_and_discover_for_provider(
                 raise
             raise MngrError(str(e)) from e
         logger.opt(exception=e).error("Error discovering agents for provider {}", provider_name)
-        emit_discovery_error_to_stdout(
+        emit_discovery_error_event(
+            mngr_ctx.config,
             error_type=type(e).__name__,
             error_message=str(e),
             source_name=str(provider_name),
+            provider_name=str(provider_name),
         )
         error_info = ProviderErrorInfo.build_for_provider(e, provider_name)
         with results_lock:
@@ -478,10 +480,12 @@ def _construct_discover_and_emit_for_provider(
                 raise
             raise MngrError(str(e)) from e
         logger.opt(exception=e).error("Error discovering agents for provider {}", provider_name)
-        emit_discovery_error_to_stdout(
+        emit_discovery_error_event(
+            mngr_ctx.config,
             error_type=type(e).__name__,
             error_message=str(e),
             source_name=str(provider_name),
+            provider_name=str(provider_name),
         )
         error_info = ProviderErrorInfo.build_for_provider(e, provider_name)
         with results_lock:
@@ -564,10 +568,12 @@ def _process_host_with_error_handling(
                 raise
             raise MngrError(str(e)) from e
         logger.opt(exception=e).error("Error processing host {}", host_ref.host_id)
-        emit_discovery_error_to_stdout(
+        emit_discovery_error_event(
+            provider.mngr_ctx.config,
             error_type=type(e).__name__,
             error_message=str(e),
             source_name=str(host_ref.host_id),
+            provider_name=str(provider.name),
         )
         error_info = HostErrorInfo.build_for_host(e, host_ref.host_id)
         with results_lock:


### PR DESCRIPTION
## Behavior delta vs before this PR

| consumer | before | after | delta |
|---|---|---|---|
| `mngr list` direct stdout consumer (e.g. `\| jq`) | got malformed `DISCOVERY_ERROR` JSONL line mixed with intended output | gets format-correct stdout only | **bug fixed** |
| `mngr observe --discovery-only` (cross-process) | did not see errors from other processes' `mngr list` runs | sees them within ~1s (one tail poll cycle) | **new capability** |
| `mngr observe --discovery-only` (in-process snapshot) | saw via direct stdout write (synchronous) | sees via file → tail (~1s latency) | preserved, +1s latency |
| `mngr events` / future tail-the-file consumer | could not see DISCOVERY_ERROR (events bypassed file) | sees them | **new capability** |

The 1-second latency in the in-process path comes from `_discovery_stream_tail_events_file`'s 1.0s poll interval. Not user-meaningful; no known consumer requires sub-second discovery-error notification.

Empirically verified: under `MODAL_CONFIG_PATH=/dev/null`, observe's stdout `event_id` exactly matches the new line in the events file — same 32-char hash — proving the full chain `in-process emit → file → tail thread → observe stdout`.

## Symptom
`mngr list --format json --on-error continue` produced **invalid JSON** when any provider failed: stdout contained a JSONL `DISCOVERY_ERROR` line followed by the main JSON document — two top-level JSON objects, which `json.load` rejects with `Extra data`.

Repro before this PR:
```sh
MODAL_CONFIG_PATH=/dev/null uv run mngr list --format json --on-error continue 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)"
# json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char 615)
```

`apps/minds/imbue/minds/config/data_types.py:38` has been carrying a defensive parser specifically for this — finds the first line starting with `{` instead of using `json.load(stdout)`. That defensive parser becomes a no-op once stdout is clean JSON.

## Root cause
`emit_discovery_error_to_stdout` (called from three sites in `api/list.py`) wrote a JSONL line directly to stdout regardless of the requested `--format`:

```python
def emit_discovery_error_to_stdout(error_type, error_message, source_name, provider_name=None) -> None:
    ...
    sys.stdout.write(json.dumps(...) + "\n")
    sys.stdout.flush()
```

For human format, this produced a stray JSON line above the table. For json format, two concatenated documents = broken JSON. For jsonl format, the line duplicated the per-provider error already emitted by the `on_error` callback.

## Fix
Replace the three call sites with `emit_discovery_error_event(mngr_ctx.config, ...)`, which appends to `~/.mngr/events/mngr/discovery/events.jsonl`. Discovery-stream consumers (`mngr observe --discovery-only`) pick the event up from the file via the existing tail thread; `mngr list` stdout stays format-correct.

Remove the now-unused `emit_discovery_error_to_stdout` function from `discovery_events.py` — only `api/list.py` called it.

## Test plan
- [x] `MODAL_CONFIG_PATH=/dev/null mngr list --format json --on-error continue` → **valid JSON**, `agents=10, errors=1`, `errors[0].provider_name='modal'`, exit 1.
- [x] `MODAL_CONFIG_PATH=/dev/null mngr list --on-error continue` → stdout starts with `NAME ...` header, no JSONL pollution, exit 1.
- [x] `MODAL_CONFIG_PATH=/dev/null mngr list --format jsonl --on-error continue` → one `event:error` line, no `DISCOVERY_ERROR` line, exit 1.
- [x] Events file gets `DISCOVERY_ERROR` entry on each failing run; each entry has a unique `event_id`.
- [x] Cross-process: separate `mngr observe --discovery-only` running in another shell sees the new event ~1s after `mngr list` completes.
- [x] In-process: `mngr observe --discovery-only` with `MODAL_CONFIG_PATH=/dev/null` gets a `DISCOVERY_ERROR` from its own internal `list_agents` call; `event_id` on observe's stdout matches the new line in the events file exactly.
- [x] `mngr list --format json` (real creds) → unchanged, valid JSON, exit 0.
- [x] 267 unit tests in `list_test.py` + `cli/list_test.py` + `discovery_events_test.py` pass.

## Scope / context
First of four follow-ups to PR #1461 (per-provider --on-error isolation). The other three (`result.warnings` infrastructure; partial JSON on `--on-error abort`; events file completeness with partial `DISCOVERY_FULL`) are independent and can land in any order.
