### PR TITLE
Make docker build timeout configurable and clearer on failure

### DIFF
--- a/changelog/mngr-fix-build-timeout.md
+++ b/changelog/mngr-fix-build-timeout.md
@@ -1,0 +1,2 @@
+- Changed: bumped the default `docker build` timeout for the docker provider from 5 to 10 minutes, and made it configurable per provider instance via the new `build_timeout_seconds` field (e.g. `mngr config set --scope user providers.docker.build_timeout_seconds 1800`).
+- Improved: when a `docker build` exceeds the configured timeout, mngr now raises a clear `DockerBuildTimeoutError` that names the timeout and points at the config knob, instead of surfacing a generic non-zero-exit `ProcessError` that hid the cause behind a wall of build output.

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -266,6 +266,19 @@ class ResourceAllocationError(HostCreationError):
     """Failed to allocate resources for the host."""
 
 
+class DockerBuildTimeoutError(HostCreationError):
+    """Raised when `docker build` exceeds the configured build timeout."""
+
+    def __init__(self, provider_name: ProviderInstanceName, timeout_seconds: int) -> None:
+        self.provider_name = provider_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"docker build timed out after {timeout_seconds} seconds for provider '{provider_name}'.")
+        self.user_help_text = (
+            f"Increase build_timeout_seconds for this provider, e.g.:\n"
+            f"  mngr config set --scope user providers.{provider_name}.build_timeout_seconds 1800"
+        )
+
+
 class HostNameConflictError(ProviderError):
     """A host with this name already exists."""
 

--- a/libs/mngr/imbue/mngr/providers/docker/config.py
+++ b/libs/mngr/imbue/mngr/providers/docker/config.py
@@ -53,6 +53,14 @@ class DockerProviderConfig(ProviderInstanceConfig):
             "DEPOT runs `depot build --load` (requires depot CLI + DEPOT_TOKEN in env)."
         ),
     )
