### PR TITLE
Mark minds Electron e2e test as flaky

### DIFF
--- a/apps/minds/changelog/flaky-electron-e2e.md
+++ b/apps/minds/changelog/flaky-electron-e2e.md
@@ -1,0 +1,1 @@
+Mark `test_create_local_docker_workspace_via_electron` as `@pytest.mark.flaky`. The test has intermittently timed out in CI on unrelated branches (e.g. waiting for `#create-form`, or for an Electron content page to settle), so offload will now retry it automatically while the underlying flakiness is investigated.

--- a/apps/minds/test_desktop_client_e2e.py
+++ b/apps/minds/test_desktop_client_e2e.py
@@ -468,6 +468,7 @@ def _destroy_agent_best_effort(workspace_name: str) -> None:
 @pytest.mark.docker
 @pytest.mark.rsync
 @pytest.mark.minds_electron
+@pytest.mark.flaky
 @pytest.mark.timeout(900)
 def test_create_local_docker_workspace_via_electron(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.flaky` to `apps/minds/test_desktop_client_e2e.py::test_create_local_docker_workspace_via_electron` so `just test-offload` retries it automatically.
- Observed intermittent failures across unrelated branches with different symptoms (`#create-form` selector timeout at 10s; Electron content-page settle timeout at 120s), indicating environmental/CI flakiness rather than a real regression.

The underlying flakiness should still be investigated and fixed in a follow-up; this is a stopgap to unblock unrelated PRs (e.g. #1710 pnpm 10 pin) from being held up by it.

## Test plan

- [ ] CI runs and `test-docker-electron` either passes or is auto-retried by offload to success on this PR.