### PR TITLE
replace per-project unit tests for ruff and ty with single top-level ones + add ty to the pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,8 @@ repos:
         language: system
         types: [python]
     -   id: ty
-#        ty resolves the uv workspace root and scans every member regardless of which files
-#        changed, so it runs over the whole workspace (pass_filenames: false) whenever any
-#        Python file is staged. This is the local type-check gate; the single
-#        test_no_type_errors in test_meta_ratchets.py is the CI backstop.
+#        ty scans the whole uv workspace regardless of which files changed, so it does
+#        not take staged filenames (pass_filenames: false).
         name: "Python type checker (ty)"
         entry: bash -c 'uv run ty check'
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,16 @@ repos:
         entry: bash -c 'uv run ruff check --fix --force-exclude --config pyproject.toml "$@" && uv run ruff format --force-exclude --config pyproject.toml "$@"' --
         language: system
         types: [python]
+    -   id: ty
+#        ty resolves the uv workspace root and scans every member regardless of which files
+#        changed, so it runs over the whole workspace (pass_filenames: false) whenever any
+#        Python file is staged. This is the local type-check gate; the single
+#        test_no_type_errors in test_meta_ratchets.py is the CI backstop.
+        name: "Python type checker (ty)"
+        entry: bash -c 'uv run ty check'
+        language: system
+        types: [python]
+        pass_filenames: false
     -   id: regenerate-cli-docs
         name: "Regenerate CLI markdown docs"
         entry: bash -c 'uv run python scripts/make_cli_docs.py && git diff --quiet libs/mngr/docs/commands/ libs/mngr/README.md'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,14 @@ repos:
         types: [python]
     -   id: ty
 #        ty scans the whole uv workspace regardless of which files changed, so it does
-#        not take staged filenames (pass_filenames: false).
+#        not take staged filenames (pass_filenames: false) and runs only at pre-push
+#        (a per-commit hook would add a fixed full-workspace scan to every commit).
         name: "Python type checker (ty)"
         entry: bash -c 'uv run ty check'
         language: system
         types: [python]
         pass_filenames: false
+        stages: [pre-push]
     -   id: regenerate-cli-docs
         name: "Regenerate CLI markdown docs"
         entry: bash -c 'uv run python scripts/make_cli_docs.py && git diff --quiet libs/mngr/docs/commands/ libs/mngr/README.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Every PR must include one changelog entry file **per project it touches**. CI wi
 
 # Silly error workarounds
 
-If you get a failure in `test_no_type_errors` (in `test_meta_ratchets.py`) that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
+If you get a failure in `test_no_type_errors` that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
 
 If you get a "ModuleNotFoundError" error for a 3rd-party dependency when running a command that is defined in this repo (like `mngr`), then run "uv tool uninstall imbue-mngr && uv tool install -e libs/mngr" (for the relevant tool) to refresh the dependencies for that tool, and then try running the command again.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Every PR must include one changelog entry file **per project it touches**. CI wi
 
 # Silly error workarounds
 
-If you get a failure in `test_no_type_errors_repo_wide` (in `test_meta_ratchets.py`) that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
+If you get a failure in `test_no_type_errors` (in `test_meta_ratchets.py`) that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
 
 If you get a "ModuleNotFoundError" error for a 3rd-party dependency when running a command that is defined in this repo (like `mngr`), then run "uv tool uninstall imbue-mngr && uv tool install -e libs/mngr" (for the relevant tool) to refresh the dependencies for that tool, and then try running the command again.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Every PR must include one changelog entry file **per project it touches**. CI wi
 
 # Silly error workarounds
 
-If you get a failure in `test_no_type_errors` that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
+If you get a failure in `test_no_type_errors_repo_wide` (in `test_meta_ratchets.py`) that seems spurious, try running `uv sync --all-packages` and then re-running the tests. If that doesn't work, the error is probably real, and should be fixed.
 
 If you get a "ModuleNotFoundError" error for a 3rd-party dependency when running a command that is defined in this repo (like `mngr`), then run "uv tool uninstall imbue-mngr && uv tool install -e libs/mngr" (for the relevant tool) to refresh the dependencies for that tool, and then try running the command again.
 

--- a/apps/minds/changelog/mngr-ty-once.md
+++ b/apps/minds/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/apps/minds/changelog/mngr-ty-once.md
+++ b/apps/minds/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/apps/minds/imbue/minds/test_ratchets.py
+++ b/apps/minds/imbue/minds/test_ratchets.py
@@ -5,8 +5,6 @@ from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -337,14 +335,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-@pytest.mark.flaky
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/apps/modal_litellm/changelog/mngr-ty-once.md
+++ b/apps/modal_litellm/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/apps/modal_litellm/changelog/mngr-ty-once.md
+++ b/apps/modal_litellm/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/apps/modal_litellm/test_ratchets.py
+++ b/apps/modal_litellm/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent
 
@@ -287,13 +285,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/apps/remote_service_connector/changelog/mngr-ty-once.md
+++ b/apps/remote_service_connector/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/apps/remote_service_connector/changelog/mngr-ty-once.md
+++ b/apps/remote_service_connector/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/apps/remote_service_connector/imbue/remote_service_connector/test_ratchets.py
+++ b/apps/remote_service_connector/imbue/remote_service_connector/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -255,16 +253,6 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)
 
 
 def test_prevent_exit_stack() -> None:

