### PR TITLE
observe: --discovery-only now honors --events-dir

### DIFF
--- a/libs/mngr/imbue/mngr/api/discovery_events.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events.py
@@ -32,6 +32,7 @@ from imbue.imbue_common.logging import format_nanosecond_iso_timestamp
 from imbue.imbue_common.logging import generate_log_event_id
 from imbue.imbue_common.logging import generate_rotation_timestamp
 from imbue.imbue_common.logging import rotation_lock
+from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.pure import pure
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
@@ -842,6 +843,7 @@ def _write_unfiltered_full_snapshot_logged(mngr_ctx: MngrContext) -> None:
 
 def run_discovery_stream(
     mngr_ctx: MngrContext,
+    events_base_dir: Path | None = None,
     on_line: Callable[[str], None] | None = None,
 ) -> None:
     """Stream discovery events as JSONL.
@@ -859,7 +861,22 @@ def run_discovery_stream(
 
     If on_line is None, events are written to stdout. Otherwise, the callback
     is called with each deduplicated JSONL line.
+
+    ``events_base_dir`` overrides where discovery events are read and written.
+    When None (default), the path is derived from ``mngr_ctx.config`` via the
+    same default the full observer uses (``default_host_dir``). When set, the
+    override is applied uniformly across the cached-snapshot reader, the
+    tail thread, and the periodic ``_write_unfiltered_full_snapshot`` calls
+    so they all land on the same directory; otherwise the tail thread would
+    read from one path while the snapshot writer wrote to another.
     """
+    if events_base_dir is not None:
+        overridden_config = mngr_ctx.config.model_copy_update(
+            to_update(mngr_ctx.config.field_ref().default_host_dir, events_base_dir),
+        )
+        mngr_ctx = mngr_ctx.model_copy_update(
+            to_update(mngr_ctx.field_ref().config, overridden_config),
+        )
     events_path = get_discovery_events_path(mngr_ctx.config)
     emitted_event_ids: set[str] = set()
     emit_lock = Lock()

--- a/libs/mngr/imbue/mngr/api/discovery_events_test.py
+++ b/libs/mngr/imbue/mngr/api/discovery_events_test.py
@@ -40,7 +40,9 @@ from imbue.mngr.api.discovery_events import make_full_discovery_snapshot_event
 from imbue.mngr.api.discovery_events import make_host_discovery_event
 from imbue.mngr.api.discovery_events import parse_discovery_event_line
 from imbue.mngr.api.discovery_events import resolve_provider_names_for_identifiers
+from imbue.mngr.api.discovery_events import run_discovery_stream
 from imbue.mngr.api.discovery_events import write_full_discovery_snapshot
+from imbue.mngr.api.observe import get_default_events_base_dir
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import DiscoverySchemaChangedError
@@ -1146,3 +1148,93 @@ def test_rotate_discovery_events_cleans_up_old_rotated_files(tmp_path: Path) -> 
     rotated = sorted(f for f in tmp_path.iterdir() if f.name.startswith("events.jsonl."))
     # With max_rotated_count=1, only the newest file should remain
     assert len(rotated) == 1
+
+
+# === run_discovery_stream events_base_dir Tests ===
+
+
+class _StopAfterFirstLine(Exception):
+    """Sentinel raised by tests' on_line callbacks to halt run_discovery_stream during Phase 1.
+
+    Phase 1 is synchronous and runs before the tail thread starts, so raising
+    from on_line propagates straight back to the caller without leaking threads.
+    """
+
+
+def _write_two_snapshots_to(events_path: Path) -> FullDiscoverySnapshotEvent:
+    """Pre-populate ``events_path`` with two DISCOVERY_FULL snapshots, return the latest.
+
+    Two snapshots are needed because ``find_latest_full_snapshot_offset`` returns 0
+    both when no snapshot exists and when one exists at byte 0; ``run_discovery_stream``
+    only enters Phase 1's cached-snapshot read when the offset is strictly > 0.
+    """
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    first = make_full_discovery_snapshot_event(agents=(), hosts=())
+    latest = make_full_discovery_snapshot_event(
+        agents=(make_test_discovered_agent(),),
+        hosts=(make_test_discovered_host(),),
+    )
+    with open(events_path, "w") as f:
+        f.write(json.dumps(first.model_dump(mode="json"), separators=(",", ":")) + "\n")
+        f.write(json.dumps(latest.model_dump(mode="json"), separators=(",", ":")) + "\n")
+    return latest
+
+
+def test_run_discovery_stream_reads_from_override_events_base_dir(
+    temp_mngr_ctx: MngrContext, tmp_path: Path
+) -> None:
+    """With events_base_dir override, run_discovery_stream reads the cached snapshot from that path."""
+    override_dir = tmp_path / "override_events"
+    override_events_path = override_dir / "events" / "mngr" / "discovery" / "events.jsonl"
+    latest = _write_two_snapshots_to(override_events_path)
+
+    captured: list[str] = []
+
+    def on_line(line: str) -> None:
+        captured.append(line)
+        raise _StopAfterFirstLine
+
+    with pytest.raises(_StopAfterFirstLine):
+        run_discovery_stream(
+            mngr_ctx=temp_mngr_ctx,
+            events_base_dir=override_dir,
+            on_line=on_line,
+        )
+
+    # The first line emitted by Phase 1 should be the latest DISCOVERY_FULL from
+    # the override location (proving the override was applied to the read path).
+    assert len(captured) == 1
+    received = json.loads(captured[0])
+    assert received["type"] == DiscoveryEventType.DISCOVERY_FULL
+    assert received["event_id"] == str(latest.event_id)
+
+
+def test_run_discovery_stream_uses_default_events_base_dir_when_none(
+    temp_mngr_ctx: MngrContext, tmp_path: Path
+) -> None:
+    """Without events_base_dir, run_discovery_stream falls back to get_default_events_base_dir."""
+    default_dir = get_default_events_base_dir(temp_mngr_ctx.config)
+    default_events_path = default_dir / "events" / "mngr" / "discovery" / "events.jsonl"
+    latest_default = _write_two_snapshots_to(default_events_path)
+
+    # Also pre-populate a different, off-path location so we can confirm it was NOT read.
+    off_path_dir = tmp_path / "off_path_events"
+    off_path_events_path = off_path_dir / "events" / "mngr" / "discovery" / "events.jsonl"
+    latest_off_path = _write_two_snapshots_to(off_path_events_path)
+
+    captured: list[str] = []
+
+    def on_line(line: str) -> None:
+        captured.append(line)
+        raise _StopAfterFirstLine
+
+    with pytest.raises(_StopAfterFirstLine):
+        run_discovery_stream(
+            mngr_ctx=temp_mngr_ctx,
+            on_line=on_line,
+        )
+
+    assert len(captured) == 1
+    received = json.loads(captured[0])
+    assert received["event_id"] == str(latest_default.event_id)
+    assert received["event_id"] != str(latest_off_path.event_id)

