### PR TITLE
WIP: shared CLAUDE_CONFIG_DIR for claude agents

### DIFF
--- a/changelog/mngr-single-claude-data-dir.md
+++ b/changelog/mngr-single-claude-data-dir.md
@@ -1,1 +1,7 @@
-Add a `use_env_config_dir` option to the `mngr_claude` plugin so multiple Claude agents can share a single CLAUDE_CONFIG_DIR instead of each provisioning their own.
+Add a `use_env_config_dir` option on the `claude` agent type config. When set
+to `true`, local Claude agents share the user's `$CLAUDE_CONFIG_DIR` instead of
+provisioning a per-agent config dir, and mngr does not write to the user's
+Claude config (no trust additions, dialog dismissal, per-agent settings, or
+keychain provisioning). Only supported for local hosts; `$CLAUDE_CONFIG_DIR`
+must be set. The user is responsible for one-time interactive `claude` setup.
+See `libs/mngr_claude/README.md` for details.

--- a/changelog/mngr-single-claude-data-dir.md
+++ b/changelog/mngr-single-claude-data-dir.md
@@ -1,0 +1,1 @@
+Add a `use_env_config_dir` option to the `mngr_claude` plugin so multiple Claude agents can share a single CLAUDE_CONFIG_DIR instead of each provisioning their own.

--- a/libs/mngr_claude/README.md
+++ b/libs/mngr_claude/README.md
@@ -3,3 +3,26 @@
 Claude agent type plugin for [mngr](../../README.md).
 
 Provides the `claude`, `code-guardian`, and `fixme-fairy` agent types.
+
+## Shared `CLAUDE_CONFIG_DIR` (local agents)
+
+By default, every Claude agent gets its own per-agent config directory under
+`$MNGR_AGENT_STATE_DIR/plugin/claude/anthropic/` (populated by copying/symlinking
+from `~/.claude/`). Set `use_env_config_dir = true` on the agent type config to
+have local Claude agents share the user's `$CLAUDE_CONFIG_DIR` instead:
+
+```toml
+[agent_types.claude]
+use_env_config_dir = true
+```
+
+When enabled:
+
+- `$CLAUDE_CONFIG_DIR` **must** be set in the parent shell; mngr errors out otherwise.
+- Only local hosts are supported.
+- mngr never writes to the user's Claude config (no trust additions, no dialog
+  dismissal, no per-agent settings.json, no keychain provisioning). The user is
+  responsible for one-time interactive `claude` setup (trust the work_dir,
+  complete onboarding, log in).
+- Other sync/override/auto-dismiss fields on the agent config are silently
+  ignored since shared mode has no per-agent dir to write into.

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -15,6 +15,7 @@ from loguru import logger
 
 from imbue.imbue_common.pure import pure
 from imbue.mngr.errors import ConfigError
+from imbue.mngr.errors import UserInputError
 from imbue.mngr.utils.file_utils import atomic_write
 
 
@@ -110,6 +111,24 @@ def get_user_claude_config_dir() -> Path:
     if original and Path(original).is_dir():
         return Path(original)
     return get_claude_config_dir()
+
+
+def resolve_shared_claude_config_dir() -> Path:
+    """Return the value of $CLAUDE_CONFIG_DIR. Raises UserInputError if unset or empty.
+
+    Used by the ``use_env_config_dir`` mode of ``ClaudeAgentConfig`` where mngr
+    delegates the claude config dir to whatever the user has in their shell env
+    rather than provisioning a per-agent dir. The flag is meaningless unless
+    the env var is set, so this helper makes the failure mode explicit.
+    """
+    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if not env_dir:
+        raise UserInputError(
+            "use_env_config_dir=True requires $CLAUDE_CONFIG_DIR to be set in the parent "
+            "process environment, but it is unset (or empty). Either set CLAUDE_CONFIG_DIR "
+            "to the directory you want claude agents to share, or set use_env_config_dir=False."
+        )
+    return Path(env_dir)
 
 
 def find_user_claude_config() -> Path:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from imbue.mngr.errors import UserInputError
 from imbue.mngr_claude.claude_config import ClaudeDirectoryNotTrustedError
 from imbue.mngr_claude.claude_config import ClaudeEffortCalloutNotDismissedError
 from imbue.mngr_claude.claude_config import acknowledge_cost_threshold
@@ -22,6 +23,7 @@ from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
 from imbue.mngr_claude.claude_config import is_source_directory_trusted
 from imbue.mngr_claude.claude_config import remove_claude_trust_for_path
+from imbue.mngr_claude.claude_config import resolve_shared_claude_config_dir
 
 
 def test_find_project_config_exact_match() -> None:
@@ -752,6 +754,29 @@ def test_get_user_claude_config_dir_credentials_fallback_resolves_to_per_agent_c
 
     assert resolved.exists()
     assert resolved.read_text() == '{"token": "abc"}'
+
+
+# Tests for resolve_shared_claude_config_dir
+
+
+def test_resolve_shared_claude_config_dir_returns_env_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With CLAUDE_CONFIG_DIR set to a non-empty path, returns it as a Path."""
+    target = tmp_path / "shared-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(target))
+    assert resolve_shared_claude_config_dir() == target
+
+
+def test_resolve_shared_claude_config_dir_raises_when_unset() -> None:
+    """Without CLAUDE_CONFIG_DIR, raises UserInputError naming the flag."""
+    with pytest.raises(UserInputError, match="use_env_config_dir"):
+        resolve_shared_claude_config_dir()
+
+
+def test_resolve_shared_claude_config_dir_raises_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty CLAUDE_CONFIG_DIR is treated the same as unset."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+    with pytest.raises(UserInputError, match="use_env_config_dir"):
+        resolve_shared_claude_config_dir()
 
 
 # Tests for find_user_claude_config

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -90,6 +90,7 @@ from imbue.mngr_claude.claude_config import is_source_directory_trusted
 from imbue.mngr_claude.claude_config import merge_hooks_config
 from imbue.mngr_claude.claude_config import read_claude_config
 from imbue.mngr_claude.claude_config import remove_claude_trust_for_path
+from imbue.mngr_claude.claude_config import resolve_shared_claude_config_dir
 
 _READY_SIGNAL_TIMEOUT_SECONDS: Final[float] = 10.0
 
@@ -263,6 +264,14 @@ class ClaudeAgentConfig(AgentTypeConfig):
         "are copied to <local_host_dir>/plugin/mngr_claude/preserved_sessions/<agent-name>--<agent-id>/. "
         "For remote agents, files are pulled to the local machine so they survive host destruction. "
         "Set to False to discard session data on destroy.",
+    )
+    use_env_config_dir: bool = Field(
+        default=False,
+        description="When True, share the user's $CLAUDE_CONFIG_DIR across all claude agents instead of "
+        "provisioning a per-agent config dir. Local hosts only; $CLAUDE_CONFIG_DIR must be set. "
+        "When set, mngr never writes to the user's Claude config; the user is responsible for "
+        "interactive `claude` setup (trust dialogs, onboarding, credentials) ahead of time. "
+        "Other sync/override/auto-dismiss fields on this config are silently ignored in this mode.",
     )
 
 
@@ -1353,18 +1362,32 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         _check_settings_local_gitignored(source_host, source_path, require_repo_rule=True)
 
     def get_claude_config_dir(self) -> Path:
-        """Return the per-agent Claude config directory path.
+        """Return the Claude config directory for this agent.
 
-        This directory replaces ~/.claude/ for this agent when CLAUDE_CONFIG_DIR
-        is set. Located at $MNGR_AGENT_STATE_DIR/plugin/claude/anthropic/.
+        Default: per-agent isolated directory at
+        ``$MNGR_AGENT_STATE_DIR/plugin/claude/anthropic/`` that replaces
+        ``~/.claude/`` for this agent.
+
+        When ``use_env_config_dir=True``: resolve to the value of
+        ``$CLAUDE_CONFIG_DIR`` (the user's shared config dir), so multiple
+        agents share a single directory. Raises ``UserInputError`` if the env
+        var is unset.
         """
