### PR TITLE
fix: retry Modal app context entry through async permission propagation

### DIFF
--- a/changelog/mngr-fix-ci-with-modal.md
+++ b/changelog/mngr-fix-ci-with-modal.md
@@ -1,0 +1,35 @@
+## Modal provider retries through async permission propagation
+
+Modal recently migrated their permission system so that the per-user
+permission entry for a just-created environment is propagated asynchronously
+(typically ~3-7 seconds after `modal environment create` returns success).
+During that window, any operation on the new environment — including by the
+creating user — raises `modal.exception.PermissionDeniedError` instead of
+the previous `NotFoundError`. The Modal team confirmed this is intended
+short-term behavior on their side and that they plan to add a server-side
+buffer.
+
+This was breaking every Modal acceptance test at fixture construction time:
+`real_modal_provider` would create a fresh test env, immediately try to enter
+its `app.run()` context, and crash on the permission error before any test
+body ran.
+
+Changes:
+
+- `imbue.modal_proxy.errors`: new `ModalProxyPermissionDeniedError`.
+- `imbue.modal_proxy.direct._translate_modal_error`: maps
+  `modal.exception.PermissionDeniedError` to the new typed error (previously
+  it fell through to the bare `ModalProxyError`).
+- `imbue.mngr_modal.backend`: both `_enter_ephemeral_app_context_with_retry`
+  and `_lookup_persistent_app_with_retry` now retry on
+  `ModalProxyPermissionDeniedError` in addition to `ModalProxyNotFoundError`,
+  matching the existing 5-attempt exponential backoff (1s→10s) used for
+  env-not-found.
+- `libs/mngr_modal/imbue/mngr_modal/conftest.py`: the test cleanup helper
+  `_classify_modal_sdk_delete` now retries Modal SDK deletes through the same
+  propagation window so that fast-running test teardowns don't spuriously
+  leak environments/volumes.
+
+No user-visible behavior change beyond fewer transient Modal failures and a
+small added startup latency (~3-7s on the very first `mngr create` against
+a brand-new environment, only on first use per profile).

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -136,7 +136,7 @@ def _lookup_persistent_app_with_env_retry(
     # Retry on PermissionDeniedError as well: after `modal environment create`
     # returns success, Modal's per-user permission entry is propagated
     # asynchronously and operations on the new env raise PermissionDeniedError
-    # for ~3s before catching up.
+    # for ~3-7 seconds before catching up.
     retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),
