### PR TITLE
mngr list: emit valid partial JSON under --on-error abort

### DIFF
--- a/changelog/wz-mngr-list-abort-partial-json.md
+++ b/changelog/wz-mngr-list-abort-partial-json.md
@@ -1,0 +1,1 @@
+`mngr list --format json/jsonl --on-error abort` now emits a valid (partial) document when a provider fails: the captured error is included alongside any agents discovered before the abort, and the command exits non-zero. Previously the abort propagated as a raise and stdout was empty, leaving callers without parseable output.

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -247,19 +247,9 @@ def list_agents(
             )
 
     except MngrError as e:
-        # Both ABORT and CONTINUE capture the error into the structured result so
-        # callers (in particular `mngr list --format json/jsonl`) can render a
-        # valid partial document rather than empty stdout. ABORT vs CONTINUE
-        # differs only at the per-provider catch level: ABORT stops further work
-        # at the first failure (the orchestrator re-raises); CONTINUE keeps every
-        # provider going. Either way, the caller learns success/failure from the
-        # populated `result.errors` and the exit code, not from a raise.
         _record_error(result, e, on_error)
     except ConcurrencyExceptionGroup as eg:
-        # ABORT-mode raises that originate inside a `with mngr_executor` block
-        # bubble up wrapped by the executor's __exit__. Unwrap and capture each
-        # MngrError; let any non-MngrError inner exception propagate so
-        # programming bugs aren't silently buried in result.errors.
+        # Unwrap `with mngr_executor` worker errors, capture MngrErrors into result.errors, and re-raise anything else.
         domain_errors: list[MngrError] = []
         for exc in eg.exceptions:
             if not isinstance(exc, MngrError):

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -9,6 +9,7 @@ from typing import Any
 from loguru import logger
 from pydantic import Field
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.logging import log_call
 from imbue.imbue_common.logging import log_span
@@ -246,15 +247,41 @@ def list_agents(
             )
 
     except MngrError as e:
-        if error_behavior == ErrorBehavior.ABORT:
-            raise
-        error_info = ErrorInfo.build(e)
-        result.errors.append(error_info)
-        if on_error:
-            on_error(error_info)
+        # Both ABORT and CONTINUE capture the error into the structured result so
+        # callers (in particular `mngr list --format json/jsonl`) can render a
+        # valid partial document rather than empty stdout. ABORT vs CONTINUE
+        # differs only at the per-provider catch level: ABORT stops further work
+        # at the first failure (the orchestrator re-raises); CONTINUE keeps every
+        # provider going. Either way, the caller learns success/failure from the
+        # populated `result.errors` and the exit code, not from a raise.
+        _record_error(result, e, on_error)
+    except ConcurrencyExceptionGroup as eg:
+        # ABORT-mode raises that originate inside a `with mngr_executor` block
+        # bubble up wrapped by the executor's __exit__. Unwrap and capture each
+        # MngrError; let any non-MngrError inner exception propagate so
+        # programming bugs aren't silently buried in result.errors.
+        domain_errors: list[MngrError] = []
+        for exc in eg.exceptions:
+            if not isinstance(exc, MngrError):
+                raise
+            domain_errors.append(exc)
+        for inner in domain_errors:
+            _record_error(result, inner, on_error)
 
     _maybe_write_full_discovery_snapshot(mngr_ctx, result, provider_names, include_filters, exclude_filters)
     return result