+        if self.agent_config.use_env_config_dir:
+            return resolve_shared_claude_config_dir()
         return self._get_agent_dir() / "plugin" / "claude" / "anthropic"
 
     def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
-        """Add CLAUDE_CONFIG_DIR, ORIGINAL_CLAUDE_CONFIG_DIR, and optionally enable common transcript emission."""
-        env_vars["CLAUDE_CONFIG_DIR"] = str(self.get_claude_config_dir())
-        env_vars["ORIGINAL_CLAUDE_CONFIG_DIR"] = str(get_user_claude_config_dir())
+        """Add CLAUDE_CONFIG_DIR, ORIGINAL_CLAUDE_CONFIG_DIR, and optionally enable common transcript emission.
+
+        In ``use_env_config_dir`` mode, leave CLAUDE_CONFIG_DIR alone (the agent
+        inherits the parent shell's value) and don't set ORIGINAL_CLAUDE_CONFIG_DIR
+        at all, since there's no per-agent dir to distinguish from the user's.
+        """
         config = self.agent_config
+        if not config.use_env_config_dir:
+            env_vars["CLAUDE_CONFIG_DIR"] = str(self.get_claude_config_dir())
+            env_vars["ORIGINAL_CLAUDE_CONFIG_DIR"] = str(get_user_claude_config_dir())
         if config.emit_common_transcript:
             env_vars["MNGR_EMIT_COMMON_TRANSCRIPT"] = "1"
 
@@ -1575,13 +1598,28 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         startup dialogs are dismissed so we fail early with a clear message.
         Interactive and auto-approve runs skip these checks because
         provision() will handle them.
+
+        In ``use_env_config_dir`` mode: enforce local-only + require
+        $CLAUDE_CONFIG_DIR to be set, and skip the dialog-dismissal
+        validation entirely (user is responsible for their own config).
         """
         config = self.agent_config
 
+        if config.use_env_config_dir:
+            if not host.is_local:
+                raise UserInputError(
+                    "use_env_config_dir=True is only supported for local hosts; "
+                    "this agent targets a non-local host. Disable use_env_config_dir "
+                    "or move the agent to a local host."
+                )
+            # Side-effect: raises if $CLAUDE_CONFIG_DIR is unset, surfacing the
+            # error inside on_before_provisioning's normal error path.
+            resolve_shared_claude_config_dir()
         # Validate dialogs for non-interactive local runs so we fail early with
         # a clear message. Skip when auto_dismiss_dialogs is True because
-        # provision() will auto-dismiss all dialogs in that case.
-        if (
+        # provision() will auto-dismiss all dialogs in that case. Skip entirely
+        # in shared mode because mngr does not write to the user's config.
+        elif (
             host.is_local
             and not mngr_ctx.is_interactive
             and not mngr_ctx.is_auto_approve
@@ -1594,6 +1632,10 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
             else:
                 trust_path = self.work_dir
             check_claude_dialogs_dismissed(find_user_claude_config(), trust_path)
+        else:
+            # Remote-host non-shared, or interactive/auto-approve local, or
+            # auto_dismiss_dialogs=True: provision() handles dialog setup.
+            pass
         if not config.check_installation:
             logger.debug("Skipped claude installation check (check_installation=False)")
             return
@@ -1895,23 +1937,30 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         - git-worktree/git-mirror: trust is extended from the source directory
         - rsync/none: trust is prompted for the work_dir
         - auto_dismiss_dialogs=True: trust is auto-added for work_dir
+
+        In ``use_env_config_dir`` mode: skip all writes to the user's Claude
+        config -- no plugin path sentinel resolution, no dialog dismissal, no
+        cost-threshold acknowledgement, and no per-agent config dir setup. The
+        user takes responsibility for their own config.
         """
+        config = self.agent_config
+
         # Resolve sentinel-prefixed installPaths in ~/.claude/ if present.
         # Deploy images have paths rewritten to a sentinel at build time
         # (because the container's home dir isn't known at build). Resolve
         # them to the actual ~/.claude/ path now, so all downstream code
-        # can assume paths use ~/.claude/ as the prefix.
-        _resolve_plugins_dir_sentinel(host)
+        # can assume paths use ~/.claude/ as the prefix. Skipped in shared
+        # mode because we don't want to rewrite the user's persistent config.
+        if not config.use_env_config_dir:
+            _resolve_plugins_dir_sentinel(host)
 
         with mngr_ctx.concurrency_group.make_concurrency_group("claude_provisioning") as concurrency_group:
-            config = self.agent_config
-
             # Provision background task scripts to the agent state directory
             provision_backgroun_script_thread = concurrency_group.start_new_thread(
                 _provision_background_scripts, (host, self._get_agent_dir(), concurrency_group)
             )
 
-            if host.is_local:
+            if host.is_local and not config.use_env_config_dir:
                 # Determine the source path for trust extension
                 source_path: Path | None = None
                 transfer_mode = options.transfer_mode
@@ -1976,8 +2025,10 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
                     _install_claude(host, config.version)
                     logger.info("Claude installed successfully")
 
-            # no matter what, *always* dismiss the cost popup, it's pointless
-            acknowledge_cost_threshold(find_user_claude_config())
+            # no matter what, *always* dismiss the cost popup, it's pointless.
+            # Skipped in shared mode -- mngr never writes to the user's config.
+            if not config.use_env_config_dir:
+                acknowledge_cost_threshold(find_user_claude_config())
 
             # Transfer plugin data from source agent before config setup (if cloning via --from).
             # This copies sessions, memory, transcript offsets, etc. The subsequent config setup
@@ -1985,8 +2036,10 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
             if options.source_agent_state_location is not None:
                 self._transfer_source_plugin_data(options.source_agent_state_location)
 
-            # Set up per-agent config directory (for both local and remote hosts)
-            self._setup_per_agent_config_dir(host, options, mngr_ctx)
+            # Set up per-agent config directory (skipped in shared mode -- the
+            # shared $CLAUDE_CONFIG_DIR is the user's responsibility to populate).
+            if not config.use_env_config_dir:
+                self._setup_per_agent_config_dir(host, options, mngr_ctx)
 
             # Configure readiness hooks (for both local and remote hosts)
             self._configure_agent_hooks(host)

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -2057,8 +2057,17 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
 
         For each specified session, searches the user's Claude config directory
         by ID (or reads a .jsonl path directly), copies the containing project
-        directory into the per-agent config dir, and writes the last session ID
-        so --resume picks it up.
+        directory into this agent's Claude config dir, and writes the last
+        session ID so --resume picks it up.
+
+        Destination resolution depends on ``use_env_config_dir``:
+        - Default (``False``): copies into the per-agent config dir at
+          ``$MNGR_AGENT_STATE_DIR/plugin/claude/anthropic/projects/<encoded>/``.
+        - Shared (``True``): copies into the user's shared
+          ``$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/``. Per spec decision
+          4c this is the only sanctioned mngr write to the user's config dir
+          in shared mode, and it only adds new project subdirs -- it never
+          modifies existing user files.
         """
         adopt_session_args: tuple[str, ...] = options.plugin_data.get("adopt_session", ())
         if not adopt_session_args:

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -2128,7 +2128,11 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         which exists, so the per-agent-keychain branch would otherwise compute the
         same label hash Claude Code itself uses and delete the user's real
         credentials. Since provision() never wrote any per-agent keychain or
-        trust entries in this mode, there is nothing for us to clean up.
+        trust entries in this mode, there is nothing for us to clean up. Session
+        preservation also skips copying the ``projects/`` directory in this mode
+        (it lives in the user's persistent dir and contains all of their
+        cross-project session history); only transcripts and the session-id
+        history from the agent state dir are preserved.
         """
         # Preserve session files before the state dir is deleted
         if self.agent_config.preserve_sessions_on_destroy:
@@ -2187,19 +2191,32 @@ def _preserve_session_files(agent: ClaudeAgent, host: OnlineHostInterface) -> No
     For local agents, this is a same-host copy. For remote agents, files are
     pulled to the local machine via copy_directory (rsync over SSH).
     Failures are logged as warnings but do not prevent agent destruction.