@@ -183,7 +183,7 @@ def _enter_ephemeral_app_context_with_env_retry(
     # Retry on PermissionDeniedError as well: after `modal environment create`
     # returns success, Modal's per-user permission entry is propagated
     # asynchronously and operations on the new env raise PermissionDeniedError
-    # for ~3s before catching up.
+    # for ~3-7 seconds before catching up.
     retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -41,6 +41,7 @@ from imbue.modal_proxy.direct import DirectModalInterface
 from imbue.modal_proxy.errors import ModalProxyAuthError
 from imbue.modal_proxy.errors import ModalProxyError
 from imbue.modal_proxy.errors import ModalProxyNotFoundError
+from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.interface import AppInterface
 from imbue.modal_proxy.interface import ModalInterface
 from imbue.modal_proxy.interface import VolumeInterface
@@ -132,7 +133,11 @@ def _lookup_persistent_app_with_env_retry(
 
 
 @retry(
-    retry=retry_if_exception_type(ModalProxyNotFoundError),
+    # Retry on PermissionDeniedError as well: after `modal environment create`
+    # returns success, Modal's per-user permission entry is propagated
+    # asynchronously and operations on the new env raise PermissionDeniedError
+    # for ~3s before catching up.
+    retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,
@@ -175,7 +180,11 @@ def _enter_ephemeral_app_context_with_env_retry(
 
 
 @retry(
-    retry=retry_if_exception_type(ModalProxyNotFoundError),
+    # Retry on PermissionDeniedError as well: after `modal environment create`
+    # returns success, Modal's per-user permission entry is propagated
+    # asynchronously and operations on the new env raise PermissionDeniedError
+    # for ~3s before catching up.
+    retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -198,8 +198,8 @@ def _invoke_modal_sdk_delete_with_retry(delete_fn: Callable[[], object]) -> None
 
     Modal's per-user permission entry for a just-created resource propagates
     asynchronously, so deletes immediately after creation can spuriously fail
-    with PermissionDeniedError for ~3s before the permission system catches
-    up. Retry with exponential backoff to ride through that window.
+    with PermissionDeniedError for ~3-7 seconds before the permission system
+    catches up. Retry with exponential backoff to ride through that window.
     """
     delete_fn()
 

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -16,6 +16,10 @@ import pytest
 import toml
 from loguru import logger
 from modal.environments import delete_environment
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_exponential
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.data_types import MngrConfig
@@ -183,6 +187,23 @@ def _apply_cleanup_outcome(
             assert_never(unreachable)
 
 
+@retry(
+    retry=retry_if_exception_type(modal.exception.PermissionDeniedError),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=1, max=5),
+    reraise=True,
+)
+def _invoke_modal_sdk_delete_with_retry(delete_fn: Callable[[], object]) -> None:
+    """Invoke a Modal SDK delete callable, retrying on transient PermissionDeniedError.
+
+    Modal's per-user permission entry for a just-created resource propagates
+    asynchronously, so deletes immediately after creation can spuriously fail
+    with PermissionDeniedError for ~3s before the permission system catches
+    up. Retry with exponential backoff to ride through that window.
+    """
+    delete_fn()
+
+
 def _classify_modal_sdk_delete(delete_fn: Callable[[], object], resource_description: str) -> ModalCleanupOutcome:
     """Run an SDK delete callable and classify the outcome as a `ModalCleanupOutcome`.
 
@@ -197,7 +218,7 @@ def _classify_modal_sdk_delete(delete_fn: Callable[[], object], resource_descrip
     returning `None`; the return value is intentionally discarded here.
     """
     try:
-        delete_fn()
+        _invoke_modal_sdk_delete_with_retry(delete_fn)
         return ModalCleanupOutcome.DELETED
     except modal.exception.NotFoundError:
         logger.debug("Modal {} already gone", resource_description)

--- a/libs/modal_proxy/imbue/modal_proxy/direct.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct.py
@@ -43,6 +43,7 @@ from imbue.modal_proxy.errors import ModalProxyError
 from imbue.modal_proxy.errors import ModalProxyInternalError
 from imbue.modal_proxy.errors import ModalProxyInvalidError
 from imbue.modal_proxy.errors import ModalProxyNotFoundError
+from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyRemoteError
 from imbue.modal_proxy.errors import ModalProxyTypeError
@@ -75,6 +76,8 @@ def _translate_modal_error(e: modal.exception.Error) -> ModalProxyError:
     """Convert a modal exception to the corresponding ModalProxy exception."""
     if isinstance(e, modal.exception.AuthError):
         return ModalProxyAuthError(str(e))
+    if isinstance(e, modal.exception.PermissionDeniedError):
+        return ModalProxyPermissionDeniedError(str(e))
     if isinstance(e, modal.exception.NotFoundError):
         return ModalProxyNotFoundError(str(e))
     if isinstance(e, modal.exception.InvalidError):

--- a/libs/modal_proxy/imbue/modal_proxy/direct_test.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct_test.py
@@ -26,6 +26,7 @@ from imbue.modal_proxy.direct import _unwrap_image
 from imbue.modal_proxy.direct import _unwrap_secret
 from imbue.modal_proxy.direct import _unwrap_volume
 from imbue.modal_proxy.errors import ModalProxyError
+from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyTypeError
 from imbue.modal_proxy.interface import AppInterface
@@ -184,6 +185,13 @@ def test_translate_resource_exhausted_to_rate_limit_error() -> None:
     result = _translate_modal_error(modal_err)
     assert isinstance(result, ModalProxyRateLimitError)
     assert "rate limit" in str(result)
+
+
+def test_translate_permission_denied_to_permission_denied_error() -> None:
+    modal_err = modal.exception.PermissionDeniedError("user lacks access to environment 'mngr_test-abc'")
+    result = _translate_modal_error(modal_err)
+    assert isinstance(result, ModalProxyPermissionDeniedError)
+    assert "lacks access" in str(result)
 
 
 # --- Volume retry predicate tests ---

--- a/libs/modal_proxy/imbue/modal_proxy/errors.py
+++ b/libs/modal_proxy/imbue/modal_proxy/errors.py
@@ -32,6 +32,17 @@ class ModalProxyNotFoundError(ModalProxyError):
     """Raised when a Modal resource is not found."""
 
 
+class ModalProxyPermissionDeniedError(ModalProxyError):
+    """Raised when Modal denies access to a resource.
+
+    Modal's per-user permission entries are propagated asynchronously, so a
+    just-created environment (or a just-deleted volume) will report this
+    error for several seconds before the permission system catches up.
+    Callers that are in the middle of a creation/teardown flow should retry
+    this error with backoff.
+    """
+
+
 class ModalProxyInvalidError(ModalProxyError):
     """Raised when an invalid argument is passed to Modal."""
 


### PR DESCRIPTION
## Summary

- Modal recently migrated their permission system. After `modal environment create` returns success, the per-user permission entry for the new env is propagated **asynchronously** (~3-7s). Any operation during that window raises `modal.exception.PermissionDeniedError` instead of the previous `NotFoundError`.
- Our retry layer in `mngr_modal.backend` only caught `ModalProxyNotFoundError`, so every Modal acceptance test crashed at `real_modal_provider` fixture construction time before any test body ran. `_translate_modal_error` also didn't have a typed `ModalProxyPermissionDeniedError`, so it fell through to a bare `ModalProxyError`.
- This change adds the typed error at the modal_proxy boundary and includes it in the existing tenacity retry policies (5 attempts, 1s→10s exponential backoff) in both the persistent and ephemeral app-entry paths. It also mirrors the retry in the test cleanup helper so fast teardowns don't spuriously leak Modal envs/volumes through the same window.

Repro before the fix (drives only the Modal SDK, no mngr code):
```
[1] app.run() against nonexistent env:
   NotFoundError: Environment '...' not found        <- our retry layer catches this
[2] modal environment create: success
[3] app.run() immediately after create:
   PermissionDeniedError: User josh-staging does not have write access ...
   PermissionDeniedError: ...
   success after ~3s                                  <- transient window
```

After the fix, the originally failing test passes (29s, 4 transparent retries through the ~7s window logged inline).

## Test plan
- [x] modal_proxy unit/integration tests pass (`just test-quick libs/modal_proxy ...`)
- [x] mngr_modal unit/integration tests pass (`just test-quick libs/mngr_modal ...`)
- [x] Ratchet tests pass
- [x] Originally failing acceptance test passes: `just test libs/mngr_modal/imbue/mngr_modal/test_modal_instance.py::test_get_host_by_id`
- [ ] Full Modal acceptance suite in CI (offload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)