### PR TITLE
make changelog deploy script actually deploy + add info on running it

### DIFF
--- a/changelog/mngr-changelog-cron-deploy-docs.md
+++ b/changelog/mngr-changelog-cron-deploy-docs.md
@@ -1,0 +1,1 @@
+- Expanded the header docstring of `scripts/setup_changelog_agent.sh` to document the deploy/trigger procedure inline: which token to set as `GH_TOKEN` (bot, not personal), `CHANGELOG_REPLACE=1` for redeploy, the on-demand trigger command, and the image-cache-clear command for stale checkpoints.

--- a/changelog/mngr-changelog-cron-deploy-docs.md
+++ b/changelog/mngr-changelog-cron-deploy-docs.md
@@ -1,1 +1,2 @@
-- Expanded the header docstring of `scripts/setup_changelog_agent.sh` to document the deploy/trigger procedure inline: which token to set as `GH_TOKEN` (bot, not personal), `CHANGELOG_REPLACE=1` for redeploy, the on-demand trigger command, and the image-cache-clear command for stale checkpoints.
+- `scripts/setup_changelog_agent.sh` is now actually idempotent: running it twice in a row replaces an existing schedule instead of erroring out. Drops the `CHANGELOG_REPLACE=1` gate.
+- Header docstring now lists the required `GH_TOKEN` and `ANTHROPIC_API_KEY` env vars and the on-demand trigger one-liner.

--- a/changelog/mngr-changelog-cron-deploy-docs.md
+++ b/changelog/mngr-changelog-cron-deploy-docs.md
@@ -1,2 +1,2 @@
-- `scripts/setup_changelog_agent.sh` is now actually idempotent: running it twice in a row replaces an existing schedule instead of erroring out. Drops the `CHANGELOG_REPLACE=1` gate.
-- Header docstring now lists the required `GH_TOKEN` and `ANTHROPIC_API_KEY` env vars and the on-demand trigger one-liner.
+- `scripts/setup_changelog_agent.sh` now redeploys when re-run: removes any existing `changelog-consolidation` schedule before recreating, so the deployed schedule always reflects the current source. Drops the `CHANGELOG_REPLACE=1` gate that previously errored on an existing schedule.
+- Header docstring now lists the required `GH_TOKEN` (token for `bot@imbue.com`) and `ANTHROPIC_API_KEY` env vars, and includes the on-demand trigger one-liner.

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -15,12 +15,30 @@ set -euo pipefail
 # Modal logs, no separate state-volume artifact needed.
 #
 # Usage:
-#   ./scripts/setup_changelog_agent.sh
+#   ./scripts/setup_changelog_agent.sh                    # first-time deploy
+#   CHANGELOG_REPLACE=1 ./scripts/setup_changelog_agent.sh # redeploy (clobbers)
 #