+
+    In ``use_env_config_dir`` mode the ``projects/`` copy is skipped: session
+    JSONLs already live in the user's persistent ``$CLAUDE_CONFIG_DIR`` (which
+    is not deleted with the agent state), and ``$CLAUDE_CONFIG_DIR/projects/``
+    contains the user's entire cross-project session history -- copying it
+    per-agent would duplicate gigabytes of unrelated sessions into mngr's
+    preserved-sessions store. Transcripts and the session-id history still
+    live under the agent state dir and are preserved as usual.
     """
     agent_dir = agent._get_agent_dir()
+    is_shared_config = agent.agent_config.use_env_config_dir
 
-    # Source paths for session data (on the agent's host)
+    # Source paths for session data (on the agent's host). In shared-config
+    # mode the projects dir is the user's persistent dir, so don't probe or
+    # copy it; sessions there survive the agent's state-dir deletion already.
     config_dir = agent.get_claude_config_dir()
     projects_dir = config_dir / "projects"
     raw_transcript_path = agent_dir / "logs" / "claude_transcript"
     common_transcript_path = agent_dir / "events" / "claude" / "common_transcript"
     history_path = agent_dir / "claude_session_id_history"
 
-    # Check which source directories/files exist on the agent's host (single roundtrip)
+    # Check which source directories/files exist on the agent's host (single roundtrip).
+    # The projects probe is omitted in shared-config mode -- we never copy it there.
+    projects_probe = "" if is_shared_config else f"[ -d {shlex.quote(str(projects_dir))} ] && echo projects;"
     check_script = (
-        f"[ -d {shlex.quote(str(projects_dir))} ] && echo projects;"
+        f"{projects_probe}"
         f" [ -d {shlex.quote(str(raw_transcript_path))} ] && echo raw_transcript;"
         f" [ -d {shlex.quote(str(common_transcript_path))} ] && echo common_transcript;"
         f" [ -f {shlex.quote(str(history_path))} ] && echo history;"
@@ -2218,7 +2235,9 @@ def _preserve_session_files(agent: ClaudeAgent, host: OnlineHostInterface) -> No
     local_host = _get_local_host(agent.mngr_ctx)
 
     with log_span("Preserving session files for agent {}", agent.name):
-        # Copy each available data category using copy_directory
+        # Copy each available data category using copy_directory.
+        # In shared-config mode, "projects" is never present in `available`
+        # because we omitted its probe -- so this branch naturally skips.
         if "projects" in available:
             _copy_to_local(local_host, host, projects_dir, dest_dir / "projects", "session projects", agent.name)
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -2122,6 +2122,13 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
         (the config dir itself is deleted with the agent state).
         For legacy agents without per-agent config dirs: cleans up the global
         ~/.claude.json trust entry.
+
+        In ``use_env_config_dir`` mode: skip keychain / trust cleanup entirely.
+        ``get_claude_config_dir()`` resolves to the user's shared $CLAUDE_CONFIG_DIR,
+        which exists, so the per-agent-keychain branch would otherwise compute the
+        same label hash Claude Code itself uses and delete the user's real
+        credentials. Since provision() never wrote any per-agent keychain or
+        trust entries in this mode, there is nothing for us to clean up.
         """
         # Preserve session files before the state dir is deleted
         if self.agent_config.preserve_sessions_on_destroy:
@@ -2129,6 +2136,12 @@ class ClaudeAgent(BaseAgent[ClaudeAgentConfig]):
                 _preserve_session_files(self, host)
             except (MngrError, OSError) as e:
                 logger.warning("Failed to preserve session files for agent {}: {}", self.name, e)
