### PR TITLE
mngr_modal: restore per-test reset of ModalProviderBackend._app_registry

### DIFF
--- a/changelog/wz-restore-modal-app-registry-reset.md
+++ b/changelog/wz-restore-modal-app-registry-reset.md
@@ -1,0 +1,9 @@
+- mngr_modal: restore the per-test reset of `ModalProviderBackend._app_registry`. The
+  autouse `_reset_modal_app_registry` fixture was deleted in #1533. After #1522
+  reshaped the test factory to dispatch through `_construct_modal_provider`
+  (which short-circuits on the class-level `_app_registry`), the reset became
+  load-bearing for cross-test isolation: the second test in a worker would
+  reuse the first test's cached app and skip `modal_interface.app_create(...)`,
+  leaving `testing_modal._apps` empty and breaking helpers like
+  `make_sandbox_with_tags`. Restoring the fixture fixes the post-merge CI
+  failures on main.

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -324,12 +324,6 @@ def temp_source_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def _reset_modal_app_registry() -> Generator[None, None, None]:
-    # Required for test isolation: ``ModalProviderBackend._app_registry`` is
-    # class-level, and ``_get_or_create_app_with_capture`` short-circuits on
-    # it before calling ``modal_interface.app_create(...)``. Without this
-    # reset, the second test in a worker reuses the first test's cached app,
-    # so the per-test ``testing_modal._apps`` is never populated and
-    # ``make_sandbox_with_tags`` raises ``IndexError``.
     yield
     ModalProviderBackend.reset_app_registry()
 

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -322,6 +322,18 @@ def temp_source_dir(tmp_path: Path) -> Path:
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def _reset_modal_app_registry() -> Generator[None, None, None]:
+    # Required for test isolation: ``ModalProviderBackend._app_registry`` is
+    # class-level, and ``_get_or_create_app_with_capture`` short-circuits on
+    # it before calling ``modal_interface.app_create(...)``. Without this
+    # reset, the second test in a worker reuses the first test's cached app,
+    # so the per-test ``testing_modal._apps`` is never populated and
+    # ``make_sandbox_with_tags`` raises ``IndexError``.
+    yield
+    ModalProviderBackend.reset_app_registry()
+
+
 def _get_leaked_modal_apps() -> list[tuple[str, str]]:
     if not worker_modal_app_names:
         return []

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -324,6 +324,7 @@ def temp_source_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture(autouse=True)
 def _reset_modal_app_registry() -> Generator[None, None, None]:
+    """Reset the Modal app registry after each test for isolation."""
     yield
     ModalProviderBackend.reset_app_registry()
 


### PR DESCRIPTION
## Summary

Fixes the post-merge CI failure on main caused by #1533 (`2c219c40`).

PR #1533's "concise comments" commit deleted the autouse `_reset_modal_app_registry` fixture from `libs/mngr_modal/imbue/mngr_modal/conftest.py`. On that PR's branch base, the deletion was harmless. After merging onto main, it combined with #1522's earlier refactor of `make_testing_provider` (now dispatches through `ModalProviderBackend._construct_modal_provider`, which short-circuits on the class-level `cls._app_registry`) to produce a textbook semantic-merge bug:

- 1st test in a worker: populates `cls._app_registry` and `testing_modal._apps`.
- 2nd test: gets a fresh function-scoped `testing_modal`. The class-level cache short-circuits before `modal_interface.app_create(...)` runs, so the new `testing_modal._apps` stays empty.
- `make_sandbox_with_tags` does `list(modal_interface._apps.values())[0]` → `IndexError`.

That matches all 9 failures on `2c219c40` (8 IndexErrors + 1 `assert N == 1` from cross-test state leakage) — see https://github.com/imbue-ai/mngr/actions/runs/25575478761.

The merge itself is textually clean — replaying it locally produces the identical tree. The PR's pre-merge CI was green because GitHub tested the PR head against its old base (which predates #1522), not against post-merge main.

## Fix

Restore the autouse fixture, with a comment explaining why it's load-bearing post-#1522 so it doesn't get pruned again.

## Test plan

- [x] Reproduced the failure with single-process pytest on the same 4 cases CI hit: 3 fail without the fix, 4 pass with.
- [x] Full `libs/mngr_modal` unit/integration tests (`just test-quick "libs/mngr_modal -m 'not modal and not docker and not docker_sdk and not acceptance and not release'"`) → 374 passed.
- [ ] CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)