### PR TITLE
mngr: rename HostedLocation -> HostLocationAddress

### DIFF
--- a/changelog/mngr-host-location-addr.md
+++ b/changelog/mngr-host-location-addr.md
@@ -1,0 +1,18 @@
+# Rename `HostedLocation` to `HostLocationAddress`
+
+Renamed the address-side `HostedLocation` type to `HostLocationAddress` so its
+name matches its peers (`HostAddress`, `AgentAddress`) and makes its
+relationship to the runtime `HostLocation` type explicit.
+
+Cascading internal renames:
+
+- `parse_hosted_location` -> `parse_host_location_address`
+- `resolve_hosted_location` -> `resolve_host_location_address`
+- `ResolvedHostedLocation` -> `ResolvedHostLocationAddress`
+- `HostedLocationParamType` -> `HostLocationAddressParamType`
+- `HOSTED_LOCATION` (Click param type instance) -> `HOST_LOCATION_ADDRESS`
+- Click param-type display name `hosted_location` -> `host_location_address`
+  (visible in command-line help / docs for `mngr push`, `mngr pull`,
+  `mngr pair`)
+
+No behavior change.

--- a/libs/mngr/docs/commands/primary/pair.md
+++ b/libs/mngr/docs/commands/primary/pair.md
@@ -36,7 +36,7 @@ mngr pair [OPTIONS] SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--source` | hosted_location | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--source` | host_location_address | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--source-agent` | agent_address | Source agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--source-host` | host_address | Source host address (HOST[.PROVIDER]) | None |
 | `--source-path` | text | Path within the agent's work directory | None |

--- a/libs/mngr/docs/commands/primary/pull.md
+++ b/libs/mngr/docs/commands/primary/pull.md
@@ -33,7 +33,7 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--source` | hosted_location | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--source` | host_location_address | Source specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--source-agent` | agent_address | Source agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--source-host` | host_address | Source host address (HOST[.PROVIDER]) [future] | None |
 | `--source-path` | text | Path within the agent's work directory | None |
@@ -59,7 +59,7 @@ mngr pull [OPTIONS] SOURCE DESTINATION
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--target` | hosted_location | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future] | None |
+| `--target` | host_location_address | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future] | None |
 | `--target-agent` | agent_address | Target agent address [future] | None |
 | `--target-host` | host_address | Target host address [future] | None |
 | `--target-path` | text | Path within target to sync to [future] | None |

--- a/libs/mngr/docs/commands/primary/push.md
+++ b/libs/mngr/docs/commands/primary/push.md
@@ -36,7 +36,7 @@ mngr push [OPTIONS] TARGET SOURCE
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--target` | hosted_location | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
+| `--target` | host_location_address | Target specification: AGENT[@HOST[.PROVIDER]][:PATH] | None |
 | `--target-agent` | agent_address | Target agent address (NAME[@HOST[.PROVIDER]]) | None |
 | `--target-host` | host_address | Target host address (HOST[.PROVIDER]) [future] | None |
 | `--target-path` | text | Path within the agent's work directory | None |

--- a/libs/mngr/imbue/mngr/api/address_parsers.py
+++ b/libs/mngr/imbue/mngr/api/address_parsers.py
@@ -1,7 +1,7 @@
 """Parsers that produce the typed address shapes shared across mngr.
 
 The four typed shapes -- :class:`HostAddress`, :class:`AgentAddress`,
-:class:`NewAgentLocation`, :class:`HostedLocation` -- live in
+:class:`NewAgentLocation`, :class:`HostLocationAddress` -- live in
 :mod:`imbue.mngr.primitives` so the lower-layer ``config`` package can reference
 them in CLI option dataclasses. The parsers are kept here in the api layer
 because they raise :class:`UserInputError` (in the ``errors`` module, which
@@ -32,9 +32,9 @@ from imbue.mngr.primitives import AgentNameOrId
 from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import InvalidName
 from imbue.mngr.primitives import NewAgentLocation
 from imbue.mngr.primitives import ProviderInstanceName
@@ -193,8 +193,8 @@ def parse_new_agent_location(s: str) -> NewAgentLocation:
 
 
 @pure
-def parse_hosted_location(s: str) -> HostedLocation:
-    """Parse a ``[NAME[@HOST[.PROVIDER]]][:PATH]`` string into a :class:`HostedLocation`.
+def parse_host_location_address(s: str) -> HostLocationAddress:
+    """Parse a ``[NAME[@HOST[.PROVIDER]]][:PATH]`` string into a :class:`HostLocationAddress`.
 
     Used for any CLI argument that designates "a location on some host" --
     sources (``mngr create --from``, ``mngr pair``) and targets
@@ -205,16 +205,16 @@ def parse_hosted_location(s: str) -> HostedLocation:
     ``foo``, not a directory; use ``:foo`` to mean a relative directory.
     """
     if s.startswith(("/", "./", "~/", "../")):
