### PR TITLE
mngr: split minds env activate into use-vs-deploy modes

### DIFF
--- a/apps/minds/changelog/mngr-fix-minds-discovery.md
+++ b/apps/minds/changelog/mngr-fix-minds-discovery.md
@@ -1,0 +1,28 @@
+`minds env activate` no longer exports `MODAL_PROFILE` by default.
+Activation now has two modes:
+
+- **Use-only (default)**: `minds env activate <name>` exports the four
+  use-side env vars (`MINDS_ROOT_NAME`, `MNGR_HOST_DIR`, `MNGR_PREFIX`,
+  `MINDS_CLIENT_CONFIG_PATH`) and emits `unset MODAL_PROFILE`. This is
+  what every non-deploying user wants -- the desktop client, mngr, and
+  Latchkey no longer try to authenticate against a Modal workspace the
+  operator may not have tokens for. Fixes the spurious "Modal is not
+  authorized" warnings + Latchkey breakage that hit anyone running
+  `minds run` after `eval "$(uv run minds env activate staging)"`
+  without a `minds-staging` profile in `~/.modal.toml`.
+- **Deploy-mode (`--deploy`)**: `minds env activate --deploy <name>`
+  additionally exports `MODAL_PROFILE=<tier's modal_workspace>` and
+  pre-validates that `~/.modal.toml` has a matching profile (fails up
+  front with a `modal token set --profile <workspace>` hint when it
+  doesn't, instead of letting downstream `modal …` shellouts surface
+  the auth error).
+
+`minds env deploy`, `minds env destroy`, and `minds env recover` now
+refuse to run unless the shell is deploy-activated (`MODAL_PROFILE`
+must equal the tier's `modal_workspace`). The refusal message tells
+the operator the exact `eval "$(uv run minds env activate --deploy
+<name>)"` to run.
+
+The packaged Electron app and `deployment_tests/helpers.py` are
+unchanged -- both set their Modal credentials independently of shell
+activation.

--- a/apps/minds/docs/environments.md
+++ b/apps/minds/docs/environments.md
@@ -116,7 +116,7 @@ Behaviour by env type:
   in one line:
 
   ```bash
-  eval "$(uv run minds env activate --create dev-<your-user>)"
+  eval "$(uv run minds env activate --create --deploy dev-<your-user>)"
   uv run minds env deploy
   ```
 

--- a/apps/minds/docs/environments.md
+++ b/apps/minds/docs/environments.md
@@ -53,7 +53,25 @@ the rest of the stack at the env's data root:
 eval "$(uv run minds env activate dev-<your-user>)"
 ```
 
-Exported variables:
+Activation has two modes:
+
+- **Use-only (default)**: exports the use-side env vars below and emits
+  `unset MODAL_PROFILE`. This is what every non-deploying user wants --
+  the desktop client, mngr, Latchkey, etc. work against the activated
+  env without touching the operator's Modal CLI auth state. A
+  previously-deploy-activated shell that gets re-activated in use-only
+  mode flips back cleanly: the `unset MODAL_PROFILE` line drops the
+  stale workspace pin before the next `modal …` shellout can pick it up.
+- **Deploy mode (`--deploy`)**: additionally exports `MODAL_PROFILE`
+  pinned to the tier's `modal_workspace`. Required for `minds env
+  deploy` / `destroy` / `recover` (they refuse without it -- see "Deploy
+  mode" below). Pre-validates that `~/.modal.toml` has a profile matching
+  the tier's `modal_workspace` and refuses up front with a
+  `modal token set --profile <workspace>` hint otherwise. Skipped when
+  the tier's `deploy.toml` is missing or its `modal_workspace` is still
+  the literal `CHANGE_ME` placeholder.
+
+Exported use-side variables (both modes):
 
 - `MINDS_ROOT_NAME` -- e.g. `minds-dev-<your-user>` (or just `minds`
   for production).
@@ -64,6 +82,9 @@ Exported variables:
   For `staging` / `production`, the in-repo
   `apps/minds/imbue/minds/config/envs/<tier>/client.toml` (committed
   to the repo).
+
+Deploy-mode adds:
+
 - `MODAL_PROFILE` -- the tier's `modal_workspace` from
   `apps/minds/imbue/minds/config/envs/<tier>/deploy.toml`. Pins every
   subsequent `modal` CLI shellout (`modal deploy`, `modal secret create`,
@@ -71,8 +92,7 @@ Exported variables:
   `active = true` in `~/.modal.toml`. **Prerequisite:** the operator
   must have a matching profile entry in `~/.modal.toml` for each tier
   they operate against (`modal token set --profile <workspace>` once
-  per tier). Skipped when the tier's `deploy.toml` is missing or its
-  `modal_workspace` is still the literal `CHANGE_ME` placeholder.
+  per tier).
 
 To deactivate:
 
@@ -144,14 +164,32 @@ in any committed staging/production file. A unit test in
 Secret values (API keys, DSNs, connection URIs) live in HCP Vault --
 see `apps/minds/docs/vault-setup.md`.
 
+## Deploy mode
+
+`minds env deploy`, `minds env destroy`, and `minds env recover` all
+refuse to run unless the shell is *deploy-activated* (i.e. the operator
+used `minds env activate --deploy <name>`). "Deploy-activated" is
+detected via `MODAL_PROFILE`: it must be set in the environment and
+must equal the tier's `modal_workspace` from `deploy.toml`. A missing or
+mismatched `MODAL_PROFILE` is a hard error -- the refusal points the
+operator at the exact `eval "$(uv run minds env activate --deploy
+<name>)"` to re-run.
+
+This split exists because activating `staging` (or any other tier) to
+*use* the deployed services should not require Modal CLI credentials
+for that tier's workspace. Bundling the two -- which prior versions did
+-- caused `mngr observe` Modal discovery to fail (and Latchkey to break)
+on every developer who had not added the tier's workspace to their
+`~/.modal.toml`.
+
 ## Deploying a tier (staging / production)
 
 ```bash
-eval "$(uv run minds env activate staging)"
+eval "$(uv run minds env activate --deploy staging)"
 uv run minds env deploy --yes-i-mean-staging
 ```
 
-(For production: `activate production` + `--yes-i-mean-production`.)
+(For production: `activate --deploy production` + `--yes-i-mean-production`.)
 
 The `--yes-i-mean-<tier>` flag is mandatory for tier deploys -- the
 unified deploy CLI uses the same code path for dev and tier deploys,
@@ -274,8 +312,10 @@ cross-dev contamination, no leftover roles to clean up.
 Bootstrap a brand-new dev env:
 
 ```bash
-# 1. Activate the env (--create idempotently mkdirs ~/.minds-<name>/ if missing).
-eval "$(uv run minds env activate --create dev-<your-user>)"
+# 1. Activate the env in deploy mode (--create idempotently mkdirs
+#    ~/.minds-<name>/ if missing; --deploy pins MODAL_PROFILE for the
+#    deploy step in step 2).
+eval "$(uv run minds env activate --create --deploy dev-<your-user>)"
 
 # 2. Deploy: provisions the Modal env, Neon project (with host_pool +
 #    litellm_cost DBs), SuperTokens app, pushes per-env Modal Secrets,
@@ -283,7 +323,10 @@ eval "$(uv run minds env activate --create dev-<your-user>)"
 #    ~/.minds-dev-<your-user>/{client.toml,secrets.toml}.
 uv run minds env deploy
 
-# 3. Launch the desktop client against the new env:
+# 3. Re-activate in use-only mode so subsequent `mngr` / `minds run`
+#    invocations don't carry a stale MODAL_PROFILE, then launch the
+#    desktop client against the new env:
+eval "$(uv run minds env activate dev-<your-user>)"
 just minds-start
 ```
 
@@ -294,14 +337,14 @@ Re-deploy in place (idempotent -- picks up any new tier-shared Vault
 values and re-deploys both Modal apps):
 
 ```bash
-eval "$(uv run minds env activate dev-<your-user>)"
+eval "$(uv run minds env activate --deploy dev-<your-user>)"
 uv run minds env deploy
 ```
 
 Tear it down (cloud resources + the env root):
 
 ```bash
-eval "$(uv run minds env activate dev-<your-user>)"
+eval "$(uv run minds env activate --deploy dev-<your-user>)"
 uv run minds env destroy
 # `minds env destroy` rmdir's ~/.minds-dev-<your-user> after success;
 # clear your shell with `eval "$(uv run minds env deactivate)"`.
@@ -383,7 +426,7 @@ Done once per tier (production / staging), out of band:
    are deployed -- typically a one-line edit per app.)
 4. Deploy the Modal apps via the unified path:
    ```bash
-   eval "$(uv run minds env activate <tier>)"
+   eval "$(uv run minds env activate --deploy <tier>)"
    uv run minds env deploy --yes-i-mean-<tier>
    ```
 5. Smoke-test:

--- a/apps/minds/docs/host-pool-setup.md
+++ b/apps/minds/docs/host-pool-setup.md
@@ -105,7 +105,7 @@ per-developer dev envs.
 ## Step 4: Push the Vault changes to Modal and redeploy
 
 ```bash
