### PR TITLE
permission-requests: preserve symlinks at the approval target

### DIFF
--- a/libs/mngr_latchkey/changelog/hynek-do-not-break-symlinks.md
+++ b/libs/mngr_latchkey/changelog/hynek-do-not-break-symlinks.md
@@ -1,0 +1,17 @@
+### permission-requests extension: preserve symlinks at the approval target
+
+`POST /permission-requests/approve/<id>` previously replaced the
+target `permissions.json` with a regular file when the target path
+was a symlink. This broke the per-agent opaque symlinks that
+`mngr latchkey link-permissions` swings into the canonical host
+permissions file: subsequent agents sharing the canonical file
+silently desynced from the granted permissions.
+
+The atomic-write helper now `lstat`s the target and, if it is a
+symlink, resolves it via `realpath` before computing the temp path
+and renaming. The atomic swap lands on the underlying file and the
+symlink stays in place. Approving against a non-symlink target,
+or a target that does not yet exist, is unchanged.
+
+`permissions.mjs` was already safe: its write paths resolve symlinks
+up front via `resolvePathParamUnderRoot`.

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
@@ -71,9 +71,11 @@
 import { randomBytes, randomUUID } from 'node:crypto';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   unlinkSync,
   writeFileSync,
@@ -567,9 +569,19 @@ function ensureDirectory(directory) {
  * under our own ``permission_requests/v2`` directory (mode 0600) and
  * writing the target permissions.json on approval (preserves existing
  * mode if any). ``mode`` is the unix mode for the *temp* file.
+ *
+ * If ``filePath`` is an existing symlink, the atomic rename targets
+ * the symlink's realpath rather than the link itself. ``rename(2)``
+ * operates on the link, not its target, so writing to the link path
+ * directly would replace the symlink with a regular file -- breaking
+ * the per-agent opaque symlinks that ``mngr latchkey link-permissions``
+ * swings into the canonical host permissions file. Resolving the link
+ * up front means the swap lands on the underlying file and the
+ * symlink stays in place.
  */
 function writeJsonFileAtomic(filePath, value, mode) {
-  const directory = dirname(filePath);
+  const destinationPath = resolveSymlinkTargetForWrite(filePath);
+  const directory = dirname(destinationPath);
   ensureDirectory(directory);
   const tempPath = join(
     directory,
@@ -578,7 +590,7 @@ function writeJsonFileAtomic(filePath, value, mode) {
   const serialized = `${JSON.stringify(value, null, 2)}\n`;
   try {
     writeFileSync(tempPath, serialized, { encoding: 'utf-8', mode });
-    renameSync(tempPath, filePath);
+    renameSync(tempPath, destinationPath);
   } catch (error) {
     try {
       unlinkSync(tempPath);
@@ -589,6 +601,40 @@ function writeJsonFileAtomic(filePath, value, mode) {
     throw new PermissionRequestsExtensionError(
       500,
       `Failed to write ${filePath}: ${message}`,
+    );
+  }
+}
+
+/**
+ * If ``filePath`` exists and is a symlink, return its realpath; if it
+ * does not exist or is a regular file, return ``filePath`` unchanged.
+ * Any other error (e.g. EACCES on ``lstat``) surfaces as a 500 so we
+ * don't silently fall back to clobbering the link.
+ */
+function resolveSymlinkTargetForWrite(filePath) {
+  let stat;
+  try {
+    stat = lstatSync(filePath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return filePath;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PermissionRequestsExtensionError(
+      500,
+      `Failed to stat ${filePath}: ${message}`,
+    );
+  }
+  if (!stat.isSymbolicLink()) {
+    return filePath;
+  }
+  try {
+    return realpathSync(filePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PermissionRequestsExtensionError(
+      500,
+      `Failed to resolve symlink ${filePath}: ${message}`,
     );
   }
 }

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
@@ -592,6 +592,53 @@ def test_approve_creates_target_when_missing(node_extension: tuple[str, Path, Pa
     assert applied["rules"] == [{"slack-api": ["slack-read-all"]}]
 
 
+def test_approve_preserves_symlink_at_target_path(
+    node_extension: tuple[str, Path, Path],
+    tmp_path: Path,
+) -> None:
+    """Approving a request must not replace a symlinked target with a regular file.
+
+    ``mngr latchkey link-permissions`` swings a per-agent opaque path
+    into the canonical host permissions file via a symlink. If the
+    extension wrote through ``rename(2)`` on the link itself, the
+    symlink would be replaced by a literal file and subsequent agents
+    sharing the canonical host file would silently desync from the
+    granted permissions. This test asserts that the symlink survives.
+    """
+    base_url, _latchkey_directory, permissions_config_path = node_extension
+    # Replace the (non-existent) target with a symlink pointing at a
+    # canonical file elsewhere on disk. The canonical file starts
+    # empty (no rules / no schemas) so we can verify both that the
+    # rules landed underneath the symlink and that the link itself
+    # survived the write.
+    canonical_path = tmp_path / "canonical_permissions.json"
+    canonical_path.write_text(json.dumps({"rules": []}))
+    assert not permissions_config_path.exists()
+    permissions_config_path.symlink_to(canonical_path)
+    assert permissions_config_path.is_symlink()
+
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "x",
+            "type": "predefined",
+            "payload": {"scope": "slack-api", "permissions": ["slack-read-all"]},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    approve_status, _ = _post_json(f"{base_url}/permission-requests/approve/{request_id}", None)
+    assert approve_status == 200
+
+    # Target path is still a symlink pointing at the canonical file.
+    assert permissions_config_path.is_symlink()
+    assert permissions_config_path.resolve() == canonical_path.resolve()
+    # The merge landed on the canonical file underneath.
+    applied = json.loads(canonical_path.read_text())
+    assert applied["rules"] == [{"slack-api": ["slack-read-all"]}]
+
+
 def test_approve_404s_on_unknown_request_id(node_extension: tuple[str, Path, Path]) -> None:
     base_url, *_ = node_extension
     status, body = _post_json(f"{base_url}/permission-requests/approve/nope", None)


### PR DESCRIPTION
renameSync(2) acts on the symlink itself, so writing through a symlinked target replaced it with a regular file. mngr latchkey link-permissions swings per-agent opaque paths into the canonical host permissions file via such symlinks, so approving a permission request silently desynced agents from the canonical file.

Resolve the target with lstatSync + realpathSync before computing the temp path and renaming, so the atomic swap lands on the underlying file and the symlink stays in place. Adds a regression test that creates a symlinked target and asserts both that the symlink survives approval and that the merged permissions end up in the canonical file underneath.