### PR TITLE
Remove DEV mode from Minds and clean up creation args

### DIFF
--- a/apps/minds/docs/design.md
+++ b/apps/minds/docs/design.md
@@ -19,7 +19,7 @@ Each workspace is created from a template repository (or local directory). The r
 
 ## Configuration
 
-All configuration lives in the template repository's `.mngr/settings.toml`. The desktop client passes `--template main` plus a mode-specific template (`--template dev` for DEV mode, `--template docker` for LOCAL mode) when running `mngr create`. The template's settings file defines everything the agent needs.
+All configuration lives in the template repository's `.mngr/settings.toml`. The desktop client passes `--template main` plus a mode-specific template (`--template docker` for LOCAL, `--template lima` for LIMA, `--template vultr` for CLOUD, or `--template imbue_cloud` for IMBUE_CLOUD) when running `mngr create`. The template's settings file defines everything the agent needs.
 
 ## Data and services
 

--- a/apps/minds/docs/overview.md
+++ b/apps/minds/docs/overview.md
@@ -30,7 +30,7 @@ Inside each agent's Docker container:
 
 Agents can be created in two ways:
 
-1. **Via the web UI**: Visit the desktop client. If no agents exist, you'll see a creation form. Enter a git repository URL (or local path), agent name, and launch mode (DEV or LOCAL). The desktop client clones the repo (if URL), runs `mngr create` with the appropriate templates, creates a Cloudflare tunnel, and injects the tunnel token.
+1. **Via the web UI**: Visit the desktop client. If no agents exist, you'll see a creation form. Enter a git repository URL (or local path), agent name, and launch mode (LOCAL, LIMA, CLOUD, or IMBUE_CLOUD). The desktop client clones the repo (if URL), runs `mngr create` with the appropriate templates, creates a Cloudflare tunnel, and injects the tunnel token.
 
 2. **Via the API**: POST to `/api/create-agent` with a JSON body containing `git_url`, `agent_name`, and `launch_mode`. Poll `/api/create-agent/{agent_id}/status` for progress.
 

--- a/apps/minds/docs/user_story.md
+++ b/apps/minds/docs/user_story.md
@@ -3,7 +3,7 @@ This is the primary flow for how a user would create a workspace for the first t
 1. User starts the desktop client: `minds`
 2. The server prints a one-time login URL to the terminal
 3. User visits the login URL to authenticate (sets a global session cookie)
-4. Since no agents exist, the landing page shows a creation form with fields for agent name, git repository URL (or local path), branch, and launch mode (DEV/LOCAL/CLOUD)
+4. Since no agents exist, the landing page shows a creation form with fields for agent name, git repository URL (or local path), branch, and launch mode (LOCAL/LIMA/CLOUD/IMBUE_CLOUD)
 5. User fills in the form and clicks Create
 6. The desktop client clones the repository to a temp directory (if a URL) or uses the local path directly, generates an agent ID, and runs `mngr create <name> --id <id> --no-connect --label workspace=<name> --template main --template <mode>`. If Cloudflare credentials are configured, it also creates a tunnel and injects the tunnel token into the agent.
 7. While creating, the user sees a progress page that polls for status

--- a/apps/minds/docs/workspace/getting_started.md
+++ b/apps/minds/docs/workspace/getting_started.md
@@ -15,7 +15,7 @@ This starts the local desktop client (default: `http://127.0.0.1:8420`). A one-t
 3. Fill in:
    - **Name**: a short identifier for the agent (e.g. "selene")
    - **Git repository**: URL or local path to a template repo (e.g. `https://github.com/imbue-ai/forever-claude-template`)
-   - **Launch mode**: LOCAL (Docker container) or DEV (runs in-place)
+   - **Launch mode**: LOCAL (Docker container on this machine), LIMA (Lima VM), CLOUD (Docker on a Vultr VPS), or IMBUE_CLOUD (leased pool host via the imbue_cloud provider)
 4. Click "Create" and wait for the Docker build + agent setup
 5. You'll be redirected to the agent's web server when creation completes
 

--- a/apps/minds/docs/workspace/glossary.md
+++ b/apps/minds/docs/workspace/glossary.md
@@ -18,4 +18,4 @@ Key concepts in the minds system:
 
 - **service event**: a JSON line in `events/services/events.jsonl` that registers (or deregisters) a service name and URL. The desktop client's MngrStreamManager watches these events to discover agent backends.
 
-- **launch mode**: how the agent runs. DEV mode runs in-place on the local host. LOCAL mode runs in a Docker container. CLOUD mode is not yet implemented.
+- **launch mode**: how the agent runs. LOCAL mode runs in a Docker container on the user's machine. LIMA runs in a Lima VM. CLOUD runs in Docker on a Vultr VPS. IMBUE_CLOUD leases a pre-baked pool host via the imbue_cloud provider plugin.

