### PR TITLE
Fix events trailing

### DIFF
--- a/changelog/hynek-fix-events-trailing.md
+++ b/changelog/hynek-fix-events-trailing.md
@@ -1,0 +1,10 @@
+- Fixed a perpetual one-event lag in remote (online-host) event
+  follow-mode tailing. When reading `events.jsonl` over the wire,
+  pyinfra's `CommandOutput.stdout` is built by `"\n".join(...)` after
+  each line is `rstrip("\n")`-ed, so a file ending in `\n` and one not
+  ending in `\n` produced identical strings. The follow loop's
+  partial-write guard then treated the most recent complete line as
+  in-flight and held it back until a later line forced it out. The
+  remote read now wraps `cat` as `{ cat <file> && printf '%s' <sentinel>; }`,
+  asserts the sentinel is present, and strips it back off to recover
+  the file's exact byte tail.

--- a/libs/mngr/imbue/mngr/api/events.py
+++ b/libs/mngr/imbue/mngr/api/events.py
@@ -46,6 +46,22 @@ FOLLOW_POLL_INTERVAL_SECONDS: Final[float] = 1.0
 SOURCE_SCAN_INTERVAL_SECONDS: Final[float] = 10.0
 ONLINE_CHECK_INTERVAL_SECONDS: Final[float] = 30.0
 _EVENTS_JSONL_FILENAME: Final[str] = "events.jsonl"
+# Sentinel suffix appended to ``cat`` output so we can recover the
+# file's true trailing-newline state through pyinfra's stdout pipeline.
+# Pyinfra's ``CommandOutput.stdout`` is constructed as ``"\n".join(lines)``
+# after each line is ``rstrip("\n")``-ed, which means a file that ends
+# with ``\n`` and one that does not produce identical ``stdout`` strings.
+# That ambiguity breaks the tail loop's ``split_complete_lines`` partial
+# write guard: it always treats the most recent line as in-flight and
+# holds it back forever, producing a perpetual one-event lag.
+#
+# By appending a known sentinel after ``cat``, we force pyinfra to emit
+# the trailing newline (if any) as a real ``\n`` between the file's last
+# line and the sentinel line. Stripping the sentinel back off recovers
+# the file's exact byte tail. The marker contains a non-newline,
+# non-printable byte (\xff) so it cannot be confused with anything that
+# could legitimately appear in a JSONL events file.
+_EVENTS_READ_SENTINEL: Final[str] = "__MNGR_EVENTS_READ_SENTINEL_8b2e6f31_\xff__"
 
 
 # =============================================================================
@@ -291,16 +307,50 @@ def _read_event_content_via_host(
     event_file_name: str,
     display_name: str,
 ) -> str:
-    """Read event content by executing cat on the online host."""
+    """Read event content by executing cat on the online host.
+
+    Wraps the ``cat`` invocation as ``{ cat <file> && printf '%s' <sentinel>; }``
+    so the file's true trailing-newline state survives pyinfra's
+    line-rejoin pipeline. Without the sentinel, a file ending in ``\n``
+    and one not ending in ``\n`` produce identical ``CommandOutput.stdout``
+    strings -- the trailing newline is lost. That ambiguity makes the
+    follow-mode tail loop's ``split_complete_lines`` partial-write guard
+    misclassify the most recent line as in-flight (because there is no
+    visible terminating ``\n`` after it) and hold it back until a later
+    line forces it out, producing a perpetual one-event lag visible to
+    minds users as "the first permission request never arrives -- I
+    have to ask the agent to re-send before any prompt appears".
+
+    ``&&`` ensures the sentinel is only emitted if ``cat`` succeeded,
+    so a truncated read (cat exiting non-zero) is detected by the
+    absent sentinel rather than masquerading as a successfully-read
+    empty file.
+    """
     logger.trace("Reading event file '{}' for {} via host", event_file_name, display_name)
     file_path = events_path / event_file_name
     result = online_host.execute_idempotent_command(
-        f"cat {shlex.quote(str(file_path))}",
+        "{{ cat {file} && printf '%s' {sentinel}; }}".format(
+            file=shlex.quote(str(file_path)),
+            sentinel=shlex.quote(_EVENTS_READ_SENTINEL),
+        ),
         timeout_seconds=30.0,
     )
     if not result.success:
         raise MngrError(f"Failed to read event file '{event_file_name}': {result.stderr}")
-    return result.stdout
+    if not result.stdout.endswith(_EVENTS_READ_SENTINEL):
+        # ``cat`` exited 0 but the sentinel is missing -- output was
+        # truncated, the shell substituted ``cat`` for something else,
+        # or some pyinfra quirk dropped the printf line. In any case
+        # we cannot safely advance the byte offset on a truncated read,
+        # so surface as an error instead of returning what we have.
+        raise MngrError(
+            "Event file {!r} read did not include the EOF sentinel; output was "
+            "truncated or pyinfra mangled the trailing line. Last 200 chars: {!r}".format(
+                event_file_name,
+                result.stdout[-200:],
+            )
+        )
+    return result.stdout.removesuffix(_EVENTS_READ_SENTINEL)
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/api/events.py
+++ b/libs/mngr/imbue/mngr/api/events.py
@@ -46,22 +46,7 @@ FOLLOW_POLL_INTERVAL_SECONDS: Final[float] = 1.0
 SOURCE_SCAN_INTERVAL_SECONDS: Final[float] = 10.0
 ONLINE_CHECK_INTERVAL_SECONDS: Final[float] = 30.0
 _EVENTS_JSONL_FILENAME: Final[str] = "events.jsonl"
