### PR TITLE
regenerate cli docs for tmr and latchkey

### DIFF
--- a/changelog/mngr-formatting.md
+++ b/changelog/mngr-formatting.md
@@ -1,0 +1,1 @@
+Regenerated CLI docs for `mngr tmr` and `mngr latchkey` to reflect current options.

--- a/libs/mngr/docs/commands/secondary/latchkey.md
+++ b/libs/mngr/docs/commands/secondary/latchkey.md
@@ -220,6 +220,128 @@ $ mngr latchkey forward
 $ mngr latchkey forward --latchkey-binary /opt/latchkey/bin/latchkey
 ```
 
+## mngr latchkey admin-jwt
+
+Mint a wildcard ``permissions-override`` JWT for the shared gateway.
+
+Materializes the admin permissions file at
+``<plugin_data_dir>/latchkey_admin_permissions.json`` (idempotent --
+an existing file is reused as-is) and mints a JWT signed for that
+path via ``latchkey gateway create-jwt --no-validate``. The JWT is
+printed on stdout as a single line.
+
+The returned token unlocks every service and every extension
+endpoint reachable through the gateway, so treat it like a root
+credential and pass it as the
+``X-Latchkey-Gateway-Permissions-Override`` header to gateway
+requests that need wildcard access (e.g. the minds desktop client
+streaming pending permission requests from the
+``permission-requests`` extension).
+
+**Usage:**
+
+```text
+mngr latchkey admin-jwt [OPTIONS]
+```
+**Options:**
+
+## Common
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `-q`, `--quiet` | boolean | Suppress all console output | `False` |
+| `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
+| `--log-file` | path | Path to log file (overrides default ~/.mngr/events/logs/<timestamp>-<pid>.json) | None |
+| `--log-commands`, `--no-log-commands` | boolean | Log commands that were executed | None |
+| `--headless` | boolean | Disable all interactive behavior (prompts, TUI, editor). Also settable via MNGR_HEADLESS env var or 'headless' config key. | `False` |
+| `--safe` | boolean | Always query all providers during discovery (disable event-stream optimization). Use this when interfacing with mngr from multiple machines. | `False` |
+| `--plugin`, `--enable-plugin` | text | Enable a plugin [repeatable] | None |
+| `--disable-plugin` | text | Disable a plugin [repeatable] | None |
+| `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
+| `-h`, `--help` | boolean | Show this message and exit. | `False` |
+
+## Other Options
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--latchkey-binary` | text | Path to the upstream ``latchkey`` CLI. Falls back to $MNGR_LATCHKEY_BINARY, then ``[plugins.latchkey].latchkey_binary`` in settings.toml, then 'latchkey' on PATH. | None |
+| `--latchkey-directory` | path | Root directory for ``LATCHKEY_DIRECTORY`` and the plugin's ``mngr_latchkey/`` metadata subtree. Falls back to $MNGR_LATCHKEY_DIRECTORY, then ``[plugins.latchkey].directory`` in settings.toml, then '~/.mngr/latchkey'. | None |
+
+
+## Examples
+
+**Capture into a shell variable**
+
+```bash
+$ ADMIN_JWT=$(mngr latchkey admin-jwt)
+```
+
+## mngr latchkey gateway-info
+
+Print the running shared gateway's URL + password as JSON.
+
+Reads the supervised ``mngr latchkey forward`` record
+to discover the bound gateway port and derives the gateway password
+locally (via ``latchkey gateway create-jwt`` against a sentinel path,
+the same way :meth:`Latchkey.derive_gateway_password` does in
+Python). Emits a single JSON object on stdout:
+
+```
+{
+  "url": "http://127.0.0.1:32867",
+  "password": "<sha256-of-derived-jwt>"
+}
+```
+
+Fails with a non-zero exit when no supervisor is running for the
+active latchkey directory, or when the supervisor has not yet
+stamped its bound gateway port onto its on-disk record (i.e. the
+supervisor is still in its startup window).
+
+The password is intentionally NOT persisted on disk; this command
+is the supported way to retrieve it without writing your own
+Python integration.
+
+**Usage:**
+
+```text
+mngr latchkey gateway-info [OPTIONS]
+```
+**Options:**
+
+## Common
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `-q`, `--quiet` | boolean | Suppress all console output | `False` |
+| `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
+| `--log-file` | path | Path to log file (overrides default ~/.mngr/events/logs/<timestamp>-<pid>.json) | None |
+| `--log-commands`, `--no-log-commands` | boolean | Log commands that were executed | None |
+| `--headless` | boolean | Disable all interactive behavior (prompts, TUI, editor). Also settable via MNGR_HEADLESS env var or 'headless' config key. | `False` |
+| `--safe` | boolean | Always query all providers during discovery (disable event-stream optimization). Use this when interfacing with mngr from multiple machines. | `False` |
+| `--plugin`, `--enable-plugin` | text | Enable a plugin [repeatable] | None |
+| `--disable-plugin` | text | Disable a plugin [repeatable] | None |
+| `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths) [repeatable] | None |
+| `-h`, `--help` | boolean | Show this message and exit. | `False` |
+
+## Other Options
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--latchkey-binary` | text | Path to the upstream ``latchkey`` CLI. Falls back to $MNGR_LATCHKEY_BINARY, then ``[plugins.latchkey].latchkey_binary`` in settings.toml, then 'latchkey' on PATH. | None |
+| `--latchkey-directory` | path | Root directory for ``LATCHKEY_DIRECTORY`` and the plugin's ``mngr_latchkey/`` metadata subtree. Falls back to $MNGR_LATCHKEY_DIRECTORY, then ``[plugins.latchkey].directory`` in settings.toml, then '~/.mngr/latchkey'. | None |
+
+
+## Examples
+
+**Capture into shell variables**
+
+```bash
+$ eval "$(mngr latchkey gateway-info | jq -r '@text "GATEWAY_URL=\(.url); GATEWAY_PASSWORD=\(.password)"')"
+```
+
 ## Examples
 
 **Inspect available subcommands**

--- a/libs/mngr/docs/commands/secondary/tmr.md
+++ b/libs/mngr/docs/commands/secondary/tmr.md
@@ -38,7 +38,7 @@ Use --use-snapshot with remote providers to build and provision one host first,
 snapshot it, then launch all remaining agents from the snapshot (much faster).
 Use --env to pass environment variables and --label to tag all agents.
 Use --prompt-suffix to append custom instructions to the agent prompt.
-Use --max-agents to limit how many agents run simultaneously (0 = no limit).
+Use --max-parallel-agents to limit how many agents run simultaneously (0 = no limit).
 
 Each agent writes its result to .test_output/testing_agent_outcome.json (in its work directory)
 with a structured JSON containing: changes (list of kind/status/summary), errored flag,
@@ -86,15 +86,14 @@ mngr tmr [OPTIONS] [PYTEST_ARGS]...
 | `--prompt-suffix` | text | Additional text to append to the agent prompt | None |
 | `--use-snapshot` | boolean | Build one agent first, snapshot its host, then launch remaining agents from the snapshot (faster for remote providers) | `False` |
 | `--snapshot` | text | Use an existing snapshot/image ID for all agents (skips building; implies --use-snapshot behavior) | None |
-| `--max-parallel` | integer | Maximum number of agents to launch concurrently (launch-time parallelism) | `4` |
+| `--max-parallel-launch` | integer | Maximum number of agents to launch concurrently (launch-time parallelism) | `10` |
 | `--agents-per-host` | integer | Number of agents sharing each remote host (ignored for local provider) | `4` |
-| `--max-agents` | integer | Maximum number of agents running at any one time (0 = no limit). When set, agents are launched incrementally as earlier ones finish. | `0` |
+| `--max-parallel-agents` | integer | Maximum number of agents running at any one time (0 = no limit). When set, agents are launched incrementally as earlier ones finish. | `0` |
 | `--launch-delay` | float | Seconds to wait between launching each agent (avoids provider rate limits) | `2.0` |
-| `--poll-interval` | float | Seconds between polling cycles when waiting for agents to finish | `10.0` |
+| `--poll-interval` | float | Seconds between polling cycles when waiting for agents to finish | `60.0` |
 | `--timeout` | float | Maximum seconds each agent can run before being stopped (per-agent timeout) | `3600.0` |
-| `--result-check-interval` | float | Seconds between direct result file checks for agents whose status may be stale | `300.0` |
 | `--integrator-timeout` | float | Maximum seconds to wait for the integrator agent to merge fix branches | `3600.0` |
-| `--output-html` | path | Path for the HTML report [default: tmr_<timestamp>/index.html] | None |
+| `--output-dir` | path | Directory for the run's outputs (HTML report at index.html, per-agent artifacts) [default: tmr_<timestamp>/] | None |
 | `--source` | directory | Source directory for test collection and agent work dirs [default: current directory] | None |
 | `--reintegrate` | text | Re-read outcomes from a previous TMR run (by run name), re-run integrator, and regenerate report. Skips test collection and agent launching. | None |
 | `--additional-authorized-host` | text | SSH public key line to install in authorized_keys on each agent host (test agents, integrator, host pool, and snapshotter), allowing inbound SSH [repeatable] | None |
@@ -146,7 +145,7 @@ $ mngr tmr --env API_KEY=xxx --label batch=run1
 **Limit to 4 concurrent agents**
 
 ```bash
-$ mngr tmr --max-agents 4 tests/
+$ mngr tmr --max-parallel-agents 4 tests/
 ```
 
 **Custom poll interval**
@@ -158,5 +157,5 @@ $ mngr tmr --poll-interval 30
 **Specify output location**
 
 ```bash
-$ mngr tmr --output-html report.html
+$ mngr tmr --output-dir reports/run-1
 ```


### PR DESCRIPTION
## Summary
- Regenerated CLI docs via `uv run python scripts/make_cli_docs.py`; picks up upstream CLI option renames for `mngr tmr` (`--max-agents` → `--max-parallel-agents`, `--max-parallel` → `--max-parallel-launch`, `--output-html` → `--output-dir`, drops `--result-check-interval`) and adds the new `mngr latchkey` doc.
- Confirmed `ruff check --fix` and `ruff format` produce no changes against the current tree.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