-# Environment:
-#   CHANGELOG_PROVIDER  - Provider to use (default: "modal").
-#   CHANGELOG_VERIFY    - Verification mode (default: "none"). Set to "quick"
-#                         or "full" to run the agent once during deploy.
+# Required environment:
+#   GH_TOKEN          - the bot account's token, NOT a personal `gh auth token`.
+#                       The bot's GitHub-verified email is bot@imbue.com, which
+#                       the consolidation prompt's git config commands match,
+#                       so commit attribution lines up. Using a personal token
+#                       pushes commits + PRs as the deployer's account.
+#   ANTHROPIC_API_KEY - used by claude inside the cron container.
+#
+# Optional environment:
+#   CHANGELOG_PROVIDER - Provider to use (default: "modal").
+#   CHANGELOG_VERIFY   - Verification mode (default: "none"). Set to "quick"
+#                        or "full" to run the agent once during deploy.
+#
+# To trigger a fire on demand and read its JSON outcome (status / pr_url / notes):
+#   env -u MNGR_HOST_DIR -u MNGR_PREFIX MNGR_ROOT_NAME=mngr-changelog-schedule \
+#     uv run mngr schedule run changelog-consolidation --provider modal $DISABLE_PLUGIN_ARGS
+# (claude's final assistant message is the structured outcome; see also Modal app logs)
+#
+# If a previous deploy left a stale image-cache checkpoint that conflicts:
+#   rm -f ~/.mngr-changelog-schedule/build/*/mngr_build/*.checkpoint \
+#         ~/.mngr-changelog-schedule/build/*/mngr_build/current.tar.gz
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent setup of the nightly changelog consolidation agent.
-#
-# This script ensures exactly one "changelog-consolidation" schedule exists.
-# Safe to run multiple times: if the schedule already exists it is removed
-# and recreated from the current source, so re-running redeploys.
+# (Re)deploy the nightly changelog-consolidation schedule from the current
+# source. Removes any existing "changelog-consolidation" schedule first, so
+# running this is the way to redeploy after editing the prompt or this
+# script.
 #
 # The scheduled agent runs at midnight PST as a headless_claude agent. The
 # orchestration steps live in scripts/changelog_consolidation_prompt.md and

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -15,15 +15,10 @@ set -euo pipefail
 # Modal logs, no separate state-volume artifact needed.
 #
 # Usage:
-#   ./scripts/setup_changelog_agent.sh                    # first-time deploy
-#   CHANGELOG_REPLACE=1 ./scripts/setup_changelog_agent.sh # redeploy (clobbers)
+#   ./scripts/setup_changelog_agent.sh
 #
 # Required environment:
-#   GH_TOKEN          - the bot account's token, NOT a personal `gh auth token`.
-#                       The bot's GitHub-verified email is bot@imbue.com, which
-#                       the consolidation prompt's git config commands match,
-#                       so commit attribution lines up. Using a personal token
-#                       pushes commits + PRs as the deployer's account.
+#   GH_TOKEN          - token for bot@imbue.com.
 #   ANTHROPIC_API_KEY - used by claude inside the cron container.
 #
 # Optional environment:
@@ -35,10 +30,6 @@ set -euo pipefail
 #   env -u MNGR_HOST_DIR -u MNGR_PREFIX MNGR_ROOT_NAME=mngr-changelog-schedule \
 #     uv run mngr schedule run changelog-consolidation --provider modal $DISABLE_PLUGIN_ARGS
 # (claude's final assistant message is the structured outcome; see also Modal app logs)
