### PR TITLE
tmr: bootstrap Modal env, raise on silent failures, fix CI tee exit code

### DIFF
--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -61,6 +61,10 @@ jobs:
             --output-dir tmr-report \
             --format jsonl \
             | tee tmr-report/events.jsonl
+          # Don't rely on pipefail to propagate mngr's exit code through tee:
+          # in this step's GHA shell, the pipeline's non-zero left-side status
+          # has been observed to read as success. Re-assert it explicitly.
+          exit "${PIPESTATUS[0]}"
 
       - name: Upload HTML report
         if: always()

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -138,6 +138,10 @@ jobs:
             ${{ inputs.test_paths }} \
             -- ${{ inputs.pytest_args }} \
             | tee tmr-report/events.jsonl
+          # Don't rely on pipefail to propagate mngr's exit code through tee:
+          # in this step's GHA shell, the pipeline's non-zero left-side status
+          # has been observed to read as success. Re-assert it explicitly.
+          exit "${PIPESTATUS[0]}"
 
       - name: Upload HTML report
         if: always()

--- a/dev/changelog/mngr-fix-scheduled-tmr.md
+++ b/dev/changelog/mngr-fix-scheduled-tmr.md
@@ -1,0 +1,3 @@
+## dev
+
+- TMR workflows (`tmr.yml`, `tmr-reintegrate.yml`) now re-assert `mngr tmr`'s exit code via `exit "${PIPESTATUS[0]}"` after the `| tee tmr-report/events.jsonl` pipeline. The implicit `pipefail` propagation was observed to not catch the left-side failure in this step, letting a failed run be reported as successful.

