### PR TITLE
workspace_server: rewrite Location headers on 3xx redirects in proxy

### DIFF
--- a/apps/minds_workspace_server/imbue/minds_workspace_server/proxy.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/proxy.py
@@ -1,5 +1,6 @@
 import re
 from typing import Final
+from urllib.parse import urlparse
 
 from imbue.imbue_common.pure import pure
 from imbue.minds_workspace_server.primitives import ServiceName
@@ -151,6 +152,50 @@ def rewrite_cookie_path(
         return set_cookie_header[: match.start(2)] + new_path + set_cookie_header[match.end(2) :]
     else:
         return set_cookie_header + f"; Path={prefix}/"
+
+
+@pure
+def rewrite_location_header(
+    location: str,
+    service_name: ServiceName,
+    backend_url: str,
+) -> str:
+    """Rewrite a Location header value so the browser follows the redirect via the service prefix.
+
+    Absolute-path values (``/foo``) are prefixed with ``/service/<name>``.
+    Absolute URLs whose host:port match the backend's are rewritten to
+    same-origin (proxy-relative) absolute paths under the service prefix,
+    since the backend's localhost address is not reachable from the
+    browser. Protocol-relative URLs (``//host/path``), relative paths,
+    and absolute URLs to other origins pass through unchanged.
+    """
+    prefix = get_service_prefix(service_name)
+
+    if location.startswith("//"):
+        return location
+
+    if location.startswith("/"):
+        if location.startswith(prefix + "/") or location == prefix:
+            return location
+        return prefix + location
+
+    parsed = urlparse(location)
+    if not (parsed.scheme and parsed.netloc):
+        return location
+
+    backend_parsed = urlparse(backend_url)
+    if parsed.netloc != backend_parsed.netloc:
+        return location
+
+    path = parsed.path or "/"
+    if not (path.startswith(prefix + "/") or path == prefix):
+        path = prefix + path
+    rewritten = path
+    if parsed.query:
+        rewritten += "?" + parsed.query
+    if parsed.fragment:
+        rewritten += "#" + parsed.fragment
+    return rewritten
 
 
 @pure

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py
@@ -7,6 +7,7 @@ from imbue.minds_workspace_server.proxy import generate_service_worker_js
 from imbue.minds_workspace_server.proxy import generate_websocket_shim_js
 from imbue.minds_workspace_server.proxy import rewrite_absolute_paths_in_html
 from imbue.minds_workspace_server.proxy import rewrite_cookie_path
+from imbue.minds_workspace_server.proxy import rewrite_location_header
 from imbue.minds_workspace_server.proxy import rewrite_proxied_html
 
 _TEST_SERVICE: ServiceName = ServiceName("web")
@@ -78,6 +79,120 @@ def test_rewrite_cookie_path_does_not_double_prefix() -> None:
         service_name=_TEST_SERVICE,
     )
     assert result == snapshot("sid=abc; Path=/service/web/api")