--- a/apps/slack_exporter/changelog/mngr-ty-once.md
+++ b/apps/slack_exporter/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/apps/slack_exporter/changelog/mngr-ty-once.md
+++ b/apps/slack_exporter/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/apps/slack_exporter/imbue/slack_exporter/test_ratchets.py
+++ b/apps/slack_exporter/imbue/slack_exporter/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/dev/changelog/mngr-ty-once.md
+++ b/dev/changelog/mngr-ty-once.md
@@ -1,0 +1,15 @@
+# Consolidated ty/ruff ratchet tests to run once repo-wide
+
+The per-project `test_no_type_errors` and `test_no_ruff_errors` tests (~36 copies,
+one per workspace member) were redundant: `ty check` resolves the uv workspace
+root (root `pyproject.toml` declares `[tool.uv.workspace] members = ["libs/*",
+"apps/*"]`) and scans every member on each invocation regardless of the directory
+it runs from, and the existing repo-wide ruff check in `test_meta_ratchets.py` is
+a strict superset of the per-project ruff checks. Each duplicate invocation was a
+full ~0.8s cold workspace scan with no cross-process cache benefit.
+
+Added a single `test_no_type_errors_repo_wide` to `test_meta_ratchets.py` (next to
+the existing `test_no_ruff_lint_errors_repo_wide`), removed the per-project copies,
+and updated the meta-ratchet expected-test-name set and `CLAUDE.md` accordingly.
+
+No user-facing behavior change.

--- a/dev/changelog/mngr-ty-once.md
+++ b/dev/changelog/mngr-ty-once.md
@@ -4,12 +4,19 @@ The per-project `test_no_type_errors` and `test_no_ruff_errors` tests (~36 copie
 one per workspace member) were redundant: `ty check` resolves the uv workspace
 root (root `pyproject.toml` declares `[tool.uv.workspace] members = ["libs/*",
 "apps/*"]`) and scans every member on each invocation regardless of the directory
-it runs from, and the existing repo-wide ruff check in `test_meta_ratchets.py` is
-a strict superset of the per-project ruff checks. Each duplicate invocation was a
-full ~0.8s cold workspace scan with no cross-process cache benefit.
+it runs from, and the repo-wide ruff check is a strict superset of the per-project
+ruff checks. Each duplicate invocation was a full ~0.8s cold workspace scan with
+no cross-process cache benefit.
 
-Added a single `test_no_type_errors_repo_wide` to `test_meta_ratchets.py` (next to
-the existing `test_no_ruff_lint_errors_repo_wide`), removed the per-project copies,
-and updated the meta-ratchet expected-test-name set and `CLAUDE.md` accordingly.
+Removed the per-project copies and kept a single repo-wide `test_no_type_errors`
+and `test_no_ruff_errors` in `test_meta_ratchets.py`, updating the meta-ratchet
+expected-test-name set and `CLAUDE.md` accordingly.
+
+Because `ty` (unlike `ruff`) was not in pre-commit, scoped local runs such as
+`just test-quick libs/<project>` no longer type-checked at all after the
+consolidation. Added a `ty` pre-commit hook (mirroring the existing `ruff` hook,
+running `uv run ty check` over the whole workspace whenever a Python file is
+staged) so local commits still get a type-check gate; the single
+`test_no_type_errors` in `test_meta_ratchets.py` remains the CI backstop.
 
 No user-facing behavior change.

--- a/dev/changelog/mngr-ty-once.md
+++ b/dev/changelog/mngr-ty-once.md
@@ -10,13 +10,14 @@ no cross-process cache benefit.
 
 Removed the per-project copies and kept a single repo-wide `test_no_type_errors`
 and `test_no_ruff_errors` in `test_meta_ratchets.py`, updating the meta-ratchet
-expected-test-name set and `CLAUDE.md` accordingly.
+expected-test-name set accordingly.
 
 Because `ty` (unlike `ruff`) was not in pre-commit, scoped local runs such as
 `just test-quick libs/<project>` no longer type-checked at all after the
-consolidation. Added a `ty` pre-commit hook (mirroring the existing `ruff` hook,
-running `uv run ty check` over the whole workspace whenever a Python file is
-staged) so local commits still get a type-check gate; the single
+consolidation. Added a `ty` hook to `.pre-commit-config.yaml` that runs
+`uv run ty check` over the whole workspace at the `pre-push` stage (ty can't
+scope to staged files, so running it per-commit would add a fixed full-workspace
+scan to every commit). Pushes now get a type-check gate; the single
 `test_no_type_errors` in `test_meta_ratchets.py` remains the CI backstop.
 
 No user-facing behavior change.

--- a/libs/concurrency_group/changelog/mngr-ty-once.md
+++ b/libs/concurrency_group/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/concurrency_group/changelog/mngr-ty-once.md
+++ b/libs/concurrency_group/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/concurrency_group/imbue/concurrency_group/test_ratchets.py
+++ b/libs/concurrency_group/imbue/concurrency_group/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/imbue_common/changelog/mngr-ty-once.md
+++ b/libs/imbue_common/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/imbue_common/changelog/mngr-ty-once.md
+++ b/libs/imbue_common/changelog/mngr-ty-once.md
@@ -4,7 +4,7 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 Also removed the now-unused `check_no_ruff_errors` helper from
 `imbue/imbue_common/ratchet_testing/ratchets.py`: its only callers were the

