### PR TITLE
mngr: refactor agent address resolution into find + resolve phases

### DIFF
--- a/changelog/mngr-consistent-resolution.md
+++ b/changelog/mngr-consistent-resolution.md
@@ -27,3 +27,9 @@ User-visible changes:
   started automatically.
 - The `--start` help text on `connect`, `capture`, and `exec` has been
   reworded to reflect what `--start` actually starts in each command.
+- `mngr connect` no longer falls back to "most recently created agent"
+  when run non-interactively without an explicit agent. It now matches
+  every other single-agent command: pass an agent name, or run it from
+  an interactive terminal to use the selector.
+- Cancelling the interactive agent selector now exits cleanly via
+  `click.Abort` instead of printing nothing and returning silently.

--- a/changelog/mngr-consistent-resolution.md
+++ b/changelog/mngr-consistent-resolution.md
@@ -1,0 +1,29 @@
+# Consistent agent address resolution across single-agent subcommands
+
+Refactored how single-agent subcommands turn an `AgentAddress` into the live
+interfaces they operate on. The "find" stage (discovery + matching against
+the address) is now strictly separate from the "ensure live" stage (bringing
+the host online, looking up the live agent, optionally starting it).
+
+Two new helpers in `imbue.mngr.cli.agent_utils` replace the previous
+`is_start_desired` / `skip_agent_state_check` flags on
+`find_one_agent` / `find_agent_for_command`:
+
+- `ensure_host_started_and_resolve_agent`: bring the host online and resolve
+  the agent ref to an `AgentInterface` without checking the agent's
+  lifecycle state. Used by `push`, `pull`, `provision`, and `rename`.
+- `ensure_host_and_agent_started`: as above, but also require / auto-start
+  the agent process. Used by `connect` and `capture`.
+
+Both helpers take a single `allow_auto_start` flag (driven by `--start`).
+
+User-visible changes:
+
+- `push`, `pull`, and `provision` no longer require the agent to be
+  running. Previously they failed when targeting a stopped agent on an
+  online host; now they operate on stopped agents directly.
+- `push`, `pull`, `provision`, and `rename` gain a `--start/--no-start`
+  flag (default `--start`) that controls whether an offline host is
+  started automatically.
+- The `--start` help text on `connect`, `capture`, and `exec` has been
+  reworded to reflect what `--start` actually starts in each command.

--- a/changelog/mngr-consistent-resolution.md
+++ b/changelog/mngr-consistent-resolution.md
@@ -5,15 +5,15 @@ interfaces they operate on. The "find" stage (discovery + matching against
 the address) is now strictly separate from the "ensure live" stage (bringing
 the host online, looking up the live agent, optionally starting it).
 
-Two new helpers in `imbue.mngr.cli.agent_utils` replace the previous
+Two new helpers in `imbue.mngr.api.find` replace the previous
 `is_start_desired` / `skip_agent_state_check` flags on
 `find_one_agent` / `find_agent_for_command`:
 
-- `ensure_host_started_and_resolve_agent`: bring the host online and resolve
+- `resolve_to_started_host_and_agent`: bring the host online and resolve
   the agent ref to an `AgentInterface` without checking the agent's
   lifecycle state. Used by `push`, `pull`, `provision`, and `rename`.
-- `ensure_host_and_agent_started`: as above, but also require / auto-start
-  the agent process. Used by `connect` and `capture`.
+- `resolve_to_started_host_and_running_agent`: as above, but also
+  require / auto-start the agent process. Used by `connect` and `capture`.
 
 Both helpers take a single `allow_auto_start` flag (driven by `--start`).
 

--- a/changelog/mngr-host-location-addr.md
+++ b/changelog/mngr-host-location-addr.md
@@ -1,0 +1,18 @@
+# Rename `HostedLocation` to `HostLocationAddress`
+
+Renamed the address-side `HostedLocation` type to `HostLocationAddress` so its
+name matches its peers (`HostAddress`, `AgentAddress`) and makes its
+relationship to the runtime `HostLocation` type explicit.
+
+Cascading internal renames:
+
+- `parse_hosted_location` -> `parse_host_location_address`
+- `resolve_hosted_location` -> `resolve_host_location_address`
+- `ResolvedHostedLocation` -> `ResolvedHostLocationAddress`
+- `HostedLocationParamType` -> `HostLocationAddressParamType`
+- `HOSTED_LOCATION` (Click param type instance) -> `HOST_LOCATION_ADDRESS`
+- Click param-type display name `hosted_location` -> `host_location_address`
+  (visible in command-line help / docs for `mngr push`, `mngr pull`,
+  `mngr pair`)
+
+No behavior change.

--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -23,10 +23,9 @@ The agent can be specified as a positional argument or via --agent:
   mngr connect --agent my-agent
 
 Filter flags (--include/--exclude plus aliases like --running, --project,
---label, ...) narrow the candidate pool used by the interactive selector
-and the non-interactive most-recent fallback. They are ignored when an
-explicit agent is given. See `mngr list --help` for the full filter
-reference; the same flags work identically here.
+--label, ...) narrow the candidate pool of the interactive selector.
+They are ignored when an explicit agent is given. See `mngr list --help`
+for the full filter reference; the same flags work identically here.
 
 Alias: conn
 

--- a/libs/mngr/docs/commands/primary/connect.md
+++ b/libs/mngr/docs/commands/primary/connect.md
@@ -46,7 +46,7 @@ mngr connect [OPTIONS] [AGENT]
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--agent` | agent_address | The agent to connect to (by name or ID, optionally @HOST[.PROVIDER]) | None |
-| `--start`, `--no-start` | boolean | Automatically start the agent if stopped | `True` |
+| `--start`, `--no-start` | boolean | Automatically start the host and agent if offline/stopped | `True` |
 
 ## Options
 

--- a/libs/mngr/docs/commands/primary/exec.md
+++ b/libs/mngr/docs/commands/primary/exec.md
@@ -52,7 +52,7 @@ mngr exec [OPTIONS] [AGENTS]... COMMAND
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--start`, `--no-start` | boolean | Automatically start the host/agent if stopped | `True` |
+| `--start`, `--no-start` | boolean | Automatically start the host if offline (the agent does not need to be running) | `True` |
 
 ## Error Handling
 

--- a/libs/mngr/docs/commands/primary/pair.md
+++ b/libs/mngr/docs/commands/primary/pair.md
@@ -36,7 +36,7 @@ mngr pair [OPTIONS] SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--source` | hosted_location | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--source` | host_location_address | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--source-agent` | agent_address | Source agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--source-host` | host_address | Source host address (HOST[.PROVIDER]) | None |
 | `--source-path` | text | Path within the agent's work directory | None |