-        return HostedLocation(path=Path(s))
+        return HostLocationAddress(path=Path(s))
 
     address_part, path = _split_path_suffix(s)
     if not address_part and path is None:
-        return HostedLocation()
+        return HostLocationAddress()
 
     agent_str, host_part = _split_at_part(address_part)
     agent = parse_agent_name_or_id(agent_str) if agent_str else None
     host = parse_host_address(host_part) if host_part else None
-    return HostedLocation(agent=agent, host=host, path=path)
+    return HostLocationAddress(agent=agent, host=host, path=path)
 
 
 # === Internal split helpers ===

--- a/libs/mngr/imbue/mngr/api/find.py
+++ b/libs/mngr/imbue/mngr/api/find.py
@@ -30,9 +30,9 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.base_provider import BaseProviderInstance
@@ -164,8 +164,8 @@ def _filter_one_agent(
     return matches[0]
 
 
-class ResolvedHostedLocation(FrozenModel):
-    """Result of resolving a :class:`HostedLocation`, including the discovered agent when available."""
+class ResolvedHostLocationAddress(FrozenModel):
+    """Result of resolving a :class:`HostLocationAddress`, including the discovered agent when available."""
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -174,14 +174,14 @@ class ResolvedHostedLocation(FrozenModel):
 
 
 @log_call
-def resolve_hosted_location(
-    parsed: HostedLocation,
+def resolve_host_location_address(
+    parsed: HostLocationAddress,
     agents_by_host: Mapping[DiscoveredHost, Sequence[DiscoveredAgent]],
     mngr_ctx: MngrContext,
     *,
     is_start_desired: bool = True,
-) -> ResolvedHostedLocation:
-    """Resolve a :class:`HostedLocation` to a concrete host, path, and optional agent.
+) -> ResolvedHostLocationAddress:
+    """Resolve a :class:`HostLocationAddress` to a concrete host, path, and optional agent.
 
     Resolves agent/host references against the discovered hosts and agents.
     If the resolved host is offline, it will be started if ``is_start_desired``
@@ -235,7 +235,7 @@ def resolve_hosted_location(
         agent_work_dir_if_available=agent_work_dir,
     )
 
-    return ResolvedHostedLocation(
+    return ResolvedHostLocationAddress(
         location=HostLocation(host=online_host, path=resolved_path),
         agent=resolved_agent,
     )

--- a/libs/mngr/imbue/mngr/api/find_test.py
+++ b/libs/mngr/imbue/mngr/api/find_test.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import Field
 
 from imbue.mngr.agents.base_agent import BaseAgent
-from imbue.mngr.api.address_parsers import parse_hosted_location
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.find import AgentMatch
 from imbue.mngr.api.find import _filter_all_agents
 from imbue.mngr.api.find import _filter_one_agent
@@ -33,91 +33,91 @@ from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 
 
-def test_parse_hosted_location_with_agent_only() -> None:
-    parsed = parse_hosted_location("my-agent")
+def test_parse_host_location_address_with_agent_only() -> None:
+    parsed = parse_host_location_address("my-agent")
 
-    assert parsed == HostedLocation(agent=AgentName("my-agent"))
+    assert parsed == HostLocationAddress(agent=AgentName("my-agent"))
 
 
-def test_parse_hosted_location_with_agent_and_host() -> None:
-    parsed = parse_hosted_location("my-agent@my-host")
+def test_parse_host_location_address_with_agent_and_host() -> None:
+    parsed = parse_host_location_address("my-agent@my-host")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_provider() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.modal")
+def test_parse_host_location_address_with_agent_host_and_provider() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.modal")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("modal")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_path() -> None:
-    parsed = parse_hosted_location("my-agent@my-host:/path/to/dir")
+def test_parse_host_location_address_with_agent_host_and_path() -> None:
+    parsed = parse_host_location_address("my-agent@my-host:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_host_and_path() -> None:
-    parsed = parse_hosted_location("@my-host:/path/to/dir")
+def test_parse_host_location_address_with_host_and_path() -> None:
+    parsed = parse_host_location_address("@my-host:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_absolute_path() -> None:
-    parsed = parse_hosted_location("/path/to/dir")
+def test_parse_host_location_address_with_absolute_path() -> None:
+    parsed = parse_host_location_address("/path/to/dir")
 
-    assert parsed == HostedLocation(path=Path("/path/to/dir"))
-
-
-def test_parse_hosted_location_with_relative_path() -> None:
-    parsed = parse_hosted_location("./path/to/dir")
-
-    assert parsed == HostedLocation(path=Path("./path/to/dir"))
+    assert parsed == HostLocationAddress(path=Path("/path/to/dir"))
 
 
-def test_parse_hosted_location_with_home_path() -> None:
-    parsed = parse_hosted_location("~/path/to/dir")
+def test_parse_host_location_address_with_relative_path() -> None:
+    parsed = parse_host_location_address("./path/to/dir")
 
-    assert parsed == HostedLocation(path=Path("~/path/to/dir"))
-
-
-def test_parse_hosted_location_with_parent_path() -> None:
-    parsed = parse_hosted_location("../path/to/dir")
-
-    assert parsed == HostedLocation(path=Path("../path/to/dir"))
+    assert parsed == HostLocationAddress(path=Path("./path/to/dir"))
 
 
-def test_parse_hosted_location_bare_name_is_agent_not_path() -> None:
+def test_parse_host_location_address_with_home_path() -> None:
+    parsed = parse_host_location_address("~/path/to/dir")
+
+    assert parsed == HostLocationAddress(path=Path("~/path/to/dir"))
+
+
+def test_parse_host_location_address_with_parent_path() -> None:
+    parsed = parse_host_location_address("../path/to/dir")
+
+    assert parsed == HostLocationAddress(path=Path("../path/to/dir"))
+
+
+def test_parse_host_location_address_bare_name_is_agent_not_path() -> None:
     """A bare name like 'foo' refers to agent 'foo', not directory 'foo'."""
-    parsed = parse_hosted_location("foo")
+    parsed = parse_host_location_address("foo")
 
-    assert parsed == HostedLocation(agent=AgentName("foo"))
+    assert parsed == HostLocationAddress(agent=AgentName("foo"))
 
 
-def test_parse_hosted_location_colon_prefix_is_local_path() -> None:
+def test_parse_host_location_address_colon_prefix_is_local_path() -> None:
     """:dirname is how to specify a relative local directory."""
-    parsed = parse_hosted_location(":my-dir")
+    parsed = parse_host_location_address(":my-dir")
 
-    assert parsed == HostedLocation(path=Path("my-dir"))
+    assert parsed == HostLocationAddress(path=Path("my-dir"))
 
 
 def test_filter_one_host_by_id() -> None:
@@ -353,76 +353,76 @@ def test__filter_one_agent_raises_when_multiple_agents_match() -> None:
         )
 
 
-def test_parse_hosted_location_with_colons_in_path() -> None:
-    parsed = parse_hosted_location("@my-host:/path/with:colons:in:it.txt")
+def test_parse_host_location_address_with_colons_in_path() -> None:
+    parsed = parse_host_location_address("@my-host:/path/with:colons:in:it.txt")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host")),
         path=Path("/path/with:colons:in:it.txt"),
     )
 
 
-def test_parse_hosted_location_with_agent_host_and_colons_in_path() -> None:
-    parsed = parse_hosted_location("agent@host:/weird:path:file.txt")
+def test_parse_host_location_address_with_agent_host_and_colons_in_path() -> None:
+    parsed = parse_host_location_address("agent@host:/weird:path:file.txt")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("agent"),
         host=HostAddress(host=HostName("host")),
         path=Path("/weird:path:file.txt"),
     )
 
 
-def test_parse_hosted_location_with_empty_path_after_colon() -> None:
-    parsed = parse_hosted_location("@my-host:")
+def test_parse_host_location_address_with_empty_path_after_colon() -> None:
+    parsed = parse_host_location_address("@my-host:")
 
-    assert parsed == HostedLocation(host=HostAddress(host=HostName("my-host")))
-
-
-def test_parse_hosted_location_with_agent_and_path() -> None:
-    parsed = parse_hosted_location("my-agent:http://example.com/path")
-
-    assert parsed == HostedLocation(agent=AgentName("my-agent"), path=Path("http://example.com/path"))
+    assert parsed == HostLocationAddress(host=HostAddress(host=HostName("my-host")))
 
 
-def test_parse_hosted_location_with_agent_host_provider() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.docker")
+def test_parse_host_location_address_with_agent_and_path() -> None:
+    parsed = parse_host_location_address("my-agent:http://example.com/path")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(agent=AgentName("my-agent"), path=Path("http://example.com/path"))
+
+
+def test_parse_host_location_address_with_agent_host_provider() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.docker")
+
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("docker")),
     )
 
 
