### PR TITLE
Fire mngr-submit signal on SessionStart for /clear and /compact

### DIFF
--- a/changelog/mngr-em-fix-clear-mngr-message-timeout.md
+++ b/changelog/mngr-em-fix-clear-mngr-message-timeout.md
@@ -1,0 +1,1 @@
+- `mngr message <agent> -m /clear` (and `-m /compact`) no longer hangs for 90 s before returning. The `mngr-submit-<session>` tmux signal that `mngr message` waits on is now also fired from the SessionStart hook when the source is `clear` or `compact`, since those TUI-local slash commands do not trigger UserPromptSubmit.

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -502,7 +502,13 @@ def build_readiness_hooks_config() -> dict[str, Any]:
     files that signal agent state.
 
     - SessionStart: creates 'session_started' file AND tracks the current session ID
-      (writes to claude_session_id and appends to claude_session_id_history)
+      (writes to claude_session_id and appends to claude_session_id_history). Also
+      signals the tmux wait-for channel that ``mngr message`` waits on, but ONLY
+      when the session start was triggered by ``/clear`` or ``/compact``. These
+      are TUI-local slash commands that do NOT trigger UserPromptSubmit, so
+      without this signal ``mngr message agent -m /clear`` would time out at
+      ``enter_submission_timeout_seconds`` even though /clear actually executed.
+      Filtering on source ensures normal startup/resume don't fire stale signals.
     - UserPromptSubmit: creates 'active' file, removes 'permissions_waiting', signals tmux wait-for
     - PermissionRequest: creates 'permissions_waiting' file (Claude is waiting for permission approval)
     - PostToolUse: removes 'permissions_waiting' file (tool completed, permission resolved)
@@ -553,6 +559,23 @@ def build_readiness_hooks_config() -> dict[str, Any]:
                                 ' echo "$_MNGR_NEW_SID" > "$MNGR_AGENT_STATE_DIR/claude_session_id.tmp"'
                                 ' && mv "$MNGR_AGENT_STATE_DIR/claude_session_id.tmp" "$MNGR_AGENT_STATE_DIR/claude_session_id";'
                                 ' echo "$_MNGR_NEW_SID${_MNGR_SOURCE:+ $_MNGR_SOURCE}" >> "$MNGR_AGENT_STATE_DIR/claude_session_id_history"'
+                            ),
+                        },
+                        {
+                            # /clear and /compact do not trigger UserPromptSubmit
+                            # (they are TUI-local commands), so without this hook
+                            # `mngr message agent -m /clear` would time out at
+                            # `enter_submission_timeout_seconds` even though /clear
+                            # ran successfully. Mirror the UserPromptSubmit signal
+                            # here, gated on source so that normal startup/resume
+                            # don't fire stale signals.
+                            "type": "command",
+                            "command": (
+                                _SESSION_GUARD + "_MNGR_HOOK_INPUT=$(cat);"
+                                ' _MNGR_SOURCE=$(echo "$_MNGR_HOOK_INPUT" | jq -r ".source // empty");'
+                                ' case "$_MNGR_SOURCE" in clear|compact)'
+                                " tmux wait-for -S \"mngr-submit-$(tmux display-message -p '#S')\" 2>/dev/null || true ;;"
+                                " esac"
                             ),
                         },
                     ]

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -670,7 +670,7 @@ def test_build_readiness_hooks_config_has_session_start_hook() -> None:
     assert "SessionStart" in config["hooks"]
     assert len(config["hooks"]["SessionStart"]) == 1
     hooks = config["hooks"]["SessionStart"][0]["hooks"]
-    assert len(hooks) == 3
+    assert len(hooks) == 4
 
     # First hook: creates session_started file for polling-based detection
     assert hooks[0]["type"] == "command"
@@ -698,6 +698,19 @@ def test_build_readiness_hooks_config_has_session_start_hook() -> None:
     # Should use atomic write (write to .tmp then mv) to prevent torn reads
     assert "claude_session_id.tmp" in session_id_hook
     assert "mv" in session_id_hook
+
+    # Fourth hook: signals tmux wait-for on /clear and /compact so that
+    # `mngr message agent -m /clear` does not time out. /clear and /compact
+    # are TUI-local slash commands that do not trigger UserPromptSubmit, so
+    # we mirror that hook's tmux wait-for signal here, filtered by source.
+    submit_signal_hook = hooks[3]["command"]
+    assert hooks[3]["type"] == "command"
+    assert "tmux wait-for -S" in submit_signal_hook
+    assert "mngr-submit-" in submit_signal_hook
+    # Should filter on source so normal startup/resume do not fire the signal
+    assert "clear" in submit_signal_hook
+    assert "compact" in submit_signal_hook
+    assert "_MNGR_SOURCE" in submit_signal_hook
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- `mngr message <agent> -m /clear` (and `-m /compact`) was timing out at 90 s before returning, even though `/clear` actually executed in the agent's TUI. Any `&&`-chained command after `mngr message /clear` would never run.
- Root cause: `mngr message`'s `_send_enter_and_wait` waits on the `mngr-submit-<session>` tmux channel, which is signaled only by Claude Code's `UserPromptSubmit` hook. `/clear` and `/compact` are TUI-local slash commands that never reach the model and therefore never trigger `UserPromptSubmit`. They DO trigger `SessionStart` with `source` set to `clear` or `compact` respectively.
- Fix: mirror `UserPromptSubmit`'s tmux wait-for signal in `SessionStart`, gated on `source` so normal `startup`/`resume` don't fire stale signals. Same channel name (`mngr-submit-<session>`), so no change needed on the `mngr message` side.

## Why this is the right scope

- The `source` filter ensures we only signal for the cases that legitimately should unblock a pending `mngr message`. `startup` would fire on every container boot and could (briefly) wake a phantom waiter; `resume` is similar. Both are excluded.
- Symmetric with the existing `UserPromptSubmit` signal — same channel, same mechanism. No changes to `base_agent.py`/`mngr message`.
- Solves `/compact` as a free side effect, since it's another TUI-local command that fires `SessionStart`.
- Source values `"clear"` and `"compact"` verified against the Claude Code hook docs at `code.claude.com/docs/en/hooks`.

## Test plan

- [x] Existing `test_build_readiness_hooks_config_session_start` updated to assert 4 hooks (was 3) and verify the new hook signals `mngr-submit-` only on `clear` / `compact`.
- [x] All 8 `test_build_readiness_hooks_config*` tests pass locally.
- [ ] CI: full suite via offload.
- [ ] Manual: `mngr message <agent> -m /clear` returns promptly (verified locally via a hand-patched copy of the running agent's `.claude/settings.local.json`; the hand-patched 4-hook config delivered the signal correctly after a `mngr stop && mngr start`).

## Limitations / not in scope

- This only solves the `/clear` and `/compact` cases. Other TUI-local slash commands (`/help`, `/effort`, `/model`, etc.) would still time out — none of them currently trigger any state hook we could mirror. A more general fix (e.g. a `--no-wait` flag on `mngr message`, or a generalized waiter that succeeds on either tmux signal OR session-id change OR enqueue event — see the FIXME at `base_agent.py:610`) is out of scope here.