--- a/apps/minds/imbue/minds/cli/run.py
+++ b/apps/minds/imbue/minds/cli/run.py
@@ -161,16 +161,10 @@ def run(
     # surviving resolver from the plugin's stdout stream.
     mngr_host_dir_str = os.environ.get("MNGR_HOST_DIR")
     mngr_host_dir = Path(mngr_host_dir_str).expanduser() if mngr_host_dir_str else (Path.home() / ".mngr")
-    # ``MINDS_ALLOW_HOST_LOOPBACK=1`` opts into the plugin dialing host loopback
-    # without an SSH tunnel — needed for ``LaunchMode.DEV`` agents which run on
-    # the bare host. Off by default so the safer "refuse loopback fallback"
-    # path applies for everyone else (PR 1482).
-    allow_host_loopback = os.getenv("MINDS_ALLOW_HOST_LOOPBACK") == "1"
     forward_config = ForwardSubprocessConfig(
         port=mngr_forward_port,
         reverse_specs=(f"0:{port}",),
         mngr_host_dir=mngr_host_dir,
-        allow_host_loopback=allow_host_loopback,
     )
     consumer, preauth_cookie = start_mngr_forward(
         config=forward_config,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -366,7 +366,6 @@ def _build_mngr_create_command(
     host's pre-baked id anyway, and pre-generating one led to bugs (e.g.
     keying gateway state under a fictional id).
 
-    DEV mode: --template main --template dev (runs in-place on local provider)
     LOCAL mode: --template main --template docker (runs in Docker container)
     LIMA mode: --template main --template lima (runs in Lima VM)
     CLOUD mode: --template main --template vultr (runs in Docker on a Vultr VPS)
@@ -375,12 +374,12 @@ def _build_mngr_create_command(
         ``agent_name``); ``imbue_cloud_*`` arguments encode the lease
         attributes (--build-arg).
 
-    For modes that create a separate host (LOCAL, LIMA, CLOUD, IMBUE_CLOUD),
-    the agent address uses ``agent_name@{agent_name}-host`` so hosts are
-    clearly attributable. ``--reuse`` and ``--update`` are passed for the
-    non-IMBUE_CLOUD modes so re-deploying resets the agent on the same
-    host instead of failing on a duplicate name (IMBUE_CLOUD's lease
-    flow is one-shot per pool host, so reuse is not meaningful there).
+    Every mode creates a separate host, so the agent address uses
+    ``agent_name@{agent_name}-host`` so hosts are clearly attributable.
+    ``--reuse`` and ``--update`` are passed for the non-IMBUE_CLOUD modes
+    so re-deploying resets the agent on the same host instead of failing
+    on a duplicate name (IMBUE_CLOUD's lease flow is one-shot per pool
+    host, so reuse is not meaningful there).
 
     Secrets (``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``, ``GH_TOKEN``)
     are forwarded by the FCT template's own ``pass_(host_)env`` declarations,
@@ -389,20 +388,12 @@ def _build_mngr_create_command(
     them up. Keeping the forwarding declaration in FCT means the same
     template works for ``mngr create`` invocations from outside minds too.
 
-    For container/VM/VPS/leased modes, ``LATCHKEY_GATEWAY`` defaults to the
-    constant agent-side URL ``http://127.0.0.1:<AGENT_SIDE_LATCHKEY_PORT>``
-    (the loopback port that ``LatchkeyDiscoveryHandler`` reverse-tunnels
-    to the host-side gateway post-discovery), so containerized agents
-    always get a working URL without the caller having to know the live
-    gateway port. DEV mode runs on the bare host with no reverse tunnel,
-    so the constant agent-side URL is meaningless there -- callers that
-    want latchkey wiring for a DEV agent must pass
-    ``latchkey_gateway_url`` explicitly with the gateway's live host
-    address (typically ``http://127.0.0.1:<dynamic_host_port>``).
-
-    Passing ``latchkey_gateway_url`` for *any* mode overrides the
-    default. Passing ``None`` for DEV opts out of latchkey wiring
-    entirely for that agent.
+    ``LATCHKEY_GATEWAY`` defaults to the constant agent-side URL
+    ``http://127.0.0.1:<AGENT_SIDE_LATCHKEY_PORT>`` -- the loopback port
+    that ``LatchkeyDiscoveryHandler`` reverse-tunnels to the host-side
+    gateway post-discovery -- so the agent always gets a working URL
+    without the caller having to know the live gateway port. Passing
+    ``latchkey_gateway_url`` overrides the default.
 
     When ``latchkey_gateway_password`` is supplied, it is also injected as
     ``LATCHKEY_GATEWAY_PASSWORD`` so the agent's ``latchkey`` CLI authenticates
@@ -414,8 +405,6 @@ def _build_mngr_create_command(
     gateway's deny-all default.
     """
     match launch_mode:
-        case LaunchMode.DEV:
-            address = str(agent_name)
         case LaunchMode.LOCAL:
             address = f"{agent_name}@{_make_host_name(agent_name)}.docker"
         case LaunchMode.LIMA:
@@ -437,30 +426,23 @@ def _build_mngr_create_command(
     # ``--format jsonl`` makes mngr emit ``{"event": "created", "agent_id": ..., "host_id": ...}``
     # as the final stdout line; ``run_mngr_create`` parses that to recover
     # the canonical agent id.
-    # Non-DEV modes bridge the agent's loopback to a host-side latchkey
-    # gateway via the reverse tunnel ``LatchkeyDiscoveryHandler`` sets up
-    # post-discovery, so the URL is always the constant agent-side port.
-    # DEV mode runs the agent on the bare host with no tunnel; tests there
-    # set ``LATCHKEY_GATEWAY`` themselves if they want one.
-    # Default the URL to the constant agent-side port for tunneled modes.
-    # DEV agents run on the bare host with no reverse tunnel and so have
-    # no constant URL to fall back on; callers that want latchkey wiring
-    # for DEV must compute and pass the live gateway URL explicitly.
-    effective_latchkey_url = latchkey_gateway_url
-    if effective_latchkey_url is None and launch_mode is not LaunchMode.DEV:
-        effective_latchkey_url = f"http://127.0.0.1:{AGENT_SIDE_LATCHKEY_PORT}"
+    # Every launch mode bridges the agent's loopback to a host-side
+    # latchkey gateway via the reverse tunnel ``LatchkeyDiscoveryHandler``
+    # sets up post-discovery, so the URL is always the constant
+    # agent-side port unless the caller passes an explicit override.
+    effective_latchkey_url = (
+        latchkey_gateway_url if latchkey_gateway_url is not None else f"http://127.0.0.1:{AGENT_SIDE_LATCHKEY_PORT}"
+    )
 
-    latchkey_env_args: list[str] = []
-    if effective_latchkey_url is not None:
-        latchkey_env_args = ["--env", f"LATCHKEY_GATEWAY={effective_latchkey_url}"]
-        if latchkey_gateway_password is not None:
-            latchkey_env_args.extend(["--env", f"LATCHKEY_GATEWAY_PASSWORD={latchkey_gateway_password}"])
-        if latchkey_permissions_override_jwt is not None:
-            latchkey_env_args.extend(
-                ["--env", f"LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE={latchkey_permissions_override_jwt}"]
-            )
-        # Suppress the per-workspace daily ping to avoid counting every agent as a separate user.
-        latchkey_env_args.extend(["--env", "LATCHKEY_DISABLE_COUNTING=1"])
+    latchkey_env_args: list[str] = ["--env", f"LATCHKEY_GATEWAY={effective_latchkey_url}"]
+    if latchkey_gateway_password is not None:
+        latchkey_env_args.extend(["--env", f"LATCHKEY_GATEWAY_PASSWORD={latchkey_gateway_password}"])
+    if latchkey_permissions_override_jwt is not None:
+        latchkey_env_args.extend(
+            ["--env", f"LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE={latchkey_permissions_override_jwt}"]
+        )
+    # Suppress the per-workspace daily ping to avoid counting every agent as a separate user.
+    latchkey_env_args.extend(["--env", "LATCHKEY_DISABLE_COUNTING=1"])
 
     mngr_command: list[str] = [
         MNGR_BINARY,
@@ -495,11 +477,6 @@ def _build_mngr_create_command(
     # while runtime-only knobs that vary per-invocation (``--new-host``,
     # ``-b lease_attributes``) stay inline.
     match launch_mode:
-        case LaunchMode.DEV:
-            # Local (same-machine) mode: the agent inherits the bootstrap-set
-            # MNGR_HOST_DIR/MNGR_PREFIX via os.environ directly, so no
-            # host-env plumbing is needed.
-            mngr_command.extend(["--template", "main", "--template", "dev"])
         case LaunchMode.LOCAL:
             mngr_command.extend(["--new-host", "--template", "main", "--template", "docker"])
             mngr_command.extend(_remote_host_env_flags())
@@ -668,7 +645,6 @@ def run_mngr_create(
     anthropic_api_key: str | None = None,
     anthropic_base_url: str | None = None,
     gh_token: str | None = None,
-    latchkey_gateway_url: str | None = None,
     latchkey_gateway_password: str | None = None,
     latchkey_permissions_override_jwt: str | None = None,
     *,
@@ -686,7 +662,7 @@ def run_mngr_create(
     ``anthropic_api_key`` / ``anthropic_base_url`` / ``gh_token`` are placed
     into the subprocess env (not argv) so they don't show up in ``ps`` output;
     the FCT template's own ``pass_(host_)env`` declarations cause mngr to
-    forward them onto the host (or the DEV agent) as appropriate.
+    forward them onto the host as appropriate.
 
     Returns ``(api_key, canonical_agent_id)``. The canonical id is parsed
     out of the ``"event": "created"`` JSONL line that ``mngr create``
@@ -701,7 +677,6 @@ def run_mngr_create(
         imbue_cloud_account=imbue_cloud_account,
         imbue_cloud_repo_url=imbue_cloud_repo_url,
         imbue_cloud_branch_or_tag=imbue_cloud_branch_or_tag,
-        latchkey_gateway_url=latchkey_gateway_url,
         latchkey_gateway_password=latchkey_gateway_password,
         latchkey_permissions_override_jwt=latchkey_permissions_override_jwt,
     )
@@ -895,7 +870,7 @@ class AgentCreator(MutableModel):
           interactively in the workspace.
 
         ``gh_token`` is optional; when provided it's forwarded to the host
-        (or the agent in DEV mode) as ``GH_TOKEN``.
+        as ``GH_TOKEN``.
 
         For ``LaunchMode.IMBUE_CLOUD``, the agent runs on a leased pool host
         via the ``imbue_cloud_<account-slug>`` provider; the plugin's
@@ -1005,7 +980,7 @@ class AgentCreator(MutableModel):
 
         For ``ai_provider == IMBUE_CLOUD``, mints a LiteLLM key (via the
         plugin CLI) and forwards ``ANTHROPIC_API_KEY``/``ANTHROPIC_BASE_URL``
-        onto the host (or DEV agent) via the subprocess env + matching
+        onto the host via the subprocess env + matching
         ``--pass-(host-)env`` flags. For ``API_KEY``, forwards the
         user-supplied key as ``ANTHROPIC_API_KEY``. For ``SUBSCRIPTION``,
         injects neither.
@@ -1149,11 +1124,7 @@ class AgentCreator(MutableModel):
                 # the post-create ``mngr provision --env`` step (which
                 # was fragile and could silently leave
                 # ``LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE`` missing in
-                # the agent env). For DEV mode we also compute the
-                # live gateway URL up front (no reverse tunnel exists
-                # for DEV, so the agent talks straight to the
-                # gateway's host port).
-                latchkey_gateway_url = self._maybe_compute_latchkey_gateway_url(launch_mode, log_queue)
+                # the agent env).
                 latchkey_gateway_password = self._maybe_derive_gateway_password(log_queue)
                 latchkey_opaque_path, latchkey_permissions_jwt = self._maybe_prepare_latchkey_permissions_handle(
                     log_queue
@@ -1166,7 +1137,6 @@ class AgentCreator(MutableModel):
                     workspace_dir=workspace_dir,
                     agent_name=parsed_name,
                     on_output=emit_log,
-                    latchkey_gateway_url=latchkey_gateway_url,
                     latchkey_gateway_password=latchkey_gateway_password,
                     latchkey_permissions_override_jwt=latchkey_permissions_jwt,
                     imbue_cloud_account=account_email if launch_mode is LaunchMode.IMBUE_CLOUD else None,
@@ -1200,10 +1170,7 @@ class AgentCreator(MutableModel):
                 # at the canonical agent-keyed permissions file. After
                 # this, ``LatchkeyPermissionGrantHandler`` can write to
                 # the canonical path and the gateway will see the
-                # changes via the symlink. Same flow for every mode
-                # (DEV included): the symlink lives under ``data_dir``
-                # which both the desktop client and any in-process DEV
-                # agent can see.
+                # changes via the symlink.
                 if latchkey_opaque_path is not None:
                     self._finalize_latchkey_permissions(canonical_id, latchkey_opaque_path, log_queue)
 
@@ -1270,46 +1237,6 @@ class AgentCreator(MutableModel):
             logger.warning("Failed to derive latchkey gateway password: {}", e)
             log_queue.put(f"[minds] Warning: latchkey password injection skipped: {e}")
             return None
-
-    def _maybe_compute_latchkey_gateway_url(
-        self,
-        launch_mode: LaunchMode,
-        log_queue: queue.Queue[str],
-    ) -> str | None:
-        """Return the ``LATCHKEY_GATEWAY`` URL to inject for this agent, or ``None``.
-
-        For tunneled modes (LOCAL / LIMA / CLOUD / IMBUE_CLOUD) the URL is
-        the constant agent-side loopback (``127.0.0.1:<AGENT_SIDE_LATCHKEY_PORT>``)
-        which ``LatchkeyDiscoveryHandler`` reverse-tunnels to whatever
-        port the host-side gateway happens to be listening on. We return
-        ``None`` for those modes so ``_build_mngr_create_command``'s own
-        constant-fallback handles them; that keeps the constant URL in a
-        single place.
-
-        For DEV mode there is no reverse tunnel: the agent runs in
-        process on the bare host and talks directly to the gateway's
-        live host-side port. We must therefore ensure the gateway is
-        actually running and read its dynamic port out of the live
-        info. Returns ``None`` (and logs a warning) when ``Latchkey``
-        is not configured or the gateway can't be started -- the agent
-        will then have no ``LATCHKEY_GATEWAY`` set and its ``latchkey``
-        CLI will fall back to local mode (no gateway proxying), which
-        is the same behaviour DEV had before this change. Other
-        latchkey env vars (password / JWT) are skipped too in that
-        case via the standard ``effective_latchkey_url is None`` gate
-        in ``_build_mngr_create_command``.
-        """
-        if launch_mode is not LaunchMode.DEV:
-            return None
-        if self.latchkey is None:
-            return None
-        try:
-            info = self.latchkey.ensure_gateway_started()
-        except LatchkeyError as e:
-            logger.warning("Failed to start latchkey gateway for DEV agent: {}", e)
-            log_queue.put(f"[minds] Warning: latchkey wiring skipped for DEV agent: {e}")
-            return None
-        return f"http://{info.host}:{info.port}"
 
     def _maybe_prepare_latchkey_permissions_handle(
         self,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -75,8 +75,8 @@ def test_make_host_name_appends_host_suffix() -> None:
     assert _make_host_name(AgentName("alpha")) == "alpha-host"
 
 
-def test_build_mngr_create_command_injects_latchkey_for_non_dev_modes() -> None:
-    """Container/VM/VPS/leased modes get the constant agent-side LATCHKEY_GATEWAY URL.
+def test_build_mngr_create_command_injects_constant_agent_side_latchkey_url() -> None:
+    """Every mode gets the constant agent-side LATCHKEY_GATEWAY URL.
 
     The reverse tunnel that ``LatchkeyDiscoveryHandler`` sets up post-discovery bridges
     the agent's loopback at ``AGENT_SIDE_LATCHKEY_PORT`` to whichever host-side gateway
@@ -95,21 +95,6 @@ def test_build_mngr_create_command_injects_latchkey_for_non_dev_modes() -> None:
     assert expected in command
 
 
-def test_build_mngr_create_command_omits_latchkey_for_dev_mode_without_url() -> None:
-    """DEV with no explicit URL gets no latchkey wiring.
-
-    There's no constant agent-side URL to fall back on for DEV (no
-    reverse tunnel), so the caller is responsible for computing the
-    live gateway URL when it wants DEV agents to use latchkey.
-    """
-    command, _ = _build_mngr_create_command(launch_mode=LaunchMode.DEV, agent_name=AgentName("hello"))
-    joined = " ".join(command)
-    assert "LATCHKEY_GATEWAY" not in joined
-    # ``LATCHKEY_DISABLE_COUNTING`` is part of the latchkey wiring, so it's
-    # also absent when latchkey is not wired (DEV without explicit URL).
-    assert "LATCHKEY_DISABLE_COUNTING" not in joined
-
-
 def test_build_mngr_create_command_disables_latchkey_counting_when_wired() -> None:
     """Whenever latchkey is wired into the workspace, the workspace-side
     ``latchkey`` CLI runs in client mode against the host-side gateway.
@@ -117,39 +102,12 @@ def test_build_mngr_create_command_disables_latchkey_counting_when_wired() -> No
     set ``LATCHKEY_DISABLE_COUNTING=1`` to avoid double-counting every
     agent as a separate goatcounter.com user.
     """
-    # Non-DEV mode: gets the constant agent-side URL by default, so latchkey is wired.
     for mode in (LaunchMode.LOCAL, LaunchMode.LIMA, LaunchMode.CLOUD):
         command, _ = _build_mngr_create_command(launch_mode=mode, agent_name=AgentName("hello"))
         assert "LATCHKEY_DISABLE_COUNTING=1" in command, f"{mode} command missing disable-counting env: {command}"
-    # DEV with explicit URL: latchkey is wired, so disable-counting is too.
-    command, _ = _build_mngr_create_command(
-        launch_mode=LaunchMode.DEV,
-        agent_name=AgentName("hello"),
-        latchkey_gateway_url="http://127.0.0.1:54321",
-    )
-    assert "LATCHKEY_DISABLE_COUNTING=1" in command
 
 
-def test_build_mngr_create_command_injects_latchkey_for_dev_mode_with_explicit_url() -> None:
-    """DEV with an explicit live gateway URL gets the full latchkey wiring.
-
-    The caller (``AgentCreator._maybe_compute_latchkey_gateway_url``)
-    queries the live gateway info for DEV, since DEV has no reverse
-    tunnel and must talk directly to the gateway's host port.
-    """
-    command, _ = _build_mngr_create_command(
-        launch_mode=LaunchMode.DEV,
-        agent_name=AgentName("hello"),
-        latchkey_gateway_url="http://127.0.0.1:54321",
-        latchkey_gateway_password="sup3rs3cret",
-        latchkey_permissions_override_jwt="eyJhbGc.fake.jwt",
-    )
-    assert "LATCHKEY_GATEWAY=http://127.0.0.1:54321" in command
-    assert "LATCHKEY_GATEWAY_PASSWORD=sup3rs3cret" in command
-    assert "LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE=eyJhbGc.fake.jwt" in command
-
-
-def test_build_mngr_create_command_explicit_url_overrides_constant_for_non_dev() -> None:
+def test_build_mngr_create_command_explicit_url_overrides_constant() -> None:
     """Passing ``latchkey_gateway_url`` overrides the default for any mode."""
     command, _ = _build_mngr_create_command(
         launch_mode=LaunchMode.LOCAL,
@@ -174,16 +132,6 @@ def test_build_mngr_create_command_injects_latchkey_password_when_supplied() -> 
     assert "LATCHKEY_GATEWAY_PASSWORD=sup3rs3cret" in command
 
 
-def test_build_mngr_create_command_omits_latchkey_password_for_dev_mode() -> None:
-    """DEV mode skips all latchkey env injection (no tunnel, no gateway wiring)."""
-    command, _ = _build_mngr_create_command(
-        launch_mode=LaunchMode.DEV,
-        agent_name=AgentName("hello"),
-        latchkey_gateway_password="sup3rs3cret",
-    )
-    assert not any(arg.startswith("LATCHKEY_GATEWAY_PASSWORD=") for arg in command)
-
-
 def test_build_mngr_create_command_injects_latchkey_jwt_when_supplied() -> None:
     """The permissions-override JWT is injected at create time so the
     agent's env file has it from the very first service start. This is
@@ -197,15 +145,6 @@ def test_build_mngr_create_command_injects_latchkey_jwt_when_supplied() -> None:
         latchkey_permissions_override_jwt="eyJhbGc.fake.jwt",
     )
     assert "LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE=eyJhbGc.fake.jwt" in command
-
-
-def test_build_mngr_create_command_omits_latchkey_jwt_for_dev_mode() -> None:
-    command, _ = _build_mngr_create_command(
-        launch_mode=LaunchMode.DEV,
-        agent_name=AgentName("hello"),
-        latchkey_permissions_override_jwt="eyJhbGc.fake.jwt",
-    )
-    assert not any(arg.startswith("LATCHKEY_GATEWAY_PERMISSIONS_OVERRIDE=") for arg in command)
 
 
 def test_build_mngr_create_command_uses_main_template_and_omits_message_arg() -> None:
@@ -262,7 +201,7 @@ def test_build_mngr_create_command_imbue_cloud_targets_account_provider() -> Non
     assert "GH_TOKEN" not in joined
     assert "--pass-host-env" not in command
     # IMBUE_CLOUD now uses the symmetric ``--template main --template imbue_cloud``
-    # shape (mirroring how DEV/LOCAL/LIMA/CLOUD use ``--template main --template <provider>``).
+    # shape (mirroring how LOCAL/LIMA/CLOUD use ``--template main --template <provider>``).
     # The provider-specific knobs (idle_mode, pass_host_env) live in the
     # ``imbue_cloud`` template instead of being inlined here.
     assert "--template" in command
@@ -278,7 +217,6 @@ def test_build_mngr_create_command_never_inlines_secret_env_flags() -> None:
     """Secret forwarding lives in FCT, not minds. The command line never carries
     ``--pass-(host-)env`` flags or secret values for any compute mode."""
     for mode, account in (
-        (LaunchMode.DEV, None),
         (LaunchMode.LOCAL, None),
         (LaunchMode.LIMA, None),
         (LaunchMode.CLOUD, None),

--- a/apps/minds/imbue/minds/desktop_client/forward_cli.py
+++ b/apps/minds/imbue/minds/desktop_client/forward_cli.py
@@ -105,15 +105,6 @@ class ForwardSubprocessConfig(FrozenModel):
     )
     mngr_binary: str = Field(default=MNGR_BINARY, description="Path to mngr binary")
     mngr_host_dir: Path = Field(default=_DEFAULT_MNGR_HOST_DIR, description="MNGR_HOST_DIR for the subprocess")
-    allow_host_loopback: bool = Field(
-        default=False,
-        description=(
-            "Pass --allow-host-loopback to the plugin. Required for LaunchMode.DEV testing where the "
-            "agent runs on the bare host and has no SSH tunnel. Off by default so a stale or "
-            "delayed-arrival ssh_info on a remote agent does not let the plugin silently dial host "
-            "loopback at the registered port (PR 1482)."
-        ),
-    )
 
 
 class EnvelopeStreamConsumer(MutableModel):
@@ -694,8 +685,6 @@ def start_mngr_forward(
         "--format",
         "jsonl",
     ]
-    if config.allow_host_loopback:
-        command.append("--allow-host-loopback")
     for include in config.agent_include:
         command.extend(["--agent-include", include])
     for spec in config.reverse_specs:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/core.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/core.py
@@ -870,9 +870,11 @@ class LatchkeyDiscoveryHandler(MutableModel):
     subprocess is running on the desktop host. Agents that reach the
     desktop via SSH (containers, VMs, VPS) also get a reverse tunnel that
     exposes the host-side gateway on the agent's own
-    ``127.0.0.1:AGENT_SIDE_LATCHKEY_PORT``. DEV-mode agents run on the
-    bare host and need no tunnel; their ``LATCHKEY_GATEWAY`` env var
-    points directly at the dynamic host port.
+    ``127.0.0.1:AGENT_SIDE_LATCHKEY_PORT``. Agents discovered without SSH
+    info (e.g. local-provider agents in tests, or any discovery that
+    arrives before the host SSH event) skip the reverse-tunnel step and
+    are expected to reach the gateway via whatever direct route already
+    exists.
 
     Tunnel setup is dispatched onto a worker thread via
     ``concurrency_group`` so the ``MngrStreamManager`` discovery-stream
@@ -902,8 +904,10 @@ class LatchkeyDiscoveryHandler(MutableModel):
             return
 
         if ssh_info is None:
-            # DEV-mode agent runs on the bare host; it reaches the gateway
-            # directly on its dynamic host port, so no tunnel is needed.
+            # No SSH info for this agent (e.g. local-provider agent in tests,
+            # or a discovery event that fired before the host SSH event); we
+            # cannot set up a reverse tunnel, so just ensure the gateway is up
+            # and let the agent reach it via whatever direct route exists.
             return
 
         agent_id_str = str(agent_id)

--- a/apps/minds/imbue/minds/desktop_client/latchkey/core_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/core_test.py
@@ -565,8 +565,12 @@ def test_discovery_handler_sets_up_reverse_tunnel_when_ssh_info_given(tmp_path: 
         manager.stop_gateway()
 
 
-def test_discovery_handler_skips_reverse_tunnel_for_dev_agents(tmp_path: Path) -> None:
-    """DEV agents (ssh_info is None) run on the bare host and need no tunnel."""
+def test_discovery_handler_skips_reverse_tunnel_when_ssh_info_missing(tmp_path: Path) -> None:
+    """Agents discovered without SSH info skip reverse-tunnel setup.
+
+    Without an SSH route the handler cannot forward the host-side gateway
+    into the agent, so it just ensures the gateway is up and returns.
+    """
     fake_binary = _make_fake_latchkey_binary(tmp_path)
     manager = Latchkey(latchkey_binary=str(fake_binary))
     manager.initialize(data_dir=tmp_path)

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -96,8 +96,10 @@ def test_render_create_form_selects_local_by_default() -> None:
 
 
 def test_render_create_form_selects_specified_launch_mode() -> None:
-    html = render_create_form(launch_mode=LaunchMode.LIMA)
-    assert 'value="LIMA" selected' in html
+    # CLOUD instead of the default LOCAL so the "selection honored over the
+    # default" assertion is meaningful.
+    html = render_create_form(launch_mode=LaunchMode.CLOUD)
+    assert 'value="CLOUD" selected' in html
     assert 'value="LOCAL" selected' not in html
 
 

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -96,8 +96,8 @@ def test_render_create_form_selects_local_by_default() -> None:
 
 
 def test_render_create_form_selects_specified_launch_mode() -> None:
-    html = render_create_form(launch_mode=LaunchMode.DEV)
-    assert 'value="DEV" selected' in html
+    html = render_create_form(launch_mode=LaunchMode.LIMA)
+    assert 'value="LIMA" selected' in html
     assert 'value="LOCAL" selected' not in html
 
 

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -761,7 +761,7 @@ def test_create_form_submit_passes_launch_mode(tmp_path: Path) -> None:
         data={
             "git_url": "file:///nonexistent-repo",
             "agent_name": "my-agent",
-            "launch_mode": "LIMA",
+            "launch_mode": "LOCAL",
         },
         follow_redirects=False,
     )
@@ -778,7 +778,7 @@ def test_create_agent_api_passes_launch_mode(tmp_path: Path) -> None:
         json={
             "git_url": "file:///nonexistent-repo",
             "agent_name": "my-agent",
-            "launch_mode": "LIMA",
+            "launch_mode": "LOCAL",
         },
     )
     assert response.status_code == 200

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -761,7 +761,7 @@ def test_create_form_submit_passes_launch_mode(tmp_path: Path) -> None:
         data={
             "git_url": "file:///nonexistent-repo",
             "agent_name": "my-agent",
-            "launch_mode": "DEV",
+            "launch_mode": "LIMA",
         },
         follow_redirects=False,
     )
@@ -778,7 +778,7 @@ def test_create_agent_api_passes_launch_mode(tmp_path: Path) -> None:
         json={
             "git_url": "file:///nonexistent-repo",
             "agent_name": "my-agent",
-            "launch_mode": "DEV",
+            "launch_mode": "LIMA",
         },
     )
     assert response.status_code == 200