-def test_parse_hosted_location_with_agent_host_provider_and_path() -> None:
-    parsed = parse_hosted_location("my-agent@my-host.modal:/path/to/dir")
+def test_parse_host_location_address_with_agent_host_provider_and_path() -> None:
+    parsed = parse_host_location_address("my-agent@my-host.modal:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         agent=AgentName("my-agent"),
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("modal")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_host_provider_and_path() -> None:
-    parsed = parse_hosted_location("@my-host.docker:/path/to/dir")
+def test_parse_host_location_address_with_host_provider_and_path() -> None:
+    parsed = parse_host_location_address("@my-host.docker:/path/to/dir")
 
-    assert parsed == HostedLocation(
+    assert parsed == HostLocationAddress(
         host=HostAddress(host=HostName("my-host"), provider=ProviderInstanceName("docker")),
         path=Path("/path/to/dir"),
     )
 
 
-def test_parse_hosted_location_with_agent_colon_path() -> None:
+def test_parse_host_location_address_with_agent_colon_path() -> None:
     """Agent name followed by colon and path (no host)."""
-    parsed = parse_hosted_location("C:/Windows/path")
+    parsed = parse_host_location_address("C:/Windows/path")
 
-    assert parsed == HostedLocation(agent=AgentName("C"), path=Path("/Windows/path"))
+    assert parsed == HostLocationAddress(agent=AgentName("C"), path=Path("/Windows/path"))
 
 
-def test_parse_hosted_location_rejects_multi_dot_host() -> None:
-    """parse_hosted_location should reject HOST.PROVIDER strings with more than one dot."""
+def test_parse_host_location_address_rejects_multi_dot_host() -> None:
+    """parse_host_location_address should reject HOST.PROVIDER strings with more than one dot."""
     with pytest.raises(UserInputError, match="contains more than one dot"):
-        parse_hosted_location("@a.b.c:/path")
+        parse_host_location_address("@a.b.c:/path")
 
 
 def test_get_host_from_list_by_id_returns_matching_host() -> None:
@@ -529,10 +529,10 @@ def test_determine_resolved_path_raises_when_no_path_and_no_agent() -> None:
         )
 
 
-def test_parse_hosted_location_with_empty_prefix_before_colon() -> None:
-    """parse_hosted_location should handle :path format (empty prefix before colon)."""
-    parsed = parse_hosted_location(":/path/to/dir")
-    assert parsed == HostedLocation(path=Path("/path/to/dir"))
+def test_parse_host_location_address_with_empty_prefix_before_colon() -> None:
+    """parse_host_location_address should handle :path format (empty prefix before colon)."""
+    parsed = parse_host_location_address(":/path/to/dir")
+    assert parsed == HostLocationAddress(path=Path("/path/to/dir"))
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/api/test_find.py
+++ b/libs/mngr/imbue/mngr/api/test_find.py
@@ -1,4 +1,4 @@
-"""Integration tests for the find module (resolve_hosted_location and ensure_host_started)."""
+"""Integration tests for the find module (resolve_host_location_address and ensure_host_started)."""
 
 from datetime import datetime
 from datetime import timezone
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from imbue.mngr.api.find import ensure_host_started
-from imbue.mngr.api.find import resolve_hosted_location
+from imbue.mngr.api.find import resolve_host_location_address
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.hosts.host import Host
@@ -17,8 +17,8 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostAddress
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostName
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
@@ -62,12 +62,12 @@ def test_ensure_host_started_returns_already_online_host(
     assert online_host is host
 
 
-def test_resolve_hosted_location_resolves_host_and_path(
+def test_resolve_host_location_address_resolves_host_and_path(
     temp_mngr_ctx: MngrContext,
     temp_work_dir: Path,
     local_provider: LocalProviderInstance,
 ) -> None:
-    """Test that resolve_hosted_location returns a valid HostLocation for a known host.
+    """Test that resolve_host_location_address returns a valid HostLocation for a known host.
 
     Verifies the function resolves a host reference and path to an online host
     with a valid HostLocation.
@@ -81,11 +81,11 @@ def test_resolve_hosted_location_resolves_host_and_path(
 
     agents_by_host: dict[DiscoveredHost, list[DiscoveredAgent]] = {host_ref: []}
 
-    parsed = HostedLocation(
+    parsed = HostLocationAddress(
         host=HostAddress(host=host_id),
         path=temp_work_dir,
     )
-    result = resolve_hosted_location(
+    result = resolve_host_location_address(
         parsed,
         agents_by_host=agents_by_host,
         mngr_ctx=temp_mngr_ctx,

--- a/libs/mngr/imbue/mngr/cli/address_params.py
+++ b/libs/mngr/imbue/mngr/cli/address_params.py
@@ -3,7 +3,7 @@
 Each ParamType wraps one of the parsers in :mod:`imbue.mngr.api.address_parsers`.
 Click invokes these during argument parsing, so command bodies receive typed
 addresses (``AgentAddress``, ``HostAddress``, ``NewAgentLocation``,
-``HostedLocation``) rather than raw strings.
+``HostLocationAddress``) rather than raw strings.
 
 Use the module-level singletons (``AGENT_ADDRESS``, ``HOST_ADDRESS``, ...) as
 the ``type=`` value on a ``@click.option`` or ``@click.argument`` decorator.
@@ -17,8 +17,8 @@ from imbue.mngr.api.address_parsers import parse_agent_address
 from imbue.mngr.api.address_parsers import parse_agent_name_or_id
 from imbue.mngr.api.address_parsers import parse_agent_or_host_address
 from imbue.mngr.api.address_parsers import parse_host_address
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.address_parsers import parse_host_name_or_id
-from imbue.mngr.api.address_parsers import parse_hosted_location
 from imbue.mngr.api.address_parsers import parse_new_agent_location
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
@@ -26,8 +26,8 @@ from imbue.mngr.primitives import AgentName
 from imbue.mngr.primitives import AgentNameOrId
 from imbue.mngr.primitives import AgentOrHostAddress
 from imbue.mngr.primitives import HostAddress
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import HostNameOrId
-from imbue.mngr.primitives import HostedLocation
 from imbue.mngr.primitives import InvalidName
 from imbue.mngr.primitives import NewAgentLocation
 
@@ -94,7 +94,7 @@ class NewAgentLocationParamType(click.ParamType):
         return _convert_with_user_input_error(parse_new_agent_location, value, param, ctx)
 
 
-class HostedLocationParamType(click.ParamType):
+class HostLocationAddressParamType(click.ParamType):
     """Click param type for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` source/target arguments.
 
     Used by commands that designate "a location on any host" -- e.g. the
@@ -102,12 +102,12 @@ class HostedLocationParamType(click.ParamType):
     of ``mngr push``/``mngr pull``, and the source argument of ``mngr pair``.
     """
 
-    name = "hosted_location"
+    name = "host_location_address"
 
-    def convert(self, value: Any, param: click.Parameter | None, ctx: click.Context | None) -> HostedLocation:
-        if isinstance(value, HostedLocation):
+    def convert(self, value: Any, param: click.Parameter | None, ctx: click.Context | None) -> HostLocationAddress:
+        if isinstance(value, HostLocationAddress):
             return value
-        return _convert_with_user_input_error(parse_hosted_location, value, param, ctx)
+        return _convert_with_user_input_error(parse_host_location_address, value, param, ctx)
 
 
 class AgentNameOrIdParamType(click.ParamType):
@@ -148,7 +148,7 @@ AGENT_ADDRESS = AgentAddressParamType()
 HOST_ADDRESS = HostAddressParamType()
 AGENT_OR_HOST_ADDRESS = AgentOrHostAddressParamType()
 NEW_AGENT_LOCATION = NewAgentLocationParamType()
-HOSTED_LOCATION = HostedLocationParamType()
+HOST_LOCATION_ADDRESS = HostLocationAddressParamType()
 AGENT_NAME_OR_ID = AgentNameOrIdParamType()
 HOST_NAME_OR_ID = HostNameOrIdParamType()
 AGENT_NAME = AgentNameParamType()

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -24,7 +24,7 @@ from imbue.imbue_common.model_update import to_update
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.imbue_common.pure import pure
 from imbue.mngr.agents.agent_registry import list_available_agent_types
-from imbue.mngr.api.address_parsers import parse_hosted_location
+from imbue.mngr.api.address_parsers import parse_host_location_address
 from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.connect import resolve_connect_command
 from imbue.mngr.api.connect import run_connect_command
@@ -32,11 +32,11 @@ from imbue.mngr.api.create import create as api_create
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.discover import discover_hosts_and_agents
-from imbue.mngr.api.find import ResolvedHostedLocation
+from imbue.mngr.api.find import ResolvedHostLocationAddress
 from imbue.mngr.api.find import ensure_agent_started
 from imbue.mngr.api.find import ensure_host_started
 from imbue.mngr.api.find import get_host_from_list_by_id
-from imbue.mngr.api.find import resolve_hosted_location
+from imbue.mngr.api.find import resolve_host_location_address
 from imbue.mngr.api.gc import register_generated_source_dir
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.cli.address_params import NEW_AGENT_LOCATION
@@ -701,7 +701,9 @@ class _CreateSetup(FrozenModel):
     )
     editor_session: EditorSession | None = Field(default=None, description="Editor session for --edit-message")
     agent_and_host_loader: _CachedAgentHostLoader = Field(description="Lazy loader for agents grouped by host")
-    resolved_source: ResolvedHostedLocation = Field(description="Resolved source location and optional source agent")
+    resolved_source: ResolvedHostLocationAddress = Field(
+        description="Resolved source location and optional source agent"
+    )
     auto_labels: _AutoLabels = Field(description="Auto-derived labels for the new agent")
     host_lifecycle: HostLifecycleOptions = Field(description="Host lifecycle options")
     plugin_cli_params: dict[str, Any] = Field(
@@ -1129,7 +1131,7 @@ def _get_source_remote_url(source_location: HostLocation) -> str | None:
 
 
 def _parse_project_name(
-    resolved_source: ResolvedHostedLocation,
+    resolved_source: ResolvedHostLocationAddress,
     opts: CreateCliOptions,
     remote_url: str | None,
 ) -> str:
@@ -1241,7 +1243,7 @@ def _resolve_source_location(
     mngr_ctx: MngrContext,
     *,
     is_start_desired: bool,
-) -> ResolvedHostedLocation:
+) -> ResolvedHostLocationAddress:
     """Resolve the source location and optionally the source agent ID and labels."""
     if opts.source is None:
         # No --from specified: default to git root
@@ -1257,7 +1259,7 @@ def _resolve_source_location(
         provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
         host = provider.get_host(HostName(LOCAL_HOST_NAME))
         online_host, _ = ensure_host_started(host, is_start_desired=is_start_desired, provider=provider)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=Path(source_path)))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=Path(source_path)))
 
     # Git URL: clone to a managed directory and treat as a local path
     if is_git_url(opts.source):
@@ -1272,10 +1274,10 @@ def _resolve_source_location(
         name_hint = pick_agent_name_hint(positional_hint, name_hint_arg, parse_project_name_from_url(opts.source))
         cloned_path = clone_git_url_to_managed_dir(opts.source, clones_base, name_hint, mngr_ctx.concurrency_group)
         register_generated_source_dir(online_host, cloned_path)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=cloned_path))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=cloned_path))
 
     # Parse the --from string once
