### PR TITLE
minds: set LATCHKEY_DISABLE_COUNTING=1 in workspaces

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -459,6 +459,8 @@ def _build_mngr_create_command(
             latchkey_env_args.extend(
                 ["--env", f"LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE={latchkey_permissions_override_jwt}"]
             )
+        # Suppress the per-workspace daily ping to avoid counting every agent as a separate user.
+        latchkey_env_args.extend(["--env", "LATCHKEY_DISABLE_COUNTING=1"])
 
     mngr_command: list[str] = [
         MNGR_BINARY,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -105,6 +105,29 @@ def test_build_mngr_create_command_omits_latchkey_for_dev_mode_without_url() -> 
     command, _ = _build_mngr_create_command(launch_mode=LaunchMode.DEV, agent_name=AgentName("hello"))
     joined = " ".join(command)
     assert "LATCHKEY_GATEWAY" not in joined
+    # ``LATCHKEY_DISABLE_COUNTING`` is part of the latchkey wiring, so it's
+    # also absent when latchkey is not wired (DEV without explicit URL).
+    assert "LATCHKEY_DISABLE_COUNTING" not in joined
+
+
+def test_build_mngr_create_command_disables_latchkey_counting_when_wired() -> None:
+    """Whenever latchkey is wired into the workspace, the workspace-side
+    ``latchkey`` CLI runs in client mode against the host-side gateway.
+    The gateway already counts as one active user, so the workspace must
+    set ``LATCHKEY_DISABLE_COUNTING=1`` to avoid double-counting every
+    agent as a separate goatcounter.com user.
+    """
+    # Non-DEV mode: gets the constant agent-side URL by default, so latchkey is wired.
+    for mode in (LaunchMode.LOCAL, LaunchMode.LIMA, LaunchMode.CLOUD):
+        command, _ = _build_mngr_create_command(launch_mode=mode, agent_name=AgentName("hello"))
+        assert "LATCHKEY_DISABLE_COUNTING=1" in command, f"{mode} command missing disable-counting env: {command}"
+    # DEV with explicit URL: latchkey is wired, so disable-counting is too.
+    command, _ = _build_mngr_create_command(
+        launch_mode=LaunchMode.DEV,
+        agent_name=AgentName("hello"),
+        latchkey_gateway_url="http://127.0.0.1:54321",
+    )
+    assert "LATCHKEY_DISABLE_COUNTING=1" in command
 
 
 def test_build_mngr_create_command_injects_latchkey_for_dev_mode_with_explicit_url() -> None:

--- a/changelog/hynek-do-not-count-latchkey-usage.md
+++ b/changelog/hynek-do-not-count-latchkey-usage.md
@@ -1,0 +1,7 @@
+- minds now injects `LATCHKEY_DISABLE_COUNTING=1` into every workspace
+  whenever latchkey is wired (alongside `LATCHKEY_GATEWAY`,
+  `LATCHKEY_GATEWAY_PASSWORD`, and `LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE`).
+  The workspace-side `latchkey` CLI runs in client mode against the
+  host-side gateway, so suppressing its daily goatcounter.com ping
+  prevents every agent from being counted as a separate active user --
+  the single host-side gateway already represents the one real user.


### PR DESCRIPTION
The host-side latchkey gateway already counts as one active user. The workspace-side latchkey CLIs run in client mode against that gateway, so leaving counting enabled there would double-count every agent as a separate user. Inject LATCHKEY_DISABLE_COUNTING=1 alongside the existing latchkey env wiring so the per-workspace daily ping is suppressed.