### PR TITLE
Convert three cli/ helpers from monkeypatch-based tests to DI

### DIFF
--- a/libs/mngr/imbue/mngr/cli/check_deps.py
+++ b/libs/mngr/imbue/mngr/cli/check_deps.py
@@ -1,5 +1,6 @@
 """Check and optionally install system dependencies for mngr."""
 
+from collections.abc import Callable
 from typing import Any
 
 import click
@@ -64,6 +65,7 @@ def _prompt_install_choice(
     missing_core: list[SystemDependency],
     need_bash: bool,
     os_name: OsName,
+    choice_reader: Callable[[str], str] = read_tty_choice,
 ) -> list[SystemDependency] | None:
     """Interactively prompt the user to choose what to install.
 
@@ -93,7 +95,7 @@ def _prompt_install_choice(
     write_human_line("  [n] Skip -- I'll install them myself")
     write_human_line("")
 
-    choice = read_tty_choice("Choice [a/c/n]: ")
+    choice = choice_reader("Choice [a/c/n]: ")
     if choice == "":
         write_human_line("No interactive terminal available. Skipping dependency installation.")
         return None

--- a/libs/mngr/imbue/mngr/cli/check_deps_test.py
+++ b/libs/mngr/imbue/mngr/cli/check_deps_test.py
@@ -1,9 +1,7 @@
 """Tests for the mngr dependencies command."""
 
-import pytest
 from click.testing import CliRunner
 
-from imbue.mngr.cli import check_deps as check_deps_mod
 from imbue.mngr.cli.check_deps import _print_status_table
 from imbue.mngr.cli.check_deps import _prompt_install_choice
 from imbue.mngr.cli.check_deps import _report_post_install_status
@@ -181,24 +179,27 @@ def test_check_deps_help(cli_runner: CliRunner) -> None:
     assert "dependencies" in result.output.lower() or "install mode" in result.output.lower()
 
 
-def test_prompt_install_choice_interactive_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_prompt_install_choice_interactive_choices() -> None:
     """_prompt_install_choice returns correct lists for 'a', 'c', and 'n' choices."""
     missing = [_MISSING_CORE, _MISSING_OPT]
     missing_core = [_MISSING_CORE]
 
     # User chooses 'a' (all) -> returns all missing deps
-    monkeypatch.setattr(check_deps_mod, "read_tty_choice", lambda _prompt: "a")
-    result = _prompt_install_choice(missing, missing_core, need_bash=False, os_name=OsName.LINUX)
+    result = _prompt_install_choice(
+        missing, missing_core, need_bash=False, os_name=OsName.LINUX, choice_reader=lambda _prompt: "a"
+    )
     assert result == missing
 
     # User chooses 'c' (core) -> returns core-only deps
-    monkeypatch.setattr(check_deps_mod, "read_tty_choice", lambda _prompt: "c")
-    result = _prompt_install_choice(missing, missing_core, need_bash=False, os_name=OsName.LINUX)
+    result = _prompt_install_choice(
+        missing, missing_core, need_bash=False, os_name=OsName.LINUX, choice_reader=lambda _prompt: "c"
+    )
     assert result == missing_core
 
     # User chooses 'n' (skip) -> returns None
-    monkeypatch.setattr(check_deps_mod, "read_tty_choice", lambda _prompt: "n")
-    result = _prompt_install_choice(missing, missing_core, need_bash=False, os_name=OsName.LINUX)
+    result = _prompt_install_choice(
+        missing, missing_core, need_bash=False, os_name=OsName.LINUX, choice_reader=lambda _prompt: "n"
+    )
     assert result is None
 
 

--- a/libs/mngr/imbue/mngr/cli/extras.py
+++ b/libs/mngr/imbue/mngr/cli/extras.py
@@ -3,6 +3,7 @@
 import os
 import platform
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -71,9 +72,12 @@ def _completion_status() -> tuple[bool, str, Path]:
     return configured, shell_type, rc_path
 
 
-def _install_completion(auto: bool) -> bool:
+def _install_completion(
+    auto: bool,
+    status_fn: Callable[[], tuple[bool, str, Path]] = _completion_status,
+) -> bool:
     """Install shell completion. Returns True if installed (or already configured)."""
-    configured, shell_type, rc_path = _completion_status()
+    configured, shell_type, rc_path = status_fn()
 
     if configured:
         write_human_line("Shell completion already configured in {}", rc_path)
@@ -117,9 +121,12 @@ def _claude_plugin_status() -> tuple[bool, bool]:
         return True, False
 
 
-def _install_claude_plugin(auto: bool) -> bool:
+def _install_claude_plugin(
+    auto: bool,
+    status_fn: Callable[[], tuple[bool, bool]] = _claude_plugin_status,
+) -> bool:
     """Install the Claude Code review plugin. Returns True if installed (or already present)."""
-    claude_available, plugin_installed = _claude_plugin_status()
+    claude_available, plugin_installed = status_fn()
 
     if not claude_available:
         write_human_line("Claude Code is not installed -- skipping Claude Code plugin.")

--- a/libs/mngr/imbue/mngr/cli/extras_test.py
+++ b/libs/mngr/imbue/mngr/cli/extras_test.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from imbue.mngr.cli import extras as extras_mod
 from imbue.mngr.cli.extras import _completion_status
 from imbue.mngr.cli.extras import _detect_shell
 from imbue.mngr.cli.extras import _generate_completion_script
@@ -99,7 +98,7 @@ def test_completion_status_returns_tuple() -> None:
     assert isinstance(rc_path, Path)
 
 
-def test_install_completion_auto_writes_script(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_completion_auto_writes_script(tmp_path: Path) -> None:
     """_install_completion writes the script when auto=True; reports configured once present."""
     rc = tmp_path / ".zshrc"
     rc.write_text("# existing config\n")
@@ -108,14 +107,12 @@ def test_install_completion_auto_writes_script(tmp_path: Path, monkeypatch: pyte
     def _status() -> tuple[bool, str, Path]:
         return ("_mngr_complete" in rc.read_text(), "zsh", rc)
 
-    monkeypatch.setattr(extras_mod, "_completion_status", _status)
-
     # First call: not configured yet -> writes the script
-    assert _install_completion(auto=True) is True
+    assert _install_completion(auto=True, status_fn=_status) is True
     assert "_mngr_complete" in rc.read_text()
 
     # Second call: now configured -> returns True without re-writing
-    assert _install_completion(auto=False) is True
+    assert _install_completion(auto=False, status_fn=_status) is True
 
 
 def test_install_completion_no_tty() -> None:
@@ -126,15 +123,13 @@ def test_install_completion_no_tty() -> None:
     assert isinstance(result, bool)
 
 
-def test_install_claude_plugin_status_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_claude_plugin_status_branches() -> None:
     """_install_claude_plugin returns correct values for different _claude_plugin_status results."""
     # When claude is not available -> returns False
-    monkeypatch.setattr(extras_mod, "_claude_plugin_status", lambda: (False, False))
-    assert _install_claude_plugin(auto=True) is False
+    assert _install_claude_plugin(auto=True, status_fn=lambda: (False, False)) is False
 
     # When plugin is already installed -> returns True
-    monkeypatch.setattr(extras_mod, "_claude_plugin_status", lambda: (True, True))
-    assert _install_claude_plugin(auto=True) is True
+    assert _install_claude_plugin(auto=True, status_fn=lambda: (True, True)) is True
 
 
 def test_plugins_status_returns_string() -> None:

--- a/libs/mngr/imbue/mngr/utils/test_ratchets.py
+++ b/libs/mngr/imbue/mngr/utils/test_ratchets.py
@@ -218,7 +218,7 @@ def test_prevent_unittest_mock_imports() -> None:
 
 
 def test_prevent_monkeypatch_setattr() -> None:
-    rc.check_monkeypatch_setattr(_DIR, snapshot(35))
+    rc.check_monkeypatch_setattr(_DIR, snapshot(29))
 
 
 def test_prevent_test_container_classes() -> None:


### PR DESCRIPTION
[AGENT] Convert three private helpers in `libs/mngr/imbue/mngr/cli/` from monkeypatch-based tests to dependency injection.

## Category

(e) A test that uses `monkeypatch.setattr` instead of dependency injection -- the `PREVENT_MONKEYPATCH_SETATTR` ratchet ground.

## Change

Three helpers were tested by patching a module-level callable they invoked:

| Helper | Was patched | Now takes |
|---|---|---|
| `_prompt_install_choice` (check_deps.py) | `read_tty_choice` | `choice_reader: Callable[[str], str] = read_tty_choice` |
| `_install_completion` (extras.py) | `_completion_status` | `status_fn: Callable[[], tuple[bool, str, Path]] = _completion_status` |
| `_install_claude_plugin` (extras.py) | `_claude_plugin_status` | `status_fn: Callable[[], tuple[bool, bool]] = _claude_plugin_status` |

Tests now pass fakes directly to the helper -- no global mutation, no test-ordering risk from the `monkeypatch.setattr(check_deps_mod, ...)` / `monkeypatch.setattr(extras_mod, ...)` pattern. Production callers continue to use the default callable, so behavior is unchanged.

## Delta

`PREVENT_MONKEYPATCH_SETATTR` ratchet in `libs/mngr/imbue/mngr/utils/test_ratchets.py`: **35 -> 29** (six fewer monkeypatch.setattr call sites).

```
$ uv run pytest libs/mngr/imbue/mngr/cli/check_deps_test.py \
      libs/mngr/imbue/mngr/cli/extras_test.py \
      libs/mngr/imbue/mngr/utils/test_ratchets.py
98 passed
```

## Principle

The ratchet exists because `monkeypatch.setattr` on a module-level attribute mutates global state and couples tests to import paths -- the test breaks if the function moves, gets renamed, or is imported differently. Passing the dependency as a parameter is the canonical fix that the ratchet's `rule_description` points at. This change applies that fix to the simplest, most self-contained cases first: callables already shaped like `Callable[[...], ...]` with a single call site inside the helper under test.

Refs `tkt-find-and-improve-something-abo-2wpx`.