-    parsed = parse_hosted_location(opts.source)
+    parsed = parse_host_location_address(opts.source)
 
     # When --from is just a local path (no agent or host component),
     # resolve it locally without loading all providers. Loading all
@@ -1287,11 +1289,11 @@ def _resolve_source_location(
         provider = get_provider_instance(LOCAL_PROVIDER_NAME, mngr_ctx)
         host = provider.get_host(HostName(LOCAL_HOST_NAME))
         online_host, _ = ensure_host_started(host, is_start_desired=is_start_desired, provider=provider)
-        return ResolvedHostedLocation(location=HostLocation(host=online_host, path=Path(source_path)))
+        return ResolvedHostLocationAddress(location=HostLocation(host=online_host, path=Path(source_path)))
 
     # Need full resolution across providers
     agents_by_host = agent_and_host_loader()
-    return resolve_hosted_location(
+    return resolve_host_location_address(
         parsed,
         agents_by_host,
         mngr_ctx,

--- a/libs/mngr/imbue/mngr/cli/create_test.py
+++ b/libs/mngr/imbue/mngr/cli/create_test.py
@@ -13,7 +13,7 @@ from click.testing import CliRunner
 
 from imbue.imbue_common.model_update import to_update
 from imbue.mngr.api.address_parsers import parse_new_agent_location
-from imbue.mngr.api.find import ResolvedHostedLocation
+from imbue.mngr.api.find import ResolvedHostLocationAddress
 from imbue.mngr.cli.create import _AutoLabels
 from imbue.mngr.cli.create import _CreateCommand
 from imbue.mngr.cli.create import _RECOVERED_MESSAGE_FILENAME
@@ -568,7 +568,7 @@ def test_parse_project_name_returns_explicit_project(
 ) -> None:
     """When --project is specified, return it directly."""
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=temp_work_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=temp_work_dir))
     opts = default_create_cli_opts.model_copy_update(
         to_update(default_create_cli_opts.field_ref().project, "explicit-project"),
     )
@@ -587,7 +587,7 @@ def test_parse_project_name_treats_dot_as_default_derivation(
     some_dir = tmp_path / "some-source"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
     opts = default_create_cli_opts.model_copy_update(
         to_update(default_create_cli_opts.field_ref().project, "."),
     )
@@ -606,7 +606,7 @@ def test_parse_project_name_inherits_from_source_agent(
     some_dir = tmp_path / "local-folder"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(
+    resolved = ResolvedHostLocationAddress(
         location=HostLocation(host=local_host, path=some_dir),
         agent=DiscoveredAgent(
             host_id=local_host.id,
@@ -631,7 +631,7 @@ def test_parse_project_name_derives_from_remote_url(
     some_dir = tmp_path / "local-folder"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
 
     result = _parse_project_name(resolved, default_create_cli_opts, remote_url="https://github.com/owner/my-repo.git")
 
@@ -647,7 +647,7 @@ def test_parse_project_name_falls_back_to_folder_name(
     some_dir = tmp_path / "some-project"
     some_dir.mkdir()
     local_host = cast(OnlineHostInterface, local_provider.get_host(HostName(LOCAL_HOST_NAME)))
-    resolved = ResolvedHostedLocation(location=HostLocation(host=local_host, path=some_dir))
+    resolved = ResolvedHostLocationAddress(location=HostLocation(host=local_host, path=some_dir))
 
     result = _parse_project_name(resolved, default_create_cli_opts, remote_url=None)
 

--- a/libs/mngr/imbue/mngr/cli/pull.py
+++ b/libs/mngr/imbue/mngr/cli/pull.py
@@ -7,8 +7,8 @@ from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.pull import pull_files
 from imbue.mngr.api.pull import pull_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -22,7 +22,7 @@ from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import UncommittedChangesMode
 
 
@@ -32,9 +32,9 @@ class PullCliOptions(CommonCliOptions):
     Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
     """
 
-    source_pos: HostedLocation | None
+    source_pos: HostLocationAddress | None
     destination_pos: str | None
-    source: HostedLocation | None
+    source: HostLocationAddress | None
     source_agent: AgentAddress | None
     source_host: HostAddress | None
     source_path: str | None
@@ -48,7 +48,7 @@ class PullCliOptions(CommonCliOptions):
     uncommitted_changes: str
     target_branch: str | None
     # Planned features (not yet implemented)
-    target: HostedLocation | None
+    target: HostLocationAddress | None
     target_agent: AgentAddress | None
     target_host: HostAddress | None
     target_path: str | None
@@ -69,13 +69,13 @@ class PullCliOptions(CommonCliOptions):
 
 
 @click.command()
-@click.argument("source_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="SOURCE")
+@click.argument("source_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="SOURCE")
 @click.argument("destination_pos", default=None, required=False, metavar="DESTINATION")
 @optgroup.group("Source Selection")
 @optgroup.option(
     "--source",
     "source",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Source specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--source-agent", type=AGENT_ADDRESS, help="Source agent address (NAME[@HOST[.PROVIDER]])")
@@ -127,7 +127,7 @@ class PullCliOptions(CommonCliOptions):
 @optgroup.group("Target (for agent-to-agent sync)")
 @optgroup.option(
     "--target",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Target specification: AGENT[@HOST[.PROVIDER]][:PATH] [future]",
 )
 @optgroup.option("--target-agent", type=AGENT_ADDRESS, help="Target agent address [future]")
@@ -196,7 +196,7 @@ def pull(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_source_loc: HostedLocation | None = opts.source if opts.source is not None else opts.source_pos
+    effective_source_loc: HostLocationAddress | None = opts.source if opts.source is not None else opts.source_pos
     effective_destination = opts.destination if opts.destination is not None else opts.destination_pos
 
     # Check for unsupported options

--- a/libs/mngr/imbue/mngr/cli/push.py
+++ b/libs/mngr/imbue/mngr/cli/push.py
@@ -7,8 +7,8 @@ from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.api.push import push_files
 from imbue.mngr.api.push import push_git
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.agent_utils import stop_agent_after_sync
 from imbue.mngr.cli.common_opts import add_common_options
@@ -22,7 +22,7 @@ from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import UncommittedChangesMode
 
 
@@ -32,9 +32,9 @@ class PushCliOptions(CommonCliOptions):
     Inherits common options (output_format, quiet, verbose, etc.) from CommonCliOptions.
     """
 
-    target_pos: HostedLocation | None
+    target_pos: HostLocationAddress | None
     source_pos: str | None
-    target: HostedLocation | None
+    target: HostLocationAddress | None
     target_agent: AgentAddress | None
     target_host: HostAddress | None
     target_path: str | None
@@ -52,13 +52,13 @@ class PushCliOptions(CommonCliOptions):
 
 
 @click.command()
-@click.argument("target_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="TARGET")
+@click.argument("target_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="TARGET")
 @click.argument("source_pos", default=None, required=False, metavar="SOURCE")
 @optgroup.group("Target Selection")
 @optgroup.option(
     "--target",
     "target",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Target specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--target-agent", type=AGENT_ADDRESS, help="Target agent address (NAME[@HOST[.PROVIDER]])")
@@ -136,7 +136,7 @@ def push(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_target_loc: HostedLocation | None = opts.target if opts.target is not None else opts.target_pos
+    effective_target_loc: HostLocationAddress | None = opts.target if opts.target is not None else opts.target_pos
     effective_source = opts.source if opts.source is not None else opts.source_pos
 
     # Check for unsupported options

--- a/libs/mngr/imbue/mngr/primitives.py
+++ b/libs/mngr/imbue/mngr/primitives.py
@@ -373,7 +373,7 @@ class AgentAddress(FrozenModel):
 
     The agent component is required; without it, this is not an agent address.
     Use :class:`HostAddress` for ``@HOST.PROVIDER`` (no agent) or
-    :class:`HostedLocation` for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` syntax.
+    :class:`HostLocationAddress` for ``[NAME[@HOST[.PROVIDER]]][:PATH]`` syntax.
     """
 
     agent: AgentNameOrId = Field(description="Agent name or ID (required)")
@@ -422,7 +422,7 @@ class NewAgentLocation(FrozenModel):
     path: Path | None = Field(default=None, description="Optional explicit work-directory path inside the host")
 
 
-class HostedLocation(FrozenModel):
+class HostLocationAddress(FrozenModel):
     """A location that lives on some host: ``[NAME[@HOST[.PROVIDER]]][:PATH]`` or a bare path.
 
     Used wherever a CLI command needs to designate "a place on any host" -- the

--- a/libs/mngr_pair/imbue/mngr_pair/cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli.py
@@ -7,8 +7,8 @@ from loguru import logger
 
 from imbue.mngr.api.find import resolve_to_started_host_and_agent
 from imbue.mngr.cli.address_params import AGENT_ADDRESS
-from imbue.mngr.cli.address_params import HOSTED_LOCATION
 from imbue.mngr.cli.address_params import HOST_ADDRESS
+from imbue.mngr.cli.address_params import HOST_LOCATION_ADDRESS
 from imbue.mngr.cli.agent_utils import find_agent_by_address_or_interactively
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
@@ -24,7 +24,7 @@ from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import AgentAddress
 from imbue.mngr.primitives import ConflictMode
 from imbue.mngr.primitives import HostAddress
-from imbue.mngr.primitives import HostedLocation
+from imbue.mngr.primitives import HostLocationAddress
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import SyncDirection
 from imbue.mngr.primitives import UncommittedChangesMode
@@ -35,8 +35,8 @@ from imbue.mngr_pair.api import pair_files
 class PairCliOptions(CommonCliOptions):
     """Options passed from the CLI to the pair command."""
 
-    source_pos: HostedLocation | None
-    source: HostedLocation | None
+    source_pos: HostLocationAddress | None
+    source: HostLocationAddress | None
     source_agent: AgentAddress | None
     source_host: HostAddress | None
     source_path: str | None
@@ -81,12 +81,12 @@ def _emit_pair_stopped(output_opts: OutputOptions) -> None:
 
 
 @click.command()
-@click.argument("source_pos", type=HOSTED_LOCATION, default=None, required=False, metavar="SOURCE")
+@click.argument("source_pos", type=HOST_LOCATION_ADDRESS, default=None, required=False, metavar="SOURCE")
 @optgroup.group("Source Selection")
 @optgroup.option(
     "--source",
     "source",
-    type=HOSTED_LOCATION,
+    type=HOST_LOCATION_ADDRESS,
     help="Source specification: AGENT[@HOST[.PROVIDER]][:PATH]",
 )
 @optgroup.option("--source-agent", type=AGENT_ADDRESS, help="Source agent address (NAME[@HOST[.PROVIDER]])")
@@ -148,7 +148,7 @@ def pair(ctx: click.Context, **kwargs) -> None:
     )
 
     # Merge positional and named arguments (named option takes precedence)
-    effective_source_loc: HostedLocation | None = opts.source if opts.source is not None else opts.source_pos
+    effective_source_loc: HostLocationAddress | None = opts.source if opts.source is not None else opts.source_pos
 
     # Build source agent address and sub-path
     source_address: AgentAddress | None = None


### PR DESCRIPTION
## Summary

- Rename `HostedLocation` to `HostLocationAddress` so its name matches its peers (`HostAddress`, `AgentAddress`) and makes the relationship to the runtime `HostLocation` type explicit.
- Cascading renames: `parse_hosted_location` -> `parse_host_location_address`, `resolve_hosted_location` -> `resolve_host_location_address`, `ResolvedHostedLocation` -> `ResolvedHostLocationAddress`, `HostedLocationParamType` -> `HostLocationAddressParamType`, `HOSTED_LOCATION` -> `HOST_LOCATION_ADDRESS`, and the Click param-type display name `hosted_location` -> `host_location_address` (visible in `push`/`pull`/`pair` `--help` output and the regenerated command docs).
- No behavior change.

## Test plan

- [x] `just test-quick "libs/mngr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` -> 3883 passed, 1 skipped
- [x] `just test-quick "libs/mngr_pair -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` -> 107 passed
- [ ] CI

Generated with [Claude Code](https://claude.com/claude-code)