--- a/libs/mngr_tmr/changelog/mngr-fix-scheduled-tmr.md
+++ b/libs/mngr_tmr/changelog/mngr-fix-scheduled-tmr.md
@@ -1,0 +1,7 @@
+## mngr_tmr
+
+- `mngr tmr --provider modal --use-snapshot` now bootstraps the Modal per-user environment on first run instead of aborting with `ProviderEmptyError`. The pre-snapshot provider lookup passes `is_for_host_creation=True`, matching the create path.
+- Exit codes follow a clearer convention: `1` for usage errors (e.g. `--reintegrate` without `--run-name`, or `--run-name` referring to an unknown run), and `2` for everything else. Previously usage errors exited `2` (click's default) and other errors exited `1`.
+- Several silent-success failure modes now produce a non-zero exit:
+  - `--reintegrate` when `mngr list` fails or the run name matches no agents.
+  - Any tmr run where every test agent failed to launch (no successful launches).

--- a/libs/mngr_tmr/changelog/mngr-fix-scheduled-tmr.md
+++ b/libs/mngr_tmr/changelog/mngr-fix-scheduled-tmr.md
@@ -1,7 +1,6 @@
 ## mngr_tmr
 
 - `mngr tmr --provider modal --use-snapshot` now bootstraps the Modal per-user environment on first run instead of aborting with `ProviderEmptyError`. The pre-snapshot provider lookup passes `is_for_host_creation=True`, matching the create path.
-- Exit codes follow a clearer convention: `1` for usage errors (e.g. `--reintegrate` without `--run-name`, or `--run-name` referring to an unknown run), and `2` for everything else. Previously usage errors exited `2` (click's default) and other errors exited `1`.
-- Several silent-success failure modes now produce a non-zero exit:
+- Several silent-success failure modes now produce a non-zero exit (click's default exit code):
   - `--reintegrate` when `mngr list` fails or the run name matches no agents.
   - Any tmr run where every test agent failed to launch (no successful launches).

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -570,25 +570,6 @@ def _run_integrator_phase(
 @add_common_options
 @click.pass_context
 def tmr(ctx: click.Context, **kwargs: object) -> None:
-    try:
-        _tmr_body(ctx)
-    except click.UsageError as exc:
-        # click.UsageError exits 2 by default; convert to a plain ClickException
-        # with exit_code=1 so the tmr convention (1=usage, 2=everything else)
-        # is preserved.
-        wrapped = click.ClickException(exc.format_message())
-        wrapped.exit_code = 1
-        raise wrapped from exc
-    except click.ClickException as exc:
-        # MngrError (and other ClickException subclasses) default to exit 1.
-        # Promote to exit 2 per the tmr convention.
-        exc.exit_code = 2
-        raise
-
-
-def _tmr_body(ctx: click.Context) -> None:
-    """Run the tmr command body. Wrapped by ``tmr`` so exit codes follow the
-    1=usage / 2=other convention regardless of which layer raised."""
     mngr_ctx, output_opts, opts = setup_command_context(
         ctx=ctx,
         command_name="tmr",

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -247,9 +247,7 @@ def _run_reintegrate(
     # Discover agents from the previous run by label
     list_result = try_list_agents(mngr_ctx)
     if list_result is None:
-        if is_human:
-            write_human_line("Failed to list agents. Nothing to reintegrate.")
-        return
+        raise MngrError("Failed to list agents. Cannot reintegrate.")
     matching_agents = [
         detail
         for detail in list_result.agents
@@ -260,9 +258,7 @@ def _run_reintegrate(
         write_human_line("Found {} agent(s) from run {}", len(matching_agents), run_name)
 
     if not matching_agents:
-        if is_human:
-            write_human_line("No agents found for run name '{}'. Nothing to reintegrate.", run_name)
-        return
+        raise click.UsageError(f"No agents found for run name {run_name!r}. Nothing to reintegrate.")
 
     # Get local host (needed by the integrator config built later).
     source_host = get_local_host(mngr_ctx)
@@ -574,6 +570,25 @@ def _run_integrator_phase(
 @add_common_options
 @click.pass_context
 def tmr(ctx: click.Context, **kwargs: object) -> None:
+    try:
+        _tmr_body(ctx)
+    except click.UsageError as exc:
+        # click.UsageError exits 2 by default; convert to a plain ClickException
+        # with exit_code=1 so the tmr convention (1=usage, 2=everything else)
+        # is preserved.
+        wrapped = click.ClickException(exc.format_message())
+        wrapped.exit_code = 1
+        raise wrapped from exc
+    except click.ClickException as exc:
+        # MngrError (and other ClickException subclasses) default to exit 1.
+        # Promote to exit 2 per the tmr convention.
+        exc.exit_code = 2
+        raise
+
+
+def _tmr_body(ctx: click.Context) -> None:
+    """Run the tmr command body. Wrapped by ``tmr`` so exit codes follow the
+    1=usage / 2=other convention regardless of which layer raised."""
     mngr_ctx, output_opts, opts = setup_command_context(
         ctx=ctx,
         command_name="tmr",
@@ -775,6 +790,16 @@ def _run_tmr_pipeline(
     _emit_integrator_branch(integrated_branch, output_opts)
 
     _print_run_commands(run, output_opts, integrated_branch)
+
+    # If no test agent ever launched successfully, surface a non-zero exit so
+    # callers (especially CI) don't read the run as successful. The HTML
+    # report (already written above) still contains the per-agent error
+    # summaries needed to diagnose the launch failures.
+    if test_node_ids and not agent_infos:
+        raise MngrError(
+            f"All {len(launch_failures)} test agent launches failed; "
+            "see the HTML report for per-agent error summaries."
+        )
 
 
 def _build_run_commands(run_name: str, integrated_branch: str | None = None) -> list[tuple[str, str]]:

--- a/libs/mngr_tmr/imbue/mngr_tmr/launching.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/launching.py
@@ -375,7 +375,13 @@ def launch_all_test_agents(
 
     launch_config = config
     if use_snapshot:
-        provider = get_provider_instance(config.provider_name, mngr_ctx)
+        # Pass is_for_host_creation=True so a backend with one-time bootstrap
+        # (Modal's per-user environment) creates that resource here. The
+        # snapshotter and every test agent that follows is a host creation,
+        # so this is the moment to allow bootstrap; without it, --use-snapshot
+        # against a fresh Modal account aborts with ProviderEmptyError before
+        # any host is created.
+        provider = get_provider_instance(config.provider_name, mngr_ctx, is_for_host_creation=True)
         if provider.supports_snapshots:
             try:
                 snapshot_name = _create_snapshot_host(config, mngr_ctx, run_name)


### PR DESCRIPTION
## Summary

Two related fixes (one in `mngr_tmr`, one in the CI workflows) for the case where the scheduled TMR run reports success even though it produced no work, e.g. https://github.com/imbue-ai/mngr/actions/runs/26445119420.

- **`mngr_tmr` (libs/mngr_tmr/imbue/mngr_tmr/launching.py)**: `--use-snapshot` against a Modal account with no per-user environment was aborting with `ProviderEmptyError` ("Modal environment ... does not exist yet"). The pre-snapshot provider lookup now passes `is_for_host_creation=True`, matching the create-host path, so the environment is bootstrapped on first use.
- **`mngr_tmr` (libs/mngr_tmr/imbue/mngr_tmr/cli.py)**: three failure modes that silently returned (so tmr exited 0) now raise:
  - `--reintegrate` when `mngr list` fails.
  - `--reintegrate --run-name <NAME>` where the name matches no agents.
  - A run where every test agent launch failed (e.g. all hit the same source-tree issue).
  Click defaults stand: `UsageError` → 2, `MngrError` → 1.
- **CI workflows (.github/workflows/tmr.yml, tmr-reintegrate.yml)**: the `mngr tmr ... | tee tmr-report/events.jsonl` pipeline was reporting success even when mngr exited non-zero. In this step's GHA shell, the implicit `pipefail` was not propagating the left-side failure. Each pipeline is now followed by `exit "${PIPESTATUS[0]}"` as a defensive assertion.

## Test plan

- [x] `just test-quick libs/mngr_tmr` (unit-test path) passes -- 175 tests.
- [x] Local repro: `mngr tmr --provider modal --use-snapshot` with a fresh `MNGR_USER_ID` previously aborted before any host was created; now it bootstraps the environment and proceeds to host creation.
- [x] `mngr tmr --reintegrate` (missing `--run-name`) exits 2 (click `UsageError`).
- [x] `mngr tmr --reintegrate --run-name <unknown>` exits 2 (treated as `UsageError`).
- [x] All-agents-failed-to-launch path exits 1 (`MngrError`).
- [ ] Watch the next scheduled TMR run (or trigger via `workflow_dispatch`) to confirm the CI step now reports failure when mngr exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)