### PR TITLE
Stop modal provider from auto-creating env on mngr list / gc

### DIFF
--- a/changelog/mngr-avoid-bad-create.md
+++ b/changelog/mngr-avoid-bad-create.md
@@ -1,0 +1,13 @@
+## Modal provider no longer auto-creates an environment from non-create commands
+
+`mngr list`, `mngr gc`, and other read flows no longer silently bootstrap a
+Modal environment (the `Created Modal environment: ...` log line) just because
+the modal provider is enabled. The Modal provider now disables itself (raises
+`ProviderUnavailableError`, which higher-level loaders skip) when its per-user
+Modal environment doesn't exist yet. Only `mngr create` is allowed to bootstrap
+the environment on first use.
+
+This is plumbed through a new `is_for_host_creation: bool = False` parameter on
+`ProviderBackendInterface.build_provider_instance` / `api.providers.get_provider_instance`,
+which all other backends accept and ignore. `mngr create` passes `True`; every
+other path leaves the default.

--- a/libs/mngr/imbue/mngr/api/create.py
+++ b/libs/mngr/imbue/mngr/api/create.py
@@ -357,8 +357,11 @@ def resolve_target_host(
 ) -> OnlineHostInterface:
     """Resolve which host to use for the agent."""
     if target_host is not None and isinstance(target_host, NewHostOptions):
-        # Create a new host using the specified provider
-        provider = get_provider_instance(target_host.provider, mngr_ctx)
+        # Create a new host using the specified provider. Pass is_for_host_creation=True
+        # so that backends with one-time bootstrap (Modal's per-user environment) are
+        # allowed to create those resources here -- the create path is the only caller
+        # authorized to do so.
+        provider = get_provider_instance(target_host.provider, mngr_ctx, is_for_host_creation=True)
         is_auto_named = target_host.name is None
         host_name = target_host.name
         if host_name is None:

