### PR TITLE
get rid of unused type: ignore

### DIFF
--- a/changelog/mngr-fix-type-error.md
+++ b/changelog/mngr-fix-type-error.md
@@ -1,0 +1,1 @@
+- Removed an unused `# type: ignore[misc]` in `ssh_tunnel_test.py` so the type-error ratchet stops failing on it.

--- a/libs/mngr_forward/imbue/mngr_forward/ssh_tunnel_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/ssh_tunnel_test.py
@@ -57,7 +57,7 @@ def test_remote_ssh_info_round_trip() -> None:
 def test_remote_ssh_info_is_frozen() -> None:
     info = RemoteSSHInfo(user="root", host="1.2.3.4", port=22, key_path=Path("/tmp/k"))
     with pytest.raises((ValueError, TypeError)):
-        info.user = "other"  # type: ignore[misc]
+        info.user = "other"
 
 
 # -- ReverseTunnelInfo / ReverseTunnelSpec ---------------------------------


### PR DESCRIPTION
## Summary

- Removes an unused `# type: ignore[misc]` on the `info.user = "other"` line of `libs/mngr_forward/imbue/mngr_forward/ssh_tunnel_test.py`. The type checker (`apps/modal_litellm/test_ratchets.py::test_no_type_errors`) was emitting `unused-type-ignore-comment` for that line and failing the ratchet.
- The assignment is inside `pytest.raises((ValueError, TypeError))`, so the runtime check that the model is frozen is still exercised; only the (no-longer-needed) static suppression is removed.

## Scope

- This PR only addresses the ssh_tunnel_test.py issue, which is present on `main`.
- A separate type error reported on the same ratchet run (`scripts/consolidate_changelog_test.py:167` — `dt.tzinfo.key`) is **not** on `main`; it lives only on `mngr/changelog-pacific-dates`. It needs a separate fix on that branch.

## Test plan

- [ ] `just test-quick "apps/modal_litellm -k test_no_type_errors"` passes (was failing on `main` before this change for the ssh_tunnel line).
- [ ] `just test-quick libs/mngr_forward/imbue/mngr_forward/ssh_tunnel_test.py::test_remote_ssh_info_is_frozen` still passes (runtime frozen-model check still raises).
- [ ] Full `just test-offload` is green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