+
+        if self.agent_config.use_env_config_dir:
+            # Shared-config mode: mngr never wrote per-agent keychain entries or
+            # ~/.claude.json trust markers, so there is nothing to clean up. Any
+            # keychain delete here would target the user's own credentials.
+            return
 
         config_dir = self.get_claude_config_dir()
         per_agent_config_exists = host.execute_idempotent_command(

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -1937,6 +1937,57 @@ def test_preserve_session_files_partial_data(
     assert not (dest_dir / "claude_session_id_history").exists()
 
 
+@pytest.mark.rsync
+def test_preserve_session_files_skips_projects_in_shared_mode(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In use_env_config_dir mode, _preserve_session_files must NOT copy the
+    user's $CLAUDE_CONFIG_DIR/projects/ directory -- that directory holds the
+    user's full cross-project session history and is not deleted with the
+    agent state. Transcripts and history (under the agent state dir) are
+    still preserved.
+    """
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+    agent_dir = agent._get_agent_dir()
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    # Populate the shared projects dir with an "unrelated" project sub-dir
+    # that, if naively copied, would leak the user's other-project sessions
+    # into the preserved-sessions store.
+    unrelated_project = shared_dir / "projects" / "-Users-someone-other-project"
+    unrelated_project.mkdir(parents=True)
+    (unrelated_project / "deadbeef.jsonl").write_text('{"private":"data"}\n')
+
+    # Populate the per-agent transcript + history (these live under the agent
+    # state dir, so they DO need preservation regardless of shared mode).
+    raw_transcript_dir = agent_dir / "logs" / "claude_transcript"
+    raw_transcript_dir.mkdir(parents=True, exist_ok=True)
+    (raw_transcript_dir / "events.jsonl").write_text('{"type":"message"}\n')
+    history_file = agent_dir / "claude_session_id_history"
+    history_file.write_text("abc123 create\n")
+
+    _preserve_session_files(agent, host)
+
+    dest_dir = _get_preserved_sessions_dir(agent)
+    assert dest_dir.exists()
+    # Projects dir must NOT be preserved (it would contain unrelated user data).
+    assert not (dest_dir / "projects").exists()
+    # Transcript and history must still be preserved.
+    assert (dest_dir / "raw_transcript" / "events.jsonl").read_text() == '{"type":"message"}\n'
+    assert (dest_dir / "claude_session_id_history").read_text() == "abc123 create\n"
+
+
 def test_provision_prompts_for_all_dialogs_when_interactive(
     local_provider: LocalProviderInstance,
     tmp_path: Path,

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -1846,6 +1846,73 @@ def test_on_destroy_handles_no_session_data(
     assert not dest_dir.exists()
 
 
+def test_on_destroy_skips_keychain_cleanup_in_shared_mode(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode, on_destroy must NOT call the macOS keychain delete -- the
+    shared $CLAUDE_CONFIG_DIR exists, so the per-agent-keychain branch would
+    otherwise hash the user's own config dir and delete the user's real
+    credentials.
+    """
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+
+    delete_calls: list[str] = []
+
+    def _fake_delete(label: str, _cg: object) -> bool:
+        delete_calls.append(label)
+        return False
+
+    with (
+        patch(f"{_CLAUDE_AGENT_MODULE}.is_macos", return_value=True),
+        patch(f"{_CLAUDE_AGENT_MODULE}._delete_macos_keychain_credential", side_effect=_fake_delete),
+    ):
+        agent.on_destroy(host)
+
+    assert delete_calls == []
+
+
+def test_on_destroy_still_calls_keychain_cleanup_in_default_mode(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Default (per-agent) mode must keep invoking the macOS keychain delete on
+    its own per-agent config dir -- this is the existing behavior, kept stable
+    by the shared-mode fix.
+    """
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
+    # Ensure per-agent config dir exists on disk so the keychain branch fires.
+    agent.get_claude_config_dir().mkdir(parents=True, exist_ok=True)
+
+    delete_calls: list[str] = []
+
+    def _fake_delete(label: str, _cg: object) -> bool:
+        delete_calls.append(label)
+        return False
+
+    with (
+        patch(f"{_CLAUDE_AGENT_MODULE}.is_macos", return_value=True),
+        patch(f"{_CLAUDE_AGENT_MODULE}._delete_macos_keychain_credential", side_effect=_fake_delete),
+    ):
+        agent.on_destroy(host)
+
+    # Two labels: API key and OAuth credentials.
+    assert len(delete_calls) == 2
+    assert any(label.startswith("Claude Code-") for label in delete_calls)
+    assert any(label.startswith("Claude Code-credentials-") for label in delete_calls)
+
+
 @pytest.mark.rsync
 def test_preserve_session_files_partial_data(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -1649,6 +1649,74 @@ def test_on_before_provisioning_skips_trust_check_when_git_common_dir_is_none(
     agent.on_before_provisioning(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=temp_mngr_ctx)
 
 
+def test_on_before_provisioning_shared_mode_succeeds_without_dialog_checks(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode, on_before_provisioning does NOT validate dialog dismissal in user config."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+    # Deliberately leave ~/.claude.json with no dialogs dismissed -- a non-shared
+    # agent would fail here.
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+
+    agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+
+def test_on_before_provisioning_shared_mode_raises_for_remote_host(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """use_env_config_dir is local-only; remote host raises UserInputError."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    agent, _ = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+    remote_host = cast(
+        OnlineHostInterface,
+        FakeHost(is_local=False, host_dir=tmp_path / "remote_host_dir"),
+    )
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+
+    with pytest.raises(UserInputError, match="local hosts"):
+        agent.on_before_provisioning(host=remote_host, options=options, mngr_ctx=temp_mngr_ctx)
+
+
+def test_on_before_provisioning_shared_mode_raises_when_env_unset(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With use_env_config_dir=True and $CLAUDE_CONFIG_DIR unset, on_before_provisioning raises."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+
+    with pytest.raises(UserInputError, match="use_env_config_dir"):
+        agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+
 def test_on_destroy_removes_trust(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
@@ -3955,6 +4023,110 @@ def test_modify_env_vars_sets_claude_config_dirs(
     # only assert it is set to a non-empty string; the exact path depends on
     # the running user's $HOME and is not load-bearing for this test.
     assert env_vars["ORIGINAL_CLAUDE_CONFIG_DIR"]
+
+
+def test_modify_env_vars_omits_claude_config_dir_in_shared_mode(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode, modify_env_vars leaves CLAUDE_CONFIG_DIR / ORIGINAL_CLAUDE_CONFIG_DIR
+    untouched so the agent inherits the parent shell's values."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+    env_vars: dict[str, str] = {}
+
+    agent.modify_env_vars(host, env_vars)
+
+    assert "CLAUDE_CONFIG_DIR" not in env_vars
+    assert "ORIGINAL_CLAUDE_CONFIG_DIR" not in env_vars
+    # Common transcript emission is independent of shared mode -- still set.
+    assert env_vars["MNGR_EMIT_COMMON_TRANSCRIPT"] == "1"
+
+
+def test_modify_env_vars_shared_mode_with_common_transcript_disabled(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode with emit_common_transcript=False, the env dict stays empty."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(
+            check_installation=False, use_env_config_dir=True, emit_common_transcript=False
+        ),
+    )
+    env_vars: dict[str, str] = {}
+
+    agent.modify_env_vars(host, env_vars)
+
+    assert env_vars == {}
+
+
+# =============================================================================
+# get_claude_config_dir Tests
+# =============================================================================
+
+
+def test_get_claude_config_dir_returns_per_agent_dir_by_default(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """Without use_env_config_dir, get_claude_config_dir returns the per-agent path."""
+    agent, _ = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
+
+    config_dir = agent.get_claude_config_dir()
+
+    assert config_dir == agent._get_agent_dir() / "plugin" / "claude" / "anthropic"
+
+
+def test_get_claude_config_dir_returns_shared_env_value_in_shared_mode(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode, get_claude_config_dir returns the value of $CLAUDE_CONFIG_DIR."""
+    shared = tmp_path / "shared-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared))
+    agent, _ = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+
+    assert agent.get_claude_config_dir() == shared
+
+
+def test_get_claude_config_dir_raises_in_shared_mode_when_env_unset(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In shared mode with $CLAUDE_CONFIG_DIR unset, get_claude_config_dir raises."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    agent, _ = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
+    )
+
+    with pytest.raises(UserInputError, match="use_env_config_dir"):
+        agent.get_claude_config_dir()
 
 
 # =============================================================================

--- a/specs/single-claude-data-dir/spec.md
+++ b/specs/single-claude-data-dir/spec.md
@@ -10,7 +10,7 @@
 - Flag is local-only. Setting it for a non-local host raises a clear error before provisioning. `CLAUDE_CONFIG_DIR` must be set in the parent process env; mngr raises a clear error if it is not.
 - `ORIGINAL_CLAUDE_CONFIG_DIR` is not relevant in this mode and is not set on the agent. `CLAUDE_CONFIG_DIR` is also not explicitly set by mngr on the agent — the agent inherits the parent shell's value (which our pre-check guarantees is non-empty).
 - Hook scripts in `work_dir/.claude/settings.local.json` and background scripts under `$MNGR_AGENT_STATE_DIR/commands/` are unchanged. Those are per-worktree / per-agent state, not Claude config dir state, so the readiness/permissions/transcript machinery keeps working.
-- All config fields that are conceptually incompatible with shared-mode (sync, override, keychain conversion, auto-dismissal) raise a config-validation error if set to a non-default value while `use_env_config_dir=True`. This refuses to silently ignore user intent.
+- Other config fields that conceptually overlap with shared-mode behavior (the `sync_*` family, `override_settings_folder`, `settings_overrides`, `convert_macos_credentials`, `auto_dismiss_dialogs`) are simply ignored when `use_env_config_dir=True`. No validation error is raised. The user takes responsibility for the combinations they pick.
 
 ## Expected Behavior
 
@@ -29,12 +29,8 @@
 - macOS keychain provisioning and cleanup are skipped: Claude Code's keychain label hash uses the shared `CLAUDE_CONFIG_DIR`, which already matches the user's normal `claude` invocations, so no per-agent label exists to populate or delete.
 - Trust handling is delegated to the user. mngr does not call `add_claude_trust_for_path`, `auto_dismiss_claude_dialogs`, `acknowledge_cost_threshold`, `dismiss_effort_callout`, `complete_onboarding`, `accept_bypass_permissions`, or `remove_claude_trust_for_path`. If the user has not pre-trusted the work_dir or pre-dismissed onboarding, Claude's TUI will block at startup; this is documented as the user's responsibility.
 - The "custom API key" approval dialog (`approve_api_key_for_claude`) is **not** called in shared mode (it writes per-agent .claude.json data we no longer produce). If `ANTHROPIC_API_KEY` is supplied via `--env`/`--pass-env`/host env and does not match the user's `primaryApiKey` or `customApiKeyResponses.approved` list in `~/.claude.json`, Claude will challenge in the TUI and deadlock `wait_for_ready_signal`. This is flagged in **Open Questions** below; the spec recommends a preflight warning but no automatic fix.
-- Configuration validation errors fire *at config-load time* (Pydantic model validator), not deep inside provisioning, so users see the conflict before host creation:
-  - `sync_home_settings=False`, `sync_claude_json=False`, `sync_repo_settings=False`, `sync_claude_credentials=False`, `symlink_user_resources=False`, `convert_macos_credentials=False`, `sync_credentials_on_login=False`, `auto_dismiss_dialogs=True`, `override_settings_folder is not None`, `settings_overrides != {}` — any non-default raises `UserInputError` when paired with `use_env_config_dir=True`.
-  - `auto_allow_permissions` is **allowed** in shared mode (writes only to `work_dir/.claude/settings.local.json`, which is per-worktree and gitignored).
-  - `preserve_sessions_on_destroy` is **allowed** in shared mode (writes only to local `host_dir`).
-  - `check_installation` and `version` are **allowed** unchanged.
-- The host-must-be-local check fires in `on_before_provisioning` (after host is online, before provisioning work). Error message names the flag and tells the user it is local-only.
+- Other config fields are silently ignored when they no longer apply (the `sync_*` family, `override_settings_folder`, `settings_overrides`, `convert_macos_credentials`, `auto_dismiss_dialogs`). `auto_allow_permissions`, `preserve_sessions_on_destroy`, `check_installation`, and `version` continue to work as today since they don't touch the user's config dir.
+- The only hard-error checks are: host-must-be-local (fires in `on_before_provisioning`, message names the flag) and `$CLAUDE_CONFIG_DIR` must be non-empty in the parent process env.
 - `claude_config.get_claude_config_dir()` (the standalone function) is unchanged: still reads `CLAUDE_CONFIG_DIR` or falls back to `~/.claude` (per decision 1b).
 - `ClaudeAgent.get_claude_config_dir()` (the instance method) checks the flag: when `True`, it returns the value of `CLAUDE_CONFIG_DIR` (raising a clear error if unset); when `False`, returns the per-agent path as today.
 - `claude_config.get_user_claude_config_dir()` and `find_user_claude_config()` are unchanged. They are not called from shared-mode code paths (callers either branch on the flag or only run in the default mode).
@@ -56,7 +52,7 @@ Packaged as a single PR. Branch: `mngr/single-claude-data-dir`.
 
 ### `libs/mngr_claude/imbue/mngr_claude/plugin.py`
 
-#### `ClaudeAgentConfig` (new field + validator)
+#### `ClaudeAgentConfig` (new field)
 
 - Add field:
   ```python
@@ -70,9 +66,7 @@ Packaged as a single PR. Branch: `mngr/single-claude-data-dir`.
       ),
   )
   ```
-- Add a `@model_validator(mode="after")` that raises `UserInputError` if `use_env_config_dir=True` is combined with any of: `sync_home_settings=False`, `sync_claude_json=False`, `sync_repo_settings=False`, `sync_claude_credentials=False`, `symlink_user_resources=False`, `convert_macos_credentials=False`, `sync_credentials_on_login=False`, `auto_dismiss_dialogs=True`, `override_settings_folder is not None`, or non-empty `settings_overrides`. Error names every conflicting field in one message.
-
-Note: the conflicting fields above include `False` values for fields that *default to True* because, in shared mode, those toggles have no effect — explicitly setting them indicates the user expects behavior that shared mode cannot provide. The validator's message documents this.
+- No model validator. Other `sync_*` / `override_*` / `settings_overrides` / `auto_dismiss_dialogs` fields are silently ignored at provisioning time when `use_env_config_dir=True` (because the code paths that read them are skipped). Documenting this in the field's description is sufficient.
 
 #### `ClaudeAgent.get_claude_config_dir`
 
@@ -121,7 +115,7 @@ Note: the conflicting fields above include `False` values for fields that *defau
 ### `libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py`, `code_guardian_agent.py`, `fixme_fairy_agent.py`, `skill_agent.py`
 
 - No code change. They inherit `ClaudeAgentConfig`'s new field and `ClaudeAgent`'s updated `provision`/`get_claude_config_dir`/`modify_env_vars` automatically.
-- One caveat: `HeadlessClaudeAgent` runs `claude -p ...` non-interactively; the same rules apply (user must have pre-trusted + pre-dismissed dialogs). The default `auto_dismiss_dialogs=True` that headless mode typically wants is now mutually exclusive with the new flag — the validator will refuse the combination, which is the right outcome.
+- One caveat: `HeadlessClaudeAgent` runs `claude -p ...` non-interactively; the same rules apply (user must have pre-trusted + pre-dismissed dialogs). `auto_dismiss_dialogs=True` is silently ignored in shared mode, so headless + shared-mode users must ensure dialogs are already dismissed in `~/.claude.json` themselves.
 
 ### Tests
 
@@ -129,8 +123,6 @@ Note: the conflicting fields above include `False` values for fields that *defau
   - `test_resolve_shared_claude_config_dir_returns_env_value` — set `CLAUDE_CONFIG_DIR`, assert the helper returns its `Path`.
   - `test_resolve_shared_claude_config_dir_raises_when_unset` — unset env, assert `UserInputError`.
 - New unit tests in `libs/mngr_claude/imbue/mngr_claude/plugin_test.py`:
-  - `test_claude_agent_config_rejects_use_env_config_dir_with_conflicting_fields` — parametrized over each conflicting field, asserts `UserInputError` (or pydantic `ValidationError` if we use a `@model_validator`).
-  - `test_claude_agent_config_allows_use_env_config_dir_with_compatible_fields` — `use_env_config_dir=True, auto_allow_permissions=True, preserve_sessions_on_destroy=True, version="2.1.50"` validates successfully.
   - `test_claude_agent_get_claude_config_dir_uses_env_in_shared_mode` — instantiate agent with flag on, monkeypatch env, assert `get_claude_config_dir()` returns the env value.
   - `test_claude_agent_modify_env_vars_omits_claude_config_dir_in_shared_mode` — assert `CLAUDE_CONFIG_DIR` and `ORIGINAL_CLAUDE_CONFIG_DIR` are not in the resulting dict; `MNGR_EMIT_COMMON_TRANSCRIPT` still present when configured.
 - New integration test (offload-only, `test_*.py` style) in `libs/mngr_claude/imbue/mngr_claude/test_shared_config_dir.py`:
@@ -151,9 +143,8 @@ Phase order is chosen so each phase ends in a working, releasable state.
 ### Phase 1 — Config plumbing only
 
 - Add the `use_env_config_dir` field on `ClaudeAgentConfig`.
-- Add the model validator that rejects conflicting field combinations.
 - Add `resolve_shared_claude_config_dir` in `claude_config.py`.
-- All unit tests for the field, validator, and helper.
+- Unit tests for the field default and the helper.
 - No behavior change yet — agents with the flag set don't yet provision differently. (Will fail at runtime because we haven't updated provision/modify_env_vars/get_claude_config_dir; this is internal-only and won't ship a release boundary until Phase 2.)
 
 ### Phase 2 — Wire flag into agent runtime
@@ -175,7 +166,6 @@ Phase order is chosen so each phase ends in a working, releasable state.
 
 ### Unit tests (run via `just test-quick libs/mngr_claude`)
 
-- Cover every validation path on `ClaudeAgentConfig`: the matrix of `use_env_config_dir=True` × each conflicting field, both at-default and non-default, asserting accept/reject.
 - Cover `resolve_shared_claude_config_dir`: set / unset / empty-string env var.
 - Cover `ClaudeAgent.get_claude_config_dir` and `modify_env_vars` directly with a minimally-constructed agent (use existing `temp_mngr_ctx` / `temp_host_dir` fixtures from `libs/mngr/imbue/mngr/utils/testing.py`).
 
@@ -198,7 +188,6 @@ Phase order is chosen so each phase ends in a working, releasable state.
 ### Ratchets
 
 - No new ratchet rules needed. The existing `PREVENT_HARDCODED_CLAUDE_DIR` ratchet keeps callers off of `Path.home() / ".claude"`.
-- The validator-rejected combinations are *runtime* checks, not regex ratchets, because they depend on field values not source text.
 
 ## Open Questions
 
@@ -210,6 +199,6 @@ These are flagged for the user to decide before or during implementation; the sp
 
 - **Plugin-level default**: Currently the flag lives on `ClaudeAgentConfig` (per decision 1a) — to opt all claude agent types into shared mode, the user must set it on each type. Should we *also* expose this as a plugin-level config in mngr's TOML (`[plugin.mngr_claude]`) that becomes the field's default? Out of scope for v1; raise later if a real workflow demands it.
 
-- **`HeadlessClaudeAgentConfig.auto_dismiss_dialogs` default**: Headless mode currently typically wants `auto_dismiss_dialogs=True`. The new validator will refuse `use_env_config_dir=True` with `auto_dismiss_dialogs=True`. If we expect headless + shared-mode to be a common combo, we may want to tweak headless's default or relax the validator for headless specifically. Spec leaves this strict for v1.
+- **`HeadlessClaudeAgentConfig.auto_dismiss_dialogs` default**: Headless mode typically wants `auto_dismiss_dialogs=True`. In shared mode this field is silently ignored, so headless + shared-mode users must ensure dialogs are pre-dismissed in `~/.claude.json`. If we expect that combo to be common, we may want to surface a warning at provisioning time. Out of scope for v1.
 
 - **Flag naming**: `use_env_config_dir` is descriptive but slightly oblique. Alternatives: `share_user_config_dir`, `use_user_claude_config_dir`, `shared_config_dir`. Spec keeps `use_env_config_dir` per the user's original request.

--- a/specs/single-claude-data-dir/spec.md
+++ b/specs/single-claude-data-dir/spec.md
@@ -1,0 +1,215 @@
+# Shared CLAUDE_CONFIG_DIR for claude agents
+
+## Overview
+
+- Today every Claude agent provisions its own per-agent config directory at `$MNGR_AGENT_STATE_DIR/plugin/claude/anthropic/`, which mngr populates by symlinking or copying from `~/.claude/`, writing per-agent `.claude.json` / `settings.json` / `installed_plugins.json`, and provisioning per-agent keychain entries on macOS.
+- Per-agent isolation is the right default but it has real costs locally: macOS keychain prompts on first run, plugin path rewrites, marketplace re-fetches, sessions split across many `projects/` trees, and ambient writes to `~/.claude.json` for trust/dialog dismissal.
+- Some users (especially heavy local-only workflows) prefer the *opposite* trade-off: have every Claude agent share the user's own `CLAUDE_CONFIG_DIR` so credentials, plugins, marketplaces, sessions, and settings just work without copy/symlink shuffling.
+- This spec adds a single opt-in flag, `use_env_config_dir: bool = False`, on `ClaudeAgentConfig`. When `True`, mngr does not create or write to a per-agent config dir; the agent inherits the user's `CLAUDE_CONFIG_DIR` from the shell env.
+- Strict invariant when the flag is on: **mngr never writes to the user's `CLAUDE_CONFIG_DIR` or to `~/.claude.json`**. Trust, dialog dismissal, credential provisioning, keychain prompts, plugin path rewriting, and per-agent settings.json generation are all skipped. The user is responsible for one-time setup (`claude` interactively at least once: trust dialogs, onboarding, credentials).
+- Flag is local-only. Setting it for a non-local host raises a clear error before provisioning. `CLAUDE_CONFIG_DIR` must be set in the parent process env; mngr raises a clear error if it is not.
+- `ORIGINAL_CLAUDE_CONFIG_DIR` is not relevant in this mode and is not set on the agent. `CLAUDE_CONFIG_DIR` is also not explicitly set by mngr on the agent — the agent inherits the parent shell's value (which our pre-check guarantees is non-empty).
+- Hook scripts in `work_dir/.claude/settings.local.json` and background scripts under `$MNGR_AGENT_STATE_DIR/commands/` are unchanged. Those are per-worktree / per-agent state, not Claude config dir state, so the readiness/permissions/transcript machinery keeps working.
+- All config fields that are conceptually incompatible with shared-mode (sync, override, keychain conversion, auto-dismissal) raise a config-validation error if set to a non-default value while `use_env_config_dir=True`. This refuses to silently ignore user intent.
+
+## Expected Behavior
+
+### Default (`use_env_config_dir=False`)
+
+- Indistinguishable from today's behavior. Every code path, env var, file layout, and dialog flow is unchanged.
+
+### When `use_env_config_dir=True`
+
+- `mngr create` on a local host succeeds without writing anything inside the directory `CLAUDE_CONFIG_DIR` points to and without writing anything to `~/.claude.json`.
+- The launched `claude` process sees `$CLAUDE_CONFIG_DIR` inherited verbatim from the parent shell. Credentials, plugins, marketplaces, skills, agents, commands, keybindings, settings, and prior sessions all come from that one directory.
+- Per-agent session JSONLs created by Claude during the run land in `$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/` (Claude's normal behavior). Different agents whose `work_dir`s differ get different project subdirs; agents that happen to share a `work_dir` share a project subdir but use distinct `--session-id`s, so their JSONL files do not collide.
+- `--adopt-session` keeps working: if the source session already lives in `$CLAUDE_CONFIG_DIR`, mngr finds it there with no copy; if not, mngr still copies the source project dir into `$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/`. (Per design decision 4c: this is the only sanctioned addition to the shared dir, and it only adds new project subdirs — it never modifies existing user files.)
+- `preserve_sessions_on_destroy` keeps working unchanged: on destroy, session JSONLs, transcripts, and the session-id history are copied to `<local_host_dir>/plugin/mngr_claude/preserved_sessions/<agent>--<id>/` exactly as today. (Sessions live in the user's persistent dir anyway, but preservation also captures the raw + common transcripts and history file from the agent state dir, which the user would otherwise lose.)
+- Hooks in `work_dir/.claude/settings.local.json` (readiness, optional auto-allow-permissions, optional macOS credential sync) are written exactly as today. The gitignore preflight check still runs.
+- macOS keychain provisioning and cleanup are skipped: Claude Code's keychain label hash uses the shared `CLAUDE_CONFIG_DIR`, which already matches the user's normal `claude` invocations, so no per-agent label exists to populate or delete.
+- Trust handling is delegated to the user. mngr does not call `add_claude_trust_for_path`, `auto_dismiss_claude_dialogs`, `acknowledge_cost_threshold`, `dismiss_effort_callout`, `complete_onboarding`, `accept_bypass_permissions`, or `remove_claude_trust_for_path`. If the user has not pre-trusted the work_dir or pre-dismissed onboarding, Claude's TUI will block at startup; this is documented as the user's responsibility.
+- The "custom API key" approval dialog (`approve_api_key_for_claude`) is **not** called in shared mode (it writes per-agent .claude.json data we no longer produce). If `ANTHROPIC_API_KEY` is supplied via `--env`/`--pass-env`/host env and does not match the user's `primaryApiKey` or `customApiKeyResponses.approved` list in `~/.claude.json`, Claude will challenge in the TUI and deadlock `wait_for_ready_signal`. This is flagged in **Open Questions** below; the spec recommends a preflight warning but no automatic fix.
+- Configuration validation errors fire *at config-load time* (Pydantic model validator), not deep inside provisioning, so users see the conflict before host creation:
+  - `sync_home_settings=False`, `sync_claude_json=False`, `sync_repo_settings=False`, `sync_claude_credentials=False`, `symlink_user_resources=False`, `convert_macos_credentials=False`, `sync_credentials_on_login=False`, `auto_dismiss_dialogs=True`, `override_settings_folder is not None`, `settings_overrides != {}` — any non-default raises `UserInputError` when paired with `use_env_config_dir=True`.
+  - `auto_allow_permissions` is **allowed** in shared mode (writes only to `work_dir/.claude/settings.local.json`, which is per-worktree and gitignored).
+  - `preserve_sessions_on_destroy` is **allowed** in shared mode (writes only to local `host_dir`).
+  - `check_installation` and `version` are **allowed** unchanged.
+- The host-must-be-local check fires in `on_before_provisioning` (after host is online, before provisioning work). Error message names the flag and tells the user it is local-only.
+- `claude_config.get_claude_config_dir()` (the standalone function) is unchanged: still reads `CLAUDE_CONFIG_DIR` or falls back to `~/.claude` (per decision 1b).
+- `ClaudeAgent.get_claude_config_dir()` (the instance method) checks the flag: when `True`, it returns the value of `CLAUDE_CONFIG_DIR` (raising a clear error if unset); when `False`, returns the per-agent path as today.
+- `claude_config.get_user_claude_config_dir()` and `find_user_claude_config()` are unchanged. They are not called from shared-mode code paths (callers either branch on the flag or only run in the default mode).
+
+## Implementation Plan
+
+Packaged as a single PR. Branch: `mngr/single-claude-data-dir`.
+
+### `libs/mngr_claude/imbue/mngr_claude/claude_config.py`
+
+- No behavioral change to `get_claude_config_dir`, `get_user_claude_config_dir`, or `find_user_claude_config`. Per decision 1b, the standalone functions keep their existing semantics; only the instance method on `ClaudeAgent` changes.
+- Add a new module-level helper:
+  ```python
+  def resolve_shared_claude_config_dir() -> Path:
+      """Return the value of $CLAUDE_CONFIG_DIR. Raises UserInputError if unset."""
+  ```
+  Raises a `UserInputError` from `imbue.mngr.errors` (already imported via plugin.py) with a message naming `use_env_config_dir` and the missing env var so the user knows which knob to flip.
+- New error class is unnecessary; the existing `UserInputError` / `ConfigError` hierarchy is sufficient.
+
+### `libs/mngr_claude/imbue/mngr_claude/plugin.py`
+
+#### `ClaudeAgentConfig` (new field + validator)
+
+- Add field:
+  ```python
+  use_env_config_dir: bool = Field(
+      default=False,
+      description=(
+          "When True, share the user's $CLAUDE_CONFIG_DIR across all claude agents "
+          "instead of provisioning a per-agent config dir. Local hosts only. "
+          "When set, mngr never writes to the user's Claude config; the user must "
+          "have completed `claude` setup interactively (trust, onboarding, credentials)."
+      ),
+  )
+  ```
+- Add a `@model_validator(mode="after")` that raises `UserInputError` if `use_env_config_dir=True` is combined with any of: `sync_home_settings=False`, `sync_claude_json=False`, `sync_repo_settings=False`, `sync_claude_credentials=False`, `symlink_user_resources=False`, `convert_macos_credentials=False`, `sync_credentials_on_login=False`, `auto_dismiss_dialogs=True`, `override_settings_folder is not None`, or non-empty `settings_overrides`. Error names every conflicting field in one message.
+
+Note: the conflicting fields above include `False` values for fields that *default to True* because, in shared mode, those toggles have no effect — explicitly setting them indicates the user expects behavior that shared mode cannot provide. The validator's message documents this.
+
+#### `ClaudeAgent.get_claude_config_dir`
+
+- Branch on `self.agent_config.use_env_config_dir`:
+  - `True`: return `resolve_shared_claude_config_dir()`.
+  - `False`: return `self._get_agent_dir() / "plugin" / "claude" / "anthropic"` (unchanged).
+
+#### `ClaudeAgent.modify_env_vars`
+
+- Branch on the flag:
+  - `True`: do not set `CLAUDE_CONFIG_DIR` or `ORIGINAL_CLAUDE_CONFIG_DIR`. Still set `MNGR_EMIT_COMMON_TRANSCRIPT` when `emit_common_transcript=True`.
+  - `False`: unchanged.
+
+#### `ClaudeAgent.on_before_provisioning`
+
+- Add a new local-only-check block at the top (before any other logic): if `self.agent_config.use_env_config_dir is True and not host.is_local`, raise `UserInputError("use_env_config_dir is local-only; host is remote")`.
+- Re-validate that `$CLAUDE_CONFIG_DIR` is set in the parent process env (calls `resolve_shared_claude_config_dir()` purely for its side-effect of raising). This is fail-fast — the same check happens at field resolution but doing it here surfaces the error inside `on_before_provisioning`'s usual error path.
+- Skip the existing dialog-dismissal validation block when the flag is on (the block calls `check_claude_dialogs_dismissed(find_user_claude_config(), trust_path)` — in shared mode we deliberately do not validate dialogs, per decision 2c).
+- API-credentials availability warning: keep as-is. (`_has_api_credentials_available` only reads, doesn't write.)
+
+#### `ClaudeAgent.provision`
+
+- Top of method, after `_resolve_plugins_dir_sentinel`: branch on the flag.
+- When `use_env_config_dir=True`:
+  - Skip `_resolve_plugins_dir_sentinel(host)` (this would rewrite the *user's* `installed_plugins.json` / `known_marketplaces.json`).
+  - Skip `interactively_dismiss_claude_dialogs` and `auto_dismiss_claude_dialogs`.
+  - Skip `acknowledge_cost_threshold(find_user_claude_config())`.
+  - Skip `_setup_per_agent_config_dir`.
+  - Keep: background-script provisioning, claude installation check / install, `_transfer_source_plugin_data` (operates on `$MNGR_AGENT_STATE_DIR/plugin/` not the config dir), `_configure_agent_hooks`.
+- When `use_env_config_dir=False`: unchanged.
+
+#### `ClaudeAgent.on_after_provisioning`
+
+- The `--adopt-session` block uses `self.get_claude_config_dir()` to find the per-agent `projects/` dir. In shared mode, `get_claude_config_dir()` now returns the user's dir, so `--adopt-session` writes copies of session files into `$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/`. No code change required here — the indirection through `get_claude_config_dir()` handles it. This matches decision 4c.
+
+#### `ClaudeAgent.on_destroy`
+
+- The per-agent-config-dir existence check (`test -d <config_dir>`) plus the macOS keychain cleanup remains correct: in shared mode the per-agent dir doesn't exist, so the `if per_agent_config_exists and is_macos()` branch is skipped naturally.
+- The "legacy" else-branch currently calls `remove_claude_trust_for_path(find_user_claude_config(), self.work_dir)`. Per decision 3b, **leave this call as-is** — `remove_claude_trust_for_path` already gates on `_mngrCreated=True`, and in shared mode we never set that marker on any user-config entry, so the call is a guaranteed no-op. No behavioral change, no risk, and we get the "legacy agent without per-agent config dir" path for free without further branching.
+- Session preservation (`_preserve_session_files`) keeps working unchanged: it calls `agent.get_claude_config_dir()` which now returns the user's dir, so it pulls session JSONLs from there.
+
+#### Deploy path (`get_files_for_deploy`, `modify_env_vars_for_deploy`)
+
+- No change. These run at deploy-image build time, where there is no `ClaudeAgentConfig` instance and no host. The flag is local-only and irrelevant to deployment.
+
+### `libs/mngr_claude/imbue/mngr_claude/headless_claude_agent.py`, `code_guardian_agent.py`, `fixme_fairy_agent.py`, `skill_agent.py`
+
+- No code change. They inherit `ClaudeAgentConfig`'s new field and `ClaudeAgent`'s updated `provision`/`get_claude_config_dir`/`modify_env_vars` automatically.
+- One caveat: `HeadlessClaudeAgent` runs `claude -p ...` non-interactively; the same rules apply (user must have pre-trusted + pre-dismissed dialogs). The default `auto_dismiss_dialogs=True` that headless mode typically wants is now mutually exclusive with the new flag — the validator will refuse the combination, which is the right outcome.
+
+### Tests
+
+- New unit tests in `libs/mngr_claude/imbue/mngr_claude/claude_config_test.py`:
+  - `test_resolve_shared_claude_config_dir_returns_env_value` — set `CLAUDE_CONFIG_DIR`, assert the helper returns its `Path`.
+  - `test_resolve_shared_claude_config_dir_raises_when_unset` — unset env, assert `UserInputError`.
+- New unit tests in `libs/mngr_claude/imbue/mngr_claude/plugin_test.py`:
+  - `test_claude_agent_config_rejects_use_env_config_dir_with_conflicting_fields` — parametrized over each conflicting field, asserts `UserInputError` (or pydantic `ValidationError` if we use a `@model_validator`).
+  - `test_claude_agent_config_allows_use_env_config_dir_with_compatible_fields` — `use_env_config_dir=True, auto_allow_permissions=True, preserve_sessions_on_destroy=True, version="2.1.50"` validates successfully.
+  - `test_claude_agent_get_claude_config_dir_uses_env_in_shared_mode` — instantiate agent with flag on, monkeypatch env, assert `get_claude_config_dir()` returns the env value.
+  - `test_claude_agent_modify_env_vars_omits_claude_config_dir_in_shared_mode` — assert `CLAUDE_CONFIG_DIR` and `ORIGINAL_CLAUDE_CONFIG_DIR` are not in the resulting dict; `MNGR_EMIT_COMMON_TRANSCRIPT` still present when configured.
+- New integration test (offload-only, `test_*.py` style) in `libs/mngr_claude/imbue/mngr_claude/test_shared_config_dir.py`:
+  - `test_shared_config_dir_local_agent_does_not_touch_user_config` — create a local agent with `use_env_config_dir=True`, point `CLAUDE_CONFIG_DIR` at a snapshot of a real `~/.claude` (copied to `tmp_path`), capture mtimes of `.claude.json`/`settings.json`/`projects/` before run, start the agent, send a no-op message, destroy, assert mtimes of pre-existing files are unchanged (newly created `projects/<encoded>/...` files are allowed).
+  - `test_shared_config_dir_remote_raises` — attempt to create a Modal agent with the flag, assert `UserInputError` from `on_before_provisioning`.
+  - `test_shared_config_dir_unset_env_raises` — `monkeypatch.delenv("CLAUDE_CONFIG_DIR")`, create agent, assert clear error.
+  - `test_shared_config_dir_adopt_session_writes_under_shared_projects_dir` — `--adopt-session` with an external `.jsonl` file, assert it is copied into `$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/`.
+
+### Docs / changelog
+
+- `changelog/mngr-single-claude-data-dir.md` — already created; expand to user-facing language describing the new flag, its purpose, and the user-side prerequisites (one-time interactive `claude` setup).
+- `libs/mngr_claude/README.md` — short paragraph naming the flag and pointing at the changelog entry.
+
+## Implementation Phases
+
+Phase order is chosen so each phase ends in a working, releasable state.
+
+### Phase 1 — Config plumbing only
+
+- Add the `use_env_config_dir` field on `ClaudeAgentConfig`.
+- Add the model validator that rejects conflicting field combinations.
+- Add `resolve_shared_claude_config_dir` in `claude_config.py`.
+- All unit tests for the field, validator, and helper.
+- No behavior change yet — agents with the flag set don't yet provision differently. (Will fail at runtime because we haven't updated provision/modify_env_vars/get_claude_config_dir; this is internal-only and won't ship a release boundary until Phase 2.)
+
+### Phase 2 — Wire flag into agent runtime
+
+- Update `ClaudeAgent.get_claude_config_dir` to branch on the flag.
+- Update `ClaudeAgent.modify_env_vars` to branch on the flag.
+- Update `ClaudeAgent.on_before_provisioning` with the local-only check and skip the dialog-dismissal validation.
+- Update `ClaudeAgent.provision` to skip per-agent config setup, dialog handling, and `acknowledge_cost_threshold` when the flag is set.
+- Unit tests for env-var omission and config-dir resolution.
+- After this phase, local-only shared-config agents work end-to-end.
+
+### Phase 3 — Tests + docs
+
+- Add integration tests in `test_shared_config_dir.py`.
+- Update changelog entry with the final user-facing language.
+- Update `libs/mngr_claude/README.md` with a short blurb pointing at the flag.
+
+## Testing Strategy
+
+### Unit tests (run via `just test-quick libs/mngr_claude`)
+
+- Cover every validation path on `ClaudeAgentConfig`: the matrix of `use_env_config_dir=True` × each conflicting field, both at-default and non-default, asserting accept/reject.
+- Cover `resolve_shared_claude_config_dir`: set / unset / empty-string env var.
+- Cover `ClaudeAgent.get_claude_config_dir` and `modify_env_vars` directly with a minimally-constructed agent (use existing `temp_mngr_ctx` / `temp_host_dir` fixtures from `libs/mngr/imbue/mngr/utils/testing.py`).
+
+### Integration tests (acceptance/release, run via offload)
+
+- Provision a real local agent with `use_env_config_dir=True` against a `tmp_path`-rooted fake `CLAUDE_CONFIG_DIR` (populated with a minimal but realistic `.claude.json` + `settings.json` + `projects/`). Capture file mtimes / SHA256 hashes before and after agent lifecycle; assert pre-existing files are byte-identical at destroy time.
+- Confirm hooks are still written to `work_dir/.claude/settings.local.json`.
+- Confirm `$MNGR_AGENT_STATE_DIR/commands/` is populated.
+- Confirm background-task transcripts still emit to `events/claude/common_transcript/events.jsonl`.
+- Confirm `--adopt-session` writes to `$CLAUDE_CONFIG_DIR/projects/<encoded-work_dir>/`, not to a per-agent dir.
+
+### Edge cases
+
+- `use_env_config_dir=True` + remote host → `on_before_provisioning` raises.
+- `use_env_config_dir=True` + `CLAUDE_CONFIG_DIR` unset → clear error at agent start.
+- `use_env_config_dir=True` + work_dir is not trusted in the shared config → Claude's TUI blocks; `wait_for_ready_signal` times out; verify the existing trust-dialog indicator catches it (`TrustDialogIndicator` matches "Yes, I trust this folder"). No code change needed, but add an integration test that confirms the error surface is reasonable.
+- `use_env_config_dir=True` + `ANTHROPIC_API_KEY` provided via mngr that doesn't match user's `primaryApiKey` → `CustomApiKeyDialogIndicator` fires; documented in Open Questions.
+- Concurrent agents sharing the same `work_dir` → distinct `--session-id`s, files in same `projects/<encoded>/` but no collision. Acceptable; covered by inspection rather than automated test.
+
+### Ratchets
+
+- No new ratchet rules needed. The existing `PREVENT_HARDCODED_CLAUDE_DIR` ratchet keeps callers off of `Path.home() / ".claude"`.
+- The validator-rejected combinations are *runtime* checks, not regex ratchets, because they depend on field values not source text.
+
+## Open Questions
+
+These are flagged for the user to decide before or during implementation; the spec carries reasonable defaults.
+
+- **API-key mismatch deadlock**: When `use_env_config_dir=True` and a non-empty `ANTHROPIC_API_KEY` is provided via mngr (`--env` / `--pass-env` / `--host-env-file`) that doesn't appear in the user's `primaryApiKey` or `customApiKeyResponses.approved` list in `~/.claude.json`, Claude will challenge in the TUI and `wait_for_ready_signal` will time out. Options: (1) ignore — let the existing dialog indicator surface a clean error; (2) preflight check in `on_before_provisioning` that reads `~/.claude.json` (read-only) and raises if a mismatch is detected; (3) add a separate, narrowly-scoped opt-in that *does* allow writing the `customApiKeyResponses` field of `~/.claude.json` for shared mode. Spec recommends (2) — read-only preflight with a clear error message — but defers to the user.
+
+- **`mngr` writing concurrent to user's own `claude` invocations**: With shared mode, both mngr-launched agents and the user's own `claude` invocations write to `~/.claude.json` (the user's own writes; mngr's writes are eliminated by this flag). The user's `claude` doesn't honor mngr's `_claude_config_lock`, so an interactive `claude` run during `mngr create` could lose updates. Likely acceptable since shared mode is opt-in and the user is explicitly choosing this trade-off; documented for clarity.
+
+- **Plugin-level default**: Currently the flag lives on `ClaudeAgentConfig` (per decision 1a) — to opt all claude agent types into shared mode, the user must set it on each type. Should we *also* expose this as a plugin-level config in mngr's TOML (`[plugin.mngr_claude]`) that becomes the field's default? Out of scope for v1; raise later if a real workflow demands it.
+
+- **`HeadlessClaudeAgentConfig.auto_dismiss_dialogs` default**: Headless mode currently typically wants `auto_dismiss_dialogs=True`. The new validator will refuse `use_env_config_dir=True` with `auto_dismiss_dialogs=True`. If we expect headless + shared-mode to be a common combo, we may want to tweak headless's default or relax the validator for headless specifically. Spec leaves this strict for v1.
+
+- **Flag naming**: `use_env_config_dir` is descriptive but slightly oblique. Alternatives: `share_user_config_dir`, `use_user_claude_config_dir`, `shared_config_dir`. Spec keeps `use_env_config_dir` per the user's original request.


### PR DESCRIPTION
## Summary
- Spec in progress via /architect: add a `use_env_config_dir` option to the `mngr_claude` plugin so multiple Claude agents can share a single CLAUDE_CONFIG_DIR instead of each provisioning their own.
- No code changes yet — this draft exists to unblock the stop hook while design Q&A continues.

## Test plan
- [ ] Spec written and reviewed
- [ ] Implementation
- [ ] Tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)