### PR TITLE
Add turn extraction and MNGR_AGENT_ID auto-discovery to mngr transcript

### DIFF
--- a/blueprint/mngr-transcript-turns/plan-mngr-transcript-turns.md
+++ b/blueprint/mngr-transcript-turns/plan-mngr-transcript-turns.md
@@ -1,0 +1,57 @@
+# Plan: Turn extraction in `mngr transcript`
+
+## Overview
+
+- Bring `extract_turn` functionality into the existing `mngr transcript` CLI command so agents can slice their own transcripts by conversational turn without a separate script.
+- Define a "turn" by `type: "user_message"` events in the common_transcript format. Stop-hook injections are already reclassified upstream as `tool_result` with `tool_name == "meta"`, so no extra filtering is required.
+- Add four new flags — `--turn N`, `--last-completed-turn`, `--count-turns`, `--list-turns` — that compose with `--role` and `--format` but are mutually exclusive with `--head` / `--tail` and with each other.
+- Make the `target` positional argument optional, falling back to the `MNGR_AGENT_ID` environment variable that mngr already exports into every agent's shell. This is the "auto-discovery" piece — an agent can run `mngr transcript --last-completed-turn --format jsonl` from a hook with no other context.
+- Out of scope: porting forever-claude-template's `extract_turn.py` callers, removing the script, and porting marker-based slicing (`--start-marker`/`--end-marker`).
+
+## Expected behavior
+
+- Running `mngr transcript <target>` without any new flag continues to print the full transcript (no change to existing behavior).
+- Running `mngr transcript` (no target) inside an agent's shell resolves the target from `$MNGR_AGENT_ID`.
+- Running `mngr transcript` with neither a target nor `$MNGR_AGENT_ID` set exits 2 with: "No target given and `MNGR_AGENT_ID` is not set. Pass an agent name/ID, or run inside an agent context."
+- `--turn N` (1-indexed from start) emits the events from `user_message` #N (inclusive) through the event immediately preceding `user_message` #N+1. If #N+1 doesn't exist, the slice runs to end-of-transcript.
+- `--turn -1` emits the slice starting at the most recent `user_message` and running to end-of-transcript (the in-progress turn). `--turn -2` emits the previous completed turn. Negative indices are Python-style.
+- `--turn 0` and out-of-range indices (`|N| > turn_count`) exit 2 with a clear "no such turn" error that reports the actual turn count.
+- `--last-completed-turn` is sugar for `--turn -2` — the most recent turn that has a `user_message` after it. It is the dominant use case from extract_turn skill callers (matches `extract_turn --nth 1`). If there is no completed turn yet (fewer than 2 `user_message` events), it exits 2 with "no completed turn yet (only N user message(s) in transcript)".
+- `--count-turns` prints just the integer count of `user_message` events to stdout and exits 0. Ignores `--role` and `--format`.
+- `--list-turns` prints a summary of each turn boundary, respecting `--format`:
+  - `human` (default): a table with columns `#`, `timestamp`, and `content_preview` (first ~80 chars of the user_message content with newlines collapsed).
+  - `json`: a pretty-printed JSON array of `{turn, timestamp, event_id, content_preview}` objects.
+  - `jsonl`: one such object per line.
+- `--turn` and `--last-completed-turn` compose with `--role`: the slice is computed first, then role-filtered before output.
+- `--turn`, `--last-completed-turn`, `--count-turns`, `--list-turns` are mutually exclusive with each other and with `--head` / `--tail`. Combining any two raises `UserInputError` at CLI parsing time with a message naming both offending flags.
+- An empty transcript or a transcript with zero `user_message` events: `--count-turns` prints `0`; `--list-turns` prints an empty table/array/(empty output for jsonl); `--turn`/`--last-completed-turn` exit 2 with a clear error.
+
+## Changes
+
+- **CLI options (`libs/mngr/imbue/mngr/cli/transcript.py`)**
+  - Make the `target` positional argument optional.
+  - Add four new options to `TranscriptCliOptions`: `turn: int | None`, `last_completed_turn: bool`, `count_turns: bool`, `list_turns: bool`.
+  - Add a validation step that rejects (a) more than one of the four turn flags set, (b) any turn flag combined with `--head` or `--tail`.
+- **Auto-discovery**
+  - When `target` is empty/None, read `MNGR_AGENT_ID` from the environment and use it as the target identifier. If unset, raise `UserInputError` with the message above.
+- **Turn computation**
+  - Add helpers (kept inside `transcript.py` unless they need to be reused) to:
+    - Compute the list of `(turn_index, event)` pairs for all `user_message` events in the parsed events.
+    - Translate a `--turn N` value (positive or negative) into the inclusive slice `[events_after_turn_start, events_before_next_turn_start)`.
+    - Translate `--last-completed-turn` to `--turn -2`.
+  - Apply `--role` filter to the slice after it is computed.
+- **Output paths**
+  - `--turn` / `--last-completed-turn`: feed the resulting event list into the existing `_emit_transcript()` so all three formats keep working unchanged.
+  - `--count-turns`: print the integer and skip `_emit_transcript()`.
+  - `--list-turns`: build summary records and emit per `--format` (new small emission helper; reuse human-table style from existing formatter as much as is practical).
+- **Tests (`libs/mngr/imbue/mngr/cli/transcript_test.py`)**
+  - Turn boundary detection over a fixture with multiple `user_message`, `assistant_message`, `tool_result` events including a `tool_name == "meta"` stop-hook event (must not affect counts/boundaries).
+  - `--turn` positive, negative, and out-of-range indices.
+  - `--last-completed-turn` happy path and "no completed turn yet" error.
+  - `--count-turns` on populated, empty, and meta-only transcripts.
+  - `--list-turns` for all three formats.
+  - Auto-discovery via `MNGR_AGENT_ID` env var, and the helpful error when both unset.
+  - Mutual exclusivity errors for every relevant flag pairing.
+  - `--role` composition with `--turn` (turn computed first, then filtered).
+- **Changelog**
+  - Add `changelog/gabriel-extract-turn.md` describing the new flags and auto-discovery in 2–4 user-facing bullets.

