### PR TITLE
tmr: --additional-authorized-host flag, --format fix, MNGR_USER_ID input

### DIFF
--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -16,7 +16,7 @@ on:
         required: true
         default: "yolo"
       modal_token_id:
-        description: "Override MODAL_TOKEN_ID (defaults to org var). NOTE: visible on the run details page to anyone with repo read access; logs are masked."
+        description: "Override MODAL_TOKEN_ID (defaults to org var)."
         required: false
         default: ""
       modal_token_secret:
@@ -24,7 +24,7 @@ on:
         required: false
         default: ""
       mngr_user_id:
-        description: "Optional MNGR_USER_ID to set on the orchestrator and pass to launched agents (lets you see CI-created modal agents from your local mngr)."
+        description: "Optional MNGR_USER_ID for the orchestrator (lets you see CI-created modal agents from your local mngr)."
         required: false
         default: ""
 
@@ -43,18 +43,11 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Mask user-supplied credentials
-        if: inputs.modal_token_id != '' || inputs.modal_token_secret != ''
+      - name: Mask user-supplied MODAL_TOKEN_SECRET
+        if: inputs.modal_token_secret != ''
         env:
-          MODAL_TOKEN_ID_INPUT: ${{ inputs.modal_token_id }}
           MODAL_TOKEN_SECRET_INPUT: ${{ inputs.modal_token_secret }}
-        run: |
-          if [ -n "$MODAL_TOKEN_ID_INPUT" ]; then
-            echo "::add-mask::$MODAL_TOKEN_ID_INPUT"
-          fi
-          if [ -n "$MODAL_TOKEN_SECRET_INPUT" ]; then
-            echo "::add-mask::$MODAL_TOKEN_SECRET_INPUT"
-          fi
+        run: echo "::add-mask::$MODAL_TOKEN_SECRET_INPUT"
 
       - uses: actions/checkout@v6
         with:
@@ -89,10 +82,6 @@ jobs:
           # `-S` overrides. parent_type=claude inherits the claude defaults,
           # and cli_args adds --dangerously-skip-permissions so non-interactive
           # agents do not hang on per-tool permission prompts.
-          extra_env_args=()
-          if [ -n "${MNGR_USER_ID}" ]; then
-            extra_env_args+=(--env "MNGR_USER_ID=${MNGR_USER_ID}")
-          fi
           uv run --project libs/mngr_tmr mngr tmr -vv \
             -S 'agent_types.yolo.parent_type="claude"' \
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
@@ -101,7 +90,6 @@ jobs:
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
-            "${extra_env_args[@]}" \
             --output-html tmr-report/index.html \
             --format jsonl \
             ${{ inputs.test_paths }} \

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -19,6 +19,10 @@ on:
         description: "Optional MNGR_USER_ID for the orchestrator (lets you see CI-created modal agents from your local mngr)."
         required: false
         default: ""
+      additional_authorized_hosts:
+        description: "Optional SSH public keys to install in authorized_keys on each agent host (one per line; allows inbound SSH for debugging)."
+        required: false
+        default: ""
 
 jobs:
   tmr:
@@ -61,6 +65,8 @@ jobs:
           git config user.name "imbue-dev"
 
       - name: Run TMR orchestrator
+        env:
+          ADDITIONAL_AUTHORIZED_HOSTS: ${{ inputs.additional_authorized_hosts }}
         run: |
           mkdir -p tmr-report
           # The "yolo" agent type is normally defined in the user's personal
@@ -68,6 +74,12 @@ jobs:
           # `-S` overrides. parent_type=claude inherits the claude defaults,
           # and cli_args adds --dangerously-skip-permissions so non-interactive
           # agents do not hang on per-tool permission prompts.
+          authorized_host_args=()
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              authorized_host_args+=(--additional-authorized-host "$line")
+            fi
+          done <<< "${ADDITIONAL_AUTHORIZED_HOSTS}"
           uv run --project libs/mngr_tmr mngr tmr -vv \
             -S 'agent_types.yolo.parent_type="claude"' \
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
@@ -76,6 +88,7 @@ jobs:
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+            "${authorized_host_args[@]}" \
             --output-html tmr-report/index.html \
             --format jsonl \
             ${{ inputs.test_paths }} \

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -15,14 +15,6 @@ on:
         description: "Agent type (e.g. yolo, claude)"
         required: true
         default: "yolo"
-      modal_token_id:
-        description: "Override MODAL_TOKEN_ID (defaults to org var)."
-        required: false
-        default: ""
-      modal_token_secret:
-        description: "Override MODAL_TOKEN_SECRET (defaults to org secret). NOTE: visible on the run details page to anyone with repo read access; logs are masked."
-        required: false
-        default: ""
       mngr_user_id:
         description: "Optional MNGR_USER_ID for the orchestrator (lets you see CI-created modal agents from your local mngr)."
         required: false