--- a/libs/mngr/docs/commands/primary/pull.md
+++ b/libs/mngr/docs/commands/primary/pull.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr pull [SOURCE] [DESTINATION] [--source <SOURCE>] [--source-agent <AGENT>] [--sync-mode <MODE>] [--include PATTERN] [--dry-run] [--stop]
+mngr pull [SOURCE] [DESTINATION] [--source <SOURCE>] [--source-agent <AGENT>] [--sync-mode <MODE>] [--include PATTERN] [--dry-run] [--start/--no-start] [--stop]
 ```
 
 Pull files or git commits from an agent to local machine [experimental].
@@ -49,6 +49,7 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--dry-run` | boolean | Show what would be transferred without actually transferring | `False` |
+| `--start`, `--no-start` | boolean | Automatically start the host if offline (the agent does not need to be running) | `True` |
 | `--stop` | boolean | Stop the agent after pulling (for state consistency) | `False` |
 | `--delete`, `--no-delete` | boolean | Delete files in destination that don't exist in source | `False` |
 | `--sync-mode` | choice (`files` &#x7C; `git` &#x7C; `full`) | What to sync: files (working directory via rsync), git (merge git branches), or full (everything) [future] | `files` |

--- a/libs/mngr/docs/commands/primary/pull.md
+++ b/libs/mngr/docs/commands/primary/pull.md
@@ -33,7 +33,7 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--source` | hosted_location | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--source` | host_location_address | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--source-agent` | agent_address | Source agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--source-host` | host_address | Source host address (HOST[.PROVIDER]) [future] | None |
 | `--source-path` | text | Path within the agent's work directory | None |
@@ -59,7 +59,7 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--target` | hosted_location | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future] | None |
+| `--target` | host_location_address | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future] | None |
 | `--target-agent` | agent_address | Target agent address [future] | None |
 | `--target-host` | host_address | Target host address [future] | None |
 | `--target-path` | text | Path within target to sync to [future] | None |

--- a/libs/mngr/docs/commands/primary/push.md
+++ b/libs/mngr/docs/commands/primary/push.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr push [TARGET] [SOURCE] [--target <TARGET>] [--source <DIR>] [--target-agent <AGENT>] [--sync-mode <MODE>] [--mirror] [--dry-run] [--stop]
+mngr push [TARGET] [SOURCE] [--target <TARGET>] [--source <DIR>] [--target-agent <AGENT>] [--sync-mode <MODE>] [--mirror] [--dry-run] [--start/--no-start] [--stop]
 ```
 
 Push files or git commits from local machine to an agent [experimental].
@@ -52,6 +52,7 @@ mngr push [OPTIONS] TARGET SOURCE
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--dry-run` | boolean | Show what would be transferred without actually transferring | `False` |
+| `--start`, `--no-start` | boolean | Automatically start the host if offline (the agent does not need to be running) | `True` |
 | `--stop` | boolean | Stop the agent after pushing (for state consistency) | `False` |
 | `--delete`, `--no-delete` | boolean | Delete files in destination that don't exist in source | `False` |
 | `--sync-mode` | choice (`files` &#x7C; `git` &#x7C; `full`) | What to sync: files (working directory via rsync), git (push git branches), or full (everything) [future] | `files` |

--- a/libs/mngr/docs/commands/primary/push.md
+++ b/libs/mngr/docs/commands/primary/push.md
@@ -36,7 +36,7 @@ mngr push [OPTIONS] TARGET SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--target` | hosted_location | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--target` | host_location_address | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--target-agent` | agent_address | Target agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--target-host` | host_address | Target host address (HOST[.PROVIDER]) [future] | None |
 | `--target-path` | text | Path within the agent's work directory | None |

--- a/libs/mngr/docs/commands/primary/rename.md
+++ b/libs/mngr/docs/commands/primary/rename.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr [rename|mv] <CURRENT> <NEW-NAME> [--dry-run] [--host] [-l KEY=VALUE ...]
+mngr [rename|mv] <CURRENT> <NEW-NAME> [--dry-run] [--start/--no-start] [--host] [-l KEY=VALUE ...]
 ```
 
 Rename an agent or host [experimental].
@@ -37,6 +37,7 @@ mngr rename [OPTIONS] CURRENT NEW-NAME
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `--dry-run` | boolean | Show what would be renamed without actually renaming | `False` |
+| `--start`, `--no-start` | boolean | Automatically start the host if offline (the agent does not need to be running) | `True` |
 | `--host` | boolean | Rename a host instead of an agent [future] | `False` |
 
 ## Labels

--- a/libs/mngr/docs/commands/secondary/capture.md
+++ b/libs/mngr/docs/commands/secondary/capture.md
@@ -35,7 +35,7 @@ mngr capture [OPTIONS] [AGENT]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--start`, `--no-start` | boolean | Automatically start the host/agent if stopped | `True` |
+| `--start`, `--no-start` | boolean | Automatically start the host and agent if offline/stopped | `True` |
 | `--full`, `--no-full` | boolean | Capture the full scrollback buffer instead of just the visible pane | `False` |
 
 ## Common

--- a/libs/mngr/docs/commands/secondary/provision.md
+++ b/libs/mngr/docs/commands/secondary/provision.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr [provision|prov] [AGENT] [--agent <AGENT>] [--extra-provision-command <CMD>] [--upload-file <LOCAL:REMOTE>] [--env <KEY=VALUE>] [--env-file <FILE>] [--[no-]restart]
+mngr [provision|prov] [AGENT] [--agent <AGENT>] [--extra-provision-command <CMD>] [--upload-file <LOCAL:REMOTE>] [--env <KEY=VALUE>] [--env-file <FILE>] [--start/--no-start] [--[no-]restart]
 ```
 
 Re-run provisioning on an existing agent [experimental].
@@ -55,6 +55,7 @@ mngr provision [OPTIONS] [AGENT]
 | ---- | ---- | ----------- | ------- |
 | `--bootstrap` | choice (`yes` &#x7C; `warn` &#x7C; `no`) | Auto-install missing required tools: yes, warn (install with warning), or no [default: warn on remote, no on local] [future] | None |
 | `--destroy-on-fail`, `--no-destroy-on-fail` | boolean | Destroy the host if provisioning fails [future] | `False` |
+| `--start`, `--no-start` | boolean | Automatically start the host if offline (the agent does not need to be running) | `True` |
 | `--restart`, `--no-restart` | boolean | Restart agent after provisioning (default: restart). Use --no-restart for non-disruptive changes like installing packages | `True` |
 
 ## Agent Provisioning

--- a/libs/mngr/imbue/mngr/api/address_parsers.py
+++ b/libs/mngr/imbue/mngr/api/address_parsers.py
@@ -1,7 +1,7 @@
 """Parsers that produce the typed address shapes shared across mngr.
 
 The four typed shapes -- :class:`HostAddress`, :class:`AgentAddress`,
-:class:`NewAgentLocation`, :class:`HostedLocation` -- live in
+:class:`NewAgentLocation`, :class:`HostLocationAddress` -- live in
 :mod:`imbue.mngr.primitives` so the lower-layer ``config`` package can reference
 them in CLI option dataclasses. The parsers are kept here in the api layer
 because they raise :class:`UserInputError` (in the ``errors`` module, which
@@ -32,9 +32,9 @@ from imbue.mngr.primitives import AgentNameOrId
 from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import InvalidName
 from imbue.mngr.primitives import NewAgentLocation
 from imbue.mngr.primitives import ProviderInstanceName
@@ -193,8 +193,8 @@ def parse_new_agent_location(s: str) -> NewAgentLocation:
 
 
 @pure
-def parse_hosted_location(s: str) -> HostedLocation:
-    """Parse a ``[NAME[@HOST[.PROVIDER]]][:PATH]`` string into a :class:`HostedLocation`.
+def parse_host_location_address(s: str) -> HostLocationAddress:
+    """Parse a ``[NAME[@HOST[.PROVIDER]]][:PATH]`` string into a :class:`HostLocationAddress`.
 
     Used for any CLI argument that designates "a location on some host" --
     sources (``mngr create --from``, ``mngr pair``) and targets
@@ -205,16 +205,16 @@ def parse_hosted_location(s: str) -> HostedLocation:
     ``foo``, not a directory; use ``:foo`` to mean a relative directory.
     """
     if s.startswith(("/", "./", "~/", "../")):
-        return HostedLocation(path=Path(s))
+        return HostLocationAddress(path=Path(s))
 
     address_part, path = _split_path_suffix(s)
     if not address_part and path is None:
-        return HostedLocation()
+        return HostLocationAddress()
 
     agent_str, host_part = _split_at_part(address_part)
     agent = parse_agent_name_or_id(agent_str) if agent_str else None
     host = parse_host_address(host_part) if host_part else None
-    return HostedLocation(agent=agent, host=host, path=path)
+    return HostLocationAddress(agent=agent, host=host, path=path)
 
 
 # === Internal split helpers ===

--- a/libs/mngr/imbue/mngr/api/events.py
+++ b/libs/mngr/imbue/mngr/api/events.py
@@ -25,10 +25,9 @@ from imbue.imbue_common.logging import ROTATED_JSONL_PATTERN
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
-from imbue.mngr.api.discover import discover_by_address
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import filter_one_agent
 from imbue.mngr.api.find import filter_one_host
+from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import MalformedJsonlLineError
@@ -187,9 +186,7 @@ def resolve_events_target(
 
 
 def _resolve_agent_events_target(address: AgentAddress, mngr_ctx: MngrContext) -> EventsTarget:
-    with log_span("Loading agents and hosts"):
-        filtered_agents_by_host, _providers = discover_by_address(address, mngr_ctx, include_destroyed=False)
-    host_ref, agent_ref = filter_one_agent(address.agent, None, filtered_agents_by_host)
+    host_ref, agent_ref = find_one_agent(address, mngr_ctx)
     with log_span("Getting events access for agent {}", agent_ref.agent_name):
         target = try_build_events_target_for_agent(
             mngr_ctx=mngr_ctx,

--- a/libs/mngr/imbue/mngr/api/exec.py
+++ b/libs/mngr/imbue/mngr/api/exec.py
@@ -12,11 +12,11 @@ from imbue.imbue_common.logging import log_call
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.mngr.api.find import AgentMatch
-from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import find_all_agents
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.find import group_agents_by_host
+from imbue.mngr.api.find import resolve_to_started_host_and_running_agent
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import HostNotFoundError
@@ -124,20 +124,12 @@ def exec_command_on_agent(
     to the agent's work_dir).
     """
     host_ref, agent_ref = find_one_agent(address, mngr_ctx)
-    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
-    host_interface = provider.get_host(host_ref.host_id)
-    host, _was_started = ensure_host_started(host_interface, is_start_desired=is_start_desired, provider=provider)
-
-    agent: AgentInterface | None = next(
-        (a for a in host.get_agents() if a.id == agent_ref.agent_id),
-        None,
+    agent, host = resolve_to_started_host_and_running_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=is_start_desired,
+        mngr_ctx=mngr_ctx,
     )
-    if agent is None:
-        raise RuntimeError(
-            f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
-            f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}."
-        )
-    ensure_agent_started(agent, host, is_start_desired=is_start_desired)
 
     # Determine working directory: explicit --cwd, or agent's work_dir
     effective_cwd = Path(cwd) if cwd is not None else agent.work_dir

--- a/libs/mngr/imbue/mngr/api/exec.py
+++ b/libs/mngr/imbue/mngr/api/exec.py
@@ -12,6 +12,7 @@ from imbue.imbue_common.logging import log_call
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.mngr.api.find import AgentMatch
+from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import find_all_agents
 from imbue.mngr.api.find import find_one_agent
@@ -118,11 +119,25 @@ def exec_command_on_agent(
 ) -> ExecResult:
     """Execute a shell command on the host where an agent runs.
 
-    Resolves the agent by :class:`AgentAddress`, optionally starts it if
-    stopped, then executes the command on its host (defaulting to the agent's
-    work_dir).
+    Resolves the agent by :class:`AgentAddress`, optionally starts the host
+    and agent if stopped, then executes the command on its host (defaulting
+    to the agent's work_dir).
     """
-    agent, host = find_one_agent(address, mngr_ctx, is_start_desired=is_start_desired)
+    host_ref, agent_ref = find_one_agent(address, mngr_ctx)
+    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
+    host_interface = provider.get_host(host_ref.host_id)
+    host, _was_started = ensure_host_started(host_interface, is_start_desired=is_start_desired, provider=provider)
+
+    agent: AgentInterface | None = next(
+        (a for a in host.get_agents() if a.id == agent_ref.agent_id),
+        None,
+    )
+    if agent is None:
+        raise RuntimeError(
+            f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
+            f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}."
+        )
+    ensure_agent_started(agent, host, is_start_desired=is_start_desired)
 
     # Determine working directory: explicit --cwd, or agent's work_dir
     effective_cwd = Path(cwd) if cwd is not None else agent.work_dir

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -113,7 +113,7 @@ def filter_one_host(
 
 
 @pure
-def filter_all_agents(
+def _filter_all_agents(
     agent: AgentNameOrId,
     agents_by_host: Mapping[DiscoveredHost, Sequence[DiscoveredAgent]],
     resolved_host: DiscoveredHost | None = None,
@@ -147,7 +147,7 @@ def _filter_one_agent(
     The multi-match error lists each matching agent in ``NAME@HOST.PROVIDER``
     form so the user can disambiguate.
     """
-    matches = filter_all_agents(agent, agents_by_host, resolved_host)
+    matches = _filter_all_agents(agent, agents_by_host, resolved_host)
     if len(matches) == 0:
         if isinstance(agent, AgentId):
             raise AgentNotFoundError(str(agent))

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -552,8 +552,8 @@ def find_one_agent_and_agents_by_host(
 
     Returns only metadata. Callers that need a live ``AgentInterface`` or
     ``OnlineHostInterface`` should compose with
-    :func:`imbue.mngr.cli.agent_utils.ensure_host_started_and_resolve_agent`
-    or :func:`imbue.mngr.cli.agent_utils.ensure_host_and_agent_started`.
+    :func:`resolve_to_started_host_and_agent` or
+    :func:`resolve_to_started_host_and_running_agent`.
 
     Raises :class:`UserInputError` if the host constraint matches no hosts.
     Raises :class:`AgentNotFoundError` / :class:`UserInputError` if the
@@ -579,3 +579,59 @@ def find_one_agent(
     """
     host_ref, agent_ref, _ = find_one_agent_and_agents_by_host(address, mngr_ctx)
     return host_ref, agent_ref
+
+
+def resolve_to_started_host_and_agent(
+    host_ref: DiscoveredHost,
+    agent_ref: DiscoveredAgent,
+    allow_auto_start: bool,
+    mngr_ctx: MngrContext,
+) -> tuple[AgentInterface, OnlineHostInterface]:
+    """Resolve discovery refs to a live ``(AgentInterface, OnlineHostInterface)``.
+
+    Composes :func:`ensure_host_started` with the metadata-to-live lookup
+    step: brings the host online (auto-starting it iff ``allow_auto_start``
+    is True), then locates ``agent_ref`` on the live host. The agent's
+    lifecycle state is *not* checked -- the returned ``AgentInterface``
+    may represent a stopped agent. Callers that need the agent process to
+    be running should use :func:`resolve_to_started_host_and_running_agent`
+    instead.
+
+    Raises :class:`UserInputError` when the host is offline and
+    ``allow_auto_start`` is False. Raises :class:`RuntimeError` if the
+    agent was found during discovery but is missing on the live host (a
+    stale-cache / host state inconsistency case).
+    """
+    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
+    host = provider.get_host(host_ref.host_id)
+    online_host, _was_started = ensure_host_started(host, is_start_desired=allow_auto_start, provider=provider)
+    for live_agent in online_host.get_agents():
+        if live_agent.id == agent_ref.agent_id:
+            return live_agent, online_host
+    raise RuntimeError(
+        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
+        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
+        "This indicates a stale discovery cache or host state inconsistency."
+    )
+
+
+def resolve_to_started_host_and_running_agent(
+    host_ref: DiscoveredHost,
+    agent_ref: DiscoveredAgent,
+    allow_auto_start: bool,
+    mngr_ctx: MngrContext,
+) -> tuple[AgentInterface, OnlineHostInterface]:
+    """Resolve discovery refs to live interfaces, requiring the agent to be running.
+
+    Same as :func:`resolve_to_started_host_and_agent` but additionally
+    ensures the agent process is running (auto-starting it iff
+    ``allow_auto_start`` is True) via :func:`ensure_agent_started`.
+
+    Raises :class:`UserInputError` when the host is offline or the agent
+    is stopped and ``allow_auto_start`` is False. Raises
+    :class:`RuntimeError` if the agent was found during discovery but is
+    missing on the live host.
+    """
+    agent, online_host = resolve_to_started_host_and_agent(host_ref, agent_ref, allow_auto_start, mngr_ctx)
+    ensure_agent_started(agent, online_host, is_start_desired=allow_auto_start)
+    return agent, online_host

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -131,7 +131,7 @@ def filter_all_agents(
 
 
 @pure
-def filter_one_agent(
+def _filter_one_agent(
     agent: AgentNameOrId,
     resolved_host: DiscoveredHost | None,
     agents_by_host: Mapping[DiscoveredHost, Sequence[DiscoveredAgent]],
@@ -205,7 +205,7 @@ def resolve_hosted_location(
     resolved_agent: DiscoveredAgent | None = None
     if parsed.agent is not None:
         with log_span("Resolving agent reference"):
-            resolved_host, resolved_agent = filter_one_agent(parsed.agent, resolved_host, agents_by_host)
+            resolved_host, resolved_agent = _filter_one_agent(parsed.agent, resolved_host, agents_by_host)
 
     with log_span("Getting host interface from provider"):
         if resolved_host is None:
@@ -557,13 +557,13 @@ def find_one_agent_and_agents_by_host(
 
     Raises :class:`UserInputError` if the host constraint matches no hosts.
     Raises :class:`AgentNotFoundError` / :class:`UserInputError` if the
-    agent cannot be resolved (see :func:`filter_one_agent`).
+    agent cannot be resolved (see :func:`_filter_one_agent`).
     """
     agents_by_host, _providers = discover_by_address(address, mngr_ctx, include_destroyed=False)
     if not agents_by_host and address.host is not None:
         raise UserInputError(f"No hosts found matching {address.host}")
 
-    host_ref, agent_ref = filter_one_agent(address.agent, resolved_host=None, agents_by_host=agents_by_host)
+    host_ref, agent_ref = _filter_one_agent(address.agent, resolved_host=None, agents_by_host=agents_by_host)
     return host_ref, agent_ref, agents_by_host
 
 

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -30,9 +30,9 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.base_provider import BaseProviderInstance
@@ -164,8 +164,8 @@ def _filter_one_agent(
     return matches[0]
 
 
-class ResolvedHostedLocation(FrozenModel):
-    """Result of resolving a :class:`HostedLocation`, including the discovered agent when available."""
+class ResolvedHostLocationAddress(FrozenModel):
+    """Result of resolving a :class:`HostLocationAddress`, including the discovered agent when available."""
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -174,14 +174,14 @@ class ResolvedHostedLocation(FrozenModel):
 
 
 @log_call
-def resolve_hosted_location(
-    parsed: HostedLocation,
+def resolve_host_location_address(
+    parsed: HostLocationAddress,
     agents_by_host: Mapping[DiscoveredHost, Sequence[DiscoveredAgent]],
     mngr_ctx: MngrContext,
     *,
     is_start_desired: bool = True,
-) -> ResolvedHostedLocation:
-    """Resolve a :class:`HostedLocation` to a concrete host, path, and optional agent.
+) -> ResolvedHostLocationAddress:
+    """Resolve a :class:`HostLocationAddress` to a concrete host, path, and optional agent.
 
     Resolves agent/host references against the discovered hosts and agents.
     If the resolved host is offline, it will be started if ``is_start_desired``
@@ -235,7 +235,7 @@ def resolve_hosted_location(
         agent_work_dir_if_available=agent_work_dir,
     )
 
-    return ResolvedHostedLocation(
+    return ResolvedHostLocationAddress(
         location=HostLocation(host=online_host, path=resolved_path),
         agent=resolved_agent,
     )

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -317,40 +317,6 @@ def ensure_agent_started(agent: AgentInterface, host: OnlineHostInterface, is_st
             )
 
 
-def materialize_agent(
-    host_ref: DiscoveredHost,
-    agent_ref: DiscoveredAgent,
-    mngr_ctx: MngrContext,
-    is_start_desired: bool = False,
-    skip_agent_state_check: bool = False,
-) -> tuple[AgentInterface, OnlineHostInterface]:
-    """Materialize discovered refs into live :class:`AgentInterface` and :class:`OnlineHostInterface`.
-
-    Brings the host online (starting it if ``is_start_desired`` and offline),
-    then looks the agent up on the live host. If ``skip_agent_state_check`` is
-    False (the default) and the agent is stopped, raises unless
-    ``is_start_desired`` is also True.
-
-    Raises :class:`UserInputError` if the host is offline and
-    ``is_start_desired`` is False. Raises :class:`RuntimeError` if the agent
-    was present at discovery time but is no longer on the live host
-    (a stale-cache / inconsistency case).
-    """
-    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
-    host = provider.get_host(host_ref.host_id)
-    online_host, _was_started = ensure_host_started(host, is_start_desired=is_start_desired, provider=provider)
-    for live_agent in online_host.get_agents():
-        if live_agent.id == agent_ref.agent_id:
-            if not skip_agent_state_check:
-                ensure_agent_started(live_agent, online_host, is_start_desired=is_start_desired)
-            return live_agent, online_host
-    raise RuntimeError(
-        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
-        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
-        "This indicates a stale discovery cache or host state inconsistency."
-    )
-
-
 class AgentMatch(FrozenModel):
     """Information about an agent that matched a search query."""
 
@@ -571,17 +537,23 @@ def _post_filter_matches_by_addresses(
     return filtered
 
 
-def find_one_agent(
+def find_one_agent_and_agents_by_host(
     address: AgentAddress,
     mngr_ctx: MngrContext,
-    is_start_desired: bool = False,
-    skip_agent_state_check: bool = False,
-) -> tuple[AgentInterface, OnlineHostInterface]:
-    """Find an agent by :class:`AgentAddress` and return live interfaces.
+) -> tuple[DiscoveredHost, DiscoveredAgent, Mapping[DiscoveredHost, Sequence[DiscoveredAgent]]]:
+    """Find an agent by :class:`AgentAddress` and return its refs plus the full discovery result.
 
-    Runs discovery (skipping irrelevant providers), matches the address's
-    agent identifier against discovered agents (filtered by the address's
-    host constraint if any), then materializes live interfaces.
+    Performs discovery (skipping irrelevant providers) and matches the
+    address's agent identifier against the discovered agents (filtered by
+    the address's host constraint if any). Returns the matching refs and
+    the unfiltered ``agents_by_host`` mapping so callers that need the
+    whole discovery result (for example to check name conflicts across
+    other agents) can reuse it instead of running discovery a second time.
+
+    Returns only metadata. Callers that need a live ``AgentInterface`` or
+    ``OnlineHostInterface`` should compose with
+    :func:`imbue.mngr.cli.agent_utils.ensure_host_started_and_resolve_agent`
+    or :func:`imbue.mngr.cli.agent_utils.ensure_host_and_agent_started`.
 
     Raises :class:`UserInputError` if the host constraint matches no hosts.
     Raises :class:`AgentNotFoundError` / :class:`UserInputError` if the
@@ -592,10 +564,18 @@ def find_one_agent(
         raise UserInputError(f"No hosts found matching {address.host}")
 
     host_ref, agent_ref = filter_one_agent(address.agent, resolved_host=None, agents_by_host=agents_by_host)
-    return materialize_agent(
-        host_ref,
-        agent_ref,
-        mngr_ctx,
-        is_start_desired=is_start_desired,
-        skip_agent_state_check=skip_agent_state_check,
-    )
+    return host_ref, agent_ref, agents_by_host
+
+
+def find_one_agent(
+    address: AgentAddress,
+    mngr_ctx: MngrContext,
+) -> tuple[DiscoveredHost, DiscoveredAgent]:
+    """Find an agent by :class:`AgentAddress` and return its discovery refs.
+
+    Thin wrapper around :func:`find_one_agent_and_agents_by_host` that
+    drops the full discovery mapping. See that function for the contract
+    and error behaviour.
+    """
+    host_ref, agent_ref, _ = find_one_agent_and_agents_by_host(address, mngr_ctx)
+    return host_ref, agent_ref

--- a/libs/mngr/imbue/mngr/api/find_address_test.py
+++ b/libs/mngr/imbue/mngr/api/find_address_test.py
@@ -12,14 +12,12 @@ from imbue.mngr.api.address_parsers import parse_host_address
 from imbue.mngr.api.find import AgentMatch
 from imbue.mngr.api.find import _address_matches_agent_match
 from imbue.mngr.api.find import _post_filter_matches_by_addresses
-from imbue.mngr.cli.agent_utils import filter_agents_by_host
 from imbue.mngr.cli.stop import stop
 from imbue.mngr.errors import AgentNotFoundError
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
-from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
@@ -227,33 +225,6 @@ def test_address_matches_agent_match_by_host_name() -> None:
 
     assert _address_matches_agent_match(address, _make_match(host_name="myhost")) is True
     assert _address_matches_agent_match(address, _make_match(host_name="other")) is False
-
-
-# =============================================================================
-# filter_agents_by_host tests
-# =============================================================================
-
-
-def test_filter_agents_by_host_keeps_matching_host() -> None:
-    """Filter keeps only hosts matching the host filter."""
-    host1 = _make_host("h1", "local")
-    host2 = _make_host("h2", "local")
-    agents_by_host: dict[DiscoveredHost, list[DiscoveredAgent]] = {host1: [], host2: []}
-
-    host_filter = HostAddress(host=HostName("h1"))
-    result = filter_agents_by_host(agents_by_host, host_filter)
-    assert len(result) == 1
-    assert host1 in result
-
-
-def test_filter_agents_by_host_raises_when_no_match() -> None:
-    """Filter raises UserInputError when no hosts match."""
-    host1 = _make_host("h1", "local")
-    agents_by_host: dict[DiscoveredHost, list[DiscoveredAgent]] = {host1: []}
-
-    host_filter = HostAddress(host=HostName("nonexistent"))
-    with pytest.raises(UserInputError):
-        filter_agents_by_host(agents_by_host, host_filter)
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/api/find_test.py
+++ b/libs/mngr/imbue/mngr/api/find_test.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import Field
 
 from imbue.mngr.agents.base_agent import BaseAgent
-from imbue.mngr.api.address_parsers import parse_hosted_location
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.find import AgentMatch
 from imbue.mngr.api.find import _filter_all_agents
 from imbue.mngr.api.find import _filter_one_agent
@@ -33,91 +33,91 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 
 
-def test_parse_hosted_location_with_agent_only() -> None:
-    parsed = parse_hosted_location("my-agent")
+def test_parse_host_location_address_with_agent_only() -> None:
+    parsed = parse_host_location_address("my-agent")
 
-    assert parsed == HostedLocation(agent=AgentName("my-agent"))
+    assert parsed == HostLocationAddress(agent=AgentName("my-agent"))
 
 
-def test_parse_hosted_location_with_agent_and_host() -> None:
-    parsed = parse_hosted_location("my-agent@my-host")
+def test_parse_host_location_address_with_agent_and_host() -> None:
+    parsed = parse_host_location_address("my-agent@my-host")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_provider() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.modal")
+def test_parse_host_location_address_with_agent_host_and_provider() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.modal")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("modal")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_path() -> None:
-    parsed = parse_hosted_location("my-agent@my-host:/path/to/dir")
+def test_parse_host_location_address_with_agent_host_and_path() -> None:
+    parsed = parse_host_location_address("my-agent@my-host:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_host_and_path() -> None:
-    parsed = parse_hosted_location("@my-host:/path/to/dir")
+def test_parse_host_location_address_with_host_and_path() -> None:
+    parsed = parse_host_location_address("@my-host:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_absolute_path() -> None:
-    parsed = parse_hosted_location("/path/to/dir")
+def test_parse_host_location_address_with_absolute_path() -> None:
+    parsed = parse_host_location_address("/path/to/dir")
 
-    assert parsed == HostedLocation(path=Path("/path/to/dir"))
-
-
-def test_parse_hosted_location_with_relative_path() -> None:
-    parsed = parse_hosted_location("./path/to/dir")
-
-    assert parsed == HostedLocation(path=Path("./path/to/dir"))
+    assert parsed == HostLocationAddress(path=Path("/path/to/dir"))
 
 
-def test_parse_hosted_location_with_home_path() -> None:
-    parsed = parse_hosted_location("~/path/to/dir")
+def test_parse_host_location_address_with_relative_path() -> None:
+    parsed = parse_host_location_address("./path/to/dir")
 
-    assert parsed == HostedLocation(path=Path("~/path/to/dir"))
-
-
-def test_parse_hosted_location_with_parent_path() -> None:
-    parsed = parse_hosted_location("../path/to/dir")
-
-    assert parsed == HostedLocation(path=Path("../path/to/dir"))
+    assert parsed == HostLocationAddress(path=Path("./path/to/dir"))
 
 
-def test_parse_hosted_location_bare_name_is_agent_not_path() -> None:
+def test_parse_host_location_address_with_home_path() -> None:
+    parsed = parse_host_location_address("~/path/to/dir")
+
+    assert parsed == HostLocationAddress(path=Path("~/path/to/dir"))
+
+
+def test_parse_host_location_address_with_parent_path() -> None:
+    parsed = parse_host_location_address("../path/to/dir")
+
+    assert parsed == HostLocationAddress(path=Path("../path/to/dir"))
+
+
+def test_parse_host_location_address_bare_name_is_agent_not_path() -> None:
     """A bare name like 'foo' refers to agent 'foo', not directory 'foo'."""
-    parsed = parse_hosted_location("foo")
+    parsed = parse_host_location_address("foo")
 
-    assert parsed == HostedLocation(agent=AgentName("foo"))
+    assert parsed == HostLocationAddress(agent=AgentName("foo"))
 
 
-def test_parse_hosted_location_colon_prefix_is_local_path() -> None:
+def test_parse_host_location_address_colon_prefix_is_local_path() -> None:
     """:dirname is how to specify a relative local directory."""
-    parsed = parse_hosted_location(":my-dir")
+    parsed = parse_host_location_address(":my-dir")
 
-    assert parsed == HostedLocation(path=Path("my-dir"))
+    assert parsed == HostLocationAddress(path=Path("my-dir"))
 
 
 def test_filter_one_host_by_id() -> None:
@@ -353,76 +353,76 @@ def test__filter_one_agent_raises_when_multiple_agents_match() -> None:
         )
 
 
-def test_parse_hosted_location_with_colons_in_path() -> None:
-    parsed = parse_hosted_location("@my-host:/path/with:colons:in:it.txt")
+def test_parse_host_location_address_with_colons_in_path() -> None:
+    parsed = parse_host_location_address("@my-host:/path/with:colons:in:it.txt")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/with:colons:in:it.txt"),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_colons_in_path() -> None:
-    parsed = parse_hosted_location("agent@host:/weird:path:file.txt")
+def test_parse_host_location_address_with_agent_host_and_colons_in_path() -> None:
+    parsed = parse_host_location_address("agent@host:/weird:path:file.txt")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("agent"),
         host=HostAddress(host=HostName("host")),
         path=Path("/weird:path:file.txt"),
     )
 
 
-def test_parse_hosted_location_with_empty_path_after_colon() -> None:
-    parsed = parse_hosted_location("@my-host:")
+def test_parse_host_location_address_with_empty_path_after_colon() -> None:
+    parsed = parse_host_location_address("@my-host:")
 
-    assert parsed == HostedLocation(host=HostAddress(host=HostName("my-host")))
-
-
-def test_parse_hosted_location_with_agent_and_path() -> None:
-    parsed = parse_hosted_location("my-agent:http://example.com/path")
-
-    assert parsed == HostedLocation(agent=AgentName("my-agent"), path=Path("http://example.com/path"))
+    assert parsed == HostLocationAddress(host=HostAddress(host=HostName("my-host")))
 
 
-def test_parse_hosted_location_with_agent_host_provider() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.docker")
+def test_parse_host_location_address_with_agent_and_path() -> None:
+    parsed = parse_host_location_address("my-agent:http://example.com/path")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(agent=AgentName("my-agent"), path=Path("http://example.com/path"))
+
+
+def test_parse_host_location_address_with_agent_host_provider() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.docker")
+
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("docker")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_provider_and_path() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.modal:/path/to/dir")
+def test_parse_host_location_address_with_agent_host_provider_and_path() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.modal:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("modal")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_host_provider_and_path() -> None:
-    parsed = parse_hosted_location("@my-host.docker:/path/to/dir")
+def test_parse_host_location_address_with_host_provider_and_path() -> None:
+    parsed = parse_host_location_address("@my-host.docker:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("docker")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_agent_colon_path() -> None:
+def test_parse_host_location_address_with_agent_colon_path() -> None:
     """Agent name followed by colon and path (no host)."""
-    parsed = parse_hosted_location("C:/Windows/path")
+    parsed = parse_host_location_address("C:/Windows/path")
 
-    assert parsed == HostedLocation(agent=AgentName("C"), path=Path("/Windows/path"))
+    assert parsed == HostLocationAddress(agent=AgentName("C"), path=Path("/Windows/path"))
 
 
-def test_parse_hosted_location_rejects_multi_dot_host() -> None:
-    """parse_hosted_location should reject HOST.PROVIDER strings with more than one dot."""
+def test_parse_host_location_address_rejects_multi_dot_host() -> None:
+    """parse_host_location_address should reject HOST.PROVIDER strings with more than one dot."""
     with pytest.raises(UserInputError, match="contains more than one dot"):
-        parse_hosted_location("@a.b.c:/path")
+        parse_host_location_address("@a.b.c:/path")
 
 
 def test_get_host_from_list_by_id_returns_matching_host() -> None:
@@ -529,10 +529,10 @@ def test_determine_resolved_path_raises_when_no_path_and_no_agent() -> None:
         )
 
 
-def test_parse_hosted_location_with_empty_prefix_before_colon() -> None:
-    """parse_hosted_location should handle :path format (empty prefix before colon)."""
-    parsed = parse_hosted_location(":/path/to/dir")
-    assert parsed == HostedLocation(path=Path("/path/to/dir"))
+def test_parse_host_location_address_with_empty_prefix_before_colon() -> None:
+    """parse_host_location_address should handle :path format (empty prefix before colon)."""
+    parsed = parse_host_location_address(":/path/to/dir")
+    assert parsed == HostLocationAddress(path=Path("/path/to/dir"))
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/api/find_test.py
+++ b/libs/mngr/imbue/mngr/api/find_test.py
@@ -7,12 +7,12 @@ from pydantic import Field
 from imbue.mngr.agents.base_agent import BaseAgent
 from imbue.mngr.api.address_parsers import parse_hosted_location
 from imbue.mngr.api.find import AgentMatch
+from imbue.mngr.api.find import _filter_one_agent
 from imbue.mngr.api.find import _find_agents_by_identifiers_or_state
 from imbue.mngr.api.find import determine_resolved_path
 from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import filter_all_agents
 from imbue.mngr.api.find import filter_all_hosts
-from imbue.mngr.api.find import filter_one_agent
 from imbue.mngr.api.find import filter_one_host
 from imbue.mngr.api.find import get_host_from_list_by_id
 from imbue.mngr.api.find import get_unique_host_from_list_by_name
@@ -199,7 +199,7 @@ def test_filter_one_host_raises_when_multiple_hosts_with_same_name() -> None:
         )
 
 
-def test_filter_one_agent_by_id() -> None:
+def test__filter_one_agent_by_id() -> None:
     host_id = HostId.generate()
     agent_id = AgentId.generate()
     host_ref = DiscoveredHost(
@@ -214,7 +214,7 @@ def test_filter_one_agent_by_id() -> None:
         provider_name=ProviderInstanceName("local"),
     )
 
-    result = filter_one_agent(
+    result = _filter_one_agent(
         agent=agent_id,
         resolved_host=None,
         agents_by_host={host_ref: [agent_ref]},
@@ -223,7 +223,7 @@ def test_filter_one_agent_by_id() -> None:
     assert result == (host_ref, agent_ref)
 
 
-def test_filter_one_agent_by_name() -> None:
+def test__filter_one_agent_by_name() -> None:
     host_id = HostId.generate()
     agent_id = AgentId.generate()
     host_ref = DiscoveredHost(
@@ -238,7 +238,7 @@ def test_filter_one_agent_by_name() -> None:
         provider_name=ProviderInstanceName("local"),
     )
 
-    result = filter_one_agent(
+    result = _filter_one_agent(
         agent=AgentName("test-agent"),
         resolved_host=None,
         agents_by_host={host_ref: [agent_ref]},
@@ -247,7 +247,7 @@ def test_filter_one_agent_by_name() -> None:
     assert result == (host_ref, agent_ref)
 
 
-def test_filter_one_agent_with_resolved_host_filters_by_host() -> None:
+def test__filter_one_agent_with_resolved_host_filters_by_host() -> None:
     host_id1 = HostId.generate()
     host_id2 = HostId.generate()
     agent_id1 = AgentId.generate()
@@ -277,7 +277,7 @@ def test_filter_one_agent_with_resolved_host_filters_by_host() -> None:
         provider_name=ProviderInstanceName("local"),
     )
 
-    result = filter_one_agent(
+    result = _filter_one_agent(
         agent=AgentName("test-agent"),
         resolved_host=host_ref1,
         agents_by_host={
@@ -289,30 +289,30 @@ def test_filter_one_agent_with_resolved_host_filters_by_host() -> None:
     assert result == (host_ref1, agent_ref1)
 
 
-def test_filter_one_agent_raises_when_not_found() -> None:
+def test__filter_one_agent_raises_when_not_found() -> None:
     with pytest.raises(UserInputError, match="Could not find agent with ID or name: nonexistent"):
-        filter_one_agent(
+        _filter_one_agent(
             agent=AgentName("nonexistent"),
             resolved_host=None,
             agents_by_host={},
         )
 
 
-def test_filter_one_agent_raises_agent_not_found_for_unknown_id() -> None:
+def test__filter_one_agent_raises_agent_not_found_for_unknown_id() -> None:
     """An unknown AgentId raises AgentNotFoundError (not UserInputError).
 
     The distinction lets callers detect "the specific agent you named no
     longer exists" separately from "your search term didn't match anything".
     """
     with pytest.raises(AgentNotFoundError):
-        filter_one_agent(
+        _filter_one_agent(
             agent=AgentId.generate(),
             resolved_host=None,
             agents_by_host={},
         )
 
 
-def test_filter_one_agent_raises_when_multiple_agents_match() -> None:
+def test__filter_one_agent_raises_when_multiple_agents_match() -> None:
     host_id1 = HostId.generate()
     host_id2 = HostId.generate()
     agent_id1 = AgentId.generate()
@@ -343,7 +343,7 @@ def test_filter_one_agent_raises_when_multiple_agents_match() -> None:
     )
 
     with pytest.raises(UserInputError, match="Multiple agents found with name 'test-agent'"):
-        filter_one_agent(
+        _filter_one_agent(
             agent=AgentName("test-agent"),
             resolved_host=None,
             agents_by_host={

--- a/libs/mngr/imbue/mngr/api/find_test.py
+++ b/libs/mngr/imbue/mngr/api/find_test.py
@@ -7,11 +7,11 @@ from pydantic import Field
 from imbue.mngr.agents.base_agent import BaseAgent
 from imbue.mngr.api.address_parsers import parse_hosted_location
 from imbue.mngr.api.find import AgentMatch
+from imbue.mngr.api.find import _filter_all_agents
 from imbue.mngr.api.find import _filter_one_agent
 from imbue.mngr.api.find import _find_agents_by_identifiers_or_state
 from imbue.mngr.api.find import determine_resolved_path
 from imbue.mngr.api.find import ensure_agent_started
-from imbue.mngr.api.find import filter_all_agents
 from imbue.mngr.api.find import filter_all_hosts
 from imbue.mngr.api.find import filter_one_host
 from imbue.mngr.api.find import get_host_from_list_by_id
@@ -882,10 +882,10 @@ def test_filter_all_hosts_host_provider_form_no_match() -> None:
     )
 
 
-# --- filter_all_agents ---
+# --- _filter_all_agents ---
 
 
-def test_filter_all_agents_by_name() -> None:
+def test__filter_all_agents_by_name() -> None:
     host_id = HostId.generate()
     host = DiscoveredHost(host_id=host_id, host_name=HostName("h"), provider_name=ProviderInstanceName("local"))
     agent = DiscoveredAgent(
@@ -894,12 +894,12 @@ def test_filter_all_agents_by_name() -> None:
         agent_name=AgentName("my-agent"),
         provider_name=ProviderInstanceName("local"),
     )
-    result = filter_all_agents(AgentName("my-agent"), {host: [agent]})
+    result = _filter_all_agents(AgentName("my-agent"), {host: [agent]})
     assert len(result) == 1
     assert result[0] == (host, agent)
 
 
-def test_filter_all_agents_by_id() -> None:
+def test__filter_all_agents_by_id() -> None:
     host_id = HostId.generate()
     host = DiscoveredHost(host_id=host_id, host_name=HostName("h"), provider_name=ProviderInstanceName("local"))
     agent = DiscoveredAgent(
@@ -908,11 +908,11 @@ def test_filter_all_agents_by_id() -> None:
         agent_name=AgentName("a"),
         provider_name=ProviderInstanceName("local"),
     )
-    result = filter_all_agents(agent.agent_id, {host: [agent]})
+    result = _filter_all_agents(agent.agent_id, {host: [agent]})
     assert len(result) == 1
 
 
-def test_filter_all_agents_no_match() -> None:
+def test__filter_all_agents_no_match() -> None:
     host_id = HostId.generate()
     host = DiscoveredHost(host_id=host_id, host_name=HostName("h"), provider_name=ProviderInstanceName("local"))
     agent = DiscoveredAgent(
@@ -921,10 +921,10 @@ def test_filter_all_agents_no_match() -> None:
         agent_name=AgentName("other"),
         provider_name=ProviderInstanceName("local"),
     )
-    assert filter_all_agents(AgentName("nonexistent"), {host: [agent]}) == []
+    assert _filter_all_agents(AgentName("nonexistent"), {host: [agent]}) == []
 
 
-def test_filter_all_agents_multiple() -> None:
+def test__filter_all_agents_multiple() -> None:
     host1_id = HostId.generate()
     host2_id = HostId.generate()
     host1 = DiscoveredHost(host_id=host1_id, host_name=HostName("h1"), provider_name=ProviderInstanceName("local"))
@@ -941,11 +941,11 @@ def test_filter_all_agents_multiple() -> None:
         agent_name=AgentName("shared"),
         provider_name=ProviderInstanceName("local"),
     )
-    result = filter_all_agents(AgentName("shared"), {host1: [agent1], host2: [agent2]})
+    result = _filter_all_agents(AgentName("shared"), {host1: [agent1], host2: [agent2]})
     assert len(result) == 2
 
 
-def test_filter_all_agents_filtered_by_host() -> None:
+def test__filter_all_agents_filtered_by_host() -> None:
     host1_id = HostId.generate()
     host2_id = HostId.generate()
     host1 = DiscoveredHost(host_id=host1_id, host_name=HostName("h1"), provider_name=ProviderInstanceName("local"))
@@ -962,7 +962,7 @@ def test_filter_all_agents_filtered_by_host() -> None:
         agent_name=AgentName("shared"),
         provider_name=ProviderInstanceName("local"),
     )
-    result = filter_all_agents(AgentName("shared"), {host1: [agent1], host2: [agent2]}, resolved_host=host1)
+    result = _filter_all_agents(AgentName("shared"), {host1: [agent1], host2: [agent2]}, resolved_host=host1)
     assert len(result) == 1
     assert result[0] == (host1, agent1)
 

--- a/libs/mngr/imbue/mngr/api/test_find.py
+++ b/libs/mngr/imbue/mngr/api/test_find.py
@@ -1,4 +1,4 @@
-"""Integration tests for the find module (resolve_hosted_location and ensure_host_started)."""
+"""Integration tests for the find module (resolve_host_location_address and ensure_host_started)."""
 
 from datetime import datetime
 from datetime import timezone
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from imbue.mngr.api.find import ensure_host_started
-from imbue.mngr.api.find import resolve_hosted_location
+from imbue.mngr.api.find import resolve_host_location_address
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.hosts.host import Host
@@ -17,8 +17,8 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
@@ -62,12 +62,12 @@ def test_ensure_host_started_returns_already_online_host(
     assert online_host is host
 
 
-def test_resolve_hosted_location_resolves_host_and_path(
+def test_resolve_host_location_address_resolves_host_and_path(
     temp_mngr_ctx: MngrContext,
     temp_work_dir: Path,
     local_provider: LocalProviderInstance,
 ) -> None:
-    """Test that resolve_hosted_location returns a valid HostLocation for a known host.
+    """Test that resolve_host_location_address returns a valid HostLocation for a known host.
 
     Verifies the function resolves a host reference and path to an online host
     with a valid HostLocation.
@@ -81,11 +81,11 @@ def test_resolve_hosted_location_resolves_host_and_path(
 
     agents_by_host: dict[DiscoveredHost, list[DiscoveredAgent]] = {host_ref: []}
 
-    parsed = HostedLocation(
+    parsed = HostLocationAddress(
         host=HostAddress(host=host_id),
         path=temp_work_dir,
     )
-    result = resolve_hosted_location(
+    result = resolve_host_location_address(
         parsed,
         agents_by_host=agents_by_host,
         mngr_ctx=temp_mngr_ctx,

--- a/libs/mngr/imbue/mngr/api/test_push.py
+++ b/libs/mngr/imbue/mngr/api/test_push.py
@@ -908,6 +908,7 @@ def test_push_git_with_remote_host_without_ssh_info_raises_assertion(
 
 
 @pytest.mark.rsync
+@pytest.mark.flaky
 def test_push_files_to_nonexistent_subdir_creates_directory(
     push_ctx: SyncTestContext,
     cg: ConcurrencyGroup,

--- a/libs/mngr/imbue/mngr/cli/address_params.py
+++ b/libs/mngr/imbue/mngr/cli/address_params.py
@@ -3,7 +3,7 @@
 Each ParamType wraps one of the parsers in :mod:`imbue.mngr.api.address_parsers`.
 Click invokes these during argument parsing, so command bodies receive typed
 addresses (``AgentAddress``, ``HostAddress``, ``NewAgentLocation``,
-``HostedLocation``) rather than raw strings.
+``HostLocationAddress``) rather than raw strings.
 
 Use the module-level singletons (``AGENT_ADDRESS``, ``HOST_ADDRESS``, ...) as
 the ``type=`` value on a ``@click.option`` or ``@click.argument`` decorator.
@@ -17,8 +17,8 @@ from imbue.mngr.api.address_parsers import parse_agent_address
 from imbue.mngr.api.address_parsers import parse_agent_name_or_id
 from imbue.mngr.api.address_parsers import parse_agent_or_host_address
 from imbue.mngr.api.address_parsers import parse_host_address
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.address_parsers import parse_host_name_or_id
-from imbue.mngr.api.address_parsers import parse_hosted_location
 from imbue.mngr.api.address_parsers import parse_new_agent_location
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
@@ -26,8 +26,8 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import AgentNameOrId
 from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import HostAddress
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import InvalidName
 from imbue.mngr.primitives import NewAgentLocation
 
@@ -94,7 +94,7 @@ class NewAgentLocationParamType(click.ParamType):
         return _convert_with_user_input_error(parse_new_agent_location, value, param, ctx)
 
 
-class HostedLocationParamType(click.ParamType):
+class HostLocationAddressParamType(click.ParamType):
     """Click param type for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` source/target arguments.
 
     Used by commands that designate "a location on any host" -- e.g. the
@@ -102,12 +102,12 @@ class HostedLocationParamType(click.ParamType):
     of ``mngr push``/``mngr pull``, and the source argument of ``mngr pair``.
     """
 
-    name = "hosted_location"
+    name = "host_location_address"
 
-    def convert(self, value: Any, param: click.Parameter | None, ctx: click.Context | None) -> HostedLocation:
-        if isinstance(value, HostedLocation):
+    def convert(self, value: Any, param: click.Parameter | None, ctx: click.Context | None) -> HostLocationAddress:
+        if isinstance(value, HostLocationAddress):
             return value
-        return _convert_with_user_input_error(parse_hosted_location, value, param, ctx)
+        return _convert_with_user_input_error(parse_host_location_address, value, param, ctx)
 
 
 class AgentNameOrIdParamType(click.ParamType):
@@ -148,7 +148,7 @@ AGENT_ADDRESS = AgentAddressParamType()
 HOST_ADDRESS = HostAddressParamType()
 AGENT_OR_HOST_ADDRESS = AgentOrHostAddressParamType()
 NEW_AGENT_LOCATION = NewAgentLocationParamType()
-HOSTED_LOCATION = HostedLocationParamType()
+HOST_LOCATION_ADDRESS = HostLocationAddressParamType()
 AGENT_NAME_OR_ID = AgentNameOrIdParamType()
 HOST_NAME_OR_ID = HostNameOrIdParamType()
 AGENT_NAME = AgentNameParamType()

--- a/libs/mngr/imbue/mngr/cli/agent_selector.py
+++ b/libs/mngr/imbue/mngr/cli/agent_selector.py
@@ -1,0 +1,292 @@
+"""Interactive urwid-based agent selector TUI.
+
+Extracted out of ``cli/connect.py`` so that ``cli/agent_utils.py`` can use
+it without creating an import cycle with the connect command module.
+"""
+
+import time
+from typing import Any
+
+from pydantic import ConfigDict
+from urwid.event_loop.abstract_loop import ExitMainLoop
+from urwid.event_loop.main_loop import MainLoop
+from urwid.widget.attr_map import AttrMap
+from urwid.widget.divider import Divider
+from urwid.widget.frame import Frame
+from urwid.widget.listbox import ListBox
+from urwid.widget.listbox import SimpleFocusListWalker
+from urwid.widget.pile import Pile
+from urwid.widget.text import Text
+from urwid.widget.wimp import SelectableIcon
+
+from imbue.imbue_common.mutable_model import MutableModel
+from imbue.imbue_common.pure import pure
+from imbue.mngr.cli.urwid_utils import create_urwid_screen_preserving_terminal
+from imbue.mngr.interfaces.data_types import AgentDetails
+from imbue.mngr.primitives import AgentLifecycleState
+
+
+@pure
+def filter_agents(
+    agents: list[AgentDetails],
+    hide_stopped: bool,
+    search_query: str,
+) -> list[AgentDetails]:
+    """Filter agents by stopped state and search query."""
+    result = agents
+
+    if hide_stopped:
+        result = [a for a in result if a.state != AgentLifecycleState.STOPPED]
+
+    if search_query:
+        query_lower = search_query.lower()
+        result = [a for a in result if query_lower in str(a.name).lower()]
+
+    return result
+
+
+def build_status_text(
+    search_query: str,
+    hide_stopped: bool,
+) -> str:
+    """Build the status bar text for the agent selector."""
+    parts = ["Status: Ready"]
+
+    if search_query:
+        parts.append(f"Search: {search_query}")
+    else:
+        parts.append("Type to search")
+
+    if hide_stopped:
+        parts.append("Filter: Hiding stopped")
+    else:
+        parts.append("Filter: All agents")
+
+    return " | ".join(parts)
+
+
+def handle_search_key(
+    key: str,
+    is_printable: bool,
+    character: str | None,
+    current_query: str,
+) -> tuple[str, bool]:
+    """Handle a key press for typeahead search. Returns (new_query, should_refresh)."""
+    if key == "backspace":
+        if current_query:
+            return current_query[:-1], True
+        else:
+            return current_query, False
+    elif is_printable and character:
+        return current_query + character, True
+    else:
+        return current_query, False
+
+
+def _create_selectable_agent_item(agent: AgentDetails, name_width: int, state_width: int) -> AttrMap:
+    """Create a selectable list item representing an agent as a table row.
+
+    Uses SelectableIcon instead of Text so that ListBox can navigate between items.
+    urwid.Text is not selectable, which prevents ListBox arrow key navigation.
+    """
+    # Pad the name and state to their column widths for proper alignment
+    name_padded = str(agent.name).ljust(name_width)
+    state_padded = agent.state.value.ljust(state_width)
+    host_str = str(agent.host.name)
+
+    # Create a single SelectableIcon with the full formatted row
+    # This ensures the entire row is selectable as one unit
+    display_text = f"{name_padded}  {state_padded}  {host_str}"
+    selectable_item = SelectableIcon(display_text, cursor_position=0)
+
+    return AttrMap(selectable_item, None, focus_map="reversed")
+
+
+class AgentSelectorState(MutableModel):
+    """Mutable state for the agent selector UI."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    agents: list[AgentDetails]
+    filtered_agents: list[AgentDetails] = []
+    list_walker: Any
+    status_text: Any
+    result: AgentDetails | None = None
+    hide_stopped: bool = False
+    search_query: str = ""
+    last_ctrl_c_time: float = 0.0
+    name_width: int = 0
+    state_width: int = 0
+
+
+def _refresh_agent_list(state: AgentSelectorState) -> None:
+    """Refresh the agent list view with current filter settings."""
+    state.filtered_agents = filter_agents(state.agents, state.hide_stopped, state.search_query)
+
+    state.list_walker.clear()
+    for agent in state.filtered_agents:
+        state.list_walker.append(_create_selectable_agent_item(agent, state.name_width, state.state_width))
+
+    if state.list_walker:
+        state.list_walker.set_focus(0)
+
+    state.status_text.set_text(build_status_text(state.search_query, state.hide_stopped))
+
+
+def _handle_selector_input(state: AgentSelectorState, key: str) -> bool:
+    """Handle keyboard input for the agent selector. Returns True if handled, False to pass through."""
+    if key == "ctrl r":
+        state.hide_stopped = not state.hide_stopped
+        _refresh_agent_list(state)
+        return True
+
+    if key == "ctrl c":
+        current_time = time.time()
+        if state.search_query:
+            # First Ctrl-c clears the search query
+            state.search_query = ""
+            state.last_ctrl_c_time = current_time
+            _refresh_agent_list(state)
+            return True
+        elif current_time - state.last_ctrl_c_time < 0.5:
+            # Second Ctrl-c within 500ms exits
+            raise ExitMainLoop()
+        else:
+            # Single Ctrl-c with no query - record time and wait for potential second
+            state.last_ctrl_c_time = current_time
+            return True
+
+    if key == "enter":
+        if state.list_walker and state.filtered_agents:
+            _, focus_index = state.list_walker.get_focus()
+            if focus_index is not None and 0 <= focus_index < len(state.filtered_agents):
+                state.result = state.filtered_agents[focus_index]
+        raise ExitMainLoop()
+
+    # Let arrow keys pass through to the ListBox for navigation
+    if key in ("up", "down", "page up", "page down", "home", "end"):
+        return False
+
+    is_printable = len(key) == 1 and key.isprintable()
+    character = key if is_printable else None
+
+    new_query, should_refresh = handle_search_key(
+        key=key,
+        is_printable=is_printable,
+        character=character,
+        current_query=state.search_query,
+    )
+
+    if should_refresh:
+        state.search_query = new_query
+        _refresh_agent_list(state)
+        return True
+
+    return False
+
+
+class SelectorInputHandler(MutableModel):
+    """Callable input handler for urwid MainLoop."""
+
+    state: AgentSelectorState
+
+    def __call__(self, key: str | tuple[str, int, int, int]) -> bool | None:
+        """Handle keyboard input. Returns True if handled, None to pass through."""
+        if isinstance(key, tuple):
+            return None
+        handled = _handle_selector_input(self.state, key)
+        return True if handled else None
+
+
+def _run_agent_selector(agents: list[AgentDetails]) -> AgentDetails | None:
+    """Run the agent selector UI and return the selected agent, or None if cancelled."""
+    # Calculate column widths based on content
+    name_width = max((len(str(a.name)) for a in agents), default=10)
+    state_width = max((len(a.state.value) for a in agents), default=7)
+
+    # Cap widths at reasonable maximums
+    name_width = min(name_width, 40)
+    state_width = min(state_width, 15)
+
+    list_walker: SimpleFocusListWalker[AttrMap] = SimpleFocusListWalker([])
+    listbox = ListBox(list_walker)
+
+    status_text = Text(build_status_text("", False))
+    status_bar = AttrMap(status_text, "status")
+
+    state = AgentSelectorState(
+        agents=agents,
+        list_walker=list_walker,
+        status_text=status_text,
+        name_width=name_width,
+        state_width=state_width,
+    )
+
+    instructions_text = (
+        "Instructions:\n"
+        "  Type - Search agents by name\n"
+        "  Up/Down - Navigate the list\n"
+        "  Enter - Select an agent\n"
+        "  Backspace - Clear search character\n"
+        "  Ctrl+C - Clear search (twice to quit)\n"
+        "  Ctrl+R - Toggle hiding stopped agents"
+    )
+    instructions = Text(instructions_text)
+
+    # Create table header matching the SelectableIcon format in list items
+    header_text = f"{'NAME'.ljust(name_width)}  {'STATE'.ljust(state_width)}  HOST"
+    header_row = AttrMap(Text(("table_header", header_text)), "table_header")
+
+    _refresh_agent_list(state)
+
+    header = Pile(
+        [
+            AttrMap(Text("Agent Selector", align="center"), "header"),
+            Divider(),
+            instructions,
+            Divider(),
+            header_row,
+            Divider("-"),
+        ]
+    )
+
+    footer = Pile(
+        [
+            Divider(),
+            status_bar,
+        ]
+    )
+
+    frame = Frame(
+        body=listbox,
+        header=header,
+        footer=footer,
+    )
+
+    palette = [
+        ("header", "white", "dark blue"),
+        ("status", "white", "dark blue"),
+        ("reversed", "standout", ""),
+        ("table_header", "bold", ""),
+    ]
+
+    input_handler = SelectorInputHandler(state=state)
+
+    with create_urwid_screen_preserving_terminal() as screen:
+        loop = MainLoop(
+            frame,
+            palette=palette,
+            unhandled_input=input_handler,
+            screen=screen,
+        )
+        loop.run()
+
+    return state.result
+
+
+def select_agent_interactively(agents: list[AgentDetails]) -> AgentDetails | None:
+    """Show an interactive UI to select an agent. Returns None if cancelled."""
+    if not agents:
+        return None
+
+    return _run_agent_selector(agents)

--- a/libs/mngr/imbue/mngr/cli/agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils.py
@@ -1,8 +1,8 @@
-from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
 from typing import assert_never
 
+import click
 from loguru import logger
 
 from imbue.imbue_common.pure import pure
@@ -14,7 +14,6 @@ from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.agent import AgentInterface
-from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentAddress
@@ -155,40 +154,14 @@ def ensure_host_and_agent_started(
     return agent, online_host
 
 
-def select_agent_interactively_with_host(
-    mngr_ctx: MngrContext,
-    agent_filter: Callable[[AgentDetails], bool] | None = None,
-    no_agents_message: str = "No agents found",
-) -> tuple[DiscoveredHost, DiscoveredAgent] | None:
-    """Show interactive UI to select an agent.
-
-    When ``agent_filter`` is provided, only agents matching the predicate
-    are shown in the interactive selector. Returns the chosen agent's
-    discovery refs, or ``None`` if the user quit without selecting.
-    Callers compose with :func:`ensure_host_started_and_resolve_agent` or
-    :func:`ensure_host_and_agent_started` to bring the result live.
-    """
-    list_result = list_agents(mngr_ctx, is_streaming=False)
-    agents = list_result.agents
-    if agent_filter is not None:
-        agents = [a for a in agents if agent_filter(a)]
-    if not agents:
-        raise UserInputError(no_agents_message)
-
-    selected = select_agent_interactively(agents)
-    if selected is None:
-        return None
-
-    return find_one_agent(AgentAddress(agent=selected.id), mngr_ctx)
-
-
-def find_agent_for_command(
+def find_agent_by_address_or_interactively(
     mngr_ctx: MngrContext,
     address: AgentAddress | None,
     host_filter: HostAddress | None,
-    agent_filter: Callable[[AgentDetails], bool] | None = None,
+    include_filters: tuple[str, ...] = (),
+    exclude_filters: tuple[str, ...] = (),
     no_agents_message: str = "No agents found",
-) -> tuple[DiscoveredHost, DiscoveredAgent] | None:
+) -> tuple[DiscoveredHost, DiscoveredAgent]:
     """Find an agent by address, or interactively if no address is given.
 
     The optional ``host_filter`` is an additional :class:`HostAddress`
@@ -196,13 +169,19 @@ def find_agent_for_command(
     It is merged into the address; if the address already pins a different
     host, this raises :class:`UserInputError`.
 
-    Returns the agent's discovery refs, or ``None`` if the user cancelled
-    interactive selection. Callers compose with
+    The optional ``include_filters`` / ``exclude_filters`` are CEL expressions
+    that narrow the candidate pool of the interactive selector. They are
+    ignored when ``address`` is given.
+
+    Returns the chosen agent's discovery refs. Callers compose with
     :func:`ensure_host_started_and_resolve_agent` or
     :func:`ensure_host_and_agent_started` to bring the result live.
 
     Raises :class:`UserInputError` if no address is given and the session
-    is not interactive.
+    is not interactive, or if the interactive candidate pool is empty.
+    Raises :class:`click.Abort` if the user quits the interactive selector
+    without choosing an agent (which Click handles as a clean cancellation
+    rather than printing a stack trace).
     """
     if address is not None:
         if host_filter is not None:
@@ -214,11 +193,21 @@ def find_agent_for_command(
     if not mngr_ctx.is_interactive:
         raise UserInputError("No agent specified and not running in interactive mode (specify an agent name or ID)")
 
-    return select_agent_interactively_with_host(
+    list_result = list_agents(
         mngr_ctx,
-        agent_filter=agent_filter,
-        no_agents_message=no_agents_message,
+        is_streaming=False,
+        include_filters=include_filters,
+        exclude_filters=exclude_filters,
     )
+    if not list_result.agents:
+        raise UserInputError(no_agents_message)
+
+    selected = select_agent_interactively(list_result.agents)
+    if selected is None:
+        logger.info("No agent selected")
+        raise click.Abort()
+
+    return find_one_agent(AgentAddress(agent=selected.id), mngr_ctx)
 
 
 def stop_agent_after_sync(

--- a/libs/mngr/imbue/mngr/cli/agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils.py
@@ -1,18 +1,24 @@
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
+from typing import assert_never
+
+from loguru import logger
 
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.list import list_agents
-from imbue.mngr.cli.connect import select_agent_interactively
+from imbue.mngr.api.providers import get_provider_instance
+from imbue.mngr.cli.agent_selector import select_agent_interactively
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.data_types import AgentDetails
+from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentAddress
+from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
@@ -38,19 +44,129 @@ def filter_agents_by_host(
     return filtered
 
 
+def _ensure_host_online(
+    host_ref: DiscoveredHost,
+    allow_auto_start: bool,
+    mngr_ctx: MngrContext,
+) -> OnlineHostInterface:
+    """Resolve a :class:`DiscoveredHost` to an :class:`OnlineHostInterface`.
+
+    Starts the host if offline and ``allow_auto_start`` is True; otherwise
+    raises :class:`UserInputError` when the host is offline.
+    """
+    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
+    host = provider.get_host(host_ref.host_id)
+    match host:
+        case OnlineHostInterface() as online_host:
+            return online_host
+        case HostInterface() as offline_host:
+            if not allow_auto_start:
+                raise UserInputError(
+                    f"Host '{offline_host.id}' is offline and automatic starting is disabled. "
+                    "Pass --start to start the host automatically."
+                )
+            logger.info("Host is offline, starting it...", host_id=offline_host.id, provider=provider.name)
+            return provider.start_host(offline_host)
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _resolve_agent_on_host(
+    host_ref: DiscoveredHost,
+    agent_ref: DiscoveredAgent,
+    online_host: OnlineHostInterface,
+) -> AgentInterface:
+    """Look up the agent that ``agent_ref`` points to on a live host.
+
+    Raises :class:`RuntimeError` if the agent was found during discovery
+    but is no longer present on the live host (a stale-cache / host state
+    inconsistency case).
+    """
+    for live_agent in online_host.get_agents():
+        if live_agent.id == agent_ref.agent_id:
+            return live_agent
+    raise RuntimeError(
+        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
+        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
+        "This indicates a stale discovery cache or host state inconsistency."
+    )
+
+
+def ensure_host_started_and_resolve_agent(
+    host_ref: DiscoveredHost,
+    agent_ref: DiscoveredAgent,
+    allow_auto_start: bool,
+    mngr_ctx: MngrContext,
+) -> tuple[AgentInterface, OnlineHostInterface]:
+    """Bring the host online and resolve the agent ref to an :class:`AgentInterface`.
+
+    The agent process's lifecycle state is *not* checked: the returned
+    ``AgentInterface`` may represent a stopped agent. Callers that need
+    the agent process to be running should use
+    :func:`ensure_host_and_agent_started` instead.
+
+    When ``allow_auto_start`` is True, an offline host is started
+    automatically. When False, an offline host raises
+    :class:`UserInputError`.
+
+    Raises :class:`RuntimeError` if the agent was found during discovery
+    but is missing on the live host.
+    """
+    online_host = _ensure_host_online(host_ref, allow_auto_start, mngr_ctx)
+    agent = _resolve_agent_on_host(host_ref, agent_ref, online_host)
+    return agent, online_host
+
+
+def ensure_host_and_agent_started(
+    host_ref: DiscoveredHost,
+    agent_ref: DiscoveredAgent,
+    allow_auto_start: bool,
+    mngr_ctx: MngrContext,
+) -> tuple[AgentInterface, OnlineHostInterface]:
+    """Bring the host online, resolve the agent, and ensure the agent is running.
+
+    When ``allow_auto_start`` is True, both an offline host and a stopped
+    agent are started automatically. When False, either condition raises
+    :class:`UserInputError`.
+
+    Raises :class:`RuntimeError` if the agent was found during discovery
+    but is missing on the live host.
+    """
+    agent, online_host = ensure_host_started_and_resolve_agent(host_ref, agent_ref, allow_auto_start, mngr_ctx)
+    lifecycle_state = agent.get_lifecycle_state()
+    if lifecycle_state in (
+        AgentLifecycleState.RUNNING,
+        AgentLifecycleState.REPLACED,
+        AgentLifecycleState.RUNNING_UNKNOWN_AGENT_TYPE,
+        AgentLifecycleState.WAITING,
+    ):
+        return agent, online_host
+    if not allow_auto_start:
+        raise UserInputError(
+            f"Agent '{agent.name}' is stopped and automatic starting is disabled. "
+            "Pass --start to start the agent automatically."
+        )
+    logger.info("Agent {} is stopped, starting it", agent.name)
+    agent.wait_for_ready_signal(
+        is_creating=False,
+        start_action=lambda: online_host.start_agents([agent.id]),
+        timeout=agent.get_ready_timeout_seconds(),
+    )
+    return agent, online_host
+
+
 def select_agent_interactively_with_host(
     mngr_ctx: MngrContext,
-    is_start_desired: bool = False,
-    skip_agent_state_check: bool = False,
     agent_filter: Callable[[AgentDetails], bool] | None = None,
     no_agents_message: str = "No agents found",
-) -> tuple[AgentInterface, OnlineHostInterface] | None:
+) -> tuple[DiscoveredHost, DiscoveredAgent] | None:
     """Show interactive UI to select an agent.
 
-    When agent_filter is provided, only agents matching the predicate are shown
-    in the interactive selector.
-
-    Returns tuple of (agent, host) or None if user quit without selecting.
+    When ``agent_filter`` is provided, only agents matching the predicate
+    are shown in the interactive selector. Returns the chosen agent's
+    discovery refs, or ``None`` if the user quit without selecting.
+    Callers compose with :func:`ensure_host_started_and_resolve_agent` or
+    :func:`ensure_host_and_agent_started` to bring the result live.
     """
     list_result = list_agents(mngr_ctx, is_streaming=False)
     agents = list_result.agents
@@ -63,23 +179,16 @@ def select_agent_interactively_with_host(
     if selected is None:
         return None
 
-    return find_one_agent(
-        AgentAddress(agent=selected.id),
-        mngr_ctx,
-        is_start_desired=is_start_desired,
-        skip_agent_state_check=skip_agent_state_check,
-    )
+    return find_one_agent(AgentAddress(agent=selected.id), mngr_ctx)
 
 
 def find_agent_for_command(
     mngr_ctx: MngrContext,
     address: AgentAddress | None,
     host_filter: HostAddress | None,
-    is_start_desired: bool = False,
-    skip_agent_state_check: bool = False,
     agent_filter: Callable[[AgentDetails], bool] | None = None,
     no_agents_message: str = "No agents found",
-) -> tuple[AgentInterface, OnlineHostInterface] | None:
+) -> tuple[DiscoveredHost, DiscoveredAgent] | None:
     """Find an agent by address, or interactively if no address is given.
 
     The optional ``host_filter`` is an additional :class:`HostAddress`
@@ -87,29 +196,26 @@ def find_agent_for_command(
     It is merged into the address; if the address already pins a different
     host, this raises :class:`UserInputError`.
 
-    Returns ``(agent, host)``, or ``None`` if the user cancelled interactive
-    selection. Raises :class:`UserInputError` if no address is given and the
-    session is not interactive.
+    Returns the agent's discovery refs, or ``None`` if the user cancelled
+    interactive selection. Callers compose with
+    :func:`ensure_host_started_and_resolve_agent` or
+    :func:`ensure_host_and_agent_started` to bring the result live.
+
+    Raises :class:`UserInputError` if no address is given and the session
+    is not interactive.
     """
     if address is not None:
         if host_filter is not None:
             if address.host is not None and address.host != host_filter:
                 raise UserInputError(f"Address host ({address.host}) conflicts with --host filter ({host_filter}).")
             address = AgentAddress(agent=address.agent, host=host_filter)
-        return find_one_agent(
-            address,
-            mngr_ctx,
-            is_start_desired=is_start_desired,
-            skip_agent_state_check=skip_agent_state_check,
-        )
+        return find_one_agent(address, mngr_ctx)
 
     if not mngr_ctx.is_interactive:
         raise UserInputError("No agent specified and not running in interactive mode (specify an agent name or ID)")
 
     return select_agent_interactively_with_host(
         mngr_ctx,
-        is_start_desired=is_start_desired,
-        skip_agent_state_check=skip_agent_state_check,
         agent_filter=agent_filter,
         no_agents_message=no_agents_message,
     )

--- a/libs/mngr/imbue/mngr/cli/agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils.py
@@ -1,11 +1,8 @@
 import click
 from loguru import logger
 
-from imbue.mngr.api.find import ensure_agent_started
-from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.list import list_agents
-from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.cli.agent_selector import select_agent_interactively
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.config.data_types import MngrContext
@@ -17,66 +14,6 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import OutputFormat
-
-
-def ensure_host_started_and_resolve_agent(
-    host_ref: DiscoveredHost,
-    agent_ref: DiscoveredAgent,
-    allow_auto_start: bool,
-    mngr_ctx: MngrContext,
-) -> tuple[AgentInterface, OnlineHostInterface]:
-    """Bring the host online and resolve the agent ref to an :class:`AgentInterface`.
-
-    Delegates host startup to :func:`imbue.mngr.api.find.ensure_host_started`.
-
-    The agent process's lifecycle state is *not* checked: the returned
-    ``AgentInterface`` may represent a stopped agent. Callers that need
-    the agent process to be running should use
-    :func:`ensure_host_and_agent_started` instead.
-
-    When ``allow_auto_start`` is True, an offline host is started
-    automatically. When False, an offline host raises
-    :class:`UserInputError`.
-
-    Raises :class:`RuntimeError` if the agent was found during discovery
-    but is missing on the live host.
-    """
-    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
-    host = provider.get_host(host_ref.host_id)
-    online_host, _was_started = ensure_host_started(host, is_start_desired=allow_auto_start, provider=provider)
-    for live_agent in online_host.get_agents():
-        if live_agent.id == agent_ref.agent_id:
-            return live_agent, online_host
-    raise RuntimeError(
-        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
-        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
-        "This indicates a stale discovery cache or host state inconsistency."
-    )
-
-
-def ensure_host_and_agent_started(
-    host_ref: DiscoveredHost,
-    agent_ref: DiscoveredAgent,
-    allow_auto_start: bool,
-    mngr_ctx: MngrContext,
-) -> tuple[AgentInterface, OnlineHostInterface]:
-    """Bring the host online, resolve the agent, and ensure the agent is running.
-
-    Delegates to :func:`ensure_host_started_and_resolve_agent` for the host
-    and resolution steps, then to
-    :func:`imbue.mngr.api.find.ensure_agent_started` for the agent's
-    lifecycle.
-
-    When ``allow_auto_start`` is True, both an offline host and a stopped
-    agent are started automatically. When False, either condition raises
-    :class:`UserInputError`.
-
-    Raises :class:`RuntimeError` if the agent was found during discovery
-    but is missing on the live host.
-    """
-    agent, online_host = ensure_host_started_and_resolve_agent(host_ref, agent_ref, allow_auto_start, mngr_ctx)
-    ensure_agent_started(agent, online_host, is_start_desired=allow_auto_start)
-    return agent, online_host
 
 
 def find_agent_by_address_or_interactively(
@@ -99,8 +36,9 @@ def find_agent_by_address_or_interactively(
     ignored when ``address`` is given.
 
     Returns the chosen agent's discovery refs. Callers compose with
-    :func:`ensure_host_started_and_resolve_agent` or
-    :func:`ensure_host_and_agent_started` to bring the result live.
+    :func:`imbue.mngr.api.find.resolve_to_started_host_and_agent` or
+    :func:`imbue.mngr.api.find.resolve_to_started_host_and_running_agent`
+    to bring the result live.
 
     Raises :class:`UserInputError` if no address is given and the session
     is not interactive, or if the interactive candidate pool is empty.

--- a/libs/mngr/imbue/mngr/cli/agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils.py
@@ -1,11 +1,12 @@
 from collections.abc import Mapping
 from collections.abc import Sequence
-from typing import assert_never
 
 import click
 from loguru import logger
 
 from imbue.imbue_common.pure import pure
+from imbue.mngr.api.find import ensure_agent_started
+from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.list import list_agents
 from imbue.mngr.api.providers import get_provider_instance
@@ -14,10 +15,8 @@ from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.agent import AgentInterface
-from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentAddress
-from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
@@ -43,54 +42,6 @@ def filter_agents_by_host(
     return filtered
 
 
-def _ensure_host_online(
-    host_ref: DiscoveredHost,
-    allow_auto_start: bool,
-    mngr_ctx: MngrContext,
-) -> OnlineHostInterface:
-    """Resolve a :class:`DiscoveredHost` to an :class:`OnlineHostInterface`.
-
-    Starts the host if offline and ``allow_auto_start`` is True; otherwise
-    raises :class:`UserInputError` when the host is offline.
-    """
-    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
-    host = provider.get_host(host_ref.host_id)
-    match host:
-        case OnlineHostInterface() as online_host:
-            return online_host
-        case HostInterface() as offline_host:
-            if not allow_auto_start:
-                raise UserInputError(
-                    f"Host '{offline_host.id}' is offline and automatic starting is disabled. "
-                    "Pass --start to start the host automatically."
-                )
-            logger.info("Host is offline, starting it...", host_id=offline_host.id, provider=provider.name)
-            return provider.start_host(offline_host)
-        case _ as unreachable:
-            assert_never(unreachable)
-
-
-def _resolve_agent_on_host(
-    host_ref: DiscoveredHost,
-    agent_ref: DiscoveredAgent,
-    online_host: OnlineHostInterface,
-) -> AgentInterface:
-    """Look up the agent that ``agent_ref`` points to on a live host.
-
-    Raises :class:`RuntimeError` if the agent was found during discovery
-    but is no longer present on the live host (a stale-cache / host state
-    inconsistency case).
-    """
-    for live_agent in online_host.get_agents():
-        if live_agent.id == agent_ref.agent_id:
-            return live_agent
-    raise RuntimeError(
-        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
-        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
-        "This indicates a stale discovery cache or host state inconsistency."
-    )
-
-
 def ensure_host_started_and_resolve_agent(
     host_ref: DiscoveredHost,
     agent_ref: DiscoveredAgent,
@@ -98,6 +49,8 @@ def ensure_host_started_and_resolve_agent(
     mngr_ctx: MngrContext,
 ) -> tuple[AgentInterface, OnlineHostInterface]:
     """Bring the host online and resolve the agent ref to an :class:`AgentInterface`.
+
+    Delegates host startup to :func:`imbue.mngr.api.find.ensure_host_started`.
 
     The agent process's lifecycle state is *not* checked: the returned
     ``AgentInterface`` may represent a stopped agent. Callers that need
@@ -111,9 +64,17 @@ def ensure_host_started_and_resolve_agent(
     Raises :class:`RuntimeError` if the agent was found during discovery
     but is missing on the live host.
     """
-    online_host = _ensure_host_online(host_ref, allow_auto_start, mngr_ctx)
-    agent = _resolve_agent_on_host(host_ref, agent_ref, online_host)
-    return agent, online_host
+    provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
+    host = provider.get_host(host_ref.host_id)
+    online_host, _was_started = ensure_host_started(host, is_start_desired=allow_auto_start, provider=provider)
+    for live_agent in online_host.get_agents():
+        if live_agent.id == agent_ref.agent_id:
+            return live_agent, online_host
+    raise RuntimeError(
+        f"Agent '{agent_ref.agent_name}' (ID: {agent_ref.agent_id}) was found during discovery but is "
+        f"no longer present on host {host_ref.host_name}.{host_ref.provider_name}. "
+        "This indicates a stale discovery cache or host state inconsistency."
+    )
 
 
 def ensure_host_and_agent_started(
@@ -124,6 +85,11 @@ def ensure_host_and_agent_started(
 ) -> tuple[AgentInterface, OnlineHostInterface]:
     """Bring the host online, resolve the agent, and ensure the agent is running.
 
+    Delegates to :func:`ensure_host_started_and_resolve_agent` for the host
+    and resolution steps, then to
+    :func:`imbue.mngr.api.find.ensure_agent_started` for the agent's
+    lifecycle.
+
     When ``allow_auto_start`` is True, both an offline host and a stopped
     agent are started automatically. When False, either condition raises
     :class:`UserInputError`.
@@ -132,25 +98,7 @@ def ensure_host_and_agent_started(
     but is missing on the live host.
     """
     agent, online_host = ensure_host_started_and_resolve_agent(host_ref, agent_ref, allow_auto_start, mngr_ctx)
-    lifecycle_state = agent.get_lifecycle_state()
-    if lifecycle_state in (
-        AgentLifecycleState.RUNNING,
-        AgentLifecycleState.REPLACED,
-        AgentLifecycleState.RUNNING_UNKNOWN_AGENT_TYPE,
-        AgentLifecycleState.WAITING,
-    ):
-        return agent, online_host
-    if not allow_auto_start:
-        raise UserInputError(
-            f"Agent '{agent.name}' is stopped and automatic starting is disabled. "
-            "Pass --start to start the agent automatically."
-        )
-    logger.info("Agent {} is stopped, starting it", agent.name)
-    agent.wait_for_ready_signal(
-        is_creating=False,
-        start_action=lambda: online_host.start_agents([agent.id]),
-        timeout=agent.get_ready_timeout_seconds(),
-    )
+    ensure_agent_started(agent, online_host, is_start_desired=allow_auto_start)
     return agent, online_host
 
 

--- a/libs/mngr/imbue/mngr/cli/agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils.py
@@ -1,10 +1,6 @@
-from collections.abc import Mapping
-from collections.abc import Sequence
-
 import click
 from loguru import logger
 
-from imbue.imbue_common.pure import pure
 from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import find_one_agent
@@ -21,25 +17,6 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import OutputFormat
-
-
-@pure
-def filter_agents_by_host(
-    agents_by_host: Mapping[DiscoveredHost, Sequence[DiscoveredAgent]],
-    host_filter: HostAddress,
-) -> dict[DiscoveredHost, Sequence[DiscoveredAgent]]:
-    """Filter agents_by_host to only include hosts matching the given :class:`HostAddress`.
-
-    Raises :class:`UserInputError` if no hosts match the filter.
-    """
-    filtered = {
-        host_ref: agent_refs
-        for host_ref, agent_refs in agents_by_host.items()
-        if host_filter.matches(HostAddress(host=host_ref.host_name, provider=host_ref.provider_name))
-    }
-    if not filtered:
-        raise UserInputError(f"No host found matching: {host_filter}")
-    return filtered
 
 
 def ensure_host_started_and_resolve_agent(

--- a/libs/mngr/imbue/mngr/cli/agent_utils_test.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils_test.py
@@ -1,17 +1,28 @@
+from pathlib import Path
+from typing import cast
+
 import pytest
 
+from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import filter_agents_by_host
 from imbue.mngr.cli.agent_utils import select_agent_interactively_with_host
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
+from imbue.mngr.providers.local.instance import LocalProviderInstance
 
 
 def _make_discovered_host(
@@ -84,3 +95,86 @@ def test_select_agent_interactively_raises_when_no_agents(
     """With a fresh context (no hosts or agents), raises UserInputError."""
     with pytest.raises(UserInputError, match="No agents found"):
         select_agent_interactively_with_host(temp_mngr_ctx)
+
+
+# =============================================================================
+# ensure_*_started helpers
+# =============================================================================
+
+
+def _create_stopped_agent_with_ref(
+    local_provider: LocalProviderInstance,
+    temp_work_dir: Path,
+    agent_name: AgentName,
+    command: CommandString,
+) -> tuple[OnlineHostInterface, DiscoveredHost, DiscoveredAgent]:
+    """Create an agent, stop it, and return the host plus discovered refs."""
+    local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
+
+    agent = local_host.create_agent_state(
+        work_dir_path=temp_work_dir,
+        options=CreateAgentOptions(
+            agent_type=AgentTypeName("generic"),
+            name=agent_name,
+            command=command,
+        ),
+    )
+
+    # Stop the agent so it's in STOPPED state
+    local_host.stop_agents([agent.id])
+
+    host_ref = DiscoveredHost(
+        provider_name=ProviderInstanceName("local"),
+        host_id=local_host.id,
+        host_name=local_host.get_name(),
+    )
+    agent_ref = DiscoveredAgent(
+        agent_id=agent.id,
+        agent_name=agent.name,
+        host_id=local_host.id,
+        provider_name=ProviderInstanceName("local"),
+    )
+    return local_host, host_ref, agent_ref
+
+
+@pytest.mark.tmux
+def test_ensure_host_started_and_resolve_agent_succeeds_for_stopped_agent(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    temp_work_dir: Path,
+) -> None:
+    """ensure_host_started_and_resolve_agent does not check the agent's lifecycle."""
+    agent_name = AgentName("stopped-resolve-test-agent")
+    local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
+        local_provider, temp_work_dir, agent_name, CommandString("sleep 47293")
+    )
+
+    found_agent, found_host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=False,
+        mngr_ctx=temp_mngr_ctx,
+    )
+    assert found_agent.id == agent_ref.agent_id
+    assert found_host.id == local_host.id
+
+
+@pytest.mark.tmux
+def test_ensure_host_and_agent_started_raises_for_stopped_agent_without_auto_start(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    temp_work_dir: Path,
+) -> None:
+    """ensure_host_and_agent_started raises when the agent is stopped and auto-start is disabled."""
+    agent_name = AgentName("stopped-ensure-test-agent")
+    _local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
+        local_provider, temp_work_dir, agent_name, CommandString("sleep 47294")
+    )
+
+    with pytest.raises(UserInputError, match="stopped and automatic starting is disabled"):
+        ensure_host_and_agent_started(
+            host_ref=host_ref,
+            agent_ref=agent_ref,
+            allow_auto_start=False,
+            mngr_ctx=temp_mngr_ctx,
+        )

--- a/libs/mngr/imbue/mngr/cli/agent_utils_test.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils_test.py
@@ -6,84 +6,20 @@ import pytest
 from imbue.imbue_common.model_update import to_update
 from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import filter_agents_by_host
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.host import CreateAgentOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
-from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
-from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
-
-
-def _make_discovered_host(
-    provider: str = "local",
-    host_id: HostId | None = None,
-    host_name: str = "test-host",
-) -> DiscoveredHost:
-    """Create a DiscoveredHost for testing."""
-    if host_id is None:
-        host_id = HostId.generate()
-    return DiscoveredHost(
-        provider_name=ProviderInstanceName(provider),
-        host_id=host_id,
-        host_name=HostName(host_name),
-    )
-
-
-def _make_discovered_agent(
-    agent_id: AgentId,
-    agent_name: str = "test-name",
-    host_id: HostId | None = None,
-    provider: str = "local",
-) -> DiscoveredAgent:
-    """Create a DiscoveredAgent for testing."""
-    if host_id is None:
-        host_id = HostId.generate()
-    return DiscoveredAgent(
-        agent_id=agent_id,
-        agent_name=AgentName(agent_name),
-        host_id=host_id,
-        provider_name=ProviderInstanceName(provider),
-    )
-
-
-# =============================================================================
-# filter_agents_by_host tests
-# =============================================================================
-
-
-def test_filter_agents_by_host_filters_by_name() -> None:
-    """Test that filter_agents_by_host keeps only matching hosts."""
-    host_ref1 = _make_discovered_host(host_name="host-1")
-    host_ref2 = _make_discovered_host(host_name="host-2")
-    agent_ref = _make_discovered_agent(agent_id=AgentId.generate())
-    agents_by_host = {host_ref1: [agent_ref], host_ref2: []}
-
-    filtered = filter_agents_by_host(agents_by_host, HostAddress(host=HostName("host-1")))
-
-    assert len(filtered) == 1
-    assert host_ref1 in filtered
-
-
-def test_filter_agents_by_host_raises_when_no_match() -> None:
-    """Test that filter_agents_by_host raises UserInputError when no hosts match."""
-    host_ref = _make_discovered_host(host_name="host-1")
-    agents_by_host = {host_ref: []}
-
-    with pytest.raises(UserInputError, match="No host found matching"):
-        filter_agents_by_host(agents_by_host, HostAddress(host=HostName("nonexistent-host")))
-
 
 # =============================================================================
 # find_agent_by_address_or_interactively tests

--- a/libs/mngr/imbue/mngr/cli/agent_utils_test.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils_test.py
@@ -3,10 +3,11 @@ from typing import cast
 
 import pytest
 
+from imbue.imbue_common.model_update import to_update
 from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import filter_agents_by_host
-from imbue.mngr.cli.agent_utils import select_agent_interactively_with_host
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.interfaces.host import CreateAgentOptions
@@ -85,16 +86,33 @@ def test_filter_agents_by_host_raises_when_no_match() -> None:
 
 
 # =============================================================================
-# select_agent_interactively_with_host tests
+# find_agent_by_address_or_interactively tests
 # =============================================================================
 
 
-def test_select_agent_interactively_raises_when_no_agents(
+def test_find_agent_by_address_or_interactively_raises_when_no_agents_in_interactive_mode(
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """With a fresh context (no hosts or agents), raises UserInputError."""
+    """In interactive mode with no agents, raises UserInputError before showing the selector."""
+    interactive_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().is_interactive, True))
     with pytest.raises(UserInputError, match="No agents found"):
-        select_agent_interactively_with_host(temp_mngr_ctx)
+        find_agent_by_address_or_interactively(
+            mngr_ctx=interactive_ctx,
+            address=None,
+            host_filter=None,
+        )
+
+
+def test_find_agent_by_address_or_interactively_raises_when_no_address_in_non_interactive_mode(
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """In non-interactive mode without an address, raises UserInputError rather than showing a selector."""
+    with pytest.raises(UserInputError, match="not running in interactive mode"):
+        find_agent_by_address_or_interactively(
+            mngr_ctx=temp_mngr_ctx,
+            address=None,
+            host_filter=None,
+        )
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/cli/agent_utils_test.py
+++ b/libs/mngr/imbue/mngr/cli/agent_utils_test.py
@@ -4,8 +4,8 @@ from typing import cast
 import pytest
 
 from imbue.imbue_common.model_update import to_update
-from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
+from imbue.mngr.api.find import resolve_to_started_host_and_running_agent
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
@@ -92,18 +92,18 @@ def _create_stopped_agent_with_ref(
 
 
 @pytest.mark.tmux
-def test_ensure_host_started_and_resolve_agent_succeeds_for_stopped_agent(
+def test_resolve_to_started_host_and_agent_succeeds_for_stopped_agent(
     local_provider: LocalProviderInstance,
     temp_mngr_ctx: MngrContext,
     temp_work_dir: Path,
 ) -> None:
-    """ensure_host_started_and_resolve_agent does not check the agent's lifecycle."""
+    """resolve_to_started_host_and_agent does not check the agent's lifecycle."""
     agent_name = AgentName("stopped-resolve-test-agent")
     local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
         local_provider, temp_work_dir, agent_name, CommandString("sleep 47293")
     )
 
-    found_agent, found_host = ensure_host_started_and_resolve_agent(
+    found_agent, found_host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=False,
@@ -114,19 +114,19 @@ def test_ensure_host_started_and_resolve_agent_succeeds_for_stopped_agent(
 
 
 @pytest.mark.tmux
-def test_ensure_host_and_agent_started_raises_for_stopped_agent_without_auto_start(
+def test_resolve_to_started_host_and_running_agent_raises_for_stopped_agent_without_auto_start(
     local_provider: LocalProviderInstance,
     temp_mngr_ctx: MngrContext,
     temp_work_dir: Path,
 ) -> None:
-    """ensure_host_and_agent_started raises when the agent is stopped and auto-start is disabled."""
+    """resolve_to_started_host_and_running_agent raises when the agent is stopped and auto-start is disabled."""
     agent_name = AgentName("stopped-ensure-test-agent")
     _local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
         local_provider, temp_work_dir, agent_name, CommandString("sleep 47294")
     )
 
     with pytest.raises(UserInputError, match="stopped and automatic starting is disabled"):
-        ensure_host_and_agent_started(
+        resolve_to_started_host_and_running_agent(
             host_ref=host_ref,
             agent_ref=agent_ref,
             allow_auto_start=False,

--- a/libs/mngr/imbue/mngr/cli/capture.py
+++ b/libs/mngr/imbue/mngr/cli/capture.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
-from imbue.mngr.cli.agent_utils import find_agent_for_command
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
@@ -48,15 +48,11 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
         command_class=CaptureCliOptions,
     )
 
-    result = find_agent_for_command(
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
         mngr_ctx=mngr_ctx,
         address=opts.agent,
         host_filter=None,
     )
-    if result is None:
-        return
-
-    host_ref, agent_ref = result
     agent, _host = ensure_host_and_agent_started(
         host_ref=host_ref,
         agent_ref=agent_ref,

--- a/libs/mngr/imbue/mngr/cli/capture.py
+++ b/libs/mngr/imbue/mngr/cli/capture.py
@@ -5,8 +5,8 @@ import click
 from click_option_group import optgroup
 from loguru import logger
 
+from imbue.mngr.api.find import resolve_to_started_host_and_running_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -53,7 +53,7 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
         address=opts.agent,
         host_filter=None,
     )
-    agent, _host = ensure_host_and_agent_started(
+    agent, _host = resolve_to_started_host_and_running_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/capture.py
+++ b/libs/mngr/imbue/mngr/cli/capture.py
@@ -6,6 +6,7 @@ from click_option_group import optgroup
 from loguru import logger
 
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
+from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -30,7 +31,7 @@ class CaptureCliOptions(CommonCliOptions):
     "--start/--no-start",
     default=True,
     show_default=True,
-    help="Automatically start the host/agent if stopped",
+    help="Automatically start the host and agent if offline/stopped",
 )
 @optgroup.option(
     "--full/--no-full",
@@ -51,12 +52,17 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
         mngr_ctx=mngr_ctx,
         address=opts.agent,
         host_filter=None,
-        is_start_desired=opts.start,
     )
     if result is None:
         return
 
-    agent, _host = result
+    host_ref, agent_ref = result
+    agent, _host = ensure_host_and_agent_started(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     logger.debug("Capturing pane content for agent: {}", agent.name)
     content = agent.capture_pane_content(include_scrollback=opts.full)

--- a/libs/mngr/imbue/mngr/cli/cleanup.py
+++ b/libs/mngr/imbue/mngr/cli/cleanup.py
@@ -22,11 +22,11 @@ from imbue.imbue_common.pure import pure
 from imbue.mngr.api.cleanup import execute_cleanup
 from imbue.mngr.api.cleanup import find_agents_for_cleanup
 from imbue.mngr.api.data_types import CleanupResult
+from imbue.mngr.cli.agent_selector import build_status_text
+from imbue.mngr.cli.agent_selector import filter_agents
+from imbue.mngr.cli.agent_selector import handle_search_key
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
-from imbue.mngr.cli.connect import build_status_text
-from imbue.mngr.cli.connect import filter_agents
-from imbue.mngr.cli.connect import handle_search_key
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -1,28 +1,17 @@
-import time
 from typing import Any
 
 import click
 from click_option_group import optgroup
 from loguru import logger
-from pydantic import ConfigDict
-from urwid.event_loop.abstract_loop import ExitMainLoop
-from urwid.event_loop.main_loop import MainLoop
-from urwid.widget.attr_map import AttrMap
-from urwid.widget.divider import Divider
-from urwid.widget.frame import Frame
-from urwid.widget.listbox import ListBox
-from urwid.widget.listbox import SimpleFocusListWalker
-from urwid.widget.pile import Pile
-from urwid.widget.text import Text
-from urwid.widget.wimp import SelectableIcon
 
-from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.list import list_agents
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
+from imbue.mngr.cli.agent_selector import select_agent_interactively
+from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
@@ -30,15 +19,10 @@ from imbue.mngr.cli.filter_opts import add_agent_filter_options
 from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
-from imbue.mngr.cli.urwid_utils import create_urwid_screen_preserving_terminal
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
-from imbue.mngr.interfaces.agent import AgentInterface
-from imbue.mngr.interfaces.data_types import AgentDetails
-from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentAddress
-from imbue.mngr.primitives import AgentLifecycleState
 
 
 class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
@@ -55,272 +39,6 @@ class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
     reconnect: bool
     session_command: str | None
     allow_unknown_host: bool
-
-
-@pure
-def filter_agents(
-    agents: list[AgentDetails],
-    hide_stopped: bool,
-    search_query: str,
-) -> list[AgentDetails]:
-    """Filter agents by stopped state and search query."""
-    result = agents
-
-    if hide_stopped:
-        result = [a for a in result if a.state != AgentLifecycleState.STOPPED]
-
-    if search_query:
-        query_lower = search_query.lower()
-        result = [a for a in result if query_lower in str(a.name).lower()]
-
-    return result
-
-
-def build_status_text(
-    search_query: str,
-    hide_stopped: bool,
-) -> str:
-    """Build the status bar text for the agent selector."""
-    parts = ["Status: Ready"]
-
-    if search_query:
-        parts.append(f"Search: {search_query}")
-    else:
-        parts.append("Type to search")
-
-    if hide_stopped:
-        parts.append("Filter: Hiding stopped")
-    else:
-        parts.append("Filter: All agents")
-
-    return " | ".join(parts)
-
-
-def handle_search_key(
-    key: str,
-    is_printable: bool,
-    character: str | None,
-    current_query: str,
-) -> tuple[str, bool]:
-    """Handle a key press for typeahead search. Returns (new_query, should_refresh)."""
-    if key == "backspace":
-        if current_query:
-            return current_query[:-1], True
-        else:
-            return current_query, False
-    elif is_printable and character:
-        return current_query + character, True
-    else:
-        return current_query, False
-
-
-def _create_selectable_agent_item(agent: AgentDetails, name_width: int, state_width: int) -> AttrMap:
-    """Create a selectable list item representing an agent as a table row.
-
-    Uses SelectableIcon instead of Text so that ListBox can navigate between items.
-    urwid.Text is not selectable, which prevents ListBox arrow key navigation.
-    """
-    # Pad the name and state to their column widths for proper alignment
-    name_padded = str(agent.name).ljust(name_width)
-    state_padded = agent.state.value.ljust(state_width)
-    host_str = str(agent.host.name)
-
-    # Create a single SelectableIcon with the full formatted row
-    # This ensures the entire row is selectable as one unit
-    display_text = f"{name_padded}  {state_padded}  {host_str}"
-    selectable_item = SelectableIcon(display_text, cursor_position=0)
-
-    return AttrMap(selectable_item, None, focus_map="reversed")
-
-
-class AgentSelectorState(MutableModel):
-    """Mutable state for the agent selector UI."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    agents: list[AgentDetails]
-    filtered_agents: list[AgentDetails] = []
-    list_walker: Any
-    status_text: Any
-    result: AgentDetails | None = None
-    hide_stopped: bool = False
-    search_query: str = ""
-    last_ctrl_c_time: float = 0.0
-    name_width: int = 0
-    state_width: int = 0
-
-
-def _refresh_agent_list(state: AgentSelectorState) -> None:
-    """Refresh the agent list view with current filter settings."""
-    state.filtered_agents = filter_agents(state.agents, state.hide_stopped, state.search_query)
-
-    state.list_walker.clear()
-    for agent in state.filtered_agents:
-        state.list_walker.append(_create_selectable_agent_item(agent, state.name_width, state.state_width))
-
-    if state.list_walker:
-        state.list_walker.set_focus(0)
-
-    state.status_text.set_text(build_status_text(state.search_query, state.hide_stopped))
-
-
-def _handle_selector_input(state: AgentSelectorState, key: str) -> bool:
-    """Handle keyboard input for the agent selector. Returns True if handled, False to pass through."""
-    if key == "ctrl r":
-        state.hide_stopped = not state.hide_stopped
-        _refresh_agent_list(state)
-        return True
-
-    if key == "ctrl c":
-        current_time = time.time()
-        if state.search_query:
-            # First Ctrl-c clears the search query
-            state.search_query = ""
-            state.last_ctrl_c_time = current_time
-            _refresh_agent_list(state)
-            return True
-        elif current_time - state.last_ctrl_c_time < 0.5:
-            # Second Ctrl-c within 500ms exits
-            raise ExitMainLoop()
-        else:
-            # Single Ctrl-c with no query - record time and wait for potential second
-            state.last_ctrl_c_time = current_time
-            return True
-
-    if key == "enter":
-        if state.list_walker and state.filtered_agents:
-            _, focus_index = state.list_walker.get_focus()
-            if focus_index is not None and 0 <= focus_index < len(state.filtered_agents):
-                state.result = state.filtered_agents[focus_index]
-        raise ExitMainLoop()
-
-    # Let arrow keys pass through to the ListBox for navigation
-    if key in ("up", "down", "page up", "page down", "home", "end"):
-        return False
-
-    is_printable = len(key) == 1 and key.isprintable()
-    character = key if is_printable else None
-
-    new_query, should_refresh = handle_search_key(
-        key=key,
-        is_printable=is_printable,
-        character=character,
-        current_query=state.search_query,
-    )
-
-    if should_refresh:
-        state.search_query = new_query
-        _refresh_agent_list(state)
-        return True
-
-    return False
-
-
-class SelectorInputHandler(MutableModel):
-    """Callable input handler for urwid MainLoop."""
-
-    state: AgentSelectorState
-
-    def __call__(self, key: str | tuple[str, int, int, int]) -> bool | None:
-        """Handle keyboard input. Returns True if handled, None to pass through."""
-        if isinstance(key, tuple):
-            return None
-        handled = _handle_selector_input(self.state, key)
-        return True if handled else None
-
-
-def _run_agent_selector(agents: list[AgentDetails]) -> AgentDetails | None:
-    """Run the agent selector UI and return the selected agent, or None if cancelled."""
-    # Calculate column widths based on content
-    name_width = max((len(str(a.name)) for a in agents), default=10)
-    state_width = max((len(a.state.value) for a in agents), default=7)
-
-    # Cap widths at reasonable maximums
-    name_width = min(name_width, 40)
-    state_width = min(state_width, 15)
-
-    list_walker: SimpleFocusListWalker[AttrMap] = SimpleFocusListWalker([])
-    listbox = ListBox(list_walker)
-
-    status_text = Text(build_status_text("", False))
-    status_bar = AttrMap(status_text, "status")
-
-    state = AgentSelectorState(
-        agents=agents,
-        list_walker=list_walker,
-        status_text=status_text,
-        name_width=name_width,
-        state_width=state_width,
-    )
-
-    instructions_text = (
-        "Instructions:\n"
-        "  Type - Search agents by name\n"
-        "  Up/Down - Navigate the list\n"
-        "  Enter - Select an agent\n"
-        "  Backspace - Clear search character\n"
-        "  Ctrl+C - Clear search (twice to quit)\n"
-        "  Ctrl+R - Toggle hiding stopped agents"
-    )
-    instructions = Text(instructions_text)
-
-    # Create table header matching the SelectableIcon format in list items
-    header_text = f"{'NAME'.ljust(name_width)}  {'STATE'.ljust(state_width)}  HOST"
-    header_row = AttrMap(Text(("table_header", header_text)), "table_header")
-
-    _refresh_agent_list(state)
-
-    header = Pile(
-        [
-            AttrMap(Text("Agent Selector", align="center"), "header"),
-            Divider(),
-            instructions,
-            Divider(),
-            header_row,
-            Divider("-"),
-        ]
-    )
-
-    footer = Pile(
-        [
-            Divider(),
-            status_bar,
-        ]
-    )
-
-    frame = Frame(
-        body=listbox,
-        header=header,
-        footer=footer,
-    )
-
-    palette = [
-        ("header", "white", "dark blue"),
-        ("status", "white", "dark blue"),
-        ("reversed", "standout", ""),
-        ("table_header", "bold", ""),
-    ]
-
-    input_handler = SelectorInputHandler(state=state)
-
-    with create_urwid_screen_preserving_terminal() as screen:
-        loop = MainLoop(
-            frame,
-            palette=palette,
-            unhandled_input=input_handler,
-            screen=screen,
-        )
-        loop.run()
-
-    return state.result
-
-
-def select_agent_interactively(agents: list[AgentDetails]) -> AgentDetails | None:
-    """Show an interactive UI to select an agent. Returns None if cancelled."""
-    if not agents:
-        return None
-
-    return _run_agent_selector(agents)
 
 
 @pure
@@ -345,7 +63,7 @@ def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) ->
     "--start/--no-start",
     default=True,
     show_default=True,
-    help="Automatically start the agent if stopped",
+    help="Automatically start the host and agent if offline/stopped",
 )
 @optgroup.group("Options")
 @optgroup.option(
@@ -384,38 +102,8 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
 
     logger.info("Finding agent...")
 
-    agent: AgentInterface
-    host: OnlineHostInterface
-
     if opts.agent is not None:
-        agent, host = find_one_agent(
-            opts.agent,
-            mngr_ctx,
-            is_start_desired=opts.start,
-        )
-    elif not mngr_ctx.is_interactive:
-        # Default to most recently created agent when running non-interactively
-        include_filters, exclude_filters = build_agent_filter_cel(
-            opts, mngr_ctx.concurrency_group, project_root=mngr_ctx.project_root
-        )
-        list_result = list_agents(
-            mngr_ctx,
-            is_streaming=False,
-            include_filters=include_filters,
-            exclude_filters=exclude_filters,
-        )
-        if not list_result.agents:
-            raise UserInputError("No agents found")
-
-        # Sort by create_time descending to get most recent first
-        sorted_agents = sorted(list_result.agents, key=lambda a: a.create_time, reverse=True)
-        most_recent = sorted_agents[0]
-        logger.info("No agent specified, connecting to most recently created: {}", most_recent.name)
-        agent, host = find_one_agent(
-            most_recent.address,
-            mngr_ctx,
-            is_start_desired=opts.start,
-        )
+        host_ref, agent_ref = find_one_agent(opts.agent, mngr_ctx)
     else:
         include_filters, exclude_filters = build_agent_filter_cel(
             opts, mngr_ctx.concurrency_group, project_root=mngr_ctx.project_root
@@ -429,16 +117,25 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
         if not list_result.agents:
             raise UserInputError("No agents found")
 
-        selected = select_agent_interactively(list_result.agents)
-        if selected is None:
-            logger.info("No agent selected")
-            return
+        if not mngr_ctx.is_interactive:
+            # Default to most recently created agent when running non-interactively
+            sorted_agents = sorted(list_result.agents, key=lambda a: a.create_time, reverse=True)
+            most_recent = sorted_agents[0]
+            logger.info("No agent specified, connecting to most recently created: {}", most_recent.name)
+            host_ref, agent_ref = find_one_agent(most_recent.address, mngr_ctx)
+        else:
+            selected = select_agent_interactively(list_result.agents)
+            if selected is None:
+                logger.info("No agent selected")
+                return
+            host_ref, agent_ref = find_one_agent(selected.address, mngr_ctx)
 
-        agent, host = find_one_agent(
-            selected.address,
-            mngr_ctx,
-            is_start_desired=opts.start,
-        )
+    agent, host = ensure_host_and_agent_started(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     # Build connection options
     connection_opts = _build_connection_options(opts, mngr_ctx)

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -4,7 +4,6 @@ import click
 from click_option_group import optgroup
 from loguru import logger
 
-from imbue.imbue_common.pure import pure
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
@@ -18,7 +17,6 @@ from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.config.data_types import CommonCliOptions
-from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentAddress
 
 
@@ -36,18 +34,6 @@ class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
     reconnect: bool
     session_command: str | None
     allow_unknown_host: bool
-
-
-@pure
-def _build_connection_options(opts: ConnectCliOptions, mngr_ctx: MngrContext) -> ConnectionOptions:
-    """Build ConnectionOptions from CLI options and config."""
-    return ConnectionOptions(
-        is_reconnect=opts.reconnect,
-        retry_count=mngr_ctx.config.retry.connect_retry_times,
-        retry_delay=mngr_ctx.config.retry.connect_retry_delay,
-        session_command=opts.session_command,
-        is_unknown_host_allowed=opts.allow_unknown_host,
-    )
 
 
 @click.command()
@@ -118,7 +104,13 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
     )
 
     # Build connection options
-    connection_opts = _build_connection_options(opts, mngr_ctx)
+    connection_opts = ConnectionOptions(
+        is_reconnect=opts.reconnect,
+        retry_count=mngr_ctx.config.retry.connect_retry_times,
+        retry_delay=mngr_ctx.config.retry.connect_retry_delay,
+        session_command=opts.session_command,
+        is_unknown_host_allowed=opts.allow_unknown_host,
+    )
 
     logger.info("Connecting to agent: {}", agent.name)
     connect_to_agent(agent, host, mngr_ctx, connection_opts)

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -7,11 +7,9 @@ from loguru import logger
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.data_types import ConnectionOptions
-from imbue.mngr.api.find import find_one_agent
-from imbue.mngr.api.list import list_agents
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.agent_selector import select_agent_interactively
 from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.filter_opts import AgentFilterCliOptions
@@ -21,7 +19,6 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 
 
@@ -30,8 +27,8 @@ class ConnectCliOptions(AgentFilterCliOptions, CommonCliOptions):
 
     Inherits common options from CommonCliOptions and the shared agent filter
     flags from AgentFilterCliOptions. Filter flags only narrow the candidate
-    pool when no explicit agent is given (interactive selector and the
-    non-interactive most-recent fallback); they are ignored otherwise.
+    pool of the interactive selector; they are ignored when an explicit
+    agent is given.
     """
 
     agent: AgentAddress | None
@@ -102,33 +99,16 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
 
     logger.info("Finding agent...")
 
-    if opts.agent is not None:
-        host_ref, agent_ref = find_one_agent(opts.agent, mngr_ctx)
-    else:
-        include_filters, exclude_filters = build_agent_filter_cel(
-            opts, mngr_ctx.concurrency_group, project_root=mngr_ctx.project_root
-        )
-        list_result = list_agents(
-            mngr_ctx,
-            is_streaming=False,
-            include_filters=include_filters,
-            exclude_filters=exclude_filters,
-        )
-        if not list_result.agents:
-            raise UserInputError("No agents found")
-
-        if not mngr_ctx.is_interactive:
-            # Default to most recently created agent when running non-interactively
-            sorted_agents = sorted(list_result.agents, key=lambda a: a.create_time, reverse=True)
-            most_recent = sorted_agents[0]
-            logger.info("No agent specified, connecting to most recently created: {}", most_recent.name)
-            host_ref, agent_ref = find_one_agent(most_recent.address, mngr_ctx)
-        else:
-            selected = select_agent_interactively(list_result.agents)
-            if selected is None:
-                logger.info("No agent selected")
-                return
-            host_ref, agent_ref = find_one_agent(selected.address, mngr_ctx)
+    include_filters, exclude_filters = build_agent_filter_cel(
+        opts, mngr_ctx.concurrency_group, project_root=mngr_ctx.project_root
+    )
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
+        mngr_ctx=mngr_ctx,
+        address=opts.agent,
+        host_filter=None,
+        include_filters=include_filters,
+        exclude_filters=exclude_filters,
+    )
 
     agent, host = ensure_host_and_agent_started(
         host_ref=host_ref,
@@ -161,10 +141,9 @@ The agent can be specified as a positional argument or via --agent:
   mngr connect --agent my-agent
 
 Filter flags (--include/--exclude plus aliases like --running, --project,
---label, ...) narrow the candidate pool used by the interactive selector
-and the non-interactive most-recent fallback. They are ignored when an
-explicit agent is given. See `mngr list --help` for the full filter
-reference; the same flags work identically here.""",
+--label, ...) narrow the candidate pool of the interactive selector.
+They are ignored when an explicit agent is given. See `mngr list --help`
+for the full filter reference; the same flags work identically here.""",
     aliases=("conn",),
     examples=(
         ("Connect to an agent by name", "mngr connect my-agent"),

--- a/libs/mngr/imbue/mngr/cli/connect.py
+++ b/libs/mngr/imbue/mngr/cli/connect.py
@@ -6,8 +6,8 @@ from loguru import logger
 
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.data_types import ConnectionOptions
+from imbue.mngr.api.find import resolve_to_started_host_and_running_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -96,7 +96,7 @@ def connect(ctx: click.Context, **kwargs: Any) -> None:
         exclude_filters=exclude_filters,
     )
 
-    agent, host = ensure_host_and_agent_started(
+    agent, host = resolve_to_started_host_and_running_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/connect_test.py
+++ b/libs/mngr/imbue/mngr/cli/connect_test.py
@@ -4,8 +4,6 @@ from imbue.mngr.cli.agent_selector import build_status_text
 from imbue.mngr.cli.agent_selector import filter_agents
 from imbue.mngr.cli.agent_selector import handle_search_key
 from imbue.mngr.cli.connect import ConnectCliOptions
-from imbue.mngr.cli.connect import _build_connection_options
-from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentName
@@ -192,37 +190,6 @@ def test_handle_search_key_printable_but_no_character() -> None:
     new_query, should_refresh = handle_search_key("tab", True, None, "test")
     assert new_query == "test"
     assert should_refresh is False
-
-
-# =============================================================================
-# Tests for _build_connection_options
-# =============================================================================
-
-
-def test_build_connection_options_default_values(temp_mngr_ctx: MngrContext) -> None:
-    """_build_connection_options should create ConnectionOptions from CLI options and config."""
-    opts = _make_connect_opts()
-    conn_opts = _build_connection_options(opts, temp_mngr_ctx)
-    assert conn_opts.is_reconnect is True
-    assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
-    assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert conn_opts.session_command is None
-    assert conn_opts.is_unknown_host_allowed is False
-
-
-def test_build_connection_options_custom_values(temp_mngr_ctx: MngrContext) -> None:
-    """_build_connection_options should map custom CLI values correctly."""
-    opts = _make_connect_opts(
-        reconnect=False,
-        session_command="ssh user@host",
-        allow_unknown_host=True,
-    )
-    conn_opts = _build_connection_options(opts, temp_mngr_ctx)
-    assert conn_opts.is_reconnect is False
-    assert conn_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
-    assert conn_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert conn_opts.session_command == "ssh user@host"
-    assert conn_opts.is_unknown_host_allowed is True
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/cli/connect_test.py
+++ b/libs/mngr/imbue/mngr/cli/connect_test.py
@@ -1,10 +1,10 @@
 """Unit tests for the connect CLI command."""
 
+from imbue.mngr.cli.agent_selector import build_status_text
+from imbue.mngr.cli.agent_selector import filter_agents
+from imbue.mngr.cli.agent_selector import handle_search_key
 from imbue.mngr.cli.connect import ConnectCliOptions
 from imbue.mngr.cli.connect import _build_connection_options
-from imbue.mngr.cli.connect import build_status_text
-from imbue.mngr.cli.connect import filter_agents
-from imbue.mngr.cli.connect import handle_search_key
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentLifecycleState

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -24,7 +24,7 @@ from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.agents.agent_registry import list_available_agent_types
-from imbue.mngr.api.address_parsers import parse_hosted_location
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.connect import resolve_connect_command
 from imbue.mngr.api.connect import run_connect_command
@@ -32,11 +32,11 @@ from imbue.mngr.api.create import create as api_create
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import ResolvedHostedLocation
+from imbue.mngr.api.find import ResolvedHostLocationAddress
 from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import get_host_from_list_by_id
-from imbue.mngr.api.find import resolve_hosted_location
+from imbue.mngr.api.find import resolve_host_location_address
 from imbue.mngr.api.gc import register_generated_source_dir
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.cli.address_params import NEW_AGENT_LOCATION
@@ -701,7 +701,9 @@ class _CreateSetup(FrozenModel):
     )
     editor_session: EditorSession | None = Field(default=None, description="Editor session for --edit-message")
     agent_and_host_loader: _CachedAgentHostLoader = Field(description="Lazy loader for agents grouped by host")
-    resolved_source: ResolvedHostedLocation = Field(description="Resolved source location and optional source agent")
+    resolved_source: ResolvedHostLocationAddress = Field(
+        description="Resolved source location and optional source agent"
+    )
     auto_labels: _AutoLabels = Field(description="Auto-derived labels for the new agent")
     host_lifecycle: HostLifecycleOptions = Field(description="Host lifecycle options")
     plugin_cli_params: dict[str, Any] = Field(
@@ -1129,7 +1131,7 @@ def _get_source_remote_url(source_location: HostLocation) -> str | None:
 
 
 def _parse_project_name(
-    resolved_source: ResolvedHostedLocation,
+    resolved_source: ResolvedHostLocationAddress,
     opts: CreateCliOptions,
     remote_url: str | None,
 ) -> str:
@@ -1241,7 +1243,7 @@ def _resolve_source_location(
     mngr_ctx: MngrContext,
     *,
     is_start_desired: bool,
-) -> ResolvedHostedLocation:
+) -> ResolvedHostLocationAddress:
     """Resolve the source location and optionally the source agent ID and labels."""
     if opts.source is None:
         # No --from specified: default to git root
@@ -1257,7 +1259,7 @@ def _resolve_source_location(
         provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
         host = provider.get_host(HostName(LOCAL_HOST_NAME))
         online_host, _ = ensure_host_started(host, is_start_desired=is_start_desired, provider=provider)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=Path(source_path)))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=Path(source_path)))
 
     # Git URL: clone to a managed directory and treat as a local path
     if is_git_url(opts.source):
@@ -1272,10 +1274,10 @@ def _resolve_source_location(
         name_hint = pick_agent_name_hint(positional_hint, name_hint_arg, parse_project_name_from_url(opts.source))
         cloned_path = clone_git_url_to_managed_dir(opts.source, clones_base, name_hint, mngr_ctx.concurrency_group)
         register_generated_source_dir(online_host, cloned_path)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=cloned_path))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=cloned_path))
 
     # Parse the --from string once
-    parsed = parse_hosted_location(opts.source)
+    parsed = parse_host_location_address(opts.source)
 
     # When --from is just a local path (no agent or host component),
     # resolve it locally without loading all providers. Loading all
@@ -1287,11 +1289,11 @@ def _resolve_source_location(
         provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
         host = provider.get_host(HostName(LOCAL_HOST_NAME))
         online_host, _ = ensure_host_started(host, is_start_desired=is_start_desired, provider=provider)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=Path(source_path)))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=Path(source_path)))
 
     # Need full resolution across providers
     agents_by_host = agent_and_host_loader()
-    return resolve_hosted_location(
+    return resolve_host_location_address(
         parsed,
         agents_by_host,
         mngr_ctx,

--- a/libs/mngr/imbue/mngr/cli/create_test.py
+++ b/libs/mngr/imbue/mngr/cli/create_test.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from imbue.imbue_common.model_update import to_update
 from imbue.mngr.api.address_parsers import parse_new_agent_location
-from imbue.mngr.api.find import ResolvedHostedLocation
+from imbue.mngr.api.find import ResolvedHostLocationAddress
 from imbue.mngr.cli.create import _AutoLabels
 from imbue.mngr.cli.create import _CreateCommand
 from imbue.mngr.cli.create import _RECOVERED_MESSAGE_FILENAME
@@ -568,7 +568,7 @@ def test_parse_project_name_returns_explicit_project(
 ) -> None:
     """When --project is specified, return it directly."""
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=temp_work_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=temp_work_dir))
     opts = default_create_cli_opts.model_copy_update(
         to_update(default_create_cli_opts.field_ref().project, "explicit-project"),
     )
@@ -587,7 +587,7 @@ def test_parse_project_name_treats_dot_as_default_derivation(
     some_dir = tmp_path / "some-source"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
     opts = default_create_cli_opts.model_copy_update(
         to_update(default_create_cli_opts.field_ref().project, "."),
     )
@@ -606,7 +606,7 @@ def test_parse_project_name_inherits_from_source_agent(
     some_dir = tmp_path / "local-folder"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(
+    resolved = ResolvedHostLocationAddress(
         location=HostLocation(host=local_host, path=some_dir),
         agent=DiscoveredAgent(
             host_id=local_host.id,
@@ -631,7 +631,7 @@ def test_parse_project_name_derives_from_remote_url(
     some_dir = tmp_path / "local-folder"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
 
     result = _parse_project_name(resolved, default_create_cli_opts, remote_url="https://github.com/owner/my-repo.git")
 
@@ -647,7 +647,7 @@ def test_parse_project_name_falls_back_to_folder_name(
     some_dir = tmp_path / "some-project"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
 
     result = _parse_project_name(resolved, default_create_cli_opts, remote_url=None)
 

--- a/libs/mngr/imbue/mngr/cli/exec.py
+++ b/libs/mngr/imbue/mngr/cli/exec.py
@@ -79,7 +79,7 @@ class ExecCliOptions(CommonCliOptions):
     "--start/--no-start",
     default=True,
     show_default=True,
-    help="Automatically start the host/agent if stopped",
+    help="Automatically start the host if offline (the agent does not need to be running)",
 )
 @optgroup.group("Error Handling")
 @optgroup.option(

--- a/libs/mngr/imbue/mngr/cli/provision.py
+++ b/libs/mngr/imbue/mngr/cli/provision.py
@@ -6,10 +6,10 @@ import click
 from click_option_group import optgroup
 from loguru import logger
 
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.provision import provision_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOST_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -162,7 +162,7 @@ def provision(ctx: click.Context, **kwargs: Any) -> None:
         address=address,
         host_filter=None,
     )
-    agent, host = ensure_host_started_and_resolve_agent(
+    agent, host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/provision.py
+++ b/libs/mngr/imbue/mngr/cli/provision.py
@@ -9,6 +9,7 @@ from loguru import logger
 from imbue.mngr.api.provision import provision_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -37,6 +38,7 @@ class ProvisionCliOptions(CommonCliOptions):
     # Behavior options
     bootstrap: str | None
     destroy_on_fail: bool
+    start: bool
     restart: bool
     # Provisioning options
     extra_provision_command: tuple[str, ...]
@@ -87,6 +89,12 @@ def _output_result(agent_name: str, output_opts: OutputOptions) -> None:
     "destroy_on_fail",
     default=False,
     help="Destroy the host if provisioning fails [future]",
+)
+@optgroup.option(
+    "--start/--no-start",
+    default=True,
+    show_default=True,
+    help="Automatically start the host if offline (the agent does not need to be running)",
 )
 @optgroup.option(
     "--restart/--no-restart",
@@ -147,19 +155,24 @@ def provision(ctx: click.Context, **kwargs: Any) -> None:
         raise UserInputError("Cannot specify both positional agent and --agent option")
     address: AgentAddress | None = opts.agent if opts.agent is not None else opts.agent_option
 
-    # Find the agent (start the host if needed, but don't require the agent to be running)
+    # Find the agent (provision needs the host online but manages the agent's
+    # state itself via --restart, so the agent process state is not required).
     result = find_agent_for_command(
         mngr_ctx=mngr_ctx,
         address=address,
         host_filter=None,
-        is_start_desired=True,
-        skip_agent_state_check=True,
     )
     if result is None:
         logger.info("No agent selected")
         return
 
-    agent, host = result
+    host_ref, agent_ref = result
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     # Parse provisioning options
     provisioning = AgentProvisioningOptions(
@@ -194,7 +207,7 @@ def provision(ctx: click.Context, **kwargs: Any) -> None:
 CommandHelpMetadata(
     key="provision",
     one_line_description="Re-run provisioning on an existing agent [experimental]",
-    synopsis="mngr [provision|prov] [AGENT] [--agent <AGENT>] [--extra-provision-command <CMD>] [--upload-file <LOCAL:REMOTE>] [--env <KEY=VALUE>] [--env-file <FILE>] [--[no-]restart]",
+    synopsis="mngr [provision|prov] [AGENT] [--agent <AGENT>] [--extra-provision-command <CMD>] [--upload-file <LOCAL:REMOTE>] [--env <KEY=VALUE>] [--env-file <FILE>] [--start/--no-start] [--[no-]restart]",
     description="""This re-runs the provisioning steps (plugin lifecycle hooks, file transfers,
 custom commands, env vars) on an agent that has already been created. Useful for
 syncing configuration, authentication, and installing additional packages. Most

--- a/libs/mngr/imbue/mngr/cli/provision.py
+++ b/libs/mngr/imbue/mngr/cli/provision.py
@@ -10,7 +10,7 @@ from imbue.mngr.api.provision import provision_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOST_ADDRESS
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import find_agent_for_command
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.env_utils import resolve_env_vars
@@ -157,16 +157,11 @@ def provision(ctx: click.Context, **kwargs: Any) -> None:
 
     # Find the agent (provision needs the host online but manages the agent's
     # state itself via --restart, so the agent process state is not required).
-    result = find_agent_for_command(
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
         mngr_ctx=mngr_ctx,
         address=address,
         host_filter=None,
     )
-    if result is None:
-        logger.info("No agent selected")
-        return
-
-    host_ref, agent_ref = result
     agent, host = ensure_host_started_and_resolve_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,

--- a/libs/mngr/imbue/mngr/cli/provision_test.py
+++ b/libs/mngr/imbue/mngr/cli/provision_test.py
@@ -27,6 +27,7 @@ def test_provision_cli_options_can_be_instantiated() -> None:
         host=None,
         bootstrap=None,
         destroy_on_fail=False,
+        start=True,
         restart=True,
         extra_provision_command=(),
         upload_file=(),

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -7,8 +7,8 @@ from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.pull import pull_files
 from imbue.mngr.api.pull import pull_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -22,7 +22,7 @@ from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import UncommittedChangesMode
 
 
@@ -32,9 +32,9 @@ class PullCliOptions(CommonCliOptions):
     Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
     """
 
-    source_pos: HostedLocation | None
+    source_pos: HostLocationAddress | None
     destination_pos: str | None
-    source: HostedLocation | None
+    source: HostLocationAddress | None
     source_agent: AgentAddress | None
     source_host: HostAddress | None
     source_path: str | None
@@ -48,7 +48,7 @@ class PullCliOptions(CommonCliOptions):
     uncommitted_changes: str
     target_branch: str | None
     # Planned features (not yet implemented)
-    target: HostedLocation | None
+    target: HostLocationAddress | None
     target_agent: AgentAddress | None
     target_host: HostAddress | None
     target_path: str | None
@@ -69,13 +69,13 @@ class PullCliOptions(CommonCliOptions):
 
 
 @click.command()
-@click.argument("source_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="SOURCE")
+@click.argument("source_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="SOURCE")
 @click.argument("destination_pos", default=None, required=False, metavar="DESTINATION")
 @optgroup.group("Source Selection")
 @optgroup.option(
     "--source",
     "source",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Source specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--source-agent", type=AGENT_ADDRESS, help="Source agent address (NAME[@HOST[.PROVIDER]])")
@@ -127,7 +127,7 @@ class PullCliOptions(CommonCliOptions):
 @optgroup.group("Target (for agent-to-agent sync)")
 @optgroup.option(
     "--target",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future]",
 )
 @optgroup.option("--target-agent", type=AGENT_ADDRESS, help="Target agent address [future]")
@@ -196,7 +196,7 @@ def pull(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_source_loc: HostedLocation | None = opts.source if opts.source is not None else opts.source_pos
+    effective_source_loc: HostLocationAddress | None = opts.source if opts.source is not None else opts.source_pos
     effective_destination = opts.destination if opts.destination is not None else opts.destination_pos
 
     # Check for unsupported options

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import click
 from click_option_group import optgroup
-from loguru import logger
 
 from imbue.mngr.api.pull import pull_files
 from imbue.mngr.api.pull import pull_git
@@ -10,7 +9,7 @@ from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import find_agent_for_command
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -283,15 +282,11 @@ def pull(ctx: click.Context, **kwargs) -> None:
     destination_path = Path(effective_destination) if effective_destination else Path.cwd()
 
     # Find the agent
-    result = find_agent_for_command(
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
         mngr_ctx=mngr_ctx,
         address=source_address,
         host_filter=None,
     )
-    if result is None:
-        logger.info("No agent selected")
-        return
-    host_ref, agent_ref = result
     agent, host = ensure_host_started_and_resolve_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -9,6 +9,7 @@ from imbue.mngr.api.pull import pull_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -40,6 +41,7 @@ class PullCliOptions(CommonCliOptions):
     source_path: str | None
     destination: str | None
     dry_run: bool
+    start: bool
     stop: bool
     delete: bool
     sync_mode: str
@@ -93,6 +95,12 @@ class PullCliOptions(CommonCliOptions):
     is_flag=True,
     default=False,
     help="Show what would be transferred without actually transferring",
+)
+@optgroup.option(
+    "--start/--no-start",
+    default=True,
+    show_default=True,
+    help="Automatically start the host if offline (the agent does not need to be running)",
 )
 @optgroup.option(
     "--stop",
@@ -283,7 +291,13 @@ def pull(ctx: click.Context, **kwargs) -> None:
     if result is None:
         logger.info("No agent selected")
         return
-    agent, host = result
+    host_ref, agent_ref = result
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     emit_info(f"Pulling from agent: {agent.name}", output_opts.output_format)
 
@@ -349,7 +363,7 @@ def pull(ctx: click.Context, **kwargs) -> None:
 CommandHelpMetadata(
     key="pull",
     one_line_description="Pull files or git commits from an agent to local machine [experimental]",
-    synopsis="mngr pull [SOURCE] [DESTINATION] [--source <SOURCE>] [--source-agent <AGENT>] [--sync-mode <MODE>] [--include PATTERN] [--dry-run] [--stop]",
+    synopsis="mngr pull [SOURCE] [DESTINATION] [--source <SOURCE>] [--source-agent <AGENT>] [--sync-mode <MODE>] [--include PATTERN] [--dry-run] [--start/--no-start] [--stop]",
     description="""Syncs files or git state from an agent's working directory to a local directory.
 Default behavior uses rsync for efficient incremental file transfer.
 Use --sync-mode=git to merge git branches instead of syncing files.

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import click
 from click_option_group import optgroup
 
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.pull import pull_files
 from imbue.mngr.api.pull import pull_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -287,7 +287,7 @@ def pull(ctx: click.Context, **kwargs) -> None:
         address=source_address,
         host_filter=None,
     )
-    agent, host = ensure_host_started_and_resolve_agent(
+    agent, host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/pull_test.py
+++ b/libs/mngr/imbue/mngr/cli/pull_test.py
@@ -1,29 +1,11 @@
 """Unit tests for pull CLI command."""
 
-from pathlib import Path
-from typing import cast
-
 import pluggy
-import pytest
 from click.testing import CliRunner
 
-from imbue.mngr.api.find import materialize_agent
 from imbue.mngr.cli.pull import PullCliOptions
 from imbue.mngr.cli.pull import pull
-from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import UserInputError
-from imbue.mngr.interfaces.host import CreateAgentOptions
-from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.main import cli
-from imbue.mngr.primitives import AgentName
-from imbue.mngr.primitives import AgentTypeName
-from imbue.mngr.primitives import CommandString
-from imbue.mngr.primitives import DiscoveredAgent
-from imbue.mngr.primitives import DiscoveredHost
-from imbue.mngr.primitives import HostName
-from imbue.mngr.primitives import ProviderInstanceName
-from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
-from imbue.mngr.providers.local.instance import LocalProviderInstance
 
 
 def test_pull_cli_options_can_be_instantiated() -> None:
@@ -37,6 +19,7 @@ def test_pull_cli_options_can_be_instantiated() -> None:
         source_path=None,
         destination=None,
         dry_run=False,
+        start=True,
         stop=False,
         delete=False,
         sync_mode="files",
@@ -123,79 +106,6 @@ def test_pull_command_sync_mode_choices() -> None:
     assert "files" in result.output
     assert "git" in result.output
     assert "full" in result.output
-
-
-def _create_stopped_agent_with_ref(
-    local_provider: LocalProviderInstance,
-    temp_work_dir: Path,
-    agent_name: AgentName,
-    command: CommandString,
-) -> tuple[OnlineHostInterface, DiscoveredHost, DiscoveredAgent]:
-    """Create an agent, stop it, and return the host plus discovered refs."""
-    local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-
-    agent = local_host.create_agent_state(
-        work_dir_path=temp_work_dir,
-        options=CreateAgentOptions(
-            agent_type=AgentTypeName("generic"),
-            name=agent_name,
-            command=command,
-        ),
-    )
-
-    # Stop the agent so it's in STOPPED state
-    local_host.stop_agents([agent.id])
-
-    host_ref = DiscoveredHost(
-        provider_name=ProviderInstanceName("local"),
-        host_id=local_host.id,
-        host_name=local_host.get_name(),
-    )
-    agent_ref = DiscoveredAgent(
-        agent_id=agent.id,
-        agent_name=agent.name,
-        host_id=local_host.id,
-        provider_name=ProviderInstanceName("local"),
-    )
-    return local_host, host_ref, agent_ref
-
-
-@pytest.mark.tmux
-def test_materialize_agent_with_skip_agent_state_check_succeeds_for_stopped_agent(
-    local_provider: LocalProviderInstance,
-    temp_mngr_ctx: MngrContext,
-    temp_work_dir: Path,
-) -> None:
-    """skip_agent_state_check=True materializes a stopped agent without error."""
-    agent_name = AgentName("stopped-find-test-agent")
-    local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
-        local_provider, temp_work_dir, agent_name, CommandString("sleep 47293")
-    )
-
-    found_agent, found_host = materialize_agent(
-        host_ref,
-        agent_ref,
-        temp_mngr_ctx,
-        skip_agent_state_check=True,
-    )
-    assert found_agent.id == agent_ref.agent_id
-    assert found_host.id == local_host.id
-
-
-@pytest.mark.tmux
-def test_materialize_agent_without_skip_raises_for_stopped_agent(
-    local_provider: LocalProviderInstance,
-    temp_mngr_ctx: MngrContext,
-    temp_work_dir: Path,
-) -> None:
-    """Without skip_agent_state_check, materializing a stopped agent raises UserInputError."""
-    agent_name = AgentName("stopped-find-test-agent-2")
-    _local_host, host_ref, agent_ref = _create_stopped_agent_with_ref(
-        local_provider, temp_work_dir, agent_name, CommandString("sleep 47294")
-    )
-
-    with pytest.raises(UserInputError, match="stopped and automatic starting is disabled"):
-        materialize_agent(host_ref, agent_ref, temp_mngr_ctx)
 
 
 def test_pull_target_branch_requires_git_mode(

--- a/libs/mngr/imbue/mngr/cli/push.py
+++ b/libs/mngr/imbue/mngr/cli/push.py
@@ -7,8 +7,8 @@ from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.push import push_files
 from imbue.mngr.api.push import push_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -22,7 +22,7 @@ from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import UncommittedChangesMode
 
 
@@ -32,9 +32,9 @@ class PushCliOptions(CommonCliOptions):
     Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
     """
 
-    target_pos: HostedLocation | None
+    target_pos: HostLocationAddress | None
     source_pos: str | None
-    target: HostedLocation | None
+    target: HostLocationAddress | None
     target_agent: AgentAddress | None
     target_host: HostAddress | None
     target_path: str | None
@@ -52,13 +52,13 @@ class PushCliOptions(CommonCliOptions):
 
 
 @click.command()
-@click.argument("target_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="TARGET")
+@click.argument("target_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="TARGET")
 @click.argument("source_pos", default=None, required=False, metavar="SOURCE")
 @optgroup.group("Target Selection")
 @optgroup.option(
     "--target",
     "target",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Target specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--target-agent", type=AGENT_ADDRESS, help="Target agent address (NAME[@HOST[.PROVIDER]])")
@@ -136,7 +136,7 @@ def push(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_target_loc: HostedLocation | None = opts.target if opts.target is not None else opts.target_pos
+    effective_target_loc: HostLocationAddress | None = opts.target if opts.target is not None else opts.target_pos
     effective_source = opts.source if opts.source is not None else opts.source_pos
 
     # Check for unsupported options

--- a/libs/mngr/imbue/mngr/cli/push.py
+++ b/libs/mngr/imbue/mngr/cli/push.py
@@ -9,6 +9,7 @@ from imbue.mngr.api.push import push_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -40,6 +41,7 @@ class PushCliOptions(CommonCliOptions):
     target_path: str | None
     source: str | None
     dry_run: bool
+    start: bool
     stop: bool
     delete: bool
     sync_mode: str
@@ -71,6 +73,12 @@ class PushCliOptions(CommonCliOptions):
     is_flag=True,
     default=False,
     help="Show what would be transferred without actually transferring",
+)
+@optgroup.option(
+    "--start/--no-start",
+    default=True,
+    show_default=True,
+    help="Automatically start the host if offline (the agent does not need to be running)",
 )
 @optgroup.option(
     "--stop",
@@ -193,7 +201,13 @@ def push(ctx: click.Context, **kwargs) -> None:
     if result is None:
         logger.info("No agent selected")
         return
-    agent, host = result
+    host_ref, agent_ref = result
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     emit_info(f"Pushing to agent: {agent.name}", output_opts.output_format)
 
@@ -259,7 +273,7 @@ def push(ctx: click.Context, **kwargs) -> None:
 CommandHelpMetadata(
     key="push",
     one_line_description="Push files or git commits from local machine to an agent [experimental]",
-    synopsis="mngr push [TARGET] [SOURCE] [--target <TARGET>] [--source <DIR>] [--target-agent <AGENT>] [--sync-mode <MODE>] [--mirror] [--dry-run] [--stop]",
+    synopsis="mngr push [TARGET] [SOURCE] [--target <TARGET>] [--source <DIR>] [--target-agent <AGENT>] [--sync-mode <MODE>] [--mirror] [--dry-run] [--start/--no-start] [--stop]",
     description="""Syncs files or git state from a local directory to an agent's working directory.
 Default behavior uses rsync for efficient incremental file transfer.
 Use --sync-mode=git to push git branches instead of syncing files.

--- a/libs/mngr/imbue/mngr/cli/push.py
+++ b/libs/mngr/imbue/mngr/cli/push.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import click
 from click_option_group import optgroup
-from loguru import logger
 
 from imbue.mngr.api.push import push_files
 from imbue.mngr.api.push import push_git
@@ -10,7 +9,7 @@ from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import find_agent_for_command
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -193,15 +192,11 @@ def push(ctx: click.Context, **kwargs) -> None:
     source_path = Path(effective_source) if effective_source else Path.cwd()
 
     # Find the agent
-    result = find_agent_for_command(
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
         mngr_ctx=mngr_ctx,
         address=target_address,
         host_filter=None,
     )
-    if result is None:
-        logger.info("No agent selected")
-        return
-    host_ref, agent_ref = result
     agent, host = ensure_host_started_and_resolve_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,

--- a/libs/mngr/imbue/mngr/cli/push.py
+++ b/libs/mngr/imbue/mngr/cli/push.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import click
 from click_option_group import optgroup
 
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.push import push_files
 from imbue.mngr.api.push import push_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -197,7 +197,7 @@ def push(ctx: click.Context, **kwargs) -> None:
         address=target_address,
         host_filter=None,
     )
-    agent, host = ensure_host_started_and_resolve_agent(
+    agent, host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/push_test.py
+++ b/libs/mngr/imbue/mngr/cli/push_test.py
@@ -18,6 +18,7 @@ def test_push_cli_options_can_be_instantiated() -> None:
         target_path=None,
         source=None,
         dry_run=False,
+        start=True,
         stop=False,
         delete=False,
         sync_mode="files",

--- a/libs/mngr/imbue/mngr/cli/rename.py
+++ b/libs/mngr/imbue/mngr/cli/rename.py
@@ -5,12 +5,11 @@ import click
 from click_option_group import optgroup
 from loguru import logger
 
-from imbue.mngr.api.discover import discover_by_address
 from imbue.mngr.api.discovery_events import emit_discovery_events_for_host
-from imbue.mngr.api.find import filter_one_agent
-from imbue.mngr.api.find import materialize_agent
+from imbue.mngr.api.find import find_one_agent_and_agents_by_host
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import AGENT_NAME
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
@@ -33,6 +32,7 @@ class RenameCliOptions(CommonCliOptions):
     current: AgentAddress
     new_name: AgentName
     dry_run: bool
+    start: bool
     label: tuple[str, ...] = ()
     # Planned features (not yet implemented)
     host: bool
@@ -77,6 +77,12 @@ def _output_result(
     help="Show what would be renamed without actually renaming",
 )
 @optgroup.option(
+    "--start/--no-start",
+    default=True,
+    show_default=True,
+    help="Automatically start the host if offline (the agent does not need to be running)",
+)
+@optgroup.option(
     "--host",
     is_flag=True,
     help="Rename a host instead of an agent [future]",
@@ -116,11 +122,15 @@ def rename(ctx: click.Context, **kwargs: Any) -> None:
         labels_to_merge[key] = value
 
     # Resolve the agent (without requiring the agent process to be running).
-    # Discovery is run explicitly so the result can also drive the
-    # name-conflict check below.
-    agents_by_host, _ = discover_by_address(opts.current, mngr_ctx)
-    host_ref, agent_ref = filter_one_agent(opts.current.agent, None, agents_by_host)
-    agent, host = materialize_agent(host_ref, agent_ref, mngr_ctx, skip_agent_state_check=True)
+    # Use the sibling find function so the full discovery result is available
+    # for the name-conflict check below without a second discovery pass.
+    host_ref, agent_ref, agents_by_host = find_one_agent_and_agents_by_host(opts.current, mngr_ctx)
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=opts.start,
+        mngr_ctx=mngr_ctx,
+    )
 
     old_name = str(agent.name)
 
@@ -165,7 +175,7 @@ def rename(ctx: click.Context, **kwargs: Any) -> None:
 CommandHelpMetadata(
     key="rename",
     one_line_description="Rename an agent or host [experimental]",
-    synopsis="mngr [rename|mv] <CURRENT> <NEW-NAME> [--dry-run] [--host] [-l KEY=VALUE ...]",
+    synopsis="mngr [rename|mv] <CURRENT> <NEW-NAME> [--dry-run] [--start/--no-start] [--host] [-l KEY=VALUE ...]",
     arguments_description="- `CURRENT`: Current name or ID of the agent to rename\n- `NEW-NAME`: New name for the agent",
     description="""Updates the agent's name in its data.json and renames the tmux session
 if the agent is currently running. Git branch names are not renamed.

--- a/libs/mngr/imbue/mngr/cli/rename.py
+++ b/libs/mngr/imbue/mngr/cli/rename.py
@@ -7,9 +7,9 @@ from loguru import logger
 
 from imbue.mngr.api.discovery_events import emit_discovery_events_for_host
 from imbue.mngr.api.find import find_one_agent_and_agents_by_host
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import AGENT_NAME
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
@@ -125,7 +125,7 @@ def rename(ctx: click.Context, **kwargs: Any) -> None:
     # Use the sibling find function so the full discovery result is available
     # for the name-conflict check below without a second discovery pass.
     host_ref, agent_ref, agents_by_host = find_one_agent_and_agents_by_host(opts.current, mngr_ctx)
-    agent, host = ensure_host_started_and_resolve_agent(
+    agent, host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=opts.start,

--- a/libs/mngr/imbue/mngr/cli/rename_test.py
+++ b/libs/mngr/imbue/mngr/cli/rename_test.py
@@ -26,6 +26,7 @@ def test_rename_cli_options_parsing_creates_valid_options() -> None:
         current=AgentAddress(agent=AgentName("my-agent")),
         new_name=AgentName("new-agent"),
         dry_run=False,
+        start=True,
         host=False,
     )
     assert opts.current == AgentAddress(agent=AgentName("my-agent"))
@@ -46,6 +47,7 @@ def test_rename_cli_options_with_dry_run() -> None:
         current=AgentAddress(agent=AgentName("agent-123")),
         new_name=AgentName("renamed-agent"),
         dry_run=True,
+        start=True,
         host=False,
     )
     assert opts.current == AgentAddress(agent=AgentName("agent-123"))

--- a/libs/mngr/imbue/mngr/cli/test_agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/test_agent_utils.py
@@ -1,42 +1,36 @@
-"""Integration tests for agent_utils.
+"""Integration tests for the interactive path of find_agent_by_address_or_interactively.
 
-These tests create a real agent via the CLI, then exercise
-select_agent_interactively_with_host and find_agent_for_command end-to-end.
-The only thing monkeypatched is the urwid TUI (select_agent_interactively),
-since it requires an interactive terminal. Everything else -- list_agents,
-discover_hosts_and_agents, find_one_agent -- runs against real data on disk.
+These tests require a real agent and an interactive context. The urwid
+TUI itself is monkeypatched (it requires a real terminal), but
+list_agents and find_one_agent run against real on-disk data.
+
+Tests of the non-interactive paths and of the ensure_* helpers live in
+agent_utils_test.py as plain unit tests.
 """
 
 import time
 
-import pluggy
+import click
 import pytest
-from click.testing import CliRunner
 
-from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import find_agent_for_command
-from imbue.mngr.cli.agent_utils import select_agent_interactively_with_host
-from imbue.mngr.cli.stop import stop
+from imbue.imbue_common.model_update import to_update
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import UserInputError
-from imbue.mngr.interfaces.agent import AgentInterface
-from imbue.mngr.interfaces.host import OnlineHostInterface
-from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 
 
 @pytest.mark.tmux
-def test_select_agent_interactively_with_host_returns_selected_agent(
+def test_find_agent_by_address_or_interactively_returns_selected_agent(
     create_test_agent,
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With a real agent, returns the (DiscoveredHost, DiscoveredAgent) tuple."""
+    """With a real agent and no address, returns the refs of the agent chosen by the TUI."""
     agent_name = f"test-select-agent-{int(time.time())}"
     create_test_agent(agent_name, "sleep 564738")
+    interactive_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().is_interactive, True))
 
     # Monkeypatch only the TUI -- return the first agent from the list.
     monkeypatch.setattr(
@@ -44,107 +38,36 @@ def test_select_agent_interactively_with_host_returns_selected_agent(
         lambda agents: agents[0],
     )
 
-    result = select_agent_interactively_with_host(temp_mngr_ctx)
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
+        mngr_ctx=interactive_ctx,
+        address=None,
+        host_filter=None,
+    )
 
-    assert result is not None
-    host_ref, agent_ref = result
     assert isinstance(host_ref, DiscoveredHost)
     assert isinstance(agent_ref, DiscoveredAgent)
     assert agent_ref.agent_name == AgentName(agent_name)
 
 
 @pytest.mark.tmux
-def test_select_agent_interactively_with_host_returns_none_when_user_quits(
+def test_find_agent_by_address_or_interactively_raises_abort_when_user_quits(
     create_test_agent,
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With a real agent present, returns None when the TUI returns None (user quit)."""
+    """With a real agent present, raises click.Abort when the TUI returns None (user quit)."""
     agent_name = f"test-select-quit-{int(time.time())}"
     create_test_agent(agent_name, "sleep 564739")
+    interactive_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().is_interactive, True))
 
     monkeypatch.setattr(
         "imbue.mngr.cli.agent_utils.select_agent_interactively",
         lambda agents: None,
     )
 
-    result = select_agent_interactively_with_host(temp_mngr_ctx)
-
-    assert result is None
-
-
-@pytest.mark.tmux
-def test_find_agent_for_command_plus_resolve_finds_stopped_agent(
-    cli_runner: CliRunner,
-    create_test_agent,
-    plugin_manager: pluggy.PluginManager,
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """find_agent_for_command + ensure_host_started_and_resolve_agent works on a stopped agent.
-
-    Regression test: commands like provision and rename need the host
-    online but do not need the agent process running. Using the
-    "resolve_agent" helper instead of "ensure_host_and_agent_started"
-    leaves the agent state untouched.
-    """
-    agent_name = f"test-find-stopped-{int(time.time())}"
-    create_test_agent(agent_name, "sleep 564740")
-
-    # Stop the agent
-    stop_result = cli_runner.invoke(stop, [agent_name], obj=plugin_manager, catch_exceptions=False)
-    assert stop_result.exit_code == 0, f"Stop failed with: {stop_result.output}"
-
-    result = find_agent_for_command(
-        mngr_ctx=temp_mngr_ctx,
-        address=AgentAddress(agent=AgentName(agent_name)),
-        host_filter=None,
-    )
-
-    assert result is not None
-    host_ref, agent_ref = result
-    agent, host = ensure_host_started_and_resolve_agent(
-        host_ref=host_ref,
-        agent_ref=agent_ref,
-        allow_auto_start=True,
-        mngr_ctx=temp_mngr_ctx,
-    )
-    assert isinstance(agent, AgentInterface)
-    assert isinstance(host, OnlineHostInterface)
-    assert agent.name == AgentName(agent_name)
-
-
-@pytest.mark.tmux
-def test_ensure_host_and_agent_started_raises_for_stopped_agent_without_auto_start(
-    cli_runner: CliRunner,
-    create_test_agent,
-    plugin_manager: pluggy.PluginManager,
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """ensure_host_and_agent_started raises for a stopped agent when allow_auto_start=False.
-
-    Verifies the default behavior for commands that require the agent to
-    be running (connect, capture): a stopped agent causes UserInputError
-    when auto-start is disabled.
-    """
-    agent_name = f"test-find-stopped-err-{int(time.time())}"
-    create_test_agent(agent_name, "sleep 564741")
-
-    # Stop the agent
-    stop_result = cli_runner.invoke(stop, [agent_name], obj=plugin_manager, catch_exceptions=False)
-    assert stop_result.exit_code == 0, f"Stop failed with: {stop_result.output}"
-
-    result = find_agent_for_command(
-        mngr_ctx=temp_mngr_ctx,
-        address=AgentAddress(agent=AgentName(agent_name)),
-        host_filter=None,
-    )
-    assert result is not None
-    host_ref, agent_ref = result
-
-    with pytest.raises(UserInputError, match="stopped and automatic starting is disabled"):
-        ensure_host_and_agent_started(
-            host_ref=host_ref,
-            agent_ref=agent_ref,
-            allow_auto_start=False,
-            mngr_ctx=temp_mngr_ctx,
+    with pytest.raises(click.Abort):
+        find_agent_by_address_or_interactively(
+            mngr_ctx=interactive_ctx,
+            address=None,
+            host_filter=None,
         )

--- a/libs/mngr/imbue/mngr/cli/test_agent_utils.py
+++ b/libs/mngr/imbue/mngr/cli/test_agent_utils.py
@@ -4,8 +4,7 @@ These tests create a real agent via the CLI, then exercise
 select_agent_interactively_with_host and find_agent_for_command end-to-end.
 The only thing monkeypatched is the urwid TUI (select_agent_interactively),
 since it requires an interactive terminal. Everything else -- list_agents,
-discover_hosts_and_agents, find_one_agent, materialize_agent --
-runs against real data on disk.
+discover_hosts_and_agents, find_one_agent -- runs against real data on disk.
 """
 
 import time
@@ -14,6 +13,8 @@ import pluggy
 import pytest
 from click.testing import CliRunner
 
+from imbue.mngr.cli.agent_utils import ensure_host_and_agent_started
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.agent_utils import select_agent_interactively_with_host
 from imbue.mngr.cli.stop import stop
@@ -23,6 +24,8 @@ from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import DiscoveredAgent
+from imbue.mngr.primitives import DiscoveredHost
 
 
 @pytest.mark.tmux
@@ -31,7 +34,7 @@ def test_select_agent_interactively_with_host_returns_selected_agent(
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With a real agent, returns the (AgentInterface, OnlineHostInterface) tuple."""
+    """With a real agent, returns the (DiscoveredHost, DiscoveredAgent) tuple."""
     agent_name = f"test-select-agent-{int(time.time())}"
     create_test_agent(agent_name, "sleep 564738")
 
@@ -44,10 +47,10 @@ def test_select_agent_interactively_with_host_returns_selected_agent(
     result = select_agent_interactively_with_host(temp_mngr_ctx)
 
     assert result is not None
-    agent, host = result
-    assert isinstance(agent, AgentInterface)
-    assert isinstance(host, OnlineHostInterface)
-    assert agent.name == AgentName(agent_name)
+    host_ref, agent_ref = result
+    assert isinstance(host_ref, DiscoveredHost)
+    assert isinstance(agent_ref, DiscoveredAgent)
+    assert agent_ref.agent_name == AgentName(agent_name)
 
 
 @pytest.mark.tmux
@@ -71,17 +74,18 @@ def test_select_agent_interactively_with_host_returns_none_when_user_quits(
 
 
 @pytest.mark.tmux
-def test_find_agent_for_command_with_stopped_agent_and_skip_agent_state_check(
+def test_find_agent_for_command_plus_resolve_finds_stopped_agent(
     cli_runner: CliRunner,
     create_test_agent,
     plugin_manager: pluggy.PluginManager,
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """find_agent_for_command with skip_agent_state_check finds a stopped agent.
+    """find_agent_for_command + ensure_host_started_and_resolve_agent works on a stopped agent.
 
-    Regression test: provision needs the host online but does not need the
-    agent process running. Without skip_agent_state_check, a stopped agent
-    raises UserInputError.
+    Regression test: commands like provision and rename need the host
+    online but do not need the agent process running. Using the
+    "resolve_agent" helper instead of "ensure_host_and_agent_started"
+    leaves the agent state untouched.
     """
     agent_name = f"test-find-stopped-{int(time.time())}"
     create_test_agent(agent_name, "sleep 564740")
@@ -90,33 +94,37 @@ def test_find_agent_for_command_with_stopped_agent_and_skip_agent_state_check(
     stop_result = cli_runner.invoke(stop, [agent_name], obj=plugin_manager, catch_exceptions=False)
     assert stop_result.exit_code == 0, f"Stop failed with: {stop_result.output}"
 
-    # With skip_agent_state_check=True, should find the stopped agent
     result = find_agent_for_command(
         mngr_ctx=temp_mngr_ctx,
         address=AgentAddress(agent=AgentName(agent_name)),
         host_filter=None,
-        is_start_desired=True,
-        skip_agent_state_check=True,
     )
 
     assert result is not None
-    agent, host = result
+    host_ref, agent_ref = result
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=True,
+        mngr_ctx=temp_mngr_ctx,
+    )
     assert isinstance(agent, AgentInterface)
     assert isinstance(host, OnlineHostInterface)
     assert agent.name == AgentName(agent_name)
 
 
 @pytest.mark.tmux
-def test_find_agent_for_command_raises_for_stopped_agent_without_skip(
+def test_ensure_host_and_agent_started_raises_for_stopped_agent_without_auto_start(
     cli_runner: CliRunner,
     create_test_agent,
     plugin_manager: pluggy.PluginManager,
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """find_agent_for_command without skip_agent_state_check raises for stopped agent.
+    """ensure_host_and_agent_started raises for a stopped agent when allow_auto_start=False.
 
-    Verifies the default behavior: when skip_agent_state_check is False
-    (the default), a stopped agent causes UserInputError.
+    Verifies the default behavior for commands that require the agent to
+    be running (connect, capture): a stopped agent causes UserInputError
+    when auto-start is disabled.
     """
     agent_name = f"test-find-stopped-err-{int(time.time())}"
     create_test_agent(agent_name, "sleep 564741")
@@ -125,10 +133,18 @@ def test_find_agent_for_command_raises_for_stopped_agent_without_skip(
     stop_result = cli_runner.invoke(stop, [agent_name], obj=plugin_manager, catch_exceptions=False)
     assert stop_result.exit_code == 0, f"Stop failed with: {stop_result.output}"
 
-    # Without skip_agent_state_check, should raise for stopped agent
+    result = find_agent_for_command(
+        mngr_ctx=temp_mngr_ctx,
+        address=AgentAddress(agent=AgentName(agent_name)),
+        host_filter=None,
+    )
+    assert result is not None
+    host_ref, agent_ref = result
+
     with pytest.raises(UserInputError, match="stopped and automatic starting is disabled"):
-        find_agent_for_command(
+        ensure_host_and_agent_started(
+            host_ref=host_ref,
+            agent_ref=agent_ref,
+            allow_auto_start=False,
             mngr_ctx=temp_mngr_ctx,
-            address=AgentAddress(agent=AgentName(agent_name)),
-            host_filter=None,
         )

--- a/libs/mngr/imbue/mngr/cli/test_connect.py
+++ b/libs/mngr/imbue/mngr/cli/test_connect.py
@@ -13,18 +13,18 @@ from urwid.widget.text import Text
 from urwid.widget.wimp import SelectableIcon
 
 from imbue.imbue_common.model_update import to_update
-from imbue.mngr.cli.connect import AgentSelectorState
+from imbue.mngr.cli.agent_selector import AgentSelectorState
+from imbue.mngr.cli.agent_selector import SelectorInputHandler
+from imbue.mngr.cli.agent_selector import _create_selectable_agent_item
+from imbue.mngr.cli.agent_selector import _handle_selector_input
+from imbue.mngr.cli.agent_selector import _refresh_agent_list
+from imbue.mngr.cli.agent_selector import build_status_text
+from imbue.mngr.cli.agent_selector import filter_agents
+from imbue.mngr.cli.agent_selector import handle_search_key
+from imbue.mngr.cli.agent_selector import select_agent_interactively
 from imbue.mngr.cli.connect import ConnectCliOptions
-from imbue.mngr.cli.connect import SelectorInputHandler
 from imbue.mngr.cli.connect import _build_connection_options
-from imbue.mngr.cli.connect import _create_selectable_agent_item
-from imbue.mngr.cli.connect import _handle_selector_input
-from imbue.mngr.cli.connect import _refresh_agent_list
-from imbue.mngr.cli.connect import build_status_text
 from imbue.mngr.cli.connect import connect
-from imbue.mngr.cli.connect import filter_agents
-from imbue.mngr.cli.connect import handle_search_key
-from imbue.mngr.cli.connect import select_agent_interactively
 from imbue.mngr.cli.create import create
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails

--- a/libs/mngr/imbue/mngr/cli/test_connect.py
+++ b/libs/mngr/imbue/mngr/cli/test_connect.py
@@ -12,7 +12,6 @@ from urwid.widget.listbox import SimpleFocusListWalker
 from urwid.widget.text import Text
 from urwid.widget.wimp import SelectableIcon
 
-from imbue.imbue_common.model_update import to_update
 from imbue.mngr.cli.agent_selector import AgentSelectorState
 from imbue.mngr.cli.agent_selector import SelectorInputHandler
 from imbue.mngr.cli.agent_selector import _create_selectable_agent_item
@@ -22,11 +21,8 @@ from imbue.mngr.cli.agent_selector import build_status_text
 from imbue.mngr.cli.agent_selector import filter_agents
 from imbue.mngr.cli.agent_selector import handle_search_key
 from imbue.mngr.cli.agent_selector import select_agent_interactively
-from imbue.mngr.cli.connect import ConnectCliOptions
-from imbue.mngr.cli.connect import _build_connection_options
 from imbue.mngr.cli.connect import connect
 from imbue.mngr.cli.create import create
-from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.main import cli
 from imbue.mngr.primitives import AgentLifecycleState
@@ -253,89 +249,35 @@ def test_connect_no_start_raises_error_for_stopped_agent(
         cleanup_tmux_session(session_name)
 
 
-# Flaky under heavy CI load: same family as test_destroy_multiple_agents -- the
-# CLI invocation drives tmux subprocesses that can exceed the 10s pytest-timeout
-# when sandboxes are contended. Offload retries flaky tests automatically.
 @pytest.mark.tmux
-@pytest.mark.flaky
-def test_connect_cli_non_interactive_selects_most_recent_agent(
+def test_connect_cli_non_interactive_requires_explicit_agent(
     cli_runner: CliRunner,
     create_test_agent,
     plugin_manager: pluggy.PluginManager,
     intercepted_execvp_calls: list[tuple[str, list[str]]],
 ) -> None:
-    """Test the non-interactive code path selects the most recently created agent.
+    """Test that mngr connect errors out in non-interactive mode when no agent is given.
 
-    When stdin is not a tty (simulated by providing input=""), the connect
-    command should detect non-interactive mode, call list_agents, sort by
-    create_time descending, and select the most recently created agent.
+    Previously the command silently picked the most recently created agent
+    in this case. That implicit fallback was removed; the command now
+    requires an explicit agent or an interactive terminal.
     """
-    agent_name_old = f"test-connect-old-{int(time.time())}"
-    agent_name_new = f"test-connect-new-{int(time.time())}"
-    create_test_agent(agent_name_old, "sleep 192837")
-    session_new = create_test_agent(agent_name_new, "sleep 283746")
+    agent_name = f"test-connect-{int(time.time())}"
+    create_test_agent(agent_name, "sleep 283746")
 
-    cli_runner.invoke(
+    result = cli_runner.invoke(
         connect,
         [],
         obj=plugin_manager,
-        catch_exceptions=False,
+        catch_exceptions=True,
         # Providing input="" makes stdin non-tty, triggering the non-interactive path
         input="",
     )
 
-    # Verify the CLI selected the most recently created agent
-    assert len(intercepted_execvp_calls) == 1
-    assert intercepted_execvp_calls[0] == ("tmux", ["tmux", "attach", "-t", f"={session_new}"])
-
-
-# =============================================================================
-# Tests for _build_connection_options (CLI option to ConnectionOptions mapping)
-# =============================================================================
-
-
-def test_build_connection_options_allow_unknown_host_true(
-    default_connect_cli_opts: ConnectCliOptions,
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """Test that allow_unknown_host=True produces is_unknown_host_allowed=True."""
-    opts = default_connect_cli_opts.model_copy_update(
-        to_update(default_connect_cli_opts.field_ref().allow_unknown_host, True),
-    )
-
-    connection_opts = _build_connection_options(opts, temp_mngr_ctx)
-
-    assert connection_opts.is_unknown_host_allowed is True
-
-
-def test_build_connection_options_allow_unknown_host_default(
-    default_connect_cli_opts: ConnectCliOptions,
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """Test that is_unknown_host_allowed defaults to False."""
-    connection_opts = _build_connection_options(default_connect_cli_opts, temp_mngr_ctx)
-
-    assert connection_opts.is_unknown_host_allowed is False
-
-
-def test_build_connection_options_maps_all_fields(
-    default_connect_cli_opts: ConnectCliOptions,
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """Test that all ConnectCliOptions fields are correctly mapped to ConnectionOptions."""
-    opts = default_connect_cli_opts.model_copy_update(
-        to_update(default_connect_cli_opts.field_ref().reconnect, False),
-        to_update(default_connect_cli_opts.field_ref().session_command, "bash"),
-        to_update(default_connect_cli_opts.field_ref().allow_unknown_host, True),
-    )
-
-    connection_opts = _build_connection_options(opts, temp_mngr_ctx)
-
-    assert connection_opts.is_reconnect is False
-    assert connection_opts.retry_count == temp_mngr_ctx.config.retry.connect_retry_times
-    assert connection_opts.retry_delay == temp_mngr_ctx.config.retry.connect_retry_delay
-    assert connection_opts.session_command == "bash"
-    assert connection_opts.is_unknown_host_allowed is True
+    assert result.exit_code != 0
+    assert "not running in interactive mode" in result.output
+    # No tmux session should have been started.
+    assert intercepted_execvp_calls == []
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/primitives.py
+++ b/libs/mngr/imbue/mngr/primitives.py
@@ -373,7 +373,7 @@ class AgentAddress(FrozenModel):
 
     The agent component is required; without it, this is not an agent address.
     Use :class:`HostAddress` for ``@HOST.PROVIDER`` (no agent) or
-    :class:`HostedLocation` for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` syntax.
+    :class:`HostLocationAddress` for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` syntax.
     """
 
     agent: AgentNameOrId = Field(description="Agent name or ID (required)")
@@ -422,7 +422,7 @@ class NewAgentLocation(FrozenModel):
     path: Path | None = Field(default=None, description="Optional explicit work-directory path inside the host")
 
 
-class HostedLocation(FrozenModel):
+class HostLocationAddress(FrozenModel):
     """A location that lives on some host: ``[NAME[@HOST[.PROVIDER]]][:PATH]`` or a bare path.
 
     Used wherever a CLI command needs to designate "a place on any host" -- the

--- a/libs/mngr_file/imbue/mngr_file/cli/get.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/get.py
@@ -8,12 +8,14 @@ import click
 from click_option_group import optgroup
 
 from imbue.imbue_common.logging import log_span
+from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.output_helpers import emit_event
 from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr_file.cli.group import file_group
 from imbue.mngr_file.cli.target import compute_volume_path
@@ -25,7 +27,7 @@ from imbue.mngr_file.data_types import PathRelativeTo
 class _FileGetCliOptions(CommonCliOptions):
     """Options for the file get subcommand."""
 
-    target: str
+    target: AgentOrHostAddress
     path: str
     output: str | None
     relative_to: str
@@ -54,7 +56,7 @@ def _emit_get_result(
 
 
 @file_group.command(name="get")
-@click.argument("target")
+@click.argument("target", type=AGENT_OR_HOST_ADDRESS)
 @click.argument("path")
 @optgroup.group("Output")
 @optgroup.option(
@@ -92,7 +94,7 @@ def file_get(ctx: click.Context, **kwargs: Any) -> None:
     # Resolve target
     with log_span("Resolving file target"):
         resolved = resolve_file_target(
-            target_identifier=opts.target,
+            target=opts.target,
             mngr_ctx=mngr_ctx,
             relative_to=relative_to,
         )

--- a/libs/mngr_file/imbue/mngr_file/cli/list.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/list.py
@@ -16,6 +16,7 @@ from tabulate import tabulate
 
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.pure import pure
+from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.output_helpers import emit_final_json
@@ -28,6 +29,7 @@ from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.data_types import VolumeFileType
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.volume import Volume
+from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr_file.cli.group import file_group
 from imbue.mngr_file.cli.target import compute_volume_path
@@ -116,7 +118,7 @@ else:
 class _FileListCliOptions(CommonCliOptions):
     """Options for the file list subcommand."""
 
-    target: str
+    target: AgentOrHostAddress
     path: str | None
     relative_to: str
     fields: str | None
@@ -317,7 +319,7 @@ def _emit_list_result(
 
 
 @file_group.command(name="list")
-@click.argument("target")
+@click.argument("target", type=AGENT_OR_HOST_ADDRESS)
 @click.argument("path", required=False, default=None)
 @optgroup.group("Path Resolution")
 @optgroup.option(
@@ -361,7 +363,7 @@ def file_list(ctx: click.Context, **kwargs: Any) -> None:
     # Resolve target
     with log_span("Resolving file target"):
         resolved = resolve_file_target(
-            target_identifier=opts.target,
+            target=opts.target,
             mngr_ctx=mngr_ctx,
             relative_to=relative_to,
         )

--- a/libs/mngr_file/imbue/mngr_file/cli/put.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/put.py
@@ -8,6 +8,7 @@ from click_option_group import optgroup
 from loguru import logger
 
 from imbue.imbue_common.logging import log_span
+from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.output_helpers import emit_event
@@ -16,6 +17,7 @@ from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import UserInputError
+from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr_file.cli.group import file_group
 from imbue.mngr_file.cli.target import compute_volume_path
@@ -27,7 +29,7 @@ from imbue.mngr_file.data_types import PathRelativeTo
 class _FilePutCliOptions(CommonCliOptions):
     """Options for the file put subcommand."""
 
-    target: str
+    target: AgentOrHostAddress
     path: str
     input: str | None
     relative_to: str
@@ -55,7 +57,7 @@ def _emit_put_result(
 
 
 @file_group.command(name="put")
-@click.argument("target")
+@click.argument("target", type=AGENT_OR_HOST_ADDRESS)
 @click.argument("path")
 @optgroup.group("Input")
 @optgroup.option(
@@ -102,7 +104,7 @@ def file_put(ctx: click.Context, **kwargs: Any) -> None:
     # Resolve target
     with log_span("Resolving file target"):
         resolved = resolve_file_target(
-            target_identifier=opts.target,
+            target=opts.target,
             mngr_ctx=mngr_ctx,
             relative_to=relative_to,
         )

--- a/libs/mngr_file/imbue/mngr_file/cli/target.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/target.py
@@ -11,15 +11,17 @@ from imbue.imbue_common.pure import pure
 from imbue.mngr.api.address_parsers import parse_agent_name_or_id
 from imbue.mngr.api.address_parsers import parse_host_address
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import filter_all_agents
 from imbue.mngr.api.find import filter_all_hosts
+from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import AgentNotFoundError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.hosts.host import get_agent_state_dir_path
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.volume import Volume
+from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
@@ -140,53 +142,60 @@ def resolve_file_target(
 
     When the target host is online, direct host access is used. When offline,
     falls back to volume access for paths under the host directory.
+
+    Note that, unlike the standard single-agent flow used by connect/push/etc.,
+    this resolver does **not** call into ``ensure_host_*`` after finding the
+    agent: ``mngr file`` is allowed to operate against an offline host
+    through the provider's volume backend, and forcing the host online would
+    silently strip that capability.
     """
-    with log_span("Discovering hosts and agents"):
-        agents_by_host, _ = discover_hosts_and_agents(
-            mngr_ctx,
-            provider_names=None,
-            agent_identifiers=(target_identifier,),
-            include_destroyed=False,
-            reset_caches=False,
-        )
-
-    all_hosts = list(agents_by_host.keys())
-
-    # Find all matching agents and hosts. The target identifier may be an
-    # agent name/ID or a host name/ID -- attempt both parses and ignore the
-    # one that doesn't apply (e.g. a host ID isn't a valid AgentName, etc.).
+    # The target identifier may name either an agent or a host. Try both
+    # interpretations and reconcile.
+    agent_match: tuple[DiscoveredHost, DiscoveredAgent] | None = None
     try:
         agent_target = parse_agent_name_or_id(target_identifier)
     except UserInputError:
         agent_target = None
-    matching_agents = filter_all_agents(agent_target, agents_by_host) if agent_target is not None else []
+    if agent_target is not None:
+        try:
+            agent_match = find_one_agent(AgentAddress(agent=agent_target), mngr_ctx)
+        except AgentNotFoundError:
+            # No agent has this exact ID. Fall through to host lookup.
+            agent_match = None
+        except UserInputError as not_found_or_ambiguous:
+            # ``_filter_one_agent`` raises ``UserInputError`` both for an
+            # unknown AgentName and for a multi-match. Treat the former as
+            # "fall through to host lookup"; the latter must reach the user.
+            if "Multiple agents found" in str(not_found_or_ambiguous):
+                raise
+            agent_match = None
+
+    host_match: DiscoveredHost | None = None
     try:
         host_target = parse_host_address(target_identifier)
     except UserInputError:
         host_target = None
-    matching_hosts = filter_all_hosts(host_target, all_hosts) if host_target is not None else []
-
-    # Check for ambiguity within each type
-    if len(matching_agents) > 1:
-        raise UserInputError(
-            f"Multiple agents found matching '{target_identifier}'. "
-            f"Use the full agent ID to disambiguate.\n\n"
-            f"To see all agent IDs, run:\n"
-            f"  mngr list --fields id,name,host"
+    if host_target is not None:
+        agents_by_host, _ = discover_hosts_and_agents(
+            mngr_ctx,
+            provider_names=None,
+            agent_identifiers=None,
+            include_destroyed=False,
+            reset_caches=False,
         )
-    if len(matching_hosts) > 1:
-        raise UserInputError(
-            f"Multiple hosts found matching '{target_identifier}'. "
-            f"Use the full host ID to disambiguate.\n\n"
-            f"To see all IDs, run:\n"
-            f"  mngr list --fields id,name,host"
-        )
-
-    has_agent_match = len(matching_agents) == 1
-    has_host_match = len(matching_hosts) == 1
+        matching_hosts = filter_all_hosts(host_target, list(agents_by_host.keys()))
+        if len(matching_hosts) > 1:
+            raise UserInputError(
+                f"Multiple hosts found matching '{target_identifier}'. "
+                f"Use the full host ID to disambiguate.\n\n"
+                f"To see all IDs, run:\n"
+                f"  mngr list --fields id,name,host"
+            )
+        if len(matching_hosts) == 1:
+            host_match = matching_hosts[0]
 
     # Check for cross-type ambiguity
-    if has_agent_match and has_host_match:
+    if agent_match is not None and host_match is not None:
         raise UserInputError(
             f"'{target_identifier}' matches both an agent and a host. "
             f"Use the full ID to disambiguate.\n\n"
@@ -195,14 +204,14 @@ def resolve_file_target(
         )
 
     # Neither matched
-    if not has_agent_match and not has_host_match:
+    if agent_match is None and host_match is None:
         raise UserInputError(
             f"No agent or host found matching: {target_identifier}\n\nTo see available agents, run:\n  mngr list"
         )
 
     # Agent matched
-    if has_agent_match:
-        discovered_host, discovered_agent = matching_agents[0]
+    if agent_match is not None:
+        discovered_host, discovered_agent = agent_match
         return _resolve_agent_target(
             discovered_host=discovered_host,
             discovered_agent=discovered_agent,
@@ -211,14 +220,14 @@ def resolve_file_target(
         )
 
     # Host matched
-    discovered_host = matching_hosts[0]
+    assert host_match is not None
     if relative_to != PathRelativeTo.HOST and relative_to != PathRelativeTo.WORK:
         raise UserInputError(
             f"--relative-to {relative_to.value.lower()} is only valid for agent targets. "
             f"Host targets always use MNGR_HOST_DIR as the base path."
         )
     return _resolve_host_target(
-        discovered_host=discovered_host,
+        discovered_host=host_match,
         mngr_ctx=mngr_ctx,
     )
 

--- a/libs/mngr_file/imbue/mngr_file/cli/target.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/target.py
@@ -8,14 +8,11 @@ from pydantic import Field
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.logging import log_span
 from imbue.imbue_common.pure import pure
-from imbue.mngr.api.address_parsers import parse_agent_name_or_id
-from imbue.mngr.api.address_parsers import parse_host_address
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import filter_all_hosts
+from imbue.mngr.api.find import filter_one_host
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import AgentNotFoundError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.hosts.host import get_agent_state_dir_path
@@ -23,6 +20,7 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.volume import Volume
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostId
@@ -131,14 +129,17 @@ class ResolveFileTargetResult(FrozenModel):
 
 
 def resolve_file_target(
-    target_identifier: str,
+    target: AgentOrHostAddress,
     mngr_ctx: MngrContext,
     relative_to: PathRelativeTo,
 ) -> ResolveFileTargetResult:
     """Resolve a TARGET argument to a host/volume and base path for file operations.
 
-    Tries agent resolution first, then host resolution. If both match, raises
-    an error requiring disambiguation. If neither matches, raises an error.
+    Whether the target is an agent or a host is determined by ``target``'s
+    runtime type (parsed by the standard ``AGENT_OR_HOST_ADDRESS`` Click
+    param type, which uses :func:`parse_agent_or_host_address`). To target a
+    host whose name shares the shape of a :class:`SafeName`, write ``@host``
+    on the command line so the parser picks the host arm.
 
     When the target host is online, direct host access is used. When offline,
     falls back to volume access for paths under the host directory.
@@ -149,85 +150,31 @@ def resolve_file_target(
     through the provider's volume backend, and forcing the host online would
     silently strip that capability.
     """
-    # The target identifier may name either an agent or a host. Try both
-    # interpretations and reconcile.
-    agent_match: tuple[DiscoveredHost, DiscoveredAgent] | None = None
-    try:
-        agent_target = parse_agent_name_or_id(target_identifier)
-    except UserInputError:
-        agent_target = None
-    if agent_target is not None:
-        try:
-            agent_match = find_one_agent(AgentAddress(agent=agent_target), mngr_ctx)
-        except AgentNotFoundError:
-            # No agent has this exact ID. Fall through to host lookup.
-            agent_match = None
-        except UserInputError as not_found_or_ambiguous:
-            # ``_filter_one_agent`` raises ``UserInputError`` both for an
-            # unknown AgentName and for a multi-match. Treat the former as
-            # "fall through to host lookup"; the latter must reach the user.
-            if "Multiple agents found" in str(not_found_or_ambiguous):
-                raise
-            agent_match = None
-
-    host_match: DiscoveredHost | None = None
-    try:
-        host_target = parse_host_address(target_identifier)
-    except UserInputError:
-        host_target = None
-    if host_target is not None:
-        agents_by_host, _ = discover_hosts_and_agents(
-            mngr_ctx,
-            provider_names=None,
-            agent_identifiers=None,
-            include_destroyed=False,
-            reset_caches=False,
-        )
-        matching_hosts = filter_all_hosts(host_target, list(agents_by_host.keys()))
-        if len(matching_hosts) > 1:
-            raise UserInputError(
-                f"Multiple hosts found matching '{target_identifier}'. "
-                f"Use the full host ID to disambiguate.\n\n"
-                f"To see all IDs, run:\n"
-                f"  mngr list --fields id,name,host"
-            )
-        if len(matching_hosts) == 1:
-            host_match = matching_hosts[0]
-
-    # Check for cross-type ambiguity
-    if agent_match is not None and host_match is not None:
-        raise UserInputError(
-            f"'{target_identifier}' matches both an agent and a host. "
-            f"Use the full ID to disambiguate.\n\n"
-            f"To see all IDs, run:\n"
-            f"  mngr list --fields id,name,host"
-        )
-
-    # Neither matched
-    if agent_match is None and host_match is None:
-        raise UserInputError(
-            f"No agent or host found matching: {target_identifier}\n\nTo see available agents, run:\n  mngr list"
-        )
-
-    # Agent matched
-    if agent_match is not None:
-        discovered_host, discovered_agent = agent_match
+    if isinstance(target, AgentAddress):
+        host_ref, agent_ref = find_one_agent(target, mngr_ctx)
         return _resolve_agent_target(
-            discovered_host=discovered_host,
-            discovered_agent=discovered_agent,
+            discovered_host=host_ref,
+            discovered_agent=agent_ref,
             mngr_ctx=mngr_ctx,
             relative_to=relative_to,
         )
 
-    # Host matched
-    assert host_match is not None
+    # Host target. filter_one_host raises if zero or multiple hosts match.
     if relative_to != PathRelativeTo.HOST and relative_to != PathRelativeTo.WORK:
         raise UserInputError(
             f"--relative-to {relative_to.value.lower()} is only valid for agent targets. "
             f"Host targets always use MNGR_HOST_DIR as the base path."
         )
+    agents_by_host, _ = discover_hosts_and_agents(
+        mngr_ctx,
+        provider_names=None,
+        agent_identifiers=None,
+        include_destroyed=False,
+        reset_caches=False,
+    )
+    host_ref = filter_one_host(target, list(agents_by_host.keys()))
     return _resolve_host_target(
-        discovered_host=host_match,
+        discovered_host=host_ref,
         mngr_ctx=mngr_ctx,
     )
 

--- a/libs/mngr_file/imbue/mngr_file/test_file_operations.py
+++ b/libs/mngr_file/imbue/mngr_file/test_file_operations.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from imbue.mngr.api.address_parsers import parse_agent_or_host_address
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr_file.cli.list import list_files_on_host
 from imbue.mngr_file.cli.target import resolve_file_target
@@ -12,7 +13,7 @@ from imbue.mngr_file.data_types import PathRelativeTo
 def test_list_files_on_localhost(temp_mngr_ctx: MngrContext) -> None:
     """List files on the local host via the host interface."""
     resolved = resolve_file_target(
-        target_identifier="localhost",
+        target=parse_agent_or_host_address("@localhost"),
         mngr_ctx=temp_mngr_ctx,
         relative_to=PathRelativeTo.HOST,
     )
@@ -29,7 +30,7 @@ def test_list_files_on_localhost(temp_mngr_ctx: MngrContext) -> None:
 def test_put_and_get_file_on_localhost(temp_mngr_ctx: MngrContext, tmp_path: Path) -> None:
     """Write a file to the local host dir and read it back."""
     resolved = resolve_file_target(
-        target_identifier="localhost",
+        target=parse_agent_or_host_address("@localhost"),
         mngr_ctx=temp_mngr_ctx,
         relative_to=PathRelativeTo.HOST,
     )
@@ -65,7 +66,7 @@ def test_put_and_get_file_on_localhost(temp_mngr_ctx: MngrContext, tmp_path: Pat
 def test_list_files_recursive_on_localhost(temp_mngr_ctx: MngrContext) -> None:
     """List files recursively on the local host dir."""
     resolved = resolve_file_target(
-        target_identifier="localhost",
+        target=parse_agent_or_host_address("@localhost"),
         mngr_ctx=temp_mngr_ctx,
         relative_to=PathRelativeTo.HOST,
     )

--- a/libs/mngr_file/imbue/mngr_file/test_target_integration.py
+++ b/libs/mngr_file/imbue/mngr_file/test_target_integration.py
@@ -2,16 +2,17 @@
 
 import pytest
 
+from imbue.mngr.api.address_parsers import parse_agent_or_host_address
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr_file.cli.target import resolve_file_target
 from imbue.mngr_file.data_types import PathRelativeTo
 
 
-def test_resolve_file_target_raises_for_nonexistent_target(temp_mngr_ctx: MngrContext) -> None:
-    with pytest.raises(UserInputError, match="No agent or host found"):
+def test_resolve_file_target_raises_for_nonexistent_agent(temp_mngr_ctx: MngrContext) -> None:
+    with pytest.raises(UserInputError, match="Could not find agent"):
         resolve_file_target(
-            target_identifier="nonexistent-target-abc123xyz",
+            target=parse_agent_or_host_address("nonexistent-target-abc123xyz"),
             mngr_ctx=temp_mngr_ctx,
             relative_to=PathRelativeTo.WORK,
         )
@@ -19,7 +20,7 @@ def test_resolve_file_target_raises_for_nonexistent_target(temp_mngr_ctx: MngrCo
 
 def test_resolve_file_target_resolves_local_host(temp_mngr_ctx: MngrContext) -> None:
     result = resolve_file_target(
-        target_identifier="localhost",
+        target=parse_agent_or_host_address("@localhost"),
         mngr_ctx=temp_mngr_ctx,
         relative_to=PathRelativeTo.HOST,
     )
@@ -31,7 +32,7 @@ def test_resolve_file_target_resolves_local_host(temp_mngr_ctx: MngrContext) -> 
 def test_resolve_file_target_host_rejects_relative_to_state(temp_mngr_ctx: MngrContext) -> None:
     with pytest.raises(UserInputError, match="only valid for agent targets"):
         resolve_file_target(
-            target_identifier="localhost",
+            target=parse_agent_or_host_address("@localhost"),
             mngr_ctx=temp_mngr_ctx,
             relative_to=PathRelativeTo.STATE,
         )

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -16,6 +16,7 @@ from imbue.imbue_common.pure import pure
 from imbue.mngr.api.discover import discover_hosts_and_agents
 from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.list import list_agents
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.primitives import AgentAddress
@@ -223,10 +224,12 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
 
 def toggle_agent_mute(mngr_ctx: MngrContext, agent_name: AgentName) -> bool:
     """Toggle the mute state of an agent. Returns the new mute state."""
-    agent, _host = find_one_agent(
-        AgentAddress(agent=agent_name),
-        mngr_ctx,
-        skip_agent_state_check=True,
+    host_ref, agent_ref = find_one_agent(AgentAddress(agent=agent_name), mngr_ctx)
+    agent, _host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=False,
+        mngr_ctx=mngr_ctx,
     )
     plugin_data = agent.get_plugin_data(PLUGIN_NAME)
     is_muted = not plugin_data.get("muted", False)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -15,8 +15,8 @@ from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.api.discover import discover_hosts_and_agents
 from imbue.mngr.api.find import find_one_agent
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.list import list_agents
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.primitives import AgentAddress
@@ -225,7 +225,7 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
 def toggle_agent_mute(mngr_ctx: MngrContext, agent_name: AgentName) -> bool:
     """Toggle the mute state of an agent. Returns the new mute state."""
     host_ref, agent_ref = find_one_agent(AgentAddress(agent=agent_name), mngr_ctx)
-    agent, _host = ensure_host_started_and_resolve_agent(
+    agent, _host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=False,

--- a/libs/mngr_pair/imbue/mngr_pair/cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli.py
@@ -5,10 +5,10 @@ import click
 from click_option_group import optgroup
 from loguru import logger
 
+from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
-from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -181,7 +181,7 @@ def pair(ctx: click.Context, **kwargs) -> None:
         address=source_address,
         host_filter=opts.source_host,
     )
-    agent, host = ensure_host_started_and_resolve_agent(
+    agent, host = resolve_to_started_host_and_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,
         allow_auto_start=True,

--- a/libs/mngr_pair/imbue/mngr_pair/cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli.py
@@ -9,7 +9,7 @@ from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
 from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
-from imbue.mngr.cli.agent_utils import find_agent_for_command
+from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
@@ -176,15 +176,11 @@ def pair(ctx: click.Context, **kwargs) -> None:
         target_path = git_root if git_root is not None else Path.cwd()
 
     # Find the agent
-    result = find_agent_for_command(
+    host_ref, agent_ref = find_agent_by_address_or_interactively(
         mngr_ctx=mngr_ctx,
         address=source_address,
         host_filter=opts.source_host,
     )
-    if result is None:
-        logger.info("No agent selected")
-        return
-    host_ref, agent_ref = result
     agent, host = ensure_host_started_and_resolve_agent(
         host_ref=host_ref,
         agent_ref=agent_ref,

--- a/libs/mngr_pair/imbue/mngr_pair/cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli.py
@@ -8,6 +8,7 @@ from loguru import logger
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
 from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.agent_utils import ensure_host_started_and_resolve_agent
 from imbue.mngr.cli.agent_utils import find_agent_for_command
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -183,7 +184,13 @@ def pair(ctx: click.Context, **kwargs) -> None:
     if result is None:
         logger.info("No agent selected")
         return
-    agent, host = result
+    host_ref, agent_ref = result
+    agent, host = ensure_host_started_and_resolve_agent(
+        host_ref=host_ref,
+        agent_ref=agent_ref,
+        allow_auto_start=True,
+        mngr_ctx=mngr_ctx,
+    )
 
     # Only local agents are supported right now
     if not host.is_local:

--- a/libs/mngr_pair/imbue/mngr_pair/cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli.py
@@ -7,8 +7,8 @@ from loguru import logger
 
 from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -24,7 +24,7 @@ from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import ConflictMode
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import SyncDirection
 from imbue.mngr.primitives import UncommittedChangesMode
@@ -35,8 +35,8 @@ from imbue.mngr_pair.api import pair_files
 class PairCliOptions(CommonCliOptions):
     """Options passed from the CLI to the pair command."""
 
-    source_pos: HostedLocation | None
-    source: HostedLocation | None
+    source_pos: HostLocationAddress | None
+    source: HostLocationAddress | None
     source_agent: AgentAddress | None
     source_host: HostAddress | None
     source_path: str | None
@@ -81,12 +81,12 @@ def _emit_pair_stopped(output_opts: OutputOptions) -> None:
 
 
 @click.command()
-@click.argument("source_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="SOURCE")
+@click.argument("source_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="SOURCE")
 @optgroup.group("Source Selection")
 @optgroup.option(
     "--source",
     "source",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Source specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--source-agent", type=AGENT_ADDRESS, help="Source agent address (NAME[@HOST[.PROVIDER]])")
@@ -148,7 +148,7 @@ def pair(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_source_loc: HostedLocation | None = opts.source if opts.source is not None else opts.source_pos
+    effective_source_loc: HostLocationAddress | None = opts.source if opts.source is not None else opts.source_pos
 
     # Build source agent address and sub-path
     source_address: AgentAddress | None = None

--- a/libs/mngr_wait/imbue/mngr_wait/api.py
+++ b/libs/mngr_wait/imbue/mngr_wait/api.py
@@ -5,11 +5,9 @@ from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.frozen_model import FrozenModel
-from imbue.imbue_common.logging import log_span
-from imbue.mngr.api.discover import discover_by_address
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import filter_one_agent
 from imbue.mngr.api.find import filter_one_host
+from imbue.mngr.api.find import find_one_agent
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import HostConnectionError
@@ -55,9 +53,7 @@ def resolve_wait_target(
 
 
 def _build_agent_resolved_target(address: AgentAddress, mngr_ctx: MngrContext) -> ResolvedTarget:
-    with log_span("Discovering hosts and agents"):
-        agents_by_host, _providers = discover_by_address(address, mngr_ctx, include_destroyed=False)
-    host_ref, agent_ref = filter_one_agent(address.agent, resolved_host=None, agents_by_host=agents_by_host)
+    host_ref, agent_ref = find_one_agent(address, mngr_ctx)
     provider = get_provider_instance(host_ref.provider_name, mngr_ctx)
     return ResolvedTarget(
         target=WaitTarget(identifier=str(address), target_type=WaitTargetType.AGENT),
@@ -68,14 +64,13 @@ def _build_agent_resolved_target(address: AgentAddress, mngr_ctx: MngrContext) -
 
 
 def _build_host_resolved_target(address: HostAddress, mngr_ctx: MngrContext) -> ResolvedTarget:
-    with log_span("Discovering hosts and agents"):
-        agents_by_host, _ = discover_hosts_and_agents(
-            mngr_ctx,
-            provider_names=None,
-            agent_identifiers=None,
-            include_destroyed=False,
-            reset_caches=False,
-        )
+    agents_by_host, _ = discover_hosts_and_agents(
+        mngr_ctx,
+        provider_names=None,
+        agent_identifiers=None,
+        include_destroyed=False,
+        reset_caches=False,
+    )
     all_hosts = list(agents_by_host.keys())
     host_ref = filter_one_host(address, all_hosts)
     provider = get_provider_instance(host_ref.provider_name, mngr_ctx)


### PR DESCRIPTION
## My summary

When trying to understand how various subcommands that operate on one agent resolve their agent addresses, I go really confused by how the old `find_one_agent`'s `is_start_desired` and `skip_agent_state_check` arguments work and interact. As it turned out, Claude was confused by it too, and it ended up passing the wrong values in a bunch of subcommands, causing them to start the agent unnecessarily when they don't actually require the agent to be started. Claude's description of the solution below is pretty decent: it's slightly more verbose but much more explicit and less confusing.

There are a couple refactor/cleanup changes related to address parsing and resolution in this PR; again, Claude's description is pretty decent this time.

Another two changes that I did not include as part of the PR:

- The `rename` subcommand today requires the host to be online, but it doesn't actually have to be. Today it operates on an online host because it also wants to rename the tmux session, but we can simply skip this when the host is offline, and manipulate the agent record through the host volume. https://github.com/imbue-ai/mngr/pull/1659
- I introduced `HostedLocation` to represent things like the argument of `mngr create --from`. I didn't realize at that time that there is already a `HostLocation` which is the runtime representation of it - this means that the former is in fact better named `HostLocationAddress` (to mirror Agent:AgentAddress, Host:HostAddress). https://github.com/imbue-ai/mngr/pull/1658

---------------

## Summary

Refactors how mngr's single-agent subcommands turn an `AgentAddress` into the live interfaces they operate on. The old flow welded three concerns into one `find_one_agent` call — discovery, host materialization, and agent lifecycle — controlled by two implicit-default flags (`is_start_desired`, `skip_agent_state_check`) that silently conflated host- and agent-state requirements. The new flow is two explicit phases:

```python
host_ref, agent_ref = find_one_agent(address, mngr_ctx)                # metadata
agent, host = resolve_to_started_host_and_[running_]agent(host_ref, agent_ref,
                                                          allow_auto_start=opts.start,
                                                          mngr_ctx=mngr_ctx)
```

Each subcommand picks the resolver that matches its actual requirement:

| Command | Resolver |
| --- | --- |
| connect, capture | `resolve_to_started_host_and_running_agent` |
| push, pull, provision, rename | `resolve_to_started_host_and_agent` (no agent-state requirement) |
| exec (single, API only) | `resolve_to_started_host_and_running_agent` |
| mngr_file | bespoke (intentionally supports offline-via-volume) |

Multi-agent commands (`start`, `stop`, `destroy`, `exec` multi, `message`) are deliberately out of scope here.

## User-visible behavior changes

- **push, pull, and provision no longer require the agent to be running.** Previously they failed against a stopped agent on an online host, even though their operations (rsync, file copy, provisioning) only need the host. Now they succeed.
- **push, pull, provision, and rename gain a `--start/--no-start` flag** (default `--start`). Previously they had no way to control host auto-start.
- **`mngr connect` no longer auto-picks the most recently created agent non-interactively.** Running `mngr connect` with no agent in a non-interactive shell used to silently pick the most recent agent; it now errors out like every other single-agent command. Use an interactive shell or pass an explicit agent.
- **`mngr file` now uses standard `AGENT_OR_HOST_ADDRESS` parsing.** A `SafeName`-shaped host name (no `host-` prefix, no dots) must be written as `@hostname` to be parsed as a host. Bare `hostname` parses as an agent. This matches every other mngr subcommand.
- **Cancelling the interactive agent selector now exits cleanly via `click.Abort`** instead of returning None silently.
- **`--start` help text** on `connect`, `capture`, `exec`, and the new flags on push/pull/provision/rename now accurately describes what each command starts.

## Notable internal changes

- New `api/find.py` helpers: `find_one_agent` (metadata-only), `find_one_agent_and_agents_by_host` (sibling returning full discovery), `resolve_to_started_host_and_agent`, `resolve_to_started_host_and_running_agent`.
- `api/exec.py:exec_command_on_agent` and `mngr_file/resolve_file_target` (agent half) now reuse the standard `find_one_agent` flow — duplicate inline resolution gone.
- The agent-selector TUI moved out of `cli/connect.py` into a new `cli/agent_selector.py` to break the import cycle the new structure exposed.
- `filter_one_agent`, `filter_all_agents`, and `materialize_agent` removed from `api/find.py`'s public surface; the unused `filter_agents_by_host` deleted.

## Test plan

- [ ] `mngr push <stopped-agent> .` — succeeds (previously failed).
- [ ] `mngr pull <stopped-agent>` — succeeds.
- [ ] `mngr provision <stopped-agent>` — works without `is_start_desired` flag, gets the host online.
- [ ] `mngr push --no-start <agent-on-offline-host>` — fails with a clear "host is offline" error.
- [ ] `mngr push <agent-on-offline-host>` (default `--start`) — auto-starts the host.
- [ ] `mngr connect` (no agent, non-interactive shell, e.g. piped output) — errors out cleanly, no longer silently picks most-recent agent.
- [ ] `mngr connect` (no agent, interactive terminal) — shows selector; Ctrl-C twice exits cleanly without stack trace.
- [ ] `mngr connect <stopped-agent>` (default `--start`) — starts agent and connects.
- [ ] `mngr connect --no-start <stopped-agent>` — fails with "agent is stopped" error.
- [ ] `mngr rename <stopped-agent> new-name` — renames the stopped agent (auto-starts host if needed).
- [ ] `mngr file get @localhost /etc/hostname` — works with explicit `@` for host.
- [ ] `mngr file get localhost /etc/hostname` — now errors (parses as agent name); previously fell back to host lookup.
- [ ] `mngr file get <stopped-agent-on-offline-host> path --relative-to state` — still works via volume backend (offline-host access preserved).
- [ ] Acceptance + release tests via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)