### PR TITLE
minds-start: scrub ambient ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL

### DIFF
--- a/changelog/gabriel-minds-start-unset-anthropic.md
+++ b/changelog/gabriel-minds-start-unset-anthropic.md
@@ -1,0 +1,1 @@
+- `just minds-start` now unsets `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` before launching the desktop client, so credentials exported in the developer's shell no longer leak into agents created by the dev app.

--- a/justfile
+++ b/justfile
@@ -214,7 +214,8 @@ deploy *args:
     uv run minds env deploy {{args}}
 
 # Start the minds desktop client (electron) in dev mode against the
-# activated env. Sources .env (for ANTHROPIC_API_KEY etc.) and sets
+# activated env. Sources .env if present, scrubs any ambient
+# ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL (see below), and sets
 # MINDS_WORKSPACE_* env vars so the create-form auto-fills "repository",
 # "name", and "branch":
 #   MINDS_WORKSPACE_GIT_URL = .external_worktrees/forever-claude-template/
@@ -304,6 +305,15 @@ minds-start agent_name="mindtest" branch="":
         . .env
         set +a
     fi
+    # Scrub ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL from the environment
+    # the desktop client inherits. In dev these are typically exported by
+    # the shell rc of whoever runs `just minds-start`, and the client
+    # would otherwise forward them into every agent it creates -- silently
+    # overriding the auth mode picked in the create form. A real packaged
+    # macOS app launched from Finder never sources shell rc files, so this
+    # leak is a dev-environment artifact; unsetting here is the
+    # proportionate fix. `unset` of an already-unset var is a no-op.
+    unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
     export MINDS_WORKSPACE_GIT_URL="$fct_wt"
     if [ -n "{{branch}}" ]; then
         export MINDS_WORKSPACE_BRANCH="{{branch}}"


### PR DESCRIPTION
## What

`just minds-start` now runs `unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL` after sourcing `.env` and before launching the desktop client.

## Why

In dev, whoever runs `just minds-start` typically has `ANTHROPIC_API_KEY` (and sometimes `ANTHROPIC_BASE_URL`) exported by their shell rc. The desktop client inherits them and forwards them into every agent it creates, silently overriding the auth mode picked in the create form.

A real packaged macOS app launched from Finder never sources shell rc files, so this leak is purely a dev-environment artifact. The `minds-start` recipe is the right boundary to fix it -- no app-level changes needed.

This replaces the heavier create-form UI approach that was originally on the `gabriel/creation-status` branch (PR #1644); that env-anthropic UI has been dropped there.