@@ -36,19 +28,13 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      MODAL_TOKEN_ID: ${{ inputs.modal_token_id || vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ inputs.modal_token_secret || secrets.MODAL_TOKEN_SECRET }}
+      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       MNGR_USER_ID: ${{ inputs.mngr_user_id }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Mask user-supplied MODAL_TOKEN_SECRET
-        if: inputs.modal_token_secret != ''
-        env:
-          MODAL_TOKEN_SECRET_INPUT: ${{ inputs.modal_token_secret }}
-        run: echo "::add-mask::$MODAL_TOKEN_SECRET_INPUT"
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -15,6 +15,18 @@ on:
         description: "Agent type (e.g. yolo, claude)"
         required: true
         default: "yolo"
+      modal_token_id:
+        description: "Override MODAL_TOKEN_ID (defaults to org var). NOTE: visible on the run details page to anyone with repo read access; logs are masked."
+        required: false
+        default: ""
+      modal_token_secret:
+        description: "Override MODAL_TOKEN_SECRET (defaults to org secret). NOTE: visible on the run details page to anyone with repo read access; logs are masked."
+        required: false
+        default: ""
+      mngr_user_id:
+        description: "Optional MNGR_USER_ID to set on the orchestrator and pass to launched agents (lets you see CI-created modal agents from your local mngr)."
+        required: false
+        default: ""
 
 jobs:
   tmr:
@@ -24,12 +36,26 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      MODAL_TOKEN_ID: ${{ inputs.modal_token_id || vars.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ inputs.modal_token_secret || secrets.MODAL_TOKEN_SECRET }}
+      MNGR_USER_ID: ${{ inputs.mngr_user_id }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Mask user-supplied credentials
+        if: inputs.modal_token_id != '' || inputs.modal_token_secret != ''
+        env:
+          MODAL_TOKEN_ID_INPUT: ${{ inputs.modal_token_id }}
+          MODAL_TOKEN_SECRET_INPUT: ${{ inputs.modal_token_secret }}
+        run: |
+          if [ -n "$MODAL_TOKEN_ID_INPUT" ]; then
+            echo "::add-mask::$MODAL_TOKEN_ID_INPUT"
+          fi
+          if [ -n "$MODAL_TOKEN_SECRET_INPUT" ]; then
+            echo "::add-mask::$MODAL_TOKEN_SECRET_INPUT"
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -63,6 +89,10 @@ jobs:
           # `-S` overrides. parent_type=claude inherits the claude defaults,
           # and cli_args adds --dangerously-skip-permissions so non-interactive
           # agents do not hang on per-tool permission prompts.
+          extra_env_args=()
+          if [ -n "${MNGR_USER_ID}" ]; then
+            extra_env_args+=(--env "MNGR_USER_ID=${MNGR_USER_ID}")
+          fi
           uv run --project libs/mngr_tmr mngr tmr -vv \
             -S 'agent_types.yolo.parent_type="claude"' \
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
@@ -71,8 +101,9 @@ jobs:
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+            "${extra_env_args[@]}" \
             --output-html tmr-report/index.html \
-            --output-format jsonl \
+            --format jsonl \
             ${{ inputs.test_paths }} \
             -- ${{ inputs.pytest_args }} \
             | tee tmr-report/events.jsonl

--- a/changelog/mngr-tmr-ci-trois.md
+++ b/changelog/mngr-tmr-ci-trois.md
@@ -1,7 +1,17 @@
+`mngr tmr` accepts a new repeatable flag `--additional-authorized-host`
+that adds SSH public key lines to the `authorized_keys` file installed
+on each agent host (test agents, host pool, snapshotter, and
+integrator). This lets you SSH directly into any agent host TMR
+creates, primarily for live debugging.
+
 The TMR GitHub Actions workflow (`.github/workflows/tmr.yml`) now uses
 the canonical `--format` flag (the previous `--output-format` was not a
-real option) and accepts a new optional `workflow_dispatch` input:
-`mngr_user_id`. When set, it is exported into the orchestrator's
-process env so the `mngr tmr` run attributes the modal agents it
-creates to that user, with the goal of letting them be observed from
-the user's local `mngr list`.
+real option) and accepts two new optional `workflow_dispatch` inputs:
+
+- `mngr_user_id`: exported into the orchestrator's process env so the
+  `mngr tmr` run attributes the modal agents it creates to that user,
+  with the goal of letting them be observed from the user's local
+  `mngr list`.
+- `additional_authorized_hosts`: one SSH public key per line; each
+  non-empty line is forwarded to `mngr tmr` as a separate
+  `--additional-authorized-host` argument.

--- a/changelog/mngr-tmr-ci-trois.md
+++ b/changelog/mngr-tmr-ci-trois.md
@@ -3,7 +3,9 @@ the canonical `--format` flag (the previous `--output-format` was not a
 real option) and accepts three new optional `workflow_dispatch` inputs:
 `modal_token_id`, `modal_token_secret`, and `mngr_user_id`. Supplying
 your own Modal credentials and user ID lets you observe and debug the
-modal agents launched by a CI run from your local `mngr list`. The
-user-supplied Modal token values are masked from step logs via
-`::add-mask::`, but they remain visible on the workflow run details
-page to anyone with repo read access.
+modal agents launched by a CI run from your local `mngr list`:
+`MNGR_USER_ID` is exported into the orchestrator's process env so the
+`mngr tmr` run itself attributes the agents it creates. A user-supplied
+`modal_token_secret` is masked from step logs via `::add-mask::`, but
+all `workflow_dispatch` input values remain visible on the workflow run
+details page to anyone with repo read access.

--- a/changelog/mngr-tmr-ci-trois.md
+++ b/changelog/mngr-tmr-ci-trois.md
@@ -1,0 +1,9 @@
+The TMR GitHub Actions workflow (`.github/workflows/tmr.yml`) now uses
+the canonical `--format` flag (the previous `--output-format` was not a
+real option) and accepts three new optional `workflow_dispatch` inputs:
+`modal_token_id`, `modal_token_secret`, and `mngr_user_id`. Supplying
+your own Modal credentials and user ID lets you observe and debug the
+modal agents launched by a CI run from your local `mngr list`. The
+user-supplied Modal token values are masked from step logs via
+`::add-mask::`, but they remain visible on the workflow run details
+page to anyone with repo read access.

--- a/changelog/mngr-tmr-ci-trois.md
+++ b/changelog/mngr-tmr-ci-trois.md
@@ -1,11 +1,7 @@
 The TMR GitHub Actions workflow (`.github/workflows/tmr.yml`) now uses
 the canonical `--format` flag (the previous `--output-format` was not a
-real option) and accepts three new optional `workflow_dispatch` inputs:
-`modal_token_id`, `modal_token_secret`, and `mngr_user_id`. Supplying
-your own Modal credentials and user ID lets you observe and debug the
-modal agents launched by a CI run from your local `mngr list`:
-`MNGR_USER_ID` is exported into the orchestrator's process env so the
-`mngr tmr` run itself attributes the agents it creates. A user-supplied
-`modal_token_secret` is masked from step logs via `::add-mask::`, but
-all `workflow_dispatch` input values remain visible on the workflow run
-details page to anyone with repo read access.
+real option) and accepts a new optional `workflow_dispatch` input:
+`mngr_user_id`. When set, it is exported into the orchestrator's
+process env so the `mngr tmr` run attributes the modal agents it
+creates to that user, with the goal of letting them be observed from
+the user's local `mngr list`.

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -133,6 +133,7 @@ class TmrCliOptions(CommonCliOptions):
     output_html: str | None
     source: str | None
     reintegrate: str | None