--- a/changelog/gabriel-extract-turn.md
+++ b/changelog/gabriel-extract-turn.md
@@ -1,0 +1,4 @@
+- `mngr transcript` learned to slice the transcript by conversational turn. Each `user_message` marks a turn boundary; framework-injected stop-hook events are already excluded by the common-transcript producer.
+- New flags: `--turn N` (1-indexed; negative counts from the end, `--turn -1` is the in-progress turn, `--turn -2` is the previous completed turn), `--last-completed-turn` (shortcut for `--turn -2`), `--count-turns` (prints the integer count), and `--list-turns` (summary respecting `--format`).
+- The `TARGET` positional argument is now optional. When omitted, `mngr transcript` resolves the current agent from the `MNGR_AGENT_ID` environment variable that mngr exports into every agent's shell. This lets in-agent hooks call `mngr transcript --last-completed-turn --format jsonl` with no extra context.
+- Turn flags are mutually exclusive with each other and with `--head`/`--tail`; they compose with `--role` (turn is computed first, then role-filtered).

--- a/libs/mngr/docs/commands/primary/create.md
+++ b/libs/mngr/docs/commands/primary/create.md
@@ -206,6 +206,10 @@ Provider: docker
   Build args are passed directly to 'docker build'. Run 'docker build --help' for details.
   Start args are passed directly to 'docker run'. Run 'docker run --help' for details.
 
+Provider: imbue_cloud
+  Build args constrain which pool host the connector leases for this `mngr create`. Recognized keys (see LeaseAttributes): repo_url, repo_branch_or_tag, cpus, memory_gb, gpu_count. Unknown keys are rejected. Example: `mngr create my-agent@my-host.imbue_cloud_alice --new-host -b cpus=4 -b repo_branch_or_tag=v1.2.3`.
+  Start args are not used by the imbue_cloud provider.
+
 Provider: lima
   Supported build arguments for the lima provider:
     --file PATH           Path to a Lima YAML config file for full VM customization.

--- a/libs/mngr/docs/commands/secondary/transcript.md
+++ b/libs/mngr/docs/commands/secondary/transcript.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr transcript TARGET [--role ROLE] [--tail N] [--head N] [--format human|json|jsonl]
+mngr transcript [TARGET] [--role ROLE] [--tail N | --head N | --turn N | --last-completed-turn | --count-turns | --list-turns] [--format human|json|jsonl]
 ```
 
 View the message transcript for an agent.
@@ -16,10 +16,22 @@ user messages, assistant messages, and tool call/result summaries in a
 common, agent-agnostic format.
 
 The command automatically finds the correct transcript file regardless
-of the agent type (e.g. claude, codex).
+of the agent type (e.g. claude, codex). If TARGET is omitted, the
+command resolves the current agent from the `MNGR_AGENT_ID` environment
+variable that mngr exports into every agent's shell.
 
 Use --role to filter by message role (user, assistant, tool). This
 option is repeatable to include multiple roles.
+
+Turn-aware options operate on conversational turns, where each
+`user_message` event marks a turn boundary. They are mutually exclusive
+with each other and with --head / --tail:
+  - --turn N: extract a single turn. Positive N is 1-indexed from the
+    start; negative N counts from the end (--turn -1 = last/in-progress,
+    --turn -2 = previous completed).
+  - --last-completed-turn: shortcut for --turn -2.
+  - --count-turns: print just the turn count and exit.
+  - --list-turns: summary table of turn boundaries (respects --format).
 
 Use --format to control output:
   - human (default): nicely formatted, readable output
@@ -29,11 +41,11 @@ Use --format to control output:
 **Usage:**
 
 ```text
-mngr transcript [OPTIONS] TARGET
+mngr transcript [OPTIONS] [TARGET]
 ```
 ## Arguments
 
-- `TARGET`: Agent name or ID whose transcript to view
+- `TARGET`: Agent name or ID whose transcript to view. Optional when the command runs inside an agent context that exports `MNGR_AGENT_ID`.
 
 **Options:**
 
@@ -49,6 +61,15 @@ mngr transcript [OPTIONS] TARGET
 | ---- | ---- | ----------- | ------- |
 | `--tail` | integer range | Show only the last N transcript events | None |
 | `--head` | integer range | Show only the first N transcript events | None |
+
+## Turns
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--turn` | integer | Extract a single turn by 1-indexed position. Negative indices count from the end (--turn -1 is the last/in-progress turn, --turn -2 is the previous completed turn). A 'turn' is the slice from one user_message (inclusive) up to the next user_message (exclusive). | None |
+| `--last-completed-turn` | boolean | Extract the most recent completed turn (equivalent to --turn -2). | `False` |
+| `--count-turns` | boolean | Print the number of turns in the transcript and exit. | `False` |
+| `--list-turns` | boolean | List each turn's number, timestamp, and a content preview instead of the events themselves. | `False` |
 
 ## Common
 