-# Sentinel suffix appended to ``cat`` output so we can recover the
-# file's true trailing-newline state through pyinfra's stdout pipeline.
-# Pyinfra's ``CommandOutput.stdout`` is constructed as ``"\n".join(lines)``
-# after each line is ``rstrip("\n")``-ed, which means a file that ends
-# with ``\n`` and one that does not produce identical ``stdout`` strings.
-# That ambiguity breaks the tail loop's ``split_complete_lines`` partial
-# write guard: it always treats the most recent line as in-flight and
-# holds it back forever, producing a perpetual one-event lag.
-#
-# By appending a known sentinel after ``cat``, we force pyinfra to emit
-# the trailing newline (if any) as a real ``\n`` between the file's last
-# line and the sentinel line. Stripping the sentinel back off recovers
-# the file's exact byte tail. The marker contains a non-newline,
-# non-printable byte (\xff) so it cannot be confused with anything that
-# could legitimately appear in a JSONL events file.
-_EVENTS_READ_SENTINEL: Final[str] = "__MNGR_EVENTS_READ_SENTINEL_8b2e6f31_\xff__"
+_EVENTS_READ_SENTINEL: Final[str] = "__MNGR_EVENTS_READ_SENTINEL_8b2e6f31__"
 
 
 # =============================================================================