--- a/libs/mngr/imbue/mngr/api/list_test.py
+++ b/libs/mngr/imbue/mngr/api/list_test.py
@@ -1309,7 +1309,9 @@ class _MismatchedProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        del is_for_host_creation
         return _MismatchedProviderInstance(
             name=name,
             host_dir=mngr_ctx.config.default_host_dir,
@@ -1348,7 +1350,9 @@ class _RaisingDiscoveryProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        del is_for_host_creation
         return _RaisingDiscoveryProviderInstance(
             name=name,
             host_dir=mngr_ctx.config.default_host_dir,

--- a/libs/mngr/imbue/mngr/api/providers.py
+++ b/libs/mngr/imbue/mngr/api/providers.py
@@ -4,6 +4,7 @@ from loguru import logger
 
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.base_provider import BaseProviderInstance
@@ -51,6 +52,7 @@ def reset_provider_instances() -> None:
 def get_provider_instance(
     name: ProviderInstanceName,
     mngr_ctx: MngrContext,
+    is_for_host_creation: bool = False,
 ) -> BaseProviderInstance:
     """Get or create a provider instance by name.
 
@@ -58,6 +60,12 @@ def get_provider_instance(
     Otherwise, creates a new instance: checks config.providers first, then falls
     back to treating the name as a backend name with defaults.
     The returned instance is tracked for cleanup at process exit via atexit.
+
+    ``is_for_host_creation`` is forwarded to the backend's
+    ``build_provider_instance`` so backends with one-time bootstrap resources
+    (currently: the Modal backend's per-user environment) can distinguish
+    create-host construction from construction for read-only or existing-host
+    operations. Only the ``mngr create`` path sets this to ``True``.
     """
     _ensure_atexit_registered()
 
@@ -75,6 +83,7 @@ def get_provider_instance(
             backend_name=provider_config.backend,
             config=provider_config,
             mngr_ctx=mngr_ctx,
+            is_for_host_creation=is_for_host_creation,
         )
         logger.trace("Built provider instance {} from config with backend {}", name, provider_config.backend)
     else:
@@ -88,6 +97,7 @@ def get_provider_instance(
             backend_name=backend_name,
             config=default_config,
             mngr_ctx=mngr_ctx,
+            is_for_host_creation=is_for_host_creation,
         )
         logger.trace("Built provider instance {} using backend name as default", name)
 
@@ -176,13 +186,23 @@ def get_all_provider_instances(
     - Provider instances with is_enabled=False in their config
     - Backends not in enabled_backends list (if the list is non-empty)
     - Providers not in provider_names (if provider_names is specified)
+    - Provider instances that declare themselves unavailable at construction
+      time (by raising ``ProviderUnavailableError``). This is how the Modal
+      backend disables itself when its per-user environment doesn't exist yet
+      -- so commands like ``mngr list`` and ``mngr gc`` do not silently
+      bootstrap a Modal environment.
 
-    Raises MngrError if ANY provider fails to instantiate. Callers that want to
-    tolerate per-provider instantiation errors should use list_provider_names_to_load.
+    Raises MngrError if ANY provider fails to instantiate for a reason other
+    than ``ProviderUnavailableError``. Callers that want to tolerate per-provider
+    instantiation errors should use list_provider_names_to_load.
     """
-    providers: list[BaseProviderInstance] = [
-        get_provider_instance(name, mngr_ctx) for name in list_provider_names_to_load(mngr_ctx, provider_names)
-    ]
+    providers: list[BaseProviderInstance] = []
+    for name in list_provider_names_to_load(mngr_ctx, provider_names):
+        try:
+            providers.append(get_provider_instance(name, mngr_ctx))
+        except ProviderUnavailableError as e:
+            logger.debug("Skipping provider {} (unavailable): {}", name, e)
+            continue
 
     if reset_caches:
         for provider in providers:

--- a/libs/mngr/imbue/mngr/interfaces/provider_backend.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_backend.py
@@ -52,6 +52,15 @@ class ProviderBackendInterface(MutableModel, ABC):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
-        """Create a configured provider instance from this backend."""
+        """Create a configured provider instance from this backend.
+
+        ``is_for_host_creation`` lets a backend distinguish construction that
+        is happening because the user is about to create a new host (so it is
+        free to bootstrap any one-time backend resources, like a Modal
+        environment) from construction that is happening for read-only or
+        existing-host operations (which must not silently create new backend-
+        side resources). Backends with no such one-time setup ignore the flag.
+        """
         ...

--- a/libs/mngr/imbue/mngr/providers/docker/backend.py
+++ b/libs/mngr/imbue/mngr/providers/docker/backend.py
@@ -59,8 +59,14 @@ class DockerProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
-        """Build a Docker provider instance."""
+        """Build a Docker provider instance.
+
+        ``is_for_host_creation`` is ignored: the Docker backend has no one-time
+        backend resources to bootstrap.
+        """
+        del is_for_host_creation
         if not isinstance(config, DockerProviderConfig):
             raise MngrError(f"Expected DockerProviderConfig, got {type(config).__name__}")
         host_dir = config.host_dir if config.host_dir is not None else Path("/mngr")

--- a/libs/mngr/imbue/mngr/providers/local/backend.py
+++ b/libs/mngr/imbue/mngr/providers/local/backend.py
@@ -48,8 +48,14 @@ class LocalProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
-        """Build a local provider instance."""
+        """Build a local provider instance.
+
+        ``is_for_host_creation`` is ignored: the local backend has no one-time
+        backend resources to bootstrap.
+        """
+        del is_for_host_creation
         if not isinstance(config, LocalProviderConfig):
             raise ConfigStructureError(f"Expected LocalProviderConfig, got {type(config).__name__}")
         # Get host_dir from typed config, falling back to default

--- a/libs/mngr/imbue/mngr/providers/registry.py
+++ b/libs/mngr/imbue/mngr/providers/registry.py
@@ -130,13 +130,21 @@ def build_provider_instance(
     backend_name: ProviderBackendName,
     config: ProviderInstanceConfig,
     mngr_ctx: MngrContext,
+    is_for_host_creation: bool = False,
 ) -> BaseProviderInstance:
-    """Build a provider instance using the registered backend."""
+    """Build a provider instance using the registered backend.
+
+    ``is_for_host_creation`` is forwarded to the backend so that backends with
+    one-time bootstrap resources (currently: the Modal backend's per-user
+    environment) can distinguish create-host construction from construction
+    for read-only / existing-host operations.
+    """
     backend_class = get_backend(backend_name)
     obj = backend_class.build_provider_instance(
         name=instance_name,
         config=config,
         mngr_ctx=mngr_ctx,
+        is_for_host_creation=is_for_host_creation,
     )
     if not isinstance(obj, BaseProviderInstance):
         raise ConfigStructureError(

--- a/libs/mngr/imbue/mngr/providers/registry_test.py
+++ b/libs/mngr/imbue/mngr/providers/registry_test.py
@@ -39,6 +39,7 @@ class _TestBackendWithSameHelp(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
         raise NotImplementedError
 

--- a/libs/mngr/imbue/mngr/providers/ssh/backend.py
+++ b/libs/mngr/imbue/mngr/providers/ssh/backend.py
@@ -68,8 +68,14 @@ Example configuration in mngr.toml:
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
-        """Build an SSH provider instance."""
+        """Build an SSH provider instance.
+
+        ``is_for_host_creation`` is ignored: the SSH backend has no one-time
+        backend resources to bootstrap.
+        """
+        del is_for_host_creation
         if not isinstance(config, SSHProviderConfig):
             raise ConfigStructureError(f"Expected SSHProviderConfig, got {type(config).__name__}")
         host_dir = config.host_dir

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/backend.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/backend.py
@@ -53,7 +53,9 @@ class ImbueCloudProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        del is_for_host_creation
         if not isinstance(config, ImbueCloudProviderConfig):
             raise MngrError(f"Expected ImbueCloudProviderConfig for instance '{name}', got {type(config).__name__}")
         connector_url = config.get_connector_url()

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/backend.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/backend.py
@@ -55,6 +55,12 @@ class ImbueCloudProviderBackend(ProviderBackendInterface):
         mngr_ctx: MngrContext,
         is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        """Build an imbue_cloud provider instance.
+
+        ``is_for_host_creation`` is ignored: the imbue_cloud backend has no
+        one-time bootstrap resources to gate on (compare the Modal backend,
+        which uses this flag to authorize creating a missing per-user env).
+        """
         del is_for_host_creation
         if not isinstance(config, ImbueCloudProviderConfig):
             raise MngrError(f"Expected ImbueCloudProviderConfig for instance '{name}', got {type(config).__name__}")

--- a/libs/mngr_lima/imbue/mngr_lima/backend.py
+++ b/libs/mngr_lima/imbue/mngr_lima/backend.py
@@ -64,6 +64,7 @@ Run 'limactl start --help' for the full list.
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
         """Build a Lima provider instance.
 
@@ -71,6 +72,7 @@ Run 'limactl start --help' for the full list.
         not performed here. This allows the provider to be registered in
         environments where limactl is not installed (e.g. CI).
         """
+        del is_for_host_creation
         if not isinstance(config, LimaProviderConfig):
             raise MngrError(f"Expected LimaProviderConfig, got {type(config).__name__}")
 

--- a/libs/mngr_lima/imbue/mngr_lima/backend.py
+++ b/libs/mngr_lima/imbue/mngr_lima/backend.py
@@ -71,6 +71,10 @@ Run 'limactl start --help' for the full list.
         Lima installation and version checks are deferred to first use,
         not performed here. This allows the provider to be registered in
         environments where limactl is not installed (e.g. CI).
+
+        ``is_for_host_creation`` is ignored: the Lima backend has no one-time
+        bootstrap resources to gate on (compare the Modal backend, which uses
+        this flag to authorize creating a missing per-user env).
         """
         del is_for_host_creation
         if not isinstance(config, LimaProviderConfig):

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -22,6 +22,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.errors import ConfigStructureError
 from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.hosts.host import Host
 from imbue.mngr.interfaces.agent import AgentInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
@@ -106,17 +107,25 @@ def _create_environment(environment_name: str, modal_interface: ModalInterface) 
 
 
 def _lookup_persistent_app_with_env_retry(
-    app_name: str, environment_name: str, modal_interface: ModalInterface
+    app_name: str,
+    environment_name: str,
+    modal_interface: ModalInterface,
+    is_environment_creation_allowed: bool,
 ) -> AppInterface:
     """Look up or create a persistent Modal app, retrying if the environment is not found.
 
-    On the first NotFoundError, creates the environment and retries with exponential backoff
-    to handle the race condition where Modal's API may not immediately see the newly created
-    environment.
+    When ``is_environment_creation_allowed`` is True and the first lookup raises
+    ``ModalProxyNotFoundError`` (because the environment does not yet exist), the
+    environment is created and the lookup is retried with exponential backoff to
+    handle Modal's eventual consistency. When False, the missing-environment
+    error is propagated -- callers that are not creating a host should never
+    cause a Modal environment to be silently created.
     """
     try:
         return modal_interface.app_lookup(app_name, create_if_missing=True, environment_name=environment_name)
     except ModalProxyNotFoundError:
+        if not is_environment_creation_allowed:
+            raise
         # Create the environment before retrying
         _create_environment(environment_name, modal_interface)
         return _lookup_persistent_app_with_retry(app_name, environment_name, modal_interface)
@@ -137,13 +146,19 @@ def _lookup_persistent_app_with_retry(
 
 
 def _enter_ephemeral_app_context_with_env_retry(
-    app: AppInterface, environment_name: str, modal_interface: ModalInterface
+    app: AppInterface,
+    environment_name: str,
+    modal_interface: ModalInterface,
+    is_environment_creation_allowed: bool,
 ) -> Any:
     """Enter an ephemeral Modal app's run context, retrying if the environment is not found.
 
-    On the first NotFoundError, creates the environment and retries with exponential backoff
-    to handle the race condition where Modal's API may not immediately see the newly created
-    environment.
+    When ``is_environment_creation_allowed`` is True and entering the run context
+    raises ``ModalProxyNotFoundError`` (because the environment does not yet exist),
+    the environment is created and the entry is retried with exponential backoff to
+    handle Modal's eventual consistency. When False, the missing-environment error
+    is propagated -- callers that are not creating a host should never cause a
+    Modal environment to be silently created.
 
     Returns the generator context so the caller can manage its lifecycle.
     """
@@ -152,6 +167,8 @@ def _enter_ephemeral_app_context_with_env_retry(
         next(gen)
         return gen
     except ModalProxyNotFoundError:
+        if not is_environment_creation_allowed:
+            raise
         # Create the environment before retrying
         _create_environment(environment_name, modal_interface)
         return _enter_ephemeral_app_context_with_retry(app, environment_name)
@@ -247,6 +264,7 @@ class ModalProviderBackend(ProviderBackendInterface):
         environment_name: str,
         is_persistent: bool,
         modal_interface: ModalInterface,
+        is_environment_creation_allowed: bool = False,
     ) -> tuple[AppInterface, ModalAppContextHandle]:
         """Get or create a Modal app with output capture.
 
@@ -261,7 +279,15 @@ class ModalProviderBackend(ProviderBackendInterface):
         a Modal account. The state-volume name is prepared here but the
         volume is created lazily by ``get_volume_for_app()``.
 
+        ``is_environment_creation_allowed`` defaults to False: read-only paths
+        (list, gc, discover) must not silently create a Modal environment if
+        one doesn't exist yet. Only the create-host path sets this to True so
+        a brand-new install of mngr can bootstrap the environment on first
+        ``mngr create``.
+
         Raises ``ModalProxyAuthError`` if Modal credentials are missing.
+        Raises ``ModalProxyNotFoundError`` if the environment does not exist
+        and ``is_environment_creation_allowed`` is False.
         """
         if app_name in cls._app_registry:
             return cls._app_registry[app_name]
@@ -275,7 +301,9 @@ class ModalProviderBackend(ProviderBackendInterface):
 
             if is_persistent:
                 with log_span("Looking up persistent Modal app: {}", app_name):
-                    app = _lookup_persistent_app_with_env_retry(app_name, environment_name, modal_interface)
+                    app = _lookup_persistent_app_with_env_retry(
+                        app_name, environment_name, modal_interface, is_environment_creation_allowed
+                    )
                 run_context = None
             else:
                 # Create the Modal app
@@ -285,7 +313,9 @@ class ModalProviderBackend(ProviderBackendInterface):
                 # Enter the app.run() context via generator so we can return the app
                 # while keeping the context active until close() is called
                 with log_span("Entering Modal app.run() context (env: {})", environment_name):
-                    run_context = _enter_ephemeral_app_context_with_env_retry(app, environment_name, modal_interface)
+                    run_context = _enter_ephemeral_app_context_with_env_retry(
+                        app, environment_name, modal_interface, is_environment_creation_allowed
+                    )
 
             # Set app metadata on the loguru writer for structured logging
             if loguru_writer is not None:
@@ -433,8 +463,20 @@ Supported build arguments for the modal provider:
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
-        """Build a Modal provider instance."""
+        """Build a Modal provider instance.
+
+        ``is_for_host_creation`` is the single switch that determines whether
+        this construction is allowed to bootstrap a missing Modal environment.
+        Only the ``mngr create`` path passes ``True``; everything else leaves
+        it at the default ``False`` so a brand-new install does not silently
+        create environments from ``mngr list`` / ``mngr gc`` / etc. When the
+        environment is missing and ``is_for_host_creation`` is ``False``, this
+        raises ``ProviderUnavailableError`` so the higher-level provider
+        loader can skip the modal provider entirely instead of constructing
+        it.
+        """
         if not isinstance(config, ModalProviderConfig):
             raise ConfigStructureError(f"Expected ModalProviderConfig, got {type(config).__name__}")
 
@@ -448,7 +490,9 @@ Supported build arguments for the modal provider:
             case _ as unreachable:
                 assert_never(unreachable)
 
-        return ModalProviderBackend._construct_modal_provider(name, config, mngr_ctx, modal_interface)
+        return ModalProviderBackend._construct_modal_provider(
+            name, config, mngr_ctx, modal_interface, is_for_host_creation=is_for_host_creation
+        )
 
     @staticmethod
     def _construct_modal_provider(
@@ -456,6 +500,7 @@ Supported build arguments for the modal provider:
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
         modal_interface: ModalInterface,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
         """Build a ``ModalProviderInstance`` against the given ``ModalInterface``.
 
@@ -465,6 +510,12 @@ Supported build arguments for the modal provider:
         ``TestingModalInterface``). Output capture is yielded off
         ``modal_interface.enable_output_capture(...)`` so this function has
         no per-implementation branches.
+
+        ``is_for_host_creation`` gates whether a missing Modal environment may
+        be created here. When ``False`` and the environment does not exist,
+        ``ProviderUnavailableError`` is raised so that read-only loaders (used
+        by ``mngr list`` / ``mngr gc`` / discovery) can skip the modal
+        provider entirely rather than creating an environment on first use.
         """
         if not isinstance(config, ModalProviderConfig):
             raise ConfigStructureError(f"Expected ModalProviderConfig, got {type(config).__name__}")
@@ -478,6 +529,7 @@ Supported build arguments for the modal provider:
                 environment_name,
                 config.is_persistent,
                 modal_interface,
+                is_environment_creation_allowed=is_for_host_creation,
             )
             volume = ModalProviderBackend.get_volume_for_app(app_name, modal_interface)
 
@@ -494,6 +546,18 @@ Supported build arguments for the modal provider:
             raise MngrError(
                 "Modal is not authorized: run 'uvx modal token set' to authenticate, or disable this provider with "
                 f"'mngr config set --scope local providers.{name}.is_enabled false'. (original error: {e})",
+            ) from e
+        except ModalProxyNotFoundError as e:
+            # Modal environment doesn't exist yet. Only the create-host path is
+            # allowed to bootstrap it -- everything else asks the loader to skip
+            # the modal provider so commands like `mngr list` / `mngr gc` don't
+            # silently create a Modal environment behind the user's back.
+            raise ProviderUnavailableError(
+                provider_name=name,
+                reason=(
+                    f"Modal environment {environment_name!r} does not exist yet. "
+                    "It will be created the first time you run `mngr create @.modal`."
+                ),
             ) from e
         except ModalProxyError as e:
             raise MngrError(f"Modal provider '{name}' failed to initialize: {e}") from e

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -556,7 +556,7 @@ Supported build arguments for the modal provider:
                 provider_name=name,
                 reason=(
                     f"Modal environment {environment_name!r} does not exist yet. "
-                    "It will be created the first time you run `mngr create @.modal`."
+                    f"It will be created the first time you run `mngr create @.{name}`."
                 ),
             ) from e
         except ModalProxyError as e:

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -81,10 +81,13 @@ def make_modal_provider_real(
         is_persistent=is_persistent,
         is_snapshotted_after_create=is_snapshotted_after_create,
     )
+    # Acceptance fixtures always need to bootstrap the per-session Modal env,
+    # so pass is_for_host_creation=True to authorize env creation.
     instance = ModalProviderBackend.build_provider_instance(
         name=ProviderInstanceName("modal-test"),
         config=config,
         mngr_ctx=mngr_ctx,
+        is_for_host_creation=True,
     )
     if not isinstance(instance, ModalProviderInstance):
         raise ConfigStructureError(f"Expected ModalProviderInstance, got {type(instance).__name__}")

--- a/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
@@ -23,6 +23,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import HostNameConflictError
 from imbue.mngr.errors import HostNotFoundError
 from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.errors import SnapshotNotFoundError
 from imbue.mngr.hosts.offline_host import OfflineHost
 from imbue.mngr.interfaces.data_types import CertifiedHostData
@@ -77,7 +78,9 @@ from imbue.mngr_modal.volume import _proxy_file_entry_type_to_volume_file_type
 from imbue.modal_proxy.data_types import FileEntry
 from imbue.modal_proxy.data_types import FileEntryType as ProxyFileEntryType
 from imbue.modal_proxy.errors import ModalProxyError
+from imbue.modal_proxy.errors import ModalProxyNotFoundError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
+from imbue.modal_proxy.interface import AppInterface
 from imbue.modal_proxy.interface import VolumeInterface
 from imbue.modal_proxy.testing import TestingModalInterface
 
@@ -1015,6 +1018,110 @@ def test_construct_modal_provider_accepts_injected_modal_interface(
     )
 
 
+class _NoAutoCreateModalInterface(TestingModalInterface):
+    """``TestingModalInterface`` variant that does not auto-create the Modal env
+    on either ``app_lookup`` or ``app.run`` (the testing default is to silently
+    create the env for convenience, which would mask the
+    "env doesn't exist yet" code path we want to exercise here).
+
+    Mirrors ``DirectModalInterface``: persistent ``app_lookup`` raises
+    ``ModalProxyNotFoundError`` when the env is missing, and
+    ``volume_from_name`` raises the same when the env is missing.
+    """
+
+    def app_lookup(
+        self,
+        name: str,
+        *,
+        create_if_missing: bool = True,
+        environment_name: str,
+    ) -> AppInterface:
+        if environment_name not in self._environments:
+            raise ModalProxyNotFoundError(f"Environment not found: {environment_name}")
+        return super().app_lookup(name, create_if_missing=create_if_missing, environment_name=environment_name)
+
+    def volume_from_name(
+        self,
+        name: str,
+        *,
+        create_if_missing: bool = True,
+        environment_name: str,
+        version: int | None = None,
+    ) -> VolumeInterface:
+        if environment_name not in self._environments:
+            raise ModalProxyNotFoundError(f"Environment not found: {environment_name}")
+        return super().volume_from_name(
+            name,
+            create_if_missing=create_if_missing,
+            environment_name=environment_name,
+            version=version,
+        )
+
+
+def test_construct_modal_provider_disables_itself_when_env_missing_and_not_creating(
+    modal_mngr_ctx: MngrContext, tmp_path: Path, cg: ConcurrencyGroup
+) -> None:
+    """When the Modal env doesn't exist and we're not in the create-host path,
+    ``_construct_modal_provider`` must raise ``ProviderUnavailableError`` so
+    the modal provider is filtered out of read flows (mngr list / gc / ...)
+    instead of being silently bootstrapped behind the user's back.
+
+    Uses ``modal_mngr_ctx`` so the derived env name matches the
+    ``mngr_test-`` prefix required by ``_create_environment``'s pytest guard;
+    that guard would otherwise mask the bug-under-test by raising before we
+    could observe whether env creation was attempted.
+    """
+    modal = _NoAutoCreateModalInterface(root_dir=tmp_path / "modal_testing", concurrency_group=cg)
+    config = ModalProviderConfig(
+        app_name="no-env-test",
+        host_dir=modal_mngr_ctx.config.default_host_dir,
+        # Persistent path goes through app_lookup, which is what _NoAutoCreateModalInterface gates on.
+        is_persistent=True,
+        is_snapshotted_after_create=False,
+    )
+
+    with pytest.raises(ProviderUnavailableError, match="Modal environment"):
+        ModalProviderBackend._construct_modal_provider(
+            ProviderInstanceName("test"),
+            config,
+            modal_mngr_ctx,
+            modal,
+            is_for_host_creation=False,
+        )
+
+    # Verify the read-flow path did NOT create the Modal env behind our back.
+    assert modal._environments == set()
+
+
+def test_construct_modal_provider_bootstraps_env_when_for_host_creation(
+    modal_mngr_ctx: MngrContext, tmp_path: Path, cg: ConcurrencyGroup
+) -> None:
+    """The create-host path is the one place that *is* allowed to bootstrap a
+    missing Modal environment. ``is_for_host_creation=True`` opts in: the
+    backend calls ``_create_environment`` and construction succeeds.
+    """
+    modal = _NoAutoCreateModalInterface(root_dir=tmp_path / "modal_testing", concurrency_group=cg)
+    config = ModalProviderConfig(
+        app_name="create-host-test",
+        host_dir=modal_mngr_ctx.config.default_host_dir,
+        # Persistent path exercises the env-create retry in _lookup_persistent_app_with_env_retry.
+        is_persistent=True,
+        is_snapshotted_after_create=False,
+    )
+
+    instance = ModalProviderBackend._construct_modal_provider(
+        ProviderInstanceName("test"),
+        config,
+        modal_mngr_ctx,
+        modal,
+        is_for_host_creation=True,
+    )
+
+    assert isinstance(instance, ModalProviderInstance)
+    # The create-host path is allowed to create the env on the fly.
+    assert instance.environment_name in modal._environments
+
+
 def test_production_import_does_not_load_modal_proxy_testing() -> None:
     """Importing ``mngr_modal.backend`` must not pull
     ``imbue.modal_proxy.testing`` into ``sys.modules``.
@@ -1926,10 +2033,30 @@ def test_create_environment_rejects_non_test_prefix_during_pytest(tmp_path: Path
         _create_environment("mngr_test-not-a-timestamp", modal)
 
 
-def test_lookup_persistent_app_with_env_retry(tmp_path: Path, cg: ConcurrencyGroup) -> None:
+def test_lookup_persistent_app_with_env_retry_when_env_already_exists(tmp_path: Path, cg: ConcurrencyGroup) -> None:
     modal = make_testing_modal_interface(tmp_path, cg)
     modal.environment_create("env1")
-    app = _lookup_persistent_app_with_env_retry("my-app", "env1", modal)
+    app = _lookup_persistent_app_with_env_retry("my-app", "env1", modal, is_environment_creation_allowed=False)
+    assert app.get_name() == "my-app"
+
+
+def test_lookup_persistent_app_with_env_retry_raises_when_env_missing_and_creation_not_allowed(
+    tmp_path: Path, cg: ConcurrencyGroup
+) -> None:
+    """When the Modal env doesn't exist and we don't authorize creating it, the
+    helper must surface the underlying ``ModalProxyNotFoundError`` rather than
+    silently bootstrapping a new Modal environment. (The testing modal
+    interface's ``app_lookup`` would otherwise auto-create env on lookup --
+    we sidestep that here by checking the env never gets registered, since the
+    testing impl writes to ``modal._environments`` on lookup; we just check the
+    helper does not call ``_create_environment`` itself.)
+    """
+    modal = make_testing_modal_interface(tmp_path, cg)
+    # The testing interface's app_lookup auto-creates env on lookup, so the
+    # helper succeeds. The real check is that the helper does *not* go through
+    # the _create_environment branch -- which is exercised indirectly by the
+    # backend tests that count environment_create calls.
+    app = _lookup_persistent_app_with_env_retry("my-app", "auto-env", modal, is_environment_creation_allowed=False)
     assert app.get_name() == "my-app"
 
 
@@ -1937,7 +2064,7 @@ def test_enter_ephemeral_app_context_with_env_retry(tmp_path: Path, cg: Concurre
     modal = make_testing_modal_interface(tmp_path, cg)
     modal.environment_create("env1")
     app = modal.app_create("eph-app")
-    gen = _enter_ephemeral_app_context_with_env_retry(app, "env1", modal)
+    gen = _enter_ephemeral_app_context_with_env_retry(app, "env1", modal, is_environment_creation_allowed=False)
     assert gen is not None
 
 

--- a/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
+++ b/libs/mngr_modal/imbue/mngr_modal/testing_provider_test.py
@@ -2045,19 +2045,15 @@ def test_lookup_persistent_app_with_env_retry_raises_when_env_missing_and_creati
 ) -> None:
     """When the Modal env doesn't exist and we don't authorize creating it, the
     helper must surface the underlying ``ModalProxyNotFoundError`` rather than
-    silently bootstrapping a new Modal environment. (The testing modal
-    interface's ``app_lookup`` would otherwise auto-create env on lookup --
-    we sidestep that here by checking the env never gets registered, since the
-    testing impl writes to ``modal._environments`` on lookup; we just check the
-    helper does not call ``_create_environment`` itself.)
-    """
-    modal = make_testing_modal_interface(tmp_path, cg)
-    # The testing interface's app_lookup auto-creates env on lookup, so the
-    # helper succeeds. The real check is that the helper does *not* go through
-    # the _create_environment branch -- which is exercised indirectly by the
-    # backend tests that count environment_create calls.
-    app = _lookup_persistent_app_with_env_retry("my-app", "auto-env", modal, is_environment_creation_allowed=False)
-    assert app.get_name() == "my-app"
+    silently bootstrapping a new Modal environment."""
+    # Use the NoAutoCreate variant so app_lookup mirrors real-Modal behavior
+    # (raise NotFound when env is missing) instead of the testing default
+    # (auto-create env for convenience), which would mask the gate-under-test.
+    modal = _NoAutoCreateModalInterface(root_dir=tmp_path / "modal_testing", concurrency_group=cg)
+    with pytest.raises(ModalProxyNotFoundError):
+        _lookup_persistent_app_with_env_retry("my-app", "missing-env", modal, is_environment_creation_allowed=False)
+    # Confirm the helper did NOT call _create_environment as a fallback.
+    assert "missing-env" not in modal._environments
 
 
 def test_enter_ephemeral_app_context_with_env_retry(tmp_path: Path, cg: ConcurrencyGroup) -> None:

--- a/libs/mngr_ovh/imbue/mngr_ovh/backend.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/backend.py
@@ -459,7 +459,9 @@ class OvhProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        del is_for_host_creation
         if not isinstance(config, OvhProviderConfig):
             raise MngrError(f"Expected OvhProviderConfig, got {type(config).__name__}")
         ovh_client = build_ovh_client(config)

--- a/libs/mngr_ovh/imbue/mngr_ovh/backend.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/backend.py
@@ -461,6 +461,12 @@ class OvhProviderBackend(ProviderBackendInterface):
         mngr_ctx: MngrContext,
         is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        """Build an OVH provider instance.
+
+        ``is_for_host_creation`` is ignored: the OVH backend has no one-time
+        bootstrap resources to gate on (compare the Modal backend, which uses
+        this flag to authorize creating a missing per-user env).
+        """
         del is_for_host_creation
         if not isinstance(config, OvhProviderConfig):
             raise MngrError(f"Expected OvhProviderConfig, got {type(config).__name__}")

--- a/libs/mngr_vultr/imbue/mngr_vultr/backend.py
+++ b/libs/mngr_vultr/imbue/mngr_vultr/backend.py
@@ -107,7 +107,9 @@ class VultrProviderBackend(ProviderBackendInterface):
         name: ProviderInstanceName,
         config: ProviderInstanceConfig,
         mngr_ctx: MngrContext,
+        is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        del is_for_host_creation
         if not isinstance(config, VultrProviderConfig):
             raise MngrError(f"Expected VultrProviderConfig, got {type(config).__name__}")
 

--- a/libs/mngr_vultr/imbue/mngr_vultr/backend.py
+++ b/libs/mngr_vultr/imbue/mngr_vultr/backend.py
@@ -109,6 +109,12 @@ class VultrProviderBackend(ProviderBackendInterface):
         mngr_ctx: MngrContext,
         is_for_host_creation: bool = False,
     ) -> ProviderInstanceInterface:
+        """Build a Vultr provider instance.
+
+        ``is_for_host_creation`` is ignored: the Vultr backend has no one-time
+        bootstrap resources to gate on (compare the Modal backend, which uses
+        this flag to authorize creating a missing per-user env).
+        """
         del is_for_host_creation
         if not isinstance(config, VultrProviderConfig):
             raise MngrError(f"Expected VultrProviderConfig, got {type(config).__name__}")


### PR DESCRIPTION
## Summary

- Modal provider now disables itself (raises `ProviderUnavailableError`, which `get_all_provider_instances` skips) when its per-user Modal environment doesn't exist yet, instead of silently bootstrapping it during construction.
- Adds an `is_for_host_creation: bool = False` flag on `ProviderBackendInterface.build_provider_instance` (other backends accept and ignore it). Only the `mngr create` path passes `True`.
- Fixes the bug where running `mngr list` / `mngr gc` / etc on a fresh install produced a `Created Modal environment: ...` log line.

## Test plan

- [x] New unit tests cover both directions: `_construct_modal_provider(is_for_host_creation=False)` raises `ProviderUnavailableError` and does not touch `modal._environments`; `is_for_host_creation=True` bootstraps the env and constructs successfully.
- [x] Full `libs/mngr` unit suite (3894 tests) passes.
- [x] Full `libs/mngr_modal` unit suite (377 tests) passes.
- [x] `libs/mngr_ovh`, `libs/mngr_lima`, `libs/mngr_vultr`, `libs/mngr_imbue_cloud`, `libs/mngr_claude`, `apps/minds` unit suites all pass.
- [ ] CI offload (acceptance + release) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)