### PR TITLE
Bump the Latchkey version to 2.12.1.

### DIFF
--- a/apps/minds/changelog/hynek-bump-latchkey-to-v2.12.1.md
+++ b/apps/minds/changelog/hynek-bump-latchkey-to-v2.12.1.md
@@ -1,0 +1,1 @@
+Bump Latchkey dependency to 2.12.1. The newest Latchkey version is capable of reusing Google Projects which is important because the default limit on Google Project count is low.

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@todesktop/runtime": "^1.6.0",
-    "latchkey": "^2.11.3"
+    "latchkey": "^2.12.1"
   },
   "devDependencies": {
     "electron": "35.7.5",

--- a/apps/minds/pnpm-lock.yaml
+++ b/apps/minds/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.4
       latchkey:
-        specifier: ^2.11.3
-        version: 2.11.3
+        specifier: ^2.12.1
+        version: 2.12.1
     devDependencies:
       '@todesktop/cli':
         specifier: ^1.8.0
@@ -1661,8 +1661,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  latchkey@2.11.3:
-    resolution: {integrity: sha512-C5ysP8gCNSdUrjpiEuPsol2cFhOfWQp5M6zb5+ZUZ0L5zDTTnD1J6apS8voEAk4kNuilbujU6VtGF3gBWryK5w==}
+  latchkey@2.12.1:
+    resolution: {integrity: sha512-asS+4PmMif/KsSfUwdKp3bb2iY2F7pV5wZaE3jwhH0IudkULt3WMzJ5eeQBhCB7Nr/uvfDioXZrviW5b6WTj7g==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4448,7 +4448,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  latchkey@2.11.3:
+  latchkey@2.12.1:
     dependencies:
       '@imbue-ai/detent': 1.2.0
       '@napi-rs/keyring': 1.2.0


### PR DESCRIPTION
The newest Latchkey version is capable of reusing Google Projects which is important because the default limit on Google Project count is low.