@@ -311,20 +296,19 @@ def _read_event_content_via_host(
 
     Wraps the ``cat`` invocation as ``{ cat <file> && printf '%s' <sentinel>; }``
     so the file's true trailing-newline state survives pyinfra's
-    line-rejoin pipeline. Without the sentinel, a file ending in ``\n``
-    and one not ending in ``\n`` produce identical ``CommandOutput.stdout``
-    strings -- the trailing newline is lost. That ambiguity makes the
-    follow-mode tail loop's ``split_complete_lines`` partial-write guard
-    misclassify the most recent line as in-flight (because there is no
-    visible terminating ``\n`` after it) and hold it back until a later
-    line forces it out, producing a perpetual one-event lag visible to
-    minds users as "the first permission request never arrives -- I
-    have to ask the agent to re-send before any prompt appears".
+    line-rejoin pipeline. Pyinfra's ``CommandOutput.stdout`` is constructed as
+    ``"\n".join(lines)`` after each line is ``rstrip("\n")``-ed, which means
+    a file that ends with ``\n`` and one that does not produce identical
+    ``stdout`` strings. That ambiguity makes the follow-mode tail loop's
+    ``split_complete_lines`` partial-write guard misclassify the most recent
+    line as in-flight (because there is no visible terminating ``\n`` after it)
+    and hold it back until a later line forces it out, producing a perpetual
+    one-event lag.
 
-    ``&&`` ensures the sentinel is only emitted if ``cat`` succeeded,
-    so a truncated read (cat exiting non-zero) is detected by the
-    absent sentinel rather than masquerading as a successfully-read
-    empty file.
+    By appending a known sentinel after ``cat``, we force pyinfra to emit
+    the trailing newline (if any) as a real ``\n`` between the file's last
+    line and the sentinel line. Stripping the sentinel back off recovers
+    the file's exact byte tail.
     """
     logger.trace("Reading event file '{}' for {} via host", event_file_name, display_name)
     file_path = events_path / event_file_name
@@ -338,11 +322,6 @@ def _read_event_content_via_host(
     if not result.success:
         raise MngrError(f"Failed to read event file '{event_file_name}': {result.stderr}")
     if not result.stdout.endswith(_EVENTS_READ_SENTINEL):
-        # ``cat`` exited 0 but the sentinel is missing -- output was
-        # truncated, the shell substituted ``cat`` for something else,
-        # or some pyinfra quirk dropped the printf line. In any case
-        # we cannot safely advance the byte offset on a truncated read,
-        # so surface as an error instead of returning what we have.
         raise MngrError(
             "Event file {!r} read did not include the EOF sentinel; output was "
             "truncated or pyinfra mangled the trailing line. Last 200 chars: {!r}".format(

--- a/libs/mngr/imbue/mngr/api/events_test.py
+++ b/libs/mngr/imbue/mngr/api/events_test.py
@@ -200,16 +200,7 @@ def events_host_target(
 
 
 def test_read_event_content_via_host(events_host_target: tuple[EventsTarget, Path]) -> None:
-    """Verify read_event_content works via host execute_command when volume is None.
-
-    Pyinfra's ``CommandOutput.stdout`` would otherwise drop the file's
-    trailing newline (it joins lines with ``\n`` after stripping each
-    line's own trailing ``\n``), so ``read_event_content`` wraps the
-    ``cat`` command with a sentinel suffix to preserve the file's true
-    byte ending. Confirmed below by asserting *exact* equality including
-    the trailing newline -- previously this test had to settle for
-    substring containment because the trailing newline was lost.
-    """
+    """Verify read_event_content works via host execute_command when volume is None."""
     target, events_dir = events_host_target
     (events_dir / "test.log").write_text("hello from host\nsecond line\n")
 
@@ -221,15 +212,7 @@ def test_read_event_content_via_host(events_host_target: tuple[EventsTarget, Pat
 def test_read_event_content_via_host_preserves_no_trailing_newline(
     events_host_target: tuple[EventsTarget, Path],
 ) -> None:
-    """Files that genuinely don't end with ``\n`` must round-trip without one too.
-
-    The sentinel-suffix wrapper handles both endings symmetrically: a
-    file ending in ``\n`` keeps it, a file that doesn't gain it. This is
-    essential for the follow-mode tail loop -- if it sees a synthetic
-    trailing newline that isn't really there, ``split_complete_lines``
-    treats the partial in-flight write as complete and emits garbage to
-    its consumer.
-    """
+    """Files that genuinely don't end with ``\n`` must round-trip without one too."""
     target, events_dir = events_host_target
     # Mid-write style content: line1 complete, line2 still being appended.
     (events_dir / "midwrite.log").write_bytes(b"line1\nline2_partial")

--- a/libs/mngr/imbue/mngr/api/events_test.py
+++ b/libs/mngr/imbue/mngr/api/events_test.py
@@ -202,17 +202,74 @@ def events_host_target(
 def test_read_event_content_via_host(events_host_target: tuple[EventsTarget, Path]) -> None:
     """Verify read_event_content works via host execute_command when volume is None.
 
-    Note: pyinfra's CommandOutput.stdout joins lines with newlines but drops
-    the final trailing newline, so host-based reads may differ from volume-based
-    reads in trailing whitespace.
+    Pyinfra's ``CommandOutput.stdout`` would otherwise drop the file's
+    trailing newline (it joins lines with ``\n`` after stripping each
+    line's own trailing ``\n``), so ``read_event_content`` wraps the
+    ``cat`` command with a sentinel suffix to preserve the file's true
+    byte ending. Confirmed below by asserting *exact* equality including
+    the trailing newline -- previously this test had to settle for
+    substring containment because the trailing newline was lost.
     """
     target, events_dir = events_host_target
     (events_dir / "test.log").write_text("hello from host\nsecond line\n")
 
     content = read_event_content(target, "test.log")
 
-    assert "hello from host" in content
-    assert "second line" in content
+    assert content == "hello from host\nsecond line\n"
+
+
+def test_read_event_content_via_host_preserves_no_trailing_newline(
+    events_host_target: tuple[EventsTarget, Path],
+) -> None:
+    """Files that genuinely don't end with ``\n`` must round-trip without one too.
+
+    The sentinel-suffix wrapper handles both endings symmetrically: a
+    file ending in ``\n`` keeps it, a file that doesn't gain it. This is
+    essential for the follow-mode tail loop -- if it sees a synthetic
+    trailing newline that isn't really there, ``split_complete_lines``
+    treats the partial in-flight write as complete and emits garbage to
+    its consumer.
+    """
+    target, events_dir = events_host_target
+    # Mid-write style content: line1 complete, line2 still being appended.
+    (events_dir / "midwrite.log").write_bytes(b"line1\nline2_partial")
+
+    content = read_event_content(target, "midwrite.log")
+
+    assert content == "line1\nline2_partial"
+
+
+def test_read_event_content_via_host_handles_empty_file(
+    events_host_target: tuple[EventsTarget, Path],
+) -> None:
+    """An empty file must round-trip as the empty string, not the sentinel.
+
+    Regression guard: the sentinel-strip step must run for every read,
+    including ones where ``cat`` produced zero bytes.
+    """
+    target, events_dir = events_host_target
+    (events_dir / "empty.log").write_bytes(b"")
+
+    content = read_event_content(target, "empty.log")
+
+    assert content == ""
+
+
+def test_read_event_content_via_host_handles_only_newline(
+    events_host_target: tuple[EventsTarget, Path],
+) -> None:
+    """A file that is just ``\n`` must round-trip as ``\n``, not as ``""``.
+
+    Regression guard for the old bug: pyinfra's stdout would have
+    stripped the trailing ``\n`` and returned ``""``, indistinguishable
+    from an empty file.
+    """
+    target, events_dir = events_host_target
+    (events_dir / "just_newline.log").write_bytes(b"\n")
+
+    content = read_event_content(target, "just_newline.log")
+
+    assert content == "\n"
 
 
 def test_read_event_content_via_host_raises_for_missing_file(events_host_target: tuple[EventsTarget, Path]) -> None:


### PR DESCRIPTION
The combination of:

- result.stdout eating trailing newlines
- and our logic considering lines without a newline as "in-flight"

Resulted in the last event always getting "stuck" in the queue (until a new event came).

Originally observed in permission request scenarios (a permission request wouldn't show up until I'd ask the agent again). After this fix, permission requests work as expected.