### PR TITLE
Bump Latchkey version to 2.11.3.

### DIFF
--- a/apps/minds/changelog/hynek-bump-latchkey.md
+++ b/apps/minds/changelog/hynek-bump-latchkey.md
@@ -1,0 +1,1 @@
+- Bump bundled Latchkey version to 2.11.3.

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@todesktop/runtime": "^1.6.0",
-    "latchkey": "^2.11.1"
+    "latchkey": "^2.11.3"
   },
   "devDependencies": {
     "electron": "35.7.5",

--- a/apps/minds/pnpm-lock.yaml
+++ b/apps/minds/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.4
       latchkey:
-        specifier: ^2.11.1
-        version: 2.11.1
+        specifier: ^2.11.3
+        version: 2.11.3
     devDependencies:
       '@todesktop/cli':
         specifier: ^1.8.0
@@ -1661,8 +1661,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  latchkey@2.11.1:
-    resolution: {integrity: sha512-FIqtGXLH4fU6XA2h8Zy38EK7AGiStcWoyz4rrBRUkJ919JSuU1H/nlK+6H1Df7cU4ux24W/YyHregoH/2DglPA==}
+  latchkey@2.11.3:
+    resolution: {integrity: sha512-C5ysP8gCNSdUrjpiEuPsol2cFhOfWQp5M6zb5+ZUZ0L5zDTTnD1J6apS8voEAk4kNuilbujU6VtGF3gBWryK5w==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4448,7 +4448,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  latchkey@2.11.1:
+  latchkey@2.11.3:
     dependencies:
       '@imbue-ai/detent': 1.2.0
       '@napi-rs/keyring': 1.2.0


### PR DESCRIPTION
Accompanied by https://github.com/imbue-ai/forever-claude-template/pull/105.