### PR TITLE
Make imbue_cloud destroy_host wipe data then release the lease

### DIFF
--- a/libs/mngr_imbue_cloud/README.md
+++ b/libs/mngr_imbue_cloud/README.md
@@ -58,13 +58,25 @@ The pool host is fully pre-provisioned, so mngr's create pipeline only
 writes the agent env file (and patches the claude config when an
 `ANTHROPIC_API_KEY` lands in env) before starting the tmux session.
 
-## Destroy vs delete
+## Destroy / delete / stop
 
-- `mngr destroy <agent>` stops the docker container on the leased VPS only;
-  the lease and on-disk data are preserved. `mngr start <agent>` brings it
-  back on the same VPS.
+- `mngr destroy <agent>` is *terminal* for imbue_cloud-leased hosts. It
+  (1) stops + removes the workspace container, drops the per-host docker
+  named volume, deletes the per-host btrfs subvolume under `/mngr-btrfs/`,
+  runs `docker system prune -a -f --volumes`, and wipes `/root` + `/tmp`
+  (keeping `/root/.ssh/authorized_keys` so the pool-management ssh path
+  keeps working through cleanup); then (2) releases the lease back to the
+  pool via the connector. Privacy-first ordering: the user's data is gone
+  before the connector flips the row to `released`. The underlying VPS is
+  destroyed later by
+  `apps/remote_service_connector/scripts/cleanup_released_hosts.py`.
 - `mngr delete <agent>` (or `mngr imbue_cloud hosts release <lease-id>`)
-  releases the VPS back to the pool and drops all data.
+  runs the same flow; it's the path mngr's GC takes after the
+  destroyed-host grace period. Safe to re-run on an already-released lease.
+- `mngr stop <agent>` is the "I'll resume this workspace later" path:
+  `docker stop`s the container on the leased VPS, preserves the lease +
+  the on-disk volume, and `mngr start <agent>` brings the same workspace
+  back up on the same VPS.
 
 ## Pool admin
 

--- a/libs/mngr_imbue_cloud/changelog/mngr-imbue-cloud-destroy-wipes.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-imbue-cloud-destroy-wipes.md
@@ -1,0 +1,29 @@
+`mngr destroy <agent>` against an imbue_cloud-leased pool host is now
+*terminal* rather than a soft `docker stop`. The new flow on the leased
+VPS:
+
+1. Stops + removes the workspace container, drops the per-host docker named
+   volume, deletes the per-host btrfs subvolume under `/mngr-btrfs/`, runs
+   `docker system prune -a -f --volumes`, and wipes `/root` + `/tmp`
+   (preserving only `/root/.ssh/authorized_keys` so the pool-management ssh
+   path still works through `cleanup_released_hosts.py`).
+2. Releases the lease back to the pool (the `/hosts/{id}/release` connector
+   call -- same as `mngr imbue_cloud hosts release`).
+3. Cleans up local per-host state (ssh keys, known_hosts, cached records).
+
+Privacy-first ordering: the agent's data is gone before the connector flips
+the row to `released`, so the eventual VPS-destroy by
+`cleanup_released_hosts.py` is belt-and-suspenders rather than the only
+barrier.
+
+To stop the container without releasing the lease (i.e. you intend to
+resume the workspace later on the same VPS), use `mngr stop <agent>`
+instead.
+
+`mngr delete <agent>` (the GC path) now also runs this same flow; it's a
+safe no-op for an already-released lease and acts as a recovery path if a
+prior `destroy` crashed mid-wipe.
+
+The wipe script (`build_pool_host_wipe_script`) is exposed as a pure free
+function in `mngr_imbue_cloud.instance` so the rendered shell can be unit
+tested without standing up an SSH transport.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py
@@ -9,11 +9,20 @@ runs the rename + label + env-injection sequence in 2 SSH round trips.
 This provider's responsibilities are then:
 - `discover_hosts` -- list this account's leased hosts via the connector.
 - `get_host` -- build a Host pointing at the leased VPS:container_ssh_port.
