### PR TITLE
Investigate minds new-chat slowness on engman

### DIFF
--- a/changelog/mngr-fix-minds-chats.md
+++ b/changelog/mngr-fix-minds-chats.md
@@ -1,0 +1,9 @@
+Investigation note for the minds "+ New Chat" slowness on the `engman` workspace. No
+code changes; spec only. Captures the timeline, where the agent actually came up
+(within ~1s), and why the dockview tab stayed in "Creating..." for ~6 minutes (the
+workspace-server's `agent_manager._agents` did not reflect the new agent because the
+`mngr observe --discovery-only` reader path most likely died on an unhandled
+exception in `_handle_observe_output_line`). Recommends wrapping that handler in a
+try/except, watchdogging the reader thread, fixing `--events-dir` being silently
+ignored in `--discovery-only` mode, and backing off `ChatPanel.fetchScreenCapture`
+so a 404 does not produce a polling storm.

--- a/changelog/mngr-fix-minds-chats.md
+++ b/changelog/mngr-fix-minds-chats.md
@@ -1,9 +1,12 @@
 Investigation note for the minds "+ New Chat" slowness on the `engman` workspace. No
 code changes; spec only. Captures the timeline, where the agent actually came up
 (within ~1s), and why the dockview tab stayed in "Creating..." for ~6 minutes (the
-workspace-server's `agent_manager._agents` did not reflect the new agent because the
-`mngr observe --discovery-only` reader path most likely died on an unhandled
-exception in `_handle_observe_output_line`). Recommends wrapping that handler in a
-try/except, watchdogging the reader thread, fixing `--events-dir` being silently
-ignored in `--discovery-only` mode, and backing off `ChatPanel.fetchScreenCapture`
-so a 404 does not produce a polling storm.
+`mngr create` subprocess most likely hung between `emit_discovery_events_for_host`
+returning and click-cmd exit on the first chat-create after workspace bootstrap, so
+`_run_creation` never reached the `_agents[agent_id] = ...` assignment or the
+`proto_agent_completed` broadcast; the observe pipeline was healthy throughout).
+Recommends adding a structured "mngr create returned (rc=N, elapsed=T)" log at the
+end of `_run_creation` so future hangs are visible, plus defensive cleanups:
+wrapping `_handle_observe_output_line` in a try/except, fixing `--events-dir` being
+silently ignored in `--discovery-only` mode, and backing off
+`ChatPanel.fetchScreenCapture` so a 404 does not produce a polling storm.