--- a/libs/imbue_common/changelog/mngr-ty-once.md
+++ b/libs/imbue_common/changelog/mngr-ty-once.md
@@ -6,4 +6,10 @@ root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
 (`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
 
+Also removed the now-unused `check_no_ruff_errors` helper from
+`imbue/imbue_common/ratchet_testing/ratchets.py`: its only callers were the
+deleted per-project `test_no_ruff_errors` tests, and the repo-wide ruff test
+runs its own `ruff check` / `ruff format --check` invocations rather than using
+the helper. (`check_no_type_errors` is kept, since the repo-wide type test uses it.)
+
 No user-facing behavior change.

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py
@@ -435,33 +435,6 @@ def check_no_type_errors(project_root: Path) -> None:
         raise AssertionError("\n".join(failure_message))
 
 
-def check_no_ruff_errors(project_root: Path) -> None:
-    """Run the ruff linter and raise AssertionError if any linting errors are found."""
-    result = subprocess.run(
-        ["uv", "run", "ruff", "check"],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        failure_message = [
-            f"Ruff linter found errors (returncode {result.returncode}):",
-            "",
-            "Full ruff stdout:",
-            "=" * 80,
-            result.stdout,
-            "=" * 80,
-            "",
-            "Full ruff stderr:",
-            "=" * 80,
-            result.stderr,
-            "=" * 80,
-        ]
-
-        raise AssertionError("\n".join(failure_message))
-
-
 def assert_posix_compatible(command: str) -> None:
     """Assert that a shell command string is POSIX-compatible using shellcheck.
 

--- a/libs/imbue_common/imbue/imbue_common/test_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,14 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-@pytest.mark.timeout(15)
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr/changelog/mngr-ty-once.md
+++ b/libs/mngr/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr/changelog/mngr-ty-once.md
+++ b/libs/mngr/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr/imbue/mngr/utils/test_ratchets.py
+++ b/libs/mngr/imbue/mngr/utils/test_ratchets.py
@@ -5,8 +5,6 @@ from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 # mngr's test_ratchets.py is nested one level deeper than other projects (in utils/),
 # so the source dir is parent.parent instead of parent.parent.parent
@@ -305,13 +303,3 @@ def test_prevent_code_in_init_files() -> None:
             'hookimpl = pluggy.HookimplMarker("mngr")',
         },
     )
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(Path(__file__).parent.parent.parent.parent)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(Path(__file__).parent.parent.parent.parent)

--- a/libs/mngr_antigravity/changelog/mngr-ty-once.md
+++ b/libs/mngr_antigravity/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_antigravity/changelog/mngr-ty-once.md
+++ b/libs/mngr_antigravity/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/test_ratchets.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_claude/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_claude/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_claude/imbue/mngr_claude/test_ratchets.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_ratchets.py
@@ -7,8 +7,6 @@ from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_BARE_PRINT
 from imbue.imbue_common.ratchet_testing.common_ratchets import check_ratchet_rule
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -284,13 +282,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_claude_subagent_proxy/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude_subagent_proxy/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_claude_subagent_proxy/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude_subagent_proxy/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_ratchets.py
@@ -7,8 +7,6 @@ from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.common_ratchets import PREVENT_BARE_PRINT
 from imbue.imbue_common.ratchet_testing.common_ratchets import check_ratchet_rule
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -304,13 +302,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_claude_usage/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude_usage/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_claude_usage/changelog/mngr-ty-once.md
+++ b/libs/mngr_claude_usage/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_claude_usage/imbue/mngr_claude_usage/test_ratchets.py
+++ b/libs/mngr_claude_usage/imbue/mngr_claude_usage/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_file/changelog/mngr-ty-once.md
+++ b/libs/mngr_file/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_file/changelog/mngr-ty-once.md
+++ b/libs/mngr_file/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_file/imbue/mngr_file/test_ratchets.py
+++ b/libs/mngr_file/imbue/mngr_file/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_forward/changelog/mngr-ty-once.md
+++ b/libs/mngr_forward/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_forward/changelog/mngr-ty-once.md
+++ b/libs/mngr_forward/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_forward/imbue/mngr_forward/test_ratchets.py
+++ b/libs/mngr_forward/imbue/mngr_forward/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_imbue_cloud/changelog/mngr-ty-once.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_imbue_cloud/changelog/mngr-ty-once.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/test_ratchets.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_kanpan/changelog/mngr-ty-once.md
+++ b/libs/mngr_kanpan/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_kanpan/changelog/mngr-ty-once.md
+++ b/libs/mngr_kanpan/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_latchkey/changelog/mngr-ty-once.md
+++ b/libs/mngr_latchkey/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_latchkey/changelog/mngr-ty-once.md
+++ b/libs/mngr_latchkey/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/test_ratchets.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/test_ratchets.py
@@ -5,8 +5,6 @@ from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -294,13 +292,3 @@ def test_prevent_code_in_init_files() -> None:
     # line plus its ``import pluggy`` are tracked here as one violation
     # of the otherwise-strict no-code-in-init rule.
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_lima/changelog/mngr-ty-once.md
+++ b/libs/mngr_lima/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_lima/changelog/mngr-ty-once.md
+++ b/libs/mngr_lima/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_lima/imbue/mngr_lima/test_ratchets.py
+++ b/libs/mngr_lima/imbue/mngr_lima/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -275,13 +273,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_modal/changelog/mngr-ty-once.md
+++ b/libs/mngr_modal/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_modal/changelog/mngr-ty-once.md
+++ b/libs/mngr_modal/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_modal/imbue/mngr_modal/test_ratchets.py
+++ b/libs/mngr_modal/imbue/mngr_modal/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -281,13 +279,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_notifications/changelog/mngr-ty-once.md
+++ b/libs/mngr_notifications/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_notifications/changelog/mngr-ty-once.md
+++ b/libs/mngr_notifications/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_notifications/imbue/mngr_notifications/test_ratchets.py
+++ b/libs/mngr_notifications/imbue/mngr_notifications/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_opencode/changelog/mngr-ty-once.md
+++ b/libs/mngr_opencode/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_opencode/changelog/mngr-ty-once.md
+++ b/libs/mngr_opencode/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_opencode/imbue/mngr_opencode/test_ratchets.py
+++ b/libs/mngr_opencode/imbue/mngr_opencode/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_ovh/changelog/mngr-ty-once.md
+++ b/libs/mngr_ovh/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_ovh/changelog/mngr-ty-once.md
+++ b/libs/mngr_ovh/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_ovh/imbue/mngr_ovh/test_ratchets.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -261,16 +259,6 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)
 
 
 def test_prevent_exit_stack() -> None:

--- a/libs/mngr_pair/changelog/mngr-ty-once.md
+++ b/libs/mngr_pair/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_pair/changelog/mngr-ty-once.md
+++ b/libs/mngr_pair/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
+++ b/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_pi_coding/changelog/mngr-ty-once.md
+++ b/libs/mngr_pi_coding/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_pi_coding/changelog/mngr-ty-once.md
+++ b/libs/mngr_pi_coding/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_pi_coding/imbue/mngr_pi_coding/test_ratchets.py
+++ b/libs/mngr_pi_coding/imbue/mngr_pi_coding/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_recursive/changelog/mngr-ty-once.md
+++ b/libs/mngr_recursive/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_recursive/changelog/mngr-ty-once.md
+++ b/libs/mngr_recursive/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_recursive/imbue/mngr_recursive/test_ratchets.py
+++ b/libs/mngr_recursive/imbue/mngr_recursive/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_schedule/changelog/mngr-ty-once.md
+++ b/libs/mngr_schedule/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_schedule/changelog/mngr-ty-once.md
+++ b/libs/mngr_schedule/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_schedule/imbue/mngr_schedule/test_ratchets.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/test_ratchets.py
@@ -5,8 +5,6 @@ from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
 from imbue.imbue_common.ratchet_testing.ratchets import TEST_FILE_PATTERNS
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -283,13 +281,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_tmr/changelog/mngr-ty-once.md
+++ b/libs/mngr_tmr/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_tmr/changelog/mngr-ty-once.md
+++ b/libs/mngr_tmr/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -281,13 +279,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_ttyd/changelog/mngr-ty-once.md
+++ b/libs/mngr_ttyd/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_ttyd/changelog/mngr-ty-once.md
+++ b/libs/mngr_ttyd/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_ttyd/imbue/mngr_ttyd/test_ratchets.py
+++ b/libs/mngr_ttyd/imbue/mngr_ttyd/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_tutor/changelog/mngr-ty-once.md
+++ b/libs/mngr_tutor/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_tutor/changelog/mngr-ty-once.md
+++ b/libs/mngr_tutor/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_tutor/imbue/mngr_tutor/test_ratchets.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_uncapped_claude/changelog/mngr-ty-once.md
+++ b/libs/mngr_uncapped_claude/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_uncapped_claude/changelog/mngr-ty-once.md
+++ b/libs/mngr_uncapped_claude/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/test_ratchets.py
+++ b/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -233,17 +231,6 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-@pytest.mark.flaky
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)
 
 
 # --- Process management ---

--- a/libs/mngr_usage/changelog/mngr-ty-once.md
+++ b/libs/mngr_usage/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_usage/changelog/mngr-ty-once.md
+++ b/libs/mngr_usage/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_usage/imbue/mngr_usage/test_ratchets.py
+++ b/libs/mngr_usage/imbue/mngr_usage/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_vps_docker/changelog/mngr-ty-once.md
+++ b/libs/mngr_vps_docker/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_vps_docker/changelog/mngr-ty-once.md
+++ b/libs/mngr_vps_docker/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/test_ratchets.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -261,16 +259,6 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)
 
 
 def test_prevent_exit_stack() -> None:

--- a/libs/mngr_vultr/changelog/mngr-ty-once.md
+++ b/libs/mngr_vultr/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_vultr/changelog/mngr-ty-once.md
+++ b/libs/mngr_vultr/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_vultr/imbue/mngr_vultr/test_ratchets.py
+++ b/libs/mngr_vultr/imbue/mngr_vultr/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -255,16 +253,6 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(1))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)
 
 
 def test_prevent_exit_stack() -> None:

--- a/libs/mngr_wait/changelog/mngr-ty-once.md
+++ b/libs/mngr_wait/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/mngr_wait/changelog/mngr-ty-once.md
+++ b/libs/mngr_wait/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
+++ b/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -279,12 +277,3 @@ def test_prevent_code_in_init_files() -> None:
 # Pyright subprocess occasionally exceeds the 10s pytest-timeout on offload
 # under cold-cache / loaded-runner conditions. The check itself is
 # deterministic; retry handles the transient slowness.
-@pytest.mark.flaky
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
+++ b/libs/mngr_wait/imbue/mngr_wait/test_ratchets.py
@@ -272,8 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-# Pyright subprocess occasionally exceeds the 10s pytest-timeout on offload
-# under cold-cache / loaded-runner conditions. The check itself is
-# deterministic; retry handles the transient slowness.

--- a/libs/modal_proxy/changelog/mngr-ty-once.md
+++ b/libs/modal_proxy/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/modal_proxy/changelog/mngr-ty-once.md
+++ b/libs/modal_proxy/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/modal_proxy/imbue/modal_proxy/test_ratchets.py
+++ b/libs/modal_proxy/imbue/modal_proxy/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/resource_guards/changelog/mngr-ty-once.md
+++ b/libs/resource_guards/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/resource_guards/changelog/mngr-ty-once.md
+++ b/libs/resource_guards/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -306,12 +304,3 @@ def test_prevent_code_in_init_files() -> None:
 # Pyright subprocess occasionally exceeds the 10s pytest-timeout on offload
 # under cold-cache / loaded-runner conditions. The check itself is
 # deterministic; retry handles the transient slowness.
-@pytest.mark.flaky
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/libs/resource_guards/imbue/resource_guards/test_ratchets.py
+++ b/libs/resource_guards/imbue/resource_guards/test_ratchets.py
@@ -299,8 +299,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-# Pyright subprocess occasionally exceeds the 10s pytest-timeout on offload
-# under cold-cache / loaded-runner conditions. The check itself is
-# deterministic; retry handles the transient slowness.

--- a/libs/skitwright/changelog/mngr-ty-once.md
+++ b/libs/skitwright/changelog/mngr-ty-once.md
@@ -4,6 +4,6 @@ Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
 `test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
 root) both scan across projects, so the per-project copies just re-ran the same
 checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
