### PR TITLE
mngr cli: drop comments that just restate the next line

### DIFF
--- a/changelog/mngr-find-and-improve-code-comments-vfoa-cli.md
+++ b/changelog/mngr-find-and-improve-code-comments-vfoa-cli.md
@@ -1,0 +1,1 @@
+- Removed three redundant block comments in `libs/mngr/imbue/mngr/cli/` (`common_opts.py`, `message.py`) that only restated the identifier on the next line. No behavior change.

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -252,7 +252,6 @@ def setup_command_context(
     # Store resolved logging config on the click context for callers that need it
     ctx.meta["logging_config"] = resolved_logging_config
 
-    # Set up logging
     setup_logging(resolved_logging_config, default_host_dir=mngr_ctx.config.default_host_dir, command=command_name)
 
     # Enter a log span for the command lifetime
@@ -455,7 +454,6 @@ def apply_config_defaults(
     strict=False, logs a warning and skips them. Callers should resolve the
     policy from MNGR_ALLOW_UNKNOWN_CONFIG once and pass the result through.
     """
-    # Get command defaults from config
     command_defaults = config.commands.get(command_name)
     if not command_defaults:
         # No config defaults for this command, return params as-is

--- a/libs/mngr/imbue/mngr/cli/message.py
+++ b/libs/mngr/imbue/mngr/cli/message.py
@@ -128,7 +128,6 @@ def _message_impl(ctx: click.Context, **kwargs) -> None:
     if opts.message_file is not None:
         resolved_message_content = Path(opts.message_file).read_text()
 
-    # Get message content
     message_content = _get_message_content(
         resolved_message_content, ctx, is_interactive=mngr_ctx.is_interactive, stdin_consumed=stdin_consumed
     )


### PR DESCRIPTION
[AGENT] Removes three block comments in `libs/mngr/imbue/mngr/cli/` that each sat one line above a single function call whose name already said the same thing. None of them captured a non-obvious WHY -- they only restated the identifier, so they read as noise.

Deletions:
- `libs/mngr/imbue/mngr/cli/common_opts.py`
  - `# Set up logging` above `setup_logging(resolved_logging_config, ...)`
  - `# Get command defaults from config` above `command_defaults = config.commands.get(command_name)`
- `libs/mngr/imbue/mngr/cli/message.py`
  - `# Get message content` above `message_content = _get_message_content(...)`

Other block comments in these files that summarise multi-line blocks at a higher level (e.g. `# Validate that --message and --message-file are not both provided`, `# Read message from file if --message-file is provided`) are left in place.

Tests: `cd libs/mngr && uv run pytest -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release' --no-cov --cov-fail-under=0` -- 3849 passed, 2 failed, 1 skipped, 400 deselected.

The 2 failures (`test_handle_not_implemented_error_interactive_opens_existing_issue`, `test_handle_not_implemented_error_interactive_opens_new_issue_form` in `imbue/mngr/cli/issue_reporting_test.py`) reproduce on `origin/main` with these edits stashed, so they are pre-existing and unrelated to this change.