### PR TITLE
make changelog bot use the right email

### DIFF
--- a/changelog/mngr-changelog-bot-email.md
+++ b/changelog/mngr-changelog-bot-email.md
@@ -1,0 +1,1 @@
+- Fixed the changelog consolidation cron's commit author email: was `dev@imbue.com`, now `bot@imbue.com`, matching the verified email on the bot GitHub account whose token the cron uses to push and open PRs. Without this, GitHub couldn't attribute consolidation commits to the bot user.

--- a/scripts/changelog_consolidation_prompt.md
+++ b/scripts/changelog_consolidation_prompt.md
@@ -44,7 +44,7 @@ with the failing step number and error detail in `notes`.
    immediately above any prior date sections (so dates remain in
    reverse-chronological order). Preserve the existing file header.
 
-6. Configure git: `git config user.email "dev@imbue.com"`,
+6. Configure git: `git config user.email "bot@imbue.com"`,
    `git config user.name "Changelog Bot"`, `gh auth setup-git`.
 
 7. `git add -A` and `git commit -m "Consolidate changelog entries for <date>"`,


### PR DESCRIPTION
## Summary

- Changelog consolidation cron's prompt was setting `git config user.email "dev@imbue.com"`, but the bot account whose `GH_TOKEN` the cron uses has `bot@imbue.com` as its verified email
- With the mismatch, consolidation commits push fine (token auth is independent of commit metadata) but show no GitHub user attribution in the UI
- Sets `user.email` to `bot@imbue.com` so commits attribute to the bot account

## Test plan

- [x] Single one-line edit in `scripts/changelog_consolidation_prompt.md`
- [ ] Will verify on first cron fire after redeploy from main with the bot token

🤖 Generated with [Claude Code](https://claude.com/claude-code)