### PR TITLE
add exclude-newer to pyproject.toml; automatically update it at release to 2 weeks ago

### DIFF
--- a/dev/changelog/mngr-exclude-newer.md
+++ b/dev/changelog/mngr-exclude-newer.md
@@ -1,0 +1,25 @@
+# Enforce the supply-chain cooldown via `[tool.uv] exclude-newer`, refreshed at release
+
+- Moved the two-week dependency cooldown from a time-relative test to uv's native
+  resolver enforcement. Added `[tool.uv] exclude-newer` to the root `pyproject.toml`
+  (initial value `2026-05-23T00:00:00Z`), so `uv lock` simply refuses to consider any
+  package version uploaded after the cutoff. This is proactive (you cannot lock a
+  too-new package) rather than after-the-fact detection.
+- `scripts/release.py` now advances the cutoff at each release: it sets
+  `exclude-newer` to (Pacific release date - 2 weeks) just before regenerating
+  `uv.lock`, and commits the root `pyproject.toml` alongside the version bumps. The
+  update is **forward-only** -- it takes `max(current_cutoff, release_date - 2 weeks)`,
+  so a release cut while the current cutoff is still younger than two weeks leaves it
+  untouched rather than pushing it back. This avoids re-excluding a deliberately-pinned
+  fresh dependency (e.g. `ty`, currently 4 days old) and breaking resolution. The
+  initial value is set to just past the newest locked package for the same reason,
+  which makes per-package exemptions unnecessary.
+- Removed `test_no_dependencies_younger_than_two_weeks` (and its
+  `_FRESHNESS_EXEMPT_PACKAGES` / `_lock_package_upload_time` helpers) from
+  `test_meta_ratchets.py`; uv now enforces the cooldown at lock time, so the test is
+  redundant. Its `ty`/`modal` exemptions are no longer needed because the cutoff is
+  kept recent enough to admit them directly.
+- Added unit tests (`scripts/release_test.py`) covering the forward-only advance, the
+  no-op when the cutoff is still within the window, and the boundary case.
+- The cooldown does not protect against a compromise that stays undetected past the
+  window; its only value is the detection delay before we adopt a release.

--- a/dev/changelog/mngr-exclude-newer.md
+++ b/dev/changelog/mngr-exclude-newer.md
@@ -6,7 +6,7 @@
   package version uploaded after the cutoff. This is proactive (you cannot lock a
   too-new package) rather than after-the-fact detection.
 - `scripts/release.py` now advances the cutoff at each release: it sets
