### PR TITLE
Bump pinned Claude Code CLI version 2.1.116 -> 2.1.141

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
         run: uv sync --all-packages
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.116
+        run: npm install -g @anthropic-ai/claude-code@2.1.141
 
       - name: Run Docker release tests
         run: PYTEST_MAX_DURATION_SECONDS=900 uv run pytest -n 0 --timeout 600 --no-cov --cov-fail-under=0 -v --tb=short -m '(docker or docker_sdk) and release'
@@ -423,7 +423,7 @@ jobs:
         run: brew install tmux unison
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.116
+        run: npm install -g @anthropic-ai/claude-code@2.1.141
 
       - name: Configure Docker Hub mirror
         if: runner.os == 'Linux'

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -57,7 +57,7 @@ jobs:
         run: uv sync --all-packages
 
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.116
+        run: npm install -g @anthropic-ai/claude-code@2.1.141
 
       - name: Configure git identity
         run: |

--- a/changelog/mngr-bump-claude-2.1.141.md
+++ b/changelog/mngr-bump-claude-2.1.141.md
@@ -1,0 +1,1 @@
+Bumped the pinned Claude Code CLI version from `2.1.116` to `2.1.141` in `libs/mngr/imbue/mngr/resources/Dockerfile` and the `.github/workflows/{ci,tmr}.yml` install steps, matching the corresponding bump to `[agent_types.claude].version` in `forever-claude-template/.mngr/settings.toml`.

--- a/libs/mngr/imbue/mngr/resources/Dockerfile
+++ b/libs/mngr/imbue/mngr/resources/Dockerfile
@@ -67,7 +67,7 @@ ENV PATH="/root/.local/bin:$PATH"
 # .mngr/settings.toml pin (`[agent_types.claude].version`). The release-test
 # `test_claude_code_version_matches_forever_claude_template_pin` enforces the
 # sync; bump both together when rolling a new claude release.
-ARG CLAUDE_CODE_VERSION="2.1.116"
+ARG CLAUDE_CODE_VERSION="2.1.141"
 RUN curl -fsSL https://claude.ai/install.sh > /tmp/install_claude.sh && ( if [ -n "$CLAUDE_CODE_VERSION" ]; then cat /tmp/install_claude.sh | bash -s "$CLAUDE_CODE_VERSION"; else cat /tmp/install_claude.sh | bash; fi && test -x /root/.local/bin/claude ) || ( cat /tmp/install_claude.sh && exit 1 )
 ENV CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}
 


### PR DESCRIPTION
## Summary
- Bumps `ARG CLAUDE_CODE_VERSION="2.1.116"` -> `"2.1.141"` in `libs/mngr/imbue/mngr/resources/Dockerfile:70`.
- Bumps `npm install -g @anthropic-ai/claude-code@2.1.116` -> `@2.1.141` in `.github/workflows/ci.yml` (x2) and `.github/workflows/tmr.yml` (x1).
- Aligns with the corresponding bump to `[agent_types.claude].version = "2.1.141"` in `forever-claude-template/.mngr/settings.toml` (Josh's `josh/settings_fixes` branch in FCT, committed there as `a6bd1c8ba7`).

## Why
Provisioning agents from forever-claude-template was failing with: `Claude version mismatch: installed version is '2.1.116', but agent config pins version '2.1.141'.` The runtime-check (in `libs/mngr_claude/.../plugin.py::provision`) compares the binary the container installed (driven by Dockerfile ARG) to the pin in FCT's `.mngr/settings.toml`. Bumping one without the other strands them.

The companion FCT bump (`Dockerfile` ARG) needs to land on `josh/settings_fixes` before the release-test `test_claude_code_version_matches_forever_claude_template_pin` and these workflows align cleanly with main.

## Test plan
- [ ] CI passes on this PR.
- [ ] After FCT-side Dockerfile bump lands on FCT main, the release-test `test_claude_code_version_matches_forever_claude_template_pin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)