+    additional_authorized_keys: tuple[str, ...]
 
 
 _MIN_FD_LIMIT = 4096
@@ -344,6 +345,7 @@ def _run_reintegrate(
         env_options=env_options,
         label_options=label_options,
         templates=integrator_templates,
+        additional_authorized_keys=opts.additional_authorized_keys,
     )
     integrator_result = _run_integrator_phase(
         results, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit
@@ -566,6 +568,13 @@ def _run_integrator_phase(
     help="Re-read outcomes from a previous TMR run (by run name), re-run integrator, and regenerate report. "
     "Skips test collection and agent launching.",
 )
+@click.option(
+    "--additional-authorized-host",
+    "additional_authorized_keys",
+    multiple=True,
+    help="SSH public key line to install in authorized_keys on each agent host "
+    "(test agents, integrator, host pool, and snapshotter), allowing inbound SSH [repeatable]",
+)
 @add_common_options
 @click.pass_context
 def tmr(ctx: click.Context, **kwargs: object) -> None:
@@ -631,6 +640,7 @@ def tmr(ctx: click.Context, **kwargs: object) -> None:
         label_options=label_options,
         snapshot=provided_snapshot,
         templates=opts.agent_template,
+        additional_authorized_keys=opts.additional_authorized_keys,
     )
 
     try:
