### PR TITLE
Workspace identity: host name, not agent name (spec WIP)

### DIFF
--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -49,13 +49,14 @@ from imbue.minds.errors import GitCloneError
 from imbue.minds.errors import GitOperationError
 from imbue.minds.errors import MngrCommandError
 from imbue.minds.primitives import AIProvider
-from imbue.minds.primitives import AgentName
 from imbue.minds.primitives import CreationId
 from imbue.minds.primitives import GitBranch
 from imbue.minds.primitives import GitUrl
 from imbue.minds.primitives import LaunchMode
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostName
 from imbue.mngr_latchkey.agent_setup import AgentLatchkeySetup
 from imbue.mngr_latchkey.agent_setup import finalize_host_permissions
 from imbue.mngr_latchkey.agent_setup import prepare_agent_latchkey
@@ -337,17 +338,16 @@ def _rsync_worktree_over_clone(
         )
 
 
-def _make_host_name(agent_name: AgentName) -> str:
-    """Build the host name for an agent.
-
-    Uses ``{agent_name}-host`` so it is obvious why the host was created.
-    """
-    return f"{agent_name}-host"
+# Constant agent name for every minds-created agent. Minds runs one agent
+# per host, so the agent name carries no per-workspace information; the
+# workspace is identified by its host name. Kept as a SafeName-typed
+# constant so callers can pass it to ``mngr`` without re-validating.
+_DEFAULT_AGENT_NAME: Final[AgentName] = AgentName("system-services")
 
 
 def _build_mngr_create_command(
     launch_mode: LaunchMode,
-    agent_name: AgentName,
+    host_name: HostName,
     imbue_cloud_account: str | None = None,
     imbue_cloud_repo_url: str | None = None,
     imbue_cloud_branch_or_tag: str | None = None,
@@ -368,15 +368,17 @@ def _build_mngr_create_command(
     CLOUD mode: --template main --template vultr (runs in Docker on a Vultr VPS)
     IMBUE_CLOUD mode: --new-host on the imbue_cloud_<slug> provider (the
         plugin's create_host adopts the pool's pre-baked agent under
-        ``agent_name``); ``imbue_cloud_*`` arguments encode the lease
-        attributes (--build-arg).
+        the lease's baked name); ``imbue_cloud_*`` arguments encode the
+        lease attributes (--build-arg).
 
     Every mode creates a separate host, so the agent address uses
-    ``agent_name@{agent_name}-host`` so hosts are clearly attributable.
-    ``--reuse`` and ``--update`` are passed for the non-IMBUE_CLOUD modes
-    so re-deploying resets the agent on the same host instead of failing
-    on a duplicate name (IMBUE_CLOUD's lease flow is one-shot per pool
-    host, so reuse is not meaningful there).
+    ``system-services@<host_name>`` -- the agent name is constant across
+    every minds workspace; the host name (the user's input from the
+    create-project form) is the workspace identifier. ``--reuse`` and
+    ``--update`` are passed for the non-IMBUE_CLOUD modes so re-deploying
+    resets the agent on the same host instead of failing on a duplicate
+    name (IMBUE_CLOUD's lease flow is one-shot per pool host, so reuse
+    is not meaningful there).
 
     Secrets (``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``, ``GH_TOKEN``)
     are forwarded by the FCT template's own ``pass_(host_)env`` declarations,
@@ -397,16 +399,16 @@ def _build_mngr_create_command(
     """
     match launch_mode:
         case LaunchMode.LOCAL:
-            address = f"{agent_name}@{_make_host_name(agent_name)}.docker"
+            address = f"{_DEFAULT_AGENT_NAME}@{host_name}.docker"
         case LaunchMode.LIMA:
-            address = f"{agent_name}@{_make_host_name(agent_name)}.lima"
+            address = f"{_DEFAULT_AGENT_NAME}@{host_name}.lima"
         case LaunchMode.CLOUD:
-            address = f"{agent_name}@{_make_host_name(agent_name)}.vultr"
+            address = f"{_DEFAULT_AGENT_NAME}@{host_name}.vultr"
         case LaunchMode.IMBUE_CLOUD:
             if not imbue_cloud_account:
                 raise MngrCommandError("IMBUE_CLOUD mode requires imbue_cloud_account")
             slug = _slugify_account(imbue_cloud_account)
-            address = f"{agent_name}@{_make_host_name(agent_name)}.imbue_cloud_{slug}"
+            address = f"{_DEFAULT_AGENT_NAME}@{host_name}.imbue_cloud_{slug}"
         case _ as unreachable:
             assert_never(unreachable)
 
@@ -434,7 +436,15 @@ def _build_mngr_create_command(
         "--format",
         "jsonl",
         "--label",
-        f"workspace={agent_name}",
+        f"workspace={host_name}",
+        # Pin the agent's per-workspace branch to the host name. mngr's
+        # default for ``--branch`` is ``:mngr/*`` where ``*`` expands to the
+        # agent name, but our agent name is the constant ``system-services``
+        # -- without this override every workspace would share the same
+        # branch ``mngr/system-services``. ``:`` keeps the base branch as
+        # ``current`` so we just rename the *new* branch.
+        "--branch",
+        f":mngr/{host_name}",
         "--env",
         f"MINDS_API_KEY={api_key}",
         "--label",
@@ -619,7 +629,7 @@ class _CreateEventCapture(MutableModel):
 def run_mngr_create(
     launch_mode: LaunchMode,
     workspace_dir: Path | None,
-    agent_name: AgentName,
+    host_name: HostName,
     on_output: OutputCallback | None = None,
     imbue_cloud_account: str | None = None,
     imbue_cloud_repo_url: str | None = None,
@@ -656,7 +666,7 @@ def run_mngr_create(
     """
     mngr_command, api_key = _build_mngr_create_command(
         launch_mode,
-        agent_name,
+        host_name,
         imbue_cloud_account=imbue_cloud_account,
         imbue_cloud_repo_url=imbue_cloud_repo_url,
         imbue_cloud_branch_or_tag=imbue_cloud_branch_or_tag,
@@ -832,7 +842,7 @@ class AgentCreator(MutableModel):
     def start_creation(
         self,
         repo_source: str,
-        agent_name: str = "",
+        host_name: str = "",
         branch: str = "",
         launch_mode: LaunchMode = LaunchMode.LOCAL,
         ai_provider: AIProvider = AIProvider.SUBSCRIPTION,
@@ -881,7 +891,13 @@ class AgentCreator(MutableModel):
         ``RandomId`` prefixes) so they can never accidentally be swapped.
         """
         log_queue: queue.Queue[str] = queue.Queue()
-        effective_name = agent_name.strip() if agent_name.strip() else extract_repo_name(repo_source)
+        # ``host_name`` falls back to a repo-derived name when blank so the
+        # API path (``/api/create-agent``) doesn't need to compute it itself.
+        # The form path already requires the field. ``HostName(...)`` is
+        # invoked downstream in ``_create_agent_background`` so any invalid
+        # input fails inside the background thread with an error_message
+        # rather than crashing this synchronous entry point.
+        effective_name = host_name.strip() if host_name.strip() else extract_repo_name(repo_source)
         effective_branch = branch.strip()
 
         creation_id = CreationId()
@@ -952,7 +968,7 @@ class AgentCreator(MutableModel):
         self,
         creation_id: CreationId,
         repo_source: str,
-        agent_name: str,
+        host_name: str,
         branch: str,
         log_queue: queue.Queue[str],
         launch_mode: LaunchMode,
@@ -1081,7 +1097,7 @@ class AgentCreator(MutableModel):
                                 alias=None,
                                 max_budget=100.0,
                                 budget_duration="1d",
-                                metadata={"agent_name": agent_name},
+                                metadata={"host_name": host_name},
                             )
                         except ImbueCloudCliError as exc:
                             raise MngrCommandError(f"Failed to create LiteLLM key: {exc}") from exc
@@ -1126,12 +1142,12 @@ class AgentCreator(MutableModel):
                 # re-creating the agent.
                 latchkey_setup = self._prepare_latchkey_or_warn(log_queue)
 
-                parsed_name = AgentName(agent_name)
-                log_queue.put("[minds] Creating agent '{}' (mode: {})...".format(agent_name, launch_mode.value))
+                parsed_host = HostName(host_name)
+                log_queue.put("[minds] Creating workspace '{}' (mode: {})...".format(host_name, launch_mode.value))
                 api_key, canonical_id, canonical_host_id = run_mngr_create(
                     launch_mode=launch_mode,
                     workspace_dir=workspace_dir,
-                    agent_name=parsed_name,
+                    host_name=parsed_host,
                     on_output=emit_log,
                     latchkey_env=latchkey_setup.env,
                     imbue_cloud_account=account_email if launch_mode is LaunchMode.IMBUE_CLOUD else None,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -27,7 +27,6 @@ from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.agent_creator import _build_mngr_create_command
 from imbue.minds.desktop_client.agent_creator import _is_git_worktree
 from imbue.minds.desktop_client.agent_creator import _is_local_path
-from imbue.minds.desktop_client.agent_creator import _make_host_name
 from imbue.minds.desktop_client.agent_creator import _redact_url_credentials
 from imbue.minds.desktop_client.agent_creator import _redact_url_credentials_in_text
 from imbue.minds.desktop_client.agent_creator import extract_repo_name
@@ -35,10 +34,10 @@ from imbue.minds.desktop_client.conftest import FakeImbueCloudCli
 from imbue.minds.desktop_client.imbue_cloud_cli import LiteLLMKeyMaterial
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.primitives import AIProvider
-from imbue.minds.primitives import AgentName
 from imbue.minds.primitives import CreationId
 from imbue.minds.primitives import LaunchMode
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import HostName
 
 
 def test_extract_repo_name_strips_dot_git_and_trailing_slash() -> None:
@@ -71,10 +70,6 @@ def test_redact_url_credentials_in_text_strips_embedded_userinfo() -> None:
     assert _redact_url_credentials_in_text(msg) == "fatal: unable to access 'https://github.com/x/y': bad"
 
 
-def test_make_host_name_appends_host_suffix() -> None:
-    assert _make_host_name(AgentName("alpha")) == "alpha-host"
-
-
 def test_build_mngr_create_command_lifts_latchkey_env_to_host_env_flags() -> None:
     """``_build_mngr_create_command`` lifts each entry of ``latchkey_env`` into a ``--host-env`` flag.
 
@@ -89,7 +84,7 @@ def test_build_mngr_create_command_lifts_latchkey_env_to_host_env_flags() -> Non
     """
     command, _ = _build_mngr_create_command(
         launch_mode=LaunchMode.LOCAL,
-        agent_name=AgentName("hello"),
+        host_name=HostName("hello"),
         latchkey_env={
             "LATCHKEY_GATEWAY": "http://127.0.0.1:1989",
             "LATCHKEY_GATEWAY_PASSWORD": "sup3rs3cret",
@@ -123,7 +118,7 @@ def test_build_mngr_create_command_omits_latchkey_when_env_is_empty() -> None:
     for latchkey_env in (None, {}):
         command, _ = _build_mngr_create_command(
             launch_mode=LaunchMode.LOCAL,
-            agent_name=AgentName("hello"),
+            host_name=HostName("hello"),
             latchkey_env=latchkey_env,
         )
         joined = " ".join(command)
@@ -134,7 +129,7 @@ def test_build_mngr_create_command_omits_latchkey_when_env_is_empty() -> None:
 def test_build_mngr_create_command_uses_main_template_and_omits_message_arg() -> None:
     command, api_key = _build_mngr_create_command(
         launch_mode=LaunchMode.LOCAL,
-        agent_name=AgentName("hello"),
+        host_name=HostName("hello"),
     )
     assert "--template" in command
     assert "main" in command
@@ -158,15 +153,16 @@ def test_build_mngr_create_command_uses_main_template_and_omits_message_arg() ->
 def test_build_mngr_create_command_imbue_cloud_targets_account_provider() -> None:
     command, api_key = _build_mngr_create_command(
         launch_mode=LaunchMode.IMBUE_CLOUD,
-        agent_name=AgentName("hello"),
+        host_name=HostName("hello"),
         imbue_cloud_account="alice@imbue.com",
         imbue_cloud_repo_url="https://github.com/imbue-ai/forever-claude-template",
         imbue_cloud_branch_or_tag="v1.2.3",
     )
     joined = " ".join(command)
     # Address points at the imbue_cloud_<slug> provider so mngr routes
-    # create_host to ImbueCloudProvider.
-    assert "@hello-host.imbue_cloud_alice-imbue-com" in joined
+    # create_host to ImbueCloudProvider. The agent name is now the constant
+    # ``system-services``; the user's input drives the host name.
+    assert "system-services@hello.imbue_cloud_alice-imbue-com" in joined
     # IMBUE_CLOUD does not pass --reuse / --update (each lease is one-shot)
     # nor --id (the canonical id is parsed from the JSONL ``created`` event).
     assert "--id" not in command
@@ -208,7 +204,7 @@ def test_build_mngr_create_command_never_inlines_secret_env_flags() -> None:
     ):
         command, _ = _build_mngr_create_command(
             launch_mode=mode,
-            agent_name=AgentName("hello"),
+            host_name=HostName("hello"),
             imbue_cloud_account=account,
         )
         joined = " ".join(command)
@@ -451,7 +447,7 @@ def test_start_creation_imbue_cloud_ai_with_local_compute_mints_litellm_key(tmp_
 
     creation_id = creator.start_creation(
         repo_source=str(_make_fake_repo(tmp_path)),
-        agent_name="my-agent",
+        host_name="my-workspace",
         launch_mode=LaunchMode.LOCAL,
         ai_provider=AIProvider.IMBUE_CLOUD,
         account_email="alice@imbue.com",
@@ -460,7 +456,7 @@ def test_start_creation_imbue_cloud_ai_with_local_compute_mints_litellm_key(tmp_
 
     assert len(cli.create_calls) == 1
     assert cli.create_calls[0]["account"] == "alice@imbue.com"
-    assert cli.create_calls[0]["metadata"] == {"agent_name": "my-agent"}
+    assert cli.create_calls[0]["metadata"] == {"host_name": "my-workspace"}
 
 
 # Flaky under heavy CI load: this is a sync unit test but its setup spins up
@@ -476,7 +472,7 @@ def test_start_creation_api_key_ai_does_not_mint_litellm_key(tmp_path: Path) -> 
 
     creation_id = creator.start_creation(
         repo_source=str(_make_fake_repo(tmp_path)),
-        agent_name="my-agent",
+        host_name="my-workspace",
         launch_mode=LaunchMode.LOCAL,
         ai_provider=AIProvider.API_KEY,
         anthropic_api_key="sk-ant-user-supplied",
@@ -494,7 +490,7 @@ def test_start_creation_subscription_ai_does_not_mint_litellm_key(tmp_path: Path
 
     creation_id = creator.start_creation(
         repo_source=str(_make_fake_repo(tmp_path)),
-        agent_name="my-agent",
+        host_name="my-workspace",
         launch_mode=LaunchMode.LOCAL,
         ai_provider=AIProvider.SUBSCRIPTION,
     )
@@ -511,7 +507,7 @@ def test_start_creation_api_key_ai_without_key_fails_with_clear_message(tmp_path
 
     creation_id = creator.start_creation(
         repo_source=str(_make_fake_repo(tmp_path)),
-        agent_name="my-agent",
+        host_name="my-workspace",
         launch_mode=LaunchMode.LOCAL,
         ai_provider=AIProvider.API_KEY,
         anthropic_api_key="",

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -88,6 +88,8 @@ from imbue.minds.primitives import ServiceName
 from imbue.minds.telegram.setup import TelegramSetupOrchestrator
 from imbue.minds.telegram.setup import TelegramSetupStatus
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import HostName
+from imbue.mngr.primitives import InvalidName
 
 _PROXY_TIMEOUT_SECONDS: Final[float] = 30.0
 
@@ -491,7 +493,7 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
 
     form = await request.form()
     git_url = str(form.get("git_url", "")).strip()
-    agent_name = str(form.get("agent_name", "")).strip()
+    host_name = str(form.get("host_name", "")).strip()
     branch = str(form.get("branch", "")).strip()
     try:
         launch_mode = LaunchMode(str(form.get("launch_mode", LaunchMode.LOCAL.value)))
@@ -514,7 +516,7 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
         # so a validation error doesn't silently revert their choice.
         html_body = render_create_form(
             git_url=git_url,
-            agent_name=agent_name,
+            host_name=host_name,
             branch=branch,
             launch_mode=launch_mode,
             ai_provider=ai_provider,
@@ -528,6 +530,16 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
 
     if not git_url:
         return _re_render_with_error("Repository URL is required.")
+
+    # Validate the host name eagerly so the user sees the error inline on
+    # the form rather than as a deferred "FAILED" status on the creating
+    # page. An empty value falls through; ``start_creation`` substitutes a
+    # repo-derived fallback for the API path.
+    if host_name:
+        try:
+            HostName(host_name)
+        except InvalidName as exc:
+            return _re_render_with_error(str(exc))
 
     is_imbue_cloud_compute = launch_mode is LaunchMode.IMBUE_CLOUD
     is_imbue_cloud_ai = ai_provider is AIProvider.IMBUE_CLOUD
@@ -562,7 +574,7 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
     # the association is keyed under the right id.
     creation_id = agent_creator.start_creation(
         git_url,
-        agent_name=agent_name,
+        host_name=host_name,
         branch=branch,
         launch_mode=launch_mode,
         ai_provider=ai_provider,
@@ -623,7 +635,7 @@ async def _handle_create_agent_api(request: Request, auth_store: AuthStoreDep) -
             media_type="application/json",
         )
     git_url = str(body.get("git_url", "")).strip()
-    agent_name = str(body.get("agent_name", "")).strip()
+    host_name = str(body.get("host_name", "")).strip()
     branch = str(body.get("branch", "")).strip()
     try:
         launch_mode = LaunchMode(str(body.get("launch_mode", LaunchMode.LOCAL.value)))
@@ -650,6 +662,17 @@ async def _handle_create_agent_api(request: Request, auth_store: AuthStoreDep) -
             content='{"error": "git_url is required"}',
             media_type="application/json",
         )
+    # Validate the host name eagerly so a malformed value returns 400 from
+    # the API rather than failing deferred in the background thread.
+    if host_name:
+        try:
+            HostName(host_name)
+        except InvalidName as exc:
+            return Response(
+                status_code=400,
+                content=json.dumps({"error": str(exc)}),
+                media_type="application/json",
+            )
     # Mirror the form path's account requirement so the API rejects
     # imbue_cloud-without-account up front instead of failing later inside
     # the background thread with a vague MngrCommandError.
@@ -679,7 +702,7 @@ async def _handle_create_agent_api(request: Request, auth_store: AuthStoreDep) -
 
     creation_id = agent_creator.start_creation(
         git_url,
-        agent_name=agent_name,
+        host_name=host_name,
         branch=branch,
         launch_mode=launch_mode,
         ai_provider=ai_provider,

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -114,7 +114,7 @@ _DEFAULT_GIT_URL: Final[str] = os.getenv(
 )
 
 
-_DEFAULT_AGENT_NAME: Final[str] = os.getenv("MINDS_WORKSPACE_NAME", "assistant")
+_DEFAULT_HOST_NAME: Final[str] = os.getenv("MINDS_WORKSPACE_NAME", "assistant")
 
 
 _DEFAULT_BRANCH: Final[str] = os.getenv("MINDS_WORKSPACE_BRANCH", "")
@@ -123,7 +123,7 @@ _DEFAULT_BRANCH: Final[str] = os.getenv("MINDS_WORKSPACE_BRANCH", "")
 @pure
 def render_create_form(
     git_url: str = "",
-    agent_name: str = "",
+    host_name: str = "",
     branch: str = "",
     launch_mode: LaunchMode | None = None,
     ai_provider: AIProvider | None = None,
@@ -139,9 +139,13 @@ def render_create_form(
     Both default to ``IMBUE_CLOUD`` when an account is selected; without
     an account we drop them to ``LOCAL`` / ``SUBSCRIPTION`` so the form
     starts in a valid state for the no-account flow.
+
+    ``host_name`` is the value of the form's "Name" field; it drives the
+    host name on the resulting workspace. (The agent itself is always
+    named ``system-services``.)
     """
     effective_url = git_url if git_url else _DEFAULT_GIT_URL
-    effective_name = agent_name if agent_name else _DEFAULT_AGENT_NAME
+    effective_name = host_name if host_name else _DEFAULT_HOST_NAME
     effective_branch = branch if branch else _DEFAULT_BRANCH
     has_account = bool(default_account_id and accounts)
     effective_launch_mode = (
@@ -155,7 +159,7 @@ def render_create_form(
     template = JINJA_ENV.get_template("create.html")
     return template.render(
         git_url=effective_url,
-        agent_name=effective_name,
+        host_name=effective_name,
         branch=effective_branch,
         launch_modes=list(LaunchMode),
         selected_launch_mode=effective_launch_mode.value,

--- a/apps/minds/imbue/minds/desktop_client/templates/create.html
+++ b/apps/minds/imbue/minds/desktop_client/templates/create.html
@@ -13,10 +13,10 @@
     <form id="create-form" action="/create" method="post">
       <div class="flex gap-6 mb-4 items-start">
         <div class="basis-[200px] shrink-0 pt-2.5">
-          <label for="agent_name" class="text-sm text-zinc-900 font-medium block">Name</label>
+          <label for="host_name" class="text-sm text-zinc-900 font-medium block">Name</label>
         </div>
         <div class="flex-1">
-          {{ ui.text_input('agent_name', value=agent_name, placeholder='assistant', id='agent_name', required=true) }}
+          {{ ui.text_input('host_name', value=host_name, placeholder='assistant', id='host_name', required=true) }}
         </div>
       </div>
 

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -73,14 +73,14 @@ def test_render_create_form_has_default_values() -> None:
     html = render_create_form()
     assert "assistant" in html
     assert "forever-claude-template" in html
-    assert "agent_name" in html
+    assert "host_name" in html
     assert "launch_mode" in html
 
 
 def test_render_create_form_prefills_values() -> None:
-    html = render_create_form(git_url="https://custom/repo", agent_name="my-bot", branch="feature/test")
+    html = render_create_form(git_url="https://custom/repo", host_name="my-workspace", branch="feature/test")
     assert "https://custom/repo" in html
-    assert "my-bot" in html
+    assert "my-workspace" in html
     assert "feature/test" in html
 
 

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -507,30 +507,30 @@ def test_create_form_submit_rejects_empty_git_url(tmp_path: Path) -> None:
     """POST /create with empty git_url returns 400."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
-    response = client.post("/create", data={"git_url": "", "agent_name": "test"})
+    response = client.post("/create", data={"git_url": "", "host_name": "test"})
     assert response.status_code == 400
 
 
-def test_create_form_submit_passes_agent_name(tmp_path: Path) -> None:
-    """POST /create passes agent_name to the creator."""
+def test_create_form_submit_passes_host_name(tmp_path: Path) -> None:
+    """POST /create passes host_name to the creator."""
     client, _, agent_creator = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={"git_url": "file:///nonexistent-repo", "agent_name": "my-agent"},
+        data={"git_url": "file:///nonexistent-repo", "host_name": "my-workspace"},
         follow_redirects=False,
     )
     assert response.status_code == 303
     agent_creator.wait_for_all()
 
 
-def test_create_agent_api_passes_agent_name(tmp_path: Path) -> None:
-    """POST /api/create-agent passes agent_name to the creator."""
+def test_create_agent_api_passes_host_name(tmp_path: Path) -> None:
+    """POST /api/create-agent passes host_name to the creator."""
     client, _, agent_creator = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/api/create-agent",
-        json={"git_url": "file:///nonexistent-repo", "agent_name": "my-agent"},
+        json={"git_url": "file:///nonexistent-repo", "host_name": "my-agent"},
     )
     assert response.status_code == 200
     data = response.json()
@@ -556,6 +556,33 @@ def test_create_agent_api_rejects_empty_git_url(tmp_path: Path) -> None:
 
     response = client.post("/api/create-agent", json={"git_url": ""})
     assert response.status_code == 400
+
+
+def test_create_form_submit_rejects_invalid_host_name(tmp_path: Path) -> None:
+    """POST /create with a host_name that fails HostName validation re-renders the form with an error."""
+    client, _, _ = _create_test_server_with_agent_creator(tmp_path)
+
+    response = client.post(
+        "/create",
+        data={"git_url": "file:///nonexistent-repo", "host_name": "bad.name"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "alphanumeric" in response.text
+    assert "bad.name" in response.text
+
+
+def test_create_agent_api_rejects_invalid_host_name(tmp_path: Path) -> None:
+    """POST /api/create-agent with a host_name that fails HostName validation returns 400."""
+    client, _, _ = _create_test_server_with_agent_creator(tmp_path)
+
+    response = client.post(
+        "/api/create-agent",
+        json={"git_url": "file:///nonexistent-repo", "host_name": "bad.name"},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert "alphanumeric" in body["error"]
 
 
 def test_create_agent_api_rejects_invalid_json(tmp_path: Path) -> None:
@@ -760,7 +787,7 @@ def test_create_form_submit_passes_launch_mode(tmp_path: Path) -> None:
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
         },
         follow_redirects=False,
@@ -777,7 +804,7 @@ def test_create_agent_api_passes_launch_mode(tmp_path: Path) -> None:
         "/api/create-agent",
         json={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
         },
     )
@@ -795,7 +822,7 @@ def test_create_agent_api_rejects_invalid_launch_mode(tmp_path: Path) -> None:
         "/api/create-agent",
         json={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "INVALID_MODE",
         },
     )
@@ -854,7 +881,7 @@ def test_create_form_submit_rejects_imbue_cloud_compute_without_account(tmp_path
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "IMBUE_CLOUD",
             "ai_provider": "SUBSCRIPTION",
             "account_id": "",
@@ -873,7 +900,7 @@ def test_create_form_submit_rejects_imbue_cloud_ai_without_account(tmp_path: Pat
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
             "ai_provider": "IMBUE_CLOUD",
             "account_id": "",
@@ -892,7 +919,7 @@ def test_create_form_submit_rejects_api_key_provider_without_key(tmp_path: Path)
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
             "ai_provider": "API_KEY",
             "anthropic_api_key": "",
@@ -911,7 +938,7 @@ def test_create_form_submit_accepts_subscription_with_no_account(tmp_path: Path)
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
             "ai_provider": "SUBSCRIPTION",
             "account_id": "",
@@ -997,7 +1024,7 @@ def test_create_form_submit_preserves_account_id_on_validation_error(tmp_path: P
         "/create",
         data={
             "git_url": "file:///nonexistent-repo",
-            "agent_name": "my-agent",
+            "host_name": "my-agent",
             "launch_mode": "LOCAL",
             "ai_provider": "IMBUE_CLOUD",
             "account_id": "",

--- a/apps/minds/imbue/minds/primitives.py
+++ b/apps/minds/imbue/minds/primitives.py
@@ -63,12 +63,6 @@ class AIProvider(UpperCaseStrEnum):
     SUBSCRIPTION = auto()
 
 
-class AgentName(NonEmptyStr):
-    """User-chosen name for an agent."""
-
-    ...
-
-
 class OneTimeCode(NonEmptyStr):
     """A single-use authentication code for workspace access."""
 

--- a/apps/remote_service_connector/imbue/remote_service_connector/app.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/app.py
@@ -18,6 +18,7 @@ import io
 import json
 import logging
 import os
+import re
 import shlex
 from collections.abc import Callable
 from collections.abc import Iterator
@@ -36,6 +37,7 @@ from fastapi import Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 from supertokens_python import InputAppInfo
 from supertokens_python import SupertokensConfig
 from supertokens_python import init as supertokens_init
@@ -279,15 +281,42 @@ AuthResult = AdminAuth | AgentAuth
 
 # -- Host pool models --
 
+# Mirror of mngr's SafeName regex (libs/mngr/imbue/mngr/primitives.py:_SAFE_NAME_RE).
+# Duplicated here -- not imported -- because this file is self-contained and
+# must not depend on the monorepo. Keep this in sync if the mngr-side rule
+# changes (alphanumeric, dashes/underscores allowed in the middle only).
+_HOST_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$|^[a-zA-Z0-9]$")
+
+
+def _validate_host_name(value: str) -> str:
+    """Field validator: enforce the SafeName regex.
+
+    Rejects empty strings and anything outside the alphanumeric+``-``/``_``
+    middle-allowed shape so the connector cannot persist a host_name that
+    mngr's ``HostName`` would refuse on the client side.
+    """
+    stripped = value.strip() if isinstance(value, str) else value
+    if not isinstance(stripped, str) or not _HOST_NAME_RE.match(stripped):
+        raise ValueError(f"host_name must be alphanumeric (with dashes/underscores allowed in the middle): {value!r}")
+    return stripped
+
 
 class LeaseHostRequest(BaseModel):
     ssh_public_key: str = Field(description="SSH public key to authorize on the leased host")
+    host_name: str = Field(
+        description=(
+            "User-chosen friendly name for the leased host. Must satisfy mngr's SafeName "
+            "regex (alphanumeric, dashes/underscores allowed in the middle). Required."
+        )
+    )
     attributes: dict[str, Any] = Field(
         description=(
             "Lease-attribute filter. Matches with PostgreSQL '@>' so only fields the request "
             "explicitly sets are constrained; missing fields are unconstrained. Required."
         ),
     )
+
+    _validate_host_name = field_validator("host_name")(_validate_host_name)
 
 
 class LeaseHostResponse(BaseModel):
@@ -298,6 +327,7 @@ class LeaseHostResponse(BaseModel):
     container_ssh_port: int = Field(description="SSH port mapped to the Docker container")
     agent_id: str = Field(description="Pre-provisioned mngr agent ID")
     host_id: str = Field(description="Host ID in the mngr provider")
+    host_name: str = Field(description="User-chosen friendly name for the leased host")
     attributes: dict[str, Any] = Field(description="Attributes the row was matched against")
 
 
@@ -313,6 +343,7 @@ class LeasedHostInfo(BaseModel):
     container_ssh_port: int = Field(description="SSH port mapped to the Docker container")
     agent_id: str = Field(description="Pre-provisioned mngr agent ID")
     host_id: str = Field(description="Host ID in the mngr provider")
+    host_name: str = Field(description="User-chosen friendly name for the leased host")
     attributes: dict[str, Any] = Field(description="Attributes attached to the lease row")
     leased_at: str = Field(description="ISO 8601 timestamp when the host was leased")
 
@@ -1595,10 +1626,13 @@ def lease_host(request: Request, body: LeaseHostRequest) -> dict[str, object]:
                             status_code=502, detail=f"Failed to inject SSH key on host: {exc}"
                         ) from exc
 
+                    # ``host_name`` is mutable per-lease: it gets overwritten with the
+                    # user-supplied name each time the pool row is leased (and could
+                    # later be patched by a rename endpoint).
                     cur.execute(
-                        "UPDATE pool_hosts SET status = 'leased', leased_to_user = %s, leased_at = NOW() "
-                        "WHERE id = %s",
-                        (admin.username, host_db_id),
+                        "UPDATE pool_hosts SET status = 'leased', leased_to_user = %s, "
+                        "leased_at = NOW(), host_name = %s WHERE id = %s",
+                        (admin.username, body.host_name, host_db_id),
                     )
         finally:
             conn.close()
@@ -1611,6 +1645,7 @@ def lease_host(request: Request, body: LeaseHostRequest) -> dict[str, object]:
             container_ssh_port=container_ssh_port,
             agent_id=agent_id,
             host_id=host_id,
+            host_name=body.host_name,
             attributes=attrs_dict,
         ).model_dump()
 
@@ -1659,7 +1694,8 @@ def list_leased_hosts(request: Request) -> list[dict[str, object]]:
         try:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT id, vps_ip, ssh_port, ssh_user, container_ssh_port, agent_id, host_id, attributes, leased_at "
+                    "SELECT id, vps_ip, ssh_port, ssh_user, container_ssh_port, agent_id, host_id, "
+                    "host_name, attributes, leased_at "
                     "FROM pool_hosts "
                     "WHERE status = 'leased' AND leased_to_user = %s",
                     (admin.username,),
@@ -1676,8 +1712,9 @@ def list_leased_hosts(request: Request) -> list[dict[str, object]]:
                 container_ssh_port=r[4],
                 agent_id=r[5],
                 host_id=r[6],
-                attributes=r[7] if isinstance(r[7], dict) else {},
-                leased_at=str(r[8]) if r[8] is not None else "",
+                host_name=r[7],
+                attributes=r[8] if isinstance(r[8], dict) else {},
+                leased_at=str(r[9]) if r[9] is not None else "",
             ).model_dump()
             for r in rows
         ]

--- a/apps/remote_service_connector/imbue/remote_service_connector/app.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/app.py
@@ -216,6 +216,14 @@ class TunnelComponentTooLongError(ValueError):
         super().__init__(f"{component_name} '{value}' exceeds maximum length of {max_length}")
 
 
+class InvalidHostNameError(ValueError):
+    """Raised when a host_name fails the SafeName regex on the lease request."""
+
+    def __init__(self, value: object) -> None:
+        self.value = value
+        super().__init__(f"host_name must be alphanumeric (with dashes/underscores allowed in the middle): {value!r}")
+
+
 # ---------------------------------------------------------------------------
 # Request / response models
 # ---------------------------------------------------------------------------
@@ -297,7 +305,7 @@ def _validate_host_name(value: str) -> str:
     """
     stripped = value.strip() if isinstance(value, str) else value
     if not isinstance(stripped, str) or not _HOST_NAME_RE.match(stripped):
-        raise ValueError(f"host_name must be alphanumeric (with dashes/underscores allowed in the middle): {value!r}")
+        raise InvalidHostNameError(value)
     return stripped
 
 

--- a/apps/remote_service_connector/imbue/remote_service_connector/app_test.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/app_test.py
@@ -1639,7 +1639,11 @@ def test_lease_host_returns_available_host(monkeypatch: pytest.MonkeyPatch) -> N
     )
     resp = client.post(
         "/hosts/lease",
-        json={"ssh_public_key": "ssh-ed25519 AAAA testkey", "attributes": {"version": "v0.1.0"}},
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "my-workspace",
+            "attributes": {"version": "v0.1.0"},
+        },
         headers=_admin_headers(),
     )
     assert resp.status_code == 200
@@ -1647,12 +1651,15 @@ def test_lease_host_returns_available_host(monkeypatch: pytest.MonkeyPatch) -> N
     assert body["host_db_id"] == "00000000-0000-0000-0000-000000000001"
     assert body["vps_ip"] == "10.0.0.1"
     assert body["agent_id"] == "agent-111"
+    assert body["host_name"] == "my-workspace"
     assert body["attributes"] == {"version": "v0.1.0"}
     # Verify SSH key was injected on both VPS and container
     assert len(backend.append_key_calls) == 2
-    # Verify host was marked as leased
+    # Verify host was marked as leased and the user-supplied host_name was
+    # written to the row.
     assert backend.pool_rows[0].status == "leased"
     assert backend.pool_rows[0].leased_to_user == _ADMIN_STUB_USERNAME
+    assert backend.pool_rows[0].host_name == "my-workspace"
 
 
 def test_lease_host_returns_503_when_pool_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1660,7 +1667,11 @@ def test_lease_host_returns_503_when_pool_empty(monkeypatch: pytest.MonkeyPatch)
     client, _backend = _make_pool_test_client(monkeypatch)
     resp = client.post(
         "/hosts/lease",
-        json={"ssh_public_key": "ssh-ed25519 AAAA testkey", "attributes": {"version": "v0.1.0"}},
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "my-workspace",
+            "attributes": {"version": "v0.1.0"},
+        },
         headers=_admin_headers(),
     )
     assert resp.status_code == 503
@@ -1673,12 +1684,35 @@ def test_lease_host_returns_503_when_version_mismatch(monkeypatch: pytest.Monkey
     backend.add_available_host(host_id=UUID("00000000-0000-0000-0000-000000000001"), version="v0.2.0")
     resp = client.post(
         "/hosts/lease",
-        json={"ssh_public_key": "ssh-ed25519 AAAA testkey", "attributes": {"version": "v0.1.0"}},
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "my-workspace",
+            "attributes": {"version": "v0.1.0"},
+        },
         headers=_admin_headers(),
     )
     assert resp.status_code == 503
     assert "No pre-created agents" in resp.json()["detail"]
     # Verify the host was not leased
+    assert backend.pool_rows[0].status == "available"
+
+
+def test_lease_host_rejects_invalid_host_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /hosts/lease rejects host_name values that fail the SafeName regex."""
+    client, backend = _make_pool_test_client(monkeypatch)
+    backend.add_available_host(host_id=UUID("00000000-0000-0000-0000-000000000001"), version="v0.1.0")
+    resp = client.post(
+        "/hosts/lease",
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "bad.name",
+            "attributes": {"version": "v0.1.0"},
+        },
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 422
+    # The available row stays available since validation rejected the request
+    # before the SELECT/UPDATE.
     assert backend.pool_rows[0].status == "available"
 
 
@@ -1831,7 +1865,11 @@ def test_route_lease_host_returns_403_when_email_not_in_allowlist(
     monkeypatch.setenv("PAID_ACCOUNT_SUFFIXES", "@imbue.com")
     resp = client.post(
         "/hosts/lease",
-        json={"ssh_public_key": "ssh-ed25519 AAAA testkey", "attributes": {"version": "v0.1.0"}},
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "my-workspace",
+            "attributes": {"version": "v0.1.0"},
+        },
         headers=_admin_headers(),
     )
     assert resp.status_code == 403
@@ -1849,7 +1887,11 @@ def test_route_lease_host_returns_403_when_paid_suffixes_unset(
     monkeypatch.delenv("PAID_ACCOUNT_SUFFIXES", raising=False)
     resp = client.post(
         "/hosts/lease",
-        json={"ssh_public_key": "ssh-ed25519 AAAA testkey", "attributes": {"version": "v0.1.0"}},
+        json={
+            "ssh_public_key": "ssh-ed25519 AAAA testkey",
+            "host_name": "my-workspace",
+            "attributes": {"version": "v0.1.0"},
+        },
         headers=_admin_headers(),
     )
     assert resp.status_code == 403

--- a/apps/remote_service_connector/imbue/remote_service_connector/testing.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/testing.py
@@ -763,6 +763,7 @@ class FakePoolRow:
     vps_instance_id: str
     agent_id: str
     host_id_str: str
+    host_name: str
     ssh_port: int
     ssh_user: str
     container_ssh_port: int
@@ -808,6 +809,7 @@ def _make_pool_row(
     status: str = "available",
     leased_to_user: str | None = None,
     leased_at: str | None = None,
+    host_name: str | None = None,
 ) -> FakePoolRow:
     row = FakePoolRow()
     row.host_id = host_id
@@ -815,6 +817,9 @@ def _make_pool_row(
     row.vps_instance_id = f"vps-{host_id}"
     row.agent_id = agent_id
     row.host_id_str = host_id_str
+    # Matches the migration's backfill: pre-leased rows default to host_id_str
+    # so they remain visible under a stable name until something leases them.
+    row.host_name = host_name if host_name is not None else host_id_str
     row.ssh_port = ssh_port
     row.ssh_user = ssh_user
     row.container_ssh_port = container_ssh_port
@@ -866,12 +871,16 @@ class FakeCursor:
                 break
 
         elif "update pool_hosts set status = 'leased'" in query_lower:
-            username, host_id = params
+            # Lease SQL now also writes the user-supplied host_name on the
+            # same UPDATE so the friendly name is set atomically with the
+            # status flip.
+            username, host_name, host_id = params
             for row in self._backend.pool_rows:
                 if row.host_id == host_id:
                     row.status = "leased"
                     row.leased_to_user = username
                     row.leased_at = "2026-01-01T00:00:00+00:00"
+                    row.host_name = host_name
                     break
 
         elif (
@@ -901,6 +910,7 @@ class FakeCursor:
                                 row.container_ssh_port,
                                 row.agent_id,
                                 row.host_id_str,
+                                row.host_name,
                                 _row_attributes(row),
                                 row.leased_at,
                             )
@@ -1009,6 +1019,7 @@ class FakePoolBackend:
         container_ssh_port: int = 2222,
         agent_id: str = "agent-abc123",
         host_id_str: str = "host-xyz",
+        host_name: str | None = None,
     ) -> FakePoolRow:
         """Add an available host to the in-memory pool."""
         row = _make_pool_row(
@@ -1020,6 +1031,7 @@ class FakePoolBackend:
             ssh_user=ssh_user,
             container_ssh_port=container_ssh_port,
             version=version,
+            host_name=host_name,
         )
         self.pool_rows.append(row)
         return row
@@ -1035,6 +1047,7 @@ class FakePoolBackend:
         container_ssh_port: int = 2222,
         agent_id: str = "agent-abc123",
         host_id_str: str = "host-xyz",
+        host_name: str | None = None,
     ) -> FakePoolRow:
         """Add a leased host to the in-memory pool."""
         row = _make_pool_row(
@@ -1049,6 +1062,7 @@ class FakePoolBackend:
             status="leased",
             leased_to_user=leased_to_user,
             leased_at="2026-01-01T00:00:00+00:00",
+            host_name=host_name,
         )
         self.pool_rows.append(row)
         return row

--- a/apps/remote_service_connector/migrations/002_host_name.sql
+++ b/apps/remote_service_connector/migrations/002_host_name.sql
@@ -1,0 +1,33 @@
+-- Migration: add a mutable, user-facing host_name to pool_hosts.
+--
+-- Minds now drives the workspace identity off the host name (the literal
+-- string the user types in the create-project form) rather than the agent
+-- name. The connector needs to round-trip that name through the lease so
+-- downstream surfaces (mngr list, future rename, etc.) see what the user
+-- chose, not the opaque host_id UUID.
+--
+-- Apply with:
+--     psql "$NEON_DB_DIRECT" -f apps/remote_service_connector/migrations/002_host_name.sql
+--
+-- Idempotent: rerunning is a no-op once the column exists.
+
+BEGIN;
+
+-- Add the column as nullable first so the backfill can run without violating
+-- the NOT NULL constraint on existing rows.
+ALTER TABLE pool_hosts ADD COLUMN IF NOT EXISTS host_name TEXT;
+
+-- Backfill existing rows to the opaque host_id so they remain visible in
+-- mngr list under the same label they currently use (the lease-fallback
+-- path in the imbue_cloud provider previously synthesized `HostName(host_id)`
+-- as the display name).
+UPDATE pool_hosts
+SET host_name = host_id
+WHERE host_name IS NULL;
+
+ALTER TABLE pool_hosts ALTER COLUMN host_name SET NOT NULL;
+
+-- Index for the lookup path that resolves a friendly name to a leased row.
+CREATE INDEX IF NOT EXISTS pool_hosts_host_name_idx ON pool_hosts (host_name);
+
+COMMIT;

--- a/changelog/mngr-workspace-host-name.md
+++ b/changelog/mngr-workspace-host-name.md
@@ -1,1 +1,1 @@
-Spec-in-progress: change minds workspace identity from agent name to host name (see `specs/`).
+Spec only: minds workspace identity moves from agent name to host name (`specs/minds-workspace-host-name/concise.md`). No user-facing change yet.

--- a/changelog/mngr-workspace-host-name.md
+++ b/changelog/mngr-workspace-host-name.md
@@ -1,0 +1,1 @@
+Spec-in-progress: change minds workspace identity from agent name to host name (see `specs/`).

--- a/changelog/mngr-workspace-host-name.md
+++ b/changelog/mngr-workspace-host-name.md
@@ -1,1 +1,1 @@
-Spec only: minds workspace identity moves from agent name to host name (`specs/minds-workspace-host-name/concise.md`). No user-facing change yet.
+Minds: the "Name" field on the create-project form now sets the *host* name (validated via mngr's `HostName` regex), not the agent name. The agent is always called `system-services`. The imbue_cloud connector grows a required `host_name` on `/hosts/lease` and `/hosts`. Sister change in `forever-claude-template` (matching branch) drops the now-unused `MINDS_WORKSPACE_NAME` from `[commands.create].pass_env`.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client.py
@@ -200,10 +200,12 @@ class ImbueCloudConnectorClient(MutableModel):
         access_token: SecretStr,
         attributes: LeaseAttributes,
         ssh_public_key: str,
+        host_name: str,
     ) -> LeaseResult:
         body = {
             "attributes": attributes.to_request_dict(),
             "ssh_public_key": ssh_public_key,
+            "host_name": host_name,
         }
         response = httpx.post(
             self._url("/hosts/lease"),

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client_test.py
@@ -43,7 +43,7 @@ def test_lease_host_503_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(httpx, "post", fake_post)
     client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
     with pytest.raises(ImbueCloudLeaseUnavailableError):
-        client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=2), "ssh-ed25519 AAAA")
+        client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=2), "ssh-ed25519 AAAA", "my-host")
 
 
 def test_lease_host_success_parses_response(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,6 +51,7 @@ def test_lease_host_success_parses_response(monkeypatch: pytest.MonkeyPatch) -> 
         body = _json.loads(request.content)
         assert body["attributes"] == {"cpus": 2}
         assert body["ssh_public_key"] == "ssh-ed25519 AAAA"
+        assert body["host_name"] == "my-host"
         return httpx.Response(
             200,
             json={
@@ -61,6 +62,7 @@ def test_lease_host_success_parses_response(monkeypatch: pytest.MonkeyPatch) -> 
                 "container_ssh_port": 2222,
                 "agent_id": "agent-abc",
                 "host_id": "host-xyz",
+                "host_name": "my-host",
                 "attributes": {"cpus": 2},
             },
         )
@@ -73,9 +75,10 @@ def test_lease_host_success_parses_response(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(httpx, "post", fake_post)
     client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
-    result = client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=2), "ssh-ed25519 AAAA")
+    result = client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=2), "ssh-ed25519 AAAA", "my-host")
     assert result.vps_ip == "10.0.0.1"
     assert result.agent_id == "agent-abc"
+    assert result.host_name == "my-host"
     assert result.attributes == {"cpus": 2}
 
 
@@ -108,7 +111,7 @@ def test_500_lease_raises_connector_error(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(httpx, "post", fake_post)
     client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
     with pytest.raises(ImbueCloudConnectorError):
-        client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=1), "ssh-ed25519 X")
+        client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=1), "ssh-ed25519 X", "my-host")
 
 
 # -- AuthPolicy translation --

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/data_types.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/data_types.py
@@ -87,6 +87,7 @@ class LeaseResult(FrozenModel):
     container_ssh_port: int = Field(description="Port that maps to the docker container's sshd")
     agent_id: str = Field(description="Pre-baked mngr agent id on the host")
     host_id: str = Field(description="Pre-baked mngr host id")
+    host_name: str = Field(description="User-chosen friendly name for the leased host")
     attributes: dict[str, Any] = Field(default_factory=dict, description="Attributes the row was matched against")
 
 
@@ -100,6 +101,7 @@ class LeasedHostInfo(FrozenModel):
     container_ssh_port: int
     agent_id: str
     host_id: str
+    host_name: str = Field(description="User-chosen friendly name for the leased host")
     attributes: dict[str, Any] = Field(default_factory=dict)
     leased_at: str = Field(description="ISO-8601 timestamp")
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
@@ -150,20 +150,14 @@ class ImbueCloudHost(Host):
         bake wrote with ``--template main --template vultr`` and therefore
         already contains the ``additional_commands`` that start
         ``minds-workspace-server``, ``cloudflared``, etc. -- and patch only
-        the minds-driven fields in place: ``name``, ``labels.workspace``,
-        and ``command`` (regenerated via ``assemble_command`` so the embedded
-        ``<MNGR_PREFIX><name>`` tmux session reference matches the new name).
-        Everything else (``additional_commands``, ``create_time``, ``work_dir``,
-        ``agent_type``, the agent UUID baked into the ``--session-id``
-        fallback) is preserved verbatim from the bake.
-
-        The previous version of this method just pinned ``options.agent_id``
-        and called ``super().create_agent_state``, which unconditionally
-        wrote a brand-new ``data.json`` from ``CreateAgentOptions``. For the
-        adopt path that clobbered the bake's ``additional_commands`` (so
-        the workspace server never started on lease) and was incompatible
-        with minds' newer "don't pre-generate an agent id" model anyway
-        (``options.agent_id`` is now always ``None`` from the minds side).
+        the minds-driven fields in place: ``labels`` and ``command``
+        (regenerated via ``assemble_command`` so the embedded
+        ``<MNGR_PREFIX><name>`` tmux session reference still resolves).
+        Everything else (``name``, ``additional_commands``, ``create_time``,
+        ``work_dir``, ``agent_type``, the agent UUID baked into the
+        ``--session-id`` fallback) is preserved verbatim from the bake --
+        the pre-baked agent name carries the workspace identity now lives on
+        the *host*, not on the agent.
 
         Falls back to ``super()`` when ``pre_baked_agent_id`` is unset or
         the on-disk ``data.json`` is missing -- e.g. after ``mngr destroy``
@@ -188,17 +182,20 @@ class ImbueCloudHost(Host):
             options_with_id = options.model_copy(update={"agent_id": self.pre_baked_agent_id})
             return super().create_agent_state(work_dir_path, options_with_id, created_branch_name)
 
-        # Hydrate the agent class so we can re-run ``assemble_command`` against
-        # the user-supplied name + the bake's UUID-derived session-id fallback.
+        # Hydrate the agent class with the bake's name; minds no longer
+        # renames the pre-baked agent (the workspace identity lives on the
+        # host now). ``options.name`` is the minds-supplied default agent
+        # name ("system-services"), kept around for non-imbue_cloud modes;
+        # for adoption we ignore it.
         agent_type = AgentTypeName(str(existing.get("type", "claude")))
         resolved = resolve_agent_type(agent_type, self.mngr_ctx.config)
         baked_work_dir = Path(str(existing.get("work_dir", str(work_dir_path))))
         create_time = _parse_create_time(existing.get("create_time"))
-        new_name = options.name or AgentName(str(existing["name"]))
+        baked_name = AgentName(str(existing["name"]))
 
         agent = resolved.agent_class(
             id=self.pre_baked_agent_id,
-            name=new_name,
+            name=baked_name,
             agent_type=agent_type,
             work_dir=baked_work_dir,
             create_time=create_time,
@@ -215,20 +212,19 @@ class ImbueCloudHost(Host):
         )
 
         # Merge labels: bake's defaults + minds' user-supplied (latter wins).
-        # Update ``workspace`` to track the new name so the minds UI's "agents
-        # for workspace foo" lookup finds this agent.
+        # Minds passes ``--label workspace=<host_name>`` so the workspace
+        # identity is propagated via the caller's labels; we don't re-derive
+        # it from any agent name.
         merged_labels: dict[str, str] = dict(existing.get("labels") or {})
         merged_labels.update(options.label_options.labels)
-        merged_labels["workspace"] = str(new_name)
 
         # Build the new data dict by patching the existing one in place. Any
         # bake-time fields we don't explicitly touch (``additional_commands``,
         # ``permissions``, ``start_on_boot``, ``initial_message`` /
         # ``resume_message`` / ``ready_timeout_seconds`` if minds didn't
-        # supply replacements, etc.) survive untouched. ``agent_id`` stays
-        # the bake's pre-baked id by construction.
+        # supply replacements, etc.) survive untouched. ``agent_id`` and
+        # ``name`` stay the bake's by construction.
         patched: dict[str, Any] = dict(existing)
-        patched["name"] = str(new_name)
         patched["command"] = str(new_command)
         patched["labels"] = merged_labels
         if options.initial_message is not None:
@@ -237,6 +233,10 @@ class ImbueCloudHost(Host):
             patched["resume_message"] = options.resume_message
         if options.ready_timeout_seconds is not None:
             patched["ready_timeout_seconds"] = options.ready_timeout_seconds
+        # Retarget the bake's pre-set branch to the minds-supplied per-host
+        # branch when the caller passes one. Caller-supplied wins; otherwise
+        # leave the bake's value intact (e.g. when an external mngr CLI user
+        # invokes the lease flow without driving branch naming).
         if created_branch_name is not None:
             patched["created_branch_name"] = created_branch_name
 
@@ -394,8 +394,3 @@ def normalize_inject_args(
         "mngr_prefix": _ensure_no_quote_chars(mngr_prefix, "MNGR_PREFIX") if mngr_prefix else None,
         "extra_env": cleaned_extra or None,
     }
-
-
-def host_label_for_agent(agent_name: AgentName) -> str:
-    """Default host name suffix for an agent (matches today's minds convention)."""
-    return f"{agent_name}-host"

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
@@ -156,8 +156,7 @@ class ImbueCloudHost(Host):
         Everything else (``name``, ``additional_commands``, ``create_time``,
         ``work_dir``, ``agent_type``, the agent UUID baked into the
         ``--session-id`` fallback) is preserved verbatim from the bake --
-        the pre-baked agent name carries the workspace identity now lives on
-        the *host*, not on the agent.
+        the workspace identity now lives on the *host*, not on the agent.
 
         Falls back to ``super()`` when ``pre_baked_agent_id`` is unset or
         the on-disk ``data.json`` is missing -- e.g. after ``mngr destroy``

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/host.py
@@ -2,21 +2,25 @@
 
 Subclasses mngr's ``Host`` so the standard ``mngr create --provider
 imbue_cloud_<account> --new-host`` pipeline can adopt a pool host's
-pre-baked agent under the caller's chosen name when one exists, and
-fall back to mngr's standard create flow when it doesn't (e.g. after
-``mngr destroy`` has wiped the previous agent's state on the leased
-container). Adoption is purely an optimization that skips a slow
-file-transfer + provisioning round when we can.
+pre-baked agent when one exists, and fall back to mngr's standard
+create flow when it doesn't (e.g. after ``mngr destroy`` has wiped the
+previous agent's state on the leased container). Adoption is purely an
+optimization that skips a slow file-transfer + provisioning round when
+we can. The workspace identity lives on the *host name*; the adopted
+agent keeps the bake's name (a constant such as ``system-services``)
+verbatim.
 
 Overrides:
 
 - ``set_env_vars`` always merges into the pre-baked ``/mngr/env``
   (clobbering would lose ``MNGR_HOST_DIR``/``MNGR_PREFIX``/etc. that
   the pool baking wrote).
-- ``create_agent_state`` always pins ``options.agent_id`` to
-  ``pre_baked_agent_id`` so the lease's canonical id stays stable
-  across destroy/recreate cycles, regardless of whether on-disk state
-  survives. The parent's ``data.json`` write then runs as usual.
+- ``create_agent_state`` preserves the bake's name and patches the
+  on-disk ``data.json`` in place when the pre-baked agent state is
+  present. It rejects an ``options.agent_id`` that mismatches
+  ``pre_baked_agent_id`` (the lease dictates the id) and, in the
+  fallback path where ``data.json`` is missing, pins ``options.agent_id``
+  to the pre-baked id before delegating to ``super()``.
 - ``create_agent_work_dir`` and ``provision_agent`` short-circuit to a
   no-transfer + minimal-provision path *only* when the pre-baked
   agent's ``data.json`` is still on disk; otherwise they delegate to
@@ -63,8 +67,11 @@ def _parse_create_time(value: Any) -> datetime:
 class ImbueCloudHost(Host):
     """A leased pool host.
 
-    The pre-baked agent's id is captured at lease time so ``create_agent_state``
-    can adopt that agent under the caller's name instead of generating a new id.
+    The pre-baked agent's id is captured at lease time so
+    ``create_agent_state`` can adopt that agent (keeping the bake's name
+    and id) instead of generating a fresh ``data.json``. The workspace
+    identity is carried by the host name; the agent name is whatever the
+    bake wrote (typically a constant such as ``system-services``).
     """
 
     pre_baked_agent_id: AgentId | None = Field(

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
@@ -833,7 +833,7 @@ class ImbueCloudProvider(BaseProviderInstance):
         for entry in leased:
             if isinstance(host, HostId) and entry.host_id == str(host):
                 return self._build_host_object(entry)
-            if isinstance(host, HostName) and entry.host_id == str(host):
+            if isinstance(host, HostName) and entry.host_name == str(host):
                 return self._build_host_object(entry)
         raise HostNotFoundError(host)
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
@@ -356,7 +356,7 @@ class ImbueCloudProvider(BaseProviderInstance):
         return [
             DiscoveredHost(
                 host_id=HostId(entry.host_id),
-                host_name=HostName(entry.host_id),
+                host_name=HostName(entry.host_name),
                 provider_name=self.name,
                 host_state=HostState.RUNNING,
             )
@@ -400,7 +400,7 @@ class ImbueCloudProvider(BaseProviderInstance):
                 fallback_state = HostState.UNAUTHENTICATED if is_auth_failure else HostState.CRASHED
                 host_ref = DiscoveredHost(
                     host_id=host_id,
-                    host_name=HostName(entry.host_id),
+                    host_name=HostName(entry.host_name),
                     provider_name=self.name,
                     host_state=fallback_state,
                 )
@@ -424,9 +424,12 @@ class ImbueCloudProvider(BaseProviderInstance):
             host_state = _derive_host_state_from_raw(raw)
             if host_state == HostState.DESTROYED and not include_destroyed:
                 continue
+            # ``entry.host_name`` is the canonical user-supplied name from the
+            # connector. On-host certified data may lag (e.g. the bake's
+            # initial value before a lease overwrites it), so the lease wins.
             host_ref = DiscoveredHost(
                 host_id=host_id,
-                host_name=HostName(_certified_host_name(raw) or entry.host_id),
+                host_name=HostName(entry.host_name),
                 provider_name=self.name,
                 host_state=host_state,
             )
@@ -669,12 +672,14 @@ class ImbueCloudProvider(BaseProviderInstance):
             datetime.fromtimestamp(ssh_activity_mtime, tz=timezone.utc) if ssh_activity_mtime is not None else None
         )
         # ``certified_data`` is the host-level data.json the pool host
-        # baked at provision time. It carries name, image, idle settings,
-        # tags, plugin state, etc. -- richer than what the lease object
-        # alone tells us. Fall back to lease-level defaults when the
-        # remote read produced an empty dict.
+        # baked at provision time. It carries image, idle settings, tags,
+        # plugin state, etc. -- richer than what the lease object alone
+        # tells us. For the friendly name we trust the lease (the
+        # connector-side canonical, mutable per-lease) rather than the
+        # baked-in certified data, which may still hold the bake-time
+        # placeholder.
         certified = raw.get("certified_data") or {}
-        host_name_str = certified.get("host_name") or lease.host_id
+        host_name_str = lease.host_name
         image = certified.get("image", "")
         tags = dict(certified.get("user_tags", {}))
         plugin = dict(certified.get("plugin", {}))
@@ -810,7 +815,7 @@ class ImbueCloudProvider(BaseProviderInstance):
         connector = PyinfraConnector(pyinfra_host)
         host = ImbueCloudHost(
             id=host_id,
-            host_name=HostName(lease.host_id),
+            host_name=HostName(lease.host_name),
             connector=connector,
             provider_instance=self,
             mngr_ctx=self.mngr_ctx,
@@ -846,7 +851,7 @@ class ImbueCloudProvider(BaseProviderInstance):
         now = datetime.now(timezone.utc)
         certified_host_data = CertifiedHostData(
             host_id=str(host_id),
-            host_name=lease.host_id,
+            host_name=lease.host_name,
             created_at=now,
             updated_at=now,
         )
@@ -931,7 +936,10 @@ class ImbueCloudProvider(BaseProviderInstance):
         tmp_private_key, tmp_public_key = save_ssh_keypair(tmp_key_dir, "ssh_key")
         public_key_text = tmp_public_key.read_text().strip()
 
-        lease_result = self.client.lease_host(token, attributes, public_key_text)
+        # ``name`` is the user-supplied HostName; send it to the connector so
+        # the leased pool row carries the same friendly name minds renders to
+        # the user. The connector validates it server-side too.
+        lease_result = self.client.lease_host(token, attributes, public_key_text, str(name))
         self.reset_caches()
 
         host_id = HostId(lease_result.host_id)
@@ -983,6 +991,7 @@ class ImbueCloudProvider(BaseProviderInstance):
             container_ssh_port=lease_result.container_ssh_port,
             agent_id=lease_result.agent_id,
             host_id=lease_result.host_id,
+            host_name=lease_result.host_name,
             attributes=lease_result.attributes,
             leased_at="",
         )

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
@@ -97,6 +97,7 @@ def test_build_offline_details_from_lease_preserves_host_and_failure_reason(tmp_
         container_ssh_port=2222,
         agent_id=str(agent_id),
         host_id=str(host_id),
+        host_name=str(host_id),
         attributes={},
         leased_at="2025-01-01T00:00:00Z",
     )

--- a/specs/minds-workspace-host-name/concise.md
+++ b/specs/minds-workspace-host-name/concise.md
@@ -5,7 +5,7 @@
 - The minds create-project form's `Name` field currently feeds the *agent* name; the host then derives from it as `<agent-name>-host`. Going forward, that field feeds the *host name directly* and the agent name becomes a hardcoded constant.
 - Every minds-created agent is named `system-services`. There is one agent per host, so the agent name carries no information for the user; the workspace is identified entirely by its host.
 - The host name is the literal string the user typed in the form, validated by mngr's existing `HostName` regex. Invalid input re-renders the form with an inline error; the JSON API returns a 400 with the same message.
-- The `mngr_imbue_cloud` connector grows a required `host_name` field on lease + listing payloads so the leased pool agent's workspace identity is durable across the connector boundary (and a rename can land later without further schema work). One-shot deploy; no backwards-compat for legacy clients or pre-existing pool rows.
+- The `remote_service_connector` (in `apps/remote_service_connector/`) grows a required `host_name` field on lease + listing payloads so the leased pool agent's workspace identity is durable across the connector boundary (and a rename can land later without further schema work). One-shot deploy; no backwards-compat for legacy clients or pre-existing pool rows.
 - On imbue_cloud lease-adoption we stop rewriting the pre-baked agent's name. We still merge in minds-supplied labels (including `workspace=<host_name>`) and still patch claude config + env for the new API key. Host rename itself is out of scope for this PR — the data model is the deliverable.
 
 ## Expected Behavior
@@ -43,10 +43,10 @@
     - In `ImbueCloudHost.create_agent_state`, stop rewriting `data.json:name`. Still merge in `options.label_options.labels` (which now contains `workspace=<host_name>`) and overwrite `data.json:created_branch_name` to `mngr/<host_name>`. Delete the line `merged_labels["workspace"] = str(new_name)` — it duplicates a label minds already passes and was tied to the now-removed agent-rename behavior.
     - In `_build_host_details_from_raw` and `discover_hosts(_and_agents)`, use the lease's `host_name` instead of the lease's `host_id` as the friendly host name.
     - Delete `host_label_for_agent`.
-- **remote_service_connector (server-side, external repo)**
-    - Add a non-null `host_name` column to the pool DB; backfill existing rows with `host_name = host_id` at deploy time.
-    - Require `host_name` on the `/hosts/lease` request body; validate it server-side with mngr's `HostName` regex; reject non-conforming names with a clear 400.
-    - Include `host_name` in `/hosts` listing responses.
+- **remote_service_connector (apps/remote_service_connector)**
+    - New SQL migration `apps/remote_service_connector/migrations/002_host_name.sql` adding a non-null `host_name TEXT` column to `pool_hosts`, backfilling existing rows with `host_name = host_id`, and adding an index for lookups.
+    - `LeaseHostRequest` in `app.py` gains a required `host_name: str` field; validate it against mngr's `HostName` regex inline (re-define the pattern locally — the connector should not import from `imbue.mngr`); reject non-conforming names with a 400.
+    - `LeaseHostResponse` and the `/hosts` listing entries (`LeasedHostInfo` shape) include `host_name`; the `INSERT` / `UPDATE` in `lease_host` and the `SELECT` in `list_leased_hosts` are extended accordingly.
 - **forever-claude-template**
     - Drop `MINDS_WORKSPACE_NAME` from `[commands.create].pass_env` in `.mngr/settings.toml`; no in-agent code reads it.
 - **mngr core (libs/mngr)** — *no changes required*. The `default_branch_name(agent_name)` helper stays untouched; minds-driven branch naming is achieved entirely via the `--branch` flag.

--- a/specs/minds-workspace-host-name/concise.md
+++ b/specs/minds-workspace-host-name/concise.md
@@ -1,0 +1,56 @@
+# Minds workspace identity = host name, not agent name
+
+## Overview
+
+- The minds create-project form's `Name` field currently feeds the *agent* name; the host then derives from it as `<agent-name>-host`. Going forward, that field feeds the *host name directly* and the agent name becomes a hardcoded constant.
+- Every minds-created agent is named `system-services`. There is one agent per host, so the agent name carries no information for the user; the workspace is identified entirely by its host.
+- The host name is the literal string the user typed in the form, validated by mngr's existing `HostName` regex. Invalid input re-renders the form with an inline error; the JSON API returns a 400 with the same message.
+- The `mngr_imbue_cloud` connector grows a required `host_name` field on lease + listing payloads so the leased pool agent's workspace identity is durable across the connector boundary (and a rename can land later without further schema work). One-shot deploy; no backwards-compat for legacy clients or pre-existing pool rows.
+- On imbue_cloud lease-adoption we stop rewriting the pre-baked agent's name. We still merge in minds-supplied labels (including `workspace=<host_name>`) and still patch claude config + env for the new API key. Host rename itself is out of scope for this PR — the data model is the deliverable.
+
+## Expected Behavior
+
+- The create-project form continues to show a single field labeled `Name` with placeholder `assistant`; the HTML input and `/api/create-agent` JSON field are now both called `host_name`. The submitted value becomes the host name on every launch mode.
+- `MINDS_WORKSPACE_NAME` (env var, default `"assistant"`) keeps its spelling and default value, but now drives the form's default *host* name instead of the agent name. It is no longer forwarded into the agent's environment (dropped from FCT's `[commands.create].pass_env`).
+- For LOCAL / LIMA / CLOUD launch modes, `mngr create` is invoked as `system-services@<host_name>.<provider>` with `--reuse --update`; re-submitting the form with an existing host name re-attaches to the existing host (deliberately — "reset my workspace"). The provider's own collision behavior governs `--new-host` failures.
+- For IMBUE_CLOUD launch mode, the plugin's `create_host` sends `host_name` on the lease request; the connector rejects names that don't pass mngr's `HostName` regex. The leased pool agent retains its baked name (no longer renamed to user input). The plugin still injects the LiteLLM API key, the gateway wiring, and the workspace label.
+- The branch minds asks `mngr create` to use is `mngr/<host_name>` (passed explicitly via `--branch`), not the core `default_branch_name(agent_name)` default. On imbue_cloud lease-adoption the pre-baked `data.json:created_branch_name` is overwritten to match.
+- The landing page workspace cards display each workspace's `labels.workspace` value (the host name the user typed). They previously rendered the agent's `name`, which would now uniformly read `system-services` — useless to the user.
+- `mngr list` filtering from minds is unchanged in shape (`include = ["has(labels.workspace)"]`); the label's value is the host name on all newly-created agents, so the filter still picks up exactly the minds-owned agents.
+- Existing user workspaces (created under the old convention, with `labels.workspace = <agent_name>` and host = `<agent_name>-host`) are left exactly as they are; no migration runs at startup or on demand. They continue to appear on the landing page under their old (agent-derived) names.
+- `mngr imbue_cloud` host listings (`mngr list` against the imbue_cloud provider) show the lease's `host_name` rather than the lease's `host_id` as the friendly name.
+- `ImbueCloudProvider.rename_host` continues to raise `NotImplementedError`; nothing in the minds UI exposes a rename action. Adding a rename command/UI is a follow-up that can build on the new connector field.
+
+## Changes
+
+- **Form + handlers (apps/minds/imbue/minds/desktop_client)**
+    - Rename the HTML input and template-renderer parameter from `agent_name` to `host_name` in `create.html`, `templates.py:render_create_form`, and `_handle_create_page` / `_handle_create_form_submit` / `_handle_create_agent_api` / `_re_render_with_error`.
+    - Keep the visible label `"Name"`; keep the placeholder driven by `MINDS_WORKSPACE_NAME` (default `"assistant"`).
+    - Validate the submitted value via `HostName(...)`; catch `InvalidName` and re-render the form (HTML) or return 400 JSON (API) with the validation message.
+    - Update all `test_desktop_client.py` POST bodies and `agent_name=...` arguments accordingly.
+- **Agent creator (apps/minds/imbue/minds/desktop_client/agent_creator.py)**
+    - Introduce a module-level constant for the hardcoded agent name (e.g. `_DEFAULT_AGENT_NAME = AgentName("system-services")`); use it everywhere `mngr create` needs an agent name.
+    - Replace the existing `_DEFAULT_AGENT_NAME` env-driven default (the one feeding the form) with a `_DEFAULT_HOST_NAME` env-driven default that continues to read `MINDS_WORKSPACE_NAME` and default to `"assistant"`.
+    - Drop `_make_host_name` and stop computing addresses as `<agent_name>-host`. Build addresses as `system-services@<host_name>.<provider>` per launch mode.
+    - Pass `--branch mngr/<host_name>` and `--label workspace=<host_name>` (instead of `workspace=<agent_name>`) to `mngr create`.
+    - Update LiteLLM key metadata to `{"host_name": host_name}` (the prior `agent_name` key was for human discoverability of the lease's owner — same meaning, new name).
+    - Adjust `start_creation` / `_create_agent_background` signatures to take `host_name` instead of `agent_name`; the `extract_repo_name` fallback (when the user submits empty) feeds the host name. Validate the resolved string via `HostName(...)` once at the boundary.
+- **Landing page (apps/minds/imbue/minds/desktop_client)**
+    - In whichever code path populates `agent_names` for `render_landing_page`, source the value from each agent's `labels.workspace` (falling back to the agent's `name` for legacy / non-minds agents that lack the label) so cards display the host name the user typed.
+- **mngr_imbue_cloud plugin (libs/mngr_imbue_cloud)**
+    - Add a required `host_name: HostName` field to `LeaseAttributes` (request side) and `LeaseResult` / `LeasedHostInfo` (response side); plumb it through `ImbueCloudConnectorClient.lease_host` and `list_hosts`.
+    - In `ImbueCloudProvider.create_host`, validate the inbound `name` argument with `HostName(...)`, pass it on the lease request, and use the connector's echo as the authoritative value when constructing `ImbueCloudHost`.
+    - In `ImbueCloudHost.create_agent_state`, stop rewriting `data.json:name`. Still merge in `options.label_options.labels` (which now contains `workspace=<host_name>`) and overwrite `data.json:created_branch_name` to `mngr/<host_name>`. Delete the line `merged_labels["workspace"] = str(new_name)` — it duplicates a label minds already passes and was tied to the now-removed agent-rename behavior.
+    - In `_build_host_details_from_raw` and `discover_hosts(_and_agents)`, use the lease's `host_name` instead of the lease's `host_id` as the friendly host name.
+    - Delete `host_label_for_agent`.
+- **remote_service_connector (server-side, external repo)**
+    - Add a non-null `host_name` column to the pool DB; backfill existing rows with `host_name = host_id` at deploy time.
+    - Require `host_name` on the `/hosts/lease` request body; validate it server-side with mngr's `HostName` regex; reject non-conforming names with a clear 400.
+    - Include `host_name` in `/hosts` listing responses.
+- **forever-claude-template**
+    - Drop `MINDS_WORKSPACE_NAME` from `[commands.create].pass_env` in `.mngr/settings.toml`; no in-agent code reads it.
+- **mngr core (libs/mngr)** — *no changes required*. The `default_branch_name(agent_name)` helper stays untouched; minds-driven branch naming is achieved entirely via the `--branch` flag.
+- **Tests**
+    - Update minds unit + integration tests (`test_desktop_client.py`, `agent_creator_test.py`, `mngr_imbue_cloud/*_test.py`) for the renamed form fields, the new constant agent name, the connector schema change, and the new label/branch wiring.
+    - Add a unit test covering the form's `HostName` validation error path (HTML re-render + JSON 400).
+    - Add a unit test for `ImbueCloudHost.create_agent_state` asserting `data.json:name` is preserved and `data.json:created_branch_name` is rewritten to `mngr/<host_name>`.


### PR DESCRIPTION
## Summary
- Spec-in-progress branch. Goal: the name in the minds create-project form drives the host name; the agent is always called \`assistant\`.
- Q&A underway via the architect skill; no code changes yet.

## Test plan
- [ ] To be filled in once the spec lands and implementation begins.

Generated with [Claude Code](https://claude.com/claude-code)