### PR TITLE
tmr: redesign agent output transfer + clean up orchestration

### DIFF
--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -64,6 +64,32 @@ jobs:
           git config user.email "dev@imbue.com"
           git config user.name "imbue-dev"
 
+      - name: Pre-trust checkout for Claude
+        # The integrator agent runs on the local host, where mngr_claude's
+        # provisioning path goes through Claude Code's trust dialog (see
+        # mngr_claude/plugin.py:interactively_dismiss_claude_dialogs). In CI
+        # there is no human to accept the dialog and no prior ~/.claude.json
+        # entry to inherit, so without seeding trust the integrator either
+        # raises ClaudeDirectoryNotTrustedError or hangs waiting on the
+        # dialog. Pre-seed the global ~/.claude.json with trust for the
+        # checkout plus the other dialogs the plugin gates on; the per-agent
+        # integrator config then inherits the trust via the plugin's
+        # copy_project_config_from path.
+        run: |
+          uv run --project libs/mngr_claude python - <<'EOF'
+          from pathlib import Path
+          from imbue.mngr_claude.claude_config import (
+              add_claude_trust_for_path,
+              complete_onboarding,
+              dismiss_effort_callout,
+              find_user_claude_config,
+          )
+          config_path = find_user_claude_config()
+          add_claude_trust_for_path(config_path, Path.cwd().resolve())
+          dismiss_effort_callout(config_path)
+          complete_onboarding(config_path)
+          EOF
+
       - name: Run TMR orchestrator
         env:
           ADDITIONAL_AUTHORIZED_HOSTS: ${{ inputs.additional_authorized_hosts }}
@@ -89,7 +115,7 @@ jobs:
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
             "${authorized_host_args[@]}" \
-            --output-html tmr-report/index.html \
+            --output-dir tmr-report \
             --format jsonl \
             ${{ inputs.test_paths }} \
             -- ${{ inputs.pytest_args }} \

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -111,6 +111,7 @@ jobs:
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
             --agent-type "${{ inputs.agent_type }}" \
             --provider modal \
+            --use-snapshot \
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \

--- a/changelog/mngr-tmr-artifact.md
+++ b/changelog/mngr-tmr-artifact.md
@@ -14,3 +14,9 @@ parsed Python objects as `AgentDetails.address` / `HostDetails.address`,
 and removing it from the wire format lets the output round-trip cleanly
 through `AgentDetails.model_validate_json` (which previously rejected the
 extra key).
+
+`Volume`: gains a `path_exists(path)` method implemented across all
+providers (local, Docker, Modal) and the `ScopedVolume` wrapper. Callers
+no longer need to fall back to `listdir` and catch
+provider-specific not-found errors to probe for a single file's
+existence.

--- a/changelog/mngr-tmr-artifact.md
+++ b/changelog/mngr-tmr-artifact.md
@@ -1,0 +1,9 @@
+`mngr tmr`: testing agents now publish a single `outputs.tar.gz` archive into
+their state directory (`$MNGR_AGENT_STATE_DIR/plugin/test-map-reduce/`),
+containing the renamed `test_output/` directory and an optional incremental
+`branch.bundle`. The orchestrator polls for the archive via the per-agent
+volume API (which works even when the host is offline) and reconstructs the
+agent's branch from the bundle, removing the previous rsync + git-pull
+finalization step. Reintegrate mode uses the same path. SSH provider, which
+does not expose a volume, is no longer supported for testing-agent outputs.
+The integrator agent is unchanged.

--- a/changelog/mngr-tmr-artifact.md
+++ b/changelog/mngr-tmr-artifact.md
@@ -7,3 +7,10 @@ agent's branch from the bundle, removing the previous rsync + git-pull
 finalization step. Reintegrate mode uses the same path. SSH provider, which
 does not expose a volume, is no longer supported for testing-agent outputs.
 The integrator agent is unchanged.
+
+`mngr list --format json`: the redundant `address` field on agent and host
+records is no longer emitted. The same value is still reachable on the
+parsed Python objects as `AgentDetails.address` / `HostDetails.address`,
+and removing it from the wire format lets the output round-trip cleanly
+through `AgentDetails.model_validate_json` (which previously rejected the
+extra key).

--- a/libs/mngr/imbue/mngr/interfaces/data_types.py
+++ b/libs/mngr/imbue/mngr/interfaces/data_types.py
@@ -470,7 +470,6 @@ class HostDetails(FrozenModel):
         description="Reason for failure if the host failed during creation",
     )
 
-    @computed_field
     @cached_property
     def address(self) -> HostAddress:
         return HostAddress(host=HostName(self.name), provider=self.provider_name)
@@ -522,7 +521,6 @@ class AgentDetails(FrozenModel):
 
     plugin: dict[str, Any] = Field(default_factory=dict, description="Plugin-specific fields")
 
-    @computed_field
     @cached_property
     def address(self) -> AgentAddress:
         return AgentAddress(agent=self.id, host=self.host.address)

--- a/libs/mngr/imbue/mngr/interfaces/volume.py
+++ b/libs/mngr/imbue/mngr/interfaces/volume.py
@@ -31,6 +31,11 @@ class Volume(MutableModel, ABC):
         ...
 
     @abstractmethod
+    def path_exists(self, path: str) -> bool:
+        """Return True if a file or directory exists at the given path."""
+        ...
+
+    @abstractmethod
     def read_file(self, path: str) -> bytes:
         """Read a file from the volume and return its contents as bytes."""
         ...
@@ -106,6 +111,9 @@ class ScopedVolume(BaseVolume):
             VolumeFile(path=self._strip_prefix(e.path), file_type=e.file_type, mtime=e.mtime, size=e.size)
             for e in entries
         ]
+
+    def path_exists(self, path: str) -> bool:
+        return self.delegate.path_exists(_scoped_path(self.prefix, path))
 
     def read_file(self, path: str) -> bytes:
         return self.delegate.read_file(_scoped_path(self.prefix, path))

--- a/libs/mngr/imbue/mngr/interfaces/volume_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/volume_test.py
@@ -27,6 +27,12 @@ class InMemoryVolume(BaseVolume):
                 )
         return results
 
+    def path_exists(self, path: str) -> bool:
+        if path in self.files:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(k.startswith(prefix) for k in self.files)
+
     def read_file(self, path: str) -> bytes:
         if path not in self.files:
             raise FileNotFoundError(path)
@@ -193,6 +199,22 @@ def test_scoped_volume_prefix_trailing_slash_stripped() -> None:
     vol = InMemoryVolume(files={"/data/file.txt": b"content"})
     scoped = ScopedVolume(delegate=vol, prefix="/data/")
     assert scoped.read_file("file.txt") == b"content"
+
+
+def test_scoped_volume_path_exists_file(volume_with_files: InMemoryVolume) -> None:
+    scoped = volume_with_files.scoped("/host")
+    assert scoped.path_exists("data.json") is True
+
+
+def test_scoped_volume_path_exists_directory(volume_with_files: InMemoryVolume) -> None:
+    scoped = volume_with_files.scoped("/host")
+    assert scoped.path_exists("agents") is True
+
+
+def test_scoped_volume_path_exists_missing(volume_with_files: InMemoryVolume) -> None:
+    scoped = volume_with_files.scoped("/host")
+    assert scoped.path_exists("nonexistent.txt") is False
+    assert scoped.path_exists("nonexistent_dir") is False
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/providers/docker/volume.py
+++ b/libs/mngr/imbue/mngr/providers/docker/volume.py
@@ -154,6 +154,11 @@ class DockerVolume(BaseVolume):
             )
         return sorted(entries, key=lambda e: e.path)
 
+    def path_exists(self, path: str) -> bool:
+        resolved = self._resolve(path)
+        exit_code, _ = self._exec(f"test -e '{resolved}'")
+        return exit_code == 0
+
     def read_file(self, path: str) -> bytes:
         resolved = self._resolve(path)
         exit_code, output = self.container.exec_run(["cat", resolved])

--- a/libs/mngr/imbue/mngr/providers/local/volume.py
+++ b/libs/mngr/imbue/mngr/providers/local/volume.py
@@ -51,6 +51,9 @@ class LocalVolume(BaseVolume):
             )
         return entries
 
+    def path_exists(self, path: str) -> bool:
+        return self._resolve(path).exists()
+
     def read_file(self, path: str) -> bytes:
         resolved = self._resolve(path)
         return resolved.read_bytes()

