### PR TITLE
Fix permission request redirect to return to requesting agent

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/templates/permissions.html
+++ b/apps/minds/imbue/minds/desktop_client/templates/permissions.html
@@ -95,6 +95,7 @@
 {% block scripts %}
 <script>
   (function () {
+    const agentReturnUrl = "{{ mngr_forward_origin }}/goto/{{ agent_id }}/";
     const form = document.getElementById("permissions-form");
     const approveBtn = document.getElementById("permissions-approve-btn");
     const errorBox = document.getElementById("permissions-error");
@@ -135,7 +136,7 @@
         }
         const data = await response.json();
         if (data.outcome === "GRANTED") {
-          window.location.href = "/";
+          window.location.href = agentReturnUrl;
           return;
         }
         if (progress) progress.classList.add("hidden");
@@ -176,7 +177,7 @@
         credentials: "same-origin",
         keepalive: true,
       }).catch(function () {});
-      window.location.href = "/";
+      window.location.href = agentReturnUrl;
     };
   })();
 </script>

--- a/changelog/gabriel-fix-permission-redirect.md
+++ b/changelog/gabriel-fix-permission-redirect.md
@@ -1,0 +1,1 @@
+- Fixed: after approving or denying a permission request in the minds app, you are now redirected back to the workspace of the agent that made the request, rather than to the home page.


### PR DESCRIPTION
## Summary
- After approving or denying a permission request in the minds app, the user was redirected to the home page (`/`) rather than back to the agent/workspace that made the request.
- The permissions template already receives `agent_id` and `mngr_forward_origin` (used in the in-page workspace link), so the fix wires the post-approve/deny `window.location.href` to `{mngr_forward_origin}/goto/{agent_id}/`.

## Test plan
- [ ] Trigger a permission request from a running agent in the minds app, click Approve, and confirm the browser lands back on that agent's workspace page (not the home page).
- [ ] Repeat with Deny and confirm the same redirect behavior.