-(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+(`test_no_type_errors` and `test_no_ruff_errors`).
 
 No user-facing behavior change.

--- a/libs/skitwright/changelog/mngr-ty-once.md
+++ b/libs/skitwright/changelog/mngr-ty-once.md
@@ -1,0 +1,9 @@
+# Dropped redundant per-project ty/ruff ratchet tests
+
+Removed this project's `test_no_type_errors` and `test_no_ruff_errors` from its
+`test_ratchets.py`. ty resolves the uv workspace root and ruff (run from the repo
+root) both scan across projects, so the per-project copies just re-ran the same
+checks. The single repo-wide equivalents now live in `test_meta_ratchets.py`
+(`test_no_type_errors_repo_wide` and `test_no_ruff_lint_errors_repo_wide`).
+
+No user-facing behavior change.

--- a/libs/skitwright/imbue/skitwright/test_ratchets.py
+++ b/libs/skitwright/imbue/skitwright/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -274,13 +272,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -171,7 +171,7 @@ def test_no_type_errors() -> None:
 
     ty resolves the uv workspace root (root pyproject.toml declares
     [tool.uv.workspace] members = ["libs/*", "apps/*"]) and scans every member, so
-    this single check covers the entire repo. CI backstop for the ty pre-commit hook.
+    this single check covers the entire repo. CI backstop for the ty pre-push hook.
 
     Timeout is 60s rather than the default 10s because the ``uv run ty check``
     subprocess can be slow on offload under load; the check is deterministic, so it

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -171,6 +171,8 @@ def test_no_import_layer_violations() -> None:
     check_no_import_lint_errors(_REPO_ROOT)
 
 
+@pytest.mark.flaky
+@pytest.mark.timeout(60)
 def test_no_type_errors_repo_wide() -> None:
     """Ensure the workspace has zero type errors (ty), once for the whole repo.
 
@@ -179,6 +181,12 @@ def test_no_type_errors_repo_wide() -> None:
     on each invocation regardless of the directory it runs from, so a single
     repo-wide check is exactly equivalent to -- and replaces -- the per-project
     test_no_type_errors copies that used to re-run the identical scan ~36 times.
+
+    The ``uv run ty check`` subprocess occasionally exceeds the default 10s
+    pytest-timeout on offload under cold-cache / loaded-runner conditions (the
+    per-project copies were marked flaky for this reason); the check itself is
+    deterministic, so the bump to 60s plus ``@pytest.mark.flaky`` retry handles
+    the transient slowness.
 
     If this fails for a reason that looks spurious, run `uv sync --all-packages`
     and re-run before treating the error as real (see CLAUDE.md).

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -19,6 +19,7 @@ from imbue.imbue_common.ratchet_testing.common_ratchets import check_ratchet_rul
 from imbue.imbue_common.ratchet_testing.core import BINARY_FILE_EXCLUSION
 from imbue.imbue_common.ratchet_testing.core import _get_all_files_with_extension
 from imbue.imbue_common.ratchet_testing.ratchets import check_no_import_lint_errors
+from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 from imbue.imbue_common.ratchet_testing.ratchets import find_bash_scripts_without_strict_mode
 from imbue.imbue_common.test_profiles import detect_branch
 from scripts.changelog_projects import DEV_PROJECT
@@ -98,8 +99,11 @@ def test_every_project_has_test_ratchets_file() -> None:
 def _get_expected_ratchet_test_names() -> frozenset[str]:
     """Derive the expected set of test function names from standard_ratchet_checks.py.
 
-    Each check_foo() function maps to test_prevent_foo(). Two additional hand-written
-    tests (test_no_type_errors, test_no_ruff_errors) are always expected.
+    Each check_foo() function maps to test_prevent_foo(). The type-check and
+    ruff-lint ratchets are NOT per-project: ty and ruff each scan the whole
+    workspace identically regardless of the directory they run from, so a single
+    repo-wide check (test_no_type_errors_repo_wide / test_no_ruff_lint_errors_repo_wide
+    in this file) replaces what used to be ~36 redundant per-project copies.
     """
     checks_path = (
         _REPO_ROOT
@@ -116,8 +120,6 @@ def _get_expected_ratchet_test_names() -> frozenset[str]:
         for node in ast.walk(tree)
         if isinstance(node, ast.FunctionDef) and node.name.startswith("check_")
     }
-    test_names.add("test_no_type_errors")
-    test_names.add("test_no_ruff_errors")
     return frozenset(test_names)
 
 
@@ -125,7 +127,9 @@ def test_all_test_ratchets_files_have_same_tests() -> None:
     """Ensure all test_ratchets.py files define precisely the expected set of test functions.
 
     The expected tests are derived from standard_ratchet_checks.py (one test_prevent_*
-    per check_* function) plus test_no_type_errors and test_no_ruff_errors.
+    per check_* function). The type-check and ruff-lint ratchets are repo-wide
+    (see test_no_type_errors_repo_wide / test_no_ruff_lint_errors_repo_wide), not
+    per-project, so they are intentionally absent from this set.
     """
     reference_tests = _get_expected_ratchet_test_names()
 
@@ -167,13 +171,28 @@ def test_no_import_layer_violations() -> None:
     check_no_import_lint_errors(_REPO_ROOT)
 
 
+def test_no_type_errors_repo_wide() -> None:
+    """Ensure the workspace has zero type errors (ty), once for the whole repo.
+
+    ty resolves the uv workspace root (root pyproject.toml declares
+    [tool.uv.workspace] members = ["libs/*", "apps/*"]) and scans every member
+    on each invocation regardless of the directory it runs from, so a single
+    repo-wide check is exactly equivalent to -- and replaces -- the per-project
+    test_no_type_errors copies that used to re-run the identical scan ~36 times.
+
+    If this fails for a reason that looks spurious, run `uv sync --all-packages`
+    and re-run before treating the error as real (see CLAUDE.md).
+    """
+    check_no_type_errors(_REPO_ROOT)
+
+
 def test_no_ruff_lint_errors_repo_wide() -> None:
     """Ensure all Python files pass ruff lint and format checks repo-wide.
 