+
+
+def _record_error(
+    result: ListResult,
+    exception: MngrError,
+    on_error: Callable[[ErrorInfo], None] | None,
+) -> None:
+    """Append an ErrorInfo derived from `exception` to result.errors and fire on_error."""
+    error_info = ErrorInfo.build(exception)
+    result.errors.append(error_info)
+    if on_error:
+        on_error(error_info)
 
 
 def _maybe_write_full_discovery_snapshot(

--- a/libs/mngr/imbue/mngr/api/list_test.py
+++ b/libs/mngr/imbue/mngr/api/list_test.py
@@ -10,7 +10,6 @@ from typing import Any
 import pluggy
 import pytest
 
-from imbue.concurrency_group.concurrency_group import ConcurrencyExceptionGroup
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.model_update import to_update
 from imbue.mngr import hookimpl
@@ -1336,22 +1335,27 @@ def test_list_agents_batch_continue_mode_records_failing_provider_error(
     assert "nonexistent-backend-xyz" in result.errors[0].message
 
 
-def test_list_agents_abort_mode_propagates_top_level_mngr_error(
+@pytest.mark.allow_warnings(match=r"Error discovering agents for provider")
+def test_list_agents_abort_mode_captures_top_level_mngr_error_into_result(
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """list_agents with ABORT mode re-raises a top-level MngrError.
+    """list_agents with ABORT mode captures top-level MngrError into result.errors.
 
-    The same unknown-backend configuration triggers an error, but in ABORT
-    mode it must propagate rather than be swallowed.
+    Both ABORT and CONTINUE return a populated ListResult; the caller decides
+    success/failure from `result.errors` and the exit code, not from a raise.
+    The semantic difference between modes is internal (per-provider stop-vs-keep)
+    and lets `mngr list --format json --on-error abort` render a valid partial
+    document with errors populated rather than producing empty stdout.
     """
     failing_ctx = _make_broken_provider_ctx(temp_mngr_ctx)
 
-    with pytest.raises(MngrError, match="nonexistent-backend-xyz"):
-        list_agents(
-            mngr_ctx=failing_ctx,
-            is_streaming=False,
-            error_behavior=ErrorBehavior.ABORT,
-        )
+    result = list_agents(
+        mngr_ctx=failing_ctx,
+        is_streaming=False,
+        error_behavior=ErrorBehavior.ABORT,
+    )
+    assert len(result.errors) == 1
+    assert "nonexistent-backend-xyz" in result.errors[0].message
 
 
 # =============================================================================
@@ -1470,25 +1474,26 @@ def test_list_agents_batch_continue_mode_handles_mismatched_provider_name(
         del _provider_config_registry[_MISMATCHED_BACKEND_NAME]
 
 
-def test_list_agents_batch_abort_mode_raises_for_mismatched_provider_name(
+def test_list_agents_batch_abort_mode_captures_mismatched_provider_name_into_result(
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """list_agents batch mode propagates the error in ABORT mode.
+    """list_agents batch mode captures the error into result.errors in ABORT mode.
 
-    Same scenario as the CONTINUE test, but with ABORT mode the
-    ProviderInstanceNotFoundError must propagate (wrapped by the
-    ConcurrencyGroupExecutor) rather than be swallowed.
+    Same scenario as the CONTINUE test, but with ABORT mode. Since `mngr list
+    --format json/jsonl --on-error abort` needs a valid (partial) document
+    rather than empty stdout, the orchestrator captures the abort-mode error
+    into result.errors instead of letting it propagate as a raise.
     """
     _backend_registry[_MISMATCHED_BACKEND_NAME] = _MismatchedProviderBackend
     _provider_config_registry[_MISMATCHED_BACKEND_NAME] = ProviderInstanceConfig
     try:
-        with pytest.raises(ConcurrencyExceptionGroup) as exc_info:
-            list_agents(
-                mngr_ctx=temp_mngr_ctx,
-                is_streaming=False,
-                error_behavior=ErrorBehavior.ABORT,
-            )
-        assert exc_info.value.only_exception_is_instance_of(MngrError)
+        result = list_agents(
+            mngr_ctx=temp_mngr_ctx,
+            is_streaming=False,
+            error_behavior=ErrorBehavior.ABORT,
+        )
+        assert len(result.errors) >= 1
+        assert any("nonexistent-provider-xyz" in e.message for e in result.errors)
     finally:
         del _backend_registry[_MISMATCHED_BACKEND_NAME]
         del _provider_config_registry[_MISMATCHED_BACKEND_NAME]

--- a/libs/mngr/imbue/mngr/cli/list_test.py
+++ b/libs/mngr/imbue/mngr/cli/list_test.py
@@ -12,6 +12,7 @@ import pluggy
 import pytest
 from click.testing import CliRunner
 
+from imbue.mngr.api.list import ErrorInfo
 from imbue.mngr.api.list import ListResult
 from imbue.mngr.cli.list import _StreamingHumanRenderer
 from imbue.mngr.cli.list import _StreamingTemplateEmitter
@@ -1242,26 +1243,35 @@ class FakeApiListAgents:
     """Replacement for api_list_agents that returns pre-built agents.
 
     When the list command calls api_list_agents, this callable returns a
-    ListResult containing the pre-configured agents. If the caller passes
-    an on_agent callback (streaming mode), agents are delivered via that
-    callback as well.
+    ListResult containing the pre-configured agents and errors. If the
+    caller passes an on_agent or on_error callback, items are delivered
+    via that callback as well.
     """
 
-    def __init__(self, agents: list[AgentDetails]) -> None:
+    def __init__(self, agents: list[AgentDetails], errors: list[ErrorInfo] | None = None) -> None:
         self.agents = agents
+        self.errors = errors or []
 
     def __call__(self, **kwargs: Any) -> ListResult:
-        result = ListResult(agents=list(self.agents))
+        result = ListResult(agents=list(self.agents), errors=list(self.errors))
         on_agent: Callable[[AgentDetails], None] | None = kwargs.get("on_agent")
         if on_agent is not None:
             for agent in self.agents:
                 on_agent(agent)
+        on_error: Callable[[ErrorInfo], None] | None = kwargs.get("on_error")
+        if on_error is not None:
+            for error in self.errors:
+                on_error(error)
         return result
 
 
-def _patch_list_agents(monkeypatch: pytest.MonkeyPatch, agents: list[AgentDetails]) -> None:
-    """Replace api_list_agents with a fake that returns the given agents."""
-    monkeypatch.setattr("imbue.mngr.cli.list.api_list_agents", FakeApiListAgents(agents))
+def _patch_list_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    agents: list[AgentDetails],
+    errors: list[ErrorInfo] | None = None,
+) -> None:
+    """Replace api_list_agents with a fake that returns the given agents (and optional errors)."""
+    monkeypatch.setattr("imbue.mngr.cli.list.api_list_agents", FakeApiListAgents(agents, errors=errors))
 
 
 # =============================================================================
@@ -1591,6 +1601,89 @@ def test_list_command_json_format_no_agents(
     assert result.exit_code == 0
     data = json.loads(result.stdout.strip())
     assert data["agents"] == []
+
+
+def test_list_command_json_format_with_errors_only(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list --format json must emit a valid JSON document when only errors are present.
+
+    Covers the empty-agents path: JSON output is `{"agents": [], "errors": [...]}`
+    rather than empty stdout (the regression that PR-C addresses for
+    `mngr list --format json --on-error abort` against a failing provider).
+    Exit code is non-zero because errors are present.
+    """
+    errors = [ErrorInfo(exception_type="MngrError", message="failed to load provider")]
+    _patch_list_agents(monkeypatch, [], errors=errors)
+
+    result = cli_runner.invoke(
+        list_command,
+        ["--format", "json", "--on-error", "abort"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    json_line = next(line for line in result.output.splitlines() if line.strip().startswith("{"))
+    data = json.loads(json_line)
+    assert data["agents"] == []
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["exception_type"] == "MngrError"
+    assert data["errors"][0]["message"] == "failed to load provider"
+
+
+def test_list_command_json_format_with_partial_agents_and_errors(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list --format json emits both partial agents and the captured errors.
+
+    The non-empty agents path also serializes errors so callers can see what
+    failed alongside the partial result set.
+    """
+    agents = [make_test_agent_details(name="alpha", state=AgentLifecycleState.RUNNING)]
+    errors = [ErrorInfo(exception_type="MngrError", message="provider X failed")]
+    _patch_list_agents(monkeypatch, agents, errors=errors)
+
+    result = cli_runner.invoke(
+        list_command,
+        ["--format", "json", "--sort", "name", "--on-error", "abort"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    # Extract the JSON document from output, which may also contain loguru warnings.
+    output_after_warnings = result.output[result.output.find("{") :]
+    data = json.loads(output_after_warnings)
+    assert len(data["agents"]) == 1
+    assert data["agents"][0]["name"] == "alpha"
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["message"] == "provider X failed"
+
+
+def test_list_command_jsonl_format_with_errors_only(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """list --format jsonl with only errors must emit one valid JSON line per error."""
+    errors = [ErrorInfo(exception_type="MngrError", message="failed to load provider")]
+    _patch_list_agents(monkeypatch, [], errors=errors)
+
+    result = cli_runner.invoke(
+        list_command,
+        ["--format", "jsonl", "--on-error", "abort"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    json_lines = [line for line in result.output.splitlines() if line.strip().startswith("{")]
+    assert len(json_lines) == 1
+    parsed = json.loads(json_lines[0])
+    assert parsed["event"] == "error"
+    assert parsed["message"] == "failed to load provider"
 
 
 def test_list_command_format_template_no_agents(

--- a/libs/mngr/imbue/mngr/cli/list_test.py
+++ b/libs/mngr/imbue/mngr/cli/list_test.py
@@ -1625,8 +1625,7 @@ def test_list_command_json_format_with_errors_only(
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    json_line = next(line for line in result.output.splitlines() if line.strip().startswith("{"))
-    data = json.loads(json_line)
+    data = json.loads(result.stdout.strip())
     assert data["agents"] == []
     assert len(data["errors"]) == 1
     assert data["errors"][0]["exception_type"] == "MngrError"
@@ -1654,9 +1653,7 @@ def test_list_command_json_format_with_partial_agents_and_errors(
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    # Extract the JSON document from output, which may also contain loguru warnings.
-    output_after_warnings = result.output[result.output.find("{") :]
-    data = json.loads(output_after_warnings)
+    data = json.loads(result.stdout)
     assert len(data["agents"]) == 1
     assert data["agents"][0]["name"] == "alpha"
     assert len(data["errors"]) == 1
@@ -1679,9 +1676,9 @@ def test_list_command_jsonl_format_with_errors_only(
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    json_lines = [line for line in result.output.splitlines() if line.strip().startswith("{")]
-    assert len(json_lines) == 1
-    parsed = json.loads(json_lines[0])
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
     assert parsed["event"] == "error"
     assert parsed["message"] == "failed to load provider"
 


### PR DESCRIPTION
## Summary

- `mngr list --format json/jsonl --on-error abort` now produces a valid (partial) document when a provider fails, instead of empty stdout. The captured error is reflected in `result.errors`/`event:error`, and the command still exits non-zero so scripts can detect failure from the exit code.
- Capture the MngrError (or its `ConcurrencyExceptionGroup` wrapping for main-thread raises inside an executor `with` block) into `result.errors` at the top of `list_agents` instead of re-raising.
- Fix `_run_list_iteration`'s empty-agents JSON path to dump `ErrorInfo` via `model_dump` rather than handing raw Pydantic objects to the JSON encoder.

This is the third in a series of follow-ups to #1461 (per-provider error isolation). PR-D (events file completeness) is separate.

## Test plan

- [x] `just test-quick libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'` — 3825 passed, 1 skipped.
- [x] Empirical probe: `mngr list --format json --on-error abort` with a configured failing provider yields valid JSON `{"agents": [], "errors": [...]}`, exit=1.
- [x] Empirical probe: `mngr list --format jsonl --on-error abort` yields one JSON-per-line `{"event": "error", ...}`, exit=1.
- [x] Empirical probe: `mngr list --on-error abort` (human format) prints `No agents found`, logs warning to stderr, exit=1.
- [ ] CI acceptance / release tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)