### PR TITLE
Fix mngr config help text: --user should be --scope user

### DIFF
--- a/changelog/mngr-help-text.md
+++ b/changelog/mngr-help-text.md
@@ -1,0 +1,1 @@
+Fix `mngr config` help text and docs example: the example showed `--user` but the actual option is `--scope user`.

--- a/libs/mngr/docs/commands/secondary/config.md
+++ b/libs/mngr/docs/commands/secondary/config.md
@@ -419,7 +419,7 @@ $ mngr config get provider.docker.image
 **Set a value at user scope**
 
 ```bash
-$ mngr config set --user provider.docker.image my-image:latest
+$ mngr config set --scope user provider.docker.image my-image:latest
 ```
 
 **Edit config in your editor**

--- a/libs/mngr/imbue/mngr/cli/config.py
+++ b/libs/mngr/imbue/mngr/cli/config.py
@@ -747,7 +747,7 @@ Configuration is stored in TOML files:
     examples=(
         ("List all configuration values", "mngr config list"),
         ("Get a specific value", "mngr config get provider.docker.image"),
-        ("Set a value at user scope", "mngr config set --user provider.docker.image my-image:latest"),
+        ("Set a value at user scope", "mngr config set --scope user provider.docker.image my-image:latest"),
         ("Edit config in your editor", "mngr config edit"),
         ("Show config file paths", "mngr config path"),
     ),


### PR DESCRIPTION
## Summary
- `mngr config --help` showed an example using `--user`, which is not a real option. The actual flag is `--scope user`.
- Fix the example in both the CLI help (libs/mngr/imbue/mngr/cli/config.py) and the generated docs page (libs/mngr/docs/commands/secondary/config.md) so copy/paste works.

## Test plan
- [ ] CI passes
- [ ] `uv run mngr config --help` shows the corrected example