-- `destroy_host` -- stop the docker container on the VPS via SSH; lease and
-  on-disk data are preserved.
-- `delete_host` -- call /hosts/{id}/release and drop on-disk plugin state.
-- `start_host` -- start the docker container on the VPS.
-- `stop_host` -- stop the docker container on the VPS.
+- `destroy_host` -- wipe the user's data on the leased VPS (container, named
+  volumes, per-host btrfs subvolume under ``/mngr-btrfs/``, ``docker system
+  prune``, ``/root`` and ``/tmp`` content) and release the lease back to the
+  pool. The privacy-first ordering means the agent's data is gone before the
+  connector flips the row to ``released``; ``cleanup_released_hosts.py``'s
+  later VPS-destroy becomes belt-and-suspenders.
+- `delete_host` -- called by mngr's GC after the destroyed-host grace
+  period. Same flow as ``destroy_host``; treated as a no-op when the lease
+  has already been released.
+- `start_host` -- start the docker container on the VPS (no-op for an
+  already-destroyed host; ``destroy_host`` is terminal for imbue_cloud).
+- `stop_host` -- stop the docker container on the VPS without releasing
+  the lease (use ``mngr stop`` when you intend to resume the workspace
+  later on the same VPS).
 """
 
 import json
@@ -97,6 +106,86 @@ from imbue.mngr_imbue_cloud.primitives import ImbueCloudAccount
 from imbue.mngr_imbue_cloud.session_store import ImbueCloudSessionStore
 
 _SSH_WAIT_TIMEOUT_SECONDS: Final[float] = 120.0
+
+# Path on every mngr_vps_docker-baked outer where the per-host btrfs loop
+# filesystem is mounted (matches ``VpsDockerProviderConfig.btrfs_mount_path``
+# default). The per-host subvolume is at ``<this>/<host_id_hex>``.
+_VPS_BTRFS_MOUNT_PATH: Final[str] = "/mngr-btrfs"
+
+# Container label that mngr_vps_docker tags the workspace container with;
+# also used as ``docker volume`` -name search prefix (the bind-options volume
+# is named ``mngr-host-vol-<host_id_hex>``).
+_LABEL_HOST_ID_KEY: Final[str] = "com.imbue.mngr.host-id"
+_HOST_VOLUME_NAME_PREFIX: Final[str] = "mngr-host-vol-"
+
+
+def build_pool_host_wipe_script(host_id: HostId) -> str:
+    """Render the bash script that wipes a leased pool VPS before release.
+
+    Runs as root on the outer (the leased VPS itself). Each step is
+    independently best-effort -- the script always exits 0 so a single
+    failed sub-step (e.g. ``docker stop`` on an already-stopped container)
+    doesn't abort the rest. The destroy-host caller still logs warnings
+    when this returns abnormally, but the privacy-relevant steps remain
+    unconditionally attempted.
+
+    Wipes:
+
+    * The workspace container (by label) and any named docker volume
+      whose name contains the host hex.
+    * The per-host btrfs subvolume backing the bind-options volume (the
+      bind source ``device=`` lives outside the container, so removing
+      the container alone leaves the data on disk).
+    * Everything docker still knows about (``system prune -a -f --volumes``).
+    * Everything under ``/root`` and ``/tmp`` except
+      ``/root/.ssh/authorized_keys`` (preserves the static pool-management
+      key the connector / cleanup_released_hosts.py needs for any
+      post-release SSH-driven maintenance).
+
+    Pure function so unit tests can assert the exact command shape
+    without standing up an SSH transport.
+    """
+    host_id_hex = host_id.get_uuid().hex
+    host_id_str = str(host_id)
+    label_filter = shlex.quote(f"label={_LABEL_HOST_ID_KEY}={host_id_str}")
+    volume_name_filter = shlex.quote(f"name={_HOST_VOLUME_NAME_PREFIX}{host_id_hex}")
+    subvolume_path = f"{_VPS_BTRFS_MOUNT_PATH}/{host_id_hex}"
+    return (
+        "set +e\n"
+        # Find + remove the workspace container by its host-id label.
+        f"container_id=$(docker ps -a --filter {label_filter} --format '{{{{.ID}}}}' | head -1)\n"
+        'if [ -n "$container_id" ]; then\n'
+        '    docker stop "$container_id" >/dev/null 2>&1\n'
+        '    docker rm -f -v "$container_id" >/dev/null 2>&1\n'
+        "fi\n"
+        # Drop the per-host named volume(s). docker volume rm -f tolerates
+        # the volume not existing.
+        f"for vol in $(docker volume ls -q --filter {volume_name_filter}); do\n"
+        '    docker volume rm -f "$vol" >/dev/null 2>&1\n'
+        "done\n"
+        # The bind-options volume's storage is a btrfs subvolume at
+        # /mngr-btrfs/<host_hex>; docker volume rm doesn't touch the bind
+        # source, so wipe it explicitly. Fall back to rm -rf if btrfs is
+        # absent (older non-btrfs hosts before the btrfs spec landed).
+        f"if [ -d {shlex.quote(subvolume_path)} ]; then\n"
+        f"    btrfs subvolume delete {shlex.quote(subvolume_path)} >/dev/null 2>&1 || "
+        f"rm -rf {shlex.quote(subvolume_path)} >/dev/null 2>&1\n"
+        "fi\n"
+        # Reclaim everything else docker holds: stopped containers, dangling
+        # images, networks, unused volumes, build cache.
+        "docker system prune -a -f --volumes >/dev/null 2>&1\n"
+        # Wipe /root content except .ssh/authorized_keys -- preserves the
+        # pool-management public key the connector relies on if it needs
+        # to reach the host again before cleanup_released_hosts.py runs.
+        "find /root -mindepth 1 -maxdepth 1 -not -name .ssh -exec rm -rf {} + 2>/dev/null\n"
+        "find /root/.ssh -mindepth 1 -not -name authorized_keys -exec rm -rf {} + 2>/dev/null\n"
+        # Wipe /tmp entirely.
+        "find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null\n"
+        # Always succeed: release is the gating step, individual wipe
+        # failures are surfaced via the script's stderr but must not
+        # block lease return.
+        "exit 0\n"
+    )
 
 
 def _certified_host_name(raw: Mapping[str, Any]) -> str | None:
@@ -1173,64 +1262,96 @@ class ImbueCloudProvider(BaseProviderInstance):
         return self._build_host_object(leased)
 
     def destroy_host(self, host: HostInterface | HostId) -> None:
-        """Stop the leased container (does NOT release the lease).
+        """Wipe user data on the leased VPS and release the lease back to the pool.
 
-        Matches the architect-spec definition of destroy: the docker container
-        is stopped on the VPS but the lease, on-disk volume, and any in-progress
-        agent work persist. Use ``delete_host`` (or ``mngr imbue_cloud hosts
-        release``) to release the lease back to the pool.
+        Three phases, in order, so the data is unreachable to the next user
+        before the lease is returned to the pool:
+
+        1. Stop + remove the workspace container, drop the per-host named
+           docker volume, delete the per-host btrfs subvolume under
+           ``/mngr-btrfs/``, run ``docker system prune -a -f --volumes``,
+           and wipe ``/root`` and ``/tmp`` (preserving ``authorized_keys``
+           so the pool-management ssh path keeps working through cleanup).
+        2. Release the lease via the connector's ``/hosts/{id}/release``
+           endpoint -- the row flips to ``released`` and gets picked up by
+           ``cleanup_released_hosts.py`` later for VPS-destroy.
+        3. Drop local per-host state (ssh keys, known_hosts, cached records).
+
+        Each step is best-effort with respect to the others: a failed wipe
+        still proceeds to release (because a stuck VPS would otherwise leak
+        a paid lease indefinitely), and a failed release still proceeds to
+        local cleanup. Operators see warnings for each partial failure.
+
+        Use ``mngr stop`` (-> ``stop_host``) instead when you intend to
+        resume the workspace later on the same VPS -- that path preserves
+        the lease and the on-disk data.
+        """
+        self._wipe_and_release_pool_host(host)
+
+    def delete_host(self, host: HostInterface) -> None:
+        """Same as ``destroy_host``; provided for the GC code path.
+
+        mngr's GC calls ``delete_host`` after the destroyed-host grace
+        period. Since ``destroy_host`` is now terminal (wipes + releases
+        the lease immediately), ``delete_host`` is functionally a re-run
+        of the same flow -- it's a no-op for an already-released lease
+        and a recovery path if a previous destroy crashed mid-wipe.
+        """
+        self._wipe_and_release_pool_host(host)
+
+    def _wipe_and_release_pool_host(self, host: HostInterface | HostId) -> None:
+        """Shared implementation for ``destroy_host`` and ``delete_host``.
+
+        See ``destroy_host`` for the contract. Split out so both entry
+        points run identically; both are now terminal for imbue_cloud.
         """
         host_id = host.id if isinstance(host, HostInterface) else host
         leased = self._find_leased(host_id)
