### PR TITLE
[continual] type-signature-tightening

### DIFF
--- a/changelog/continual-type-signature-tightening.md
+++ b/changelog/continual-type-signature-tightening.md
@@ -1,0 +1,1 @@
+- Types: progressively tighten type annotations across `libs/mngr/` and the `libs/mngr_*/` plugins -- bare generics get parameterized, `Optional[T]` migrates to PEP-604 `T | None`, and `Any` is narrowed where a real type works. Same principle as the `PREVENT_BARE_GENERIC_TYPES` ratchet. Behaviour unchanged.

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
+from typing import Any
 from typing import Final
 
 from loguru import logger
@@ -262,7 +263,7 @@ def _refresh_tail_path(state: TailState, location: AgentLocation) -> None:
 _TERMINAL_STOP_REASONS: Final[frozenset[str]] = frozenset({"end_turn", "stop_sequence", "max_tokens"})
 
 
-def is_end_turn_event(event: dict) -> bool:
+def is_end_turn_event(event: dict[str, Any]) -> bool:
     """Return True for an assistant message that finishes the turn without a tool call."""
     if event.get("type") != "assistant":
         return False

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
@@ -281,7 +281,7 @@ def is_end_turn_event(event: dict[str, Any]) -> bool:
     return True
 
 
-def extract_assistant_text(event: dict) -> str:
+def extract_assistant_text(event: dict[str, Any]) -> str:
     """Concatenate text blocks from an assistant message event."""
     message = event.get("message")
     if not isinstance(message, dict):

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
@@ -423,7 +423,7 @@ class _WaitRuntime:
     target_missing_since: float | None = None
 
 
-def is_api_error_event(event: dict) -> bool:
+def is_api_error_event(event: dict[str, Any]) -> bool:
     """Return True if the event is an assistant message Claude Code marked
     as an API error (e.g. rate limit, transient API failure).
 

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
@@ -185,7 +185,7 @@ def test_prevent_literal_with_multiple_options() -> None:
 
 
 def test_prevent_bare_generic_types() -> None:
-    rc.check_bare_generic_types(_DIR, snapshot(3))
+    rc.check_bare_generic_types(_DIR, snapshot(2))
 
 
 def test_prevent_typing_builtin_imports() -> None:

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
@@ -185,7 +185,7 @@ def test_prevent_literal_with_multiple_options() -> None:
 
 
 def test_prevent_bare_generic_types() -> None:
-    rc.check_bare_generic_types(_DIR, snapshot(2))
+    rc.check_bare_generic_types(_DIR, snapshot(1))
 
 
 def test_prevent_typing_builtin_imports() -> None:

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
@@ -185,7 +185,7 @@ def test_prevent_literal_with_multiple_options() -> None:
 
 
 def test_prevent_bare_generic_types() -> None:
-    rc.check_bare_generic_types(_DIR, snapshot(4))
+    rc.check_bare_generic_types(_DIR, snapshot(3))
 
 
 def test_prevent_typing_builtin_imports() -> None:


### PR DESCRIPTION
[AGENT] Continual effort: tighten type annotations across libs/mngr/ and libs/mngr_*/, replacing bare generics, Any, and overly-loose container types. See engman:continual_efforts/type-signature-tightening.md for the recipe and engman:continual_efforts/README.md for the per-commit-review protocol.