### PR TITLE
Classify missing-host-key SSH errors as HostAuthenticationError

### DIFF
--- a/changelog/mngr-fix-gc.md
+++ b/changelog/mngr-fix-gc.md
@@ -1,0 +1,1 @@
+Fixed `mngr gc` crashing on hosts whose SSH host key is missing from `known_hosts`. Such errors now raise `HostAuthenticationError` (a trust failure) instead of the generic `HostConnectionError`, so existing per-host gc handlers skip them with a warning instead of aborting the whole run.

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -236,7 +236,11 @@ class OuterHost(OuterHostInterface):
             if not self.connector.host.connected:
                 self.connector.host.connect(raise_exceptions=True)
         except ConnectError as e:
-            if "authentication error" in str(e).lower():
+            message = str(e).lower()
+            # Missing/unverifiable host keys are a trust failure: we have no basis to
+            # authenticate the remote sshd, so this is an authentication problem rather
+            # than a generic connectivity one.
+            if "authentication error" in message or "no host key for" in message:
                 raise HostAuthenticationError(f"Authentication failed when connecting to host: {e}") from e
             else:
                 raise HostConnectionError(f"Failed to connect to host: {e}") from e

--- a/libs/mngr/imbue/mngr/hosts/outer_host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host_test.py
@@ -1,6 +1,14 @@
 """Unit tests for OuterHost and the outer-host accessors."""
 
+from typing import cast
+
+import pytest
+from pyinfra.api.exceptions import ConnectError
+from pyinfra.api.host import Host as PyinfraHost
+
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import HostAuthenticationError
+from imbue.mngr.errors import HostConnectionError
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.hosts.outer_host import OuterHost
 from imbue.mngr.hosts.outer_host import create_local_pyinfra_host
@@ -146,3 +154,80 @@ def test_outer_host_streaming_local_streams_stderr(temp_mngr_ctx: MngrContext) -
     assert "to-stderr" in received
     assert "to-stdout" in result.stdout
     assert "to-stderr" in result.stderr
+
+
+class _FakePyinfraHostRaisingOnConnect:
+    """Minimal pyinfra-host stand-in whose ``connect()`` raises a configured ConnectError.
+
+    Just enough surface for ``OuterHost._ensure_connected`` to exercise its
+    ``ConnectError`` -> ``HostAuthenticationError`` / ``HostConnectionError``
+    classifier without touching the network or paramiko.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.connected = False
+        self.name = "fake-ssh-host"
+        self.connector_cls = type("SSHConnector", (), {})
+        self._message = message
+
+    def connect(self, raise_exceptions: bool = False) -> None:
+        raise ConnectError(self._message)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Exact wording produced by pyinfra's StrictPolicy when known_hosts has no
+        # entry for the target. The lower() in _ensure_connected normalises the
+        # capitalised "No host key" to "no host key".
+        "SSH error: StrictPolicy: No host key for [example.com]:2222 found in known_hosts",
+        # Wording produced by pyinfra's ssh connector when paramiko reports an
+        # AuthenticationException; covers the pre-existing branch of the
+        # discriminator alongside the new "no host key for" branch.
+        "Authentication error (username=alice): bad password",
+    ],
+    ids=["missing-host-key", "auth-failure"],
+)
+def test_ensure_connected_classifies_trust_failures_as_auth_error(
+    temp_mngr_ctx: MngrContext,
+    message: str,
+) -> None:
+    """Trust failures (missing host key, bad credentials) raise HostAuthenticationError.
+
+    Regression test for ``mngr gc`` crashing on hosts whose SSH host key is
+    missing from ``known_hosts``: pyinfra wraps that as ``ConnectError("SSH
+    error: StrictPolicy: No host key for ...")``, and ``_ensure_connected``
+    must classify it as ``HostAuthenticationError`` so callers that only catch
+    that subclass (e.g. ``_gc_single_host_work_dir``) skip the host with a
+    warning instead of letting the bare ``HostConnectionError`` propagate.
+    """
+    fake = _FakePyinfraHostRaisingOnConnect(message)
+    outer = OuterHost(
+        id=HostId.generate(),
+        connector=PyinfraConnector(cast(PyinfraHost, fake)),
+        mngr_ctx=temp_mngr_ctx,
+    )
+
+    with pytest.raises(HostAuthenticationError):
+        outer._ensure_connected()
+
+
+def test_ensure_connected_classifies_unrelated_connect_errors_as_connection_error(
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Non-trust ConnectErrors stay as the generic HostConnectionError, not auth."""
+    fake = _FakePyinfraHostRaisingOnConnect(
+        "Could not resolve hostname: example.invalid",
+    )
+    outer = OuterHost(
+        id=HostId.generate(),
+        connector=PyinfraConnector(cast(PyinfraHost, fake)),
+        mngr_ctx=temp_mngr_ctx,
+    )
+
+    with pytest.raises(HostConnectionError) as excinfo:
+        outer._ensure_connected()
+    # HostAuthenticationError subclasses HostConnectionError, so we must check
+    # the concrete type to confirm we did NOT promote a generic connectivity
+    # failure to a trust failure.
+    assert not isinstance(excinfo.value, HostAuthenticationError)


### PR DESCRIPTION
## Summary

`mngr gc` was crashing with `paramiko.ssh_exception.SSHException: StrictPolicy: No host key for ... found in known_hosts` when any provider returned a host whose per-host `known_hosts` was empty (e.g. an `imbue_cloud` lease where the initial `_scan_container_host_key` best-effort scan failed).

`outer_host._ensure_connected` previously classified that as a generic `HostConnectionError`, which `_gc_single_host_work_dir` does not catch (it only catches the two narrower subclasses `HostOfflineError` and `HostAuthenticationError`). The exception propagated out of the future and aborted the whole gc run.

The fix is a 3-line change: a missing/unverifiable host key is conceptually a trust failure, so we now raise `HostAuthenticationError` for messages containing `"no host key for"` (alongside the existing `"authentication error"` match). The existing per-host handlers in gc then skip the host with a warning and gc completes normally.

## Test plan

- [x] Reproduce: `uv run mngr gc` against an `imbue_cloud` lease with empty per-host `known_hosts` -> previously crashed
- [x] After fix: `mngr gc` skips the affected host with a warning and runs all remaining phases to clean exit
- [ ] CI: existing tests still pass

## Followups (not in this PR)

- `mngr_imbue_cloud.ImbueCloudProvider.create_host` calls `_scan_container_host_key` best-effort and on failure leaves `known_hosts` empty with a comment claiming "mngr's auto-add policy" will recover -- but `create_pyinfra_host` hardcodes `ssh_strict_host_key_checking: yes`, so no auto-add ever happens. The lease ends up silently broken from then on.