### PR TITLE
disable claude_subagent_proxy plugin in project settings

### DIFF
--- a/.mngr/settings.toml
+++ b/.mngr/settings.toml
@@ -47,3 +47,6 @@ default_sandbox_timeout = 7200
 
 [plugins.forward]
 enabled = true
+
+[plugins.claude_subagent_proxy]
+enabled = false

--- a/changelog/mngr-jskldjfkld.md
+++ b/changelog/mngr-jskldjfkld.md
@@ -1,0 +1,1 @@
+Disable the `claude_subagent_proxy` plugin in the project-level `.mngr/settings.toml` so that `uv run mngr create` from this repo does not install the experimental Task-tool proxy hooks into newly provisioned Claude agents.


### PR DESCRIPTION
## Summary
- Adds `[plugins.claude_subagent_proxy] enabled = false` to `.mngr/settings.toml` so that `uv run mngr create` from this monorepo does not install the experimental Task-tool proxy hooks into newly provisioned Claude agents.
- The plugin is workspace-only (not installed in the standalone `imbue-mngr` tool at `~/.local/share/uv/tools/imbue-mngr/`), so this closes the one path by which it could be accidentally enabled for agents in this repo.

## Test plan
- [x] Validated pre-change: `pm.hook.on_after_provisioning.get_hookimpls()` returned both `claude_subagent_proxy` and `ttyd`; `pm.has_plugin('claude_subagent_proxy')` was `True`.
- [x] Validated post-change: same call returns only `ttyd`; `pm.has_plugin('claude_subagent_proxy')` is `False`; `uv run mngr plugin list` reports `claude_subagent_proxy ... false`.
- [ ] CI green.

Generated with [Claude Code](https://claude.com/claude-code)
