### PR TITLE
ci: upgrade offload from 0.9.0 to 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.0-${{ runner.os }}
+          key: cargo-offload-0.9.2-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.0'; then
-            cargo install offload@0.9.0 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.2'; then
+            cargo install offload@0.9.2 --force
           fi
 
       - name: Restore offload test durations from previous run
@@ -255,12 +255,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.0-${{ runner.os }}
+          key: cargo-offload-0.9.2-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.0'; then
-            cargo install offload@0.9.0 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.2'; then
+            cargo install offload@0.9.2 --force
           fi
 
       - name: Restore offload test durations from previous run

--- a/changelog/danver-upgrade-to-offload-0-9-2.md
+++ b/changelog/danver-upgrade-to-offload-0-9-2.md
@@ -1,0 +1,1 @@
+Upgrade offload from 0.9.0 to 0.9.2 in CI. Picks up a fix for thin-diff application.

--- a/changelog/danver-upgrade-to-offload-0-9-2.md
+++ b/changelog/danver-upgrade-to-offload-0-9-2.md
@@ -1,1 +1,1 @@
-Upgrade offload from 0.9.0 to 0.9.2 in CI. Picks up a fix for thin-diff application.
+Upgrade offload from 0.9.0 to 0.9.2 in CI. Picks up a fix for thin-diff application. Adds the offload binary to the sandbox image (via a multi-stage build) so 0.9.2's `offload apply-diff` step works without falling back to a full rebuild, and propagates `GITHUB_HEAD_REF` / `GITHUB_REF_NAME` through to sandboxes so branch-aware tests like the changelog-entry ratchet identify the PR branch correctly.

--- a/justfile
+++ b/justfile
@@ -58,7 +58,9 @@ test-offload args="":
     : "${MODAL_TOKEN_SECRET:?must be set}"
     just _generate-dockerignore
     trap "rm -f .dockerignore" EXIT
-    offload -c offload-modal.toml run --trace {{args}} || [[ $? -eq 2 ]]
+    offload -c offload-modal.toml run --trace \
+        --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
+        --env "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" {{args}} || [[ $? -eq 2 ]]
 
     # Copy results to the main worktree so new worktrees inherit baselines via COPY mode.
     MAIN_WORKTREE=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
@@ -78,7 +80,9 @@ test-offload-acceptance args="":
     # MODAL_IMAGE_BUILDER_VERSION=2025.06 is required for enable_docker support (Docker-in-Docker alpha).
     MODAL_IMAGE_BUILDER_VERSION=2025.06 offload -c offload-modal-acceptance.toml run --trace \
         --env "MODAL_TOKEN_ID=$MODAL_TOKEN_ID" \
-        --env "MODAL_TOKEN_SECRET=$MODAL_TOKEN_SECRET" {{args}} || [[ $? -eq 2 ]]
+        --env "MODAL_TOKEN_SECRET=$MODAL_TOKEN_SECRET" \
+        --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
+        --env "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" {{args}} || [[ $? -eq 2 ]]
 
 # Run release tests on Modal via Offload (with Docker-in-Docker)
 test-offload-release args="":
@@ -99,7 +103,9 @@ test-offload-release args="":
         --env "MODAL_TOKEN_ID=$MODAL_TOKEN_ID" \
         --env "MODAL_TOKEN_SECRET=$MODAL_TOKEN_SECRET" \
         --env "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
-        --env "IS_RELEASE=1" {{args}} || [[ $? -eq 2 ]]
+        --env "IS_RELEASE=1" \
+        --env "GITHUB_HEAD_REF=${GITHUB_HEAD_REF:-}" \
+        --env "GITHUB_REF_NAME=${GITHUB_REF_NAME:-}" {{args}} || [[ $? -eq 2 ]]
 
     # Copy results to the main worktree so new worktrees inherit baselines via COPY mode.
     MAIN_WORKTREE=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')

--- a/libs/mngr/imbue/mngr/resources/Dockerfile
+++ b/libs/mngr/imbue/mngr/resources/Dockerfile
@@ -1,3 +1,13 @@
+# Build stage: compile the offload binary so the final image can apply
+# thin diffs at sandbox-prepare time. Offload >=0.9.0 expects to invoke
+# `offload apply-diff` inside the sandbox image; without the binary present,
+# offload falls back to a full image rebuild on every run, defeating the
+# checkpoint cache. Keep this version pinned in sync with the offload
+# version pinned in .github/workflows/ci.yml.
+FROM rust:1-bookworm AS offload-builder
+ARG OFFLOAD_VERSION=0.9.2
+RUN cargo install offload@${OFFLOAD_VERSION} --locked --root /opt/offload
+
 FROM python:3.12-slim
 
 # Install system dependencies including tini for proper signal handling
@@ -63,6 +73,11 @@ ENV CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}
 
 # without this, there are some annoying bugs on modal's side with snapshotting
 ENV UV_LINK_MODE=copy
+
+# offload binary, used by `offload apply-diff` during sandbox prepare to
+# layer thin diffs over the cached checkpoint image (see the offload-builder
+# stage above for the version pin and rationale).
+COPY --from=offload-builder /opt/offload/bin/offload /usr/local/bin/offload
 
 # copy in all of our code (offload exports the repo tree as the build context;
 # mngr_schedule unpacks its packaged tarball producer-side via


### PR DESCRIPTION
## Summary
- Bump offload version pin in CI from 0.9.0 to 0.9.2 (both `test-offload` and `test-offload-acceptance` jobs).
- Updates the `cargo-offload-*` cache key to bust the old binary cache.
- Picks up a fix for thin-diff application in offload.

## Test plan
- [ ] CI installs offload 0.9.2 and `test-offload` passes.
- [ ] `test-offload-acceptance` passes.

Co-authored-by: Sculptor <sculptor@imbue.com>