### PR TITLE
test: register snapshot fixture app for Modal leak detection

### DIFF
--- a/changelog/mngr-fix-ci-with-modal-again.md
+++ b/changelog/mngr-fix-ci-with-modal-again.md
@@ -9,10 +9,18 @@ it) and the fixture deploying to the default `main` environment, leaked
 apps accumulated silently in `main` until they hit the workspace's deployed-
 app cap.
 
-This change adds `register_modal_test_app(app_name)` to the fixture setup
-so the leak detector can surface any future failures.
+This change:
 
-This is a partial fix focused on detection. The underlying design issues
-(`deploy_function(..., environment_name=None, ...)` deploying to `main`,
-and `_stop_app` not actually deleting the app) are tracked separately and
-require a larger refactor of the fixture's env routing.
+- Adds `register_modal_test_app(app_name)` to the fixture setup so the leak
+  detector can surface any future failures.
+- Hardens `_stop_app` and `_delete_volume` in the same file: explicit
+  `--env main` (since the fixture deploys there), explicit `--yes` instead
+  of feeding stdin, and a `logger.warning` when the subprocess returns
+  non-zero so silent cleanup failures stop being invisible.
+
+This is a partial fix focused on detection and visibility. The underlying
+design issue -- `deploy_function(..., environment_name=None, ...)` deploying
+to `main` and `modal app stop` only transitioning the row to `stopped` (not
+deleting it) -- still requires a larger refactor that routes the fixture
+through a per-test Modal env so `modal environment delete` can cascade the
+app away on teardown.

--- a/changelog/mngr-fix-ci-with-modal-again.md
+++ b/changelog/mngr-fix-ci-with-modal-again.md
@@ -1,0 +1,18 @@
+## Register snapshot-fixture Modal app for leak detection
+
+`libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py`'s
+`deployed_snapshot_function` fixture was registering only the test volume,
+not the test app, so leaked snapshot apps were invisible to the session-end
+leak detector in `pytest_sessionfinish`. Combined with `_stop_app` calling
+`modal app stop` (which transitions the app to `stopped` but does not delete
+it) and the fixture deploying to the default `main` environment, leaked
+apps accumulated silently in `main` until they hit the workspace's deployed-
+app cap.
+
+This change adds `register_modal_test_app(app_name)` to the fixture setup
+so the leak detector can surface any future failures.
+
+This is a partial fix focused on detection. The underlying design issues
+(`deploy_function(..., environment_name=None, ...)` deploying to `main`,
+and `_stop_app` not actually deleting the app) are tracked separately and
+require a larger refactor of the fixture's env routing.

--- a/libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py
+++ b/libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py
@@ -18,6 +18,7 @@ import pytest
 from imbue.mngr.primitives import HostState
 from imbue.mngr.utils.polling import wait_for
 from imbue.mngr.utils.testing import get_short_random_string
+from imbue.mngr.utils.testing import register_modal_test_app
 from imbue.mngr.utils.testing import register_modal_test_volume
 from imbue.mngr_modal.constants import MODAL_TEST_APP_PREFIX
 from imbue.mngr_modal.routes.deployment import deploy_function
@@ -140,6 +141,7 @@ def deployed_snapshot_function() -> Generator[tuple[str, str], None, None]:
     app_name = _get_test_app_name()
     # The deployed function creates a volume named {app_name}-state
     volume_name = f"{app_name}-state"
+    register_modal_test_app(app_name)
     register_modal_test_volume(volume_name)
 
     try:

--- a/libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py
+++ b/libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py
@@ -14,6 +14,7 @@ from typing import Any
 import httpx
 import modal
 import pytest
+from loguru import logger
 
 from imbue.mngr.primitives import HostState
 from imbue.mngr.utils.polling import wait_for
@@ -44,22 +45,42 @@ def _get_test_app_name() -> str:
 
 
 def _stop_app(app_name: str) -> None:
-    """Stop and clean up a Modal app."""
-    subprocess.run(
-        ["uv", "run", "modal", "app", "stop", app_name],
-        input=b"y\n",
+    """Stop a Modal app in the `main` env (where the fixture deploys to).
+
+    Uses `--yes` and explicit `--env main` so the call is deterministic and
+    independent of the active local profile / `MODAL_ENVIRONMENT`. Note this
+    transitions the app to `stopped`, not deleted; the row still exists in
+    `modal app list`. Proper deletion needs the fixture to live inside a
+    per-test env that gets `modal environment delete`d in teardown.
+    """
+    result = subprocess.run(
+        ["uv", "run", "modal", "app", "stop", "--yes", "--env", "main", app_name],
         capture_output=True,
         timeout=60,
     )
+    if result.returncode != 0:
+        logger.warning(
+            "modal app stop failed for {} (rc={}): {}",
+            app_name,
+            result.returncode,
+            (result.stderr or result.stdout).decode("utf-8", errors="replace").strip(),
+        )
 
 
 def _delete_volume(volume_name: str) -> None:
-    """Delete a Modal volume."""
-    subprocess.run(
-        ["uv", "run", "modal", "volume", "delete", volume_name, "--yes"],
+    """Delete a Modal volume in the `main` env."""
+    result = subprocess.run(
+        ["uv", "run", "modal", "volume", "delete", "--yes", "--env", "main", volume_name],
         capture_output=True,
         timeout=60,
     )
+    if result.returncode != 0:
+        logger.warning(
+            "modal volume delete failed for {} (rc={}): {}",
+            volume_name,
+            result.returncode,
+            (result.stderr or result.stdout).decode("utf-8", errors="replace").strip(),
+        )
 
 
 def _warmup_function(url: str) -> None:


### PR DESCRIPTION
## Summary

Investigation prompted by all (or most) test Modal apps appearing in the
`main` environment in the staging Modal account and hitting the deployed-
app cap (1012 leaked `mngr-test-snapshot-*` apps observed).

**Root cause is not PR #1714.** PR #1714 only changed
`PermissionDeniedError` translation + retry; it does not touch which env
Modal places an app in. The actual culprit is a longstanding bug in
`libs/mngr_modal/imbue/mngr_modal/routes/test_snapshot_and_shutdown.py`'s
`deployed_snapshot_function` fixture:

- The fixture calls `deploy_function(..., environment_name=None, ...)` and
  the in-file helpers `_create_test_sandbox` / `_write_host_record_to_volume`
  call `modal.App.lookup` / `modal.Volume.from_name` with no
  `environment_name=`. All of those fall through to the workspace default,
  which is `main`.
- The fixture's `_stop_app` uses `modal app stop`, which transitions the app
  to `stopped` state but does not delete it. Stopped apps still count toward
  the deployed-app cap.
- The fixture registered only the test volume, not the test app, so
  `pytest_sessionfinish`'s leak detector never had a chance to surface the
  accumulating leaks.

Confirmed via timestamps: leaked apps span the entire day prior to PR #1714
merging at 17:43 PDT (08:26-18:49 PDT), so the leak rate is independent of
that PR.

## This PR (scoped fix)

Adds `register_modal_test_app(app_name)` to the fixture so the leak detector
catches any future failures. This stops the silent accumulation.

## Out of scope (follow-up)

- Re-routing the fixture through a per-test Modal env (so apps stop going
  to `main` in the first place) — design decision, larger change.
- Replacing `modal app stop` with an actual delete operation.
- Cleaning up the existing 1012 leaked `mngr-test-snapshot-*` apps in
  `main` and the 135 empty `mngr_test-*` envs.

## Test plan
- [ ] Existing snapshot fixture tests still pass in CI
- [ ] Leak detector now reports if cleanup fails for snapshot apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)