### PR TITLE
Disable Latchkey usage counting in all pytest sessions

### DIFF
--- a/libs/imbue_common/changelog/hynek-do-not-track-latchkey-in-tests.md
+++ b/libs/imbue_common/changelog/hynek-do-not-track-latchkey-in-tests.md
@@ -1,0 +1,1 @@
+- The shared conftest hooks now set `LATCHKEY_DISABLE_COUNTING=1` in `os.environ` once per pytest session. Any subprocess spawned by a test (directly or transitively, e.g. the Latchkey Gateway started by the minds Electron e2e test) inherits the opt-out, so test runs no longer count toward Latchkey's public daily usage counter.

--- a/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
+++ b/libs/imbue_common/imbue/imbue_common/conftest_hooks.py
@@ -956,6 +956,15 @@ def register_conftest_hooks(namespace: dict) -> None:
         return
     _registered = True
 
+    # Opt out of Latchkey's daily usage counting for every test in the
+    # monorepo. Setting it here (rather than in CI workflows or individual
+    # tests) means *any* test that ends up spawning a ``latchkey gateway``
+    # subprocess -- directly, through ``mngr latchkey forward``, or
+    # transitively via Electron / minds in the e2e suite -- inherits the
+    # opt-out through ``os.environ``. Test runs are not real usage and
+    # should never bump the public counter.
+    os.environ["LATCHKEY_DISABLE_COUNTING"] = "1"
+
     # Discover and register every resource guard declared via the
     # resource_guards entry point group. This is the single source of
     # truth for the monorepo's guarded resources: any installed package can


### PR DESCRIPTION
Set LATCHKEY_DISABLE_COUNTING=1 in os.environ inside the shared register_conftest_hooks(). Any test that ends up spawning a latchkey gateway -- directly, through 'mngr latchkey forward', or transitively via Electron / minds in the e2e suite (e.g. the test-docker-electron CI job) -- inherits the opt-out through the environment. Test runs are not real usage and must not bump the public daily counter.