### PR TITLE
fix bad merge: LaunchMode.LOCAL -> LaunchMode.DOCKER 

### DIFF
--- a/apps/minds/changelog/mngr-fix-type-error.md
+++ b/apps/minds/changelog/mngr-fix-type-error.md
@@ -1,0 +1,1 @@
+- Fixed a stale `LaunchMode.LOCAL` reference in `agent_creator_test.py` that was missed during the `LaunchMode.LOCAL` -> `LaunchMode.DOCKER` rename, which was causing `test_no_type_errors` to fail. No user-visible behavior change.

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -127,7 +127,7 @@ def test_build_mngr_create_command_does_not_inject_minds_api_key() -> None:
     ``--env`` or ``--host-env``.
     """
     for mode, account in (
-        (LaunchMode.LOCAL, None),
+        (LaunchMode.DOCKER, None),
         (LaunchMode.LIMA, None),
         (LaunchMode.CLOUD, None),
         (LaunchMode.IMBUE_CLOUD, "alice@imbue.com"),


### PR DESCRIPTION
## Summary

`test_no_type_errors` in `apps/minds` was failing on `main` because `agent_creator_test.py:130` still referenced `LaunchMode.LOCAL`. Commit 609e7d46b renamed `LaunchMode.LOCAL` -> `LaunchMode.DOCKER` everywhere except this one test reference.

This changes the stale reference to `LaunchMode.DOCKER`.

## Testing

- `just test-quick "apps/minds/imbue/minds/test_ratchets.py::test_no_type_errors"` — 1 passed
- `just test-quick "apps/minds/imbue/minds/desktop_client/agent_creator_test.py::test_build_mngr_create_command_does_not_inject_minds_api_key"` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)