### PR TITLE
api/list: drop stale "NOT IMPLEMENTED YET" marker on provider_names

### DIFF
--- a/changelog/mngr-em-cnco-2.md
+++ b/changelog/mngr-em-cnco-2.md
@@ -1,0 +1,1 @@
+Remove a stale "(NOT IMPLEMENTED YET)" marker on the `provider_names` parameter of `imbue.mngr.api.list.list_agents`. The filter has long been wired through both batch and streaming codepaths into `list_provider_names_to_load`; the parameter-doc inline comment had not caught up.

--- a/libs/mngr/imbue/mngr/api/list.py
+++ b/libs/mngr/imbue/mngr/api/list.py
@@ -131,7 +131,7 @@ def list_agents(
     include_filters: tuple[str, ...] = (),
     # CEL expressions - exclude agents matching these
     exclude_filters: tuple[str, ...] = (),
-    # If specified, only list agents from these providers (NOT IMPLEMENTED YET)
+    # If specified, only list agents from these providers
     provider_names: tuple[str, ...] | None = None,
     # How to handle errors (abort or continue)
     error_behavior: ErrorBehavior = ErrorBehavior.ABORT,


### PR DESCRIPTION
[AGENT] ## Summary

- Removes "(NOT IMPLEMENTED YET)" from the inline parameter-doc comment on `list_agents(..., provider_names, ...)` in `libs/mngr/imbue/mngr/api/list.py`. The filter has long been fully implemented end-to-end.

Pure comment fix; no behavior change.

## Why

The parameter is threaded through both fan-out paths into `list_provider_names_to_load(mngr_ctx, provider_names)` in `api/providers.py:110-160`, which filters configured providers and default backends by the `provider_filter` set. `_maybe_write_full_discovery_snapshot` also relies on `provider_names is None` to decide whether the listing is complete. The stale marker was misleading callers reading the source -- they'd assume the filter was a no-op and write wrappers around it.

Identified during the same calibration identify-* synthesis pass that produced #1568 (SYNTHESIS.md finding C).

## Test plan

- [ ] CI green
- [ ] Spot-confirm the comment edit at `libs/mngr/imbue/mngr/api/list.py:134`. No behavior to exercise.

Generated with [Claude Code](https://claude.com/claude-code)