-    Runs both ruff check and ruff format --check over the entire repo root.
-    Per-project test_ratchets.py files also run ruff check within each project;
-    this test acts as a CI backstop for the pre-commit hook and additionally
-    covers repo-root and scripts/ files.
+    Runs both ruff check and ruff format --check over the entire repo root. This
+    is the sole ruff ratchet (the per-project copies were redundant -- this root
+    invocation is a strict superset, additionally covering repo-root and scripts/
+    files) and acts as the CI backstop for the ruff pre-commit hook.
     """
     fix_hint = "To fix: `uv run ruff check --fix . && uv run ruff format .`"
     errors: list[str] = []

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -101,9 +101,9 @@ def _get_expected_ratchet_test_names() -> frozenset[str]:
 
     Each check_foo() function maps to test_prevent_foo(). The type-check and
     ruff-lint ratchets are NOT per-project: ty and ruff each scan the whole
-    workspace identically regardless of the directory they run from, so a single
-    repo-wide check (test_no_type_errors_repo_wide / test_no_ruff_lint_errors_repo_wide
-    in this file) replaces what used to be ~36 redundant per-project copies.
+    workspace identically regardless of the directory they run from, so single
+    repo-wide checks (test_no_type_errors / test_no_ruff_errors in this file)
+    replace what used to be ~36 redundant per-project copies.
     """
     checks_path = (
         _REPO_ROOT
@@ -127,9 +127,9 @@ def test_all_test_ratchets_files_have_same_tests() -> None:
     """Ensure all test_ratchets.py files define precisely the expected set of test functions.
 
     The expected tests are derived from standard_ratchet_checks.py (one test_prevent_*
-    per check_* function). The type-check and ruff-lint ratchets are repo-wide
-    (see test_no_type_errors_repo_wide / test_no_ruff_lint_errors_repo_wide), not
-    per-project, so they are intentionally absent from this set.
+    per check_* function). The type-check and ruff-lint ratchets run once repo-wide
+    (test_no_type_errors / test_no_ruff_errors in this file), not per-project, so
+    they are intentionally absent from this set.
     """
     reference_tests = _get_expected_ratchet_test_names()
 
@@ -172,14 +172,15 @@ def test_no_import_layer_violations() -> None:
 
 
 @pytest.mark.timeout(60)
-def test_no_type_errors_repo_wide() -> None:
+def test_no_type_errors() -> None:
     """Ensure the workspace has zero type errors (ty), once for the whole repo.
 
     ty resolves the uv workspace root (root pyproject.toml declares
     [tool.uv.workspace] members = ["libs/*", "apps/*"]) and scans every member
-    on each invocation regardless of the directory it runs from, so a single
-    repo-wide check is exactly equivalent to -- and replaces -- the per-project
-    test_no_type_errors copies that used to re-run the identical scan ~36 times.
+    on each invocation regardless of the directory it runs from, so this single
+    repo-wide check is exactly equivalent to -- and replaces -- the ~36
+    per-project copies that used to re-run the identical scan once per project.
+    Local iteration is covered by the ``ty`` pre-commit hook; this is the CI backstop.
 
     The ``uv run ty check`` subprocess occasionally exceeds the default 10s
     pytest-timeout on offload under cold-cache / loaded-runner conditions, so the
@@ -192,8 +193,8 @@ def test_no_type_errors_repo_wide() -> None:
     check_no_type_errors(_REPO_ROOT)
 
 
-def test_no_ruff_lint_errors_repo_wide() -> None:
-    """Ensure all Python files pass ruff lint and format checks repo-wide.
+def test_no_ruff_errors() -> None:
+    """Ensure all Python files pass ruff lint and format checks, once for the whole repo.
 
     Runs both ruff check and ruff format --check over the entire repo root. This
     is the sole ruff ratchet (the per-project copies were redundant -- this root

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -171,7 +171,6 @@ def test_no_import_layer_violations() -> None:
     check_no_import_lint_errors(_REPO_ROOT)
 
 
-@pytest.mark.flaky
 @pytest.mark.timeout(60)
 def test_no_type_errors_repo_wide() -> None:
     """Ensure the workspace has zero type errors (ty), once for the whole repo.
@@ -183,10 +182,9 @@ def test_no_type_errors_repo_wide() -> None:
     test_no_type_errors copies that used to re-run the identical scan ~36 times.
 
     The ``uv run ty check`` subprocess occasionally exceeds the default 10s
-    pytest-timeout on offload under cold-cache / loaded-runner conditions (the
-    per-project copies were marked flaky for this reason); the check itself is
-    deterministic, so the bump to 60s plus ``@pytest.mark.flaky`` retry handles
-    the transient slowness.
+    pytest-timeout on offload under cold-cache / loaded-runner conditions, so the
+    timeout is bumped to 60s. The check itself is deterministic (no retry needed):
+    60s is ample headroom for a scan that runs in ~1s locally.
 
     If this fails for a reason that looks spurious, run `uv sync --all-packages`
     and re-run before treating the error as real (see CLAUDE.md).

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -99,11 +99,7 @@ def test_every_project_has_test_ratchets_file() -> None:
 def _get_expected_ratchet_test_names() -> frozenset[str]:
     """Derive the expected set of test function names from standard_ratchet_checks.py.
 
-    Each check_foo() function maps to test_prevent_foo(). The type-check and
-    ruff-lint ratchets are NOT per-project: ty and ruff each scan the whole
-    workspace identically regardless of the directory they run from, so single
-    repo-wide checks (test_no_type_errors / test_no_ruff_errors in this file)
-    replace what used to be ~36 redundant per-project copies.
+    Each check_foo() function maps to test_prevent_foo().
     """
     checks_path = (
         _REPO_ROOT
@@ -127,9 +123,7 @@ def test_all_test_ratchets_files_have_same_tests() -> None:
     """Ensure all test_ratchets.py files define precisely the expected set of test functions.
 
     The expected tests are derived from standard_ratchet_checks.py (one test_prevent_*
-    per check_* function). The type-check and ruff-lint ratchets run once repo-wide
-    (test_no_type_errors / test_no_ruff_errors in this file), not per-project, so
-    they are intentionally absent from this set.
+    per check_* function).
     """
     reference_tests = _get_expected_ratchet_test_names()
 
@@ -173,33 +167,26 @@ def test_no_import_layer_violations() -> None:
 
 @pytest.mark.timeout(60)
 def test_no_type_errors() -> None:
-    """Ensure the workspace has zero type errors (ty), once for the whole repo.
+    """Ensure the whole workspace has zero type errors (ty).
 
     ty resolves the uv workspace root (root pyproject.toml declares
-    [tool.uv.workspace] members = ["libs/*", "apps/*"]) and scans every member
-    on each invocation regardless of the directory it runs from, so this single
-    repo-wide check is exactly equivalent to -- and replaces -- the ~36
-    per-project copies that used to re-run the identical scan once per project.
-    Local iteration is covered by the ``ty`` pre-commit hook; this is the CI backstop.
+    [tool.uv.workspace] members = ["libs/*", "apps/*"]) and scans every member, so
+    this single check covers the entire repo. CI backstop for the ty pre-commit hook.
 
-    The ``uv run ty check`` subprocess occasionally exceeds the default 10s
-    pytest-timeout on offload under cold-cache / loaded-runner conditions, so the
-    timeout is bumped to 60s. The check itself is deterministic (no retry needed):
-    60s is ample headroom for a scan that runs in ~1s locally.
-
-    If this fails for a reason that looks spurious, run `uv sync --all-packages`
-    and re-run before treating the error as real (see CLAUDE.md).
+    Timeout is 60s rather than the default 10s because the ``uv run ty check``
+    subprocess can be slow on offload under load; the check is deterministic, so it
+    is not marked flaky. If a failure looks spurious, run ``uv sync --all-packages``
+    and re-run before treating it as real (see CLAUDE.md).
     """
     check_no_type_errors(_REPO_ROOT)
 
 
 def test_no_ruff_errors() -> None:
-    """Ensure all Python files pass ruff lint and format checks, once for the whole repo.
+    """Ensure all Python files pass ruff lint and format checks repo-wide.
 
-    Runs both ruff check and ruff format --check over the entire repo root. This
-    is the sole ruff ratchet (the per-project copies were redundant -- this root
-    invocation is a strict superset, additionally covering repo-root and scripts/
-    files) and acts as the CI backstop for the ruff pre-commit hook.
+    Runs both ruff check and ruff format --check from the repo root, covering all
+    workspace members plus repo-root and scripts/ files. CI backstop for the ruff
+    pre-commit hook.
     """
     fix_hint = "To fix: `uv run ruff check --fix . && uv run ruff format .`"
     errors: list[str] = []


### PR DESCRIPTION
ty and ruff will no longer run in per-project pytest--each project's run was actually running on the whole repo. they will instead run on pre-push (both ty and ruff) and precommit (ruff only). this adds a delay of ~0.7s to pre-push, but speeds up the tests more, since it's not doing the same work 36 times (ty doesn't cache so all of the work is indeed redone). this is especially meaningful on modal where sometimes the per-project `test_no_type_errors` would hit their 10s timeout

---

## Summary

Each package's `test_no_type_errors` ran `uv run ty check`, which — because the root `pyproject.toml` declares `[tool.uv.workspace] members = ["libs/*", "apps/*"]` — resolves the **workspace root** and scans every member (1186 files) on *every* invocation, regardless of `cwd`. So all ~36 per-project copies re-ran the identical full-workspace scan (~0.7s each, with no cross-process cache benefit — ty has no on-disk cache, only in-memory Salsa incrementality for its server/watch modes). The per-project `test_no_ruff_errors` were likewise redundant with the repo-wide ruff check that already lived in `test_meta_ratchets.py`.

This consolidates both to run **once** repo-wide:

- Keep a single `test_no_type_errors` and `test_no_ruff_errors` in `test_meta_ratchets.py` (in its existing `# --- Repo-wide ratchets (run once, not per-project) ---` section). The ty test carries `@pytest.mark.timeout(60)` because `uv run ty check` can exceed the default 10s under cold-cache/loaded-runner conditions; it is intentionally **not** marked `flaky` (the check is deterministic, so a retry would only risk masking a real failure).
- Remove `test_no_type_errors` / `test_no_ruff_errors` (and their now-unused imports) from all 36 per-project `test_ratchets.py` files, and drop them from the meta-ratchet expected-test-name set (`_get_expected_ratchet_test_names`).
- Remove the now-dead `check_no_ruff_errors` helper from `imbue_common/ratchet_testing/ratchets.py` (its only callers were the deleted per-project tests; the repo-wide ruff test inlines its own `ruff check` + `ruff format --check`). `check_no_type_errors` is kept and reused by the repo-wide ty test.

### Local type-check gate (ty pre-push hook)

`ruff` was already in pre-commit, so dropping its per-project copies lost no local gate. But `ty` was **not**, so after consolidation a scoped run like `just test-quick libs/<project>` no longer type-checked at all (the repo-wide test in `test_meta_ratchets.py` isn't collected when you scope pytest to a single project). To close that gap, this adds a `ty` hook in `.pre-commit-config.yaml`. Because ty scans the whole workspace and can't scope to staged files (a fixed ~0.7s scan), it is staged at **`pre-push`** rather than per-commit — the commit loop stays fast and ty still gates before code leaves the machine. The single `test_no_type_errors` remains the CI backstop. Verified end-to-end: the hook is skipped at the commit stage, runs on `git push`, passes on a clean tree, and fails on a deliberately-introduced type error.

Type/lint coverage is unchanged — the single repo-wide checks are equivalent to (ty) or a strict superset of (ruff) the per-project ones. Under local xdist the ratchet group no longer serializes ~36 redundant scans on one worker; under offload they no longer fan out into ~36 sandboxes that each re-scan the whole workspace.

Docstrings and one changelog entry per touched project (36 projects + the synthetic `dev` bucket for the root-level files) are updated to match.

## Testing

- `just test-quick "test_meta_ratchets.py"` — 18 passed (incl. `test_no_type_errors`, `test_no_ruff_errors`, `test_all_test_ratchets_files_have_same_tests`).
- `just test-quick "scripts/sync_common_ratchets_test.py <sample per-project test_ratchets.py>"` — 117 passed.
- Manually verified the `ty` hook staging: skipped at `pre-commit`, runs at `pre-push` (and on a real `git push`), and fails on an introduced type error.
- Full unit/integration + acceptance suites run in CI via offload (`test-offload-acceptance` green, which exercises the per-project changelog-entry check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)