### PR TITLE
Minds: route /goto/ to mngr_forward plugin in Electron

### DIFF
--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -24,6 +24,7 @@ const mruWindows = []; // most recently focused first
 let appMenuInstalled = false;
 
 let backendBaseUrl = null;
+let mngrForwardBaseUrl = null;
 let workspaceList = []; // [{id, name, account}]
 let isShuttingDown = false;
 let initialBundle = null; // the first window created at startup
@@ -74,8 +75,15 @@ function toAbsoluteUrl(url) {
 // the agent's subdomain and redirects into the workspace's dockview UI.
 // Returns null if the backend hasn't come up yet.
 function workspaceUrlForAgent(agentId) {
-  if (!agentId || !backendBaseUrl) return null;
-  return `${backendBaseUrl}/goto/${encodeURIComponent(agentId)}/`;
+  // `/goto/` lives on the mngr_forward plugin (which owns subdomain
+  // forwarding), not the minds backend. Use mngrForwardBaseUrl when it has
+  // been received; fall back to backendBaseUrl during the startup window
+  // before the mngr_forward_started event arrives (rare -- the user can't
+  // open a workspace in that window).
+  if (!agentId) return null;
+  const origin = mngrForwardBaseUrl || backendBaseUrl;
+  if (!origin) return null;
+  return `${origin}/goto/${encodeURIComponent(agentId)}/`;
 }
 
 function findBundleForWorkspace(agentId) {
@@ -1429,6 +1437,9 @@ async function handleMngrForwardStarted(event) {
     return;
   }
   const url = `http://localhost:${port}`;
+  // Cache the plugin origin so workspaceUrlForAgent() can build /goto/ URLs
+  // against the correct port (the plugin, not minds).
+  mngrForwardBaseUrl = url;
   const baseSpec = {
     url,
     name: 'mngr_forward_session',

--- a/changelog/gabriel-fix-open-in-new-window.md
+++ b/changelog/gabriel-fix-open-in-new-window.md
@@ -1,0 +1,1 @@
+Minds: fix "Open in new window" navigating to a 404. The Electron `workspaceUrlForAgent` now targets the `mngr_forward` plugin (which owns subdomain forwarding and `/goto/`), not the minds backend.


### PR DESCRIPTION
## Summary

- The Electron `workspaceUrlForAgent` was building `/goto/<agent>/` URLs against the minds backend origin, but `/goto/` is served by the `mngr_forward` plugin (which owns subdomain forwarding), not minds. As a result, "Open in new window" (both the sidebar hover icon and the native context-menu item) navigated to a 404 on the minds origin.
- Cache the plugin origin from the `mngr_forward_started` event and use it in `workspaceUrlForAgent`, falling back to the minds origin only during the brief startup window before that event arrives.

The in-page sidebar JS already built `/goto/` links against the plugin origin via a template-injected `data-mngr-forward-origin` attribute, which is why the primary "click a workspace row" navigation worked; only the Electron-constructed URL paths were broken.

## Test plan

- [ ] Open Minds, right-click a workspace in the sidebar, choose "Open in new window" -> verify the new window lands on the workspace (no 404).
- [ ] Click the hover-revealed "Open in new window" icon on a sidebar row -> same.
- [ ] Confirm clicking a row to navigate the current window still works.