-  `exclude-newer` to (Pacific release date - 2 weeks) just before regenerating
+  `exclude-newer` to (today's UTC date - 2 weeks) just before regenerating
   `uv.lock`, and commits the root `pyproject.toml` alongside the version bumps. The
   update is **forward-only** -- it takes `max(current_cutoff, release_date - 2 weeks)`,
   so a release cut while the current cutoff is still younger than two weeks leaves it

--- a/dev/changelog/mngr-exclude-newer.md
+++ b/dev/changelog/mngr-exclude-newer.md
@@ -11,7 +11,7 @@
   update is **forward-only** -- it takes `max(current_cutoff, release_date - 2 weeks)`,
   so a release cut while the current cutoff is still younger than two weeks leaves it
   untouched rather than pushing it back. This avoids re-excluding a deliberately-pinned
-  fresh dependency (e.g. `ty`, currently 4 days old) and breaking resolution. The
+  fresh dependency and breaking resolution. The
   initial value is set to just past the newest locked package for the same reason,
   which makes per-package exemptions unnecessary.
 - Removed `test_no_dependencies_younger_than_two_weeks` (and its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 # when resolving, so we only adopt releases public long enough for malware to
 # surface. scripts/release.py advances it to 2 weeks before each release, but
 # only ever forward -- pushing it back would re-exclude a deliberately-pinned
-# fresh dep (e.g. `ty`) and break resolution. This only buys a detection delay;
+# fresh dep and break resolution. This only buys a detection delay;
 # it can't catch a compromise that stays undetected past the window.
 exclude-newer = "2026-05-23T00:00:00Z"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,19 @@ dependencies = [
     "click>=8.0.0",
 ]
 
+[tool.uv]
+# Supply-chain cooldown: uv won't consider any package version uploaded after
+# this timestamp when resolving/locking, so we only adopt registry releases
+# that have been public long enough for the community to flag malware before we
+# pull them. scripts/release.py advances this cutoff toward (release date - two
+# weeks) at each release, but only ever forward -- never pushing it back to
+# re-restrict a cutoff that is still younger than the cooldown window (doing so
+# would re-exclude a deliberately-pinned fresh dep like `ty` and break
+# resolution). See `update_exclude_newer` in scripts/release.py. The cooldown
+# does not protect against a compromise that stays undetected past the window;
+# its only value is the detection delay before we adopt a release.
+exclude-newer = "2026-05-23T00:00:00Z"
+
 [tool.uv.sources]
 imbue-common = { workspace = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,12 @@ dependencies = [
 ]
 
 [tool.uv]
-# Supply-chain cooldown: uv won't consider any package version uploaded after
-# this timestamp when resolving/locking, so we only adopt registry releases
-# that have been public long enough for the community to flag malware before we
-# pull them. scripts/release.py advances this cutoff toward (release date - two
-# weeks) at each release, but only ever forward -- never pushing it back to
-# re-restrict a cutoff that is still younger than the cooldown window (doing so
-# would re-exclude a deliberately-pinned fresh dep like `ty` and break
-# resolution). See `update_exclude_newer` in scripts/release.py. The cooldown
-# does not protect against a compromise that stays undetected past the window;
-# its only value is the detection delay before we adopt a release.
+# Supply-chain cooldown: uv ignores any package uploaded after this timestamp
+# when resolving, so we only adopt releases public long enough for malware to
+# surface. scripts/release.py advances it to 2 weeks before each release, but
+# only ever forward -- pushing it back would re-exclude a deliberately-pinned
+# fresh dep (e.g. `ty`) and break resolution. This only buys a detection delay;
+# it can't catch a compromise that stays undetected past the window.
 exclude-newer = "2026-05-23T00:00:00Z"
 
 [tool.uv.sources]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -32,14 +32,11 @@ import sys
 from collections import deque
 from datetime import date
 from datetime import datetime
-from datetime import time
 from datetime import timedelta
 from datetime import timezone
 from pathlib import Path
-from typing import Any
 from typing import Final
 from typing import TextIO
-from typing import cast
 
 import httpx
 import semver
@@ -283,7 +280,7 @@ def _write_version(pkg_pypi_name: str, new_version: str) -> None:
     """Update the version field in a package's pyproject.toml."""
     pkg = PACKAGE_BY_PYPI_NAME[pkg_pypi_name]
     doc = tomlkit.loads(pkg.pyproject_path.read_text())
-    project = cast(dict[str, Any], doc["project"])
+    project = doc["project"]
     project["version"] = new_version
     pkg.pyproject_path.write_text(tomlkit.dumps(doc))
 
@@ -298,7 +295,7 @@ def update_internal_dep_pins(all_versions: dict[str, str]) -> list[str]:
         if not pkg.internal_deps:
             continue
         doc = tomlkit.loads(pkg.pyproject_path.read_text())
-        project = cast(dict[str, Any], doc["project"])
+        project = doc["project"]
         # Modify the tomlkit array in-place to preserve formatting and comments
         deps = project["dependencies"]
         is_changed = False
@@ -329,19 +326,18 @@ def update_exclude_newer(pyproject_path: Path, release_date: date) -> str | None
     would re-exclude that dep and break resolution. So the new cutoff is the later
     of the current value and ``release_date - DEPENDENCY_COOLDOWN``.
 
-    ``release_date`` is combined with midnight UTC to form the cutoff, matching
-    the UTC upload-times uv compares it against. The committed value is therefore
-    identical regardless of who cuts the release, and the time-of-day is
-    immaterial for a two-week boundary.
+    The cutoff is anchored at midnight UTC, matching the UTC upload-times uv
+    compares it against. The committed value is therefore identical regardless of
+    who cuts the release, and the time-of-day is immaterial for a two-week boundary.
 
     Returns the new cutoff string if it changed, or ``None`` if the current cutoff
     already wins (in which case no write is performed).
     """
     doc = tomlkit.loads(pyproject_path.read_text())
-    tool = cast(dict[str, Any], doc["tool"])
-    uv_config = cast(dict[str, Any], tool["uv"])
-    current = datetime.fromisoformat(str(uv_config["exclude-newer"]).replace("Z", "+00:00"))
-    candidate = datetime.combine(release_date - DEPENDENCY_COOLDOWN, time.min, tzinfo=timezone.utc)
+    uv_config = doc["tool"]["uv"]
+    current = datetime.fromisoformat(str(uv_config["exclude-newer"]))
+    candidate_date = release_date - DEPENDENCY_COOLDOWN
+    candidate = datetime(candidate_date.year, candidate_date.month, candidate_date.day, tzinfo=timezone.utc)
     new_cutoff = max(current, candidate)
     if new_cutoff == current:
         return None

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -30,6 +30,11 @@ import json
 import subprocess
 import sys
 from collections import deque
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from typing import Any
 from typing import Final
@@ -56,6 +61,11 @@ from imbue.mngr.utils.polling import poll_for_value
 
 BUMP_KINDS: Final[tuple[str, ...]] = ("major", "minor", "patch")
 BUMP_LEVEL_ORDER: Final[dict[str, int]] = {"patch": 0, "minor": 1, "major": 2}
+
+# Supply-chain cooldown window: the resolver only adopts registry releases that
+# have been public at least this long. Enforced via the root `[tool.uv]
+# exclude-newer` cutoff, which a release advances to (release date - this window).
+DEPENDENCY_COOLDOWN: Final[timedelta] = timedelta(weeks=2)
 
 PUBLISH_WORKFLOW: Final[str] = "publish.yml"
 ACTIONS_URL: Final[str] = "https://github.com/imbue-ai/mngr/actions/workflows/publish.yml"
@@ -305,6 +315,39 @@ def update_internal_dep_pins(all_versions: dict[str, str]) -> list[str]:
             pkg.pyproject_path.write_text(tomlkit.dumps(doc))
             modified.append(pkg.pypi_name)
     return modified
+
+
+def update_exclude_newer(pyproject_path: Path, release_date: date) -> str | None:
+    """Advance the root ``[tool.uv] exclude-newer`` cutoff, forward-only.
+
+    The cutoff is the supply-chain cooldown boundary: uv refuses to consider any
+    package uploaded after it when resolving, so we only adopt registry releases
+    that have been public long enough for the community to flag malware. We move
+    it to ``release_date`` minus the cooldown window, but never backward -- if the
+    current cutoff is still younger than the window (e.g. it was set recently to
+    admit a freshly-pinned, deliberately-trusted dep like ``ty``), pushing it back
+    would re-exclude that dep and break resolution. So the new cutoff is the later
+    of the current value and ``release_date - DEPENDENCY_COOLDOWN``.
+
+    The window is anchored to the Pacific release date but written as a UTC
+    timestamp so the committed value is identical regardless of who cuts the
+    release; the few-hours fuzz is immaterial for a two-week boundary.
+
+    Returns the new cutoff string if it changed, or ``None`` if the current cutoff
+    already wins (in which case no write is performed).
+    """
+    doc = tomlkit.loads(pyproject_path.read_text())
+    tool = cast(dict[str, Any], doc["tool"])
+    uv_config = cast(dict[str, Any], tool["uv"])
+    current = datetime.fromisoformat(str(uv_config["exclude-newer"]).replace("Z", "+00:00"))
+    candidate = datetime.combine(release_date - DEPENDENCY_COOLDOWN, time.min, tzinfo=timezone.utc)
+    new_cutoff = max(current, candidate)
+    if new_cutoff == current:
+        return None
+    new_value = new_cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+    uv_config["exclude-newer"] = new_value
+    pyproject_path.write_text(tomlkit.dumps(doc))
+    return new_value
 
 
 def gh_is_available() -> bool:
@@ -782,6 +825,16 @@ def main() -> None:
     if pin_modified:
         print(f"Updated dependency pins in: {', '.join(pin_modified)}")
 
+    release_date = today_pacific()
+
+    # Advance the supply-chain cooldown cutoff before re-locking so the
+    # regenerated uv.lock records the new `[options] exclude-newer`. Forward-only:
+    # a release run while the cutoff is still younger than the window leaves it
+    # untouched (see update_exclude_newer).
+    new_cutoff = update_exclude_newer(REPO_ROOT / "pyproject.toml", date.fromisoformat(release_date))
+    if new_cutoff is not None:
+        print(f"Advanced exclude-newer cooldown cutoff to {new_cutoff}")
+
     print("Regenerating uv.lock...")
     run("uv", "lock")
 
@@ -793,7 +846,6 @@ def main() -> None:
     # and dev/ changelogs are not versioned and stay untouched -- their
     # entries accumulate in [Unreleased] indefinitely (the consolidator
     # keeps appending there).
-    release_date = today_pacific()
     finalized_paths: list[Path] = []
     versions_to_finalize: dict[str, str] = {
         **{name: current_versions[name] for name in confirmed_new},
@@ -818,6 +870,9 @@ def main() -> None:
     commit_msg = f"Release {tag} ({', '.join(all_released_names)})"
 
     files_to_add = [
+        # Root pyproject.toml carries the `[tool.uv] exclude-newer` cutoff that
+        # update_exclude_newer may have advanced above.
+        "pyproject.toml",
         *[str(pkg.pyproject_path.relative_to(REPO_ROOT)) for pkg in PACKAGES],
         "uv.lock",
         *[str(p.relative_to(REPO_ROOT)) for p in finalized_paths],

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -329,9 +329,10 @@ def update_exclude_newer(pyproject_path: Path, release_date: date) -> str | None
     would re-exclude that dep and break resolution. So the new cutoff is the later
     of the current value and ``release_date - DEPENDENCY_COOLDOWN``.
 
-    The window is anchored to the Pacific release date but written as a UTC
-    timestamp so the committed value is identical regardless of who cuts the
-    release; the few-hours fuzz is immaterial for a two-week boundary.
+    ``release_date`` is combined with midnight UTC to form the cutoff, matching
+    the UTC upload-times uv compares it against. The committed value is therefore
+    identical regardless of who cuts the release, and the time-of-day is
+    immaterial for a two-week boundary.
 
     Returns the new cutoff string if it changed, or ``None`` if the current cutoff
     already wins (in which case no write is performed).
@@ -825,13 +826,13 @@ def main() -> None:
     if pin_modified:
         print(f"Updated dependency pins in: {', '.join(pin_modified)}")
 
-    release_date = today_pacific()
-
     # Advance the supply-chain cooldown cutoff before re-locking so the
     # regenerated uv.lock records the new `[options] exclude-newer`. Forward-only:
     # a release run while the cutoff is still younger than the window leaves it
-    # untouched (see update_exclude_newer).
-    new_cutoff = update_exclude_newer(REPO_ROOT / "pyproject.toml", date.fromisoformat(release_date))
+    # untouched (see update_exclude_newer). Anchored to UTC (today's date) to match
+    # the UTC upload-times uv compares it against -- deliberately independent of the
+    # Pacific changelog date used below.
+    new_cutoff = update_exclude_newer(REPO_ROOT / "pyproject.toml", datetime.now(timezone.utc).date())
     if new_cutoff is not None:
         print(f"Advanced exclude-newer cooldown cutoff to {new_cutoff}")
 
@@ -846,6 +847,7 @@ def main() -> None:
     # and dev/ changelogs are not versioned and stay untouched -- their
     # entries accumulate in [Unreleased] indefinitely (the consolidator
     # keeps appending there).
+    release_date = today_pacific()
     finalized_paths: list[Path] = []
     versions_to_finalize: dict[str, str] = {
         **{name: current_versions[name] for name in confirmed_new},

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -322,8 +322,8 @@ def update_exclude_newer(pyproject_path: Path, release_date: date) -> str | None
     that have been public long enough for the community to flag malware. We move
     it to ``release_date`` minus the cooldown window, but never backward -- if the
     current cutoff is still younger than the window (e.g. it was set recently to
-    admit a freshly-pinned, deliberately-trusted dep like ``ty``), pushing it back
-    would re-exclude that dep and break resolution. So the new cutoff is the later
+    admit a freshly-pinned, deliberately-trusted dep), pushing it back would
+    re-exclude that dep and break resolution. So the new cutoff is the later
     of the current value and ``release_date - DEPENDENCY_COOLDOWN``.
 
     The cutoff is anchored at midnight UTC, matching the UTC upload-times uv

--- a/scripts/release_test.py
+++ b/scripts/release_test.py
@@ -1,4 +1,6 @@
 import sys
+import tomllib
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,7 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 from scripts.release import _gate_release_on_pending_changelog_entries  # noqa: E402
 from scripts.release import _pluralize_entry  # noqa: E402
+from scripts.release import update_exclude_newer  # noqa: E402
 
 
 def _write_changelog_entry(tmp_path: Path, name: str, content: str = "- entry", project: str = "mngr") -> None:
@@ -77,3 +80,46 @@ def test_gate_blocks_and_returns_false_with_pending_entries(
     assert "libs/mngr_lima/changelog/fake-b.md" in err
     # The error path prints the on-demand command for the user to copy.
     assert "mngr schedule run" in err
+
+
+def _write_root_pyproject(tmp_path: Path, exclude_newer: str) -> Path:
+    """Write a minimal root pyproject.toml carrying a `[tool.uv] exclude-newer`.
+
+    Includes an unrelated key under [tool.uv] so the tests can assert that
+    update_exclude_newer rewrites only the cutoff and preserves the rest.
+    """
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        f'[tool.uv]\nexclude-newer = "{exclude_newer}"\n\n[tool.uv.sources]\nimbue-common = {{ workspace = true }}\n'
+    )
+    return path
+
+
+def test_update_exclude_newer_advances_stale_cutoff(tmp_path: Path) -> None:
+    # A cutoff well older than two weeks before the release date is advanced to
+    # exactly (release_date - 2 weeks), and unrelated config is preserved.
+    path = _write_root_pyproject(tmp_path, "2026-01-01T00:00:00Z")
+    result = update_exclude_newer(path, date(2026, 5, 27))
+    assert result == "2026-05-13T00:00:00Z"
+    doc = tomllib.loads(path.read_text())
+    assert doc["tool"]["uv"]["exclude-newer"] == "2026-05-13T00:00:00Z"
+    assert doc["tool"]["uv"]["sources"]["imbue-common"] == {"workspace": True}
+
+
+def test_update_exclude_newer_keeps_recent_cutoff(tmp_path: Path) -> None:
+    # A cutoff younger than the cooldown window (only 4 days before the release
+    # date) must be left untouched: advancing it would push it back and re-exclude
+    # whatever freshly-pinned dep it was set to admit.
+    path = _write_root_pyproject(tmp_path, "2026-05-23T00:00:00Z")
+    original = path.read_text()
+    result = update_exclude_newer(path, date(2026, 5, 27))
+    assert result is None
+    assert path.read_text() == original
+
+
+def test_update_exclude_newer_noop_at_window_boundary(tmp_path: Path) -> None:
+    # A cutoff exactly at (release_date - 2 weeks) is a no-op: max() ties to the
+    # current value, so no rewrite happens.
+    path = _write_root_pyproject(tmp_path, "2026-05-13T00:00:00Z")
+    result = update_exclude_newer(path, date(2026, 5, 27))
+    assert result is None

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -4,10 +4,6 @@ import os
 import re
 import subprocess
 import sys
-import tomllib
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 from pathlib import Path
 
 import pytest
@@ -733,100 +729,4 @@ def test_top_level_coverage_omit_covers_subproject_omits() -> None:
     ]
     assert len(errors) == 0, (
         "Top-level [tool.coverage.run].omit is missing entries for files that subprojects omit:\n" + "\n".join(errors)
-    )
-
-
-# --- Dependency freshness (supply-chain cooldown) ---
-
-# How long a release must have been public before we will lock it.
-_DEPENDENCY_COOLDOWN = timedelta(weeks=2)
-
-# Packages exempt from the cooldown above. Each must be a deliberately-chosen,
-# trusted pin -- never an auto-floated dependency. Justify every entry.
-_FRESHNESS_EXEMPT_PACKAGES: frozenset[str] = frozenset(
-    {
-        # Our type checker: a dev-only tool (never shipped in a published wheel),
-        # pinned to the latest release for the best type coverage.
-        "ty",
-        # Explicitly pinned to ==1.4.3 for API stability (see libs/mngr_modal).
-        "modal",
-    }
-)
-
-
-def _lock_package_upload_time(package: dict) -> datetime | None:
-    """Return the earliest registry upload time recorded for a locked package.
-
-    Workspace / path / git sources carry no `upload-time`, so they return None
-    (and are not subject to the cooldown).
-    """
-    raw_times: list[str] = []
-    sdist = package.get("sdist")
-    if isinstance(sdist, dict) and sdist.get("upload-time"):
-        raw_times.append(sdist["upload-time"])
-    for wheel in package.get("wheels", []):
-        if wheel.get("upload-time"):
-            raw_times.append(wheel["upload-time"])
-    if not raw_times:
-        return None
-    return min(datetime.fromisoformat(t.replace("Z", "+00:00")) for t in raw_times)
-
-
-def test_no_dependencies_younger_than_two_weeks() -> None:
-    """Ensure no locked dependency was published within the last two weeks.
-
-    This is a supply-chain cooldown: we only adopt registry releases that have
-    been public long enough for the community to flag malware before we pull
-    them. It does NOT protect us from a compromise that stays undetected for
-    longer than the window, nor does it shield the first project to lock a fresh
-    release; its only value is the detection delay before we adopt (and, for
-    runtime deps in published wheels, re-propagate) a release.
-
-    Enforced as a (time-relative) test rather than a `[tool.uv] exclude-newer`
-    pin so the cutoff tracks "two weeks before now" automatically -- uv only
-    accepts a fixed date in static config. Regenerate a compliant lock with:
-
-        uv lock --upgrade --exclude-newer "2 weeks"
-
-    adding `--exclude-newer-package <name>=<date>` for each exempted package
-    (see _FRESHNESS_EXEMPT_PACKAGES), which the global cutoff would otherwise
-    exclude.
-    """
-    lock = tomllib.loads((_REPO_ROOT / "uv.lock").read_text())
-    packages = lock.get("package", [])
-    now = datetime.now(timezone.utc)
-
-    too_new: list[str] = []
-    examined = 0
-    for package in packages:
-        uploaded = _lock_package_upload_time(package)
-        if uploaded is None:
-            continue
-        examined += 1
-        if package["name"] in _FRESHNESS_EXEMPT_PACKAGES:
-            continue
-        age = now - uploaded
-        if age < _DEPENDENCY_COOLDOWN:
-            too_new.append(
-                f"  - {package['name']} {package['version']} (published {uploaded.date()}, {age.days}d ago)"
-            )
-
-    # Guard against silently disabling the cooldown: if a future uv release stops
-    # emitting `upload-time` (or renames the key), every package would parse as
-    # None and this test would pass vacuously. Registry packages dominate the lock
-    # (only workspace/path/git entries lack an upload time), so require a healthy
-    # fraction to have yielded a parseable one.
-    assert examined >= len(packages) // 2, (
-        f"Only {examined} of {len(packages)} locked packages had a parseable `upload-time`. "
-        "The uv.lock format may have changed, which would silently disable this "
-        "dependency-freshness cooldown -- update `_lock_package_upload_time`."
-    )
-
-    assert not too_new, (
-        "These locked dependencies are younger than two weeks (supply-chain cooldown):\n"
-        + "\n".join(sorted(too_new))
-        + '\n\nRe-lock with `uv lock --upgrade --exclude-newer "2 weeks"` (adding '
-        "`--exclude-newer-package <name>=<date>` for any exempted package), wait until they "
-        "age out, or -- only for a deliberately-trusted pin -- add the package to "
-        "_FRESHNESS_EXEMPT_PACKAGES with justification."
     )

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-05-23T00:00:00Z"
+
 [manifest]
 members = [
     "concurrency-group",


### PR DESCRIPTION
## What

Moves the two-week supply-chain cooldown from a time-relative meta test to uv's native resolver enforcement, and refreshes the cutoff at release time (the natural maintenance point, per discussion).

## Why

The previous approach (`test_no_dependencies_younger_than_two_weeks`) used a time-relative test specifically because "uv only accepts a fixed date in static config." But `scripts/release.py` already exists as a maintenance hook, so we can keep a static `exclude-newer` fresh by bumping it at each release — which makes the cooldown *enforced at lock time* (you cannot lock a too-new package) rather than merely detected after the fact.

## Changes

- **`pyproject.toml`**: add `[tool.uv] exclude-newer` (initial `2026-05-23T00:00:00Z`). uv refuses to consider any package uploaded after the cutoff when resolving. The initial value sits just past the newest currently-locked package (`ty`, 4 days old), so the lock is unchanged and no per-package exemptions are needed.
- **`scripts/release.py`**: `update_exclude_newer` advances the cutoff to `(Pacific release date − 2 weeks)` just before re-locking, **forward-only** via `max(current, release_date − 2 weeks)`. A release cut while the cutoff is still younger than the window leaves it untouched — so a deliberately-pinned fresh dep (e.g. `ty`) is never re-excluded, which would otherwise break resolution. The root `pyproject.toml` is committed with the release.
- **`test_meta_ratchets.py`**: remove the now-redundant `test_no_dependencies_younger_than_two_weeks` and its `ty`/`modal` exemptions; uv enforces the cooldown at lock time now.
- **`scripts/release_test.py`**: unit tests for the advance, the within-window no-op, and the boundary case.

## Verification

- `just test-quick "test_meta_ratchets.py scripts/release_test.py"`: 26 passed, 0 failed.
- ruff check + format and `ty check` pass on all touched files.
- Manually exercised `update_exclude_newer` against the real `pyproject.toml`: a release "tomorrow" keeps the recent cutoff (no-op), a release 3 weeks out advances it to `release − 2 weeks` while still admitting `ty`; tomlkit preserves the comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)