-eval "$(uv run minds env activate production)"
+eval "$(uv run minds env activate --deploy production)"
 uv run minds env deploy --yes-i-mean-production
 ```
 

--- a/apps/minds/docs/staging-bringup.md
+++ b/apps/minds/docs/staging-bringup.md
@@ -59,9 +59,12 @@ become Vault entries in step 4.
   modal token set --profile minds-staging
   ```
   Verify a `[minds-staging]` block landed in `~/.modal.toml`. The
-  `MODAL_PROFILE` export in `minds env activate staging` (see step 6)
-  pins every subsequent `modal` shellout to this profile -- the
+  `MODAL_PROFILE` export in `minds env activate --deploy staging` (see
+  step 6) pins every subsequent `modal` shellout to this profile -- the
   account you're logged into via `active = true` is irrelevant.
+  Without `--deploy`, the `[minds-staging]` block is still checked at
+  *deploy* time (by the activate-time validator) but not needed for
+  *use*-time activation.
 
 - [ ] **Neon project for staging.** Create a single project under your
   Neon org (any name; the staging tier uses `creates_resources=false`
@@ -252,21 +255,24 @@ After every push:
 ## 5. Verify Modal CLI talks to `minds-staging`
 
 ```bash
-eval "$(uv run minds env activate staging)"
+eval "$(uv run minds env activate --deploy staging)"
 echo "$MODAL_PROFILE"   # expect: minds-staging
 modal environment list  # should NOT error; no envs needed yet for SHARED tier
 ```
 
 If `modal` complains about missing auth, re-run `modal token set
---profile minds-staging`. The `MODAL_PROFILE` export the activation
-emits is what pins every `modal` shellout below to this workspace.
+--profile minds-staging`. The `MODAL_PROFILE` export the `--deploy`
+activation emits is what pins every `modal` shellout below to this
+workspace. Without `--deploy`, `MODAL_PROFILE` is not exported (and
+plain `activate` actively unsets it) -- that mode is for *using* the
+deployed tier, not deploying it.
 
 ---
 
 ## 6. First-time tier deploy
 
 ```bash
-eval "$(uv run minds env activate staging)"
+eval "$(uv run minds env activate --deploy staging)"
 uv run minds env deploy --yes-i-mean-staging
 ```
 

--- a/apps/minds/docs/staging-bringup.md
+++ b/apps/minds/docs/staging-bringup.md
@@ -61,10 +61,12 @@ become Vault entries in step 4.
   Verify a `[minds-staging]` block landed in `~/.modal.toml`. The
   `MODAL_PROFILE` export in `minds env activate --deploy staging` (see
   step 6) pins every subsequent `modal` shellout to this profile -- the
-  account you're logged into via `active = true` is irrelevant.
-  Without `--deploy`, the `[minds-staging]` block is still checked at
-  *deploy* time (by the activate-time validator) but not needed for
-  *use*-time activation.
+  account you're logged into via `active = true` is irrelevant. The
+  presence of the `[minds-staging]` block is only checked when you pass
+  `--deploy` (which pre-validates `~/.modal.toml` and fails fast with a
+  `modal token set --profile minds-staging` hint if the block is
+  missing). Plain `minds env activate staging` -- use-only activation --
+  does not need the block and never reads `~/.modal.toml`.
 
 - [ ] **Neon project for staging.** Create a single project under your
   Neon org (any name; the staging tier uses `creates_resources=false`

--- a/apps/minds/docs/vault-setup.md
+++ b/apps/minds/docs/vault-setup.md
@@ -119,13 +119,16 @@ All deploys (dev / staging / production) flow through the unified
 
 ```bash
 # Tier deploys (staging / production):
-eval "$(uv run minds env activate staging)"
+eval "$(uv run minds env activate --deploy staging)"
 uv run minds env deploy --yes-i-mean-staging
 
 # Dev env deploys (per-developer):
-eval "$(uv run minds env activate dev-<your-user>)"
+eval "$(uv run minds env activate --deploy dev-<your-user>)"
 uv run minds env deploy
 ```
+
+(`--deploy` is required: `minds env deploy` refuses without it. See
+`docs/environments.md` for the use-vs-deploy split.)
 
 `minds env deploy` reads `apps/minds/imbue/minds/config/envs/<tier>/deploy.toml`
 for the Modal workspace name + the list of services to push from

--- a/apps/minds/imbue/minds/cli/_activated_env.py
+++ b/apps/minds/imbue/minds/cli/_activated_env.py
@@ -5,9 +5,16 @@ all refuse to run unless the calling shell has been activated against a
 specific minds env (``MINDS_ROOT_NAME`` set + matching the bootstrap
 pattern). The check + error-message text is identical across both
 subcommands, so it lives here rather than being duplicated.
+
+``minds env deploy`` / ``destroy`` / ``recover`` additionally require
+*deploy-mode* activation (``minds env activate --deploy``), which pins
+``MODAL_PROFILE`` to the tier's Modal workspace. The deploy-mode gate
+also lives here so all three commands share the same refusal text.
 """
 
 import os
+import tomllib
+from pathlib import Path
 from typing import Final
 
 import click
@@ -19,6 +26,14 @@ from imbue.minds.bootstrap import env_name_from_root_name
 from imbue.minds.bootstrap import is_minds_root_name_set_to_active_env
 from imbue.minds.config.loader import EnvConfigError
 from imbue.minds.config.loader import load_deploy_config
+
+# Env var the activation exports set to pin every ``modal`` CLI
+# shellout to a specific workspace, regardless of which profile is
+# marked ``active = true`` in ``~/.modal.toml``. Only exported by
+# ``minds env activate --deploy``; plain ``minds env activate`` emits
+# ``unset MODAL_PROFILE`` so a previously-deploy-activated shell
+# reverts cleanly.
+MODAL_PROFILE_ENV_VAR: Final[str] = "MODAL_PROFILE"
 
 PRODUCTION_ENV_NAME: Final[str] = "production"
 STAGING_ENV_NAME: Final[str] = "staging"
@@ -81,6 +96,87 @@ def modal_profile_for_tier_or_none(tier: str) -> str | None:
     if not workspace or workspace == "CHANGE_ME":
         return None
     return workspace
+
+
+def validate_modal_profile_exists_in_modal_toml(workspace: str) -> None:
+    """Raise ``ClickException`` if ``~/.modal.toml`` has no profile named ``workspace``.
+
+    Called by ``minds env activate --deploy`` so the operator hits a clean
+    error at activation time (with a copy-pasteable ``modal token set``
+    hint) instead of a confusing Modal SDK auth failure on the first
+    subsequent ``modal …`` shellout.
+
+    Reads ``$HOME/.modal.toml`` (which is also what the Modal SDK reads
+    by default). The file is TOML with one section per profile, keyed by
+    the workspace name; a matching profile is any section whose key
+    equals ``workspace`` and whose value is a table.
+
+    A missing or unparseable ``~/.modal.toml`` is treated the same as a
+    missing profile -- the operator's mitigation is the same in either
+    case.
+    """
+    modal_toml = Path.home() / ".modal.toml"
+    if not modal_toml.is_file():
+        raise click.ClickException(
+            f"~/.modal.toml not found, so the Modal profile {workspace!r} required for "
+            f"deploy-mode activation cannot exist. Run `modal token set --profile {workspace}` "
+            f"(after `uvx modal token new` if you have no Modal account on this machine yet) "
+            f"and re-run."
+        )
+    try:
+        data = tomllib.loads(modal_toml.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise click.ClickException(
+            f"Could not read ~/.modal.toml ({exc}); cannot verify the {workspace!r} profile "
+            f"required for deploy-mode activation."
+        ) from exc
+    if not isinstance(data.get(workspace), dict):
+        raise click.ClickException(
+            f"~/.modal.toml has no profile named {workspace!r}, which deploy-mode activation "
+            f"of this tier requires. Run `modal token set --profile {workspace}` (after "
+            f"`uvx modal token new` if you have no Modal account on this machine yet) and "
+            f"re-run."
+        )
+
+
+def require_deploy_mode_activation(*, env_name: str, tier: str) -> None:
+    """Raise ``ClickException`` unless the shell is deploy-activated for this tier.
+
+    ``minds env deploy`` / ``destroy`` / ``recover`` all call this so the
+    operator cannot accidentally run a deploy with the wrong (or no)
+    ``MODAL_PROFILE`` pinned -- which previously caused silent misroutes
+    to the wrong Modal workspace.
+
+    Deploy-activated means ``MODAL_PROFILE`` is set in the environment
+    and equals the tier's ``modal_workspace`` from ``deploy.toml``.
+    Tiers with no committed ``modal_workspace`` (deploy.toml missing or
+    the literal ``CHANGE_ME`` placeholder) skip the gate -- there is no
+    workspace to pin to in that case.
+    """
+    expected_workspace = modal_profile_for_tier_or_none(tier)
+    if expected_workspace is None:
+        return
+    current = os.environ.get(MODAL_PROFILE_ENV_VAR, "")
+    if current == expected_workspace:
+        return
+    reactivate_hint = (
+        f"Re-activate this shell with deploy-mode: "
+        f'`eval "$(uv run minds env activate --deploy {env_name})"` and re-run.'
+    )
+    if not current:
+        raise click.ClickException(
+            f"This shell was activated for use only -- minds env deploy/destroy/recover "
+            f"require MODAL_PROFILE pinned to {expected_workspace!r}, but it is unset. "
+            f"(Activation now distinguishes use-mode from deploy-mode; plain "
+            f"`minds env activate <name>` no longer exports MODAL_PROFILE.) "
+            f"{reactivate_hint}"
+        )
+    raise click.ClickException(
+        f"MODAL_PROFILE={current!r} does not match this tier's modal_workspace "
+        f"{expected_workspace!r}; minds env deploy/destroy/recover refuse to run with a "
+        f"mismatched Modal profile, since it would silently misroute the deploy to the "
+        f"wrong Modal workspace. {reactivate_hint}"
+    )
 
 
 def require_activated_env_name() -> str:

--- a/apps/minds/imbue/minds/cli/_activated_env.py
+++ b/apps/minds/imbue/minds/cli/_activated_env.py
@@ -101,8 +101,16 @@ def modal_profile_for_tier_or_none(tier: str) -> str | None:
 def _modal_config_path() -> Path:
     """Resolve the path the Modal SDK reads for its config.
 
-    Mirrors Modal SDK's ``modal/config.py`` exactly:
-    ``os.environ.get('MODAL_CONFIG_PATH') or os.path.expanduser('~/.modal.toml')``.
+    Mirrors Modal SDK's ``modal/config.py`` selection rule
+    (``os.environ.get('MODAL_CONFIG_PATH') or os.path.expanduser('~/.modal.toml')``)
+    with one deliberate extension: we also run ``expanduser`` on the
+    ``MODAL_CONFIG_PATH`` override. The SDK passes the override straight
+    to ``open()``, so an operator who sets ``MODAL_CONFIG_PATH=~/foo.toml``
+    would crash with ENOENT on the next ``modal …`` shellout -- our
+    ``expanduser`` lets us surface that as a clean validation refusal
+    (or accept the file if it actually exists at the expanded path)
+    instead of a confusing SDK auth failure later.
+
     Honoring ``MODAL_CONFIG_PATH`` is essential -- if we hardcoded
     ``~/.modal.toml`` while the operator had pointed Modal at a
     different file via the env var, our deploy-mode validation would

--- a/apps/minds/imbue/minds/cli/_activated_env.py
+++ b/apps/minds/imbue/minds/cli/_activated_env.py
@@ -98,44 +98,66 @@ def modal_profile_for_tier_or_none(tier: str) -> str | None:
     return workspace
 
 
+def _modal_config_path() -> Path:
+    """Resolve the path the Modal SDK reads for its config.
+
+    Mirrors Modal SDK's ``modal/config.py`` exactly:
+    ``os.environ.get('MODAL_CONFIG_PATH') or os.path.expanduser('~/.modal.toml')``.
+    Honoring ``MODAL_CONFIG_PATH`` is essential -- if we hardcoded
+    ``~/.modal.toml`` while the operator had pointed Modal at a
+    different file via the env var, our deploy-mode validation would
+    read a different file than the subsequent ``modal …`` shellout
+    actually uses, defeating the whole point of pre-validation.
+    """
+    override = os.environ.get("MODAL_CONFIG_PATH")
+    if override:
+        return Path(os.path.expanduser(override))
+    return Path.home() / ".modal.toml"
+
+
 def validate_modal_profile_exists_in_modal_toml(workspace: str) -> None:
-    """Raise ``ClickException`` if ``~/.modal.toml`` has no profile named ``workspace``.
+    """Raise ``ClickException`` if Modal's config file has no profile named ``workspace``.
 
     Called by ``minds env activate --deploy`` so the operator hits a clean
     error at activation time (with a copy-pasteable ``modal token set``
     hint) instead of a confusing Modal SDK auth failure on the first
     subsequent ``modal …`` shellout.
 
-    Reads ``$HOME/.modal.toml`` (which is also what the Modal SDK reads
-    by default). The file is TOML with one section per profile, keyed by
-    the workspace name; a matching profile is any section whose key
-    equals ``workspace`` and whose value is a table.
+    Reads the same file the Modal SDK reads: ``$MODAL_CONFIG_PATH`` if
+    set, otherwise ``$HOME/.modal.toml`` (see :func:`_modal_config_path`).
+    The file is TOML with one section per profile, keyed by the workspace
+    name; a matching profile is any section whose key equals ``workspace``
+    and whose value is a table.
 
-    A missing or unparseable ``~/.modal.toml`` is treated the same as a
-    missing profile -- the operator's mitigation is the same in either
-    case.
+    Raises a distinct ``ClickException`` for each of three failure modes
+    -- file missing, file unparseable, profile section missing -- so the
+    operator's error message names the actual cause. All three messages
+    include a copy-pasteable ``modal token set --profile <workspace>``
+    hint and name the exact config path being checked (so an operator
+    with a non-default ``MODAL_CONFIG_PATH`` doesn't get a misleading
+    pointer to ``~/.modal.toml``).
     """
-    modal_toml = Path.home() / ".modal.toml"
+    modal_toml = _modal_config_path()
     if not modal_toml.is_file():
         raise click.ClickException(
-            f"~/.modal.toml not found, so the Modal profile {workspace!r} required for "
-            f"deploy-mode activation cannot exist. Run `modal token set --profile {workspace}` "
-            f"(after `uvx modal token new` if you have no Modal account on this machine yet) "
-            f"and re-run."
+            f"Modal config file {str(modal_toml)!r} not found, so the Modal profile "
+            f"{workspace!r} required for deploy-mode activation cannot exist. Run "
+            f"`modal token set --profile {workspace}` (after `uvx modal token new` if you "
+            f"have no Modal account on this machine yet) and re-run."
         )
     try:
         data = tomllib.loads(modal_toml.read_text())
     except (OSError, tomllib.TOMLDecodeError) as exc:
         raise click.ClickException(
-            f"Could not read ~/.modal.toml ({exc}); cannot verify the {workspace!r} profile "
-            f"required for deploy-mode activation."
+            f"Could not read Modal config file {str(modal_toml)!r} ({exc}); cannot verify "
+            f"the {workspace!r} profile required for deploy-mode activation."
         ) from exc
     if not isinstance(data.get(workspace), dict):
         raise click.ClickException(
-            f"~/.modal.toml has no profile named {workspace!r}, which deploy-mode activation "
-            f"of this tier requires. Run `modal token set --profile {workspace}` (after "
-            f"`uvx modal token new` if you have no Modal account on this machine yet) and "
-            f"re-run."
+            f"Modal config file {str(modal_toml)!r} has no profile named {workspace!r}, "
+            f"which deploy-mode activation of this tier requires. Run "
+            f"`modal token set --profile {workspace}` (after `uvx modal token new` if you "
+            f"have no Modal account on this machine yet) and re-run."
         )
 
 

--- a/apps/minds/imbue/minds/cli/_activated_env_test.py
+++ b/apps/minds/imbue/minds/cli/_activated_env_test.py
@@ -1,10 +1,19 @@
-"""Unit tests for the env-name -> tier mapping shared by minds CLI subcommands."""
+"""Unit tests for the env-name -> tier mapping and the deploy-mode gate
+shared by minds CLI subcommands."""
+
+from pathlib import Path
+
+import click
+import pytest
 
 from imbue.minds.cli._activated_env import CI_TIER
 from imbue.minds.cli._activated_env import DEV_TIER
+from imbue.minds.cli._activated_env import MODAL_PROFILE_ENV_VAR
 from imbue.minds.cli._activated_env import PRODUCTION_ENV_NAME
 from imbue.minds.cli._activated_env import STAGING_ENV_NAME
+from imbue.minds.cli._activated_env import require_deploy_mode_activation
 from imbue.minds.cli._activated_env import tier_for_env_name
+from imbue.minds.cli._activated_env import validate_modal_profile_exists_in_modal_toml
 
 
 def test_tier_for_env_name_production() -> None:
@@ -34,3 +43,88 @@ def test_tier_for_env_name_dev_prefixed_with_ci_substring_still_dev() -> None:
     the old ``dev-ci-`` naming convention) must still route to dev.
     """
     assert tier_for_env_name("dev-ci-leftover") == DEV_TIER
+
+
+# -- validate_modal_profile_exists_in_modal_toml --
+
+
+def test_validate_modal_profile_accepts_matching_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    modal_toml = tmp_path / ".modal.toml"
+    modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+    # No exception.
+    validate_modal_profile_exists_in_modal_toml("minds-dev")
+
+
+def test_validate_modal_profile_rejects_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with pytest.raises(click.ClickException) as excinfo:
+        validate_modal_profile_exists_in_modal_toml("minds-staging")
+    assert "~/.modal.toml not found" in str(excinfo.value)
+    assert "modal token set --profile minds-staging" in str(excinfo.value)
+
+
+def test_validate_modal_profile_rejects_missing_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    modal_toml = tmp_path / ".modal.toml"
+    modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+    with pytest.raises(click.ClickException) as excinfo:
+        validate_modal_profile_exists_in_modal_toml("minds-staging")
+    assert "no profile named 'minds-staging'" in str(excinfo.value)
+    assert "modal token set --profile minds-staging" in str(excinfo.value)
+
+
+def test_validate_modal_profile_rejects_unparseable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    modal_toml = tmp_path / ".modal.toml"
+    modal_toml.write_text("this is not valid toml = = =")
+    with pytest.raises(click.ClickException) as excinfo:
+        validate_modal_profile_exists_in_modal_toml("minds-dev")
+    assert "Could not read ~/.modal.toml" in str(excinfo.value)
+
+
+def test_validate_modal_profile_rejects_non_table_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare scalar at the workspace key is not a valid profile."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    modal_toml = tmp_path / ".modal.toml"
+    # A top-level scalar key collides namespace-wise with the workspace
+    # name but does not satisfy "section named workspace".
+    modal_toml.write_text('"minds-dev" = "not a table"\n')
+    with pytest.raises(click.ClickException):
+        validate_modal_profile_exists_in_modal_toml("minds-dev")
+
+
+# -- require_deploy_mode_activation --
+
+
+def test_require_deploy_mode_passes_when_modal_profile_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dev tier's modal_workspace is `minds-dev` (per the committed deploy.toml)."""
+    monkeypatch.setenv(MODAL_PROFILE_ENV_VAR, "minds-dev")
+    # No exception.
+    require_deploy_mode_activation(env_name="dev-foo", tier=DEV_TIER)
+
+
+def test_require_deploy_mode_rejects_unset_modal_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(MODAL_PROFILE_ENV_VAR, raising=False)
+    with pytest.raises(click.ClickException) as excinfo:
+        require_deploy_mode_activation(env_name="dev-foo", tier=DEV_TIER)
+    message = str(excinfo.value)
+    assert "use only" in message
+    assert "MODAL_PROFILE pinned to 'minds-dev'" in message
+    assert "minds env activate --deploy dev-foo" in message
+
+
+def test_require_deploy_mode_rejects_mismatched_modal_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MODAL_PROFILE_ENV_VAR, "some-other-workspace")
+    with pytest.raises(click.ClickException) as excinfo:
+        require_deploy_mode_activation(env_name="dev-foo", tier=DEV_TIER)
+    message = str(excinfo.value)
+    assert "some-other-workspace" in message
+    assert "minds-dev" in message
+    assert "minds env activate --deploy dev-foo" in message
+
+
+def test_require_deploy_mode_passes_for_staging_with_matching_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(MODAL_PROFILE_ENV_VAR, "minds-staging")
+    # No exception -- staging deploy.toml ships with modal_workspace="minds-staging".
+    require_deploy_mode_activation(env_name=STAGING_ENV_NAME, tier=STAGING_ENV_NAME)

--- a/apps/minds/imbue/minds/cli/_activated_env_test.py
+++ b/apps/minds/imbue/minds/cli/_activated_env_test.py
@@ -50,6 +50,7 @@ def test_tier_for_env_name_dev_prefixed_with_ci_substring_still_dev() -> None:
 
 def test_validate_modal_profile_accepts_matching_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
     # No exception.
@@ -58,40 +59,81 @@ def test_validate_modal_profile_accepts_matching_section(tmp_path: Path, monkeyp
 
 def test_validate_modal_profile_rejects_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     with pytest.raises(click.ClickException) as excinfo:
         validate_modal_profile_exists_in_modal_toml("minds-staging")
-    assert "~/.modal.toml not found" in str(excinfo.value)
-    assert "modal token set --profile minds-staging" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "not found" in message
+    assert str(tmp_path / ".modal.toml") in message
+    assert "modal token set --profile minds-staging" in message
 
 
 def test_validate_modal_profile_rejects_missing_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
     with pytest.raises(click.ClickException) as excinfo:
         validate_modal_profile_exists_in_modal_toml("minds-staging")
-    assert "no profile named 'minds-staging'" in str(excinfo.value)
-    assert "modal token set --profile minds-staging" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "no profile named 'minds-staging'" in message
+    assert "modal token set --profile minds-staging" in message
 
 
 def test_validate_modal_profile_rejects_unparseable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text("this is not valid toml = = =")
     with pytest.raises(click.ClickException) as excinfo:
         validate_modal_profile_exists_in_modal_toml("minds-dev")
-    assert "Could not read ~/.modal.toml" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "Could not read" in message
+    assert str(tmp_path / ".modal.toml") in message
 
 
 def test_validate_modal_profile_rejects_non_table_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A bare scalar at the workspace key is not a valid profile."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     # A top-level scalar key collides namespace-wise with the workspace
     # name but does not satisfy "section named workspace".
     modal_toml.write_text('"minds-dev" = "not a table"\n')
     with pytest.raises(click.ClickException):
         validate_modal_profile_exists_in_modal_toml("minds-dev")
+
+
+def test_validate_modal_profile_honors_modal_config_path_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When MODAL_CONFIG_PATH is set, validation must read that file (matching the Modal SDK)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Profile lives in the override path, NOT in ~/.modal.toml.
+    override_path = tmp_path / "alt-modal-config.toml"
+    override_path.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+    monkeypatch.setenv("MODAL_CONFIG_PATH", str(override_path))
+    # Validation reads the override path and finds the profile.
+    validate_modal_profile_exists_in_modal_toml("minds-dev")
+
+
+def test_validate_modal_profile_rejects_when_override_lacks_profile_even_if_home_has_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With MODAL_CONFIG_PATH set, ~/.modal.toml is ignored entirely (mirrors Modal SDK)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Profile present in HOME but not the override -- validation must
+    # still fail, because Modal SDK would read the override and miss it.
+    home_toml = tmp_path / ".modal.toml"
+    home_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+    override_path = tmp_path / "alt-modal-config.toml"
+    override_path.write_text('[some-other-profile]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+    monkeypatch.setenv("MODAL_CONFIG_PATH", str(override_path))
+    with pytest.raises(click.ClickException) as excinfo:
+        validate_modal_profile_exists_in_modal_toml("minds-dev")
+    message = str(excinfo.value)
+    assert str(override_path) in message
+    assert "no profile named 'minds-dev'" in message
 
 
 # -- require_deploy_mode_activation --

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -142,7 +142,7 @@ _ACTIVATION_ENV_VARS: Final[tuple[str, ...]] = (
     "MNGR_PREFIX",
     "MINDS_CLIENT_CONFIG_PATH",
     # Modal CLI workspace selector. Only set by ``activate --deploy``;
-    # see :func:`_collect_activation_exports` and the ``--deploy`` flag
+    # see :func:`_build_deploy_mode_exports` and the ``--deploy`` flag
     # on ``minds env activate``.
     MODAL_PROFILE_ENV_VAR,
 )

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -715,7 +715,12 @@ def env_activate(name: str, create: bool, is_deploy_mode: bool) -> None:
     # success, so subsequent activations have something to compare against.
     if config_path.is_file():
         _try_run_generation_check(env_name=name, client_config_path=config_path, env_root=target)
-    _print_activation_exports(name=name, exports={**use_side_exports, **deploy_exports}, unsets=deploy_unsets)
+    _print_activation_exports(
+        name=name,
+        exports={**use_side_exports, **deploy_exports},
+        unsets=deploy_unsets,
+        is_deploy_mode=is_deploy_mode,
+    )
 
 
 def _activate_reserved_env(name: str, *, is_deploy_mode: bool) -> None:
@@ -761,7 +766,12 @@ def _activate_reserved_env(name: str, *, is_deploy_mode: bool) -> None:
     if name == _STAGING_ENV_NAME:
         env_root = mngr_host.parent
         _try_run_generation_check(env_name=name, client_config_path=repo_client, env_root=env_root)
-    _print_activation_exports(name=name, exports={**use_side_exports, **deploy_exports}, unsets=deploy_unsets)
+    _print_activation_exports(
+        name=name,
+        exports={**use_side_exports, **deploy_exports},
+        unsets=deploy_unsets,
+        is_deploy_mode=is_deploy_mode,
+    )
 
 
 def _build_deploy_mode_exports(*, tier: str, is_deploy_mode: bool) -> tuple[dict[str, str], tuple[str, ...]]:
@@ -786,8 +796,20 @@ def _build_deploy_mode_exports(*, tier: str, is_deploy_mode: bool) -> tuple[dict
     return {MODAL_PROFILE_ENV_VAR: workspace}, ()
 
 
-def _print_activation_exports(*, name: str, exports: dict[str, str], unsets: tuple[str, ...] = ()) -> None:
-    write_stdout_line(f'# Activated env {name!r}. Source via: eval "$(uv run minds env activate {name})"')
+def _print_activation_exports(
+    *,
+    name: str,
+    exports: dict[str, str],
+    unsets: tuple[str, ...] = (),
+    is_deploy_mode: bool = False,
+) -> None:
+    # Mirror the invocation mode in the header so a user who copy-pastes
+    # the suggested re-source command back into a fresh shell lands in
+    # the same mode they started in -- otherwise re-sourcing a `--deploy`
+    # activation via the header would silently drop MODAL_PROFILE and
+    # trip the deploy-mode gate on the next minds env deploy/destroy.
+    deploy_flag = " --deploy" if is_deploy_mode else ""
+    write_stdout_line(f'# Activated env {name!r}. Source via: eval "$(uv run minds env activate{deploy_flag} {name})"')
     for key, value in exports.items():
         write_stdout_line(f"export {key}={shlex.quote(value)}")
     for key in unsets:

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -39,11 +39,14 @@ from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.bootstrap import mngr_host_dir_for
 from imbue.minds.bootstrap import mngr_prefix_for
 from imbue.minds.bootstrap import root_name_for_env_name
+from imbue.minds.cli._activated_env import MODAL_PROFILE_ENV_VAR
 from imbue.minds.cli._activated_env import PRODUCTION_ENV_NAME as _PRODUCTION_ENV_NAME
 from imbue.minds.cli._activated_env import STAGING_ENV_NAME as _STAGING_ENV_NAME
 from imbue.minds.cli._activated_env import modal_profile_for_tier_or_none
 from imbue.minds.cli._activated_env import require_activated_env_name
+from imbue.minds.cli._activated_env import require_deploy_mode_activation
 from imbue.minds.cli._activated_env import tier_for_env_name as _tier_for_env_name
+from imbue.minds.cli._activated_env import validate_modal_profile_exists_in_modal_toml
 from imbue.minds.config.loader import EnvConfigError
 from imbue.minds.config.loader import load_client_config
 from imbue.minds.config.loader import load_deploy_config
@@ -126,22 +129,22 @@ from imbue.mngr_ovh.iam_tags import IamResource
 # env.py -> pool.py back-reference.
 _RESERVED_TIER_ENV_NAMES: Final[frozenset[str]] = frozenset({"production", "staging"})
 
-# Env vars exported by ``activate`` (and unset by ``deactivate``). The
-# list lives here so the two sides stay in sync.
+# Env vars unset by ``deactivate``. Includes every var that any
+# activation mode (use-only or ``--deploy``) might have exported, so a
+# single ``deactivate`` fully clears the shell regardless of which mode
+# was used to activate it. ``MODAL_PROFILE`` is included even though
+# plain ``activate`` does not export it, because plain ``activate`` does
+# explicitly emit ``unset MODAL_PROFILE`` (so a previously-deploy-
+# activated shell flips back cleanly); ``deactivate`` mirrors that.
 _ACTIVATION_ENV_VARS: Final[tuple[str, ...]] = (
     MINDS_ROOT_NAME_ENV_VAR,
     "MNGR_HOST_DIR",
     "MNGR_PREFIX",
     "MINDS_CLIENT_CONFIG_PATH",
-    # Modal CLI workspace selector. Set to the tier's ``modal_workspace``
-    # so every subsequent ``modal`` shellout (``modal deploy``,
-    # ``modal secret create``, ``modal environment create``, etc.) targets
-    # the right Modal account, regardless of which profile is marked
-    # ``active = true`` in ``~/.modal.toml``. The user must have a
-    # matching profile entry in ``~/.modal.toml`` (run
-    # ``modal token set --profile <workspace>`` once per tier they
-    # operate against).
-    "MODAL_PROFILE",
+    # Modal CLI workspace selector. Only set by ``activate --deploy``;
+    # see :func:`_collect_activation_exports` and the ``--deploy`` flag
+    # on ``minds env activate``.
+    MODAL_PROFILE_ENV_VAR,
 )
 
 
@@ -597,7 +600,24 @@ def env() -> None:
         "name (`staging` / `production` always auto-create)."
     ),
 )
-def env_activate(name: str, create: bool) -> None:
+@click.option(
+    "--deploy",
+    "is_deploy_mode",
+    is_flag=True,
+    default=False,
+    help=(
+        "Activate in deploy mode: in addition to the use-side env vars (MINDS_ROOT_NAME, "
+        "MNGR_HOST_DIR, MNGR_PREFIX, MINDS_CLIENT_CONFIG_PATH), export MODAL_PROFILE pinned "
+        "to the tier's modal_workspace from deploy.toml. Required for `minds env deploy`, "
+        "`minds env destroy`, and `minds env recover`. Without this flag (the default), "
+        "activate emits `unset MODAL_PROFILE` so a previously-deploy-activated shell flips "
+        "back to use-only -- the rest of the stack (mngr, minds run, Latchkey) no longer "
+        "tries to authenticate against a Modal workspace the operator may not have tokens "
+        "for. Fails up front if `~/.modal.toml` has no profile matching the tier's "
+        "modal_workspace (run `modal token set --profile <workspace>` first)."
+    ),
+)
+def env_activate(name: str, create: bool, is_deploy_mode: bool) -> None:
     """Print shell exports that activate env ``NAME`` in the calling shell.
 
     Refuses when a recover-target file exists at the monorepo root --
@@ -606,10 +626,26 @@ def env_activate(name: str, create: bool) -> None:
 
     Designed for ``eval "$(uv run minds env activate <name>)"``: after
     sourcing, ``mngr`` writes to ``~/.minds-<name>/mngr``, ``minds run``
-    picks up the per-env client config without a ``--config-file`` flag,
-    and ``minds env deploy`` / ``destroy`` operate on this env.
+    picks up the per-env client config without a ``--config-file`` flag.
+    ``minds env deploy`` / ``destroy`` / ``recover`` additionally require
+    ``--deploy`` activation (see below).
 
-    Emitted variables:
+    Activation modes:
+
+    - **Use-only (default)**: exports the four use-side env vars and
+      emits ``unset MODAL_PROFILE``. Lets the operator run the desktop
+      client, browse agents, hit Latchkey, etc. against the activated
+      env without touching their Modal CLI auth state. This is what
+      every non-deploying user wants.
+    - **Deploy mode (``--deploy``)**: additionally exports
+      ``MODAL_PROFILE=<tier's modal_workspace>`` so every subsequent
+      ``modal`` shellout (``modal deploy``, ``modal secret create``,
+      etc.) targets the right Modal account, regardless of which profile
+      is marked ``active = true`` in ``~/.modal.toml``. Pre-validates
+      that ``~/.modal.toml`` has a matching profile and refuses
+      otherwise (with a ``modal token set --profile <workspace>`` hint).
+
+    Emitted use-side variables (both modes):
 
     - ``MINDS_ROOT_NAME`` -- ``minds`` for the reserved ``production``
       name, ``minds-<name>`` for every other env. Validation runs at
@@ -639,7 +675,7 @@ def env_activate(name: str, create: bool) -> None:
     _refuse_if_any_recover_target_exists()
 
     if name in _RESERVED_TIER_ENV_NAMES or name == _PRODUCTION_ENV_NAME:
-        _activate_reserved_env(name)
+        _activate_reserved_env(name, is_deploy_mode=is_deploy_mode)
         return
 
     try:
@@ -663,15 +699,15 @@ def env_activate(name: str, create: bool) -> None:
 
     root_name = root_name_for_env_name(name)
     config_path = client_config_file(dev_env_name)
-    exports = {
+    use_side_exports = {
         MINDS_ROOT_NAME_ENV_VAR: root_name,
         "MNGR_HOST_DIR": str(mngr_host_dir_for(root_name)),
         "MNGR_PREFIX": mngr_prefix_for(root_name),
         "MINDS_CLIENT_CONFIG_PATH": str(config_path),
     }
-    modal_profile = modal_profile_for_tier_or_none(_tier_for_env_name(name))
-    if modal_profile is not None:
-        exports["MODAL_PROFILE"] = modal_profile
+    deploy_exports, deploy_unsets = _build_deploy_mode_exports(
+        tier=_tier_for_env_name(name), is_deploy_mode=is_deploy_mode
+    )
     # Check the tier generation id + auto-wipe local state on mismatch.
     # Skipped silently when the per-env client.toml doesn't exist yet
     # (fresh `activate --create` before the first deploy) -- the deploy
@@ -679,10 +715,10 @@ def env_activate(name: str, create: bool) -> None:
     # success, so subsequent activations have something to compare against.
     if config_path.is_file():
         _try_run_generation_check(env_name=name, client_config_path=config_path, env_root=target)
-    _print_activation_exports(name=name, exports=exports)
+    _print_activation_exports(name=name, exports={**use_side_exports, **deploy_exports}, unsets=deploy_unsets)
 
 
-def _activate_reserved_env(name: str) -> None:
+def _activate_reserved_env(name: str, *, is_deploy_mode: bool) -> None:
     """Activate ``staging`` or ``production`` -- in-repo client.toml is the truth.
 
     Auto-creates the env root if missing so subsequent commands have
@@ -711,15 +747,13 @@ def _activate_reserved_env(name: str) -> None:
     mngr_host = mngr_host_dir_for(root_name)
     mngr_host.parent.mkdir(parents=True, exist_ok=True)
 
-    exports = {
+    use_side_exports = {
         MINDS_ROOT_NAME_ENV_VAR: root_name,
         "MNGR_HOST_DIR": str(mngr_host),
         "MNGR_PREFIX": mngr_prefix_for(root_name),
         "MINDS_CLIENT_CONFIG_PATH": str(repo_client),
     }
-    modal_profile = modal_profile_for_tier_or_none(name)
-    if modal_profile is not None:
-        exports["MODAL_PROFILE"] = modal_profile
+    deploy_exports, deploy_unsets = _build_deploy_mode_exports(tier=name, is_deploy_mode=is_deploy_mode)
     # Generation-id check applies to staging (the shared tier where
     # destroy/redeploy by one dev outdates everyone's local state).
     # Production destroy is hard-refused so a mismatch there is
@@ -727,13 +761,37 @@ def _activate_reserved_env(name: str) -> None:
     if name == _STAGING_ENV_NAME:
         env_root = mngr_host.parent
         _try_run_generation_check(env_name=name, client_config_path=repo_client, env_root=env_root)
-    _print_activation_exports(name=name, exports=exports)
+    _print_activation_exports(name=name, exports={**use_side_exports, **deploy_exports}, unsets=deploy_unsets)
 
 
-def _print_activation_exports(*, name: str, exports: dict[str, str]) -> None:
+def _build_deploy_mode_exports(*, tier: str, is_deploy_mode: bool) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Return ``(exports, unsets)`` for the deploy-side activation knobs.
+
+    Use-only activation (the default) emits ``unset MODAL_PROFILE`` so a
+    previously-deploy-activated shell flips back cleanly; deploy-mode
+    activation emits ``export MODAL_PROFILE=<workspace>`` after
+    validating that ``~/.modal.toml`` has a matching profile. Tiers
+    whose ``deploy.toml`` has no committed ``modal_workspace`` (or the
+    literal ``CHANGE_ME`` placeholder) skip both the export and the
+    unset -- there is no workspace to pin to, so plain-activate
+    inheritance of an operator-set ``MODAL_PROFILE`` stays the operator's
+    own concern.
+    """
+    workspace = modal_profile_for_tier_or_none(tier)
+    if workspace is None:
+        return {}, ()
+    if not is_deploy_mode:
+        return {}, (MODAL_PROFILE_ENV_VAR,)
+    validate_modal_profile_exists_in_modal_toml(workspace)
+    return {MODAL_PROFILE_ENV_VAR: workspace}, ()
+
+
+def _print_activation_exports(*, name: str, exports: dict[str, str], unsets: tuple[str, ...] = ()) -> None:
     write_stdout_line(f'# Activated env {name!r}. Source via: eval "$(uv run minds env activate {name})"')
     for key, value in exports.items():
         write_stdout_line(f"export {key}={shlex.quote(value)}")
+    for key in unsets:
+        write_stdout_line(f"unset {key}")
 
 
 # Trailing marker file name under each env root. Stores the generation
@@ -958,6 +1016,9 @@ def env_deploy(
     """Provision or upgrade the currently-activated env.
 
     Refuses when a recover-target file exists at the monorepo root.
+    Refuses unless the shell is *deploy-activated* (i.e. ``MODAL_PROFILE``
+    matches the tier's ``modal_workspace``); the refusal points the
+    operator at ``eval "$(uv run minds env activate --deploy <name>)"``.
 
     Reads the activated env from ``MINDS_ROOT_NAME`` (set by
     ``minds env activate``) and dispatches:
@@ -986,6 +1047,7 @@ def env_deploy(
     output_format: OutputFormat = ctx.obj.get("output_format", OutputFormat.HUMAN)
     env_name = require_activated_env_name()
     tier = _tier_for_env_name(env_name)
+    require_deploy_mode_activation(env_name=env_name, tier=tier)
     _refuse_if_this_env_recover_target_exists(env_name)
 
     if tier == _PRODUCTION_ENV_NAME and not yes_i_mean_production:
@@ -1096,7 +1158,8 @@ def env_destroy(ctx: click.Context, keep_agents: bool, yes_i_mean_staging: bool)
     Refuses hard-coded when no env is activated. Refuses hard-coded when
     the activated env is ``production`` (production teardown is
     operator-managed outside this CLI). ``staging`` requires
-    ``--yes-i-mean-staging``.
+    ``--yes-i-mean-staging``. Also refuses unless the shell is
+    *deploy-activated* (see :func:`env_deploy` for the same gate).
 
     The same destroy flow runs for every env type (see
     :func:`provisioning.destroy_env`). The only branches are the
@@ -1109,6 +1172,7 @@ def env_destroy(ctx: click.Context, keep_agents: bool, yes_i_mean_staging: bool)
     output_format: OutputFormat = ctx.obj.get("output_format", OutputFormat.HUMAN)
     env_name = require_activated_env_name()
     tier = _tier_for_env_name(env_name)
+    require_deploy_mode_activation(env_name=env_name, tier=tier)
     _refuse_if_this_env_recover_target_exists(env_name)
 
     if tier == _PRODUCTION_ENV_NAME:
@@ -1164,13 +1228,15 @@ def env_recover(_ctx: click.Context) -> None:
     recover after a partial recovery converges.
 
     Refuses to run if no recover-target file exists for the activated
-    env. To recover a different env, activate it first.
+    env. To recover a different env, activate it first. Also refuses
+    unless the shell is *deploy-activated* (see :func:`env_deploy`).
     """
     try:
         repo_root = find_monorepo_root()
     except MindError as exc:
         raise click.ClickException(str(exc)) from exc
     env_name = require_activated_env_name()
+    require_deploy_mode_activation(env_name=env_name, tier=_tier_for_env_name(env_name))
     if not recover_target_exists(repo_root=repo_root, env_name=env_name):
         # Help the operator if they have recover-target files for OTHER
         # envs sitting around (a common mistake when juggling several

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -1270,7 +1270,7 @@ def env_recover(_ctx: click.Context) -> None:
                 f"No recover-target file for activated env {env_name!r} at "
                 f"{recover_target_path(repo_root=repo_root, env_name=env_name)}. Other recover-target files exist:\n"
                 f"{leftover_list}\nActivate the env you want to recover (e.g. "
-                f'`eval "$(uv run minds env activate <env-name>)"`) and re-run.'
+                f'`eval "$(uv run minds env activate --deploy <env-name>)"`) and re-run.'
             )
         raise click.ClickException(
             f"No recover-target file at {recover_target_path(repo_root=repo_root, env_name=env_name)}; "

--- a/apps/minds/imbue/minds/cli/env_test.py
+++ b/apps/minds/imbue/minds/cli/env_test.py
@@ -85,6 +85,24 @@ def test_activate_dev_env_deploy_mode_exports_modal_profile(_isolated_env: Path)
     assert "unset MODAL_PROFILE" not in result.output
 
 
+def test_activate_use_only_header_omits_deploy_flag(_isolated_env: Path) -> None:
+    """The 'Source via:' header should omit --deploy when the user did not pass it."""
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "dev-foo"])
+    assert result.exit_code == 0, result.output
+    assert 'eval "$(uv run minds env activate dev-foo)"' in result.output
+    assert "--deploy" not in result.output
+
+
+def test_activate_deploy_mode_header_includes_deploy_flag(_isolated_env: Path) -> None:
+    """The 'Source via:' header should include --deploy so re-sourcing preserves the mode."""
+    _write_modal_toml_with_profile(_isolated_env, "minds-dev")
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
+    assert result.exit_code == 0, result.output
+    assert 'eval "$(uv run minds env activate --deploy dev-foo)"' in result.output
+
+
 def test_activate_deploy_mode_refuses_when_modal_toml_lacks_profile(_isolated_env: Path) -> None:
     """No matching ``~/.modal.toml`` profile = clean refusal with a ``modal token set`` hint."""
     runner = CliRunner()

--- a/apps/minds/imbue/minds/cli/env_test.py
+++ b/apps/minds/imbue/minds/cli/env_test.py
@@ -1,0 +1,152 @@
+"""Tests for ``minds env activate``'s use-vs-deploy split.
+
+Covers:
+
+- Plain ``activate <name>``: exports use-side vars, emits ``unset
+  MODAL_PROFILE``, never emits ``export MODAL_PROFILE=...``.
+- ``activate --deploy <name>``: also exports ``MODAL_PROFILE`` pinned to
+  the tier's ``modal_workspace``, after validating ``~/.modal.toml`` has
+  a matching profile.
+- ``activate --deploy <name>`` fails up front when ``~/.modal.toml``
+  lacks the required profile.
+- ``env deploy`` / ``env destroy`` refuse to run when the shell is not
+  deploy-activated, and the refusal message points at the right
+  ``--deploy`` re-activation command.
+- ``env deactivate`` continues to ``unset`` MODAL_PROFILE so a previously
+  deploy-activated shell fully clears.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from imbue.minds.cli._activated_env import MODAL_PROFILE_ENV_VAR
+from imbue.minds.cli.env import env
+
+
+@pytest.fixture
+def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Strip activation env vars; tests opt in to a specific env explicitly."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
+    monkeypatch.delenv(MODAL_PROFILE_ENV_VAR, raising=False)
+    return tmp_path
+
+
+def _write_modal_toml_with_profile(home: Path, workspace: str) -> None:
+    """Drop a minimal ``~/.modal.toml`` with one section so deploy-mode validation passes."""
+    (home / ".modal.toml").write_text(f'[{workspace}]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
+
+
+# -- activate: use-only mode --
+
+
+def test_activate_dev_env_use_only_omits_modal_profile_export(_isolated_env: Path) -> None:
+    """Plain ``activate --create`` emits no ``export MODAL_PROFILE=`` line."""
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "dev-foo"])
+    assert result.exit_code == 0, result.output
+    assert "export MINDS_ROOT_NAME=minds-dev-foo" in result.output
+    assert "export MNGR_HOST_DIR=" in result.output
+    assert "export MNGR_PREFIX=" in result.output
+    assert "export MINDS_CLIENT_CONFIG_PATH=" in result.output
+    # The key contract: no MODAL_PROFILE export in use-only mode.
+    assert "export MODAL_PROFILE=" not in result.output
+
+
+def test_activate_dev_env_use_only_emits_unset_modal_profile(_isolated_env: Path) -> None:
+    """Plain ``activate`` emits ``unset MODAL_PROFILE`` so a deploy-mode shell flips back cleanly."""
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "dev-foo"])
+    assert result.exit_code == 0, result.output
+    assert "unset MODAL_PROFILE" in result.output
+
+
+def test_activate_dev_env_use_only_does_not_validate_modal_toml(_isolated_env: Path) -> None:
+    """A missing ``~/.modal.toml`` is fine for use-only activation."""
+    runner = CliRunner()
+    assert not (_isolated_env / ".modal.toml").exists()
+    result = runner.invoke(env, ["activate", "--create", "dev-foo"])
+    assert result.exit_code == 0, result.output
+
+
+# -- activate: deploy mode --
+
+
+def test_activate_dev_env_deploy_mode_exports_modal_profile(_isolated_env: Path) -> None:
+    """``--deploy`` exports ``MODAL_PROFILE`` pinned to the dev tier's modal_workspace."""
+    _write_modal_toml_with_profile(_isolated_env, "minds-dev")
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
+    assert result.exit_code == 0, result.output
+    assert "export MODAL_PROFILE=minds-dev" in result.output
+    # And no contradictory unset.
+    assert "unset MODAL_PROFILE" not in result.output
+
+
+def test_activate_deploy_mode_refuses_when_modal_toml_lacks_profile(_isolated_env: Path) -> None:
+    """No matching ``~/.modal.toml`` profile = clean refusal with a ``modal token set`` hint."""
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
+    assert result.exit_code != 0, result.output
+    assert "modal token set --profile minds-dev" in result.output
+
+
+def test_activate_deploy_mode_refuses_when_modal_toml_has_wrong_profile(_isolated_env: Path) -> None:
+    """A ``~/.modal.toml`` with a different profile still trips the refusal."""
+    _write_modal_toml_with_profile(_isolated_env, "some-other-workspace")
+    runner = CliRunner()
+    result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
+    assert result.exit_code != 0, result.output
+    assert "no profile named 'minds-dev'" in result.output
+
+
+# -- env deploy / destroy gate --
+
+
+def test_env_deploy_refuses_without_deploy_activation(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``minds env deploy`` requires deploy-mode activation; refuses otherwise."""
+    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
+    runner = CliRunner()
+    result = runner.invoke(env, ["deploy"], obj={})
+    assert result.exit_code != 0, result.output
+    assert "use only" in result.output
+    assert "minds env activate --deploy dev-foo" in result.output
+
+
+def test_env_deploy_refuses_with_mismatched_modal_profile(
+    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``MODAL_PROFILE`` that does not match the tier is a hard error."""
+    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
+    monkeypatch.setenv(MODAL_PROFILE_ENV_VAR, "some-other-workspace")
+    runner = CliRunner()
+    result = runner.invoke(env, ["deploy"], obj={})
+    assert result.exit_code != 0, result.output
+    assert "some-other-workspace" in result.output
+    assert "minds-dev" in result.output
+
+
+def test_env_destroy_refuses_without_deploy_activation(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``minds env destroy`` shares the same deploy-mode gate as deploy."""
+    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
+    runner = CliRunner()
+    result = runner.invoke(env, ["destroy"], obj={})
+    assert result.exit_code != 0, result.output
+    assert "minds env activate --deploy dev-foo" in result.output
+
+
+# -- deactivate --
+
+
+def test_deactivate_unsets_modal_profile(_isolated_env: Path) -> None:
+    """A deactivated shell drops every var either activation mode might have exported."""
+    runner = CliRunner()
+    result = runner.invoke(env, ["deactivate"])
+    assert result.exit_code == 0, result.output
+    assert "unset MODAL_PROFILE" in result.output
+    assert "unset MINDS_ROOT_NAME" in result.output
+    assert "unset MNGR_HOST_DIR" in result.output
+    assert "unset MNGR_PREFIX" in result.output
+    assert "unset MINDS_CLIENT_CONFIG_PATH" in result.output

--- a/apps/minds/imbue/minds/cli/env_test.py
+++ b/apps/minds/imbue/minds/cli/env_test.py
@@ -31,6 +31,9 @@ def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
     monkeypatch.delenv(MODAL_PROFILE_ENV_VAR, raising=False)
+    # Make sure no inherited MODAL_CONFIG_PATH redirects deploy-mode
+    # validation away from the test's ~/.modal.toml fixture file.
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     return tmp_path
 
 

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -24,6 +24,7 @@ from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.bootstrap import mngr_host_dir_for
 from imbue.minds.bootstrap import mngr_prefix_for
 from imbue.minds.bootstrap import root_name_for_env_name
+from imbue.minds.cli._activated_env import MODAL_PROFILE_ENV_VAR
 from imbue.minds.cli._activated_env import modal_profile_for_tier_or_none
 from imbue.minds.cli._activated_env import tier_for_env_name
 from imbue.minds.deployment_tests.data_types import SharedEnvHandle
@@ -69,7 +70,7 @@ def build_minds_env_subprocess_env(name: DevEnvName) -> dict[str, str]:
     env["MINDS_CLIENT_CONFIG_PATH"] = str(client_config_file(name))
     modal_profile = modal_profile_for_tier_or_none(tier_for_env_name(str(name)))
     if modal_profile is not None:
-        env["MODAL_PROFILE"] = modal_profile
+        env[MODAL_PROFILE_ENV_VAR] = modal_profile
     return env
 
 
@@ -218,7 +219,7 @@ def modal_env_exists(name: DevEnvName) -> bool:
     sub_env = dict(os.environ)
     modal_profile = modal_profile_for_tier_or_none(tier_for_env_name(str(name)))
     if modal_profile is not None:
-        sub_env["MODAL_PROFILE"] = modal_profile
+        sub_env[MODAL_PROFILE_ENV_VAR] = modal_profile
     result = subprocess.run(
         ["uv", "run", "modal", "environment", "list", "--json"],
         env=sub_env,

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -45,14 +45,17 @@ _SUPERTOKENS_PROBE_TIMEOUT_SECONDS: Final[float] = 30.0
 def build_minds_env_subprocess_env(name: DevEnvName) -> dict[str, str]:
     """Build the env dict for a ``minds env deploy/destroy`` subprocess targeting ``name``.
 
-    Mirrors what ``minds env activate <name>`` exports (without going
-    through the print-shell-vars indirection): MINDS_ROOT_NAME, MNGR_HOST_DIR,
-    MNGR_PREFIX, MINDS_CLIENT_CONFIG_PATH, and (for tiers with a
-    committed ``modal_workspace``) MODAL_PROFILE. The MODAL_PROFILE
-    lookup goes through the same ``modal_profile_for_tier_or_none``
-    helper ``minds env activate`` itself uses, so a separated CI Modal
-    workspace (planned) automatically lands here without having to
-    update a test-only hardcoded constant.
+    Mirrors what ``minds env activate --deploy <name>`` exports (without
+    going through the print-shell-vars indirection): MINDS_ROOT_NAME,
+    MNGR_HOST_DIR, MNGR_PREFIX, MINDS_CLIENT_CONFIG_PATH, and (for tiers
+    with a committed ``modal_workspace``) MODAL_PROFILE. The
+    MODAL_PROFILE lookup goes through the same
+    ``modal_profile_for_tier_or_none`` helper ``minds env activate``
+    itself uses, so a separated CI Modal workspace (planned)
+    automatically lands here without having to update a test-only
+    hardcoded constant. Including MODAL_PROFILE is required for the
+    subprocess deploy/destroy to satisfy the deploy-mode activation
+    gate enforced by ``require_deploy_mode_activation``.
 
     Inherits VAULT_TOKEN / VAULT_ADDR / VAULT_NAMESPACE / ANTHROPIC_API_KEY
     from the parent process unchanged so the subprocess can read Vault +

--- a/apps/minds/scripts/test_deployments.py
+++ b/apps/minds/scripts/test_deployments.py
@@ -722,7 +722,7 @@ def services_against(env_name: str, tests: tuple[str, ...], no_fct_push: bool) -
     if not target_client_toml.is_file():
         raise click.ClickException(
             f"No client.toml found at {target_client_toml} for env {env_name!r}. "
-            f'Activate + deploy the env first: `eval "$(uv run minds env activate {env_name})" && uv run minds env deploy`.'
+            f'Activate + deploy the env first: `eval "$(uv run minds env activate --create --deploy {env_name})" && uv run minds env deploy`.'
         )
     if not target_secrets_toml.is_file():
         raise click.ClickException(

--- a/dev/changelog/mngr-fix-minds-discovery.md
+++ b/dev/changelog/mngr-fix-minds-discovery.md
@@ -1,0 +1,5 @@
+Add `specs/minds-env-activate-split/concise.md`: design for splitting
+`minds env activate` into a default use-mode (no `MODAL_PROFILE`) and an
+opt-in `--deploy` mode. Fixes the spurious Modal-discovery warnings and
+Latchkey breakage hit by users who activated `staging` only to *use* the
+deployed tier but had no Modal token for the `minds-staging` workspace.

--- a/specs/minds-env-activate-split/concise.md
+++ b/specs/minds-env-activate-split/concise.md
@@ -1,0 +1,29 @@
+# Split `minds env activate` into use-mode vs deploy-mode
+
+## Overview
+
+- `minds env activate <name>` today exports both *use-side* shell state (data root, mngr profile, client config path) and a *deploy-side* var (`MODAL_PROFILE`, pinning the Modal CLI to the tier's workspace). The two are unrelated -- a user who only wants to *use* a deployed tier has no reason to pin a Modal workspace they have no token for.
+- Bundling them causes concrete breakage. With `MODAL_PROFILE` set to a workspace the user has no Modal token for, `mngr observe`'s Modal discovery fails on every poll; `BackendResolver.get_agent_display_info` returns nothing; Latchkey's permission dialog refuses to render. The repo-local `.mngr/settings.toml` hard-enables the modal provider, so this bites every developer running `minds run` from inside the mngr monorepo.
+- This spec splits activation in two: default `minds env activate <name>` exports only use-side vars; opt-in `minds env activate --deploy <name>` additionally exports `MODAL_PROFILE` and pre-validates the operator's Modal setup. Deploy/destroy/recover commands refuse to run unless deploy-mode is active.
+- The split has no effect on the packaged Electron build (which writes use-side vars itself from the bundled config and never deploys) and no effect on `deployment_tests/helpers.py` (which already injects `MODAL_PROFILE` directly into the pytest subprocess env, independent of shell activation).
+- Out of scope: the related `mngr observe` warning-vs-error log-level fix, the UI banner for blocking error states, and any change to how repo-local `.mngr/settings.toml` enables providers. Those are being handled separately.
+
+## Expected Behavior
+
+- `minds env activate <name>` (no flag) exports `MINDS_ROOT_NAME`, `MNGR_HOST_DIR`, `MNGR_PREFIX`, `MINDS_CLIENT_CONFIG_PATH`, and emits `unset MODAL_PROFILE`. The shell can now run `minds run`, `mngr ...`, browse agents, hit Latchkey -- everything except deploy/destroy/recover.
+- `minds env activate --deploy <name>` exports the same four use-side vars, additionally exports `MODAL_PROFILE=<tier's modal_workspace>`, and **hard-refuses** if `~/.modal.toml` has no profile matching that workspace -- the error names the missing profile and points at `modal token set --profile <workspace>`. Skipped only when the tier's `deploy.toml` has no `modal_workspace` (or the literal `CHANGE_ME` placeholder), matching today's behavior.
+- `minds env deactivate` continues to `unset` all five vars (`MODAL_PROFILE` stays in the unset list), so a previously deploy-activated shell fully reverts.
+- `minds env deploy` / `minds env destroy` / `minds env recover` refuse to run when the shell is not deploy-activated. "Deploy-activated" means `MODAL_PROFILE` is set **and** equals the tier's `modal_workspace` from `deploy.toml`. A missing `MODAL_PROFILE`, or one that doesn't match the activated tier, is a hard error pointing the operator at the right re-activation command.
+- A previously deploy-activated shell that gets re-activated with plain `activate` (no `--deploy`) flips back to use-only mode: the new `unset MODAL_PROFILE` line removes the stale workspace pin before the next `modal ...` shellout can pick it up, and the deploy/destroy/recover refusal then fires correctly until the operator re-activates with `--deploy`.
+- The first line printed by `activate` is unchanged (`# Activated env 'staging'. Source via: ...`). Mode is implicit in whether `MODAL_PROFILE` appears in the export list.
+- All tiers (`production` / `staging` / `dev-<user>` / `ci-<...>`) behave identically with respect to the split. The only per-tier difference is the `modal_workspace` value pulled from each tier's `deploy.toml`.
+- `deployment_tests/helpers.py` is unchanged. It already constructs subprocess envs with `MODAL_PROFILE` injected directly via `modal_profile_for_tier_or_none`, parallel to the shell-activation path, and the split doesn't touch that helper.
+- The packaged Electron app is unchanged. It writes only the use-side vars from `_bundled/` and never invokes `minds env deploy`, so the new gate has nothing to refuse.
+
+## Changes
+
+- Add a `--deploy` flag to `minds env activate`. Default activation drops `MODAL_PROFILE` from the exports it emits and instead emits `unset MODAL_PROFILE`. `--deploy` adds the `MODAL_PROFILE=<workspace>` export as today, plus a precondition check against `~/.modal.toml` that hard-fails with a `modal token set --profile <workspace>` hint when the matching profile is missing.
+- Wire a deploy-mode-required check into `minds env deploy`, `minds env destroy`, and `minds env recover`. The check reads `MODAL_PROFILE` from the env, compares against the activated tier's `modal_workspace` (loaded from `deploy.toml`), and refuses on mismatch or absence with a prescriptive error: tell the operator they activated for use only, give them the exact `eval "$(uv run minds env activate --deploy <name>)"` to run, and briefly explain that activation now distinguishes use-mode from deploy-mode.
+- Update `minds env activate`'s docstring and the user-facing docs (`apps/minds/docs/environments.md`, the README usage snippets, and any help text that references `eval "$(...)"`) to describe both modes and call out that deploy/destroy/recover require `--deploy`.
+- Add unit / acceptance test coverage: plain `activate` emits `unset MODAL_PROFILE` and does not emit a `MODAL_PROFILE=` line; `--deploy` emits the export and fails when `~/.modal.toml` lacks the matching profile; `minds env deploy` (and destroy/recover) refuses without deploy-mode and with a tier-mismatched `MODAL_PROFILE`, and succeeds with a correctly deploy-activated shell.
+- No code changes to `deployment_tests/helpers.py`, the Electron bundler, or the repo-local `.mngr/settings.toml`. No changes to which env vars get pinned for use-mode (still the same four).


### PR DESCRIPTION
## Summary
- Draft PR for the in-flight `minds env activate` split: default activation exports only use-side env vars; new `--deploy` flag adds `MODAL_PROFILE` (and any other deploy-side credentials).
- Goal: stop spurious Modal-discovery / Latchkey breakage for users who only want to *use* a deployed minds env but have no token for that tier's Modal workspace.
- Spec is being authored via /architect; implementation follows.

## Test plan
- [ ] Spec written and reviewed
- [ ] Implementation lands
- [ ] Unit + acceptance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)