+
+
+# -- Location header rewriting --
+
+_BACKEND_URL: str = "http://127.0.0.1:8000"
+
+
+def test_rewrite_location_absolute_path_is_prefixed() -> None:
+    result = rewrite_location_header(
+        location="/login",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/login")
+
+
+def test_rewrite_location_absolute_path_preserves_query_and_fragment() -> None:
+    result = rewrite_location_header(
+        location="/login?next=/dashboard#anchor",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/login?next=/dashboard#anchor")
+
+
+def test_rewrite_location_absolute_path_does_not_double_prefix() -> None:
+    result = rewrite_location_header(
+        location="/service/web/login",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/login")
+
+
+def test_rewrite_location_same_origin_url_becomes_proxy_relative_path() -> None:
+    result = rewrite_location_header(
+        location="http://127.0.0.1:8000/login",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/login")
+
+
+def test_rewrite_location_same_origin_url_preserves_query() -> None:
+    result = rewrite_location_header(
+        location="http://127.0.0.1:8000/login?next=/dashboard",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/login?next=/dashboard")
+
+
+def test_rewrite_location_external_url_is_unchanged() -> None:
+    result = rewrite_location_header(
+        location="https://example.com/elsewhere",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("https://example.com/elsewhere")
+
+
+def test_rewrite_location_protocol_relative_url_is_unchanged() -> None:
+    result = rewrite_location_header(
+        location="//example.com/page",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("//example.com/page")
+
+
+def test_rewrite_location_relative_path_is_unchanged() -> None:
+    result = rewrite_location_header(
+        location="login",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("login")
+
+
+def test_rewrite_location_dot_relative_path_is_unchanged() -> None:
+    result = rewrite_location_header(
+        location="./login",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("./login")
+
+
+def test_rewrite_location_fragment_only_is_unchanged() -> None:
+    result = rewrite_location_header(
+        location="#anchor",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("#anchor")
+
+
+def test_rewrite_location_absolute_path_does_not_double_prefix_exact_match() -> None:
+    prefix = f"/service/{_TEST_SERVICE}"
+    result = rewrite_location_header(
+        location=prefix,
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == prefix
+
+
+def test_rewrite_location_site_absolute_root_is_prefixed() -> None:
+    result = rewrite_location_header(
+        location="/",
+        service_name=_TEST_SERVICE,
+        backend_url=_BACKEND_URL,
+    )
+    assert result == snapshot("/service/web/")
 
 
 # -- Absolute path rewriting --

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher.py
@@ -39,6 +39,7 @@ from imbue.minds_workspace_server.proxy import generate_backend_loading_html
 from imbue.minds_workspace_server.proxy import generate_bootstrap_html
 from imbue.minds_workspace_server.proxy import generate_service_worker_js
 from imbue.minds_workspace_server.proxy import rewrite_cookie_path
+from imbue.minds_workspace_server.proxy import rewrite_location_header
 from imbue.minds_workspace_server.proxy import rewrite_proxied_html
 
 _PROXY_TIMEOUT_SECONDS: Final[float] = 30.0
@@ -176,17 +177,28 @@ def _build_proxy_response(
     service_name: ServiceName,
 ) -> Response:
     """Transform a backend httpx response into a FastAPI Response with header/content rewriting."""
+    is_redirect = 300 <= backend_response.status_code < 400
+    backend_request_url = str(backend_response.request.url)
     resp_headers: dict[str, list[str]] = {}
     for header_key, header_value in backend_response.headers.multi_items():
-        if header_key.lower() in _EXCLUDED_RESPONSE_HEADERS:
+        header_key_lower = header_key.lower()
+        if header_key_lower in _EXCLUDED_RESPONSE_HEADERS:
             continue
-        if header_key.lower() == "set-cookie":
-            header_value = rewrite_cookie_path(
+        if header_key_lower == "set-cookie":
+            rewritten_value = rewrite_cookie_path(
                 set_cookie_header=header_value,
                 service_name=service_name,
             )
+        elif is_redirect and header_key_lower == "location":
+            rewritten_value = rewrite_location_header(
+                location=header_value,
+                service_name=service_name,
+                backend_url=backend_request_url,
+            )
+        else:
+            rewritten_value = header_value
         resp_headers.setdefault(header_key, [])
-        resp_headers[header_key].append(header_value)
+        resp_headers[header_key].append(rewritten_value)
 
     content: str | bytes = backend_response.content
 

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py
@@ -18,6 +18,8 @@ from fastapi import Request
 from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
 from fastapi.responses import PlainTextResponse
+from fastapi.responses import RedirectResponse
+from fastapi.responses import Response
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocket
@@ -91,6 +93,21 @@ def _build_stub_backend() -> FastAPI:
     @stub.get("/echo-query")
     def echo_query(request: Request) -> JSONResponse:
         return JSONResponse({"query": request.url.query})
+
+    @stub.get("/redirect-absolute-path")
+    def redirect_absolute_path() -> RedirectResponse:
+        return RedirectResponse(url="/login", status_code=302)
+
+    @stub.get("/redirect-same-origin")
+    def redirect_same_origin(request: Request) -> Response:
+        target = f"{request.url.scheme}://{request.url.netloc}/login?next=/dashboard"
+        response = Response(status_code=302)
+        response.headers["Location"] = target
+        return response
+
+    @stub.get("/redirect-external")
+    def redirect_external() -> RedirectResponse:
+        return RedirectResponse(url="https://example.com/elsewhere", status_code=302)
 
     @stub.get("/events")
     def sse_endpoint() -> StreamingResponse:
@@ -224,6 +241,52 @@ def test_set_cookie_is_rewritten_to_service_path(workspace_client: TestClient) -
     assert response.status_code == 200
     set_cookie = response.headers.get("set-cookie", "")
     assert "Path=/service/web/" in set_cookie
+
+
+def test_redirect_absolute_path_location_is_prefixed(workspace_client: TestClient) -> None:
+    """A 3xx with an absolute-path Location header is rewritten under the service prefix."""
+    response = workspace_client.get(
+        "/service/web/redirect-absolute-path",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/service/web/login"
+
+
+def test_redirect_same_origin_absolute_url_is_rewritten_to_prefixed_path(
+    workspace_client: TestClient,
+) -> None:
+    """A 3xx with a same-origin absolute-URL Location is rewritten to a proxy-relative prefixed path."""
+    response = workspace_client.get(
+        "/service/web/redirect-same-origin",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/service/web/login?next=/dashboard"
+
+
+def test_redirect_external_location_passes_through(workspace_client: TestClient) -> None:
+    """A 3xx with an external Location URL is left unchanged."""
+    response = workspace_client.get(
+        "/service/web/redirect-external",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://example.com/elsewhere"
+
+
+def test_2xx_without_location_is_unchanged(workspace_client: TestClient) -> None:
+    """A 2xx response with no Location header passes through with no Location added."""
+    response = workspace_client.get(
+        "/service/web/plain",
+        cookies={"sw_installed_web": "1"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    assert "location" not in {k.lower() for k in response.headers.keys()}
 
 
 def test_unknown_service_returns_loading_page_for_html(workspace_client: TestClient) -> None:

--- a/changelog/gabe-forwarder-redirect-fix-v2.md
+++ b/changelog/gabe-forwarder-redirect-fix-v2.md
@@ -1,0 +1,4 @@
+- Fixed: `workspace_server`'s `/service/<name>/` HTTP proxy now rewrites the `Location` header on 3xx responses so backend redirects (e.g. `Location: /login`) follow through the service-prefixed path (`/service/<name>/login`) instead of bouncing the browser to the workspace_server's top-level path
+  - Absolute-path Location values are prefixed with the service path
+  - Same-origin absolute-URL Location values (those targeting the backend's own host:port) are rewritten into proxy-relative absolute paths under the service prefix, since the backend's localhost address is not reachable from the browser
+  - Fully external Location URLs (e.g. `https://example.com/`) and protocol-relative URLs pass through unchanged


### PR DESCRIPTION
## Summary

The workspace_server forwarder rewrites cookies and HTML body content for proxied responses, but never rewrote the `Location` header on 3xx redirects. Backends issuing redirects (e.g. OAuth flows, 302-after-POST) sent absolute URLs pointing at the backend's own host, which the browser then followed off-proxy and broke the session.

This PR adds `rewrite_location_header` in `proxy.py` and wires it into `_build_proxy_response` to apply on 3xx responses, alongside the existing cookie / HTML rewriters. Same-origin absolute URLs (those targeting the backend's own host:port) are rewritten into proxy-relative paths under the service prefix, since the backend's localhost address is not reachable from the browser. Protocol-relative, fully external, and relative-path Locations pass through unchanged.

Replaces #1509 -- same logic, recreated as a single clean commit off `main` to avoid the merge-history mess. Drops the `else: pass` ratchet workaround in favor of a `rewritten_value` local that gives the elif a meaningful else branch.

## Test plan

- [x] `proxy_test.py` -- 16 unit tests covering rewriter cases (absolute path, query/fragment preservation, no double-prefix, exact-prefix match, same-origin URL collapse, external URL passthrough, protocol-relative passthrough, relative path passthrough, dot-relative path, fragment-only, site-absolute root).
- [x] `service_dispatcher_test.py` -- 4 integration tests exercising real `RedirectResponse` (absolute path, same-origin URL, external URL) and a non-redirect 200 sanity check.
- [x] `just test-quick "apps/minds_workspace_server/imbue/minds_workspace_server/proxy_test.py apps/minds_workspace_server/imbue/minds_workspace_server/service_dispatcher_test.py"` -- 55 passed.
- [x] `just test-quick "apps/minds_workspace_server -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` -- 268 passed (1 unrelated pre-existing failure in `agent_manager_test.py::test_start_observe_spawns_long_lived_subprocess`, also fails on clean `origin/main`).
- [x] `ruff check` + `ruff format --check` -- clean.