-        if leased is None:
-            logger.warning("destroy_host: no lease record for host {}; nothing to do", host_id)
-            return
-        try:
-            with self.outer_host_for(host_id) as outer:
-                assert outer is not None
-                container_id = self._resolve_container_id_on_outer(outer, host_id)
-                if container_id is None:
-                    logger.debug("destroy_host: no container for host {}; nothing to do", host_id)
-                else:
-                    self._run_outer_docker_command(
-                        outer, f"stop {shlex.quote(container_id)}", host_id=host_id, label="docker-stop"
-                    )
-                    logger.debug("Stopped container {} for host {}", container_id, host_id)
-        except HostNotFoundError:
+        host_db_id: str | None = None
+        if isinstance(host, HostInterface):
+            host_db_id = self._resolve_host_db_id(host, host_id)
+        if host_db_id is None and leased is not None:
+            host_db_id = str(leased.host_db_id)
+
+        if leased is None and host_db_id is None:
             logger.warning(
-                "destroy_host: SSH key for host {} is missing; cannot stop container remotely. "
-                "Run `mngr imbue_cloud hosts release` to release the lease instead.",
+                "destroy_host: no lease record for host {} (already released?); running local cleanup only.",
                 host_id,
             )
+            self._cleanup_local_host_state(host_id)
             return