@@ -107,4 +128,28 @@ $ mngr transcript my-agent --format jsonl
 
 ```bash
 $ mngr transcript my-agent --format json
+```
+
+**Count turns in the transcript**
+
+```bash
+$ mngr transcript my-agent --count-turns
+```
+
+**Extract the previous completed turn (from inside an agent)**
+
+```bash
+$ mngr transcript --last-completed-turn --format jsonl
+```
+
+**Extract the second turn**
+
+```bash
+$ mngr transcript my-agent --turn 2 --format jsonl
+```
+
+**List all turn boundaries**
+
+```bash
+$ mngr transcript my-agent --list-turns
 ```

--- a/libs/mngr/imbue/mngr/cli/transcript.py
+++ b/libs/mngr/imbue/mngr/cli/transcript.py
@@ -15,6 +15,7 @@ from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
+from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import MngrError
@@ -181,24 +182,20 @@ def _emit_turn_summary(summaries: list[dict[str, Any]], output_opts: OutputOptio
     match output_opts.output_format:
         case OutputFormat.JSONL:
             for s in summaries:
-                sys.stdout.write(json.dumps(s, separators=(",", ":")) + "\n")
-            sys.stdout.flush()
+                write_human_line(json.dumps(s, separators=(",", ":")))
 
         case OutputFormat.JSON:
-            sys.stdout.write(json.dumps(summaries, indent=2) + "\n")
-            sys.stdout.flush()
+            write_human_line(json.dumps(summaries, indent=2))
 
         case OutputFormat.HUMAN:
             if not summaries:
-                sys.stdout.write("(no turns)\n")
-                sys.stdout.flush()
+                write_human_line("(no turns)")
                 return
             header = f"{'#':>4}  {'timestamp':<24}  preview"
-            sys.stdout.write(header + "\n")
-            sys.stdout.write("-" * len(header) + "\n")
+            write_human_line(header)
+            write_human_line("-" * len(header))
             for s in summaries:
-                sys.stdout.write(f"{s['turn']:>4}  {str(s['timestamp']):<24}  {s['content_preview']}\n")
-            sys.stdout.flush()
+                write_human_line(f"{s['turn']:>4}  {str(s['timestamp']):<24}  {s['content_preview']}")
 
         case _ as unreachable:
             assert_never(unreachable)
@@ -399,8 +396,7 @@ def transcript(ctx: click.Context, **kwargs: Any) -> None:
 
     if opts.count_turns:
         count = len(_user_message_indices(all_events))
-        sys.stdout.write(f"{count}\n")
-        sys.stdout.flush()
+        write_human_line(str(count))
         return
 
     if opts.list_turns:

--- a/libs/mngr/imbue/mngr/cli/transcript.py
+++ b/libs/mngr/imbue/mngr/cli/transcript.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from typing import Any
 from typing import assert_never
@@ -25,13 +26,20 @@ from imbue.mngr.utils.jsonl_warn import MalformedJsonLineWarner
 class TranscriptCliOptions(CommonCliOptions):
     """Options passed from the CLI to the transcript command."""
 
-    target: str
+    target: str | None
     role: tuple[str, ...]
     tail: int | None
     head: int | None
+    turn: int | None
+    last_completed_turn: bool
+    count_turns: bool
+    list_turns: bool
 
 
 _COMMON_TRANSCRIPT_SUFFIX = "common_transcript"
+_USER_MESSAGE_TYPE = "user_message"
+_LIST_TURNS_PREVIEW_CHARS = 80
+_AGENT_ID_ENV_VAR = "MNGR_AGENT_ID"
 
 
 def _find_common_transcript_source(target: EventsTarget) -> str:
@@ -105,6 +113,97 @@ def _get_event_role(event: dict[str, Any]) -> str | None:
             return None
 
 
+def _user_message_indices(events: list[dict[str, Any]]) -> list[int]:
+    """Return the indices (into events) of every user_message event.
+
+    Stop-hook injections and other framework-meta events are already
+    reclassified to ``tool_result`` (with ``tool_name == "meta"``) by the
+    common_transcript producer, so a plain ``type == "user_message"`` check
+    is sufficient.
+    """
+    return [i for i, event in enumerate(events) if event.get("type") == _USER_MESSAGE_TYPE]
+
+
+def _resolve_turn_index(turn: int, turn_count: int) -> int:
+    """Normalize a 1-indexed or negative turn argument to a 0-based index into the user_message list.
+
+    Raises UserInputError if ``turn`` is 0, out of range, or the transcript has no turns.
+    """
+    if turn_count == 0:
+        raise UserInputError("Transcript has no turns (no user_message events).")
+    if turn == 0:
+        raise UserInputError("--turn is 1-indexed; use --turn 1 for the first turn or --turn -1 for the last.")
+    if turn > 0:
+        if turn > turn_count:
+            raise UserInputError(f"--turn {turn} out of range; transcript has {turn_count} turn(s).")
+        return turn - 1
+    if -turn > turn_count:
+        raise UserInputError(f"--turn {turn} out of range; transcript has {turn_count} turn(s).")
+    return turn_count + turn
+
+
+def _slice_for_turn(
+    events: list[dict[str, Any]], turn_starts: list[int], zero_based_turn: int
+) -> list[dict[str, Any]]:
+    """Return events from turn_starts[zero_based_turn] (inclusive) to turn_starts[zero_based_turn + 1] (exclusive).
+
+    If the turn is the last one, the slice runs to end-of-transcript.
+    """
+    start = turn_starts[zero_based_turn]
+    if zero_based_turn + 1 < len(turn_starts):
+        end = turn_starts[zero_based_turn + 1]
+        return events[start:end]
+    return events[start:]
+
+
+def _build_turn_summary(events: list[dict[str, Any]], turn_starts: list[int]) -> list[dict[str, Any]]:
+    """Build summary records for --list-turns, one per turn boundary."""
+    summaries: list[dict[str, Any]] = []
+    for ordinal, event_index in enumerate(turn_starts, start=1):
+        event = events[event_index]
+        content = str(event.get("content", ""))
+        preview = " ".join(content.split())
+        if len(preview) > _LIST_TURNS_PREVIEW_CHARS:
+            preview = preview[:_LIST_TURNS_PREVIEW_CHARS] + "..."
+        summaries.append(
+            {
+                "turn": ordinal,
+                "timestamp": event.get("timestamp", ""),
+                "event_id": event.get("event_id", ""),
+                "content_preview": preview,
+            }
+        )
+    return summaries
+
+
+def _emit_turn_summary(summaries: list[dict[str, Any]], output_opts: OutputOptions) -> None:
+    """Emit turn-summary records in the requested format."""
+    match output_opts.output_format:
+        case OutputFormat.JSONL:
+            for s in summaries:
+                sys.stdout.write(json.dumps(s, separators=(",", ":")) + "\n")
+            sys.stdout.flush()
+
+        case OutputFormat.JSON:
+            sys.stdout.write(json.dumps(summaries, indent=2) + "\n")
+            sys.stdout.flush()
+
+        case OutputFormat.HUMAN:
+            if not summaries:
+                sys.stdout.write("(no turns)\n")
+                sys.stdout.flush()
+                return
+            header = f"{'#':>4}  {'timestamp':<24}  preview"
+            sys.stdout.write(header + "\n")
+            sys.stdout.write("-" * len(header) + "\n")
+            for s in summaries:
+                sys.stdout.write(f"{s['turn']:>4}  {str(s['timestamp']):<24}  {s['content_preview']}\n")
+            sys.stdout.flush()
+
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
 def _format_event_human(event: dict[str, Any]) -> str:
     """Format a single transcript event for human-readable display."""
     event_type = event.get("type", "unknown")
@@ -172,8 +271,44 @@ def _emit_transcript(
             assert_never(unreachable)
 
 
+def _resolve_target_identifier(target: str | None) -> str:
+    """Return the explicit target if given, else fall back to MNGR_AGENT_ID.
+
+    Raises UserInputError if neither is available.
+    """
+    if target is not None and target != "":
+        return target
+    env_target = os.environ.get(_AGENT_ID_ENV_VAR)
+    if env_target:
+        return env_target
+    raise UserInputError(
+        f"No target given and `{_AGENT_ID_ENV_VAR}` is not set. Pass an agent name/ID, or run inside an agent context."
+    )
+
+
+def _validate_turn_options(opts: TranscriptCliOptions) -> None:
+    """Reject incompatible combinations of head/tail and the turn-family flags."""
+    if opts.head is not None and opts.tail is not None:
+        raise UserInputError("Cannot specify both --head and --tail")
+
+    turn_flags = [
+        ("--turn", opts.turn is not None),
+        ("--last-completed-turn", opts.last_completed_turn),
+        ("--count-turns", opts.count_turns),
+        ("--list-turns", opts.list_turns),
+    ]
+    active_turn_flags = [name for name, is_active in turn_flags if is_active]
+    if len(active_turn_flags) > 1:
+        raise UserInputError(
+            f"Cannot specify more than one of {', '.join(active_turn_flags)}; these flags are mutually exclusive."
+        )
+    if active_turn_flags and (opts.head is not None or opts.tail is not None):
+        slicing = "--head" if opts.head is not None else "--tail"
+        raise UserInputError(f"Cannot combine {active_turn_flags[0]} with {slicing}.")
+
+
 @click.command(name="transcript")
-@click.argument("target")
+@click.argument("target", default=None, required=False)
 @optgroup.group("Filtering")
 @optgroup.option(
     "--role",
@@ -193,6 +328,35 @@ def _emit_transcript(
     default=None,
     help="Show only the first N transcript events",
 )
+@optgroup.group("Turns")
+@optgroup.option(
+    "--turn",
+    type=int,
+    default=None,
+    help=(
+        "Extract a single turn by 1-indexed position. Negative indices count from the end "
+        "(--turn -1 is the last/in-progress turn, --turn -2 is the previous completed turn). "
+        "A 'turn' is the slice from one user_message (inclusive) up to the next user_message (exclusive)."
+    ),
+)
+@optgroup.option(
+    "--last-completed-turn",
+    is_flag=True,
+    default=False,
+    help="Extract the most recent completed turn (equivalent to --turn -2).",
+)
+@optgroup.option(
+    "--count-turns",
+    is_flag=True,
+    default=False,
+    help="Print the number of turns in the transcript and exit.",
+)
+@optgroup.option(
+    "--list-turns",
+    is_flag=True,
+    default=False,
+    help="List each turn's number, timestamp, and a content preview instead of the events themselves.",
+)
 @add_common_options
 @click.pass_context
 def transcript(ctx: click.Context, **kwargs: Any) -> None:
@@ -203,12 +367,12 @@ def transcript(ctx: click.Context, **kwargs: Any) -> None:
         is_format_template_supported=False,
     )
 
-    if opts.head is not None and opts.tail is not None:
-        raise UserInputError("Cannot specify both --head and --tail")
+    _validate_turn_options(opts)
+    target_identifier = _resolve_target_identifier(opts.target)
 
     # Resolve the target agent
     target = resolve_events_target(
-        identifier=opts.target,
+        identifier=target_identifier,
         mngr_ctx=mngr_ctx,
     )
 
@@ -222,10 +386,42 @@ def transcript(ctx: click.Context, **kwargs: Any) -> None:
     except (MngrError, OSError) as e:
         raise MngrError(f"Failed to read transcript for {target.display_name}: {e}") from e
 
-    # Parse and filter events
+    # For turn-aware operations we need unfiltered events to compute boundaries,
+    # then apply role filtering to the resulting slice. For other operations we
+    # can filter at parse time.
+    turn_mode = opts.turn is not None or opts.last_completed_turn or opts.count_turns or opts.list_turns
+    parse_roles: tuple[str, ...] = () if turn_mode else opts.role
     all_events = _parse_transcript_events(
-        content, roles=opts.role, source_description=f"transcript file '{event_file_name}' for {target.display_name}"
+        content,
+        roles=parse_roles,
+        source_description=f"transcript file '{event_file_name}' for {target.display_name}",
     )
+
+    if opts.count_turns:
+        count = len(_user_message_indices(all_events))
+        sys.stdout.write(f"{count}\n")
+        sys.stdout.flush()
+        return
+
+    if opts.list_turns:
+        summaries = _build_turn_summary(all_events, _user_message_indices(all_events))
+        _emit_turn_summary(summaries, output_opts)
+        return
+
+    if opts.turn is not None or opts.last_completed_turn:
+        turn_starts = _user_message_indices(all_events)
+        if opts.last_completed_turn:
+            if len(turn_starts) < 2:
+                raise UserInputError(f"No completed turn yet (only {len(turn_starts)} user message(s) in transcript).")
+            zero_based = len(turn_starts) - 2
+        else:
+            assert opts.turn is not None
+            zero_based = _resolve_turn_index(opts.turn, len(turn_starts))
+        sliced = _slice_for_turn(all_events, turn_starts, zero_based)
+        if opts.role:
+            sliced = [e for e in sliced if _get_event_role(e) in opts.role]
+        _emit_transcript(sliced, output_opts)
+        return
 
     # Apply head/tail
     if opts.head is not None:
@@ -243,17 +439,35 @@ def transcript(ctx: click.Context, **kwargs: Any) -> None:
 CommandHelpMetadata(
     key="transcript",
     one_line_description="View the message transcript for an agent",
-    synopsis="mngr transcript TARGET [--role ROLE] [--tail N] [--head N] [--format human|json|jsonl]",
-    arguments_description="- `TARGET`: Agent name or ID whose transcript to view",
+    synopsis=(
+        "mngr transcript [TARGET] [--role ROLE] [--tail N | --head N | --turn N | --last-completed-turn"
+        " | --count-turns | --list-turns] [--format human|json|jsonl]"
+    ),
+    arguments_description=(
+        "- `TARGET`: Agent name or ID whose transcript to view. Optional when "
+        "the command runs inside an agent context that exports `MNGR_AGENT_ID`."
+    ),
     description="""View the common transcript for an agent. The transcript contains
 user messages, assistant messages, and tool call/result summaries in a
 common, agent-agnostic format.
 
 The command automatically finds the correct transcript file regardless
-of the agent type (e.g. claude, codex).
+of the agent type (e.g. claude, codex). If TARGET is omitted, the
+command resolves the current agent from the `MNGR_AGENT_ID` environment
+variable that mngr exports into every agent's shell.
 
 Use --role to filter by message role (user, assistant, tool). This
 option is repeatable to include multiple roles.
+
+Turn-aware options operate on conversational turns, where each
+`user_message` event marks a turn boundary. They are mutually exclusive
+with each other and with --head / --tail:
+  - --turn N: extract a single turn. Positive N is 1-indexed from the
+    start; negative N counts from the end (--turn -1 = last/in-progress,
+    --turn -2 = previous completed).
+  - --last-completed-turn: shortcut for --turn -2.
+  - --count-turns: print just the turn count and exit.
+  - --list-turns: summary table of turn boundaries (respects --format).
 
 Use --format to control output:
   - human (default): nicely formatted, readable output
@@ -266,6 +480,13 @@ Use --format to control output:
         ("View last 20 events", "mngr transcript my-agent --tail 20"),
         ("Output as JSONL for piping", "mngr transcript my-agent --format jsonl"),
         ("Output as JSON", "mngr transcript my-agent --format json"),
+        ("Count turns in the transcript", "mngr transcript my-agent --count-turns"),
+        (
+            "Extract the previous completed turn (from inside an agent)",
+            "mngr transcript --last-completed-turn --format jsonl",
+        ),
+        ("Extract the second turn", "mngr transcript my-agent --turn 2 --format jsonl"),
+        ("List all turn boundaries", "mngr transcript my-agent --list-turns"),
     ),
     see_also=(
         ("event", "View all events from an agent or host"),

--- a/libs/mngr/imbue/mngr/cli/transcript_test.py
+++ b/libs/mngr/imbue/mngr/cli/transcript_test.py
@@ -1,6 +1,7 @@
 import json
 
 import pluggy
+import pytest
 from click.testing import CliRunner
 
 from imbue.mngr.cli.testing import create_agent_with_events_dir
@@ -9,15 +10,23 @@ from imbue.mngr.cli.transcript import TranscriptCliOptions
 from imbue.mngr.cli.transcript import _format_event_human
 from imbue.mngr.cli.transcript import _get_event_role
 from imbue.mngr.cli.transcript import _parse_transcript_events
+from imbue.mngr.cli.transcript import _resolve_target_identifier
+from imbue.mngr.cli.transcript import _resolve_turn_index
+from imbue.mngr.cli.transcript import _user_message_indices
 from imbue.mngr.cli.transcript import transcript
+from imbue.mngr.errors import UserInputError
 from imbue.mngr.utils.testing import capture_loguru
 
 
 def _make_transcript_opts(
-    target: str = "my-agent",
+    target: str | None = "my-agent",
     role: tuple[str, ...] = (),
     tail: int | None = None,
     head: int | None = None,
+    turn: int | None = None,
+    last_completed_turn: bool = False,
+    count_turns: bool = False,
+    list_turns: bool = False,
 ) -> TranscriptCliOptions:
     return TranscriptCliOptions(
         output_format="human",
@@ -31,7 +40,40 @@ def _make_transcript_opts(
         role=role,
         tail=tail,
         head=head,
+        turn=turn,
+        last_completed_turn=last_completed_turn,
+        count_turns=count_turns,
+        list_turns=list_turns,
     )
+
+
+def _make_numbered_user_assistant_events(num_turns: int) -> list[dict[str, str | list | bool]]:
+    """Build a transcript with N turns; each turn is a user_message + assistant_message."""
+    events: list[dict[str, str | list | bool]] = []
+    for i in range(num_turns):
+        events.append(
+            {
+                "timestamp": f"2026-01-01T00:00:{i * 2:02d}Z",
+                "type": "user_message",
+                "event_id": f"u{i}",
+                "source": "claude/common_transcript",
+                "role": "user",
+                "content": f"prompt-{i}",
+            }
+        )
+        events.append(
+            {
+                "timestamp": f"2026-01-01T00:00:{i * 2 + 1:02d}Z",
+                "type": "assistant_message",
+                "event_id": f"a{i}",
+                "source": "claude/common_transcript",
+                "role": "assistant",
+                "text": f"reply-{i}",
+                "tool_calls": [],
+                "model": "test-model",
+            }
+        )
+    return events
 
 
 # =============================================================================
@@ -472,3 +514,415 @@ def test_transcript_cli_no_transcript_gives_error(
     )
     assert result.exit_code != 0
     assert "No common transcript found" in result.output
+
+
+# =============================================================================
+# Turn-helper unit tests
+# =============================================================================
+
+
+def test_user_message_indices_picks_up_user_messages_only() -> None:
+    events = _make_numbered_user_assistant_events(3)
+    assert _user_message_indices(events) == [0, 2, 4]
+
+
+def test_user_message_indices_ignores_meta_tool_results() -> None:
+    """Stop-hook injections are reclassified to tool_result(tool_name='meta') upstream.
+
+    They must not affect turn counts.
+    """
+    events: list[dict] = [
+        {"type": "user_message", "content": "real prompt", "event_id": "u1"},
+        {"type": "assistant_message", "text": "ok", "event_id": "a1"},
+        {"type": "tool_result", "tool_name": "meta", "output": "Stop hook feedback...", "event_id": "m1"},
+        {"type": "user_message", "content": "second prompt", "event_id": "u2"},
+        {"type": "assistant_message", "text": "ok", "event_id": "a2"},
+    ]
+    assert _user_message_indices(events) == [0, 3]
+
+
+def test_resolve_turn_index_positive_one_indexed() -> None:
+    assert _resolve_turn_index(1, 4) == 0
+    assert _resolve_turn_index(4, 4) == 3
+
+
+def test_resolve_turn_index_negative_python_style() -> None:
+    assert _resolve_turn_index(-1, 4) == 3
+    assert _resolve_turn_index(-4, 4) == 0
+
+
+def test_resolve_turn_index_rejects_zero() -> None:
+    with pytest.raises(UserInputError, match="1-indexed"):
+        _resolve_turn_index(0, 4)
+
+
+def test_resolve_turn_index_rejects_out_of_range_positive() -> None:
+    with pytest.raises(UserInputError, match="out of range"):
+        _resolve_turn_index(5, 4)
+
+
+def test_resolve_turn_index_rejects_out_of_range_negative() -> None:
+    with pytest.raises(UserInputError, match="out of range"):
+        _resolve_turn_index(-5, 4)
+
+
+def test_resolve_turn_index_empty_transcript() -> None:
+    with pytest.raises(UserInputError, match="no turns"):
+        _resolve_turn_index(1, 0)
+
+
+# =============================================================================
+# Auto-discovery (MNGR_AGENT_ID) unit tests
+# =============================================================================
+
+
+def test_resolve_target_identifier_prefers_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MNGR_AGENT_ID", "from-env")
+    assert _resolve_target_identifier("explicit-target") == "explicit-target"
+
+
+def test_resolve_target_identifier_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MNGR_AGENT_ID", "from-env")
+    assert _resolve_target_identifier(None) == "from-env"
+
+
+def test_resolve_target_identifier_treats_empty_string_as_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MNGR_AGENT_ID", "from-env")
+    assert _resolve_target_identifier("") == "from-env"
+
+
+def test_resolve_target_identifier_errors_when_neither_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MNGR_AGENT_ID", raising=False)
+    with pytest.raises(UserInputError, match="MNGR_AGENT_ID"):
+        _resolve_target_identifier(None)
+
+
+# =============================================================================
+# CLI: mutual exclusivity
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--turn", "1", "--last-completed-turn"],
+        ["--turn", "1", "--count-turns"],
+        ["--turn", "1", "--list-turns"],
+        ["--last-completed-turn", "--count-turns"],
+        ["--last-completed-turn", "--list-turns"],
+        ["--count-turns", "--list-turns"],
+    ],
+)
+def test_transcript_cli_rejects_two_turn_flags_together(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    flags: list[str],
+) -> None:
+    result = cli_runner.invoke(transcript, ["my-agent", *flags], obj=plugin_manager)
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--turn", "1", "--head", "5"],
+        ["--turn", "1", "--tail", "5"],
+        ["--last-completed-turn", "--head", "5"],
+        ["--count-turns", "--tail", "5"],
+        ["--list-turns", "--head", "5"],
+    ],
+)
+def test_transcript_cli_rejects_turn_flag_combined_with_head_or_tail(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    flags: list[str],
+) -> None:
+    result = cli_runner.invoke(transcript, ["my-agent", *flags], obj=plugin_manager)
+    assert result.exit_code != 0
+    assert "Cannot combine" in result.output
+
+
+# =============================================================================
+# CLI: --count-turns / --list-turns / --turn integration
+# =============================================================================
+
+
+def test_transcript_cli_count_turns_returns_integer(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(3)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="count-turns-test", events=events)
+
+    result = cli_runner.invoke(transcript, ["count-turns-test", "--count-turns"], obj=plugin_manager)
+    assert result.exit_code == 0
+    assert result.output.strip() == "3"
+
+
+def test_transcript_cli_count_turns_ignores_meta_tool_results(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    """Meta-reclassified stop-hook events must not be counted as turns."""
+    events: list[dict] = [
+        {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "user_message",
+            "event_id": "u1",
+            "source": "claude/common_transcript",
+            "role": "user",
+            "content": "first prompt",
+        },
+        {
+            "timestamp": "2026-01-01T00:00:01Z",
+            "type": "tool_result",
+            "event_id": "meta1",
+            "source": "claude/common_transcript",
+            "tool_name": "meta",
+            "tool_call_id": "meta-xyz",
+            "output": "Stop hook feedback...",
+            "is_error": False,
+        },
+        {
+            "timestamp": "2026-01-01T00:00:02Z",
+            "type": "user_message",
+            "event_id": "u2",
+            "source": "claude/common_transcript",
+            "role": "user",
+            "content": "second prompt",
+        },
+    ]
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="count-meta-test", events=events)
+
+    result = cli_runner.invoke(transcript, ["count-meta-test", "--count-turns"], obj=plugin_manager)
+    assert result.exit_code == 0
+    assert result.output.strip() == "2"
+
+
+def test_transcript_cli_count_turns_empty_transcript_is_zero(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="count-empty-test", events=[])
+    result = cli_runner.invoke(transcript, ["count-empty-test", "--count-turns"], obj=plugin_manager)
+    assert result.exit_code == 0
+    assert result.output.strip() == "0"
+
+
+def test_transcript_cli_list_turns_jsonl(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(2)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="list-turns-jsonl-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript, ["list-turns-jsonl-test", "--list-turns", "--format", "jsonl"], obj=plugin_manager
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first == {
+        "turn": 1,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "event_id": "u0",
+        "content_preview": "prompt-0",
+    }
+    second = json.loads(lines[1])
+    assert second["turn"] == 2
+    assert second["event_id"] == "u1"
+
+
+def test_transcript_cli_list_turns_human_includes_header(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(2)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="list-turns-human-test", events=events)
+
+    result = cli_runner.invoke(transcript, ["list-turns-human-test", "--list-turns"], obj=plugin_manager)
+    assert result.exit_code == 0
+    assert "preview" in result.output
+    assert "prompt-0" in result.output
+    assert "prompt-1" in result.output
+
+
+def test_transcript_cli_list_turns_truncates_long_preview(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    long_content = "a" * 200
+    events = [
+        {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "type": "user_message",
+            "event_id": "u0",
+            "source": "claude/common_transcript",
+            "role": "user",
+            "content": long_content,
+        }
+    ]
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="list-turns-trunc-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript, ["list-turns-trunc-test", "--list-turns", "--format", "jsonl"], obj=plugin_manager
+    )
+    assert result.exit_code == 0
+    parsed = json.loads(result.output.strip())
+    assert parsed["content_preview"].endswith("...")
+    assert len(parsed["content_preview"]) == 80 + len("...")
+
+
+def test_transcript_cli_turn_positive_extracts_correct_slice(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(3)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="turn-positive-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript, ["turn-positive-test", "--turn", "2", "--format", "jsonl"], obj=plugin_manager
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event_id"] == "u1"
+    assert json.loads(lines[1])["event_id"] == "a1"
+
+
+def test_transcript_cli_turn_negative_one_returns_in_progress_turn(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(3)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="turn-neg-one-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript, ["turn-neg-one-test", "--turn", "-1", "--format", "jsonl"], obj=plugin_manager
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event_id"] == "u2"
+    assert json.loads(lines[1])["event_id"] == "a2"
+
+
+def test_transcript_cli_last_completed_turn_matches_negative_two(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(3)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="last-completed-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript, ["last-completed-test", "--last-completed-turn", "--format", "jsonl"], obj=plugin_manager
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event_id"] == "u1"
+    assert json.loads(lines[1])["event_id"] == "a1"
+
+
+def test_transcript_cli_last_completed_turn_errors_with_one_user_message(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(1)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="last-completed-one-test", events=events)
+
+    result = cli_runner.invoke(transcript, ["last-completed-one-test", "--last-completed-turn"], obj=plugin_manager)
+    assert result.exit_code != 0
+    assert "No completed turn" in result.output
+
+
+def test_transcript_cli_turn_out_of_range_gives_clear_error(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(2)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="turn-oor-test", events=events)
+
+    result = cli_runner.invoke(transcript, ["turn-oor-test", "--turn", "5"], obj=plugin_manager)
+    assert result.exit_code != 0
+    assert "out of range" in result.output
+    assert "transcript has 2 turn" in result.output
+
+
+def test_transcript_cli_turn_composes_with_role_filter(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+) -> None:
+    events = _make_numbered_user_assistant_events(2)
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="turn-role-test", events=events)
+
+    result = cli_runner.invoke(
+        transcript,
+        ["turn-role-test", "--turn", "1", "--role", "assistant", "--format", "jsonl"],
+        obj=plugin_manager,
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["event_id"] == "a0"
+
+
+# =============================================================================
+# CLI: auto-discovery via MNGR_AGENT_ID
+# =============================================================================
+
+
+def test_transcript_cli_uses_mngr_agent_id_when_target_omitted(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    create_agent_with_sample_transcript(local_provider.host_dir, agent_name="env-discovery-test")
+    monkeypatch.setenv("MNGR_AGENT_ID", "env-discovery-test")
+
+    result = cli_runner.invoke(transcript, ["--format", "jsonl"], obj=plugin_manager)
+    assert result.exit_code == 0
+    lines = [line for line in result.output.strip().split("\n") if line.strip()]
+    assert len(lines) == 3
+
+
+def test_transcript_cli_errors_when_target_omitted_and_no_env(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    local_provider,
+    temp_mngr_ctx,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MNGR_AGENT_ID", raising=False)
+
+    result = cli_runner.invoke(transcript, [], obj=plugin_manager)
+    assert result.exit_code != 0
+    assert "MNGR_AGENT_ID" in result.output

--- a/libs/mngr/imbue/mngr/cli/transcript_test.py
+++ b/libs/mngr/imbue/mngr/cli/transcript_test.py
@@ -47,10 +47,10 @@ def _make_transcript_opts(
     )
 
 
-def _make_numbered_user_assistant_events(num_turns: int) -> list[dict[str, str | list | bool]]:
+def _make_numbered_user_assistant_events(turn_count: int) -> list[dict[str, str | list | bool]]:
     """Build a transcript with N turns; each turn is a user_message + assistant_message."""
     events: list[dict[str, str | list | bool]] = []
-    for i in range(num_turns):
+    for i in range(turn_count):
         events.append(
             {
                 "timestamp": f"2026-01-01T00:00:{i * 2:02d}Z",


### PR DESCRIPTION
## Summary

Extends `mngr transcript` so agents (and their hooks) can slice their own transcript by conversational turn without a separate script, where a "turn" is delimited by `user_message` events in the common_transcript JSONL format. Also makes the `TARGET` positional optional so an agent running inside its own shell doesn't have to know and pass its own identifier.

## Changes

- New flags (mutually exclusive with each other and with `--head` / `--tail`; compose with `--role`, which is applied after the turn slice):
  - `--turn N`: 1-indexed; negative counts from the end (`--turn -1` is the in-progress turn, `--turn -2` is the previous completed turn).
  - `--last-completed-turn`: shortcut for `--turn -2`, intended for in-agent stop hooks.
  - `--count-turns`: prints the integer count and exits.
  - `--list-turns`: per-turn summary (number, timestamp, preview) honoring `--format`.
- `TARGET` is now optional. When omitted, the command resolves the current agent from the `MNGR_AGENT_ID` env var that mngr already exports into every agent's shell. If neither is provided, it exits with a clear error.
- Turn boundary detection ignores meta `tool_result` events (e.g. stop-hook injections are already reclassified upstream by `common_transcript.sh`, so they don't open a new turn).
- Auto-regenerated `docs/commands/secondary/transcript.md` covers the new synopsis/options/examples. Also includes a small drift update to `docs/commands/primary/create.md` that the `regenerate-cli-docs` pre-commit hook produced from main.

Out of scope: porting `forever-claude-template`'s `extract_turn.py` callers, removing that script, and marker-based slicing.

## Test plan

- [x] `just test-quick "libs/mngr/imbue/mngr/cli/transcript_test.py"` — 70 passed.
- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 3872 passed.
- [x] Pre-commit (ruff + regenerate-cli-docs) clean.
- [x] `/verify-architecture` — approach matches existing patterns (option groups, `OutputFormat` switch, `write_human_line`, `UserInputError`).
- [x] `/autofix` — 0 fixes needed; 2 NITPICK observations recorded (cosmetic).
- [x] `/verify-conversation` — clean; minor issues self-disclosed.
- [ ] CI: full offload suite (acceptance + release).