--- a/specs/fix-minds-new-chat-slowness/investigation.md
+++ b/specs/fix-minds-new-chat-slowness/investigation.md
@@ -1,0 +1,100 @@
+# Investigation: minds "+ New Chat" appears to hang for ~6 min
+
+Captured from a live `engman` workspace (host `host-3f74174b139a451e99a8c1d6b7aa3fdc`,
+local-host id inside container `host-78bcf7f3d6a54563a65869adb20bcebb`) where the user
+clicked "+ → New Chat", named the agent `driver`, and the dockview tab stayed in its
+"Creating..." / "No conversation data" state for ~6 minutes before the agent surfaced.
+
+This document is investigation-only. No code is changed.
+
+## Timeline (UTC)
+
+- `18:10:33.578` `mngr create driver --id ... --transfer none --template chat --no-connect` starts (PID 7465 in the engman container).
+- `18:10:33.779` `/mngr/agents/agent-36f.../data.json` written.
+- `18:10:34.376` `Starting agent driver ...`.
+- `18:10:34.391` `Starting agent driver in tmux session minds-driver`.
+- `18:10:34.547` `Calling on_agent_created hooks` — `mngr create` returns successfully.
+- `18:10:34.549` `AGENT_DISCOVERED` for `agent-36f...` written to `/mngr/events/mngr/discovery/events.jsonl`.
+- `18:10:39.112` first `DISCOVERY_FULL` snapshot containing both `engman` and `driver`.
+- ~every 10s thereafter: another `DISCOVERY_FULL` (2254 bytes, 1 line) — the workspace-server's `mngr observe --discovery-only` subprocess (PID 1300) logs `Discovery tail: consumed 2254 new bytes, 1 lines from events file` for each, uninterrupted, through the entire window.
+- `~18:10:33`–`~18:16:24` uvicorn access log on the system-interface service: a flood of `GET /api/agents/agent-36f.../screen?scrollback=true` returning `404 Not Found`, plus `/events 404`, `/stream 404`.
+- `~18:16:24` first `/screen?scrollback=true` returns `200 OK`.
+- `18:16:30.359` `session_watcher._discover_sessions` starts ticking for the new agent (frontend has reloaded; `/events`, `/stream` now return 200).
+- `18:16:35.598` user sends first message; `send_message_to_agents` calls `discover_hosts_and_agents` directly.
+
+## Where the agent actually lives
+
+`mngr create` from inside the engman container lands the new agent on the in-container
+`local` provider (`host-78bcf7f3d6a54563a65869adb20bcebb`). From outside the container,
+the same agent shows up under the `docker` host `engman-host`. Both are correct views of
+the same tmux session (`minds-driver`).
+
+## Why the UI hung
+
+`apps/system_interface/imbue/minds_workspace_server/server.py:_get_screen_capture` (and
+`_get_events`, `_stream_events`) call `_find_agent`, which only consults
+`agent_manager._agents`. While `_agents` does not contain the new agent, every chat-tab
+API for that agent returns 404.
+
+`ChatPanel.fetchScreenCapture` re-fires on every `m.redraw` while
+`screenContent === null && !screenLoading`, so a 404 turns into a hot polling loop. That
+is the source of the ~hundreds of `screen?scrollback=true 404` lines in the access log.
+
+## Why `_agents` did not update
+
+`agent_manager._handle_full_snapshot` is what populates `_agents` from observe events.
+The `mngr observe --discovery-only` pipeline upstream of that handler was healthy
+throughout the gap:
+
+- `/mngr/events/mngr/discovery/events.jsonl` was being appended to every ~10s.
+- The observe subprocess's own debug log (`/mngr/events/logs/mngr/events.jsonl`, written
+  by loguru from PID 1300) shows `Discovery tail: consumed 2254 new bytes, 1 lines from
+  events file` every ~10s without a gap. That log line lives in
+  `discovery_events.py:_discovery_stream_tail_events_file`, immediately before the loop
+  that calls `_discovery_stream_emit_line` for each new line. `_discovery_stream_emit_line`
+  ends with `sys.stdout.write(...)` + `sys.stdout.flush()`, so for that debug line to keep
+  firing on schedule, the OS pipe to the workspace-server must have been getting drained.
+
+So events were reaching the workspace-server's stdout reader. The bug is downstream of
+that — between the reader and `_agents`. Most likely culprit:
+
+- `agent_manager._handle_observe_output_line` calls `parse_discovery_event_line(stripped)`
+  and re-raises (`json.JSONDecodeError` from a malformed/non-JSON line, or
+  `DiscoverySchemaChangedError` from an unexpected event-type, or an explicit
+  `BaseMngrError` if `parse_discovery_event_line` returns `None`). It has no `try/except`.
+  An exception there propagates out of `PartialOutputContainer.write` and out of
+  `gather_output`, killing the read thread for that subprocess wrapper. `_watch_observe_process`
+  only fires on subprocess exit, not on a dead reader thread, so the bug would be
+  invisible.
+
+`_agents` likely got repaired around `~18:16:24` when something else (most plausibly the
+`send_message_to_agents` path that runs `discover_hosts_and_agents` in-process at
+`18:16:35`, or an analogous earlier trigger) refreshed state directly, bypassing the
+broken observe pipeline.
+
+## Side findings (not the cause but worth fixing later)
+
+- `agent_manager._build_observe_command` passes `--events-dir
+  $MNGR_AGENT_STATE_DIR/workspace_server/observe`, but
+  `libs/mngr/imbue/mngr/cli/observe.py:64-69` only honours `events_base_dir` in the
+  *non-discovery* branch. With `--discovery-only`, `run_discovery_stream` uses
+  `get_discovery_events_path(mngr_ctx.config)` (i.e. `$MNGR_HOST_DIR/events/mngr/discovery/events.jsonl`).
+  That is why each agent's `workspace_server/observe/` directory is empty.
+- `_handle_observe_output_line` is the most fragile point in the pipeline because it
+  has no exception guard and re-raises on any unparseable line.
+- The chat agent inherits `type = "claude"`, which has `sync_claude_credentials = true`
+  (only `agent_types.main` overrides to `false`). On a local host this resolves to
+  `_sync_user_resources` (symlink), which is fast — not a contributor here.
+
+## Recommended next steps (out of scope for this PR)
+
+1. Wrap `_handle_observe_output_line` in a `try/except (json.JSONDecodeError,
+   DiscoverySchemaChangedError, BaseMngrError, ValidationError)` that logs at warning
+   level and continues, so a single bad line cannot decapitate observe consumption.
+2. Add a watchdog on the *reader* thread itself (not just the subprocess), or restart
+   the observe subprocess when the reader dies.
+3. Fix `mngr observe --discovery-only` to honour `--events-dir`, or drop the flag from
+   `agent_manager._build_observe_command` so callers do not assume a per-agent file is
+   being written.
+4. Make `ChatPanel.fetchScreenCapture` back off (or only fire once per agent until the
+   agent is known) so a transient 404 does not produce a polling storm.