-#
-# If a previous deploy left a stale image-cache checkpoint that conflicts:
-#   rm -f ~/.mngr-changelog-schedule/build/*/mngr_build/*.checkpoint \
-#         ~/.mngr-changelog-schedule/build/*/mngr_build/current.tar.gz
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -78,9 +69,9 @@ names = sorted({ep.name for ep in importlib.metadata.entry_points(group='mngr')}
 print(' '.join(f'--disable-plugin {n}' for n in names))
 ")
 
-# Check if the trigger already exists. Error unless CHANGELOG_REPLACE=1 was
-# set, since the user probably wants to know they're about to clobber a live
-# schedule.
+# Always remove an existing trigger before recreating, so the script is
+# truly idempotent (running it twice produces a schedule that matches the
+# current source, regardless of whether one already exists).
 EXISTING=$(uv run mngr schedule list --provider "$PROVIDER" --all --format json $DISABLE_PLUGIN_ARGS 2>/dev/null || echo '{"schedules":[]}')
 if echo "$EXISTING" | python3 -c "
 import json, sys
@@ -88,12 +79,7 @@ data = json.load(sys.stdin)
 names = [s['trigger']['name'] for s in data.get('schedules', [])]
 sys.exit(0 if '${TRIGGER_NAME}' in names else 1)
 " 2>/dev/null; then
-    if [ "${CHANGELOG_REPLACE:-}" != "1" ]; then
-        echo "Error: Schedule '${TRIGGER_NAME}' already exists on provider '$PROVIDER'." >&2
-        echo "       Set CHANGELOG_REPLACE=1 to remove the existing schedule and redeploy." >&2
-        exit 1
-    fi
-    echo "CHANGELOG_REPLACE=1 set. Removing existing schedule before redeploy..."
+    echo "Removing existing schedule '${TRIGGER_NAME}' before redeploy..."
     uv run mngr schedule remove "$TRIGGER_NAME" --provider "$PROVIDER" --force $DISABLE_PLUGIN_ARGS
 fi
 

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # Idempotent setup of the nightly changelog consolidation agent.
 #
 # This script ensures exactly one "changelog-consolidation" schedule exists.
-# Safe to run multiple times: skips creation if the schedule already exists.
+# Safe to run multiple times: if the schedule already exists it is removed
+# and recreated from the current source, so re-running redeploys.
 #
 # The scheduled agent runs at midnight PST as a headless_claude agent. The
 # orchestration steps live in scripts/changelog_consolidation_prompt.md and

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -69,9 +69,8 @@ names = sorted({ep.name for ep in importlib.metadata.entry_points(group='mngr')}
 print(' '.join(f'--disable-plugin {n}' for n in names))
 ")
 
-# Always remove an existing trigger before recreating, so the script is
-# truly idempotent (running it twice produces a schedule that matches the
-# current source, regardless of whether one already exists).
+# Always remove an existing trigger before recreating, so the deployed
+# schedule reflects the current source no matter what was deployed before.
 EXISTING=$(uv run mngr schedule list --provider "$PROVIDER" --all --format json $DISABLE_PLUGIN_ARGS 2>/dev/null || echo '{"schedules":[]}')
 if echo "$EXISTING" | python3 -c "
 import json, sys

--- a/scripts/setup_changelog_agent.sh
+++ b/scripts/setup_changelog_agent.sh
@@ -140,5 +140,6 @@ uv run mngr schedule add "$TRIGGER_NAME" \
 echo "Schedule '${TRIGGER_NAME}' created successfully."
 echo ""
 echo "To trigger a run on demand and read its outcome JSON:"
-echo "  uv run mngr schedule run $TRIGGER_NAME --provider $PROVIDER $DISABLE_PLUGIN_ARGS"
+echo "  env -u MNGR_HOST_DIR -u MNGR_PREFIX MNGR_ROOT_NAME=mngr-changelog-schedule \\"
+echo "    uv run mngr schedule run $TRIGGER_NAME --provider $PROVIDER $DISABLE_PLUGIN_ARGS"
 echo "(claude's final assistant message is a single JSON object: {status, pr_url, notes})"


### PR DESCRIPTION
## Summary

Two coordinated changes to `scripts/setup_changelog_agent.sh`:

**Documentation:** the header docstring now covers what isn't otherwise obvious from reading the script:
- `GH_TOKEN` should be a token for `bot@imbue.com` (the prompt's `git config user.email` is set to match, so commits attribute correctly).
- `ANTHROPIC_API_KEY` is also required.
- On-demand trigger one-liner that produces the JSON outcome (status / pr_url / notes).

**Behavior:** the script now always (re)deploys.
- Drops the `CHANGELOG_REPLACE=1` gate that previously errored if a schedule already existed; running the script always removes the existing trigger and recreates it from the current source.
- Header reworded from "Idempotent setup..." to "(Re)deploy the nightly changelog-consolidation schedule from the current source."

Closes #1549 (separate README draft, replaced by inline header docs). Existing inline comments in the script body already cover the deploy pitfalls (output-format flags, single-quoted `-S`, cli_args-vs-agent_args).

## Test plan

- [x] `bash -n` parse OK
- [x] Manual redeploy + on-demand trigger from this branch (the trigger surfaced a separate fine-grained-PAT scoping issue on the bot account, which is being resolved out-of-band — not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)