@@ -812,7 +812,8 @@ def test_create_form_shows_launch_mode_dropdown(tmp_path: Path) -> None:
     assert "launch_mode" in response.text
     assert "local" in response.text
     assert "cloud" in response.text
-    assert "dev" in response.text
+    assert "lima" in response.text
+    assert "imbue_cloud" in response.text
 
 
 def test_create_form_shows_ai_provider_dropdown(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/primitives.py
+++ b/apps/minds/imbue/minds/primitives.py
@@ -37,7 +37,6 @@ class LaunchMode(UpperCaseStrEnum):
 
     LOCAL = auto()
     CLOUD = auto()
-    DEV = auto()
     LIMA = auto()
     IMBUE_CLOUD = auto()
 

--- a/apps/minds/test_desktop_client_e2e.py
+++ b/apps/minds/test_desktop_client_e2e.py
@@ -89,8 +89,8 @@ _MINIMAL_TEMPLATE_SETTINGS = textwrap.dedent(
 def minds_template_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[Path, None, None]:
     """Create a controllable minds template repo for the e2e tests.
 
-    Writes a minimal `.{MNGR_ROOT_NAME}/settings.toml` defining the `main`,
-    `dev`, and `docker` templates that `AgentCreator._build_mngr_create_command`
+    Writes a minimal `.{MNGR_ROOT_NAME}/settings.toml` defining the `main`
+    and `docker` templates that `AgentCreator._build_mngr_create_command`
     passes to `mngr create`. Sets `MINDS_TEMPLATE_REPO` so the desktop client
     uses the local path instead of cloning forever-claude-template from
     GitHub; this sidesteps both the network clone and the fact that the

--- a/apps/minds/test_desktop_client_e2e.py
+++ b/apps/minds/test_desktop_client_e2e.py
@@ -10,18 +10,15 @@ from the GitHub repo into a temporary directory.
 
 Run from the repo root:
     just test apps/minds/test_desktop_client_e2e.py::test_create_agent_e2e
-    just test apps/minds/test_desktop_client_e2e.py::test_create_agent_dev_mode_e2e
 
 The Docker E2E test waits for /tmp/minds-e2e-done before tearing down:
     touch /tmp/minds-e2e-done
 """
 
 import os
-import shutil
 import socket
 import subprocess
 import sys
-import tempfile
 import textwrap
 import threading
 from collections.abc import Generator
@@ -49,7 +46,7 @@ _SIGNAL_FILE = Path("/tmp/minds-e2e-done")
 
 # Minimal template repo config for the test fixture. Mirrors the shape of
 # forever-claude-template's `.mngr/settings.toml` (the templates and agent
-# types that `AgentCreator` references via `--template main --template dev`)
+# types that `AgentCreator` references via `--template main --template <mode>`)
 # but omits the production-only `extra_provision_command` that expects a
 # populated `vendor/mngr/` submodule -- the test wants to exercise the minds
 # agent-creation plumbing, not the full template's provisioning script.
@@ -78,9 +75,6 @@ _MINIMAL_TEMPLATE_SETTINGS = textwrap.dedent(
 
     [create_templates.main]
     type = "main"
-
-    [create_templates.dev]
-    provider = "local"
 
     [create_templates.docker]
     provider = "docker"
@@ -188,23 +182,6 @@ def _destroy_agent(agent_name: str) -> None:
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
         logger.debug("mngr destroy {} failed (best-effort cleanup): {}", agent_name, exc)
-
-    # Clean up any leftover worktree branch from dev-mode agents.
-    # mngr destroy removes the worktree directory but not the git branch.
-    # Only relevant when using a local checkout (not a cloned URL).
-    template_repo = os.environ.get("MINDS_TEMPLATE_REPO")
-    if template_repo is not None:
-        branch_name = f"mngr/{agent_name}"
-        try:
-            subprocess.run(
-                ["git", "branch", "-D", branch_name],
-                capture_output=True,
-                timeout=5,
-                text=True,
-                cwd=str(Path(template_repo).expanduser()),
-            )
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-            logger.debug("git branch -D {} failed (best-effort cleanup): {}", branch_name, exc)
 
 
 class DesktopClientFixture:
@@ -414,85 +391,3 @@ def test_create_agent_e2e(tmp_path: Path, minds_template_repo: Path) -> None:
         _destroy_agent(_AGENT_NAME)
         server.stop()
         _SIGNAL_FILE.unlink(missing_ok=True)
-
-
-_DEV_AGENT_NAME = "forever-dev"
-
-
-# docker / docker_sdk / tmux marks are required because `mngr create` shells
-# out to the docker binary, uses the Python docker SDK during provisioning
-# (even in DEV mode, which runs the agent on the local provider), and spawns
-# the agent inside a tmux pane.
-#
-# Skipped for the same reason as test_create_agent_e2e above (see its
-# inline comment for the full write-up): Modal pty buffering + slow
-# sandbox filesystem make the initial `mngr create --message` send sit
-# apparently-stuck for well over the 90s wait, even though the same
-# send flow runs fine locally. Dev-mode exits via pytest-timeout at
-# 120s because the send hasn't completed by then.
-@pytest.mark.release
-@pytest.mark.docker
-@pytest.mark.docker_sdk
-@pytest.mark.tmux
-@pytest.mark.timeout(120)
-@pytest.mark.skip(reason="TUI send-enter timeout in test-docker-release; needs follow-up, see inline comment")
-def test_create_agent_dev_mode_e2e(tmp_path: Path, minds_template_repo: Path) -> None:
-    """Create a DEV-mode agent (local provider, no Docker) and verify its web server is proxied.
-
-    This is faster than the Docker E2E test because it skips the Docker build.
-    The agent runs in a local git worktree with its own UV tool installation.
-    """
-    _configure_logging()
-    _load_env()
-    os.environ["MINDS_WORKSPACE_NAME"] = _DEV_AGENT_NAME
-
-    # Set up isolated UV tool directories so the extra_provision_command
-    # installs mngr into a temp location instead of clobbering the host's install.
-    uv_tool_dir = tempfile.mkdtemp(prefix="minds-e2e-uv-tool-")
-    uv_tool_bin_dir = tempfile.mkdtemp(prefix="minds-e2e-uv-bin-")
-    orig_uv_tool_dir = os.environ.get("UV_TOOL_DIR")
-    orig_uv_tool_bin_dir = os.environ.get("UV_TOOL_BIN_DIR")
-    os.environ["UV_TOOL_DIR"] = uv_tool_dir
-    os.environ["UV_TOOL_BIN_DIR"] = uv_tool_bin_dir
-
-    server = DesktopClientFixture(tmp_path)
-    client: httpx.Client | None = None
-
-    try:
-        _destroy_agent(_DEV_AGENT_NAME)
-        server.start()
-
-        client = httpx.Client(
-            base_url=server.base_url,
-            cookies={"minds_session": "skip"},
-            timeout=15.0,
-        )
-        os.environ["SKIP_AUTH"] = "1"
-
-        agent_id = _create_agent_with_retry(
-            client,
-            max_attempts=2,
-            agent_name=_DEV_AGENT_NAME,
-            launch_mode="DEV",
-        )
-        logger.info("Agent ready: {}", agent_id)
-
-        # Wait for the desktop client to discover the agent's web server
-        # and verify it is accessible through the proxy.
-        _wait_for_web_server(client, agent_id, timeout_seconds=60)
-
-    finally:
-        if client is not None:
-            client.close()
-        _destroy_agent(_DEV_AGENT_NAME)
-        server.stop()
-        shutil.rmtree(uv_tool_dir, ignore_errors=True)
-        shutil.rmtree(uv_tool_bin_dir, ignore_errors=True)
-        if orig_uv_tool_dir is None:
-            os.environ.pop("UV_TOOL_DIR", None)
-        else:
-            os.environ["UV_TOOL_DIR"] = orig_uv_tool_dir
-        if orig_uv_tool_bin_dir is None:
-            os.environ.pop("UV_TOOL_BIN_DIR", None)
-        else:
-            os.environ["UV_TOOL_BIN_DIR"] = orig_uv_tool_bin_dir

--- a/changelog/mngr-tweak-template.md
+++ b/changelog/mngr-tweak-template.md
@@ -1,5 +1,13 @@
-No user-visible mngr changes on this branch. Companion changes live in the
-forever-claude-template repo on the same-named branch (`mngr/tweak-template`):
-default `~/.tmux.conf` provisioning, `--cap-add=SYS_PTRACE` for the docker
-template, removal of the unused `events_processor/` project, and the
-crystallization Stop hook is disabled.
+- Removed `LaunchMode.DEV` from minds. The web create form, `/create`, and
+  `/api/create-agent` now offer only `LOCAL`, `LIMA`, `CLOUD`, and
+  `IMBUE_CLOUD`; submitting `launch_mode=DEV` returns 400. The DEV-only
+  latchkey gateway helper, the `MINDS_ALLOW_HOST_LOOPBACK` env var, and the
+  `allow_host_loopback` field on `ForwardSubprocessConfig` are gone (the
+  generic `mngr_forward --allow-host-loopback` CLI flag stays for
+  non-minds consumers).
+
+Companion changes live in the forever-claude-template repo on the
+same-named branch (`mngr/tweak-template`): default `~/.tmux.conf`
+provisioning, `--cap-add=SYS_PTRACE` for the docker template, removal of
+the unused `events_processor/` project, removal of `[create_templates.dev]`,
+and the crystallization Stop hook is disabled.

--- a/changelog/mngr-tweak-template.md
+++ b/changelog/mngr-tweak-template.md
@@ -1,0 +1,5 @@
+No user-visible mngr changes on this branch. Companion changes live in the
+forever-claude-template repo on the same-named branch (`mngr/tweak-template`):
+default `~/.tmux.conf` provisioning, `--cap-add=SYS_PTRACE` for the docker
+template, removal of the unused `events_processor/` project, and the
+crystallization Stop hook is disabled.

--- a/specs/remove-minds-dev-mode/concise.md
+++ b/specs/remove-minds-dev-mode/concise.md
@@ -1,0 +1,30 @@
+# Remove DEV mode from minds
+
+## Overview
+
+- DEV mode (running the agent in-place on the local machine, no Docker / SSH tunnel) is the only minds launch mode without container isolation, and is the only one that needs special-cased latchkey wiring and host-loopback dialing. It is broken in practice and is the dominant source of mode-specific branching in `agent_creator.py` and `forward_cli.py`.
+- Removing DEV collapses every remaining `LaunchMode` (`LOCAL`, `LIMA`, `CLOUD`, `IMBUE_CLOUD`) onto the same shape: agent runs on a separate host accessed via SSH; latchkey is reachable at the constant agent-side port via the reverse tunnel.
+- Hard removal (no deprecation): the `LaunchMode.DEV` enum value, every `case LaunchMode.DEV` branch, the DEV-only latchkey helper, the `MINDS_ALLOW_HOST_LOOPBACK` env var and the `allow_host_loopback` field on `ForwardSubprocessConfig` are all deleted. The generic `mngr_forward --allow-host-loopback` CLI flag stays for non-minds users.
+- The FCT-side `[create_templates.dev]` block (worktree-base override + UV-tool provisioning + DEV-only `pass_env`) is deleted in the same `mngr/tweak-template` FCT branch that the previous task already opened.
+- The already-skipped `test_create_agent_dev_mode_e2e` is deleted with the rest; no LIMA-mode replacement.
+
+## Expected Behavior
+
+- The web create form's "Compute provider" dropdown no longer offers `dev`; it shows only `local`, `cloud`, `lima`, `imbue_cloud`.
+- POSTing `launch_mode=DEV` to `/create` or `/api/create-agent` produces the existing `Invalid launch_mode` 400 path (handled by the `LaunchMode(...)` constructor in `app.py`).
+- Setting `MINDS_ALLOW_HOST_LOOPBACK=1` in minds' env has no effect (the var is no longer read). `mngr forward --allow-host-loopback` still works for any non-minds caller.
+- `mngr create --template main --template dev` from inside the FCT now fails with mngr's standard "Template 'dev' not found" `UserInputError`, which is the desired behaviour for an explicitly-removed mode.
+- All existing non-DEV launch flows are unchanged: same `mngr create` command shape, same latchkey wiring, same secret forwarding.
+
+## Changes
+
+- `apps/minds/imbue/minds/primitives.py`: drop `DEV` from the `LaunchMode` enum.
+- `apps/minds/imbue/minds/desktop_client/agent_creator.py`: drop both `case LaunchMode.DEV` branches in `_build_mngr_create_command` (address builder + per-mode template/runtime block); drop the `is not LaunchMode.DEV` gate around the constant-port latchkey URL fallback; delete `_maybe_compute_latchkey_gateway_url` and inline its only call site to use the constant agent-side URL; clean up DEV references in surrounding docstrings/comments.
+- `apps/minds/imbue/minds/desktop_client/forward_cli.py`: drop the `allow_host_loopback` field on `ForwardSubprocessConfig` and the `if config.allow_host_loopback: command.append("--allow-host-loopback")` line in the subprocess command builder; clean up the DEV-mention in the field docstring (now gone).
+- `apps/minds/imbue/minds/cli/run.py`: drop the `MINDS_ALLOW_HOST_LOOPBACK` lookup and the `allow_host_loopback=...` kwarg passed to `ForwardSubprocessConfig`; clean up the DEV-only comment.
+- `apps/minds/imbue/minds/desktop_client/templates_test.py`: remove `test_render_create_form_selects_specified_launch_mode` (asserts `value="DEV" selected`); the existing "all launch modes are rendered" test continues to cover the remaining four modes.
+- `apps/minds/imbue/minds/desktop_client/agent_creator_test.py`: remove the DEV-only tests (`..._omits_latchkey_for_dev_mode_without_url`, `..._injects_latchkey_for_dev_mode_with_explicit_url`, `..._omits_latchkey_password_for_dev_mode`, `..._omits_latchkey_jwt_for_dev_mode`) and drop the `(LaunchMode.DEV, None)` row from the `_never_inlines_secret_env_flags` parametrization; tighten `..._disables_latchkey_counting_when_wired` to drop its DEV branch.
+- `apps/minds/imbue/minds/desktop_client/test_desktop_client.py`: remove `test_create_form_submit_passes_launch_mode` and `test_create_agent_api_passes_launch_mode` (both pin DEV through the request path); leave `test_create_agent_api_rejects_invalid_launch_mode` (it uses `INVALID_MODE` and is unaffected).
+- `apps/minds/test_desktop_client_e2e.py`: delete the skipped `test_create_agent_dev_mode_e2e` and `_DEV_AGENT_NAME` constant.
+- `apps/minds/docs/{design.md,overview.md,user_story.md,workspace/glossary.md}`: drop DEV-mode mentions; the surviving descriptions list `LOCAL`, `LIMA`, `CLOUD`, `IMBUE_CLOUD`.
+- `.external_worktrees/forever-claude-template/.mngr/settings.toml`: delete the `[create_templates.dev]` block in its entirety; this lands on the existing `mngr/tweak-template` FCT branch.


### PR DESCRIPTION
## Summary

Remove DEV create mode.

Also:

No user-visible mngr changes. The actual work for this branch lives in
the forever-claude-template repo on the same-named branch
[`mngr/tweak-template`](https://github.com/imbue-ai/forever-claude-template/tree/mngr/tweak-template):

- Default `~/.tmux.conf` (`alternate-screen off`, `mouse on`) provisioned
  by `[create_templates.main]`. Stacking with the per-mode templates is
  pinned by a new `test_mngr_template_stacking.py`.
- `--cap-add=SYS_PTRACE` added to the docker template's `start_arg`
  (it's a `docker run` flag, not a `docker build` one).
- Unused `events_processor/` project, its skill, and the corresponding
  CLAUDE.md section removed.
- `detect_crystallization_candidate.py` Stop hook disabled in
  `.claude/settings.json`.

This PR is intentionally near-empty (just a changelog entry) -- the
mngr-side branch was scaffolded so the FCT worktree could live under
`.external_worktrees/`.

## Test plan

- [x] FCT root suite passes (`135 passed`) including the new
      `test_mngr_template_stacking.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)