--- a/libs/mngr/imbue/mngr/cli/observe.py
+++ b/libs/mngr/imbue/mngr/cli/observe.py
@@ -66,7 +66,10 @@ def observe(ctx: click.Context, **kwargs: Any) -> None:
         events_base_dir = get_default_events_base_dir(mngr_ctx.config)
 
     if opts.discovery_only:
-        run_discovery_stream(mngr_ctx=mngr_ctx)
+        # Pass the same resolved events_base_dir as the full-observer path so
+        # --events-dir is honored consistently across both branches; otherwise
+        # the discovery stream silently falls back to the config default.
+        run_discovery_stream(mngr_ctx=mngr_ctx, events_base_dir=events_base_dir)
         return
 
     # Acquire an exclusive lock per output directory


### PR DESCRIPTION
[AGENT] Fixes a silent fallback in `mngr observe --discovery-only`: the `observe()` function resolved `events_base_dir` from `opts.events_dir` (or the `default_host_dir` default) but never plumbed it to `run_discovery_stream`, so the discovery stream's reader and snapshot writer fell back to the config default regardless of `--events-dir`.

## Fix shape

- `cli/observe.py`: pass the resolved `events_base_dir` to `run_discovery_stream` so both observe branches use the same value computed at the top of `observe()` — drift between them is now mechanically impossible.
- `api/discovery_events.py`: add an `events_base_dir: Path | None = None` kwarg to `run_discovery_stream`. When set, override `mngr_ctx.config.default_host_dir` once at function entry. This single override propagates uniformly to:
  - the cached-snapshot reader (`get_discovery_events_path(mngr_ctx.config)`)
  - the tail thread (uses the same `events_path`)
  - the inner `_write_unfiltered_full_snapshot` -> `list_agents` -> `_maybe_write_full_discovery_snapshot` chain, which derives its write path from `mngr_ctx.config`.

  Without that, the tail thread would read from one path while the snapshot writer wrote to another — a custom `--events-dir` would silently be ignored on the discovery-only path.

## Tests

Added two tests in `api/discovery_events_test.py`:
- `test_run_discovery_stream_reads_from_override_events_base_dir`: pre-populates the override path with DISCOVERY_FULL snapshots, runs `run_discovery_stream(events_base_dir=override)`, verifies Phase 1 emits from the override location.
- `test_run_discovery_stream_uses_default_events_base_dir_when_none`: pre-populates both the default and an off-path location, verifies the default is read and the off-path location is ignored.

Tests use a sentinel exception raised from `on_line` to halt Phase 1 synchronously before the tail thread starts (no monkeypatch — the repo has a `PREVENT_MONKEYPATCH_SETATTR` ratchet).

## Verification

- `cd libs/mngr && PYTEST_MAX_DURATION_SECONDS=300 uv run pytest -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release' --no-cov --cov-fail-under=0 imbue/mngr/cli/` → 1304 passed, 2 pre-existing failures in `issue_reporting_test.py` (verified to exist on main, unrelated to this change).
- `cd libs/mngr && PYTEST_MAX_DURATION_SECONDS=600 uv run pytest imbue/mngr/cli/` → 1408 passed, 1 skipped, same 2 pre-existing failures.
- `cd libs/mngr && PYTEST_MAX_DURATION_SECONDS=180 uv run pytest -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release' --no-cov --cov-fail-under=0 imbue/mngr/api/discovery_events_test.py imbue/mngr/api/observe_test.py` → 117 passed.

Reference: PR #1565 (https://github.com/imbue-ai/mngr/pull/1565) side findings.