+    build_timeout_seconds: int = Field(
+        default=600,
+        description=(
+            "Maximum time (in seconds) to wait for `docker build` to finish before aborting. "
+            "Increase this when your Dockerfile pulls large bases or downloads heavy assets "
+            "(e.g. browser binaries) that would otherwise exceed the default."
+        ),
+    )
     is_host_volume_created: bool = Field(
         default=True,
         description=(

--- a/libs/mngr/imbue/mngr/providers/docker/config_test.py
+++ b/libs/mngr/imbue/mngr/providers/docker/config_test.py
@@ -10,3 +10,13 @@ def test_builder_defaults_to_docker() -> None:
 def test_explicit_builder_is_honored() -> None:
     """`builder` is a plain config field; the constructor argument wins."""
     assert DockerProviderConfig(builder=DockerBuilder.DEPOT).builder is DockerBuilder.DEPOT
+
+
+def test_build_timeout_seconds_defaults_to_ten_minutes() -> None:
+    """Default build timeout is 10 minutes, matching slower base-image pulls."""
+    assert DockerProviderConfig().build_timeout_seconds == 600
+
+
+def test_explicit_build_timeout_seconds_is_honored() -> None:
+    """`build_timeout_seconds` is configurable per provider instance."""
+    assert DockerProviderConfig(build_timeout_seconds=1800).build_timeout_seconds == 1800

--- a/libs/mngr/imbue/mngr/providers/docker/instance.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance.py
@@ -25,9 +25,11 @@ from pydantic import PrivateAttr
 from pyinfra.api import Host as PyinfraHost
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.errors import ProcessTimeoutError
 from imbue.concurrency_group.subprocess_utils import FinishedProcess
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.model_update import to_update
+from imbue.mngr.errors import DockerBuildTimeoutError
 from imbue.mngr.errors import HostNotFoundError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import ProviderUnavailableError
@@ -629,12 +631,17 @@ kill -TERM 1
         `executable` defaults to DOCKER; pass DEPOT to use the depot.dev remote
         builder (only valid for build subcommands).
         """
-        return self.mngr_ctx.concurrency_group.run_process_to_completion(
+        # Defer the success/timeout/non-zero distinction to FinishedProcess.check(), which
+        # raises ProcessTimeoutError on timeout instead of a generic ProcessError.
+        result = self.mngr_ctx.concurrency_group.run_process_to_completion(
             [executable.value.lower()] + args,
             timeout=timeout,
             env=self._docker_env(),
             on_output=self._log_docker_creation_command_output,
+            is_checked_after=False,
         )
+        result.check()
+        return result
 
     def _log_docker_creation_command_output(self, line: str, is_stdout: bool) -> None:
         """Log output from docker subprocess calls, prefixing with [DOCKER]."""
@@ -648,8 +655,12 @@ kill -TERM 1
         # depot requires --load to import the resulting image into the local daemon.
         extra_args = ["--load"] if builder is DockerBuilder.DEPOT else []
         args = ["build", *extra_args, "-t", tag, *build_args]
+        timeout_seconds = self.config.build_timeout_seconds
         with log_span("Running {} build with {} args", builder.value.lower(), len(build_args)):
-            self._run_docker_creation_command(args, executable=builder)
+            try:
+                self._run_docker_creation_command(args, timeout=timeout_seconds, executable=builder)
+            except ProcessTimeoutError as e:
+                raise DockerBuildTimeoutError(provider_name=self.name, timeout_seconds=timeout_seconds) from e
         return tag
 
     def _build_default_image(self, tag: str) -> str:

--- a/libs/mngr/imbue/mngr/providers/docker/instance_test.py
+++ b/libs/mngr/imbue/mngr/providers/docker/instance_test.py
@@ -6,14 +6,19 @@ from pathlib import Path
 
 import pytest
 
+from imbue.concurrency_group.errors import ProcessTimeoutError
+from imbue.concurrency_group.subprocess_utils import FinishedProcess
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import DockerBuildTimeoutError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.hosts.offline_host import OfflineHost
 from imbue.mngr.interfaces.data_types import CertifiedHostData
+from imbue.mngr.primitives import DockerBuilder
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.providers.docker.config import DockerProviderConfig
 from imbue.mngr.providers.docker.instance import CONTAINER_SSH_PORT
 from imbue.mngr.providers.docker.instance import DockerProviderInstance
 from imbue.mngr.providers.docker.instance import LABEL_HOST_ID
@@ -439,3 +444,58 @@ def test_discover_hosts_and_agents_returns_empty_when_daemon_offline(temp_mngr_c
     provider = make_offline_docker_provider(temp_mngr_ctx)
     result = provider.discover_hosts_and_agents(cg=temp_mngr_ctx.concurrency_group)
     assert result == {}
+
+
+# =========================================================================
+# Build Timeout
+# =========================================================================
+
+
+class _BuildTimingOutDockerProvider(DockerProviderInstance):
+    """Provider subclass that simulates a build process timing out.
+
+    Lets us exercise the timeout-translation path in `_build_image` without
+    needing a real Docker daemon or a long-running subprocess.
+    """
+
+    def _run_docker_creation_command(
+        self,
+        args: list[str],
+        timeout: float = 300,
+        executable: DockerBuilder = DockerBuilder.DOCKER,
+    ) -> FinishedProcess:
+        raise ProcessTimeoutError(
+            command=tuple([executable.value.lower()] + args),
+            stdout="",
+            stderr="",
+            is_output_already_logged=True,
+        )
+
+
+def test_build_image_translates_process_timeout_to_docker_build_timeout_error(
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """A timed-out `docker build` surfaces as a clear DockerBuildTimeoutError."""
+    config = DockerProviderConfig(build_timeout_seconds=42)
+    provider = _BuildTimingOutDockerProvider(
+        name=ProviderInstanceName("test-docker-timeout"),
+        host_dir=Path("/mngr"),
+        mngr_ctx=temp_mngr_ctx,
+        config=config,
+    )
+    with pytest.raises(DockerBuildTimeoutError) as exc_info:
+        provider._build_image(["--file", "Dockerfile", "."], "test-tag")
+    assert exc_info.value.timeout_seconds == 42
+    assert exc_info.value.provider_name == ProviderInstanceName("test-docker-timeout")
+    assert "timed out after 42 seconds" in str(exc_info.value)
+
+
+def test_docker_build_timeout_error_help_text_mentions_config_setting() -> None:
+    """The error tells the user how to raise the timeout in their config."""
+    error = DockerBuildTimeoutError(
+        provider_name=ProviderInstanceName("my-docker"),
+        timeout_seconds=600,
+    )
+    assert error.user_help_text is not None
+    assert "build_timeout_seconds" in error.user_help_text
+    assert "my-docker" in error.user_help_text


### PR DESCRIPTION
## Summary

- Adds `DockerProviderConfig.build_timeout_seconds` (default 600s, up from the previous hard-coded 300s) so heavy Dockerfiles -- e.g. ones that pull large bases or download browser binaries -- can finish without being aborted mid-build. Configurable per provider instance.
- When a build does exceed the timeout, `_build_image` now raises a dedicated `DockerBuildTimeoutError` that names the timeout and points at the config knob, instead of surfacing a generic `ProcessError` where the timeout was buried in the build output.
- Routes docker subprocess timeouts through `FinishedProcess.check()` so they consistently raise `ProcessTimeoutError` rather than being collapsed into a non-zero-exit `ProcessError`.

## Test plan

- [x] `just test-quick libs/mngr/imbue/mngr/providers/docker/config_test.py libs/mngr/imbue/mngr/providers/docker/instance_test.py` (45 passed)
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release' --deselect libs/mngr/imbue/mngr/utils/test_ratchets.py::test_no_type_errors"` (3835 passed; the type-check ratchet exceeds the 10s pytest-timeout under load -- runs cleanly in isolation and `uv run ty check` reports "All checks passed!")
- [x] `just test-quick libs/concurrency_group ...` (157 passed)
- [ ] CI (acceptance + release tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)