@@ -764,6 +774,7 @@ def _run_tmr_pipeline(
         env_options=env_options,
         label_options=label_options,
         templates=integrator_templates,
+        additional_authorized_keys=opts.additional_authorized_keys,
     )
     integrator_result = _run_integrator_phase(
         results, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit

--- a/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
@@ -119,6 +119,10 @@ class TmrLaunchConfig(FrozenModel):
         default=(),
         description="Create template names to apply when creating agents",
     )
+    additional_authorized_keys: tuple[str, ...] = Field(
+        default=(),
+        description="SSH public key lines to install in authorized_keys on each agent host (allows inbound SSH)",
+    )
 
 
 class IntegratorResult(FrozenModel):

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -21,6 +21,7 @@ from imbue.mngr.hosts.host import HostLocation
 from imbue.mngr.interfaces.host import AgentDataOptions
 from imbue.mngr.interfaces.host import AgentGitOptions
 from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import HostEnvironmentOptions
 from imbue.mngr.interfaces.host import NewHostBuildOptions
 from imbue.mngr.interfaces.host import NewHostOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
@@ -88,6 +89,11 @@ def _resolve_build_options(config: TmrLaunchConfig, mngr_ctx: MngrContext) -> Ne
     build_args = tuple(str(a) for a in raw_build_args) if isinstance(raw_build_args, (list, tuple)) else ()
     start_args = tuple(str(a) for a in raw_start_args) if isinstance(raw_start_args, (list, tuple)) else ()
     return NewHostBuildOptions(snapshot=config.snapshot, build_args=build_args, start_args=start_args)
+
+
+def _build_host_environment(config: TmrLaunchConfig) -> HostEnvironmentOptions:
+    """Build HostEnvironmentOptions for hosts created by tmr."""
+    return HostEnvironmentOptions(authorized_keys=config.additional_authorized_keys)
 
 
 def build_agent_options(
@@ -160,7 +166,12 @@ def _create_tmr_agent(
         target_host = config.source_host
     else:
         build = _resolve_build_options(config, mngr_ctx)
-        target_host = NewHostOptions(provider=config.provider_name, name=host_name, build=build)
+        target_host = NewHostOptions(
+            provider=config.provider_name,
+            name=host_name,
+            build=build,
+            environment=_build_host_environment(config),
+        )
 
     if is_snapshotter:
         source_location = HostLocation(host=config.source_host, path=config.source_dir)
@@ -289,9 +300,15 @@ def _create_host_pool(
         max_workers=max_parallel,
     ) as executor:
         futures = []
+        host_environment = _build_host_environment(config)
         for i in range(host_count):
             h_name = HostName(f"{run_name}-host-{i}")
-            new_host_opts = NewHostOptions(provider=config.provider_name, name=h_name, build=build)
+            new_host_opts = NewHostOptions(
+                provider=config.provider_name,
+                name=h_name,
+                build=build,
+                environment=host_environment,
+            )
             futures.append(executor.submit(resolve_target_host, new_host_opts, mngr_ctx))
         for future in futures:
             try:


### PR DESCRIPTION
## Summary
- Fix the TMR orchestrator invocation in `.github/workflows/tmr.yml`: replace `--output-format jsonl` (not a real option) with the canonical `--format jsonl`. The previous flag silently no-op'd, so JSONL emission may not have been reaching `tmr-report/events.jsonl` and the integrator-branch detection step that parses it.
- Add a new repeatable `mngr tmr` flag `--additional-authorized-host`. Each value is an SSH public key line that gets installed in the `authorized_keys` of every agent host TMR creates (test agents, pooled hosts, snapshotter, and integrator), so you can SSH in directly for live debugging. Plumbed via `TmrLaunchConfig.additional_authorized_keys` into `NewHostOptions.environment.authorized_keys` at both host-creation sites in `launching.py`.
- Add two new optional `workflow_dispatch` inputs to the workflow:
  - `mngr_user_id`: exported into the orchestrator's process env so the `mngr tmr` run attributes the modal agents it creates to that user, with the goal of letting them be observed via the user's local `mngr list`.
  - `additional_authorized_hosts`: multi-line; each non-empty line becomes one `--additional-authorized-host` arg.

## Test plan
- [ ] Dispatch the workflow with no extra inputs; confirm it still runs end-to-end and that `tmr-report/events.jsonl` contains JSONL events (in particular an `integrator_branch` event when fixes are produced).
- [ ] Dispatch with `mngr_user_id` set to your personal `MNGR_USER_ID`; verify whether the launched modal sandboxes become visible in your local `mngr list --provider modal`. (CI runs under the org Modal token, so this hypothesis may not hold; if it doesn't, we'll need to reintroduce per-user Modal credential inputs.)
- [ ] Dispatch with `additional_authorized_hosts` set to one or more SSH public keys (one per line); SSH directly into a launched agent host using a private key matching one of those public keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)