-        self.reset_caches()
 
-    def delete_host(self, host: HostInterface) -> None:
-        """Release the lease back to the pool and drop local state.
-
-        Called by mngr's GC after the destroyed-host grace period (or directly
-        when an operator wants the lease freed immediately). The lease return
-        is the authoritative step here; container removal is best-effort
-        because the connector will reuse the VPS for a new lease anyway.
-        """
-        host_id = host.id
-        host_db_id = self._resolve_host_db_id(host, host_id)
-        leased = self._find_leased(host_id)
         if leased is not None:
             try:
                 with self.outer_host_for(host_id) as outer:
                     assert outer is not None
-                    container_id = self._resolve_container_id_on_outer(outer, host_id)
-                    if container_id is not None:
-                        self._run_outer_docker_command(
-                            outer,
-                            f"rm -f -v {shlex.quote(container_id)}",
-                            host_id=host_id,
-                            label="docker-rm",
+                    script = build_pool_host_wipe_script(host_id)
+                    result = outer.execute_idempotent_command(script, timeout_seconds=300.0)
+                    if not result.success:
+                        # The script exits 0 at the end on purpose; a non-zero
+                        # exit indicates the SSH transport itself or shell-
+                        # invocation framing failed. Log + proceed -- release
+                        # is the gating step regardless.
+                        logger.warning(
+                            "destroy_host: wipe script returned non-zero for {} "
+                            "(stderr={!r}); proceeding with release.",
+                            host_id,
+                            result.stderr.strip(),
                         )
-                        logger.debug("Removed container {} for host {}", container_id, host_id)
-            except (HostNotFoundError, MngrError) as exc:
-                logger.warning("delete_host: failed to remove container for host {}: {}", host_id, exc)
+                    else:
+                        logger.debug("Wiped pool VPS data for host {}", host_id)
+            except HostNotFoundError:
+                logger.warning(
+                    "destroy_host: SSH key for host {} is missing; cannot wipe data on VPS. Proceeding with release.",
+                    host_id,
+                )
+            except MngrError as exc:
+                logger.warning(
+                    "destroy_host: data wipe failed for host {}: {}. Proceeding with release.",
+                    host_id,
+                    exc,
+                )
+
         if host_db_id is not None:
             account = self._require_account()
             token = self._get_access_token(account)

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
@@ -15,6 +15,7 @@ from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr_imbue_cloud.data_types import LeasedHostInfo
 from imbue.mngr_imbue_cloud.instance import ImbueCloudProvider
 from imbue.mngr_imbue_cloud.instance import _map_docker_status_to_host_state
+from imbue.mngr_imbue_cloud.instance import build_pool_host_wipe_script
 from imbue.mngr_imbue_cloud.primitives import LeaseDbId
 
 
@@ -143,3 +144,87 @@ def test_build_offline_details_from_lease_preserves_host_and_failure_reason(tmp_
     assert len(agent_details_list) == 1
     assert agent_details_list[0].id == agent_id
     assert agent_details_list[0].host == host_details
+
+
+# =============================================================================
+# build_pool_host_wipe_script -- the destroy_host data-wipe script generator.
+# Pure function; we assert on the exact command shape that destroy_host's
+# SSH transport will execute on the leased VPS.
+# =============================================================================
+
+
+_WIPE_HOST_ID = HostId("host-2e6c6d70f14c4f3cbb14da81f68a5dc9")
+_WIPE_HOST_HEX = "2e6c6d70f14c4f3cbb14da81f68a5dc9"
+
+
+def test_build_pool_host_wipe_script_starts_with_set_plus_e() -> None:
+    """Every wipe step is best-effort -- the script must NOT abort on first failure."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert script.startswith("set +e\n"), script[:50]
+
+
+def test_build_pool_host_wipe_script_ends_with_exit_zero() -> None:
+    """Caller relies on a clean exit so a single failed wipe doesn't block release."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert script.rstrip().endswith("exit 0"), script[-50:]
+
+
+def test_build_pool_host_wipe_script_filters_container_by_host_id_label() -> None:
+    """Container lookup must filter on the canonical mngr_vps_docker host-id label.
+
+    ``shlex.quote`` is a no-op for the alphanumeric-with-dashes HostId so the
+    rendered filter is unquoted; that's still valid shell because the value
+    contains no spaces or metacharacters.
+    """
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    expected_label = f"label=com.imbue.mngr.host-id={_WIPE_HOST_ID}"
+    assert f"docker ps -a --filter {expected_label}" in script
+
+
+def test_build_pool_host_wipe_script_removes_container_with_volumes() -> None:
+    """``docker rm -f -v`` to drop anonymous volumes attached to the workspace container."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert 'docker rm -f -v "$container_id"' in script
+
+
+def test_build_pool_host_wipe_script_drops_named_host_volume_by_hex() -> None:
+    """The per-host bind-options volume name embeds the host hex; filter by it."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    expected_filter = f"name=mngr-host-vol-{_WIPE_HOST_HEX}"
+    assert f"docker volume ls -q --filter {expected_filter}" in script
+    assert 'docker volume rm -f "$vol"' in script
+
+
+def test_build_pool_host_wipe_script_deletes_btrfs_subvolume_with_rm_rf_fallback() -> None:
+    """btrfs subvolume delete preferred; falls back to rm -rf for non-btrfs hosts."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    subvol_path = f"/mngr-btrfs/{_WIPE_HOST_HEX}"
+    assert f"if [ -d {subvol_path} ]; then" in script
+    assert f"btrfs subvolume delete {subvol_path}" in script
+    assert f"rm -rf {subvol_path}" in script
+
+
+def test_build_pool_host_wipe_script_runs_docker_system_prune() -> None:
+    """Reclaim everything else docker still holds (stopped containers, dangling images, ...)."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert "docker system prune -a -f --volumes" in script
+
+
+def test_build_pool_host_wipe_script_wipes_root_and_tmp_preserving_authorized_keys() -> None:
+    """``/root`` and ``/tmp`` get wiped; ``authorized_keys`` survives so the pool-mgmt key keeps working."""
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert "find /root -mindepth 1 -maxdepth 1 -not -name .ssh -exec rm -rf {} +" in script
+    assert "find /root/.ssh -mindepth 1 -not -name authorized_keys -exec rm -rf {} +" in script
+    assert "find /tmp -mindepth 1 -maxdepth 1 -exec rm -rf {} +" in script
+
+
+def test_build_pool_host_wipe_script_renders_safe_host_id_inline() -> None:
+    """``shlex.quote`` is a no-op on the `[a-z0-9-]` HostId shape, so the
+    rendered template carries the host id inline (still valid shell since
+    the value has no spaces or metacharacters). The point of routing through
+    ``shlex.quote`` is to remain safe if the HostId shape ever broadens; the
+    test here pins today's expected rendering.
+    """
+    script = build_pool_host_wipe_script(_WIPE_HOST_ID)
+    assert f"label=com.imbue.mngr.host-id={_WIPE_HOST_ID}" in script
+    assert f"name=mngr-host-vol-{_WIPE_HOST_HEX}" in script


### PR DESCRIPTION
## Summary
- `mngr destroy <agent>` against an imbue_cloud-leased pool host is now *terminal*: it wipes the user's data on the leased VPS, then releases the lease back to the pool.
- Privacy-first ordering: data is gone before the connector flips the row to `released`, so the eventual VPS-destroy by `cleanup_released_hosts.py` is belt-and-suspenders rather than the only barrier.
- Wipe steps (on the VPS, best-effort, single SSH session): stop+`rm -fv` workspace container → `docker volume rm` the per-host named volume → `btrfs subvolume delete /mngr-btrfs/<host_hex>` → `docker system prune -a -f --volumes` → wipe `/root` (preserving `authorized_keys`) and `/tmp`.
- `mngr stop <agent>` unchanged: still the "I'll resume this workspace later on the same VPS" path that preserves the lease + on-disk volume.
- `mngr delete <agent>` (the GC path after the destroyed-host grace period) now runs the same wipe+release flow; safe to re-run on an already-released lease.
- The wipe script is a pure free function (`build_pool_host_wipe_script`) so the rendered shell is unit-testable without an SSH transport.

## Base
Stacked on `mngr/vps-docker-btrfs` (PR #1770) because the wipe needs to know about the per-host btrfs subvolume layout that PR introduces.

## Test plan
- [x] `just test-quick libs/mngr_imbue_cloud` -- 129 passed
- [x] `test_meta_ratchets` -- 18 passed
- [x] End-to-end: ran the new `destroy_host` against two live OVH pool leases in `dev-josh-1` (one online with the new btrfs storage, one offline from an older bake). Both rows flipped to `status=released` cleanly; the online host's `Wiped pool VPS data for host ...` debug line confirmed the wipe SSH ran end-to-end.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)