--- a/libs/mngr/imbue/mngr/providers/local/volume_test.py
+++ b/libs/mngr/imbue/mngr/providers/local/volume_test.py
@@ -134,6 +134,21 @@ def test_scoped_listdir_works_when_root_path_is_symlink(symlink_volume: LocalVol
     assert entries[0].file_type == VolumeFileType.DIRECTORY
 
 
+def test_path_exists_returns_true_for_file(volume: LocalVolume) -> None:
+    volume.write_files({"hello.txt": b"world"})
+    assert volume.path_exists("hello.txt") is True
+
+
+def test_path_exists_returns_true_for_directory(volume: LocalVolume) -> None:
+    volume.write_files({"sub/file.txt": b"x"})
+    assert volume.path_exists("sub") is True
+
+
+def test_path_exists_returns_false_for_missing(volume: LocalVolume) -> None:
+    assert volume.path_exists("nonexistent.txt") is False
+    assert volume.path_exists("missing/dir") is False
+
+
 def test_path_traversal_blocked(volume: LocalVolume) -> None:
     """Paths with '..' that escape the volume root should be rejected."""
     with pytest.raises(MngrError, match="escapes volume root"):

--- a/libs/mngr_modal/imbue/mngr_modal/volume.py
+++ b/libs/mngr_modal/imbue/mngr_modal/volume.py
@@ -13,6 +13,7 @@ from imbue.mngr_modal.errors import ModalMngrError
 from imbue.modal_proxy.data_types import FileEntry as ProxyFileEntry
 from imbue.modal_proxy.data_types import FileEntryType as ProxyFileEntryType
 from imbue.modal_proxy.errors import ModalProxyInternalError
+from imbue.modal_proxy.errors import ModalProxyNotFoundError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.interface import VolumeInterface
 
@@ -72,6 +73,16 @@ class ModalVolume(BaseVolume):
     def listdir(self, path: str) -> list[VolumeFile]:
         entries = self.modal_volume.listdir(path)
         return [_proxy_file_entry_to_volume_file(e) for e in entries]
+
+    @_translate_transient_proxy_errors
+    def path_exists(self, path: str) -> bool:
+        # Modal has no stat-like primitive; probe via listdir, which accepts
+        # both file and directory paths and raises NotFoundError otherwise.
+        try:
+            self.modal_volume.listdir(path)
+            return True
+        except ModalProxyNotFoundError:
+            return False
 
     @_translate_transient_proxy_errors
     def read_file(self, path: str) -> bytes:

--- a/libs/mngr_tmr/imbue/mngr_tmr/api.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from loguru import logger
 
-from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.api.list import ListResult
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
@@ -39,10 +38,10 @@ from imbue.mngr_tmr.launching import stop_agent_on_host
 from imbue.mngr_tmr.mngr_cli import CliError
 from imbue.mngr_tmr.mngr_cli import list_agents as cli_list_agents
 from imbue.mngr_tmr.pulling import finalize_agent
+from imbue.mngr_tmr.pulling import is_agent_outputs_ready
 from imbue.mngr_tmr.pulling import pull_agent_branch as pull_agent_branch
 from imbue.mngr_tmr.pulling import pull_agent_outputs as pull_agent_outputs
 from imbue.mngr_tmr.pulling import read_integrator_result as read_integrator_result
-from imbue.mngr_tmr.pulling import try_read_agent_result
 from imbue.mngr_tmr.pulling import try_read_integrator_outcome
 from imbue.mngr_tmr.report import generate_html_report
 from imbue.mngr_tmr.utils import CollectTestsError as CollectTestsError
@@ -95,11 +94,6 @@ def should_pull_changes(result: TestMapReduceResult) -> bool:
     return _should_pull(result.errored, result.changes, result.tests_passing_before, result.tests_passing_after)
 
 
-def should_pull_changes_from_result(result: TestResult) -> bool:
-    """Determine whether an agent's changes should be pulled (from a TestResult)."""
-    return _should_pull(result.errored, result.changes, result.tests_passing_before, result.tests_passing_after)
-
-
 def launch_and_poll_agents(
     test_node_ids: list[str],
     config: TmrLaunchConfig,
@@ -116,7 +110,6 @@ def launch_and_poll_agents(
     launch_failures: list[TestMapReduceResult],
     artifact_output_dir: Path | None = None,
     source_dir: Path | None = None,
-    base_commit: str | None = None,
 ) -> tuple[dict[str, AgentDetails], set[str], dict[str, TestResult]]:
     """Launch agents incrementally and poll until all finish.
 
@@ -178,15 +171,16 @@ def launch_and_poll_agents(
             info = agent_id_to_info[agent_id_str]
             elapsed = now - info.created_at
             if elapsed >= agent_timeout_seconds:
-                result = try_read_agent_result(info.work_dir, all_hosts[agent_id_str])
-                if result is not None:
+                host = all_hosts[agent_id_str]
+                if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, AgentId(agent_id_str)):
                     logger.info(
-                        "Agent '{}' has result file (found before timeout stop), treating as done", info.agent_name
+                        "Agent '{}' has outputs archive (found before timeout stop), treating as done",
+                        info.agent_name,
                     )
                     pending_ids.discard(agent_id_str)
                     continue
                 logger.warning("Agent '{}' timed out after {:.0f}s, stopping", info.agent_name, elapsed)
-                stop_agent_on_host(all_hosts[agent_id_str], AgentId(agent_id_str), info.agent_name)
+                stop_agent_on_host(host, AgentId(agent_id_str), info.agent_name)
                 pending_ids.discard(agent_id_str)
                 timed_out_ids.add(agent_id_str)
                 timed_out_this_round = True
@@ -238,25 +232,19 @@ def launch_and_poll_agents(
             changed = True
 
             pre_read = finalize_agent(
+                mngr_ctx=mngr_ctx,
+                provider_name=config.provider_name,
+                host=all_hosts[agent_id_str],
                 agent_id=agent_detail.id,
                 agent_name=agent_detail.name,
-                host=all_hosts[agent_id_str],
+                branch_name=agent_detail.initial_branch,
                 artifact_output_dir=artifact_output_dir,
+                source_dir=source_dir,
                 cg=mngr_ctx.concurrency_group,
                 should_stop=agent_detail.state == AgentLifecycleState.WAITING,
             )
             if pre_read is not None:
                 cached_results[agent_id_str] = pre_read
-                if base_commit is not None and source_dir is not None and should_pull_changes_from_result(pre_read):
-                    pull_agent_branch(
-                        agent_detail.id,
-                        agent_detail.name,
-                        agent_detail.initial_branch,
-                        all_hosts[agent_id_str],
-                        source_dir,
-                        mngr_ctx.concurrency_group,
-                        base_commit,
-                    )
 
         for agent_id_str in list(pending_ids):
             if agent_id_str not in seen_ids:
@@ -276,36 +264,26 @@ def launch_and_poll_agents(
             if now - last_result_check[agent_id_str] >= result_check_interval_seconds:
                 last_result_check[agent_id_str] = now
                 info = agent_id_to_info[agent_id_str]
-                result = try_read_agent_result(info.work_dir, all_hosts[agent_id_str])
-                if result is not None:
+                host = all_hosts[agent_id_str]
+                if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, AgentId(agent_id_str)):
                     logger.info(
-                        "Agent '{}' has result file (detected via direct check), treating as done",
+                        "Agent '{}' has outputs archive (detected via direct check), treating as done",
                         info.agent_name,
                     )
                     pre_read = finalize_agent(
+                        mngr_ctx=mngr_ctx,
+                        provider_name=config.provider_name,
+                        host=host,
                         agent_id=AgentId(agent_id_str),
                         agent_name=info.agent_name,
-                        host=all_hosts[agent_id_str],
+                        branch_name=info.branch_name,
                         artifact_output_dir=artifact_output_dir,
+                        source_dir=source_dir,
                         cg=mngr_ctx.concurrency_group,
                         should_stop=True,
                     )
                     if pre_read is not None:
                         cached_results[agent_id_str] = pre_read
-                        if (
-                            base_commit is not None
-                            and source_dir is not None
-                            and should_pull_changes_from_result(pre_read)
-                        ):
-                            pull_agent_branch(
-                                AgentId(agent_id_str),
-                                info.agent_name,
-                                info.branch_name,
-                                all_hosts[agent_id_str],
-                                source_dir,
-                                mngr_ctx.concurrency_group,
-                                base_commit,
-                            )
                     pending_ids.discard(agent_id_str)
                     changed = True
 
@@ -330,7 +308,13 @@ def _collect_agent_results(
     missing_detail_summary: str,
     cached_results: dict[str, TestResult] | None = None,
 ) -> list[TestMapReduceResult]:
-    """Shared iteration over agents to build result list."""
+    """Shared iteration over agents to build result list.
+
+    Relies entirely on ``cached_results``: an agent that finished writes its
+    outcome into the outputs archive, which is downloaded and parsed during
+    finalization. An agent with no cached result either is still running
+    (intermediate report) or failed to publish (final report).
+    """
     cached_results = cached_results or {}
     results: list[TestMapReduceResult] = []
 
@@ -349,27 +333,24 @@ def _collect_agent_results(
             continue
 
         detail = final_details.get(agent_id_str)
+        test_result = cached_results.get(agent_id_str)
 
         if detail is None:
-            if agent_id_str in hosts:
-                direct_result = cached_results.get(agent_id_str) or try_read_agent_result(
-                    agent_info.work_dir, hosts[agent_id_str]
-                )
-                if direct_result is not None:
-                    results.append(
-                        TestMapReduceResult(
-                            test_node_id=agent_info.test_node_id,
-                            agent_name=agent_info.agent_name,
-                            changes=direct_result.changes,
-                            errored=direct_result.errored,
-                            tests_passing_before=direct_result.tests_passing_before,
-                            tests_passing_after=direct_result.tests_passing_after,
-                            summary_markdown=direct_result.summary_markdown,
-                            branch_name=agent_info.branch_name,
-                            test_runs=direct_result.test_runs,
-                        )
+            if test_result is not None:
+                results.append(
+                    TestMapReduceResult(
+                        test_node_id=agent_info.test_node_id,
+                        agent_name=agent_info.agent_name,
+                        changes=test_result.changes,
+                        errored=test_result.errored,
+                        tests_passing_before=test_result.tests_passing_before,
+                        tests_passing_after=test_result.tests_passing_after,
+                        summary_markdown=test_result.summary_markdown,
+                        branch_name=agent_info.branch_name,
+                        test_runs=test_result.test_runs,
                     )
-                    continue
+                )
+                continue
             results.append(
                 TestMapReduceResult(
                     test_node_id=agent_info.test_node_id,
@@ -380,9 +361,6 @@ def _collect_agent_results(
             )
             continue
 
-        test_result = cached_results.get(agent_id_str) or try_read_agent_result(
-            agent_info.work_dir, hosts[agent_id_str]
-        )
         if test_result is not None:
             results.append(
                 TestMapReduceResult(
@@ -416,16 +394,15 @@ def gather_results(
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
     hosts: dict[str, OnlineHostInterface],
-    source_dir: Path,
-    cg: ConcurrencyGroup,
-    base_commit: str | None = None,
     cached_results: dict[str, TestResult] | None = None,
     launch_failures: Sequence[TestMapReduceResult] = (),
 ) -> list[TestMapReduceResult]:
-    """Gather results from all finished agents, pulling branches where appropriate.
+    """Gather results from all finished agents.
 
-    ``launch_failures`` are prepended to the returned list so agents that
-    failed to launch still appear in the report.
+    Branches were already applied via each agent's bundle during the per-agent
+    pull step, so this function just assembles the per-agent result records.
+    ``launch_failures`` are prepended so agents that failed to launch still
+    appear in the report.
     """
     results = _collect_agent_results(
         agents=agents,
@@ -436,25 +413,6 @@ def gather_results(
         missing_detail_summary="Agent details not found after polling",
         cached_results=cached_results,
     )
-
-    # Pull branches from remote agents whose changes should be kept.
-    # In the main polling flow, branches are pulled during finalization (before
-    # stopping agents). This loop serves as a fallback for the reintegrate flow.
-    if base_commit is not None:
-        for result in results:
-            if should_pull_changes(result):
-                agent_id_str = next(str(info.agent_id) for info in agents if info.test_node_id == result.test_node_id)
-                detail = final_details.get(agent_id_str)
-                if detail is not None:
-                    pull_agent_branch(
-                        detail.id,
-                        detail.name,
-                        detail.initial_branch,
-                        hosts[agent_id_str],
-                        source_dir,
-                        cg,
-                        base_commit=base_commit,
-                    )
 
     return [*launch_failures, *results]
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/api_test.py
@@ -376,9 +376,10 @@ def test_build_current_results_launch_failures_come_before_running_agents() -> N
 
 
 def _write_local_result(local_dir: Path, content: str) -> None:
-    """Write a testing_agent_outcome.json in a local agent output directory."""
-    local_dir.mkdir(parents=True, exist_ok=True)
-    (local_dir / TESTING_AGENT_OUTCOME_FILENAME).write_text(content)
+    """Write a testing_agent_outcome.json under the local agent's extracted test_output dir."""
+    test_output_dir = local_dir / "test_output"
+    test_output_dir.mkdir(parents=True, exist_ok=True)
+    (test_output_dir / TESTING_AGENT_OUTCOME_FILENAME).write_text(content)
 
 
 def _write_integrator_result_in_work_dir(work_dir: Path, content: str) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -297,28 +297,32 @@ def _run_reintegrate(
         html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Pull outputs (artifacts + result.json) for each agent, then gather results
+    # Pull outputs (artifacts + outcome + branch bundle) for each agent via
+    # the volume API. The host does not need to be online for this step.
     cached_results: dict[str, TestResult] = {}
     cg = mngr_ctx.concurrency_group
-    for info in agent_infos:
-        agent_id_str = str(info.agent_id)
-        if agent_id_str in agent_hosts:
-            result = pull_agent_outputs(info.agent_id, info.agent_name, agent_hosts[agent_id_str], output_dir, cg)
-            if result is not None:
-                cached_results[agent_id_str] = result
+    for detail in matching_agents:
+        agent_id_str = str(detail.id)
+        result = pull_agent_outputs(
+            mngr_ctx=mngr_ctx,
+            provider_name=detail.host.provider_name,
+            host_id=detail.host.id,
+            agent_id=detail.id,
+            agent_name=detail.name,
+            branch_name=detail.initial_branch,
+            destination_dir=output_dir,
+            source_dir=source_dir,
+            cg=cg,
+        )
+        if result is not None:
+            cached_results[agent_id_str] = result
 
     base_commit = get_base_commit(source_dir, cg)
-    is_remote_provider = any(
-        d.host is not None and d.host.provider_name != LOCAL_PROVIDER_NAME for d in matching_agents
-    )
     results = gather_results(
         agents=agent_infos,
         final_details=final_details,
         timed_out_ids=set(),
         hosts=agent_hosts,
-        source_dir=source_dir,
-        cg=cg,
-        base_commit=base_commit if is_remote_provider else None,
         cached_results=cached_results,
     )
 
@@ -723,7 +727,6 @@ def _run_tmr_pipeline(
         _emit_agents_launched(len(agent_infos), output_opts)
         remaining_node_ids = []
 
-    is_remote_provider = ProviderInstanceName(opts.provider).lower() != LOCAL_PROVIDER_NAME
     final_details, timed_out_ids, cached_results = launch_and_poll_agents(
         test_node_ids=remaining_node_ids,
         config=config,
@@ -740,22 +743,18 @@ def _run_tmr_pipeline(
         launch_failures=launch_failures,
         artifact_output_dir=output_dir,
         source_dir=source_dir,
-        base_commit=base_commit if is_remote_provider else None,
     )
 
     if use_batched:
         _emit_agents_launched(len(agent_infos), output_opts)
 
-    # Step 8: Gather final results (branches already pulled during polling for
-    # remote providers; gather_results re-attempts for any that were missed)
+    # Step 8: Gather final results (artifacts and branch bundles were already
+    # downloaded and applied during per-agent finalization).
     results = gather_results(
         agents=agent_infos,
         final_details=final_details,
         timed_out_ids=timed_out_ids,
         hosts=agent_hosts,
-        source_dir=source_dir,
-        cg=mngr_ctx.concurrency_group,
-        base_commit=base_commit if is_remote_provider else None,
         cached_results=cached_results,
         launch_failures=launch_failures,
     )

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -18,6 +18,7 @@ from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.env_utils import resolve_env_vars
 from imbue.mngr.cli.env_utils import resolve_labels
+from imbue.mngr.cli.headless_runner import get_local_host
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
@@ -39,7 +40,6 @@ from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
-from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.registry import get_config_class
 from imbue.mngr_tmr.data_types import IntegratorResult
 from imbue.mngr_tmr.data_types import TestAgentInfo
@@ -255,9 +255,7 @@ def _run_reintegrate(
         return
 
     # Get local host (needed for local agent host mapping and integrator config)
-    local_provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
-    local_host_ref = local_provider.get_host(HostName(LOCAL_HOST_NAME))
-    source_host, _ = ensure_host_started(local_host_ref, is_start_desired=True, provider=local_provider)
+    source_host = get_local_host(mngr_ctx)
 
     # Build agent infos and hosts from discovered agents
     agent_infos: list[TestAgentInfo] = []
@@ -615,9 +613,7 @@ def tmr(ctx: click.Context, **kwargs: object) -> None:
     _emit_test_count(len(test_node_ids), output_opts)
 
     # Step 3: Get the local host for source_location (tests are collected locally)
-    local_provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
-    local_host_ref = local_provider.get_host(HostName(LOCAL_HOST_NAME))
-    source_host, _ = ensure_host_started(local_host_ref, is_start_desired=True, provider=local_provider)
+    source_host = get_local_host(mngr_ctx)
 
     # Step 4: Build launch config and launch agents
     env_options = AgentEnvironmentOptions(env_vars=resolve_env_vars((), opts.env))

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -37,24 +37,22 @@ from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.providers.registry import get_config_class
-from imbue.mngr_tmr.data_types import IntegratorResult
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import TestAgentInfo
-from imbue.mngr_tmr.data_types import TestMapReduceResult
-from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import launch_all_test_agents
 from imbue.mngr_tmr.launching import launch_integrator_agent
 from imbue.mngr_tmr.mngr_cli import try_list_agents
-from imbue.mngr_tmr.orchestration import gather_results
 from imbue.mngr_tmr.orchestration import launch_and_poll_agents
 from imbue.mngr_tmr.orchestration import wait_for_integrator
 from imbue.mngr_tmr.pulling import pull_agent_branch
 from imbue.mngr_tmr.pulling import pull_agent_outputs
-from imbue.mngr_tmr.pulling import read_integrator_result
+from imbue.mngr_tmr.pulling import pull_integrator_outputs
 from imbue.mngr_tmr.report import generate_html_report
+from imbue.mngr_tmr.report import list_pullable_branches
 from imbue.mngr_tmr.utils import collect_tests
 from imbue.mngr_tmr.utils import get_base_commit
-from imbue.mngr_tmr.utils import should_pull_changes
 
 _DEFAULT_TIMEOUT_SECONDS = 3600.0
 _DEFAULT_INTEGRATOR_TIMEOUT_SECONDS = 3600.0
@@ -252,32 +250,28 @@ def _run_reintegrate(
     # Get local host (needed by the integrator config built later).
     source_host = get_local_host(mngr_ctx)
 
-    # Build agent infos from discovered agents. Output pulling uses the volume
-    # API directly, so the testing agents' hosts do not need to be online.
-    agent_infos: list[TestAgentInfo] = [
-        TestAgentInfo(
-            test_node_id=detail.labels.get("test_node_id", str(detail.name)),
-            agent_id=detail.id,
+    # Build per-agent metadata from discovered agents. Output pulling uses
+    # the volume API directly, so the testing agents' hosts do not need to
+    # be online.
+    test_agent_metadata: list[AgentMetadata] = [
+        AgentMetadata(
+            kind=AgentKind.TESTING_AGENT,
             agent_name=detail.name,
-            work_dir=detail.work_dir,
+            test_node_id=detail.labels.get("test_node_id", str(detail.name)),
             branch_name=detail.initial_branch,
-            created_at=0.0,
         )
         for detail in matching_agents
     ]
 
     # Compute output directory
     output_dir = Path(opts.output_dir) if opts.output_dir is not None else Path(f"tmr_{run_name}_reintegrate")
-    html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Pull outputs (artifacts + outcome + branch bundle) for each agent via
     # the volume API. The host does not need to be online for this step.
-    cached_results: dict[str, TestResult] = {}
     cg = mngr_ctx.concurrency_group
     for detail in matching_agents:
-        agent_id_str = str(detail.id)
-        result = pull_agent_outputs(
+        pull_agent_outputs(
             mngr_ctx=mngr_ctx,
             provider_name=detail.host.provider_name,
             host_id=detail.host.id,
@@ -288,21 +282,13 @@ def _run_reintegrate(
             source_dir=source_dir,
             cg=cg,
         )
-        if result is not None:
-            cached_results[agent_id_str] = result
 
     base_commit = get_base_commit(source_dir, cg)
-    results = gather_results(
-        agents=agent_infos,
-        timed_out_ids=set(),
-        cached_results=cached_results,
-    )
 
     # Write pre-integrator report
     generate_html_report(
-        results,
-        html_path,
-        test_artifacts_dir=output_dir,
+        test_agent_metadata,
+        output_dir,
         run_commands=_build_run_commands(run_name),
     )
 
@@ -324,36 +310,38 @@ def _run_reintegrate(
         templates=integrator_templates,
         additional_authorized_keys=opts.additional_authorized_keys,
     )
-    integrator_result = _run_integrator_phase(
-        results, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit
+    integrator_meta = _run_integrator_phase(
+        test_agent_metadata, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit
     )
-    integrated_branch = integrator_result.branch_name if integrator_result is not None else None
+    integrated_branch = integrator_meta.branch_name if integrator_meta is not None else None
     generate_html_report(
-        results,
-        html_path,
-        integrator=integrator_result,
-        test_artifacts_dir=output_dir,
+        test_agent_metadata,
+        output_dir,
+        integrator_metadata=integrator_meta,
         run_commands=_build_run_commands(run_name, integrated_branch),
     )
-    _emit_report_path(html_path, output_opts)
+    _emit_report_path(output_dir / "index.html", output_opts)
     _emit_integrator_branch(integrated_branch, output_opts)
     _print_run_commands(run_name, output_opts, integrated_branch)
 
 
 def _run_integrator_phase(
-    results: list[TestMapReduceResult],
+    test_agent_metadata: list[AgentMetadata],
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     opts: TmrCliOptions,
     output_dir: Path,
     base_commit: str | None = None,
-) -> IntegratorResult | None:
+) -> AgentMetadata | None:
     """Launch an integrator agent to cherry-pick all fix branches into a linear stack.
 
     All pullable branches are integrated. Test/doc/tutorial commits are squashed
     into one commit; FIX_IMPL commits are kept separate and stacked by priority.
+    Returns the integrator's metadata (kind=INTEGRATOR) with branch_name set
+    when a branch was produced; the report reads the integrator outcome JSON
+    from disk.
     """
-    fix_branches = [r.branch_name for r in results if should_pull_changes(r) and r.branch_name is not None]
+    fix_branches = list_pullable_branches(test_agent_metadata, output_dir)
     if not fix_branches:
         return None
 
@@ -376,15 +364,21 @@ def _run_integrator_phase(
     )
 
     if integrator_branch is None:
-        return IntegratorResult(agent_name=integrator.agent_name, branch_name=None)
+        return AgentMetadata(
+            kind=AgentKind.INTEGRATOR,
+            agent_name=integrator.agent_name,
+            branch_name=None,
+            error_summary="Integrator timed out before producing a branch.",
+        )
 
-    integrator_result = read_integrator_result(
-        agent_id=integrator.agent_id,
-        agent_name=integrator.agent_name,
-        host=integrator_host,
-        branch_name=integrator_branch,
-        destination_dir=output_dir,
-        cg=mngr_ctx.concurrency_group,
+    # Pull the integrator's outputs into output_dir so the reporter can parse
+    # the integrator outcome JSON from disk.
+    pull_integrator_outputs(
+        integrator.agent_id,
+        integrator.agent_name,
+        integrator_host,
+        output_dir,
+        mngr_ctx.concurrency_group,
     )
 
     # Only pull branches from remote providers; local worktree branches already exist
@@ -400,7 +394,11 @@ def _run_integrator_phase(
             base_commit=base_commit,
         )
 
-    return integrator_result
+    return AgentMetadata(
+        kind=AgentKind.INTEGRATOR,
+        agent_name=integrator.agent_name,
+        branch_name=integrator_branch,
+    )
 
 
 @click.command("tmr", cls=_TmrCommand, context_settings={"ignore_unknown_options": True})
@@ -648,10 +646,9 @@ def _run_tmr_pipeline(
     provided_snapshot: SnapshotName | None,
     env_options: AgentEnvironmentOptions,
 ) -> None:
-    """Run the main TMR pipeline (launch, poll, gather, integrate, report)."""
-    # Step 6: Compute output directory and html_path before launching
+    """Run the main TMR pipeline (launch, poll, integrate, report)."""
+    # Step 6: Compute output directory before launching
     output_dir = Path(opts.output_dir) if opts.output_dir is not None else Path(f"tmr_{timestamp}")
-    html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Step 7: Launch and poll agents
@@ -659,7 +656,7 @@ def _run_tmr_pipeline(
     # Otherwise, all agents are launched up front and then polled via the same function.
     use_batched = opts.max_parallel_agents > 0 and opts.max_parallel_agents < len(test_node_ids)
 
-    launch_failures: list[TestMapReduceResult] = []
+    launch_failures: list[AgentMetadata] = []
 
     if use_batched:
         if opts.use_snapshot and output_opts.output_format == OutputFormat.HUMAN:
@@ -685,7 +682,7 @@ def _run_tmr_pipeline(
         _emit_agents_launched(len(agent_infos), output_opts)
         remaining_node_ids = []
 
-    timed_out_ids, cached_results = launch_and_poll_agents(
+    test_agent_metadata = launch_and_poll_agents(
         test_node_ids=remaining_node_ids,
         config=config,
         mngr_ctx=mngr_ctx,
@@ -694,30 +691,22 @@ def _run_tmr_pipeline(
         max_agents=opts.max_parallel_agents,
         agent_timeout_seconds=opts.timeout,
         poll_interval_seconds=opts.poll_interval,
-        report_path=html_path,
+        output_dir=output_dir,
         all_agents=agent_infos,
         all_hosts=agent_hosts,
         launch_failures=launch_failures,
-        artifact_output_dir=output_dir,
         source_dir=source_dir,
     )
 
     if use_batched:
         _emit_agents_launched(len(agent_infos), output_opts)
 
-    # Step 8: Gather final results (artifacts and branch bundles were already
-    # downloaded and applied during per-agent finalization).
-    results = gather_results(
-        agents=agent_infos,
-        timed_out_ids=timed_out_ids,
-        cached_results=cached_results,
-        launch_failures=launch_failures,
-    )
+    # Step 8: Write the post-polling report (pre-integrator). Artifacts and
+    # branch bundles were already downloaded during per-agent finalization;
+    # the reporter parses outcome JSON from disk.
+    generate_html_report(test_agent_metadata, output_dir)
 
-    # Step 9: Write report with final results (artifacts already pulled during polling)
-    generate_html_report(results, html_path, test_artifacts_dir=output_dir)
-
-    # Step 10: Build integrator config (defaults to local provider) and integrate
+    # Step 9: Build integrator config (defaults to local provider) and integrate
     integrator_agent_type = opts.integrator_type if opts.integrator_type is not None else opts.agent_type
     integrator_templates = opts.integrator_template if opts.integrator_template else opts.agent_template
     integrator_config = TmrLaunchConfig(
@@ -731,18 +720,17 @@ def _run_tmr_pipeline(
         templates=integrator_templates,
         additional_authorized_keys=opts.additional_authorized_keys,
     )
-    integrator_result = _run_integrator_phase(
-        results, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit
+    integrator_meta = _run_integrator_phase(
+        test_agent_metadata, integrator_config, mngr_ctx, opts, output_dir, base_commit=base_commit
     )
-    integrated_branch = integrator_result.branch_name if integrator_result is not None else None
+    integrated_branch = integrator_meta.branch_name if integrator_meta is not None else None
     generate_html_report(
-        results,
-        html_path,
-        integrator=integrator_result,
-        test_artifacts_dir=output_dir,
+        test_agent_metadata,
+        output_dir,
+        integrator_metadata=integrator_meta,
         run_commands=_build_run_commands(e2e_run_prefix, integrated_branch),
     )
-    _emit_report_path(html_path, output_opts)
+    _emit_report_path(output_dir / "index.html", output_opts)
     _emit_integrator_branch(integrated_branch, output_opts)
 
     _print_run_commands(e2e_run_prefix, output_opts, integrated_branch)

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -11,8 +11,6 @@ from typing import assert_never
 import click
 from loguru import logger
 
-from imbue.mngr.api.find import ensure_host_started
-from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.cli.common_opts import CommonCliOptions
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -34,7 +32,6 @@ from imbue.mngr.interfaces.host import AgentEnvironmentOptions
 from imbue.mngr.interfaces.host import AgentLabelOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentTypeName
-from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import ProviderBackendName
@@ -254,37 +251,24 @@ def _run_reintegrate(
             write_human_line("No agents found for run name '{}'. Nothing to reintegrate.", run_name)
         return
 
-    # Get local host (needed for local agent host mapping and integrator config)
+    # Get local host (needed by the integrator config built later).
     source_host = get_local_host(mngr_ctx)
 
-    # Build agent infos and hosts from discovered agents
+    # Build agent infos from discovered agents. Output pulling uses the volume
+    # API directly, so the testing agents' hosts do not need to be online.
     agent_infos: list[TestAgentInfo] = []
-    agent_hosts: dict[str, OnlineHostInterface] = {}
     final_details: dict[str, AgentDetails] = {}
-
     for detail in matching_agents:
-        agent_id_str = str(detail.id)
-        info = TestAgentInfo(
-            test_node_id=detail.labels.get("test_node_id", str(detail.name)),
-            agent_id=detail.id,
-            agent_name=detail.name,
-            work_dir=detail.work_dir,
-            created_at=0.0,
+        agent_infos.append(
+            TestAgentInfo(
+                test_node_id=detail.labels.get("test_node_id", str(detail.name)),
+                agent_id=detail.id,
+                agent_name=detail.name,
+                work_dir=detail.work_dir,
+                created_at=0.0,
+            )
         )
-        agent_infos.append(info)
-        final_details[agent_id_str] = detail
-        if detail.host is not None:
-            is_local = detail.host.provider_name == LOCAL_PROVIDER_NAME
-            if is_local:
-                agent_hosts[agent_id_str] = source_host
-            else:
-                try:
-                    host_provider = get_provider_instance(detail.host.provider_name, mngr_ctx)
-                    host_ref = host_provider.get_host(HostName(detail.host.name))
-                    host, _ = ensure_host_started(host_ref, is_start_desired=True, provider=host_provider)
-                    agent_hosts[agent_id_str] = host
-                except (MngrError, HostError, OSError, BaseExceptionGroup) as exc:
-                    logger.warning("Could not connect to host for agent '{}': {}", detail.name, exc)
+        final_details[str(detail.id)] = detail
 
     # Compute output directory
     if opts.output_html is not None:
@@ -320,7 +304,6 @@ def _run_reintegrate(
         agents=agent_infos,
         final_details=final_details,
         timed_out_ids=set(),
-        hosts=agent_hosts,
         cached_results=cached_results,
     )
 
@@ -750,7 +733,6 @@ def _run_tmr_pipeline(
         agents=agent_infos,
         final_details=final_details,
         timed_out_ids=timed_out_ids,
-        hosts=agent_hosts,
         cached_results=cached_results,
         launch_failures=launch_failures,
     )

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -320,6 +320,7 @@ def _run_reintegrate(
     integrator_config = TmrLaunchConfig(
         source_dir=source_dir,
         source_host=source_host,
+        base_commit=base_commit,
         agent_type=AgentTypeName(integrator_agent_type),
         provider_name=ProviderInstanceName(opts.integrator_provider),
         env_options=env_options,
@@ -601,6 +602,7 @@ def tmr(ctx: click.Context, **kwargs: object) -> None:
     config = TmrLaunchConfig(
         source_dir=source_dir,
         source_host=source_host,
+        base_commit=base_commit,
         agent_type=AgentTypeName(opts.agent_type),
         provider_name=ProviderInstanceName(opts.provider),
         env_options=env_options,
@@ -728,6 +730,7 @@ def _run_tmr_pipeline(
     integrator_config = TmrLaunchConfig(
         source_dir=source_dir,
         source_host=source_host,
+        base_commit=base_commit,
         agent_type=AgentTypeName(integrator_agent_type),
         provider_name=ProviderInstanceName(opts.integrator_provider),
         env_options=env_options,

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -41,24 +41,24 @@ from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.registry import get_config_class
-from imbue.mngr_tmr.api import collect_tests
-from imbue.mngr_tmr.api import gather_results
-from imbue.mngr_tmr.api import get_base_commit
-from imbue.mngr_tmr.api import launch_all_test_agents
-from imbue.mngr_tmr.api import launch_and_poll_agents
-from imbue.mngr_tmr.api import launch_integrator_agent
-from imbue.mngr_tmr.api import pull_agent_branch
-from imbue.mngr_tmr.api import pull_agent_outputs
-from imbue.mngr_tmr.api import read_integrator_result
-from imbue.mngr_tmr.api import should_pull_changes
-from imbue.mngr_tmr.api import try_list_agents
-from imbue.mngr_tmr.api import wait_for_integrator
 from imbue.mngr_tmr.data_types import IntegratorResult
 from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
+from imbue.mngr_tmr.launching import launch_all_test_agents
+from imbue.mngr_tmr.launching import launch_integrator_agent
+from imbue.mngr_tmr.mngr_cli import try_list_agents
+from imbue.mngr_tmr.orchestration import gather_results
+from imbue.mngr_tmr.orchestration import launch_and_poll_agents
+from imbue.mngr_tmr.orchestration import wait_for_integrator
+from imbue.mngr_tmr.pulling import pull_agent_branch
+from imbue.mngr_tmr.pulling import pull_agent_outputs
+from imbue.mngr_tmr.pulling import read_integrator_result
 from imbue.mngr_tmr.report import generate_html_report
+from imbue.mngr_tmr.utils import collect_tests
+from imbue.mngr_tmr.utils import get_base_commit
+from imbue.mngr_tmr.utils import should_pull_changes
 
 _DEFAULT_TIMEOUT_SECONDS = 3600.0
 _DEFAULT_INTEGRATOR_TIMEOUT_SECONDS = 3600.0

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -27,7 +27,6 @@ from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import HostError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UnknownBackendError
-from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import AgentEnvironmentOptions
 from imbue.mngr.interfaces.host import AgentLabelOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
@@ -125,7 +124,6 @@ class TmrCliOptions(CommonCliOptions):
     launch_delay: float
     poll_interval: float
     timeout: float
-    result_check_interval: float
     integrator_timeout: float
     output_html: str | None
     source: str | None
@@ -256,19 +254,17 @@ def _run_reintegrate(
 
     # Build agent infos from discovered agents. Output pulling uses the volume
     # API directly, so the testing agents' hosts do not need to be online.
-    agent_infos: list[TestAgentInfo] = []
-    final_details: dict[str, AgentDetails] = {}
-    for detail in matching_agents:
-        agent_infos.append(
-            TestAgentInfo(
-                test_node_id=detail.labels.get("test_node_id", str(detail.name)),
-                agent_id=detail.id,
-                agent_name=detail.name,
-                work_dir=detail.work_dir,
-                created_at=0.0,
-            )
+    agent_infos: list[TestAgentInfo] = [
+        TestAgentInfo(
+            test_node_id=detail.labels.get("test_node_id", str(detail.name)),
+            agent_id=detail.id,
+            agent_name=detail.name,
+            work_dir=detail.work_dir,
+            branch_name=detail.initial_branch,
+            created_at=0.0,
         )
-        final_details[str(detail.id)] = detail
+        for detail in matching_agents
+    ]
 
     # Compute output directory
     if opts.output_html is not None:
@@ -302,7 +298,6 @@ def _run_reintegrate(
     base_commit = get_base_commit(source_dir, cg)
     results = gather_results(
         agents=agent_infos,
-        final_details=final_details,
         timed_out_ids=set(),
         cached_results=cached_results,
     )
@@ -378,38 +373,34 @@ def _run_integrator_phase(
     integrator_deadline = time.monotonic() + opts.integrator_timeout
     integrator_branch = wait_for_integrator(
         integrator=integrator,
-        mngr_ctx=mngr_ctx,
         poll_interval_seconds=opts.poll_interval,
         host=integrator_host,
         deadline=integrator_deadline,
     )
 
-    integrator_result: IntegratorResult | None = None
-    if integrator_branch is not None:
-        is_remote = config.provider_name.lower() != LOCAL_PROVIDER_NAME
-        list_result = try_list_agents(mngr_ctx)
-        for agent_detail in list_result.agents if list_result is not None else []:
-            if str(agent_detail.id) == str(integrator.agent_id):
-                integrator_result = read_integrator_result(
-                    agent_detail, integrator_host, integrator_branch, output_dir, mngr_ctx.concurrency_group
-                )
-                # Only pull branches from remote providers; local worktree branches already exist
-                if is_remote:
-                    pull_agent_branch(
-                        agent_detail.id,
-                        agent_detail.name,
-                        agent_detail.initial_branch,
-                        integrator_host,
-                        config.source_dir,
-                        mngr_ctx.concurrency_group,
-                        base_commit=base_commit,
-                    )
-                break
+    if integrator_branch is None:
+        return IntegratorResult(agent_name=integrator.agent_name, branch_name=None)
 
-    if integrator_result is None:
-        integrator_result = IntegratorResult(
-            agent_name=integrator.agent_name,
-            branch_name=integrator_branch,
+    integrator_result = read_integrator_result(
+        agent_id=integrator.agent_id,
+        agent_name=integrator.agent_name,
+        host=integrator_host,
+        branch_name=integrator_branch,
+        destination_dir=output_dir,
+        cg=mngr_ctx.concurrency_group,
+    )
+
+    # Only pull branches from remote providers; local worktree branches already exist
+    is_remote = config.provider_name.lower() != LOCAL_PROVIDER_NAME
+    if is_remote:
+        pull_agent_branch(
+            integrator.agent_id,
+            integrator.agent_name,
+            integrator_branch,
+            integrator_host,
+            config.source_dir,
+            mngr_ctx.concurrency_group,
+            base_commit=base_commit,
         )
 
     return integrator_result
@@ -509,7 +500,7 @@ def _run_integrator_phase(
 )
 @click.option(
     "--poll-interval",
-    default=10.0,
+    default=60.0,
     show_default=True,
     type=float,
     help="Seconds between polling cycles when waiting for agents to finish",
@@ -520,13 +511,6 @@ def _run_integrator_phase(
     show_default=True,
     type=float,
     help="Maximum seconds each agent can run before being stopped (per-agent timeout)",
-)
-@click.option(
-    "--result-check-interval",
-    default=300.0,
-    show_default=True,
-    type=float,
-    help="Seconds between direct result file checks for agents whose status may be stale",
 )
 @click.option(
     "--integrator-timeout",
@@ -706,7 +690,7 @@ def _run_tmr_pipeline(
         _emit_agents_launched(len(agent_infos), output_opts)
         remaining_node_ids = []
 
-    final_details, timed_out_ids, cached_results = launch_and_poll_agents(
+    timed_out_ids, cached_results = launch_and_poll_agents(
         test_node_ids=remaining_node_ids,
         config=config,
         mngr_ctx=mngr_ctx,
@@ -715,7 +699,6 @@ def _run_tmr_pipeline(
         max_agents=opts.max_agents,
         agent_timeout_seconds=opts.timeout,
         poll_interval_seconds=opts.poll_interval,
-        result_check_interval_seconds=opts.result_check_interval,
         report_path=html_path,
         all_agents=agent_infos,
         all_hosts=agent_hosts,
@@ -731,7 +714,6 @@ def _run_tmr_pipeline(
     # downloaded and applied during per-agent finalization).
     results = gather_results(
         agents=agent_infos,
-        final_details=final_details,
         timed_out_ids=timed_out_ids,
         cached_results=cached_results,
         launch_failures=launch_failures,

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -118,14 +118,14 @@ class TmrCliOptions(CommonCliOptions):
     prompt_suffix: str | None
     use_snapshot: bool
     snapshot: str | None
-    max_parallel: int
+    max_parallel_launch: int
     agents_per_host: int
-    max_agents: int
+    max_parallel_agents: int
     launch_delay: float
     poll_interval: float
     timeout: float
     integrator_timeout: float
-    output_html: str | None
+    output_dir: str | None
     source: str | None
     reintegrate: str | None
     additional_authorized_keys: tuple[str, ...]
@@ -267,12 +267,8 @@ def _run_reintegrate(
     ]
 
     # Compute output directory
-    if opts.output_html is not None:
-        html_path = Path(opts.output_html)
-        output_dir = html_path.parent
-    else:
-        output_dir = Path(f"tmr_{run_name}_reintegrate")
-        html_path = output_dir / "index.html"
+    output_dir = Path(opts.output_dir) if opts.output_dir is not None else Path(f"tmr_{run_name}_reintegrate")
+    html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Pull outputs (artifacts + outcome + branch bundle) for each agent via
@@ -471,8 +467,8 @@ def _run_integrator_phase(
     help="Use an existing snapshot/image ID for all agents (skips building; implies --use-snapshot behavior)",
 )
 @click.option(
-    "--max-parallel",
-    default=4,
+    "--max-parallel-launch",
+    default=10,
     show_default=True,
     type=int,
     help="Maximum number of agents to launch concurrently (launch-time parallelism)",
@@ -485,7 +481,7 @@ def _run_integrator_phase(
     help="Number of agents sharing each remote host (ignored for local provider)",
 )
 @click.option(
-    "--max-agents",
+    "--max-parallel-agents",
     default=0,
     show_default=True,
     type=int,
@@ -521,10 +517,11 @@ def _run_integrator_phase(
     help="Maximum seconds to wait for the integrator agent to merge fix branches",
 )
 @click.option(
-    "--output-html",
+    "--output-dir",
     default=None,
     type=click.Path(),
-    help="Path for the HTML report [default: tmr_<timestamp>/index.html]",
+    help="Directory for the run's outputs (HTML report at index.html, per-agent artifacts) "
+    "[default: tmr_<timestamp>/]",
 )
 @click.option(
     "--source",
@@ -653,24 +650,20 @@ def _run_tmr_pipeline(
 ) -> None:
     """Run the main TMR pipeline (launch, poll, gather, integrate, report)."""
     # Step 6: Compute output directory and html_path before launching
-    if opts.output_html is not None:
-        html_path = Path(opts.output_html)
-        output_dir = html_path.parent
-    else:
-        output_dir = Path(f"tmr_{timestamp}")
-        html_path = output_dir / "index.html"
+    output_dir = Path(opts.output_dir) if opts.output_dir is not None else Path(f"tmr_{timestamp}")
+    html_path = output_dir / "index.html"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Step 7: Launch and poll agents
-    # When max_agents > 0, agents are launched incrementally as earlier ones finish.
+    # When max_parallel_agents > 0, agents are launched incrementally as earlier ones finish.
     # Otherwise, all agents are launched up front and then polled via the same function.
-    use_batched = opts.max_agents > 0 and opts.max_agents < len(test_node_ids)
+    use_batched = opts.max_parallel_agents > 0 and opts.max_parallel_agents < len(test_node_ids)
 
     launch_failures: list[TestMapReduceResult] = []
 
     if use_batched:
         if opts.use_snapshot and output_opts.output_format == OutputFormat.HUMAN:
-            write_human_line("WARNING: --use-snapshot is not supported with --max-agents and will be ignored")
+            write_human_line("WARNING: --use-snapshot is not supported with --max-parallel-agents and will be ignored")
         agent_infos: list[TestAgentInfo] = []
         agent_hosts: dict[str, OnlineHostInterface] = {}
         remaining_node_ids = test_node_ids
@@ -684,7 +677,7 @@ def _run_tmr_pipeline(
             launch_failures=launch_failures,
             prompt_suffix=opts.prompt_suffix or "",
             use_snapshot=opts.use_snapshot and provided_snapshot is None,
-            max_parallel=opts.max_parallel,
+            max_parallel=opts.max_parallel_launch,
             launch_delay_seconds=opts.launch_delay,
             agents_per_host=opts.agents_per_host,
             run_name=e2e_run_prefix,
@@ -698,7 +691,7 @@ def _run_tmr_pipeline(
         mngr_ctx=mngr_ctx,
         pytest_flags=testing_flags,
         prompt_suffix=opts.prompt_suffix or "",
-        max_agents=opts.max_agents,
+        max_agents=opts.max_parallel_agents,
         agent_timeout_seconds=opts.timeout,
         poll_interval_seconds=opts.poll_interval,
         report_path=html_path,
@@ -812,7 +805,7 @@ Use --use-snapshot with remote providers to build and provision one host first,
 snapshot it, then launch all remaining agents from the snapshot (much faster).
 Use --env to pass environment variables and --label to tag all agents.
 Use --prompt-suffix to append custom instructions to the agent prompt.
-Use --max-agents to limit how many agents run simultaneously (0 = no limit).
+Use --max-parallel-agents to limit how many agents run simultaneously (0 = no limit).
 
 Each agent writes its result to .test_output/testing_agent_outcome.json (in its work directory)
 with a structured JSON containing: changes (list of kind/status/summary), errored flag,
@@ -824,9 +817,9 @@ tests_passing_before/after booleans, and a markdown summary.""",
         ("Use Docker provider", "mngr tmr --provider docker tests/"),
         ("Modal with snapshot", "mngr tmr --provider modal --use-snapshot tests/"),
         ("Pass env vars and labels", "mngr tmr --env API_KEY=xxx --label batch=run1"),
-        ("Limit to 4 concurrent agents", "mngr tmr --max-agents 4 tests/"),
+        ("Limit to 4 concurrent agents", "mngr tmr --max-parallel-agents 4 tests/"),
         ("Custom poll interval", "mngr tmr --poll-interval 30"),
-        ("Specify output location", "mngr tmr --output-html report.html"),
+        ("Specify output location", "mngr tmr --output-dir reports/run-1"),
     ),
     see_also=(
         ("create", "Create a new agent"),

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
@@ -29,7 +29,7 @@ def test_cli_help_contains_options(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(tmr, ["--help"])
     assert "--agent-type" in result.output
     assert "--poll-interval" in result.output
-    assert "--output-html" in result.output
+    assert "--output-dir" in result.output
     assert "--source" in result.output
 
 
@@ -46,7 +46,7 @@ def test_cli_help_contains_timeout_options(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(tmr, ["--help"])
     assert "--timeout" in result.output
     assert "--integrator-timeout" in result.output
-    assert "--max-agents" in result.output
+    assert "--max-parallel-agents" in result.output
 
 
 def _human_output_opts() -> OutputOptions:

--- a/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
@@ -101,6 +101,7 @@ class TmrLaunchConfig(FrozenModel):
 
     source_dir: Path = Field(description="Source directory for agent work dirs")
     source_host: OnlineHostInterface = Field(description="Local host where source code lives")
+    base_commit: str = Field(description="Commit at source_dir HEAD when the run started; used as the bundle base")
     agent_type: AgentTypeName = Field(description="Type of agent to run (claude, codex, etc.)")
     provider_name: ProviderInstanceName = Field(description="Provider for agent hosts (local, docker, modal)")
     env_options: AgentEnvironmentOptions = Field(

--- a/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/data_types.py
@@ -96,6 +96,40 @@ class TestAgentInfo(FrozenModel):
     created_at: float = Field(description="Monotonic timestamp (time.monotonic()) when the agent was created")
 
 
+class AgentKind(UpperCaseStrEnum):
+    """What flavor of tmr agent a directory under the output dir holds."""
+
+    TESTING_AGENT = auto()
+    INTEGRATOR = auto()
+
+
+class AgentMetadata(FrozenModel):
+    """In-memory hand-off between orchestration and the reporter.
+
+    Orchestration carries one of these per agent. The reporter combines it
+    with whatever it finds under ``<output_dir>/<agent_name>/`` (extracted
+    outcome JSON, branch bundle, etc.) to render rows. Orchestration is the
+    only authority on ``test_node_id``, ``branch_name``, and whether the
+    agent failed to publish outputs (``error_summary``); the outcome JSON
+    schema is a contract between the agent and the reporter and never
+    crosses orchestration.
+    """
+
+    kind: AgentKind = Field(description="What flavor of tmr agent this is")
+    agent_name: AgentName = Field(description="Agent name (matches the subdir under output_dir)")
+    test_node_id: str | None = Field(
+        default=None,
+        description="Pytest node id for testing agents; None for the integrator",
+    )
+    branch_name: str | None = Field(default=None, description="Branch the agent committed to, if any")
+    error_summary: str | None = Field(
+        default=None,
+        description="Markdown to render when the agent did not complete normally (timeout, "
+        "launch failure, etc.). When None, the reporter looks for the agent's outcome JSON "
+        "under output_dir/<agent_name>/test_output/.",
+    )
+
+
 class TmrLaunchConfig(FrozenModel):
     """Common configuration for launching tmr agents."""
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -31,8 +31,9 @@ from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import TransferMode
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import TestAgentInfo
-from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.prompts import build_integrator_prompt
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
@@ -64,8 +65,10 @@ def _make_test_agent_identity(test_node_id: str) -> tuple[AgentName, str]:
     return AgentName(f"tmr-{name_suffix}-{short_id}"), f"mngr-tmr/{name_suffix}-{short_id}"
 
 
-def _make_launch_failure_result(test_node_id: str, agent_name: AgentName, error: object) -> TestMapReduceResult:
-    """Build a TestMapReduceResult marking that an agent failed to launch.
+def _make_launch_failure_metadata(
+    test_node_id: str, agent_name: AgentName, branch_name: str, error: object
+) -> AgentMetadata:
+    """Build an AgentMetadata marking that an agent failed to launch.
 
     Used so launch failures still appear in the HTML report (as errored
     entries in the FAILED section) instead of silently disappearing.
@@ -73,11 +76,12 @@ def _make_launch_failure_result(test_node_id: str, agent_name: AgentName, error:
     attempt, so the report row matches the host/tmux session if the
     user retained it for debugging.
     """
-    return TestMapReduceResult(
-        test_node_id=test_node_id,
+    return AgentMetadata(
+        kind=AgentKind.TESTING_AGENT,
         agent_name=agent_name,
-        errored=True,
-        summary_markdown=f"Failed to launch agent: {error}",
+        test_node_id=test_node_id,
+        branch_name=branch_name,
+        error_summary=f"Failed to launch agent: {error}",
     )
 
 
@@ -326,7 +330,7 @@ def launch_all_test_agents(
     config: TmrLaunchConfig,
     mngr_ctx: MngrContext,
     pytest_flags: tuple[str, ...],
-    launch_failures: list[TestMapReduceResult],
+    launch_failures: list[AgentMetadata],
     prompt_suffix: str = "",
     use_snapshot: bool = False,
     max_parallel: int = 4,
@@ -373,7 +377,7 @@ def launch_all_test_agents(
         name="tmr_launch",
         max_workers=max_parallel,
     ) as executor:
-        futures: list[tuple[Future[tuple[TestAgentInfo, OnlineHostInterface]], str, AgentName]] = []
+        futures: list[tuple[Future[tuple[TestAgentInfo, OnlineHostInterface]], str, AgentName, str]] = []
         for i, test_node_id in enumerate(test_node_ids):
             if i > 0 and launch_delay_seconds > 0:
                 time.sleep(launch_delay_seconds)
@@ -396,16 +400,17 @@ def launch_all_test_agents(
                     ),
                     test_node_id,
                     agent_name,
+                    branch_name,
                 )
             )
-        for future, test_node_id, agent_name in futures:
+        for future, test_node_id, agent_name, branch_name in futures:
             try:
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
             except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
-                launch_failures.append(_make_launch_failure_result(test_node_id, agent_name, exc))
+                launch_failures.append(_make_launch_failure_metadata(test_node_id, agent_name, branch_name, exc))
 
     logger.info("Launched {} agent(s)", len(agents))
     return agents, agent_hosts, launch_config.snapshot
@@ -439,7 +444,7 @@ def launch_agents_up_to_limit(
     all_agents: list[TestAgentInfo],
     all_hosts: dict[str, OnlineHostInterface],
     agent_id_to_info: dict[str, TestAgentInfo],
-    launch_failures: list[TestMapReduceResult],
+    launch_failures: list[AgentMetadata],
 ) -> None:
     """Launch agents from remaining_tests until we hit max_agents running.
 
@@ -458,14 +463,17 @@ def launch_agents_up_to_limit(
         except TimeoutError:
             logger.warning("Agent creation timed out after {}s for {}", _AGENT_CREATION_TIMEOUT_SECONDS, test_node_id)
             launch_failures.append(
-                _make_launch_failure_result(
-                    test_node_id, agent_name, f"creation timed out after {_AGENT_CREATION_TIMEOUT_SECONDS}s"
+                _make_launch_failure_metadata(
+                    test_node_id,
+                    agent_name,
+                    branch_name,
+                    f"creation timed out after {_AGENT_CREATION_TIMEOUT_SECONDS}s",
                 )
             )
             continue
         except (MngrError, HostError, AgentError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", test_node_id, exc)
-            launch_failures.append(_make_launch_failure_result(test_node_id, agent_name, exc))
+            launch_failures.append(_make_launch_failure_metadata(test_node_id, agent_name, branch_name, exc))
             continue
         all_agents.append(info)
         all_hosts[str(info.agent_id)] = host

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -121,6 +121,7 @@ def _build_agent_options(
         target_path=target_path,
         transfer_mode=transfer_mode,
         git=AgentGitOptions(
+            base_branch=config.base_commit,
             new_branch_name=branch_name,
         ),
         data_options=AgentDataOptions(is_rsync_enabled=False),

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -50,7 +50,7 @@ _AGENT_CREATION_TIMEOUT_SECONDS = 600.0
 _HOST_CODE_DIR = Path("/code")
 
 
-def make_test_agent_identity(test_node_id: str) -> tuple[AgentName, str]:
+def _make_test_agent_identity(test_node_id: str) -> tuple[AgentName, str]:
     """Generate (agent_name, branch_name) for a test agent.
 
     Both share a fresh random short_id so they identify the same launch
@@ -96,7 +96,7 @@ def _build_host_environment(config: TmrLaunchConfig) -> HostEnvironmentOptions:
     return HostEnvironmentOptions(authorized_keys=config.additional_authorized_keys)
 
 
-def build_agent_options(
+def _build_agent_options(
     agent_name: AgentName,
     branch_name: str,
     config: TmrLaunchConfig,
@@ -175,7 +175,7 @@ def _create_tmr_agent(
 
     if is_snapshotter:
         source_location = HostLocation(host=config.source_host, path=config.source_dir)
-        agent_options = build_agent_options(
+        agent_options = _build_agent_options(
             agent_name,
             branch_name,
             config,
@@ -184,7 +184,7 @@ def _create_tmr_agent(
         )
     elif existing_host is not None and config.snapshot is not None:
         source_location = HostLocation(host=existing_host, path=_HOST_CODE_DIR)
-        agent_options = build_agent_options(
+        agent_options = _build_agent_options(
             agent_name,
             branch_name,
             config,
@@ -193,7 +193,7 @@ def _create_tmr_agent(
         )
     else:
         source_location = HostLocation(host=config.source_host, path=config.source_dir)
-        agent_options = build_agent_options(agent_name, branch_name, config, initial_message=initial_message)
+        agent_options = _build_agent_options(agent_name, branch_name, config, initial_message=initial_message)
 
     return api_create(
         source_location=source_location,
@@ -203,7 +203,7 @@ def _create_tmr_agent(
     )
 
 
-def launch_test_agent(
+def _launch_test_agent(
     test_node_id: str,
     agent_name: AgentName,
     branch_name: str,
@@ -378,11 +378,11 @@ def launch_all_test_agents(
                 time.sleep(launch_delay_seconds)
             existing_host = host_pool[i % len(host_pool)] if host_pool else None
             h_name = HostName(f"{run_name}-host-{i}") if not is_local and not host_pool else None
-            agent_name, branch_name = make_test_agent_identity(test_node_id)
+            agent_name, branch_name = _make_test_agent_identity(test_node_id)
             futures.append(
                 (
                     executor.submit(
-                        launch_test_agent,
+                        _launch_test_agent,
                         test_node_id,
                         agent_name,
                         branch_name,
@@ -410,7 +410,7 @@ def launch_all_test_agents(
     return agents, agent_hosts, launch_config.snapshot
 
 
-def launch_with_timeout(
+def _launch_with_timeout(
     test_node_id: str,
     agent_name: AgentName,
     branch_name: str,
@@ -422,7 +422,7 @@ def launch_with_timeout(
     """Launch a test agent with a timeout. Raises TimeoutError if creation takes too long."""
     with ConcurrencyGroupExecutor(mngr_ctx.concurrency_group, name="launch-agent", max_workers=1) as executor:
         future = executor.submit(
-            launch_test_agent, test_node_id, agent_name, branch_name, config, mngr_ctx, pytest_flags, prompt_suffix
+            _launch_test_agent, test_node_id, agent_name, branch_name, config, mngr_ctx, pytest_flags, prompt_suffix
         )
         return future.result(timeout=_AGENT_CREATION_TIMEOUT_SECONDS)
 
@@ -449,9 +449,9 @@ def launch_agents_up_to_limit(
     """
     while remaining_tests and (max_agents <= 0 or len(pending_ids) < max_agents):
         test_node_id = remaining_tests.pop(0)
-        agent_name, branch_name = make_test_agent_identity(test_node_id)
+        agent_name, branch_name = _make_test_agent_identity(test_node_id)
         try:
-            info, host = launch_with_timeout(
+            info, host = _launch_with_timeout(
                 test_node_id, agent_name, branch_name, config, mngr_ctx, pytest_flags, prompt_suffix
             )
         except TimeoutError:

--- a/libs/mngr_tmr/imbue/mngr_tmr/mngr_cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/mngr_cli.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.subprocess_utils import FinishedProcess
 from imbue.mngr.api.list import ListResult
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import AgentDetails
 
@@ -80,7 +81,7 @@ def _parse_list_json(raw_json: str) -> ListResult:
     return ListResult(agents=agents)
 
 
-def list_agents(
+def _list_agents(
     cg: ConcurrencyGroup,
     timeout: float = _LIST_AGENTS_TIMEOUT_SECONDS,
 ) -> ListResult:
@@ -102,3 +103,12 @@ def list_agents(
             )
         )
     return ListResult()
+
+
+def try_list_agents(mngr_ctx: MngrContext) -> ListResult | None:
+    """Call ``mngr list`` and return None on failure or timeout."""
+    try:
+        return _list_agents(mngr_ctx.concurrency_group)
+    except (CliError, OSError) as exc:
+        logger.warning("mngr list failed: {}", exc)
+        return None

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -1,7 +1,9 @@
 """Polling and result-collection orchestration for the test-mapreduce plugin.
 
-Drives the main map-reduce loop: poll launched agents, finalize them when
-they finish, and assemble per-test result records for the report.
+Drives the main map-reduce loop: poll each launched agent's volume for the
+outputs archive, pull when it appears, and assemble per-test result records
+for the report. The polling cadence is the existence check on the agent's
+``outputs.tar.gz`` -- we never call ``mngr list``.
 """
 
 import time
@@ -11,38 +13,18 @@ from pathlib import Path
 from loguru import logger
 
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
-from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import launch_agents_up_to_limit
 from imbue.mngr_tmr.launching import stop_agent_on_host
-from imbue.mngr_tmr.mngr_cli import try_list_agents
 from imbue.mngr_tmr.pulling import finalize_agent
 from imbue.mngr_tmr.pulling import is_agent_outputs_ready
-from imbue.mngr_tmr.pulling import try_read_integrator_outcome
+from imbue.mngr_tmr.pulling import is_integrator_outputs_ready
 from imbue.mngr_tmr.report import generate_html_report
-
-_TERMINAL_STATES = frozenset(
-    {
-        AgentLifecycleState.DONE,
-        AgentLifecycleState.STOPPED,
-        AgentLifecycleState.WAITING,
-    }
-)
-
-_MISSING_AGENT_MAX_ROUNDS = 30
-
-# How many poll cycles we wait for the outputs archive to become visible
-# on the agent's volume after the agent reaches a terminal lifecycle state.
-# Volumes (notably Modal) propagate writes asynchronously, so we give the
-# orchestrator's view a chance to catch up before declaring the agent
-# failed. At the default 10s poll cadence this is ~2 minutes.
-_TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS = 12
 
 
 def launch_and_poll_agents(
@@ -54,14 +36,13 @@ def launch_and_poll_agents(
     max_agents: int,
     agent_timeout_seconds: float,
     poll_interval_seconds: float,
-    result_check_interval_seconds: float,
     report_path: Path | None,
     all_agents: list[TestAgentInfo],
     all_hosts: dict[str, OnlineHostInterface],
     launch_failures: list[TestMapReduceResult],
     artifact_output_dir: Path | None = None,
     source_dir: Path | None = None,
-) -> tuple[dict[str, AgentDetails], set[str], dict[str, TestResult]]:
+) -> tuple[set[str], dict[str, TestResult]]:
     """Launch agents incrementally and poll until all finish.
 
     Handles two modes depending on arguments:
@@ -75,23 +56,16 @@ def launch_and_poll_agents(
     pre-existing entries are tracked from the start, and newly launched
     agents (or new launch failures) are appended during execution.
 
-    Returns (final_details, timed_out_ids, cached_results).
+    Returns (timed_out_ids, cached_results).
     """
     remaining_tests = list(test_node_ids)
     pending_ids: set[str] = set()
     agent_id_to_info: dict[str, TestAgentInfo] = {}
-    final_details: dict[str, AgentDetails] = {}
     timed_out_ids: set[str] = set()
-    missing_rounds: dict[str, int] = {}
     cached_results: dict[str, TestResult] = {}
-    last_result_check: dict[str, float] = {}
-    terminal_without_outputs_rounds: dict[str, int] = {}
 
     for info in all_agents:
-        agent_id_str = str(info.agent_id)
-        agent_id_to_info[agent_id_str] = info
-        pending_ids.add(agent_id_str)
-        last_result_check[agent_id_str] = info.created_at
+        pending_ids.add(str(info.agent_id))
 
     launch_kwargs: dict = {
         "remaining_tests": remaining_tests,
@@ -108,49 +82,60 @@ def launch_and_poll_agents(
     }
 
     launch_agents_up_to_limit(**launch_kwargs)
-    for aid in pending_ids:
-        if aid not in last_result_check:
-            last_result_check[aid] = agent_id_to_info[aid].created_at
 
     if report_path is not None:
-        current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
+        current_results = _build_current_results(all_agents, timed_out_ids, launch_failures)
         generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
     while pending_ids or remaining_tests:
         now = time.monotonic()
-        timed_out_this_round = False
+        changed = False
+
         for agent_id_str in list(pending_ids):
             info = agent_id_to_info[agent_id_str]
+            host = all_hosts[agent_id_str]
+            agent_id = AgentId(agent_id_str)
+
+            if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, agent_id):
+                logger.info("Agent '{}' published outputs, finalizing", info.agent_name)
+                pre_read = finalize_agent(
+                    mngr_ctx=mngr_ctx,
+                    provider_name=config.provider_name,
+                    host=host,
+                    agent_id=agent_id,
+                    agent_name=info.agent_name,
+                    branch_name=info.branch_name,
+                    artifact_output_dir=artifact_output_dir,
+                    source_dir=source_dir,
+                    cg=mngr_ctx.concurrency_group,
+                    should_stop=True,
+                )
+                if pre_read is not None:
+                    cached_results[agent_id_str] = pre_read
+                pending_ids.discard(agent_id_str)
+                changed = True
+                continue
+
             elapsed = now - info.created_at
             if elapsed >= agent_timeout_seconds:
-                host = all_hosts[agent_id_str]
-                if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, AgentId(agent_id_str)):
-                    logger.info(
-                        "Agent '{}' has outputs archive (found before timeout stop), treating as done",
-                        info.agent_name,
-                    )
-                    pending_ids.discard(agent_id_str)
-                    continue
-                logger.warning("Agent '{}' timed out after {:.0f}s, stopping", info.agent_name, elapsed)
-                stop_agent_on_host(host, AgentId(agent_id_str), info.agent_name)
+                logger.warning(
+                    "Agent '{}' timed out after {:.0f}s without publishing outputs, stopping",
+                    info.agent_name,
+                    elapsed,
+                )
+                stop_agent_on_host(host, agent_id, info.agent_name)
                 pending_ids.discard(agent_id_str)
                 timed_out_ids.add(agent_id_str)
-                timed_out_this_round = True
+                changed = True
 
         launch_agents_up_to_limit(**launch_kwargs)
-        for aid in pending_ids:
-            if aid not in last_result_check:
-                last_result_check[aid] = agent_id_to_info[aid].created_at
 
-        if timed_out_this_round and report_path is not None:
-            current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
+        if changed and report_path is not None:
+            current_results = _build_current_results(all_agents, timed_out_ids, launch_failures)
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
         if not pending_ids and not remaining_tests:
             break
-
-        if not pending_ids:
-            continue
 
         pending_names = [agent_id_to_info[aid].agent_name for aid in pending_ids]
         queued_msg = f", {len(remaining_tests)} queued" if remaining_tests else ""
@@ -160,134 +145,24 @@ def launch_and_poll_agents(
             queued_msg,
             ", ".join(str(n) for n in pending_names),
         )
-        list_result = try_list_agents(mngr_ctx)
-        if list_result is None:
-            time.sleep(poll_interval_seconds)
-            continue
+        time.sleep(poll_interval_seconds)
 
-        seen_ids: set[str] = set()
-        changed = False
-        for agent_detail in list_result.agents:
-            agent_id_str = str(agent_detail.id)
-            seen_ids.add(agent_id_str)
-            if agent_id_str not in pending_ids:
-                continue
-            if agent_detail.state not in _TERMINAL_STATES:
-                continue
-
-            host = all_hosts[agent_id_str]
-            archive_ready = is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, agent_detail.id)
-            if not archive_ready:
-                # The agent's lifecycle says it's done but the outputs archive
-                # is not visible on the volume yet -- typically a volume
-                # propagation delay. Keep it pending and try again next cycle.
-                # Give up after a grace window so a genuinely-crashed agent
-                # doesn't keep the run from finishing.
-                rounds = terminal_without_outputs_rounds.get(agent_id_str, 0) + 1
-                terminal_without_outputs_rounds[agent_id_str] = rounds
-                if rounds < _TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS:
-                    logger.info(
-                        "Agent '{}' in state {} but outputs not yet visible (round {}/{})",
-                        agent_detail.name,
-                        agent_detail.state,
-                        rounds,
-                        _TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS,
-                    )
-                    continue
-                logger.warning(
-                    "Agent '{}' has been in state {} for {} rounds without publishing outputs; giving up",
-                    agent_detail.name,
-                    agent_detail.state,
-                    rounds,
-                )
-
-            logger.info("Agent '{}' finished (state={})", agent_detail.name, agent_detail.state)
-            final_details[agent_id_str] = agent_detail
-            pending_ids.discard(agent_id_str)
-            missing_rounds.pop(agent_id_str, None)
-            terminal_without_outputs_rounds.pop(agent_id_str, None)
-            changed = True
-
-            pre_read = finalize_agent(
-                mngr_ctx=mngr_ctx,
-                provider_name=config.provider_name,
-                host=host,
-                agent_id=agent_detail.id,
-                agent_name=agent_detail.name,
-                branch_name=agent_detail.initial_branch,
-                artifact_output_dir=artifact_output_dir,
-                source_dir=source_dir,
-                cg=mngr_ctx.concurrency_group,
-                should_stop=agent_detail.state == AgentLifecycleState.WAITING,
-            )
-            if pre_read is not None:
-                cached_results[agent_id_str] = pre_read
-
-        for agent_id_str in list(pending_ids):
-            if agent_id_str not in seen_ids:
-                rounds = missing_rounds.get(agent_id_str, 0) + 1
-                missing_rounds[agent_id_str] = rounds
-                if rounds >= _MISSING_AGENT_MAX_ROUNDS:
-                    logger.warning("Agent {} disappeared after {} rounds, treating as error", agent_id_str, rounds)
-                    pending_ids.discard(agent_id_str)
-                    changed = True
-
-        launch_agents_up_to_limit(**launch_kwargs)
-        for aid in pending_ids:
-            if aid not in last_result_check:
-                last_result_check[aid] = agent_id_to_info[aid].created_at
-
-        for agent_id_str in list(pending_ids):
-            if now - last_result_check[agent_id_str] >= result_check_interval_seconds:
-                last_result_check[agent_id_str] = now
-                info = agent_id_to_info[agent_id_str]
-                host = all_hosts[agent_id_str]
-                if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, AgentId(agent_id_str)):
-                    logger.info(
-                        "Agent '{}' has outputs archive (detected via direct check), treating as done",
-                        info.agent_name,
-                    )
-                    pre_read = finalize_agent(
-                        mngr_ctx=mngr_ctx,
-                        provider_name=config.provider_name,
-                        host=host,
-                        agent_id=AgentId(agent_id_str),
-                        agent_name=info.agent_name,
-                        branch_name=info.branch_name,
-                        artifact_output_dir=artifact_output_dir,
-                        source_dir=source_dir,
-                        cg=mngr_ctx.concurrency_group,
-                        should_stop=True,
-                    )
-                    if pre_read is not None:
-                        cached_results[agent_id_str] = pre_read
-                    pending_ids.discard(agent_id_str)
-                    changed = True
-
-        if (changed or timed_out_this_round) and report_path is not None:
-            current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
-            generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
-
-        if pending_ids or remaining_tests:
-            time.sleep(poll_interval_seconds)
-
-    return final_details, timed_out_ids, cached_results
+    return timed_out_ids, cached_results
 
 
 def _collect_agent_results(
     agents: list[TestAgentInfo],
-    final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
-    missing_detail_errored: bool,
-    missing_detail_summary: str,
+    missing_summary: str,
     cached_results: dict[str, TestResult] | None = None,
 ) -> list[TestMapReduceResult]:
     """Shared iteration over agents to build result list.
 
     Relies entirely on ``cached_results``: an agent that finished writes its
     outcome into the outputs archive, which is downloaded and parsed during
-    finalization. An agent with no cached result either is still running
-    (intermediate report) or failed to publish (final report).
+    finalization. An agent with no cached result and not in ``timed_out_ids``
+    has not produced outputs yet (intermediate report) or failed to do so
+    before polling stopped (final report).
     """
     cached_results = cached_results or {}
     results: list[TestMapReduceResult] = []
@@ -306,35 +181,7 @@ def _collect_agent_results(
             )
             continue
 
-        detail = final_details.get(agent_id_str)
         test_result = cached_results.get(agent_id_str)
-
-        if detail is None:
-            if test_result is not None:
-                results.append(
-                    TestMapReduceResult(
-                        test_node_id=agent_info.test_node_id,
-                        agent_name=agent_info.agent_name,
-                        changes=test_result.changes,
-                        errored=test_result.errored,
-                        tests_passing_before=test_result.tests_passing_before,
-                        tests_passing_after=test_result.tests_passing_after,
-                        summary_markdown=test_result.summary_markdown,
-                        branch_name=agent_info.branch_name,
-                        test_runs=test_result.test_runs,
-                    )
-                )
-                continue
-            results.append(
-                TestMapReduceResult(
-                    test_node_id=agent_info.test_node_id,
-                    agent_name=agent_info.agent_name,
-                    errored=missing_detail_errored,
-                    summary_markdown=missing_detail_summary,
-                )
-            )
-            continue
-
         if test_result is not None:
             results.append(
                 TestMapReduceResult(
@@ -345,27 +192,26 @@ def _collect_agent_results(
                     tests_passing_before=test_result.tests_passing_before,
                     tests_passing_after=test_result.tests_passing_after,
                     summary_markdown=test_result.summary_markdown,
-                    branch_name=detail.initial_branch or agent_info.branch_name,
+                    branch_name=agent_info.branch_name,
                     test_runs=test_result.test_runs,
                 )
             )
-        else:
-            results.append(
-                TestMapReduceResult(
-                    test_node_id=agent_info.test_node_id,
-                    agent_name=agent_info.agent_name,
-                    errored=True,
-                    summary_markdown="Failed to read agent result",
-                    branch_name=detail.initial_branch or agent_info.branch_name,
-                )
+            continue
+
+        results.append(
+            TestMapReduceResult(
+                test_node_id=agent_info.test_node_id,
+                agent_name=agent_info.agent_name,
+                errored=False,
+                summary_markdown=missing_summary,
             )
+        )
 
     return results
 
 
 def gather_results(
     agents: list[TestAgentInfo],
-    final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
     cached_results: dict[str, TestResult] | None = None,
     launch_failures: Sequence[TestMapReduceResult] = (),
@@ -379,10 +225,8 @@ def gather_results(
     """
     results = _collect_agent_results(
         agents=agents,
-        final_details=final_details,
         timed_out_ids=timed_out_ids,
-        missing_detail_errored=True,
-        missing_detail_summary="Agent details not found after polling",
+        missing_summary="Agent never published outputs",
         cached_results=cached_results,
     )
 
@@ -391,9 +235,9 @@ def gather_results(
 
 def _build_current_results(
     agents: list[TestAgentInfo],
-    final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
     launch_failures: Sequence[TestMapReduceResult] = (),
+    cached_results: dict[str, TestResult] | None = None,
 ) -> list[TestMapReduceResult]:
     """Build current results without pulling branches, for intermediate reports.
 
@@ -404,48 +248,27 @@ def _build_current_results(
         *launch_failures,
         *_collect_agent_results(
             agents=agents,
-            final_details=final_details,
             timed_out_ids=timed_out_ids,
-            missing_detail_errored=False,
-            missing_detail_summary="Agent is still running...",
+            missing_summary="Agent is still running...",
+            cached_results=cached_results,
         ),
     ]
 
 
 def wait_for_integrator(
     integrator: TestAgentInfo,
-    mngr_ctx: MngrContext,
     poll_interval_seconds: float,
     host: OnlineHostInterface,
     deadline: float,
 ) -> str | None:
-    """Poll the integrator agent until it finishes or times out."""
-    agent_id_str = str(integrator.agent_id)
-
+    """Poll for the integrator agent's outcome file and stop it once visible."""
     while time.monotonic() < deadline:
-        list_result = try_list_agents(mngr_ctx)
-        if list_result is None:
-            time.sleep(poll_interval_seconds)
-            continue
-
-        for agent_detail in list_result.agents:
-            if str(agent_detail.id) != agent_id_str:
-                continue
-
-            if agent_detail.state == AgentLifecycleState.WAITING:
-                stop_agent_on_host(host, agent_detail.id, agent_detail.name)
-                return agent_detail.initial_branch
-
-            if agent_detail.state in _TERMINAL_STATES:
-                logger.info("Integrator agent finished (state={})", agent_detail.state)
-                return agent_detail.initial_branch
-
-        if try_read_integrator_outcome(integrator.work_dir, host):
-            logger.info("Integrator outcome file detected, treating as done")
+        if is_integrator_outputs_ready(integrator.work_dir, host):
+            logger.info("Integrator outcome file detected, stopping agent")
+            stop_agent_on_host(host, integrator.agent_id, integrator.agent_name)
             return integrator.branch_name
-
         time.sleep(poll_interval_seconds)
 
     logger.warning("Integrator agent timed out, stopping it")
-    stop_agent_on_host(host, AgentId(agent_id_str), integrator.agent_name)
+    stop_agent_on_host(host, integrator.agent_id, integrator.agent_name)
     return None

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -1,13 +1,14 @@
-"""Polling and result-collection orchestration for the test-mapreduce plugin.
+"""Polling orchestration for the test-mapreduce plugin.
 
 Drives the main map-reduce loop: poll each launched agent's volume for the
-outputs archive, pull when it appears, and assemble per-test result records
-for the report. The polling cadence is the existence check on the agent's
-``outputs.tar.gz`` -- we never call ``mngr list``.
+outputs archive, pull when it appears, and hand a list of ``AgentMetadata``
+back to the caller. The polling cadence is the existence check on the
+agent's ``outputs.tar.gz`` -- we never call ``mngr list``. Outcome JSON
+parsing is the reporter's responsibility; this module treats extracted
+contents as opaque.
 """
 
 import time
-from collections.abc import Sequence
 from pathlib import Path
 
 from loguru import logger
@@ -15,9 +16,9 @@ from loguru import logger
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import TestAgentInfo
-from imbue.mngr_tmr.data_types import TestMapReduceResult
-from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import launch_agents_up_to_limit
 from imbue.mngr_tmr.launching import stop_agent_on_host
@@ -25,6 +26,33 @@ from imbue.mngr_tmr.pulling import finalize_agent
 from imbue.mngr_tmr.pulling import is_agent_outputs_ready
 from imbue.mngr_tmr.pulling import is_integrator_outputs_ready
 from imbue.mngr_tmr.report import generate_html_report
+
+
+def _metadata_for(info: TestAgentInfo, error_summary: str | None = None) -> AgentMetadata:
+    return AgentMetadata(
+        kind=AgentKind.TESTING_AGENT,
+        agent_name=info.agent_name,
+        test_node_id=info.test_node_id,
+        branch_name=info.branch_name,
+        error_summary=error_summary,
+    )
+
+
+def _emit_report(
+    output_dir: Path | None,
+    all_agents: list[TestAgentInfo],
+    timed_out_ids: set[str],
+    launch_failures: list[AgentMetadata],
+) -> None:
+    if output_dir is None:
+        return
+    metadata: list[AgentMetadata] = list(launch_failures)
+    for info in all_agents:
+        if str(info.agent_id) in timed_out_ids:
+            metadata.append(_metadata_for(info, error_summary="Agent was stopped because the timeout was reached."))
+        else:
+            metadata.append(_metadata_for(info))
+    generate_html_report(metadata, output_dir)
 
 
 def launch_and_poll_agents(
@@ -36,13 +64,12 @@ def launch_and_poll_agents(
     max_agents: int,
     agent_timeout_seconds: float,
     poll_interval_seconds: float,
-    report_path: Path | None,
+    output_dir: Path | None,
     all_agents: list[TestAgentInfo],
     all_hosts: dict[str, OnlineHostInterface],
-    launch_failures: list[TestMapReduceResult],
-    artifact_output_dir: Path | None = None,
+    launch_failures: list[AgentMetadata],
     source_dir: Path | None = None,
-) -> tuple[set[str], dict[str, TestResult]]:
+) -> list[AgentMetadata]:
     """Launch agents incrementally and poll until all finish.
 
     Handles two modes depending on arguments:
@@ -52,17 +79,19 @@ def launch_and_poll_agents(
     2. Pre-launched polling (test_node_ids empty, all_agents pre-populated):
        polls the already-launched agents without launching any new ones.
 
-    all_agents, all_hosts, and launch_failures are input/output parameters:
-    pre-existing entries are tracked from the start, and newly launched
-    agents (or new launch failures) are appended during execution.
+    ``all_agents``, ``all_hosts``, and ``launch_failures`` are input/output
+    parameters: pre-existing entries are tracked from the start, and newly
+    launched agents (or new launch failures) are appended during execution.
+    Intermediate reports are written to ``output_dir/index.html`` when
+    ``output_dir`` is set.
 
-    Returns (timed_out_ids, cached_results).
+    Returns the final list of ``AgentMetadata`` (launch failures first, then
+    one entry per launched agent).
     """
     remaining_tests = list(test_node_ids)
     pending_ids: set[str] = set()
     agent_id_to_info: dict[str, TestAgentInfo] = {}
     timed_out_ids: set[str] = set()
-    cached_results: dict[str, TestResult] = {}
 
     for info in all_agents:
         agent_id_str = str(info.agent_id)
@@ -84,10 +113,7 @@ def launch_and_poll_agents(
     }
 
     launch_agents_up_to_limit(**launch_kwargs)
-
-    if report_path is not None:
-        current_results = _build_current_results(all_agents, timed_out_ids, launch_failures)
-        generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
+    _emit_report(output_dir, all_agents, timed_out_ids, launch_failures)
 
     while pending_ids or remaining_tests:
         now = time.monotonic()
@@ -100,20 +126,18 @@ def launch_and_poll_agents(
 
             if is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, agent_id):
                 logger.info("Agent '{}' published outputs, finalizing", info.agent_name)
-                pre_read = finalize_agent(
+                finalize_agent(
                     mngr_ctx=mngr_ctx,
                     provider_name=config.provider_name,
                     host=host,
                     agent_id=agent_id,
                     agent_name=info.agent_name,
                     branch_name=info.branch_name,
-                    artifact_output_dir=artifact_output_dir,
+                    artifact_output_dir=output_dir,
                     source_dir=source_dir,
                     cg=mngr_ctx.concurrency_group,
                     should_stop=True,
                 )
-                if pre_read is not None:
-                    cached_results[agent_id_str] = pre_read
                 pending_ids.discard(agent_id_str)
                 changed = True
                 continue
@@ -132,9 +156,8 @@ def launch_and_poll_agents(
 
         launch_agents_up_to_limit(**launch_kwargs)
 
-        if changed and report_path is not None:
-            current_results = _build_current_results(all_agents, timed_out_ids, launch_failures)
-            generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
+        if changed:
+            _emit_report(output_dir, all_agents, timed_out_ids, launch_failures)
 
         if not pending_ids and not remaining_tests:
             break
@@ -149,110 +172,18 @@ def launch_and_poll_agents(
         )
         time.sleep(poll_interval_seconds)
 
-    return timed_out_ids, cached_results
-
-
-def _collect_agent_results(
-    agents: list[TestAgentInfo],
-    timed_out_ids: set[str],
-    missing_summary: str,
-    cached_results: dict[str, TestResult] | None = None,
-) -> list[TestMapReduceResult]:
-    """Shared iteration over agents to build result list.
-
-    Relies entirely on ``cached_results``: an agent that finished writes its
-    outcome into the outputs archive, which is downloaded and parsed during
-    finalization. An agent with no cached result and not in ``timed_out_ids``
-    has not produced outputs yet (intermediate report) or failed to do so
-    before polling stopped (final report).
-    """
-    cached_results = cached_results or {}
-    results: list[TestMapReduceResult] = []
-
-    for agent_info in agents:
-        agent_id_str = str(agent_info.agent_id)
-
-        if agent_id_str in timed_out_ids:
-            results.append(
-                TestMapReduceResult(
-                    test_node_id=agent_info.test_node_id,
-                    agent_name=agent_info.agent_name,
-                    errored=True,
-                    summary_markdown="Agent was stopped because the timeout was reached.",
-                )
-            )
-            continue
-
-        test_result = cached_results.get(agent_id_str)
-        if test_result is not None:
-            results.append(
-                TestMapReduceResult(
-                    test_node_id=agent_info.test_node_id,
-                    agent_name=agent_info.agent_name,
-                    changes=test_result.changes,
-                    errored=test_result.errored,
-                    tests_passing_before=test_result.tests_passing_before,
-                    tests_passing_after=test_result.tests_passing_after,
-                    summary_markdown=test_result.summary_markdown,
-                    branch_name=agent_info.branch_name,
-                    test_runs=test_result.test_runs,
-                )
-            )
-            continue
-
-        results.append(
-            TestMapReduceResult(
-                test_node_id=agent_info.test_node_id,
-                agent_name=agent_info.agent_name,
-                errored=False,
-                summary_markdown=missing_summary,
-            )
-        )
-
-    return results
-
-
-def gather_results(
-    agents: list[TestAgentInfo],
-    timed_out_ids: set[str],
-    cached_results: dict[str, TestResult] | None = None,
-    launch_failures: Sequence[TestMapReduceResult] = (),
-) -> list[TestMapReduceResult]:
-    """Gather results from all finished agents.
-
-    Branches were already applied via each agent's bundle during the per-agent
-    pull step, so this function just assembles the per-agent result records.
-    ``launch_failures`` are prepended so agents that failed to launch still
-    appear in the report.
-    """
-    results = _collect_agent_results(
-        agents=agents,
-        timed_out_ids=timed_out_ids,
-        missing_summary="Agent never published outputs",
-        cached_results=cached_results,
-    )
-
-    return [*launch_failures, *results]
-
-
-def _build_current_results(
-    agents: list[TestAgentInfo],
-    timed_out_ids: set[str],
-    launch_failures: Sequence[TestMapReduceResult] = (),
-    cached_results: dict[str, TestResult] | None = None,
-) -> list[TestMapReduceResult]:
-    """Build current results without pulling branches, for intermediate reports.
-
-    ``launch_failures`` are prepended so agents that failed to launch still
-    appear in the report.
-    """
     return [
         *launch_failures,
-        *_collect_agent_results(
-            agents=agents,
-            timed_out_ids=timed_out_ids,
-            missing_summary="Agent is still running...",
-            cached_results=cached_results,
+        *(
+            _metadata_for(
+                info,
+                error_summary=(
+                    "Agent was stopped because the timeout was reached."
+                    if str(info.agent_id) in timed_out_ids
+                    else None
+                ),
+            )
+            for info in all_agents
         ),
     ]
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -65,7 +65,9 @@ def launch_and_poll_agents(
     cached_results: dict[str, TestResult] = {}
 
     for info in all_agents:
-        pending_ids.add(str(info.agent_id))
+        agent_id_str = str(info.agent_id)
+        agent_id_to_info[agent_id_str] = info
+        pending_ids.add(agent_id_str)
 
     launch_kwargs: dict = {
         "remaining_tests": remaining_tests,

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -105,7 +105,7 @@ def launch_and_poll_agents(
             last_result_check[aid] = agent_id_to_info[aid].created_at
 
     if report_path is not None:
-        current_results = _build_current_results(all_agents, final_details, timed_out_ids, all_hosts, launch_failures)
+        current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
         generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
     while pending_ids or remaining_tests:
@@ -135,9 +135,7 @@ def launch_and_poll_agents(
                 last_result_check[aid] = agent_id_to_info[aid].created_at
 
         if timed_out_this_round and report_path is not None:
-            current_results = _build_current_results(
-                all_agents, final_details, timed_out_ids, all_hosts, launch_failures
-            )
+            current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
         if not pending_ids and not remaining_tests:
@@ -232,9 +230,7 @@ def launch_and_poll_agents(
                     changed = True
 
         if (changed or timed_out_this_round) and report_path is not None:
-            current_results = _build_current_results(
-                all_agents, final_details, timed_out_ids, all_hosts, launch_failures
-            )
+            current_results = _build_current_results(all_agents, final_details, timed_out_ids, launch_failures)
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
         if pending_ids or remaining_tests:
@@ -247,7 +243,6 @@ def _collect_agent_results(
     agents: list[TestAgentInfo],
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
-    hosts: dict[str, OnlineHostInterface],
     missing_detail_errored: bool,
     missing_detail_summary: str,
     cached_results: dict[str, TestResult] | None = None,
@@ -337,7 +332,6 @@ def gather_results(
     agents: list[TestAgentInfo],
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
-    hosts: dict[str, OnlineHostInterface],
     cached_results: dict[str, TestResult] | None = None,
     launch_failures: Sequence[TestMapReduceResult] = (),
 ) -> list[TestMapReduceResult]:
@@ -352,7 +346,6 @@ def gather_results(
         agents=agents,
         final_details=final_details,
         timed_out_ids=timed_out_ids,
-        hosts=hosts,
         missing_detail_errored=True,
         missing_detail_summary="Agent details not found after polling",
         cached_results=cached_results,
@@ -365,7 +358,6 @@ def _build_current_results(
     agents: list[TestAgentInfo],
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],
-    hosts: dict[str, OnlineHostInterface],
     launch_failures: Sequence[TestMapReduceResult] = (),
 ) -> list[TestMapReduceResult]:
     """Build current results without pulling branches, for intermediate reports.
@@ -379,7 +371,6 @@ def _build_current_results(
             agents=agents,
             final_details=final_details,
             timed_out_ids=timed_out_ids,
-            hosts=hosts,
             missing_detail_errored=False,
             missing_detail_summary="Agent is still running...",
         ),

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -37,6 +37,13 @@ _TERMINAL_STATES = frozenset(
 
 _MISSING_AGENT_MAX_ROUNDS = 30
 
+# How many poll cycles we wait for the outputs archive to become visible
+# on the agent's volume after the agent reaches a terminal lifecycle state.
+# Volumes (notably Modal) propagate writes asynchronously, so we give the
+# orchestrator's view a chance to catch up before declaring the agent
+# failed. At the default 10s poll cadence this is ~2 minutes.
+_TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS = 12
+
 
 def launch_and_poll_agents(
     test_node_ids: list[str],
@@ -78,6 +85,7 @@ def launch_and_poll_agents(
     missing_rounds: dict[str, int] = {}
     cached_results: dict[str, TestResult] = {}
     last_result_check: dict[str, float] = {}
+    terminal_without_outputs_rounds: dict[str, int] = {}
 
     for info in all_agents:
         agent_id_str = str(info.agent_id)
@@ -167,16 +175,43 @@ def launch_and_poll_agents(
             if agent_detail.state not in _TERMINAL_STATES:
                 continue
 
+            host = all_hosts[agent_id_str]
+            archive_ready = is_agent_outputs_ready(mngr_ctx, config.provider_name, host.id, agent_detail.id)
+            if not archive_ready:
+                # The agent's lifecycle says it's done but the outputs archive
+                # is not visible on the volume yet -- typically a volume
+                # propagation delay. Keep it pending and try again next cycle.
+                # Give up after a grace window so a genuinely-crashed agent
+                # doesn't keep the run from finishing.
+                rounds = terminal_without_outputs_rounds.get(agent_id_str, 0) + 1
+                terminal_without_outputs_rounds[agent_id_str] = rounds
+                if rounds < _TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS:
+                    logger.info(
+                        "Agent '{}' in state {} but outputs not yet visible (round {}/{})",
+                        agent_detail.name,
+                        agent_detail.state,
+                        rounds,
+                        _TERMINAL_WITHOUT_OUTPUTS_MAX_ROUNDS,
+                    )
+                    continue
+                logger.warning(
+                    "Agent '{}' has been in state {} for {} rounds without publishing outputs; giving up",
+                    agent_detail.name,
+                    agent_detail.state,
+                    rounds,
+                )
+
             logger.info("Agent '{}' finished (state={})", agent_detail.name, agent_detail.state)
             final_details[agent_id_str] = agent_detail
             pending_ids.discard(agent_id_str)
             missing_rounds.pop(agent_id_str, None)
+            terminal_without_outputs_rounds.pop(agent_id_str, None)
             changed = True
 
             pre_read = finalize_agent(
                 mngr_ctx=mngr_ctx,
                 provider_name=config.provider_name,
-                host=all_hosts[agent_id_str],
+                host=host,
                 agent_id=agent_detail.id,
                 agent_name=agent_detail.name,
                 branch_name=agent_detail.initial_branch,

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration.py
@@ -1,12 +1,7 @@
-"""Core orchestration for the test-mapreduce plugin.
+"""Polling and result-collection orchestration for the test-mapreduce plugin.
 
-Implements the map-reduce pattern: collect tests via pytest, launch an agent per
-test, poll for completion, gather results, and pull code changes.
-
-Sub-modules:
-- utils: shared helpers (FD diagnostics, template resolution, test collection)
-- launching: agent/host creation and launching
-- pulling: result/artifact pulling and branch management
+Drives the main map-reduce loop: poll launched agents, finalize them when
+they finish, and assemble per-test result records for the report.
 """
 
 import time
@@ -15,39 +10,22 @@ from pathlib import Path
 
 from loguru import logger
 
-from imbue.mngr.api.list import ListResult
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentLifecycleState
-from imbue.mngr_tmr.data_types import Change
-from imbue.mngr_tmr.data_types import ChangeKind
-from imbue.mngr_tmr.data_types import ChangeStatus
 from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import launch_agents_up_to_limit
-
-# Re-export public API used by cli.py and tests
-from imbue.mngr_tmr.launching import launch_all_test_agents as launch_all_test_agents
-from imbue.mngr_tmr.launching import launch_integrator_agent as launch_integrator_agent
-from imbue.mngr_tmr.launching import launch_test_agent as launch_test_agent
 from imbue.mngr_tmr.launching import stop_agent_on_host
-from imbue.mngr_tmr.mngr_cli import CliError
-from imbue.mngr_tmr.mngr_cli import list_agents as cli_list_agents
+from imbue.mngr_tmr.mngr_cli import try_list_agents
 from imbue.mngr_tmr.pulling import finalize_agent
 from imbue.mngr_tmr.pulling import is_agent_outputs_ready
-from imbue.mngr_tmr.pulling import pull_agent_branch as pull_agent_branch
-from imbue.mngr_tmr.pulling import pull_agent_outputs as pull_agent_outputs
-from imbue.mngr_tmr.pulling import read_integrator_result as read_integrator_result
 from imbue.mngr_tmr.pulling import try_read_integrator_outcome
 from imbue.mngr_tmr.report import generate_html_report
-from imbue.mngr_tmr.utils import CollectTestsError as CollectTestsError
-from imbue.mngr_tmr.utils import collect_tests as collect_tests
-from imbue.mngr_tmr.utils import get_base_commit as get_base_commit
-from imbue.mngr_tmr.utils import resolve_templates as resolve_templates
 
 _TERMINAL_STATES = frozenset(
     {
@@ -58,40 +36,6 @@ _TERMINAL_STATES = frozenset(
 )
 
 _MISSING_AGENT_MAX_ROUNDS = 30
-
-
-def try_list_agents(mngr_ctx: MngrContext) -> ListResult | None:
-    """List agents via the ``mngr list`` CLI, returning None on failure or timeout."""
-    try:
-        return cli_list_agents(mngr_ctx.concurrency_group)
-    except (CliError, OSError) as exc:
-        logger.warning("mngr list failed: {}", exc)
-        return None
-
-
-def _should_pull(
-    errored: bool,
-    changes: dict[ChangeKind, Change],
-    tests_passing_before: bool | None,
-    tests_passing_after: bool | None,
-) -> bool:
-    """Core logic: should we pull an agent's changes?
-
-    Pull when: not errored, at least one succeeded change, and tests are at
-    least as good as before (if they were passing, they must still be passing).
-    """
-    if errored:
-        return False
-    if not any(c.status == ChangeStatus.SUCCEEDED for c in changes.values()):
-        return False
-    if tests_passing_before is True and tests_passing_after is not True:
-        return False
-    return True
-
-
-def should_pull_changes(result: TestMapReduceResult) -> bool:
-    """Determine whether an agent's changes should be pulled (from a TestMapReduceResult)."""
-    return _should_pull(result.errored, result.changes, result.tests_passing_before, result.tests_passing_after)
 
 
 def launch_and_poll_agents(
@@ -161,7 +105,7 @@ def launch_and_poll_agents(
             last_result_check[aid] = agent_id_to_info[aid].created_at
 
     if report_path is not None:
-        current_results = build_current_results(all_agents, final_details, timed_out_ids, all_hosts, launch_failures)
+        current_results = _build_current_results(all_agents, final_details, timed_out_ids, all_hosts, launch_failures)
         generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
 
     while pending_ids or remaining_tests:
@@ -191,7 +135,7 @@ def launch_and_poll_agents(
                 last_result_check[aid] = agent_id_to_info[aid].created_at
 
         if timed_out_this_round and report_path is not None:
-            current_results = build_current_results(
+            current_results = _build_current_results(
                 all_agents, final_details, timed_out_ids, all_hosts, launch_failures
             )
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
@@ -288,7 +232,7 @@ def launch_and_poll_agents(
                     changed = True
 
         if (changed or timed_out_this_round) and report_path is not None:
-            current_results = build_current_results(
+            current_results = _build_current_results(
                 all_agents, final_details, timed_out_ids, all_hosts, launch_failures
             )
             generate_html_report(current_results, report_path, test_artifacts_dir=artifact_output_dir)
@@ -417,7 +361,7 @@ def gather_results(
     return [*launch_failures, *results]
 
 
-def build_current_results(
+def _build_current_results(
     agents: list[TestAgentInfo],
     final_details: dict[str, AgentDetails],
     timed_out_ids: set[str],

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
@@ -105,6 +105,7 @@ def _make_config(provider: str = "local", snapshot: SnapshotName | None = None) 
     return TmrLaunchConfig.model_construct(
         source_dir=Path("/tmp/src"),
         source_host=None,
+        base_commit="0" * 40,
         agent_type=AgentTypeName("claude"),
         provider_name=ProviderInstanceName(provider),
         env_options=AgentEnvironmentOptions(),
@@ -147,6 +148,7 @@ def test_build_agent_options_passes_env_and_labels() -> None:
     config_with_env_and_labels = TmrLaunchConfig.model_construct(
         source_dir=config.source_dir,
         source_host=None,
+        base_commit=config.base_commit,
         agent_type=config.agent_type,
         provider_name=config.provider_name,
         env_options=env,

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
@@ -20,11 +20,6 @@ from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import TransferMode
-from imbue.mngr_tmr.api import CollectTestsError
-from imbue.mngr_tmr.api import build_current_results
-from imbue.mngr_tmr.api import collect_tests
-from imbue.mngr_tmr.api import read_integrator_result
-from imbue.mngr_tmr.api import should_pull_changes
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
@@ -32,18 +27,23 @@ from imbue.mngr_tmr.data_types import ReportSection
 from imbue.mngr_tmr.data_types import TestAgentInfo
 from imbue.mngr_tmr.data_types import TestMapReduceResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
-from imbue.mngr_tmr.launching import build_agent_options as _build_agent_options
+from imbue.mngr_tmr.launching import _build_agent_options
+from imbue.mngr_tmr.orchestration import _build_current_results
 from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
-from imbue.mngr_tmr.pulling import read_local_result as _read_local_result
-from imbue.mngr_tmr.report import report_section_of
+from imbue.mngr_tmr.pulling import _read_local_result
+from imbue.mngr_tmr.pulling import read_integrator_result
+from imbue.mngr_tmr.report import _report_section_of
 from imbue.mngr_tmr.testing import BLOCKED_FIX
 from imbue.mngr_tmr.testing import FAILED_FIX
 from imbue.mngr_tmr.testing import SUCCEEDED_FIX
 from imbue.mngr_tmr.testing import make_test_result
+from imbue.mngr_tmr.utils import CollectTestsError
+from imbue.mngr_tmr.utils import collect_tests
 from imbue.mngr_tmr.utils import sanitize_test_name_for_agent
 from imbue.mngr_tmr.utils import short_random_id
+from imbue.mngr_tmr.utils import should_pull_changes
 from imbue.mngr_tmr.utils import transfer_mode_for_provider
 
 
@@ -280,7 +280,7 @@ def test_should_not_pull_improvement_that_breaks_tests() -> None:
     assert should_pull_changes(make_test_result(changes=improved, before=True, after=False)) is False
 
 
-def test_build_current_results_pending_agents() -> None:
+def test__build_current_results_pending_agents() -> None:
     """Agents not in final_details should appear as PENDING."""
     agents = [
         TestAgentInfo(
@@ -298,14 +298,14 @@ def test_build_current_results_pending_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = build_current_results(agents=agents, final_details={}, timed_out_ids=set(), hosts={})
+    results = _build_current_results(agents=agents, final_details={}, timed_out_ids=set(), hosts={})
     assert len(results) == 2
-    assert report_section_of(results[0]) == ReportSection.RUNNING
-    assert report_section_of(results[1]) == ReportSection.RUNNING
+    assert _report_section_of(results[0]) == ReportSection.RUNNING
+    assert _report_section_of(results[1]) == ReportSection.RUNNING
     assert "still running" in results[0].summary_markdown
 
 
-def test_build_current_results_timed_out_agents() -> None:
+def test__build_current_results_timed_out_agents() -> None:
     """Timed-out agents should appear as ERRORED."""
     agent_id = AgentId.generate()
     agents = [
@@ -317,13 +317,13 @@ def test_build_current_results_timed_out_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)}, hosts={})
+    results = _build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)}, hosts={})
     assert len(results) == 1
     assert results[0].errored is True
-    assert report_section_of(results[0]) == ReportSection.FAILED
+    assert _report_section_of(results[0]) == ReportSection.FAILED
 
 
-def test_build_current_results_includes_launch_failures() -> None:
+def test__build_current_results_includes_launch_failures() -> None:
     """Agents that failed to launch should appear in the results as ERRORED."""
     failure = TestMapReduceResult(
         test_node_id="tests/test_a.py::test_one",
@@ -331,7 +331,7 @@ def test_build_current_results_includes_launch_failures() -> None:
         errored=True,
         summary_markdown="Failed to launch agent: boom",
     )
-    results = build_current_results(
+    results = _build_current_results(
         agents=[],
         final_details={},
         timed_out_ids=set(),
@@ -342,10 +342,10 @@ def test_build_current_results_includes_launch_failures() -> None:
     assert results[0].test_node_id == "tests/test_a.py::test_one"
     assert results[0].errored is True
     assert "Failed to launch agent: boom" in results[0].summary_markdown
-    assert report_section_of(results[0]) == ReportSection.FAILED
+    assert _report_section_of(results[0]) == ReportSection.FAILED
 
 
-def test_build_current_results_launch_failures_come_before_running_agents() -> None:
+def test__build_current_results_launch_failures_come_before_running_agents() -> None:
     """Launch failures should be ordered before live-agent results in the report."""
     failure = TestMapReduceResult(
         test_node_id="tests/test_failed.py::test_one",
@@ -360,7 +360,7 @@ def test_build_current_results_launch_failures_come_before_running_agents() -> N
         work_dir=Path("/tmp/work"),
         created_at=0.0,
     )
-    results = build_current_results(
+    results = _build_current_results(
         agents=[agent],
         final_details={},
         timed_out_ids=set(),

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
@@ -8,8 +8,6 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.data_types import EnvVar
 from imbue.mngr.interfaces.host import AgentEnvironmentOptions
 from imbue.mngr.interfaces.host import AgentLabelOptions
-from imbue.mngr.interfaces.host import OnlineHostInterface
-from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import ProviderInstanceName
@@ -18,27 +16,19 @@ from imbue.mngr.primitives import TransferMode
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
-from imbue.mngr_tmr.data_types import ReportSection
-from imbue.mngr_tmr.data_types import TestAgentInfo
-from imbue.mngr_tmr.data_types import TestMapReduceResult
+from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TmrLaunchConfig
 from imbue.mngr_tmr.launching import _build_agent_options
-from imbue.mngr_tmr.orchestration import _build_current_results
-from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
-from imbue.mngr_tmr.pulling import _read_local_result
-from imbue.mngr_tmr.pulling import read_integrator_result
-from imbue.mngr_tmr.report import _report_section_of
 from imbue.mngr_tmr.testing import BLOCKED_FIX
 from imbue.mngr_tmr.testing import FAILED_FIX
 from imbue.mngr_tmr.testing import SUCCEEDED_FIX
-from imbue.mngr_tmr.testing import make_test_result
 from imbue.mngr_tmr.utils import CollectTestsError
 from imbue.mngr_tmr.utils import collect_tests
 from imbue.mngr_tmr.utils import sanitize_test_name_for_agent
 from imbue.mngr_tmr.utils import short_random_id
-from imbue.mngr_tmr.utils import should_pull_changes
+from imbue.mngr_tmr.utils import should_pull_changes_from_outcome
 from imbue.mngr_tmr.utils import transfer_mode_for_provider
 
 
@@ -236,235 +226,56 @@ def test_collect_tests_bad_file_raises(tmp_path: Path, cg: ConcurrencyGroup) -> 
         collect_tests(pytest_args=("non_existent_test_file.py",), source_dir=tmp_path, cg=cg)
 
 
-# --- should_pull_changes tests ---
-# Uses shared helpers from testing: make_test_result, SUCCEEDED_FIX, FAILED_FIX, BLOCKED_FIX
+# --- should_pull_changes_from_outcome tests ---
+
+
+def _outcome(
+    changes: dict[ChangeKind, Change] | None = None,
+    errored: bool = False,
+    before: bool | None = None,
+    after: bool | None = None,
+) -> TestResult:
+    return TestResult(
+        changes=changes if changes is not None else {},
+        errored=errored,
+        tests_passing_before=before,
+        tests_passing_after=after,
+    )
 
 
 def test_should_pull_succeeded_fix_with_tests_passing() -> None:
-    assert should_pull_changes(make_test_result(changes=SUCCEEDED_FIX, before=False, after=True)) is True
+    assert should_pull_changes_from_outcome(_outcome(changes=SUCCEEDED_FIX, before=False, after=True)) is True
 
 
 def test_should_pull_succeeded_fix_tests_were_failing_still_failing() -> None:
-    assert should_pull_changes(make_test_result(changes=SUCCEEDED_FIX, before=False, after=False)) is True
+    assert should_pull_changes_from_outcome(_outcome(changes=SUCCEEDED_FIX, before=False, after=False)) is True
 
 
 def test_should_not_pull_when_errored() -> None:
     assert (
-        should_pull_changes(make_test_result(changes=SUCCEEDED_FIX, errored=True, before=False, after=True)) is False
+        should_pull_changes_from_outcome(_outcome(changes=SUCCEEDED_FIX, errored=True, before=False, after=True))
+        is False
     )
 
 
 def test_should_not_pull_when_no_succeeded_changes() -> None:
-    assert should_pull_changes(make_test_result(changes=FAILED_FIX, before=False, after=False)) is False
-    assert should_pull_changes(make_test_result(changes=BLOCKED_FIX, before=False, after=False)) is False
+    assert should_pull_changes_from_outcome(_outcome(changes=FAILED_FIX, before=False, after=False)) is False
+    assert should_pull_changes_from_outcome(_outcome(changes=BLOCKED_FIX, before=False, after=False)) is False
 
 
 def test_should_not_pull_when_no_changes() -> None:
-    assert should_pull_changes(make_test_result(before=True, after=True)) is False
+    assert should_pull_changes_from_outcome(_outcome(before=True, after=True)) is False
 
 
 def test_should_not_pull_when_regression() -> None:
-    assert should_pull_changes(make_test_result(changes=SUCCEEDED_FIX, before=True, after=False)) is False
+    assert should_pull_changes_from_outcome(_outcome(changes=SUCCEEDED_FIX, before=True, after=False)) is False
 
 
 def test_should_pull_improvement_tests_still_passing() -> None:
     improved = {ChangeKind.IMPROVE_TEST: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="improved")}
-    assert should_pull_changes(make_test_result(changes=improved, before=True, after=True)) is True
+    assert should_pull_changes_from_outcome(_outcome(changes=improved, before=True, after=True)) is True
 
 
 def test_should_not_pull_improvement_that_breaks_tests() -> None:
     improved = {ChangeKind.IMPROVE_TEST: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="improved")}
-    assert should_pull_changes(make_test_result(changes=improved, before=True, after=False)) is False
-
-
-def test__build_current_results_pending_agents() -> None:
-    """Agents not in final_details should appear as PENDING."""
-    agents = [
-        TestAgentInfo(
-            test_node_id="tests/test_a.py::test_one",
-            agent_id=AgentId.generate(),
-            agent_name=AgentName("tmr-test-one-abc123"),
-            work_dir=Path("/tmp/work"),
-            created_at=0.0,
-        ),
-        TestAgentInfo(
-            test_node_id="tests/test_b.py::test_two",
-            agent_id=AgentId.generate(),
-            agent_name=AgentName("tmr-test-two-def456"),
-            work_dir=Path("/tmp/work"),
-            created_at=0.0,
-        ),
-    ]
-    results = _build_current_results(agents=agents, timed_out_ids=set())
-    assert len(results) == 2
-    assert _report_section_of(results[0]) == ReportSection.RUNNING
-    assert _report_section_of(results[1]) == ReportSection.RUNNING
-    assert "still running" in results[0].summary_markdown
-
-
-def test__build_current_results_timed_out_agents() -> None:
-    """Timed-out agents should appear as ERRORED."""
-    agent_id = AgentId.generate()
-    agents = [
-        TestAgentInfo(
-            test_node_id="tests/test_a.py::test_one",
-            agent_id=agent_id,
-            agent_name=AgentName("tmr-test-one-abc123"),
-            work_dir=Path("/tmp/work"),
-            created_at=0.0,
-        ),
-    ]
-    results = _build_current_results(agents=agents, timed_out_ids={str(agent_id)})
-    assert len(results) == 1
-    assert results[0].errored is True
-    assert _report_section_of(results[0]) == ReportSection.FAILED
-
-
-def test__build_current_results_includes_launch_failures() -> None:
-    """Agents that failed to launch should appear in the results as ERRORED."""
-    failure = TestMapReduceResult(
-        test_node_id="tests/test_a.py::test_one",
-        agent_name=AgentName("tmr-test-one-launch-failed"),
-        errored=True,
-        summary_markdown="Failed to launch agent: boom",
-    )
-    results = _build_current_results(
-        agents=[],
-        timed_out_ids=set(),
-        launch_failures=[failure],
-    )
-    assert len(results) == 1
-    assert results[0].test_node_id == "tests/test_a.py::test_one"
-    assert results[0].errored is True
-    assert "Failed to launch agent: boom" in results[0].summary_markdown
-    assert _report_section_of(results[0]) == ReportSection.FAILED
-
-
-def test__build_current_results_launch_failures_come_before_running_agents() -> None:
-    """Launch failures should be ordered before live-agent results in the report."""
-    failure = TestMapReduceResult(
-        test_node_id="tests/test_failed.py::test_one",
-        agent_name=AgentName("tmr-test-one-launch-failed"),
-        errored=True,
-        summary_markdown="Failed to launch agent: boom",
-    )
-    agent = TestAgentInfo(
-        test_node_id="tests/test_running.py::test_two",
-        agent_id=AgentId.generate(),
-        agent_name=AgentName("tmr-test-two-abc123"),
-        work_dir=Path("/tmp/work"),
-        created_at=0.0,
-    )
-    results = _build_current_results(
-        agents=[agent],
-        timed_out_ids=set(),
-        launch_failures=[failure],
-    )
-    assert len(results) == 2
-    assert results[0].test_node_id == "tests/test_failed.py::test_one"
-    assert results[1].test_node_id == "tests/test_running.py::test_two"
-
-
-# --- _read_local_result / read_integrator_result tests ---
-
-
-def _write_local_result(local_dir: Path, content: str) -> None:
-    """Write a testing_agent_outcome.json under the local agent's extracted test_output dir."""
-    test_output_dir = local_dir / "test_output"
-    test_output_dir.mkdir(parents=True, exist_ok=True)
-    (test_output_dir / TESTING_AGENT_OUTCOME_FILENAME).write_text(content)
-
-
-def _write_integrator_result_locally(destination_dir: Path, agent_name: AgentName, content: str) -> None:
-    """Write an integrator_outcome.json into the spot where read_integrator_result reads it from."""
-    target_dir = destination_dir / str(agent_name)
-    target_dir.mkdir(parents=True, exist_ok=True)
-    (target_dir / INTEGRATOR_OUTCOME_FILENAME).write_text(content)
-
-
-def test_read_local_result_parses_changes(tmp_path: Path) -> None:
-    local_dir = tmp_path / "agent-output"
-    _write_local_result(
-        local_dir,
-        '{"changes": {"FIX_TEST": {"status": "SUCCEEDED", "summary_markdown": "Fixed it"}},'
-        ' "errored": false, "tests_passing_before": false, "tests_passing_after": true,'
-        ' "summary_markdown": "All good"}',
-    )
-    result = _read_local_result(local_dir, AgentName("tmr-test"))
-    assert result is not None
-    assert ChangeKind.FIX_TEST in result.changes
-    assert result.changes[ChangeKind.FIX_TEST].status == ChangeStatus.SUCCEEDED
-    assert result.tests_passing_before is False
-    assert result.tests_passing_after is True
-    assert result.summary_markdown == "All good"
-
-
-def test_read_local_result_empty_changes(tmp_path: Path) -> None:
-    local_dir = tmp_path / "agent-output"
-    _write_local_result(
-        local_dir,
-        '{"changes": {}, "errored": false, "tests_passing_before": true,'
-        ' "tests_passing_after": true, "summary_markdown": "Clean pass"}',
-    )
-    result = _read_local_result(local_dir, AgentName("tmr-test"))
-    assert result is not None
-    assert result.changes == {}
-    assert result.errored is False
-
-
-def test_read_local_result_invalid_json(tmp_path: Path) -> None:
-    local_dir = tmp_path / "agent-output"
-    _write_local_result(local_dir, "not json")
-    result = _read_local_result(local_dir, AgentName("tmr-test"))
-    assert result is None
-
-
-def test_read_local_result_missing_file(tmp_path: Path) -> None:
-    local_dir = tmp_path / "agent-output"
-    local_dir.mkdir(parents=True, exist_ok=True)
-    result = _read_local_result(local_dir, AgentName("tmr-test"))
-    assert result is None
-
-
-def test_read_integrator_result_parses_merged_failed(localhost: OnlineHostInterface, tmp_path: Path) -> None:
-    agent_id = AgentId.generate()
-    agent_name = AgentName("tmr-integrator-test")
-    _write_integrator_result_locally(
-        tmp_path,
-        agent_name,
-        '{"squashed_branches": ["branch-a", "branch-b"], "squashed_commit_hash": "abc1234",'
-        ' "impl_priority": ["branch-d"], "impl_commit_hashes": {"branch-d": "def5678"}, "failed": ["branch-c"]}',
-    )
-    cg = ConcurrencyGroup(name="test")
-    result = read_integrator_result(
-        agent_id=agent_id,
-        agent_name=agent_name,
-        host=localhost,
-        branch_name="mngr-tmr/integrated",
-        destination_dir=tmp_path,
-        cg=cg,
-    )
-    assert result.squashed_branches == ("branch-a", "branch-b")
-    assert result.squashed_commit_hash == "abc1234"
-    assert result.impl_priority == ("branch-d",)
-    assert result.impl_commit_hashes == {"branch-d": "def5678"}
-    assert result.failed == ("branch-c",)
-    assert result.branch_name == "mngr-tmr/integrated"
-
-
-def test_read_integrator_result_missing_file(localhost: OnlineHostInterface, tmp_path: Path) -> None:
-    agent_id = AgentId.generate()
-    agent_name = AgentName("tmr-integrator-test")
-    cg = ConcurrencyGroup(name="test")
-    result = read_integrator_result(
-        agent_id=agent_id,
-        agent_name=agent_name,
-        host=localhost,
-        branch_name="mngr-tmr/integrated",
-        destination_dir=tmp_path,
-        cg=cg,
-    )
-    assert result.branch_name == "mngr-tmr/integrated"
-    assert result.squashed_branches == ()
-    assert result.impl_priority == ()
-    assert result.failed == ()
+    assert should_pull_changes_from_outcome(_outcome(changes=improved, before=True, after=False)) is False

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
@@ -1,22 +1,17 @@
 """Unit tests for test-mapreduce API functions."""
 
-from datetime import datetime
-from datetime import timezone
 from pathlib import Path
 
 import pytest
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.data_types import EnvVar
-from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import AgentEnvironmentOptions
 from imbue.mngr.interfaces.host import AgentLabelOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
-from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import AgentTypeName
-from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.primitives import TransferMode
@@ -298,7 +293,7 @@ def test__build_current_results_pending_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = _build_current_results(agents=agents, final_details={}, timed_out_ids=set())
+    results = _build_current_results(agents=agents, timed_out_ids=set())
     assert len(results) == 2
     assert _report_section_of(results[0]) == ReportSection.RUNNING
     assert _report_section_of(results[1]) == ReportSection.RUNNING
@@ -317,7 +312,7 @@ def test__build_current_results_timed_out_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = _build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)})
+    results = _build_current_results(agents=agents, timed_out_ids={str(agent_id)})
     assert len(results) == 1
     assert results[0].errored is True
     assert _report_section_of(results[0]) == ReportSection.FAILED
@@ -333,7 +328,6 @@ def test__build_current_results_includes_launch_failures() -> None:
     )
     results = _build_current_results(
         agents=[],
-        final_details={},
         timed_out_ids=set(),
         launch_failures=[failure],
     )
@@ -361,7 +355,6 @@ def test__build_current_results_launch_failures_come_before_running_agents() -> 
     )
     results = _build_current_results(
         agents=[agent],
-        final_details={},
         timed_out_ids=set(),
         launch_failures=[failure],
     )
@@ -380,31 +373,11 @@ def _write_local_result(local_dir: Path, content: str) -> None:
     (test_output_dir / TESTING_AGENT_OUTCOME_FILENAME).write_text(content)
 
 
-def _write_integrator_result_in_work_dir(work_dir: Path, content: str) -> None:
-    """Write an integrator_outcome.json in the agent's .test_output directory."""
-    result_dir = work_dir / ".test_output"
-    result_dir.mkdir(parents=True, exist_ok=True)
-    (result_dir / INTEGRATOR_OUTCOME_FILENAME).write_text(content)
-
-
-def _make_agent_detail(agent_id: AgentId, host_dir: Path) -> AgentDetails:
-    """Build a minimal AgentDetails for testing result reading.
-
-    Uses model_construct to skip validation of the host field, which requires
-    a HostDetails that these tests don't need.
-    """
-    return AgentDetails.model_construct(
-        id=agent_id,
-        name=AgentName("tmr-test"),
-        type="claude",
-        command=CommandString("echo"),
-        work_dir=host_dir / "workdir",
-        initial_branch="mngr-tmr/test",
-        create_time=datetime.now(timezone.utc),
-        start_on_boot=False,
-        state=AgentLifecycleState.DONE,
-        host=None,
-    )
+def _write_integrator_result_locally(destination_dir: Path, agent_name: AgentName, content: str) -> None:
+    """Write an integrator_outcome.json into the spot where read_integrator_result reads it from."""
+    target_dir = destination_dir / str(agent_name)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / INTEGRATOR_OUTCOME_FILENAME).write_text(content)
 
 
 def test_read_local_result_parses_changes(tmp_path: Path) -> None:
@@ -451,16 +424,24 @@ def test_read_local_result_missing_file(tmp_path: Path) -> None:
     assert result is None
 
 
-def test_read_integrator_result_parses_merged_failed(localhost: OnlineHostInterface) -> None:
+def test_read_integrator_result_parses_merged_failed(localhost: OnlineHostInterface, tmp_path: Path) -> None:
     agent_id = AgentId.generate()
-    detail = _make_agent_detail(agent_id, localhost.host_dir)
-    _write_integrator_result_in_work_dir(
-        detail.work_dir,
+    agent_name = AgentName("tmr-integrator-test")
+    _write_integrator_result_locally(
+        tmp_path,
+        agent_name,
         '{"squashed_branches": ["branch-a", "branch-b"], "squashed_commit_hash": "abc1234",'
         ' "impl_priority": ["branch-d"], "impl_commit_hashes": {"branch-d": "def5678"}, "failed": ["branch-c"]}',
     )
     cg = ConcurrencyGroup(name="test")
-    result = read_integrator_result(detail, localhost, "mngr-tmr/integrated", destination_dir=None, cg=cg)
+    result = read_integrator_result(
+        agent_id=agent_id,
+        agent_name=agent_name,
+        host=localhost,
+        branch_name="mngr-tmr/integrated",
+        destination_dir=tmp_path,
+        cg=cg,
+    )
     assert result.squashed_branches == ("branch-a", "branch-b")
     assert result.squashed_commit_hash == "abc1234"
     assert result.impl_priority == ("branch-d",)
@@ -469,11 +450,18 @@ def test_read_integrator_result_parses_merged_failed(localhost: OnlineHostInterf
     assert result.branch_name == "mngr-tmr/integrated"
 
 
-def test_read_integrator_result_missing_file(localhost: OnlineHostInterface) -> None:
+def test_read_integrator_result_missing_file(localhost: OnlineHostInterface, tmp_path: Path) -> None:
     agent_id = AgentId.generate()
-    detail = _make_agent_detail(agent_id, localhost.host_dir)
+    agent_name = AgentName("tmr-integrator-test")
     cg = ConcurrencyGroup(name="test")
-    result = read_integrator_result(detail, localhost, "mngr-tmr/integrated", destination_dir=None, cg=cg)
+    result = read_integrator_result(
+        agent_id=agent_id,
+        agent_name=agent_name,
+        host=localhost,
+        branch_name="mngr-tmr/integrated",
+        destination_dir=tmp_path,
+        cg=cg,
+    )
     assert result.branch_name == "mngr-tmr/integrated"
     assert result.squashed_branches == ()
     assert result.impl_priority == ()

--- a/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/orchestration_test.py
@@ -298,7 +298,7 @@ def test__build_current_results_pending_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = _build_current_results(agents=agents, final_details={}, timed_out_ids=set(), hosts={})
+    results = _build_current_results(agents=agents, final_details={}, timed_out_ids=set())
     assert len(results) == 2
     assert _report_section_of(results[0]) == ReportSection.RUNNING
     assert _report_section_of(results[1]) == ReportSection.RUNNING
@@ -317,7 +317,7 @@ def test__build_current_results_timed_out_agents() -> None:
             created_at=0.0,
         ),
     ]
-    results = _build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)}, hosts={})
+    results = _build_current_results(agents=agents, final_details={}, timed_out_ids={str(agent_id)})
     assert len(results) == 1
     assert results[0].errored is True
     assert _report_section_of(results[0]) == ReportSection.FAILED
@@ -335,7 +335,6 @@ def test__build_current_results_includes_launch_failures() -> None:
         agents=[],
         final_details={},
         timed_out_ids=set(),
-        hosts={},
         launch_failures=[failure],
     )
     assert len(results) == 1
@@ -364,7 +363,6 @@ def test__build_current_results_launch_failures_come_before_running_agents() -> 
         agents=[agent],
         final_details={},
         timed_out_ids=set(),
-        hosts={},
         launch_failures=[failure],
     )
     assert len(results) == 2

--- a/libs/mngr_tmr/imbue/mngr_tmr/prompts.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/prompts.py
@@ -169,6 +169,39 @@ Fields:
   (matching the --mngr-e2e-run-name used) and description_markdown (brief
   description of what this run was for).
 
+# Publishing the outputs archive
+
+After the outcome file is written, package the outputs and publish them
+where the orchestrator can find them. Run this from the git repo root:
+
+```bash
+ARCHIVE_DIR="$MNGR_AGENT_STATE_DIR/plugin/{PLUGIN_NAME}"
+mkdir -p "$ARCHIVE_DIR"
+
+STAGING=$(mktemp -d)
+trap 'rm -rf "$STAGING"' EXIT
+
+# Rename .test_output -> test_output inside the archive
+cp -a .test_output "$STAGING/test_output"
+
+# Include an incremental git bundle if any commits exist beyond the base.
+# The bundle is created with the explicit branch name so the orchestrator
+# can fetch ``$BRANCH:$BRANCH`` cleanly.
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ -n "$(git rev-list --max-count=1 "$MNGR_GIT_BASE_BRANCH..$BRANCH" 2>/dev/null)" ]; then
+    git bundle create "$STAGING/branch.bundle" "$MNGR_GIT_BASE_BRANCH..$BRANCH"
+fi
+
+TARBALL="$ARCHIVE_DIR/outputs.tar.gz"
+tar -czf "$TARBALL.tmp" -C "$STAGING" .
+mv "$TARBALL.tmp" "$TARBALL"
+```
+
+This MUST be the very last step. The orchestrator polls for outputs.tar.gz
+and treats its appearance as the signal that you are done. The .tmp + rename
+sequence prevents the orchestrator from reading a half-written archive. Omit
+branch.bundle when you made no commits beyond the base branch.
+
 # Important: do not ask for user input
 
 For this initial request, do NOT ask the user for any input or clarification.

--- a/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
@@ -1,22 +1,29 @@
 """Result and artifact pulling for the test-mapreduce plugin."""
 
+import io
 import json
+import tarfile
 from pathlib import Path
 
 from loguru import logger
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ProcessError
+from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.api.pull import pull_files
 from imbue.mngr.api.pull import pull_git
+from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import AgentNotFoundOnHostError
 from imbue.mngr.errors import HostError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.interfaces.volume import Volume
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import UncommittedChangesMode
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
@@ -26,7 +33,14 @@ from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TestRunInfo
 from imbue.mngr_tmr.launching import stop_agent_on_host
 from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
+from imbue.mngr_tmr.prompts import PLUGIN_NAME
 from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
+
+_OUTPUTS_ARCHIVE_NAME = "outputs.tar.gz"
+_OUTPUTS_ARCHIVE_SUBPATH = f"plugin/{PLUGIN_NAME}/{_OUTPUTS_ARCHIVE_NAME}"
+_OUTPUTS_ARCHIVE_PARENT_SUBPATH = f"plugin/{PLUGIN_NAME}"
+_EXTRACTED_TEST_OUTPUT_DIR = "test_output"
+_BRANCH_BUNDLE_NAME = "branch.bundle"
 
 
 def _parse_result_json(raw: str) -> TestResult:
@@ -61,29 +75,173 @@ def _parse_result_json(raw: str) -> TestResult:
     )
 
 
-def try_read_agent_result(
-    work_dir: Path,
-    host: OnlineHostInterface,
-) -> TestResult | None:
-    """Try to read an agent's outcome file remotely, returning None if not found."""
-    result_path = work_dir / ".test_output" / TESTING_AGENT_OUTCOME_FILENAME
-    try:
-        raw = host.read_text_file(result_path)
-        return _parse_result_json(raw)
-    except (HostError, FileNotFoundError, OSError, json.JSONDecodeError, KeyError, ValueError) as e:
-        logger.debug("Could not read remote outcome file {}: {}", result_path, e)
-        return None
-
-
 def read_local_result(local_dir: Path, agent_name: AgentName) -> TestResult | None:
-    """Read and parse the testing agent outcome from a locally-pulled output directory."""
-    result_path = local_dir / TESTING_AGENT_OUTCOME_FILENAME
+    """Read and parse the testing agent outcome from a locally-extracted output directory."""
+    result_path = local_dir / _EXTRACTED_TEST_OUTPUT_DIR / TESTING_AGENT_OUTCOME_FILENAME
     try:
         raw = result_path.read_text()
         return _parse_result_json(raw)
     except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
         logger.warning("Failed to read local result for agent '{}': {}", agent_name, exc)
         return None
+
+
+def _get_agent_volume(
+    mngr_ctx: MngrContext,
+    provider_name: ProviderInstanceName,
+    host_id: HostId,
+    agent_id: AgentId,
+) -> Volume | None:
+    """Return the volume scoped to a single agent's state directory.
+
+    Returns None when the provider does not expose a host volume (e.g. SSH)
+    or when the volume cannot otherwise be resolved.
+    """
+    try:
+        provider = get_provider_instance(provider_name, mngr_ctx)
+        host_volume = provider.get_volume_for_host(host_id)
+    except (MngrError, OSError) as exc:
+        logger.warning("Failed to resolve volume for host {}: {}", host_id, exc)
+        return None
+    if host_volume is None:
+        return None
+    return host_volume.get_agent_volume(agent_id)
+
+
+def is_agent_outputs_ready(
+    mngr_ctx: MngrContext,
+    provider_name: ProviderInstanceName,
+    host_id: HostId,
+    agent_id: AgentId,
+) -> bool:
+    """Check whether the agent has finished writing its outputs archive.
+
+    Listing the archive's parent directory rather than reading the archive
+    itself keeps the existence check cheap; the partially-written .tmp file
+    is filtered out by matching the final name exactly.
+    """
+    agent_volume = _get_agent_volume(mngr_ctx, provider_name, host_id, agent_id)
+    if agent_volume is None:
+        return False
+    try:
+        entries = agent_volume.listdir(_OUTPUTS_ARCHIVE_PARENT_SUBPATH)
+    except (MngrError, OSError):
+        return False
+    return any(Path(entry.path).name == _OUTPUTS_ARCHIVE_NAME for entry in entries)
+
+
+def _apply_branch_bundle(
+    source_dir: Path,
+    bundle_path: Path,
+    branch_name: str,
+    agent_name: AgentName,
+    cg: ConcurrencyGroup,
+) -> None:
+    """Fetch a branch from a bundle into the local source_dir repo.
+
+    The bundle was created with ``git bundle create ... <base>..<branch>``,
+    so it carries the ref under its branch name; the fetch refspec maps
+    that ref onto the same local branch name. Idempotent for repeated
+    invocations and a no-op on the local provider (where the branch
+    already exists in the worktree-sharing repo).
+    """
+    result = cg.run_process_to_completion(
+        ["git", "fetch", "--no-tags", str(bundle_path), f"+{branch_name}:{branch_name}"],
+        cwd=source_dir,
+        is_checked_after=False,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "Failed to apply branch bundle for agent '{}' (branch {}): {}",
+            agent_name,
+            branch_name,
+            result.stderr.strip(),
+        )
+    else:
+        logger.info("Applied branch bundle for agent '{}' onto branch '{}'", agent_name, branch_name)
+
+
+def pull_agent_outputs(
+    mngr_ctx: MngrContext,
+    provider_name: ProviderInstanceName,
+    host_id: HostId,
+    agent_id: AgentId,
+    agent_name: AgentName,
+    branch_name: str | None,
+    destination_dir: Path,
+    source_dir: Path | None,
+    cg: ConcurrencyGroup,
+) -> TestResult | None:
+    """Download and extract the outputs archive for a single testing agent.
+
+    Reads ``outputs.tar.gz`` from the agent's state volume, extracts it
+    under ``destination_dir/<agent_name>/``, and (if a ``branch.bundle`` is
+    present and ``source_dir`` is given) fetches the bundled branch into
+    the local repo. Returns the parsed outcome read from the extracted
+    ``test_output/`` directory, or None on any failure.
+    """
+    agent_volume = _get_agent_volume(mngr_ctx, provider_name, host_id, agent_id)
+    if agent_volume is None:
+        logger.warning(
+            "Cannot pull outputs for agent '{}': provider '{}' does not expose a volume",
+            agent_name,
+            provider_name,
+        )
+        return None
+
+    try:
+        archive_bytes = agent_volume.read_file(_OUTPUTS_ARCHIVE_SUBPATH)
+    except (MngrError, OSError) as exc:
+        logger.warning("Failed to read outputs archive for agent '{}': {}", agent_name, exc)
+        return None
+
+    local_dest = destination_dir / str(agent_name)
+    local_dest.mkdir(parents=True, exist_ok=True)
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
+            tar.extractall(local_dest, filter="data")
+    except (tarfile.TarError, OSError) as exc:
+        logger.warning("Failed to extract outputs archive for agent '{}': {}", agent_name, exc)
+        return None
+    logger.info("Extracted outputs archive for agent '{}' to {}", agent_name, local_dest)
+
+    if source_dir is not None and branch_name is not None:
+        bundle_path = local_dest / _BRANCH_BUNDLE_NAME
+        if bundle_path.is_file():
+            _apply_branch_bundle(source_dir, bundle_path, branch_name, agent_name, cg)
+
+    return read_local_result(local_dest, agent_name)
+
+
+def finalize_agent(
+    mngr_ctx: MngrContext,
+    provider_name: ProviderInstanceName,
+    host: OnlineHostInterface,
+    agent_id: AgentId,
+    agent_name: AgentName,
+    branch_name: str | None,
+    artifact_output_dir: Path | None,
+    source_dir: Path | None,
+    cg: ConcurrencyGroup,
+    should_stop: bool,
+) -> TestResult | None:
+    """Pull outputs and read result from a finished agent, then optionally stop it."""
+    result: TestResult | None = None
+    if artifact_output_dir is not None:
+        result = pull_agent_outputs(
+            mngr_ctx=mngr_ctx,
+            provider_name=provider_name,
+            host_id=host.id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            branch_name=branch_name,
+            destination_dir=artifact_output_dir,
+            source_dir=source_dir,
+            cg=cg,
+        )
+    if should_stop:
+        stop_agent_on_host(host, agent_id, agent_name)
+    return result
 
 
 def _get_agent_from_host(
@@ -99,59 +257,6 @@ def _get_agent_from_host(
         if agent.id == agent_id:
             return agent
     raise AgentNotFoundOnHostError(agent_id, host.id)
-
-
-def pull_agent_outputs(
-    agent_id: AgentId,
-    agent_name: AgentName,
-    host: OnlineHostInterface,
-    destination_dir: Path,
-    cg: ConcurrencyGroup,
-) -> TestResult | None:
-    """Pull .test_output (artifacts + outcome file) from an agent via rsync, then read result locally."""
-    try:
-        agent = _get_agent_from_host(host, agent_id)
-    except (MngrError, HostError, AgentNotFoundOnHostError) as exc:
-        logger.warning("Could not find agent '{}' on host to pull outputs: {}", agent_name, exc)
-        return None
-
-    local_dest = destination_dir / str(agent_name)
-    local_dest.mkdir(parents=True, exist_ok=True)
-
-    try:
-        pull_files(
-            agent=agent,
-            host=host,
-            destination=local_dest,
-            source_path=agent.work_dir / ".test_output",
-            is_dry_run=False,
-            is_delete=False,
-            uncommitted_changes=UncommittedChangesMode.CLOBBER,
-            cg=cg,
-        )
-        logger.info("Pulled .test_output from agent '{}' to {}", agent_name, local_dest)
-    except (MngrError, HostError, OSError) as exc:
-        logger.warning("Failed to pull .test_output from agent '{}': {}", agent_name, exc)
-        return None
-
-    return read_local_result(local_dest, agent_name)
-
-
-def finalize_agent(
-    agent_id: AgentId,
-    agent_name: AgentName,
-    host: OnlineHostInterface,
-    artifact_output_dir: Path | None,
-    cg: ConcurrencyGroup,
-    should_stop: bool,
-) -> TestResult | None:
-    """Pull outputs and read result from a finished agent, then optionally stop it."""
-    pre_read: TestResult | None = None
-    if artifact_output_dir is not None:
-        pre_read = pull_agent_outputs(agent_id, agent_name, host, artifact_output_dir, cg)
-    if should_stop:
-        stop_agent_on_host(host, agent_id, agent_name)
-    return pre_read
 
 
 def pull_integrator_outputs(
@@ -233,6 +338,9 @@ def pull_agent_branch(
     base_commit: str | None = None,
 ) -> str | None:
     """Pull the agent's git branch into the local repo.
+
+    Used by the integrator path; testing agents go through the bundle
+    contained in their outputs archive instead.
 
     Returns the branch name if successful, None otherwise.
     """

--- a/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
@@ -38,7 +38,6 @@ from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 
 _OUTPUTS_ARCHIVE_NAME = "outputs.tar.gz"
 _OUTPUTS_ARCHIVE_SUBPATH = f"plugin/{PLUGIN_NAME}/{_OUTPUTS_ARCHIVE_NAME}"
-_OUTPUTS_ARCHIVE_PARENT_SUBPATH = f"plugin/{PLUGIN_NAME}"
 _EXTRACTED_TEST_OUTPUT_DIR = "test_output"
 _BRANCH_BUNDLE_NAME = "branch.bundle"
 
@@ -116,18 +115,17 @@ def is_agent_outputs_ready(
 ) -> bool:
     """Check whether the agent has finished writing its outputs archive.
 
-    Listing the archive's parent directory rather than reading the archive
-    itself keeps the existence check cheap; the partially-written .tmp file
-    is filtered out by matching the final name exactly.
+    Matches the final archive name exactly so the partially-written ``.tmp``
+    file (which the agent renames on completion) is not mistaken for the
+    finished output.
     """
     agent_volume = _get_agent_volume(mngr_ctx, provider_name, host_id, agent_id)
     if agent_volume is None:
         return False
     try:
-        entries = agent_volume.listdir(_OUTPUTS_ARCHIVE_PARENT_SUBPATH)
+        return agent_volume.path_exists(_OUTPUTS_ARCHIVE_SUBPATH)
     except (MngrError, OSError):
         return False
-    return any(Path(entry.path).name == _OUTPUTS_ARCHIVE_NAME for entry in entries)
 
 
 def _apply_branch_bundle(

--- a/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
@@ -17,7 +17,6 @@ from imbue.mngr.errors import AgentNotFoundOnHostError
 from imbue.mngr.errors import HostError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.agent import AgentInterface
-from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.volume import Volume
 from imbue.mngr.primitives import AgentId
@@ -258,19 +257,20 @@ def _get_agent_from_host(
 
 
 def _pull_integrator_outputs(
-    agent_detail: AgentDetails,
+    agent_id: AgentId,
+    agent_name: AgentName,
     host: OnlineHostInterface,
     destination_dir: Path,
     cg: ConcurrencyGroup,
 ) -> bool:
     """Pull the integrator agent's .test_output via rsync. Returns True on success."""
     try:
-        agent = _get_agent_from_host(host, agent_detail.id)
+        agent = _get_agent_from_host(host, agent_id)
     except (MngrError, HostError, AgentNotFoundOnHostError) as exc:
         logger.warning("Could not find integrator agent on host: {}", exc)
         return False
 
-    local_dest = destination_dir / str(agent_detail.name)
+    local_dest = destination_dir / str(agent_name)
     local_dest.mkdir(parents=True, exist_ok=True)
     try:
         pull_files(
@@ -290,33 +290,26 @@ def _pull_integrator_outputs(
 
 
 def read_integrator_result(
-    agent_detail: AgentDetails,
+    agent_id: AgentId,
+    agent_name: AgentName,
     host: OnlineHostInterface,
     branch_name: str | None,
-    destination_dir: Path | None,
+    destination_dir: Path,
     cg: ConcurrencyGroup,
 ) -> IntegratorResult:
     """Pull the integrator agent's .test_output and read the outcome file."""
-    empty = IntegratorResult(agent_name=agent_detail.name, branch_name=branch_name)
+    empty = IntegratorResult(agent_name=agent_name, branch_name=branch_name)
 
-    if destination_dir is not None:
-        _pull_integrator_outputs(agent_detail, host, destination_dir, cg)
-        local_result = destination_dir / str(agent_detail.name) / INTEGRATOR_OUTCOME_FILENAME
-        try:
-            data = json.loads(local_result.read_text())
-        except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
-            logger.warning("Failed to read integrator result locally: {}", exc)
-            return empty
-    else:
-        result_path = agent_detail.work_dir / ".test_output" / INTEGRATOR_OUTCOME_FILENAME
-        try:
-            data = json.loads(host.read_text_file(result_path))
-        except (HostError, OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
-            logger.warning("Failed to read integrator result: {}", exc)
-            return empty
+    _pull_integrator_outputs(agent_id, agent_name, host, destination_dir, cg)
+    local_result = destination_dir / str(agent_name) / INTEGRATOR_OUTCOME_FILENAME
+    try:
+        data = json.loads(local_result.read_text())
+    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read integrator result locally: {}", exc)
+        return empty
 
     return IntegratorResult(
-        agent_name=agent_detail.name,
+        agent_name=agent_name,
         squashed_branches=tuple(data.get("squashed_branches", ())),
         squashed_commit_hash=data.get("squashed_commit_hash"),
         impl_priority=tuple(data.get("impl_priority", ())),
@@ -383,7 +376,7 @@ def _create_local_branch(destination: Path, branch_name: str, base_commit: str, 
         logger.info("Branch '{}' already exists, reusing it", branch_name)
 
 
-def try_read_integrator_outcome(work_dir: Path, host: OnlineHostInterface) -> bool:
+def is_integrator_outputs_ready(work_dir: Path, host: OnlineHostInterface) -> bool:
     """Check if the integrator's outcome file exists on the remote host."""
     result_path = work_dir / ".test_output" / INTEGRATOR_OUTCOME_FILENAME
     try:

--- a/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
@@ -1,7 +1,12 @@
-"""Result and artifact pulling for the test-mapreduce plugin."""
+"""Result and artifact pulling for the test-mapreduce plugin.
+
+Pulls the agent's outputs archive (test agents) or rsyncs ``.test_output``
+(integrator) onto local disk and applies any branch bundle. Outcome JSON
+parsing lives in ``report.py``; the orchestration code that calls this
+module treats the extracted contents as an opaque blob.
+"""
 
 import io
-import json
 import tarfile
 from pathlib import Path
 
@@ -24,64 +29,13 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import UncommittedChangesMode
-from imbue.mngr_tmr.data_types import Change
-from imbue.mngr_tmr.data_types import ChangeKind
-from imbue.mngr_tmr.data_types import ChangeStatus
-from imbue.mngr_tmr.data_types import IntegratorResult
-from imbue.mngr_tmr.data_types import TestResult
-from imbue.mngr_tmr.data_types import TestRunInfo
 from imbue.mngr_tmr.launching import stop_agent_on_host
 from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import PLUGIN_NAME
-from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 
 _OUTPUTS_ARCHIVE_NAME = "outputs.tar.gz"
 _OUTPUTS_ARCHIVE_SUBPATH = f"plugin/{PLUGIN_NAME}/{_OUTPUTS_ARCHIVE_NAME}"
-_EXTRACTED_TEST_OUTPUT_DIR = "test_output"
 _BRANCH_BUNDLE_NAME = "branch.bundle"
-
-
-def _parse_result_json(raw: str) -> TestResult:
-    """Parse an outcome JSON string into a TestResult.
-
-    Raises json.JSONDecodeError, KeyError, or ValueError on invalid data.
-    """
-    data = json.loads(raw)
-    raw_changes = data.get("changes", {})
-    changes: dict[ChangeKind, Change] = {
-        ChangeKind(kind_str): Change(
-            status=ChangeStatus(entry["status"]),
-            summary_markdown=entry.get("summary_markdown", entry.get("summary", "")),
-        )
-        for kind_str, entry in raw_changes.items()
-    }
-    raw_runs = data.get("test_runs", [])
-    test_runs = tuple(
-        TestRunInfo(
-            run_name=run_entry.get("run_name", ""),
-            description_markdown=run_entry.get("description_markdown", ""),
-        )
-        for run_entry in raw_runs
-    )
-    return TestResult(
-        changes=changes,
-        errored=data.get("errored", False),
-        tests_passing_before=data.get("tests_passing_before"),
-        tests_passing_after=data.get("tests_passing_after"),
-        summary_markdown=data.get("summary_markdown", ""),
-        test_runs=test_runs,
-    )
-
-
-def _read_local_result(local_dir: Path, agent_name: AgentName) -> TestResult | None:
-    """Read and parse the testing agent outcome from a locally-extracted output directory."""
-    result_path = local_dir / _EXTRACTED_TEST_OUTPUT_DIR / TESTING_AGENT_OUTCOME_FILENAME
-    try:
-        raw = result_path.read_text()
-        return _parse_result_json(raw)
-    except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
-        logger.warning("Failed to read local result for agent '{}': {}", agent_name, exc)
-        return None
 
 
 def _get_agent_volume(
@@ -168,14 +122,15 @@ def pull_agent_outputs(
     destination_dir: Path,
     source_dir: Path | None,
     cg: ConcurrencyGroup,
-) -> TestResult | None:
+) -> bool:
     """Download and extract the outputs archive for a single testing agent.
 
     Reads ``outputs.tar.gz`` from the agent's state volume, extracts it
     under ``destination_dir/<agent_name>/``, and (if a ``branch.bundle`` is
     present and ``source_dir`` is given) fetches the bundled branch into
-    the local repo. Returns the parsed outcome read from the extracted
-    ``test_output/`` directory, or None on any failure.
+    the local repo. Returns True on success, False on any failure. The
+    extracted contents are treated as opaque here -- the reporter parses
+    the outcome JSON on demand.
     """
     agent_volume = _get_agent_volume(mngr_ctx, provider_name, host_id, agent_id)
     if agent_volume is None:
@@ -184,13 +139,13 @@ def pull_agent_outputs(
             agent_name,
             provider_name,
         )
-        return None
+        return False
 
     try:
         archive_bytes = agent_volume.read_file(_OUTPUTS_ARCHIVE_SUBPATH)
     except (MngrError, OSError) as exc:
         logger.warning("Failed to read outputs archive for agent '{}': {}", agent_name, exc)
-        return None
+        return False
 
     local_dest = destination_dir / str(agent_name)
     local_dest.mkdir(parents=True, exist_ok=True)
@@ -199,7 +154,7 @@ def pull_agent_outputs(
             tar.extractall(local_dest, filter="data")
     except (tarfile.TarError, OSError) as exc:
         logger.warning("Failed to extract outputs archive for agent '{}': {}", agent_name, exc)
-        return None
+        return False
     logger.info("Extracted outputs archive for agent '{}' to {}", agent_name, local_dest)
 
     if source_dir is not None and branch_name is not None:
@@ -207,7 +162,7 @@ def pull_agent_outputs(
         if bundle_path.is_file():
             _apply_branch_bundle(source_dir, bundle_path, branch_name, agent_name, cg)
 
-    return _read_local_result(local_dest, agent_name)
+    return True
 
 
 def finalize_agent(
@@ -221,11 +176,11 @@ def finalize_agent(
     source_dir: Path | None,
     cg: ConcurrencyGroup,
     should_stop: bool,
-) -> TestResult | None:
-    """Pull outputs and read result from a finished agent, then optionally stop it."""
-    result: TestResult | None = None
+) -> bool:
+    """Pull outputs from a finished agent, then optionally stop it. Returns pull success."""
+    pulled = True
     if artifact_output_dir is not None:
-        result = pull_agent_outputs(
+        pulled = pull_agent_outputs(
             mngr_ctx=mngr_ctx,
             provider_name=provider_name,
             host_id=host.id,
@@ -238,7 +193,7 @@ def finalize_agent(
         )
     if should_stop:
         stop_agent_on_host(host, agent_id, agent_name)
-    return result
+    return pulled
 
 
 def _get_agent_from_host(
@@ -256,14 +211,19 @@ def _get_agent_from_host(
     raise AgentNotFoundOnHostError(agent_id, host.id)
 
 
-def _pull_integrator_outputs(
+def pull_integrator_outputs(
     agent_id: AgentId,
     agent_name: AgentName,
     host: OnlineHostInterface,
     destination_dir: Path,
     cg: ConcurrencyGroup,
 ) -> bool:
-    """Pull the integrator agent's .test_output via rsync. Returns True on success."""
+    """Pull the integrator agent's .test_output via rsync. Returns True on success.
+
+    Contents land directly under ``destination_dir/<agent_name>/`` (no
+    ``test_output/`` subdir, because rsync flattens the trailing-slashed
+    source). The reporter parses the outcome JSON from that location.
+    """
     try:
         agent = _get_agent_from_host(host, agent_id)
     except (MngrError, HostError, AgentNotFoundOnHostError) as exc:
@@ -287,36 +247,6 @@ def _pull_integrator_outputs(
     except (MngrError, HostError, OSError) as exc:
         logger.warning("Failed to pull integrator outputs: {}", exc)
         return False
-
-
-def read_integrator_result(
-    agent_id: AgentId,
-    agent_name: AgentName,
-    host: OnlineHostInterface,
-    branch_name: str | None,
-    destination_dir: Path,
-    cg: ConcurrencyGroup,
-) -> IntegratorResult:
-    """Pull the integrator agent's .test_output and read the outcome file."""
-    empty = IntegratorResult(agent_name=agent_name, branch_name=branch_name)
-
-    _pull_integrator_outputs(agent_id, agent_name, host, destination_dir, cg)
-    local_result = destination_dir / str(agent_name) / INTEGRATOR_OUTCOME_FILENAME
-    try:
-        data = json.loads(local_result.read_text())
-    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to read integrator result locally: {}", exc)
-        return empty
-
-    return IntegratorResult(
-        agent_name=agent_name,
-        squashed_branches=tuple(data.get("squashed_branches", ())),
-        squashed_commit_hash=data.get("squashed_commit_hash"),
-        impl_priority=tuple(data.get("impl_priority", ())),
-        impl_commit_hashes=data.get("impl_commit_hashes", {}),
-        failed=tuple(data.get("failed", ())),
-        branch_name=branch_name,
-    )
 
 
 def pull_agent_branch(

--- a/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/pulling.py
@@ -75,7 +75,7 @@ def _parse_result_json(raw: str) -> TestResult:
     )
 
 
-def read_local_result(local_dir: Path, agent_name: AgentName) -> TestResult | None:
+def _read_local_result(local_dir: Path, agent_name: AgentName) -> TestResult | None:
     """Read and parse the testing agent outcome from a locally-extracted output directory."""
     result_path = local_dir / _EXTRACTED_TEST_OUTPUT_DIR / TESTING_AGENT_OUTCOME_FILENAME
     try:
@@ -210,7 +210,7 @@ def pull_agent_outputs(
         if bundle_path.is_file():
             _apply_branch_bundle(source_dir, bundle_path, branch_name, agent_name, cg)
 
-    return read_local_result(local_dest, agent_name)
+    return _read_local_result(local_dest, agent_name)
 
 
 def finalize_agent(
@@ -259,7 +259,7 @@ def _get_agent_from_host(
     raise AgentNotFoundOnHostError(agent_id, host.id)
 
 
-def pull_integrator_outputs(
+def _pull_integrator_outputs(
     agent_detail: AgentDetails,
     host: OnlineHostInterface,
     destination_dir: Path,
@@ -302,7 +302,7 @@ def read_integrator_result(
     empty = IntegratorResult(agent_name=agent_detail.name, branch_name=branch_name)
 
     if destination_dir is not None:
-        pull_integrator_outputs(agent_detail, host, destination_dir, cg)
+        _pull_integrator_outputs(agent_detail, host, destination_dir, cg)
         local_result = destination_dir / str(agent_detail.name) / INTEGRATOR_OUTCOME_FILENAME
         try:
             data = json.loads(local_result.read_text())

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -402,8 +402,10 @@ def _find_test_artifact_runs(
 
     run_descriptions: dict[str, str] = {tr.run_name: tr.description_markdown for tr in test_runs}
 
+    # Extracted layout from outputs.tar.gz: <agent_dir>/test_output/e2e/<run>/...
+    test_output_dir = agent_dir / "test_output"
     found: list[tuple[str, str, Path]] = []
-    for candidate_root in [agent_dir / "e2e", agent_dir]:
+    for candidate_root in [test_output_dir / "e2e", test_output_dir, agent_dir / "e2e", agent_dir]:
         if not candidate_root.is_dir():
             continue
         for run_dir in sorted(candidate_root.iterdir()):

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -55,7 +55,7 @@ _md = MarkdownIt()
 _NON_IMPL_CHANGE_KINDS = frozenset({ChangeKind.FIX_TEST, ChangeKind.IMPROVE_TEST, ChangeKind.FIX_TUTORIAL})
 
 
-def report_section_of(result: TestMapReduceResult) -> ReportSection:
+def _report_section_of(result: TestMapReduceResult) -> ReportSection:
     """Derive a report section from a result for report grouping/coloring.
 
     ``errored=True`` indicates an infrastructure failure (launch failed,
@@ -88,7 +88,7 @@ def generate_html_report(
     """Generate an HTML report summarizing test-mapreduce results."""
     counts: dict[ReportSection, int] = {}
     for r in results:
-        sec = report_section_of(r)
+        sec = _report_section_of(r)
         counts[sec] = counts.get(sec, 0) + 1
 
     agent_artifact_runs: dict[str, list[tuple[str, str, Path]]] = {}
@@ -202,7 +202,7 @@ def _build_grouped_tables(
     agent_artifact_runs = agent_artifact_runs or {}
     grouped: dict[ReportSection, list[TestMapReduceResult]] = {}
     for r in results:
-        sec = report_section_of(r)
+        sec = _report_section_of(r)
         grouped.setdefault(sec, []).append(r)
 
     sections = ""

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -1,10 +1,17 @@
 """HTML report generation for the test-mapreduce plugin.
 
-Builds a self-contained HTML page with a TOC sidebar, per-section
-tables, and embedded test artifacts.
+The reporter takes a list of ``AgentMetadata`` from orchestration and
+reads each agent's outcome JSON from ``output_dir/<agent_name>/`` on
+demand. Outcome JSON shape is a contract between the agents and this
+module; orchestration does not parse it. Parsed outcomes are cached
+in-process (test-agent outcomes and the integrator outcome are
+immutable once an agent has published them, so caching is safe).
 """
 
 import html
+import json
+from collections.abc import Iterable
+from collections.abc import Sequence
 from pathlib import Path
 
 from loguru import logger
@@ -15,13 +22,27 @@ from imbue.mngr.utils.detail_renderer import ASCIINEMA_PLAYER_CSS
 from imbue.mngr.utils.detail_renderer import ASCIINEMA_PLAYER_JS
 from imbue.mngr.utils.detail_renderer import DETAIL_CSS
 from imbue.mngr.utils.detail_renderer import render_test_detail
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
 from imbue.mngr_tmr.data_types import IntegratorResult
 from imbue.mngr_tmr.data_types import ReportSection
 from imbue.mngr_tmr.data_types import TestMapReduceResult
+from imbue.mngr_tmr.data_types import TestResult
 from imbue.mngr_tmr.data_types import TestRunInfo
+from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
+from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
+from imbue.mngr_tmr.utils import should_pull_changes_from_outcome as _should_pull_outcome
+
+_EXTRACTED_TEST_OUTPUT_DIR = "test_output"
+
+# Outcome JSON for a given agent is immutable once present. Cache keyed by
+# agent_name so generate_html_report can be called many times during polling
+# without re-parsing.
+_TESTING_OUTCOME_CACHE: dict[AgentName, TestResult] = {}
+_INTEGRATOR_OUTCOME_CACHE: dict[AgentName, IntegratorResult] = {}
 
 _SECTION_ORDER: list[ReportSection] = [
     ReportSection.NON_IMPL_FIXES,
@@ -55,6 +76,157 @@ _md = MarkdownIt()
 _NON_IMPL_CHANGE_KINDS = frozenset({ChangeKind.FIX_TEST, ChangeKind.IMPROVE_TEST, ChangeKind.FIX_TUTORIAL})
 
 
+def _parse_outcome_json(raw: str) -> TestResult:
+    """Parse an outcome JSON string into a TestResult.
+
+    Raises json.JSONDecodeError, KeyError, or ValueError on invalid data.
+    """
+    data = json.loads(raw)
+    raw_changes = data.get("changes", {})
+    changes: dict[ChangeKind, Change] = {
+        ChangeKind(kind_str): Change(
+            status=ChangeStatus(entry["status"]),
+            summary_markdown=entry.get("summary_markdown", entry.get("summary", "")),
+        )
+        for kind_str, entry in raw_changes.items()
+    }
+    raw_runs = data.get("test_runs", [])
+    test_runs = tuple(
+        TestRunInfo(
+            run_name=run_entry.get("run_name", ""),
+            description_markdown=run_entry.get("description_markdown", ""),
+        )
+        for run_entry in raw_runs
+    )
+    return TestResult(
+        changes=changes,
+        errored=data.get("errored", False),
+        tests_passing_before=data.get("tests_passing_before"),
+        tests_passing_after=data.get("tests_passing_after"),
+        summary_markdown=data.get("summary_markdown", ""),
+        test_runs=test_runs,
+    )
+
+
+def _outcome_path_for_testing_agent(output_dir: Path, agent_name: AgentName) -> Path:
+    return output_dir / str(agent_name) / _EXTRACTED_TEST_OUTPUT_DIR / TESTING_AGENT_OUTCOME_FILENAME
+
+
+def _outcome_path_for_integrator(output_dir: Path, agent_name: AgentName) -> Path:
+    # The integrator agent still uses rsync, which drops .test_output's contents
+    # directly under <agent_name>/ (no test_output/ subdir).
+    return output_dir / str(agent_name) / INTEGRATOR_OUTCOME_FILENAME
+
+
+def _load_testing_agent_outcome(agent_name: AgentName, output_dir: Path) -> TestResult | None:
+    """Read and cache a testing agent's outcome from the extracted output dir."""
+    cached = _TESTING_OUTCOME_CACHE.get(agent_name)
+    if cached is not None:
+        return cached
+    path = _outcome_path_for_testing_agent(output_dir, agent_name)
+    try:
+        raw = path.read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        outcome = _parse_outcome_json(raw)
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        logger.warning("Failed to parse outcome for agent '{}': {}", agent_name, exc)
+        return None
+    _TESTING_OUTCOME_CACHE[agent_name] = outcome
+    return outcome
+
+
+def _load_integrator_outcome(meta: AgentMetadata, output_dir: Path) -> IntegratorResult:
+    """Read and cache the integrator's outcome, returning an empty result on miss."""
+    empty = IntegratorResult(agent_name=meta.agent_name, branch_name=meta.branch_name)
+    cached = _INTEGRATOR_OUTCOME_CACHE.get(meta.agent_name)
+    if cached is not None:
+        return cached
+    path = _outcome_path_for_integrator(output_dir, meta.agent_name)
+    try:
+        data = json.loads(path.read_text())
+    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to read integrator outcome for '{}': {}", meta.agent_name, exc)
+        return empty
+    result = IntegratorResult(
+        agent_name=meta.agent_name,
+        squashed_branches=tuple(data.get("squashed_branches", ())),
+        squashed_commit_hash=data.get("squashed_commit_hash"),
+        impl_priority=tuple(data.get("impl_priority", ())),
+        impl_commit_hashes=data.get("impl_commit_hashes", {}),
+        failed=tuple(data.get("failed", ())),
+        branch_name=meta.branch_name,
+    )
+    _INTEGRATOR_OUTCOME_CACHE[meta.agent_name] = result
+    return result
+
+
+def _row_from_metadata(meta: AgentMetadata, outcome: TestResult | None) -> TestMapReduceResult:
+    """Build a renderable row from per-agent metadata + optional parsed outcome."""
+    if meta.error_summary is not None:
+        return TestMapReduceResult(
+            test_node_id=meta.test_node_id or str(meta.agent_name),
+            agent_name=meta.agent_name,
+            errored=True,
+            summary_markdown=meta.error_summary,
+            branch_name=meta.branch_name,
+        )
+    if outcome is None:
+        return TestMapReduceResult(
+            test_node_id=meta.test_node_id or str(meta.agent_name),
+            agent_name=meta.agent_name,
+            summary_markdown="Agent is still running...",
+            branch_name=meta.branch_name,
+        )
+    return TestMapReduceResult(
+        test_node_id=meta.test_node_id or str(meta.agent_name),
+        agent_name=meta.agent_name,
+        changes=outcome.changes,
+        errored=outcome.errored,
+        tests_passing_before=outcome.tests_passing_before,
+        tests_passing_after=outcome.tests_passing_after,
+        summary_markdown=outcome.summary_markdown,
+        branch_name=meta.branch_name,
+        test_runs=outcome.test_runs,
+    )
+
+
+def _build_rows(agents: Sequence[AgentMetadata], output_dir: Path) -> list[TestMapReduceResult]:
+    """Build renderable rows for all testing agents (one per AgentMetadata).
+
+    Skips the integrator -- it has its own panel in the report, not a row.
+    """
+    rows: list[TestMapReduceResult] = []
+    for meta in agents:
+        if meta.kind is not AgentKind.TESTING_AGENT:
+            continue
+        outcome = _load_testing_agent_outcome(meta.agent_name, output_dir) if meta.error_summary is None else None
+        rows.append(_row_from_metadata(meta, outcome))
+    return rows
+
+
+def list_pullable_branches(agents: Iterable[AgentMetadata], output_dir: Path) -> list[str]:
+    """Return branch names for testing agents whose outcomes qualify for integration.
+
+    Reads the outcome JSON for each agent from disk (cached) and applies the
+    ``should_pull_changes`` predicate. Used by the integrator phase to decide
+    which agent branches to cherry-pick.
+    """
+    branches: list[str] = []
+    for meta in agents:
+        if meta.kind is not AgentKind.TESTING_AGENT:
+            continue
+        if meta.error_summary is not None or meta.branch_name is None:
+            continue
+        outcome = _load_testing_agent_outcome(meta.agent_name, output_dir)
+        if outcome is None:
+            continue
+        if _should_pull_outcome(outcome):
+            branches.append(meta.branch_name)
+    return branches
+
+
 def _report_section_of(result: TestMapReduceResult) -> ReportSection:
     """Derive a report section from a result for report grouping/coloring.
 
@@ -79,32 +251,40 @@ def _report_section_of(result: TestMapReduceResult) -> ReportSection:
 
 
 def generate_html_report(
-    results: list[TestMapReduceResult],
-    output_path: Path,
-    integrator: IntegratorResult | None = None,
-    test_artifacts_dir: Path | None = None,
+    agents: Sequence[AgentMetadata],
+    output_dir: Path,
+    *,
+    integrator_metadata: AgentMetadata | None = None,
     run_commands: list[tuple[str, str]] | None = None,
 ) -> Path:
-    """Generate an HTML report summarizing test-mapreduce results."""
+    """Generate an HTML report summarizing the run.
+
+    Walks ``agents`` and reads each testing agent's outcome from
+    ``output_dir/<agent_name>/test_output/``; reads the integrator's
+    outcome (if any) from ``output_dir/<integrator_name>/``. Writes the
+    report to ``output_dir/index.html`` and returns that path.
+    """
+    rows = _build_rows(agents, output_dir)
+    integrator = _load_integrator_outcome(integrator_metadata, output_dir) if integrator_metadata is not None else None
+
     counts: dict[ReportSection, int] = {}
-    for r in results:
+    for r in rows:
         sec = _report_section_of(r)
         counts[sec] = counts.get(sec, 0) + 1
 
     agent_artifact_runs: dict[str, list[tuple[str, str, Path]]] = {}
-    if test_artifacts_dir is not None:
-        for r in results:
-            try:
-                runs = _find_test_artifact_runs(test_artifacts_dir, r.agent_name, r.test_runs)
-            except OSError as exc:
-                if "Too many open files" in str(exc):
-                    logger.warning("FD exhaustion while scanning artifacts for '{}': {}", r.agent_name, exc)
-                raise
-            if runs:
-                agent_artifact_runs[str(r.agent_name)] = runs
+    for r in rows:
+        try:
+            runs = _find_test_artifact_runs(output_dir, r.agent_name, r.test_runs)
+        except OSError as exc:
+            if "Too many open files" in str(exc):
+                logger.warning("FD exhaustion while scanning artifacts for '{}': {}", r.agent_name, exc)
+            raise
+        if runs:
+            agent_artifact_runs[str(r.agent_name)] = runs
 
     toc_html = _build_toc_sidebar(counts)
-    tables_html = _build_grouped_tables(results, agent_artifact_runs, integrator, run_commands)
+    tables_html = _build_grouped_tables(rows, agent_artifact_runs, integrator, run_commands)
     panels_html = _build_artifact_panels(agent_artifact_runs)
 
     has_artifacts = bool(agent_artifact_runs)
@@ -133,7 +313,7 @@ def generate_html_report(
 {toc_html}
   <div class="main-content">
     <h1>Test Map-Reduce Report</h1>
-    <p class="summary">{len(results)} test(s)</p>
+    <p class="summary">{len(rows)} test(s)</p>
 {_build_run_commands_html(run_commands)}
 {tables_html}
   </div>
@@ -142,7 +322,8 @@ def generate_html_report(
 </body>
 </html>
 """
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "index.html"
+    output_dir.mkdir(parents=True, exist_ok=True)
     output_path.write_text(report_html)
     logger.info("HTML report written to {}", output_path)
     return output_path

--- a/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 
 from imbue.mngr.primitives import AgentName
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
@@ -17,7 +19,9 @@ from imbue.mngr_tmr.report import _report_section_of
 from imbue.mngr_tmr.report import generate_html_report
 from imbue.mngr_tmr.testing import FAILED_FIX
 from imbue.mngr_tmr.testing import SUCCEEDED_FIX
+from imbue.mngr_tmr.testing import make_metadata_and_outcome
 from imbue.mngr_tmr.testing import make_test_result
+from imbue.mngr_tmr.testing import write_integrator_outcome
 
 # --- report_section_of tests ---
 
@@ -267,29 +271,31 @@ def test_build_grouped_tables_impl_priority_sorting() -> None:
 
 
 def test_generate_html_report(tmp_path: Path) -> None:
-    results = [
-        TestMapReduceResult(
+    output_dir = tmp_path / "out"
+    agents = [
+        make_metadata_and_outcome(
+            output_dir,
+            "tmr-test-pass",
             test_node_id="tests/test_a.py::test_pass",
-            agent_name=AgentName("tmr-test-pass"),
             tests_passing_before=True,
             tests_passing_after=True,
             summary_markdown="Passed immediately",
         ),
-        TestMapReduceResult(
+        make_metadata_and_outcome(
+            output_dir,
+            "tmr-test-fixed",
             test_node_id="tests/test_b.py::test_fixed",
-            agent_name=AgentName("tmr-test-fixed"),
+            branch_name="mngr-tmr/test-fixed",
             changes=SUCCEEDED_FIX,
             tests_passing_before=False,
             tests_passing_after=True,
             summary_markdown="Fixed missing import",
-            branch_name="mngr-tmr/test-fixed",
         ),
     ]
-    output_path = tmp_path / "report.html"
-    result_path = generate_html_report(results, output_path)
-    assert result_path == output_path
-    assert output_path.exists()
-    content = output_path.read_text()
+    result_path = generate_html_report(agents, output_dir)
+    assert result_path == output_dir / "index.html"
+    assert result_path.exists()
+    content = result_path.read_text()
     assert "Test Map-Reduce Report" in content
     assert "Clean pass" in content
     assert "Non-implementation fixes" in content
@@ -306,27 +312,33 @@ def test_generate_html_report_groups_clean_pass_before_running(tmp_path: Path) -
     assert "Clean pass" in tables_html
 
 
-def test_generate_html_report_creates_parent_dirs(tmp_path: Path) -> None:
-    output_path = tmp_path / "subdir" / "nested" / "report.html"
-    results = [make_test_result(before=True, after=True)]
-    generate_html_report(results, output_path)
-    assert output_path.exists()
+def test_generate_html_report_creates_output_dir(tmp_path: Path) -> None:
+    output_dir = tmp_path / "subdir" / "nested"
+    agents = [make_metadata_and_outcome(output_dir, "a", tests_passing_before=True, tests_passing_after=True)]
+    generate_html_report(agents, output_dir)
+    assert (output_dir / "index.html").exists()
 
 
 def test_generate_html_report_all_report_sections(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
     impl_fix = {ChangeKind.FIX_IMPL: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="fixed impl")}
     blocked_changes = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.BLOCKED, summary_markdown="blocked")}
-    results = [
-        make_test_result(),
-        make_test_result(changes=SUCCEEDED_FIX, before=False, after=True),
-        make_test_result(changes=impl_fix, before=False, after=True),
-        make_test_result(changes=blocked_changes, before=False, after=False),
-        make_test_result(errored=True),
-        make_test_result(before=True, after=True),
+    agents = [
+        make_metadata_and_outcome(output_dir, "running-agent", write_outcome=False),
+        make_metadata_and_outcome(
+            output_dir, "non-impl", changes=SUCCEEDED_FIX, tests_passing_before=False, tests_passing_after=True
+        ),
+        make_metadata_and_outcome(
+            output_dir, "impl-fix", changes=impl_fix, tests_passing_before=False, tests_passing_after=True
+        ),
+        make_metadata_and_outcome(
+            output_dir, "blocked", changes=blocked_changes, tests_passing_before=False, tests_passing_after=False
+        ),
+        make_metadata_and_outcome(output_dir, "failed", error_summary="boom"),
+        make_metadata_and_outcome(output_dir, "clean", tests_passing_before=True, tests_passing_after=True),
     ]
-    output_path = tmp_path / "all_sections.html"
-    generate_html_report(results, output_path)
-    content = output_path.read_text()
+    result_path = generate_html_report(agents, output_dir)
+    content = result_path.read_text()
     for sec in ReportSection:
         label = {
             ReportSection.NON_IMPL_FIXES: "Non-implementation fixes",
@@ -339,61 +351,81 @@ def test_generate_html_report_all_report_sections(tmp_path: Path) -> None:
         assert label in content
 
 
-def test_generate_html_report_empty_results(tmp_path: Path) -> None:
-    output_path = tmp_path / "empty.html"
-    generate_html_report([], output_path)
-    assert "0 test(s)" in output_path.read_text()
+def test_generate_html_report_empty_agents(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    result_path = generate_html_report([], output_dir)
+    assert "0 test(s)" in result_path.read_text()
 
 
 def test_generate_html_report_with_integrator(tmp_path: Path) -> None:
-    results = [make_test_result(changes=SUCCEEDED_FIX, before=False, after=True)]
-    integrator = IntegratorResult(
+    output_dir = tmp_path / "out"
+    agents = [
+        make_metadata_and_outcome(
+            output_dir,
+            "agent-a",
+            branch_name="mngr-tmr/a",
+            changes=SUCCEEDED_FIX,
+            tests_passing_before=False,
+            tests_passing_after=True,
+        ),
+    ]
+    integrator_meta = AgentMetadata(
+        kind=AgentKind.INTEGRATOR,
         agent_name=AgentName("tmr-integrator-abc123"),
-        squashed_branches=("mngr-tmr/a",),
         branch_name="mngr-tmr/integrated-abc123",
     )
-    output_path = tmp_path / "integrator.html"
-    generate_html_report(results, output_path, integrator=integrator)
-    content = output_path.read_text()
+    write_integrator_outcome(
+        output_dir,
+        integrator_meta.agent_name,
+        {"squashed_branches": ["mngr-tmr/a"], "squashed_commit_hash": "abc", "impl_priority": [], "failed": []},
+    )
+    result_path = generate_html_report(agents, output_dir, integrator_metadata=integrator_meta)
+    content = result_path.read_text()
     assert "Test Map-Reduce Report" in content
     assert "Merged?" in content
 
 
 def test_generate_html_report_integrator_with_failures(tmp_path: Path) -> None:
-    results = [make_test_result(before=True, after=True)]
-    integrator = IntegratorResult(
-        squashed_branches=("mngr-tmr/a",),
-        failed=("mngr-tmr/b",),
+    output_dir = tmp_path / "out"
+    agents = [make_metadata_and_outcome(output_dir, "a", tests_passing_before=True, tests_passing_after=True)]
+    integrator_meta = AgentMetadata(
+        kind=AgentKind.INTEGRATOR,
+        agent_name=AgentName("tmr-integrator-abc123"),
         branch_name="mngr-tmr/integrated-abc123",
     )
-    output_path = tmp_path / "integrator_partial.html"
-    generate_html_report(results, output_path, integrator=integrator)
-    assert output_path.exists()
+    write_integrator_outcome(
+        output_dir,
+        integrator_meta.agent_name,
+        {"squashed_branches": ["mngr-tmr/a"], "failed": ["mngr-tmr/b"]},
+    )
+    result_path = generate_html_report(agents, output_dir, integrator_metadata=integrator_meta)
+    assert result_path.exists()
 
 
 def test_generate_html_report_without_integrator(tmp_path: Path) -> None:
-    results = [make_test_result(before=True, after=True)]
-    output_path = tmp_path / "no_integrator.html"
-    generate_html_report(results, output_path)
-    content = output_path.read_text()
-    assert "Test Map-Reduce Report" in content
+    output_dir = tmp_path / "out"
+    agents = [make_metadata_and_outcome(output_dir, "a", tests_passing_before=True, tests_passing_after=True)]
+    result_path = generate_html_report(agents, output_dir)
+    assert "Test Map-Reduce Report" in result_path.read_text()
 
 
 def test_generate_html_report_html_escaped(tmp_path: Path) -> None:
+    output_dir = tmp_path / "out"
     xss_branch = "<script>alert('xss')</script>"
-    results = [
-        TestMapReduceResult(
+    agents = [
+        make_metadata_and_outcome(
+            output_dir,
+            "xss-agent",
             test_node_id="t::xss",
-            agent_name=AgentName("xss-agent"),
+            branch_name=xss_branch,
             changes=SUCCEEDED_FIX,
             tests_passing_before=False,
             tests_passing_after=True,
             summary_markdown="<img onerror=alert(1)>",
-            branch_name=xss_branch,
         )
     ]
-    output_path = tmp_path / "escape.html"
-    generate_html_report(results, output_path)
-    content = output_path.read_text()
+    result_path = generate_html_report(agents, output_dir)
+    content = result_path.read_text()
     assert "<script>alert" not in content
     assert "&lt;script&gt;" in content

--- a/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
@@ -13,8 +13,8 @@ from imbue.mngr_tmr.report import _build_grouped_tables
 from imbue.mngr_tmr.report import _build_toc_sidebar
 from imbue.mngr_tmr.report import _merged_status
 from imbue.mngr_tmr.report import _render_markdown
+from imbue.mngr_tmr.report import _report_section_of
 from imbue.mngr_tmr.report import generate_html_report
-from imbue.mngr_tmr.report import report_section_of
 from imbue.mngr_tmr.testing import FAILED_FIX
 from imbue.mngr_tmr.testing import SUCCEEDED_FIX
 from imbue.mngr_tmr.testing import make_test_result
@@ -23,33 +23,33 @@ from imbue.mngr_tmr.testing import make_test_result
 
 
 def test_report_section_errored() -> None:
-    assert report_section_of(make_test_result(errored=True)) == ReportSection.FAILED
+    assert _report_section_of(make_test_result(errored=True)) == ReportSection.FAILED
 
 
 def test_report_section_running() -> None:
-    assert report_section_of(make_test_result()) == ReportSection.RUNNING
+    assert _report_section_of(make_test_result()) == ReportSection.RUNNING
 
 
 def test_report_section_clean_pass() -> None:
-    assert report_section_of(make_test_result(before=True, after=True)) == ReportSection.CLEAN_PASS
+    assert _report_section_of(make_test_result(before=True, after=True)) == ReportSection.CLEAN_PASS
 
 
 def test_report_section_non_impl_fixes() -> None:
     assert (
-        report_section_of(make_test_result(changes=SUCCEEDED_FIX, before=False, after=True))
+        _report_section_of(make_test_result(changes=SUCCEEDED_FIX, before=False, after=True))
         == ReportSection.NON_IMPL_FIXES
     )
 
 
 def test_report_section_impl_fixes() -> None:
     impl_fix = {ChangeKind.FIX_IMPL: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="fixed")}
-    assert report_section_of(make_test_result(changes=impl_fix, before=False, after=True)) == ReportSection.IMPL_FIXES
+    assert _report_section_of(make_test_result(changes=impl_fix, before=False, after=True)) == ReportSection.IMPL_FIXES
 
 
 def test_report_section_blocked_all_changes_blocked() -> None:
     blocked_changes = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.BLOCKED, summary_markdown="blocked")}
     assert (
-        report_section_of(make_test_result(changes=blocked_changes, before=False, after=False))
+        _report_section_of(make_test_result(changes=blocked_changes, before=False, after=False))
         == ReportSection.BLOCKED
     )
 
@@ -57,13 +57,13 @@ def test_report_section_blocked_all_changes_blocked() -> None:
 def test_report_section_failed_changes_are_non_impl() -> None:
     """FAILED (not BLOCKED) changes route to NON_IMPL_FIXES, not BLOCKED."""
     assert (
-        report_section_of(make_test_result(changes=FAILED_FIX, before=False, after=False))
+        _report_section_of(make_test_result(changes=FAILED_FIX, before=False, after=False))
         == ReportSection.NON_IMPL_FIXES
     )
 
 
 def test_report_section_blocked_no_changes_tests_failing() -> None:
-    assert report_section_of(make_test_result(before=False, after=False)) == ReportSection.BLOCKED
+    assert _report_section_of(make_test_result(before=False, after=False)) == ReportSection.BLOCKED
 
 
 # --- render_markdown tests ---

--- a/libs/mngr_tmr/imbue/mngr_tmr/testing.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/testing.py
@@ -1,10 +1,18 @@
 """Shared test utilities for mngr-test-mapreduce tests."""
 
+import json
+from pathlib import Path
+
 from imbue.mngr.primitives import AgentName
+from imbue.mngr_tmr.data_types import AgentKind
+from imbue.mngr_tmr.data_types import AgentMetadata
 from imbue.mngr_tmr.data_types import Change
 from imbue.mngr_tmr.data_types import ChangeKind
 from imbue.mngr_tmr.data_types import ChangeStatus
 from imbue.mngr_tmr.data_types import TestMapReduceResult
+from imbue.mngr_tmr.data_types import TestResult
+from imbue.mngr_tmr.prompts import INTEGRATOR_OUTCOME_FILENAME
+from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 
 SUCCEEDED_FIX = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="fixed")}
 FAILED_FIX = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.FAILED, summary_markdown="failed")}
@@ -17,7 +25,7 @@ def make_test_result(
     before: bool | None = None,
     after: bool | None = None,
 ) -> TestMapReduceResult:
-    """Build a minimal TestMapReduceResult for testing."""
+    """Build a minimal TestMapReduceResult for testing render-internal helpers."""
     return TestMapReduceResult(
         test_node_id="t::t",
         agent_name=AgentName("a"),
@@ -26,3 +34,74 @@ def make_test_result(
         tests_passing_before=before,
         tests_passing_after=after,
     )
+
+
+def _serialize_outcome(outcome: TestResult) -> dict[str, object]:
+    return {
+        "changes": {
+            k.value: {"status": v.status.value, "summary_markdown": v.summary_markdown}
+            for k, v in outcome.changes.items()
+        },
+        "errored": outcome.errored,
+        "tests_passing_before": outcome.tests_passing_before,
+        "tests_passing_after": outcome.tests_passing_after,
+        "summary_markdown": outcome.summary_markdown,
+        "test_runs": [
+            {"run_name": r.run_name, "description_markdown": r.description_markdown} for r in outcome.test_runs
+        ],
+    }
+
+
+def write_test_outcome(output_dir: Path, agent_name: AgentName, outcome: TestResult) -> None:
+    """Write a testing-agent outcome JSON where the reporter expects it."""
+    target = output_dir / str(agent_name) / "test_output" / TESTING_AGENT_OUTCOME_FILENAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(_serialize_outcome(outcome)))
+
+
+def write_integrator_outcome(output_dir: Path, agent_name: AgentName, payload: dict[str, object]) -> None:
+    """Write an integrator outcome JSON where the reporter expects it."""
+    target = output_dir / str(agent_name) / INTEGRATOR_OUTCOME_FILENAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload))
+
+
+def make_metadata_and_outcome(
+    output_dir: Path,
+    agent_name: str,
+    *,
+    test_node_id: str = "t::t",
+    branch_name: str | None = None,
+    error_summary: str | None = None,
+    changes: dict[ChangeKind, Change] | None = None,
+    errored: bool = False,
+    tests_passing_before: bool | None = None,
+    tests_passing_after: bool | None = None,
+    summary_markdown: str = "",
+    write_outcome: bool = True,
+) -> AgentMetadata:
+    """Build an ``AgentMetadata`` and (unless ``write_outcome`` is False) write
+    its outcome JSON under ``output_dir/<agent_name>/test_output/``.
+
+    Mirrors what orchestration would emit at runtime: errored agents have
+    ``error_summary`` set and no outcome on disk; "running" agents have
+    neither.
+    """
+    name = AgentName(agent_name)
+    metadata = AgentMetadata(
+        kind=AgentKind.TESTING_AGENT,
+        agent_name=name,
+        test_node_id=test_node_id,
+        branch_name=branch_name,
+        error_summary=error_summary,
+    )
+    if error_summary is None and write_outcome:
+        outcome = TestResult(
+            changes=changes if changes is not None else {},
+            errored=errored,
+            tests_passing_before=tests_passing_before,
+            tests_passing_after=tests_passing_after,
+            summary_markdown=summary_markdown,
+        )
+        write_test_outcome(output_dir, name, outcome)
+    return metadata

--- a/libs/mngr_tmr/imbue/mngr_tmr/utils.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/utils.py
@@ -12,8 +12,25 @@ from imbue.mngr.errors import MngrError
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import TransferMode
+from imbue.mngr_tmr.data_types import ChangeStatus
+from imbue.mngr_tmr.data_types import TestMapReduceResult
 
 _SHORT_ID_LENGTH = 6
+
+
+def should_pull_changes(result: TestMapReduceResult) -> bool:
+    """Decide whether an agent's changes should be kept.
+
+    Pull when: not errored, at least one SUCCEEDED change, and tests are at
+    least as good as before (if they were passing, they must still be passing).
+    """
+    if result.errored:
+        return False
+    if not any(c.status == ChangeStatus.SUCCEEDED for c in result.changes.values()):
+        return False
+    if result.tests_passing_before is True and result.tests_passing_after is not True:
+        return False
+    return True
 
 
 def resolve_templates(

--- a/libs/mngr_tmr/imbue/mngr_tmr/utils.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/utils.py
@@ -13,22 +13,22 @@ from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import TransferMode
 from imbue.mngr_tmr.data_types import ChangeStatus
-from imbue.mngr_tmr.data_types import TestMapReduceResult
+from imbue.mngr_tmr.data_types import TestResult
 
 _SHORT_ID_LENGTH = 6
 
 
-def should_pull_changes(result: TestMapReduceResult) -> bool:
-    """Decide whether an agent's changes should be kept.
+def should_pull_changes_from_outcome(outcome: TestResult) -> bool:
+    """Decide whether an agent's changes should be kept based on its parsed outcome.
 
     Pull when: not errored, at least one SUCCEEDED change, and tests are at
     least as good as before (if they were passing, they must still be passing).
     """
-    if result.errored:
+    if outcome.errored:
         return False
-    if not any(c.status == ChangeStatus.SUCCEEDED for c in result.changes.values()):
+    if not any(c.status == ChangeStatus.SUCCEEDED for c in outcome.changes.values()):
         return False
-    if result.tests_passing_before is True and result.tests_passing_after is not True:
+    if outcome.tests_passing_before is True and outcome.tests_passing_after is not True:
         return False
     return True
 


### PR DESCRIPTION
See human summary below: https://github.com/imbue-ai/mngr/pull/1619#pullrequestreview-4284123404

## Summary

Two threads of change to ``mngr tmr``: a new output-transfer scheme that fixes brittleness around finalizing agents, and a decoupling of orchestration from result-data shape so the reporter and the polling loop can evolve independently.

### Output transfer

Testing agents now publish a single ``outputs.tar.gz`` into their state directory (``\$MNGR_AGENT_STATE_DIR/plugin/test-map-reduce/``), containing the renamed ``test_output/`` directory and an optional incremental ``branch.bundle``. The orchestrator polls for that archive via the per-agent volume API (works even when the host is offline), downloads it, extracts, and reconstructs the agent's branch from the bundle -- replacing the previous rsync + git-pull steps.

Reintegrate mode uses the same path. SSH provider, which does not expose a volume, is no longer supported for testing-agent outputs. The integrator agent's transfer mechanism is unchanged (still rsync), but its outcome is read from disk by the reporter rather than handed across in memory.

### Polling

Polling is now driven entirely by the existence of ``outputs.tar.gz`` on the agent's volume. ``mngr list`` is no longer called from the main loop. This fixes a race where an agent reaching a terminal lifecycle state before its archive was visible on the volume would be marked failed forever. ``--poll-interval`` default raised to 60s; ``--result-check-interval`` is gone (the volume check is the only signal now).

### Orchestration / reporter decoupling

The outcome JSON schema is a contract between agents and ``report.py`` only. Orchestration treats extracted contents as opaque blobs; it hands a list of ``AgentMetadata`` (kind, agent_name, test_node_id, branch_name, error_summary) to the reporter, which reads each agent's outcome from disk on demand and caches per-agent.

This collapses several pieces of orchestration code (``_collect_agent_results``, ``gather_results``, ``_build_current_results``, the ``cached_results`` dict) and makes the reporter the only place that needs to know about ``TestResult`` / ``IntegratorResult`` shape. Future pluggable reporting can swap ``generate_html_report`` without touching the polling loop.

### CLI flag changes

- ``--max-parallel`` → ``--max-parallel-launch`` (default 4 → 10).
- ``--max-agents`` → ``--max-parallel-agents``.
- ``--output-html PATH`` → ``--output-dir DIR``; the report is always written to ``\<dir\>/index.html``.
- ``--result-check-interval`` removed.
- ``--poll-interval`` default 10s → 60s.

### Other user-visible changes

- ``mngr list --format json`` no longer emits the redundant ``address`` field on agent/host records. Same value is still reachable on the parsed Python objects; removing it from the wire format lets the output round-trip through ``model_validate_json``.
- ``Volume`` gains a ``path_exists(path)`` method, implemented for local, Docker, Modal, and the ``ScopedVolume`` wrapper.
- New CI step in ``.github/workflows/tmr.yml`` pre-trusts the repo checkout for Claude (so the integrator agent's local-host trust-dialog flow doesn't hang in CI). CI now also passes ``--use-snapshot`` to the orchestrator.

### Internals worth mentioning

- ``api.py`` renamed to ``orchestration.py``; the rest of the package now imports from ``mngr_cli``, ``pulling``, ``utils``, ``launching``, ``orchestration`` directly instead of through a re-export hub.
- Module-private helpers prefixed with ``_`` across the package.
- ``AgentDetails.address`` and ``HostDetails.address`` are now plain ``@cached_property`` (not ``@computed_field``) so JSON round-trips cleanly.
- ``base_commit`` threaded through ``TmrLaunchConfig`` into ``AgentGitOptions.base_branch`` so ``\$MNGR_GIT_BASE_BRANCH`` is populated for agents (was empty, which broke the bundle command).

## Test plan

- [ ] CI: ``just test-offload`` -- unit + integration suites under the new shapes.
- [ ] CI: the dispatch ``TMR`` workflow with ``--use-snapshot`` and the pre-trust step -- should produce a valid HTML report and integrator branch end to end.
- [ ] Local: ``mngr tmr`` against the ``local`` provider on a small test set. Verify:
  - Per-agent ``output_dir/\<agent\>/test_output/testing_agent_outcome.json`` lands on disk.
  - Per-agent ``output_dir/\<agent\>/branch.bundle`` is created when the agent committed.
  - Each agent's branch ends up in the local repo via ``git fetch \<bundle\>``.
- [ ] Local: ``mngr tmr`` against ``--provider modal`` with at least two agents. Verify:
  - ``output_dir/index.html`` is regenerated during polling, not just at the end.
  - Once each agent publishes the archive, it shows up in the report (no permanent "still running" rows).
- [ ] Local: ``mngr tmr --reintegrate \<run-name\>`` against a previous run that produced fix branches. Verify:
  - Agent outputs are re-extracted from the volume.
  - Integrator runs and produces a branch.
  - Report renders with the integrator's squashed/impl/failed columns populated.
- [ ] Manual: a deliberately-killed agent (e.g., stop a testing agent before it writes the archive). Should time out per ``--timeout`` and render as "Agent was stopped because the timeout was reached." in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)