### PR TITLE
[continual] minor-style-cleanups

### DIFF
--- a/changelog/continual-minor-style-cleanups.md
+++ b/changelog/continual-minor-style-cleanups.md
@@ -1,0 +1,1 @@
+- Style: progressively apply mechanical, low-risk style fixes across `libs/mngr/` and the `libs/mngr_*/` plugins -- magic numbers hoisted to named constants, `time.time()` swapped for `time.monotonic()` in interval measurements, f-string adoption, dead-import removal, and other patterns called out in `style_guide.md`. Behaviour unchanged.

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 import click
 from click_option_group import optgroup
@@ -181,7 +182,7 @@ class PullCliOptions(CommonCliOptions):
 )
 @add_common_options
 @click.pass_context
-def pull(ctx: click.Context, **kwargs) -> None:
+def pull(ctx: click.Context, **kwargs: Any) -> None:
     mngr_ctx, output_opts, opts = setup_command_context(
         ctx=ctx,
         command_name="pull",


### PR DESCRIPTION
[AGENT] Continual effort: tiny mechanical style cleanups (magic numbers, time.time->monotonic, f-strings, PEP-604 unions, etc.) in libs/mngr/ and libs/mngr_*/. See engman:continual_efforts/minor-style-cleanups.md for the recipe and engman:continual_efforts/README.md for the per-commit-review protocol.