--- a/specs/fix-minds-new-chat-slowness/investigation.md
+++ b/specs/fix-minds-new-chat-slowness/investigation.md
@@ -4,97 +4,194 @@ Captured from a live `engman` workspace (host `host-3f74174b139a451e99a8c1d6b7aa
 local-host id inside container `host-78bcf7f3d6a54563a65869adb20bcebb`) where the user
 clicked "+ → New Chat", named the agent `driver`, and the dockview tab stayed in its
 "Creating..." / "No conversation data" state for ~6 minutes before the agent surfaced.
+A subsequent attempt by the user to create-and-destroy a new chat on the **same**
+workspace-server process (PID 869, no restart between the two tests) worked fine,
+which constrains the diagnosis: this is a transient/first-use problem, not a permanent
+broken pipeline.
 
 This document is investigation-only. No code is changed.
 
 ## Timeline (UTC)
 
-- `18:10:33.578` `mngr create driver --id ... --transfer none --template chat --no-connect` starts (PID 7465 in the engman container).
+- `18:00:46` engman primary agent created.
+- `18:00:55` `runtime-backup` service starts inside the container (60s interval).
+- `18:01:04.534` minds-workspace-server starts; `_initial_discover` runs in-process and
+  populates `agent_manager._agents` with `engman` only.
+- `18:01:04.699` first `DISCOVERY_FULL` snapshot written to
+  `/mngr/events/mngr/discovery/events.jsonl` by that in-process `list_agents`.
+- `18:01:09.788` `mngr observe --discovery-only` subprocess (PID 1300) starts, spawned
+  by `agent_manager._start_observe`.
+- `18:10:33.578` `mngr create driver --id ... --transfer none --template chat
+  --no-connect` starts (PID 7465 inside the engman container, parent is PID 869 the
+  workspace-server).
 - `18:10:33.779` `/mngr/agents/agent-36f.../data.json` written.
 - `18:10:34.376` `Starting agent driver ...`.
-- `18:10:34.391` `Starting agent driver in tmux session minds-driver`.
-- `18:10:34.547` `Calling on_agent_created hooks` — `mngr create` returns successfully.
-- `18:10:34.549` `AGENT_DISCOVERED` for `agent-36f...` written to `/mngr/events/mngr/discovery/events.jsonl`.
-- `18:10:39.112` first `DISCOVERY_FULL` snapshot containing both `engman` and `driver`.
-- ~every 10s thereafter: another `DISCOVERY_FULL` (2254 bytes, 1 line) — the workspace-server's `mngr observe --discovery-only` subprocess (PID 1300) logs `Discovery tail: consumed 2254 new bytes, 1 lines from events file` for each, uninterrupted, through the entire window.
-- `~18:10:33`–`~18:16:24` uvicorn access log on the system-interface service: a flood of `GET /api/agents/agent-36f.../screen?scrollback=true` returning `404 Not Found`, plus `/events 404`, `/stream 404`.
+- `18:10:34.391` `Starting agent driver in tmux session minds-driver` — tmux session
+  exists from this point.
+- `18:10:34.547` `Calling on_agent_created hooks`. Three immediately-following lines
+  (`Loading all agents from host...`, `Listing agent dir for host...`, `Listing agent
+  files from dir for host...`) fire at the same millisecond — the `host.discover_agents()`
+  scan inside `emit_discovery_events_for_host`.
+- `18:10:34.549` `AGENT_DISCOVERED` for `agent-36f...` written to
+  `/mngr/events/mngr/discovery/events.jsonl` by `mngr create` itself.
+- **No further log lines for PID 7465 are recorded in `/mngr/events/logs/mngr/events.jsonl`.**
+  `log_span`'s `[done in N sec]` / `[failed after N sec]` exit messages are at TRACE
+  level (see `libs/imbue_common/.../logging.py`), and TRACE is not retained in the
+  events file, so the absence is not by itself proof that mngr create hung — it may
+  have exited cleanly without further DEBUG-or-above logging.
+- `18:10:39.112` first `DISCOVERY_FULL` containing both `engman` and `driver`. Every
+  subsequent ~10s snapshot also contains both.
+- `~18:10:33–~18:16:24` uvicorn access log (system_interface): a flood of `GET
+  /api/agents/agent-36f.../screen?scrollback=true` returning `404 Not Found`, plus
+  `/events 404`, `/stream 404`. Since `_get_screen_capture` calls `_find_agent` which
+  only consults `agent_manager._agents`, this means `_agents` did not contain the new
+  chat agent during this entire window.
 - `~18:16:24` first `/screen?scrollback=true` returns `200 OK`.
-- `18:16:30.359` `session_watcher._discover_sessions` starts ticking for the new agent (frontend has reloaded; `/events`, `/stream` now return 200).
-- `18:16:35.598` user sends first message; `send_message_to_agents` calls `discover_hosts_and_agents` directly.
+- `18:16:30.359` `session_watcher._discover_sessions` starts ticking for the new
+  agent. Frontend has reloaded; `/events` and `/stream` now return 200.
+- `18:16:35.598` user sends first message; `send_message_to_agents` calls
+  `discover_hosts_and_agents` directly (not via the observe pipeline).
 
 ## Where the agent actually lives
 
 `mngr create` from inside the engman container lands the new agent on the in-container
 `local` provider (`host-78bcf7f3d6a54563a65869adb20bcebb`). From outside the container,
-the same agent shows up under the `docker` host `engman-host`. Both are correct views of
-the same tmux session (`minds-driver`).
+the same agent shows up under the `docker` host `engman-host`. Both are correct views
+of the same tmux session (`minds-driver`).
 
 ## Why the UI hung
 
 `apps/system_interface/imbue/minds_workspace_server/server.py:_get_screen_capture` (and
 `_get_events`, `_stream_events`) call `_find_agent`, which only consults
 `agent_manager._agents`. While `_agents` does not contain the new agent, every chat-tab
-API for that agent returns 404.
+API for that agent returns 404. `ChatPanel.fetchScreenCapture` re-fires on every
+`m.redraw` while `screenContent === null && !screenLoading`, so a 404 turns into a hot
+polling loop — the source of the ~hundreds of `screen?scrollback=true 404` lines in the
+access log.
 
-`ChatPanel.fetchScreenCapture` re-fires on every `m.redraw` while
-`screenContent === null && !screenLoading`, so a 404 turns into a hot polling loop. That
-is the source of the ~hundreds of `screen?scrollback=true 404` lines in the access log.
+So the question reduces to: **why did `agent_manager._agents` not include the new chat
+agent until ~6 minutes after `mngr create` had already started the agent?**
 
-## Why `_agents` did not update
+## Two paths feed `_agents`
 
-`agent_manager._handle_full_snapshot` is what populates `_agents` from observe events.
-The `mngr observe --discovery-only` pipeline upstream of that handler was healthy
-throughout the gap:
+1. **Direct from `_run_creation`.** `agent_manager._run_creation` runs `mngr create`
+   via `run_local_command_modern_version` (blocking), then under `self._lock` does
+   `self._agents[agent_id] = AgentStateItem(...)` — but **only when
+   `result.returncode == 0`**. After that it broadcasts `proto_agent_completed`.
+2. **Indirect from `mngr observe`.** Every ~10s, the observe subprocess writes a fresh
+   `DISCOVERY_FULL` to the discovery events file; its tail thread reads new lines and
+   pipes them to its stdout; the workspace-server's pipe reader hands each line to
+   `_handle_observe_output_line`, which dispatches `FullDiscoverySnapshotEvent` to
+   `_handle_full_snapshot` (replaces `self._agents`).
 
-- `/mngr/events/mngr/discovery/events.jsonl` was being appended to every ~10s.
-- The observe subprocess's own debug log (`/mngr/events/logs/mngr/events.jsonl`, written
-  by loguru from PID 1300) shows `Discovery tail: consumed 2254 new bytes, 1 lines from
-  events file` every ~10s without a gap. That log line lives in
-  `discovery_events.py:_discovery_stream_tail_events_file`, immediately before the loop
-  that calls `_discovery_stream_emit_line` for each new line. `_discovery_stream_emit_line`
-  ends with `sys.stdout.write(...)` + `sys.stdout.flush()`, so for that debug line to keep
-  firing on schedule, the OS pipe to the workspace-server must have been getting drained.
+For `_agents` to be missing the new agent for ~6 min, **both paths must have failed to
+update it during that window**.
 
-So events were reaching the workspace-server's stdout reader. The bug is downstream of
-that — between the reader and `_agents`. Most likely culprit:
+### Why path #2 likely was reaching the workspace-server
 
-- `agent_manager._handle_observe_output_line` calls `parse_discovery_event_line(stripped)`
-  and re-raises (`json.JSONDecodeError` from a malformed/non-JSON line, or
-  `DiscoverySchemaChangedError` from an unexpected event-type, or an explicit
-  `BaseMngrError` if `parse_discovery_event_line` returns `None`). It has no `try/except`.
-  An exception there propagates out of `PartialOutputContainer.write` and out of
-  `gather_output`, killing the read thread for that subprocess wrapper. `_watch_observe_process`
-  only fires on subprocess exit, not on a dead reader thread, so the bug would be
-  invisible.
+Strong evidence the observe pipeline was healthy upstream of `_handle_full_snapshot`:
 
-`_agents` likely got repaired around `~18:16:24` when something else (most plausibly the
-`send_message_to_agents` path that runs `discover_hosts_and_agents` in-process at
-`18:16:35`, or an analogous earlier trigger) refreshed state directly, bypassing the
-broken observe pipeline.
+- `/mngr/events/mngr/discovery/events.jsonl` was being appended every ~10s (we can see
+  the timestamps).
+- Inside the observe subprocess (PID 1300), the loguru `Discovery tail: consumed N new
+  bytes, M lines from events file` debug line in
+  `discovery_events.py:_discovery_stream_tail_events_file` fires every ~10s without a
+  gap from `18:10:35` through `18:16:27`. That log line lives **immediately before**
+  the loop that calls `_discovery_stream_emit_line` for each new line, and emit ends
+  with `sys.stdout.write(...)` + `sys.stdout.flush()`. For the next iteration's
+  `Discovery tail` log to appear on schedule, every prior `flush()` must have returned
+  — which means the OS pipe to the workspace-server **was getting drained**.
 
-## Side findings (not the cause but worth fixing later)
+So either `_handle_observe_output_line` was being called and silently doing nothing
+useful for those events, OR — much more likely — the workspace-server had _already_
+populated `_agents` with the new chat agent at `~18:10:39`, but something else was
+making the `/screen` lookup fail.
+
+…but `_find_agent` only checks `_agents.get(agent_id)`, full stop. There is no second
+condition. So `_agents` really did not have the agent.
+
+### Why path #1 likely was the one blocked
+
+The user-visible symptom that the chat tab showed the build log ("Creating agent...")
+during the wait is more compatible with path #1 being stuck than with `_agents` being
+silently mis-updated:
+
+- The build log only renders while `isProtoAgent(agentId)` is true, i.e. while the
+  frontend has not yet seen `proto_agent_completed`. That broadcast only fires from
+  the bottom of `_run_creation`, after `run_local_command_modern_version` returns.
+- So the user seeing "Creating agent..." for ~6 min implies `mngr create` (PID 7465)
+  did not exit for ~6 min, even though the agent process was up and running by
+  `18:10:34`.
+- Once the user reloaded and the WS reconnected, the frontend re-receives `agents_updated`
+  with the **current** `_agents` snapshot (`server.py:_run_ws_broadcast_loop` sends
+  `agents_updated` immediately on accept). If `mngr create` had already returned and
+  `_run_creation` had populated `_agents`, the new agent would have appeared on the
+  reload. The user reports it did **not** show up after the reload — consistent with
+  `_run_creation` still being blocked on the subprocess.
+
+The events file has nothing further from PID 7465 after `18:10:34.547`, but as noted
+that is consistent both with "exited cleanly" (no DEBUG output expected after `Listing
+agent files from dir for host`) and with "hung" (no log produced because no further
+code ran). What disambiguates is the user's report and the WS reload behavior.
+
+## Best guess at the root cause
+
+**The `mngr create` subprocess hung between `emit_discovery_events_for_host`
+returning and click-cmd exit, for ~6 minutes, on the first chat-create after the
+workspace had just been bootstrapped.** The subsequent same-session test worked.
+
+Plausible candidates inside that window (none individually proven):
+
+- A plugin's `on_agent_created` hook doing first-time work that happened to contend
+  with concurrent activity on the workspace (e.g. `runtime-backup` running its 60s
+  git cycle, or the engman primary agent's claude finishing its initial session
+  setup). After the first run, the cache/state is warm.
+- The `mngr_modal` plugin's `on_agent_created` (`libs/mngr_modal/.../backend.py:588`)
+  unconditionally raises `MngrError` when the host is not a `Host` (modal). This
+  hook fires for **every** create, including local ones, even when modal is disabled
+  via `[providers.modal] is_enabled = false`. If pluggy is configured to swallow
+  hook exceptions (which it commonly is for non-firstresult hooks), the raise is
+  silently logged and execution continues — but the path through pluggy's exception
+  bookkeeping under load could explain a stall on the first call. (This deserves
+  direct verification: I did not catch the hook firing live.)
+- Concurrent FS / git operations: `runtime-backup` runs `git commit` inside
+  `/code/runtime/.git` every 60s; the chat agent's `mngr create` does its own
+  `Calling provision for agent driver` work that may touch overlapping paths. A
+  flock or git index lock contention could stall `mngr create` until the backup
+  cycle releases.
+
+Because the bug is transient and self-resolved, definitive root-cause requires
+reproducing the cold-start condition (fresh workspace, first chat creation within
+the first ~10 min after engman startup).
+
+## Side findings (cosmetic / pre-existing)
 
 - `agent_manager._build_observe_command` passes `--events-dir
   $MNGR_AGENT_STATE_DIR/workspace_server/observe`, but
   `libs/mngr/imbue/mngr/cli/observe.py:64-69` only honours `events_base_dir` in the
   *non-discovery* branch. With `--discovery-only`, `run_discovery_stream` uses
-  `get_discovery_events_path(mngr_ctx.config)` (i.e. `$MNGR_HOST_DIR/events/mngr/discovery/events.jsonl`).
-  That is why each agent's `workspace_server/observe/` directory is empty.
-- `_handle_observe_output_line` is the most fragile point in the pipeline because it
-  has no exception guard and re-raises on any unparseable line.
-- The chat agent inherits `type = "claude"`, which has `sync_claude_credentials = true`
-  (only `agent_types.main` overrides to `false`). On a local host this resolves to
-  `_sync_user_resources` (symlink), which is fast — not a contributor here.
+  `get_discovery_events_path(mngr_ctx.config)` (i.e.
+  `$MNGR_HOST_DIR/events/mngr/discovery/events.jsonl`). That is why each agent's
+  `workspace_server/observe/` directory is empty.
+- `_handle_observe_output_line` re-raises `json.JSONDecodeError` /
+  `DiscoverySchemaChangedError` / `BaseMngrError` without a `try/except`. This is
+  not the cause here (the reader thread was clearly alive), but it is fragile and
+  worth hardening.
+- `ChatPanel.fetchScreenCapture` re-fires on every redraw while `screenContent ===
+  null && !screenLoading`, so any 404 produces a polling storm. Worth backing off.
 
-## Recommended next steps (out of scope for this PR)
+## Recommended next steps to actually pin this down
 
-1. Wrap `_handle_observe_output_line` in a `try/except (json.JSONDecodeError,
-   DiscoverySchemaChangedError, BaseMngrError, ValidationError)` that logs at warning
-   level and continues, so a single bad line cannot decapitate observe consumption.
-2. Add a watchdog on the *reader* thread itself (not just the subprocess), or restart
-   the observe subprocess when the reader dies.
-3. Fix `mngr observe --discovery-only` to honour `--events-dir`, or drop the flag from
-   `agent_manager._build_observe_command` so callers do not assume a per-agent file is
-   being written.
-4. Make `ChatPanel.fetchScreenCapture` back off (or only fire once per agent until the
-   agent is known) so a transient 404 does not produce a polling storm.
+1. Reproduce the cold-start condition: spin up a fresh minds workspace and trigger
+   the first new-chat within the first few minutes. If the hang reproduces, it is
+   first-call-only.
+2. Add a structured "mngr create returned (rc=N, elapsed=T)" log line at the end of
+   `_run_creation`. The current absence makes it impossible to tell from logs
+   whether the subprocess hung or returned.
+3. Wrap `_handle_observe_output_line` in a `try/except (json.JSONDecodeError,
+   DiscoverySchemaChangedError, BaseMngrError, ValidationError)` that logs at
+   warning level and continues. Defensive only.
+4. Fix `mngr observe --discovery-only` to honour `--events-dir`, or drop the flag
+   from `agent_manager._build_observe_command`.
+5. Make `ChatPanel.fetchScreenCapture` back off after a 404 so a stuck agent does
+   not produce a polling storm.


### PR DESCRIPTION
[AGENT] ## Summary

Investigation only — no code changes. User reported clicking "+ → New Chat" in the dockview UI on the freshly-bootstrapped `engman` minds workspace appeared to hang for ~6 min before the new chat agent ("driver") finally appeared. A subsequent same-session test (no workspace-server restart) worked fine, so this is a transient/first-use issue, not a permanently broken pipeline.

## Findings

The chat agent itself was up in ~1s (data.json written, tmux session live, AGENT_DISCOVERED event in the discovery file at `18:10:34.549`). The hang was specifically `mngr create` not exiting until ~`18:16:24`. Evidence pointing at path #1 (`_run_creation` adding to `_agents` directly) being blocked:

- The frontend stayed on the build log ("Creating agent...") which only renders while `proto_agent_completed` has not yet broadcast — and that broadcast fires from the bottom of `_run_creation`, after `run_local_command_modern_version` returns.
- Reloading the page reconnected the WS, which on accept sends current `_agents` (`server.py:_run_ws_broadcast_loop`); the user reports the new agent still did not appear after the reload.
- The observe pipeline upstream of `_handle_full_snapshot` was clearly healthy throughout the gap (the `Discovery tail: consumed 2254 new bytes, 1 lines from events file` debug line in the observe subprocess fired every 10s without a gap, which means each `sys.stdout.flush()` after each emitted line returned — i.e. the workspace-server pipe was being drained).
- Loguru `[done]/[failed]` exit messages from `log_span` are TRACE level and are not retained in the events file, so the absence of further DEBUG logs from PID 7465 after `Listing agent files from dir for host` at `10:34.547` is consistent with both "exited cleanly" and "hung". The user-facing symptoms disambiguate to "hung".

Plausible candidates inside the gap window (none individually proven): a plugin's `on_agent_created` doing first-time work; `mngr_modal`'s `on_agent_created` unconditionally raising `MngrError` on non-modal hosts (this hook fires even when modal is disabled in settings); FS / git contention with `runtime-backup`'s 60s commit cycle.

## Side findings (pre-existing, not the cause)

- `agent_manager._build_observe_command` passes `--events-dir` but `mngr observe --discovery-only` ignores it (`libs/mngr/.../cli/observe.py:64-69`).
- `_handle_observe_output_line` has no `try/except` around `parse_discovery_event_line`.
- `ChatPanel.fetchScreenCapture` re-fires on every redraw while `screenContent === null && !screenLoading`, producing the 404 polling storm in the access log.

## Recommended next steps

Listed in `specs/fix-minds-new-chat-slowness/investigation.md`. Most useful: log `mngr create returned (rc=N, elapsed=T)` from `_run_creation` so future hangs are visible, and try to reproduce the cold-start condition.

## Test plan

Investigation only.
