### PR TITLE
mngr_tmr: add CI workflow for TMR + integrator_branch event

### DIFF
--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -1,0 +1,107 @@
+name: TMR
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_paths:
+        description: "Test paths (space-separated, passed as positional args before --)"
+        required: true
+        default: "libs/mngr/imbue/mngr/e2e/test_basic.py"
+      pytest_args:
+        description: "Pytest args after `--` (must be valid bash; quote values containing spaces, e.g. `-m \"foo and bar\"`)"
+        required: true
+        default: "-m release"
+      agent_type:
+        description: "Agent type (e.g. yolo, claude)"
+        required: true
+        default: "yolo"
+
+jobs:
+  tmr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Install Python dependencies
+        run: uv sync --all-packages
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@2.1.116
+
+      - name: Configure git identity
+        run: |
+          git config user.email "dev@imbue.com"
+          git config user.name "imbue-dev"
+
+      - name: Run TMR orchestrator
+        run: |
+          mkdir -p tmr-report
+          # The "yolo" agent type is normally defined in the user's personal
+          # mngr config; CI has no such config, so we synthesize it inline via
+          # `-S` overrides. parent_type=claude inherits the claude defaults,
+          # and cli_args adds --dangerously-skip-permissions so non-interactive
+          # agents do not hang on per-tool permission prompts.
+          uv run --project libs/mngr_tmr mngr tmr -vv \
+            -S 'agent_types.yolo.parent_type="claude"' \
+            -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
+            --agent-type "${{ inputs.agent_type }}" \
+            --provider modal \
+            --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
+            --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
+            --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+            --output-html tmr-report/index.html \
+            --output-format jsonl \
+            ${{ inputs.test_paths }} \
+            -- ${{ inputs.pytest_args }} \
+            | tee tmr-report/events.jsonl
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tmr-report
+          path: tmr-report/
+          retention-days: 30
+
+      - name: Push integrator branch and open PR
+        if: success()
+        run: |
+          set -euo pipefail
+          branch=$(jq -r 'select(.event == "integrator_branch") | .branch_name' < tmr-report/events.jsonl | tail -n 1)
+          if [ -z "$branch" ]; then
+            echo "No integrator branch was produced (no fixes to integrate); skipping PR."
+            exit 0
+          fi
+          echo "Integrator branch: $branch"
+          git push --set-upstream origin "$branch"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "TMR: $branch" \
+            --body "Automated PR from TMR workflow run [#${{ github.run_id }}]($run_url).
+
+          The HTML report is attached as the \`tmr-report\` artifact on that run; download and open \`index.html\` in a browser." \
+            --draft

--- a/changelog/mngr-tmr-in-ci-deux.md
+++ b/changelog/mngr-tmr-in-ci-deux.md
@@ -1,0 +1,3 @@
+Add `.github/workflows/tmr.yml`: a manually-dispatched CI workflow that runs `mngr tmr` against Modal, uploads the HTML report as an artifact, and opens a draft PR for the integrator branch. The provider is hardcoded to `modal`; `test_paths`, `pytest_args`, and `agent_type` are exposed as workflow inputs, with defaults reproducing the local invocation against `libs/mngr/imbue/mngr/e2e/test_basic.py -m release` with `--agent-type yolo`.
+
+The `mngr tmr` CLI also now emits an `integrator_branch` event on its structured stdout stream (in `--output-format jsonl`/`json`), so consumers like the new workflow can pick up the branch name without parsing human-formatted output.

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -159,6 +159,19 @@ def _emit_report_path(path: Path, output_opts: OutputOptions) -> None:
             assert_never(unreachable)
 
 
+def _emit_integrator_branch(branch_name: str | None, output_opts: OutputOptions) -> None:
+    """Emit the name of the integrator branch, if one was produced."""
+    if branch_name is None:
+        return
+    match output_opts.output_format:
+        case OutputFormat.JSON | OutputFormat.JSONL:
+            emit_event("integrator_branch", {"branch_name": branch_name}, output_opts.output_format)
+        case OutputFormat.HUMAN:
+            pass
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
 def _run_reintegrate(
     opts: TmrCliOptions,
     mngr_ctx: MngrContext,
@@ -172,22 +185,27 @@ def _run_reintegrate(
     """
     assert opts.reintegrate is not None
     run_name = opts.reintegrate
-    write_human_line("Reintegrating run: {}", run_name)
+    is_human = output_opts.output_format == OutputFormat.HUMAN
+    if is_human:
+        write_human_line("Reintegrating run: {}", run_name)
 
     # Discover agents from the previous run by label
     list_result = try_list_agents(mngr_ctx)
     if list_result is None:
-        write_human_line("Failed to list agents. Nothing to reintegrate.")
+        if is_human:
+            write_human_line("Failed to list agents. Nothing to reintegrate.")
         return
     matching_agents = [
         detail
         for detail in list_result.agents
         if detail.labels.get("tmr_run_name") == run_name and not str(detail.name).startswith("tmr-integrator-")
     ]
-    write_human_line("Found {} agent(s) from run {}", len(matching_agents), run_name)
+    if is_human:
+        write_human_line("Found {} agent(s) from run {}", len(matching_agents), run_name)
 
     if not matching_agents:
-        write_human_line("No agents found for run name '{}'. Nothing to reintegrate.", run_name)
+        if is_human:
+            write_human_line("No agents found for run name '{}'. Nothing to reintegrate.", run_name)
         return
 
     # Get local host (needed for local agent host mapping and integrator config)
@@ -294,7 +312,8 @@ def _run_reintegrate(
         run_commands=_build_run_commands(run_name, integrated_branch),
     )
     _emit_report_path(html_path, output_opts)
-    _print_run_commands(run_name, integrated_branch)
+    _emit_integrator_branch(integrated_branch, output_opts)
+    _print_run_commands(run_name, output_opts, integrated_branch)
 
 
 def _run_integrator_phase(
@@ -586,7 +605,7 @@ def tmr(ctx: click.Context, **kwargs: object) -> None:
         )
     except KeyboardInterrupt:
         traceback.print_exc()
-        _print_run_commands(e2e_run_prefix, None)
+        _print_run_commands(e2e_run_prefix, output_opts, None)
         raise
 
 
@@ -624,7 +643,7 @@ def _run_tmr_pipeline(
     launch_failures: list[TestMapReduceResult] = []
 
     if use_batched:
-        if opts.use_snapshot:
+        if opts.use_snapshot and output_opts.output_format == OutputFormat.HUMAN:
             write_human_line("WARNING: --use-snapshot is not supported with --max-agents and will be ignored")
         agent_infos: list[TestAgentInfo] = []
         agent_hosts: dict[str, OnlineHostInterface] = {}
@@ -711,8 +730,9 @@ def _run_tmr_pipeline(
         run_commands=_build_run_commands(e2e_run_prefix, integrated_branch),
     )
     _emit_report_path(html_path, output_opts)
+    _emit_integrator_branch(integrated_branch, output_opts)
 
-    _print_run_commands(e2e_run_prefix, integrated_branch)
+    _print_run_commands(e2e_run_prefix, output_opts, integrated_branch)
 
 
 def _build_run_commands(run_name: str, integrated_branch: str | None = None) -> list[tuple[str, str]]:
@@ -726,8 +746,15 @@ def _build_run_commands(run_name: str, integrated_branch: str | None = None) -> 
     return commands
 
 
-def _print_run_commands(run_name: str, integrated_branch: str | None = None) -> None:
-    """Print useful commands for managing a TMR run's agents."""
+def _print_run_commands(run_name: str, output_opts: OutputOptions, integrated_branch: str | None = None) -> None:
+    """Print useful commands for managing a TMR run's agents.
+
+    Only emits in HUMAN output mode; in JSON/JSONL the run name and integrator
+    branch are already exposed via structured events, and unguarded
+    `write_human_line` calls would pollute the structured stream.
+    """
+    if output_opts.output_format != OutputFormat.HUMAN:
+        return
     write_human_line("")
     for label, cmd in _build_run_commands(run_name, integrated_branch):
         write_human_line("{}:", label)

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
@@ -11,6 +11,7 @@ from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr_tmr.cli import _TmrCommand
 from imbue.mngr_tmr.cli import _emit_agents_launched
+from imbue.mngr_tmr.cli import _emit_integrator_branch
 from imbue.mngr_tmr.cli import _emit_report_path
 from imbue.mngr_tmr.cli import _emit_test_count
 from imbue.mngr_tmr.cli import tmr
@@ -84,6 +85,27 @@ def test_emit_test_count_jsonl() -> None:
 
 def test_emit_agents_launched_json() -> None:
     _emit_agents_launched(5, OutputOptions(output_format=OutputFormat.JSON))
+
+
+def test_emit_integrator_branch_human() -> None:
+    _emit_integrator_branch("mngr-tmr/integrated-abc123", _human_output_opts())
+
+
+def test_emit_integrator_branch_json() -> None:
+    _emit_integrator_branch("mngr-tmr/integrated-abc123", OutputOptions(output_format=OutputFormat.JSON))
+
+
+def test_emit_integrator_branch_jsonl(capsys: Any) -> None:
+    _emit_integrator_branch("mngr-tmr/integrated-abc123", OutputOptions(output_format=OutputFormat.JSONL))
+    captured = capsys.readouterr()
+    assert '"event": "integrator_branch"' in captured.out
+    assert '"branch_name": "mngr-tmr/integrated-abc123"' in captured.out
+
+
+def test_emit_integrator_branch_none_emits_nothing(capsys: Any) -> None:
+    _emit_integrator_branch(None, OutputOptions(output_format=OutputFormat.JSONL))
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 def _invoke_tmr_command(


### PR DESCRIPTION
## Summary

- New manually-dispatched GitHub Actions workflow (`.github/workflows/tmr.yml`) that runs `mngr tmr` against Modal, uploads the HTML report as a `tmr-report` artifact, and opens a draft PR for the integrator branch (`mngr-tmr/integrated-*`). Provider is hardcoded to `modal`; `test_paths`, `pytest_args`, and `agent_type` are exposed as inputs, with defaults reproducing the existing local invocation against `libs/mngr/imbue/mngr/e2e/test_basic.py -m release` with `--agent-type yolo`.
- New `integrator_branch` event on the `mngr tmr` structured stdout stream (in `--output-format jsonl`/`json`), so the workflow can detect the branch via `jq` instead of parsing human-formatted output.
- `_print_run_commands` and the reintegrate path's status messages are now gated on HUMAN output mode, keeping the JSONL stream pure structured events.

## Notes

- The `yolo` agent type lives in user-scope mngr config and is not in the repo, so the workflow synthesizes it inline via `-S 'agent_types.yolo.parent_type=\"claude\"' -S 'agent_types.yolo.cli_args=[\"--dangerously-skip-permissions\"]'`. Without `--dangerously-skip-permissions`, agents would hang on per-tool permission prompts.
- PRs created by `GITHUB_TOKEN` do not trigger downstream workflows (GitHub recursion guard); `ci.yml` will not run on the autogenerated PR until someone closes/reopens it or pushes a commit.
- Required secrets/variables (`MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `ANTHROPIC_API_KEY`) are already configured for the rest of `ci.yml`; nothing new needs adding.

## Test plan

- [ ] Trigger the workflow via Actions → TMR → Run workflow with the default inputs and confirm:
  - [ ] `tmr-report` artifact is uploaded and contains `index.html` plus `events.jsonl`.
  - [ ] A draft PR is opened against `main` with `mngr-tmr/integrated-*` as the head branch.
- [ ] `just test-offload` passes in CI (covers the cli changes including the four new `_emit_integrator_branch` unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)