### PR TITLE
mngr_uncapped_claude: add missing changelog/ directory

### DIFF
--- a/libs/mngr_uncapped_claude/changelog/mngr-uncapped-claude-changelog.md
+++ b/libs/mngr_uncapped_claude/changelog/mngr-uncapped-claude-changelog.md
@@ -1,0 +1,13 @@
+### Add the missing changelog/ directory to mngr_uncapped_claude
+
+The recently added `mngr_uncapped_claude` project shipped with
+`CHANGELOG.md` and `UNABRIDGED_CHANGELOG.md` but no `changelog/`
+directory for per-PR entry files, which left the project out of the
+uniform changelog layout that every other project follows (and failed
+`test_meta_ratchets.py::test_every_project_has_changelog_layout`).
+
+This adds the `changelog/` directory (tracked via `.gitkeep`, matching
+the convention used by every other project) so the nightly consolidator
+can fan per-PR entries into the project's `UNABRIDGED_CHANGELOG.md` and
+`CHANGELOG.md`. No behavior of the `mngr uncapped-claude` command
+changes.


### PR DESCRIPTION
## Summary

The recently added `mngr_uncapped_claude` library shipped with `CHANGELOG.md` and `UNABRIDGED_CHANGELOG.md` but no `changelog/` directory for per-PR entry files. This left it out of the uniform changelog layout every other project follows and failed `test_meta_ratchets.py::test_every_project_has_changelog_layout`.

`mngr_uncapped_claude` provides the `mngr uncapped-claude` command -- a drop-in replacement for `claude -p` implemented on top of `mngr`.

## Changes

- Add `libs/mngr_uncapped_claude/changelog/` (tracked via `.gitkeep`, matching the convention used by every other project).
- Add this PR's per-PR changelog entry.

No behavior of the `mngr uncapped-claude` command changes.

## Testing

- `test_meta_ratchets.py::test_every_project_has_changelog_layout` -- passes
- `test_meta_ratchets.py` (full file, `-m 'not flaky'`) -- 15 passed
- `test_meta_ratchets.py::test_pr_has_changelog_entry` (acceptance) -- passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)