### PR TITLE
[continual] api-interface-docstrings

### DIFF
--- a/changelog/continual-api-interface-docstrings.md
+++ b/changelog/continual-api-interface-docstrings.md
@@ -1,0 +1,1 @@
+- Docs: api-package interface docstrings progressively rewritten to focus on the contract rather than implementation details, per the principle established in #1568. Behaviour unchanged.

--- a/libs/mngr/imbue/mngr/interfaces/agent.py
+++ b/libs/mngr/imbue/mngr/interfaces/agent.py
@@ -67,17 +67,15 @@ class AgentInterface(MutableModel, ABC, Generic[AgentConfigT]):
         command_override: CommandString | None,
         initial_message: str | None = None,
     ) -> CommandString:
-        """Assemble the full command to execute for this agent.
+        """Assemble the command line used to start this agent.
 
-        ``initial_message`` is the ``CreateAgentOptions.initial_message`` value
-        (the content of ``--message`` / ``--message-file``) threaded through
-        so agent types that bake the prompt into the command line (e.g.
-        streaming headless agents that ``cat`` a staged prompt file) can make
-        that decision without reading ``data.json`` -- at assembly time,
-        inside ``Host.create_agent_state``, ``data.json`` has not been
-        written yet.
+        ``agent_args`` are extra arguments to append to the command.
+        ``command_override`` replaces the default command when set.
+        ``initial_message`` may be incorporated into the returned command by
+        agent types that consume the first user message at startup (e.g.
+        headless agents that read a staged prompt file).
 
-        May raise NoCommandDefinedError if no command is defined.
+        Raises NoCommandDefinedError if no command can be assembled.
         """
         ...
 

--- a/libs/mngr/imbue/mngr/interfaces/host.py
+++ b/libs/mngr/imbue/mngr/interfaces/host.py
@@ -594,13 +594,17 @@ class OnlineHostInterface(HostInterface, OuterHostInterface, ABC):
         extra_args: str | None = None,
         exclude_git: bool = False,
     ) -> None:
-        """Copy a directory from source_host:source_path to self:target_path using rsync.
+        """Copy a directory tree from ``source_host:source_path`` to ``self:target_path``.
 
-        Handles all combinations of local/remote source and target:
-        - Local to local
-        - Local to remote (push via SSH)
-        - Remote to local (pull via SSH)
-        - Remote to remote (via local temp directory as intermediary)
+        Works regardless of whether either end is local or remote; the choice of
+        transport is up to the implementation (e.g. ``rsync`` over SSH, with a
+        laptop-side temp directory staging remote-to-remote copies).
+
+        ``extra_args`` is passed through to the underlying transport command, so
+        the accepted syntax tracks whichever tool the implementation invokes.
+        ``exclude_git`` omits ``.git`` directories from the copy.
+
+        Raises ``MngrError`` if the copy does not complete successfully.
         """
         ...
 

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance.py
@@ -580,9 +580,14 @@ class ProviderInstanceInterface(MutableModel, ABC):
 
     @abstractmethod
     def list_volumes(self) -> list[VolumeInfo]:
-        """List all volumes managed by this provider.
+        """Return the volumes that this provider instance considers its own.
 
-        Returns volumes with mngr- prefix in name or with mngr-managed tags.
+        How a volume is recognised as managed by this provider is an
+        implementation detail (e.g. a name prefix on the underlying volume,
+        a tag, or a layout under an internal state volume).
+
+        Returns an empty list when there are no managed volumes, including
+        when this provider does not support volumes (see ``supports_volumes``).
         """
         ...
 


### PR DESCRIPTION
[AGENT] Continual effort: tighten public-API docstrings on @abstractmethod and Field(description=...) sites per the principle Josh stated on mngr#1568 (describe the contract, not the implementation). See engman:continual_efforts/api-interface-docstrings.md for the recipe and engman:continual_efforts/README.md for the per-commit-review protocol.