### PR TITLE
minds-workspace-server: stop applications.toml watcher from pinning CPU

### DIFF
--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager.py
@@ -99,13 +99,19 @@ class _LogQueueCallback(MutableModel):
 
 
 class _ApplicationsFileHandler(FileSystemEventHandler):
-    """Watchdog handler that triggers on any change to applications.toml.
+    """Watchdog handler that triggers on mutating changes to applications.toml.
 
-    Uses ``on_any_event`` rather than ``on_modified`` because scripts/forward_port.py
-    upserts atomically via ``tempfile.mkstemp`` + ``os.replace``. Atomic replaces
-    surface through watchdog as moved/created events, not modified events, so a
-    handler that only overrides ``on_modified`` would silently miss every
-    service registration after the watcher starts.
+    Subscribes to mutation events (modified/created/deleted/moved/closed)
+    rather than ``on_any_event`` because watchdog's default inotify mask also
+    includes ``IN_OPEN`` / ``IN_CLOSE_NOWRITE``. Reacting to those would form
+    a feedback loop -- the handler reads the file, the read triggers fresh
+    open/close-no-write events, and one CPU core is pinned per agent watcher.
+
+    ``on_modified`` alone is insufficient because scripts/forward_port.py
+    upserts atomically via ``tempfile.mkstemp`` + ``os.replace``, which
+    surfaces as a moved/created event, not a modified event. ``on_closed``
+    (``IN_CLOSE_WRITE``) is included so that direct writers which don't go
+    through an atomic rename still trigger a re-read on close.
 
     Events are filtered to only those whose src or dest path basename is
     ``applications.toml``. Without this filter we'd also fire on every write
@@ -117,7 +123,7 @@ class _ApplicationsFileHandler(FileSystemEventHandler):
     agent_id: str
     on_change: Any
 
-    def on_any_event(self, event: FileSystemEvent) -> None:
+    def _maybe_fire(self, event: FileSystemEvent) -> None:
         if event.is_directory:
             return
         paths = [event.src_path]
@@ -125,6 +131,12 @@ class _ApplicationsFileHandler(FileSystemEventHandler):
             paths.append(event.dest_path)
         if any(os.path.basename(p) == _APPLICATIONS_TOML_BASENAME for p in paths):
             self.on_change(self.agent_id)
+
+    on_modified = _maybe_fire
+    on_created = _maybe_fire
+    on_deleted = _maybe_fire
+    on_moved = _maybe_fire
+    on_closed = _maybe_fire
 
 
 def _make_applications_file_handler(

--- a/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
+++ b/apps/minds_workspace_server/imbue/minds_workspace_server/agent_manager_test.py
@@ -7,8 +7,10 @@ import threading
 from pathlib import Path
 
 import pytest
+from watchdog.events import FileClosedNoWriteEvent
 from watchdog.events import FileModifiedEvent
 from watchdog.events import FileMovedEvent
+from watchdog.events import FileOpenedEvent
 
 from imbue.minds_workspace_server.agent_manager import AgentManager
 from imbue.minds_workspace_server.agent_manager import _LogQueueCallback
@@ -390,6 +392,34 @@ def test_applications_file_handler_ignores_unrelated_paths(tmp_path: Path) -> No
     handler.dispatch(FileModifiedEvent(src_path=str(tmp_path / "applications.toml.abc123.tmp")))
 
     assert seen == []
+
+
+def test_applications_file_handler_ignores_open_and_close_no_write(tmp_path: Path) -> None:
+    """The handler must not fire on read-only events (FileOpenedEvent /
+    FileClosedNoWriteEvent). Watchdog 3+ emits these on Linux for any open()
+    / close() of the watched file -- including the read() inside
+    _read_applications itself. If the handler reacts to them it triggers an
+    inotify feedback loop that pins one CPU core per agent watcher.
+    """
+    seen: list[str] = []
+    handler = _make_applications_file_handler("agent-x", lambda aid: seen.append(aid))
+
+    handler.dispatch(FileOpenedEvent(src_path=str(tmp_path / "applications.toml")))
+    handler.dispatch(FileClosedNoWriteEvent(src_path=str(tmp_path / "applications.toml")))
+
+    assert seen == []
+
+
+def test_applications_file_handler_fires_on_modify(tmp_path: Path) -> None:
+    """A direct write (e.g. ``echo ... > applications.toml``) surfaces as a
+    FileModifiedEvent and must still trigger the change callback.
+    """
+    seen: list[str] = []
+    handler = _make_applications_file_handler("agent-x", lambda aid: seen.append(aid))
+
+    handler.dispatch(FileModifiedEvent(src_path=str(tmp_path / "applications.toml")))
+
+    assert seen == ["agent-x"]
 
 
 def test_stop_app_watcher_nonexistent(agent_manager: AgentManager) -> None:

--- a/changelog/gabriel-cpu.md
+++ b/changelog/gabriel-cpu.md
@@ -1,0 +1,7 @@
+Fix CPU pin in minds-workspace-server caused by an inotify feedback loop on
+`runtime/applications.toml`. The `_ApplicationsFileHandler` watcher reacted
+to every event type that watchdog dispatches -- including `IN_OPEN` /
+`IN_CLOSE_NOWRITE`, which were re-emitted by the handler's own re-read of
+the file, pinning one CPU core per active agent. The handler now only
+subscribes to mutation events (`on_modified`, `on_created`, `on_deleted`,
+`on_moved`, `on_closed`) so a read no longer feeds the watcher.


### PR DESCRIPTION
## Summary
- `_ApplicationsFileHandler` subscribed via `on_any_event`, which on Linux includes `FileOpenedEvent` / `FileClosedNoWriteEvent`. The handler reacted by reading `applications.toml`, the read produced fresh open/close-no-write events, and one CPU core was pinned per active agent watcher (py-spy in an affected container showed Thread-1 spending ~100% in `_read_applications` -> `tomllib.loads` -> `read_text`).
- Fix: replace the catch-all with explicit mutation handlers (`on_modified` / `on_created` / `on_deleted` / `on_moved` / `on_closed`) so reads no longer feed the watcher. `on_closed` covers `IN_CLOSE_WRITE`, which is the legitimate "writer just finished" signal.
- The basename filter is preserved, so writes to `forward_port.py`'s `applications.toml.*.tmp` scratch files are still ignored.
- Same anti-pattern exists in `session_watcher._ChangeHandler` -- left for a follow-up since nothing currently triggers it in a hot loop.

## Test plan
- [x] New unit test: `FileOpenedEvent` / `FileClosedNoWriteEvent` -> handler must NOT fire.
- [x] New unit test: `FileModifiedEvent` -> handler must fire.
- [x] Existing handler tests (atomic move, scratch-file ignore) still pass.
- [x] `uv run ruff check` / `uv run ruff format --check` clean on changed files.
- [ ] Manual verification in an affected Linux container: `cat $work_dir/runtime/applications.toml` repeatedly, confirm `top` shows `minds-workspace-server` near 0% CPU and a 30s `py-spy record` no longer shows the dispatch thread dominating.
- [ ] Manual verification of legitimate updates: a service registration via `forward_port.py` (atomic rename) and a direct `echo ... > applications.toml` both still trigger `broadcast_applications_updated`.

Note: one pre-existing local test failure (`test_start_observe_spawns_long_lived_subprocess`) is unrelated -- the locally-installed `mngr` tool doesn't accept the `--on-error` flag the production code passes. Confirmed reproducible on clean main.