### PR TITLE
CLAUDE.md: replace ModuleNotFoundError workaround that breaks the host install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,6 @@ Every PR must include a changelog entry file. CI will fail if it is missing.
 
 If you get a failure in `test_no_type_errors` that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
 
-If you get a "ModuleNotFoundError" error for a 3rd-party dependency when running a command that is defined in this repo (like `mngr`), then run "uv tool uninstall imbue-mngr && uv tool install -e libs/mngr" (for the relevant tool) to refresh the dependencies for that tool, and then try running the command again.
+If you get a "ModuleNotFoundError" for a workspace package (e.g. `imbue.mngr_*`) when running a command from inside a worktree, run `uv sync --all-packages` from the worktree root. This rebuilds the worktree's venv so editable workspace packages resolve. **Do NOT** rebuild the host `imbue-mngr` tool install via `uv tool uninstall` / `uv tool install` against `imbue-mngr` (or the plugin packages: `apps/system_interface`, `libs/mngr_*`) — the Dockerfile sets up the host install with a specific plugin recipe; a partial reinstall silently drops the plugin set from mngr's venv and breaks downstream agent operations (e.g. `mngr stop` fails schema validation on `agent_types.claude`). If you genuinely need to rebuild the host install (Dockerfile change), do it from a shell outside any agent harness.
 
 If you get a failure when trying to commit the first time, just try committing again (the pre-commit hook returns a non-zero exit code when ruff reformats files).

--- a/changelog/mngr-9b18.md
+++ b/changelog/mngr-9b18.md
@@ -1,0 +1,1 @@
+Rewrite the CLAUDE.md "ModuleNotFoundError" workaround to point at `uv sync --all-packages` (the safe worktree-local refresh) and to explicitly warn against running `uv tool uninstall imbue-mngr && uv tool install -e libs/mngr`. The old wording told agents to do exactly the operation that wedged the loop on 2026-05-11 by dropping the plugin set from mngr's venv.


### PR DESCRIPTION
[AGENT] ## Summary

Replace the CLAUDE.md "ModuleNotFoundError" workaround. The previous text told agents to run `uv tool uninstall imbue-mngr && uv tool install -e libs/mngr`, which is exactly the operation that wedged the engman driver loop for ~12h on 2026-05-11. The reinstall doesn't re-register the plugin set (mngr_claude, mngr_modal, mngr_wait) that the Dockerfile installs via `mngr plugin add`, so they silently disappear from mngr's venv and `mngr stop` starts failing schema validation on `agent_types.claude`.

Replacement points at the safer worktree-local refresh (`uv sync --all-packages` inside the worktree) and explicitly warns against `uv tool install/uninstall` against `imbue-mngr` or any plugin package (`apps/system_interface`, `libs/mngr_*`).

## Why

Three independent layers of protection collapsed when the original instruction was written into this CLAUDE.md:

1. The mngr CLAUDE.md said "if X breaks, do Y" — but Y is the very thing that breaks the host install.
2. An agent reading just this CLAUDE.md and following its advice ends up with a broken host install. They then have no clean way back without manual operator intervention.
3. The engman driver (which lives in `joshalbrecht/engman` and operates on the mngr worktrees) added a PreToolUse hook `scripts/claude_prevent_mngr_tool_disruption.sh` after the 2026-05-11 incident to block the operation. But a doc that instructs the agent to do it anyway means the hook is the only safety net — if anyone ever weakens it, the loop wedges again.

This change removes the contradiction at the doc level.

## Scope

- One-line replacement in `CLAUDE.md` "Silly error workarounds" section.
- One changelog entry.
- No code changes.

## Test plan

- [x] Diff is exactly two lines (one removed, one added) plus the changelog file.
- [ ] CI green (this PR doesn't touch code, so CI should sail through).

Generated with [Claude Code](https://claude.com/claude-code)
