### PR TITLE
Add host_backup service: continuous restic backup of /mngr/ (vps-docker outer helper)

### DIFF
--- a/dev/changelog/mngr-mind-backup.md
+++ b/dev/changelog/mngr-mind-backup.md
@@ -1,0 +1,7 @@
+Added spec `specs/host-backup/concise.md` for a new continuous-backup service
+that runs inside every mind workspace. The service uses restic against a
+Cloudflare R2 bucket by default and takes consistent btrfs subvolume snapshots
+on lima / vps-docker (no-op on plain docker). Implementation lives in a new
+`libs/host_backup/` library in forever-claude-template plus an outer
+`snapshot_helper.sh` systemd unit shipped via `libs/mngr_vps_docker` cloud-init
+(this monorepo's changes will follow in a separate PR per project).

--- a/dev/changelog/mngr-mind-backup.md
+++ b/dev/changelog/mngr-mind-backup.md
@@ -1,7 +1,10 @@
-Added spec `specs/host-backup/concise.md` for a new continuous-backup service
-that runs inside every mind workspace. The service uses restic against a
-Cloudflare R2 bucket by default and takes consistent btrfs subvolume snapshots
-on lima / vps-docker (no-op on plain docker). Implementation lives in a new
-`libs/host_backup/` library in forever-claude-template plus an outer
-`snapshot_helper.sh` systemd unit shipped via `libs/mngr_vps_docker` cloud-init
-(this monorepo's changes will follow in a separate PR per project).
+Added spec `specs/host-backup/concise.md` for a new continuous-backup
+service that runs inside every mind workspace. The service uses restic
+against a Cloudflare R2 bucket by default and takes consistent btrfs
+subvolume snapshots on lima / vps-docker (no-op on plain docker). The
+in-container `host_backup` library + bootstrap config wiring lives in
+forever-claude-template (separate PR). This monorepo's changes provision
+the outer-side `snapshot_helper.sh` systemd unit on vps-docker hosts;
+see `libs/mngr_vps_docker/changelog/mngr-mind-backup.md` and
+`libs/mngr_ovh/changelog/mngr-mind-backup.md` for the per-project
+details.

--- a/libs/mngr_ovh/changelog/mngr-mind-backup.md
+++ b/libs/mngr_ovh/changelog/mngr-mind-backup.md
@@ -1,0 +1,4 @@
+Added `inotify-tools` and `jq` to `_REQUIRED_OUTER_PACKAGES` so the new
+`snapshot_helper.service` provisioned by `mngr_vps_docker` has the tools
+it needs on OVH-leased outers (the cloud-init path on Vultr / generic
+VPSes pulls these in via the cloud-init `packages:` list).

--- a/libs/mngr_ovh/imbue/mngr_ovh/bootstrap.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/bootstrap.py
@@ -39,6 +39,14 @@ _ROOT_VERIFY_COMMAND: str = 'test "$(whoami)" = root && echo OK'
 #   (Vultr) get rsync for free because their base images include it;
 #   OVH does not, so the gap has to be closed here.
 #
+# * ``inotify-tools`` and ``jq`` -- both required by the per-host
+#   ``snapshot_helper.service`` that ``mngr_vps_docker`` installs on
+#   every outer (the script blocks on ``inotifywait`` for snapshot
+#   requests from the in-container ``host_backup`` service, and uses
+#   ``jq`` to parse + emit the JSON request/result files). Cloud-init
+#   backends pull these in via the cloud-init ``packages:`` list; OVH
+#   has to install them here for parity.
+#
 # Kept as a tuple so the list is easy to extend if future vps_docker
 # revisions need another tool the image doesn't ship.
 _REQUIRED_OUTER_PACKAGES: tuple[str, ...] = ("rsync", "inotify-tools", "jq")

--- a/libs/mngr_ovh/imbue/mngr_ovh/bootstrap.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/bootstrap.py
@@ -41,7 +41,7 @@ _ROOT_VERIFY_COMMAND: str = 'test "$(whoami)" = root && echo OK'
 #
 # Kept as a tuple so the list is easy to extend if future vps_docker
 # revisions need another tool the image doesn't ship.
-_REQUIRED_OUTER_PACKAGES: tuple[str, ...] = ("rsync",)
+_REQUIRED_OUTER_PACKAGES: tuple[str, ...] = ("rsync", "inotify-tools", "jq")
 # apt-get update + install on a fresh VPS routinely takes 30-90s
 # (Debian mirrors plus package extraction). The default
 # ``exec_command(timeout=60)`` is the per-read I/O timeout, but

--- a/libs/mngr_vps_docker/changelog/mngr-mind-backup.md
+++ b/libs/mngr_vps_docker/changelog/mngr-mind-backup.md
@@ -1,0 +1,20 @@
+Provisioned a per-host outer-side btrfs snapshot helper for the new
+forever-claude-template `host_backup` service. Each vps-docker host now
+gets:
+
+- `/usr/local/sbin/snapshot_helper.sh` + `snapshot_helper.service` (a
+  systemd unit shipped as a bundled resource in
+  `imbue/mngr_vps_docker/resources/`) that watches a per-host docker
+  volume `mngr-snapshot-trigger-<host_id_hex>` for `request.json` files
+  and produces matching `result.json` files describing the outcome of
+  `btrfs subvolume snapshot` / `btrfs subvolume delete` against the
+  per-host subvolume.
+- That docker volume is mounted into the agent container at
+  `/mngr-snapshot/` so the in-container `host_backup` script can do the
+  RPC; the outer's `<btrfs-mount>/snapshots/` directory is bind-mounted
+  read-only into the container at `/mngr-snapshots/` so restic can read
+  the snapshot the helper produced.
+- Cloud-init now installs `inotify-tools` and `jq` so the helper has
+  what it needs at boot.
+- `destroy_host` removes the per-host snapshot-trigger volume alongside
+  the existing host-volume cleanup.

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -30,7 +31,7 @@ def test_load_resource_text_returns_snapshot_helper_service() -> None:
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
-def test_snapshot_helper_script_passes_bash_syntax_check(tmp_path) -> None:
+def test_snapshot_helper_script_passes_bash_syntax_check(tmp_path: Path) -> None:
     """`bash -n` must accept snapshot_helper.sh as valid syntax."""
     script_path = tmp_path / "snapshot_helper.sh"
     script_path.write_text(_load_resource_text("snapshot_helper.sh"))

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
@@ -1,0 +1,51 @@
+"""Unit tests for the snapshot_helper.* resources and their loader."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from imbue.mngr_vps_docker.instance import OUTER_HELPER_SCRIPT_PATH
+from imbue.mngr_vps_docker.instance import OUTER_HELPER_SERVICE_PATH
+from imbue.mngr_vps_docker.instance import _load_resource_text
+
+
+def test_load_resource_text_returns_snapshot_helper_script() -> None:
+    """The bundled snapshot_helper.sh must be loadable via importlib.resources."""
+    content = _load_resource_text("snapshot_helper.sh")
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "snapshot" in content
+    assert "cleanup" in content
+
+
+def test_load_resource_text_returns_snapshot_helper_service() -> None:
+    """The bundled systemd unit must be loadable and contain a [Service] section."""
+    content = _load_resource_text("snapshot_helper.service")
+    assert "[Unit]" in content
+    assert "[Service]" in content
+    assert "ExecStart=/usr/local/sbin/snapshot_helper.sh" in content
+    assert "Restart=always" in content
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
+def test_snapshot_helper_script_passes_bash_syntax_check(tmp_path) -> None:
+    """`bash -n` must accept snapshot_helper.sh as valid syntax."""
+    script_path = tmp_path / "snapshot_helper.sh"
+    script_path.write_text(_load_resource_text("snapshot_helper.sh"))
+    result = subprocess.run(
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_install_paths_are_well_known_absolute_paths() -> None:
+    """The outer install paths must be absolute (we use them in shell commands)."""
+    assert OUTER_HELPER_SCRIPT_PATH.is_absolute()
+    assert OUTER_HELPER_SERVICE_PATH.is_absolute()
+    assert str(OUTER_HELPER_SCRIPT_PATH).startswith("/usr/local/sbin/")
+    assert str(OUTER_HELPER_SERVICE_PATH).startswith("/etc/systemd/system/")

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/_snapshot_helper_test.py
@@ -8,31 +8,17 @@ from pathlib import Path
 
 import pytest
 
-from imbue.mngr_vps_docker.instance import OUTER_HELPER_SCRIPT_PATH
-from imbue.mngr_vps_docker.instance import OUTER_HELPER_SERVICE_PATH
 from imbue.mngr_vps_docker.instance import _load_resource_text
-
-
-def test_load_resource_text_returns_snapshot_helper_script() -> None:
-    """The bundled snapshot_helper.sh must be loadable via importlib.resources."""
-    content = _load_resource_text("snapshot_helper.sh")
-    assert content.startswith("#!/usr/bin/env bash")
-    assert "snapshot" in content
-    assert "cleanup" in content
-
-
-def test_load_resource_text_returns_snapshot_helper_service() -> None:
-    """The bundled systemd unit must be loadable and contain a [Service] section."""
-    content = _load_resource_text("snapshot_helper.service")
-    assert "[Unit]" in content
-    assert "[Service]" in content
-    assert "ExecStart=/usr/local/sbin/snapshot_helper.sh" in content
-    assert "Restart=always" in content
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="bash not on PATH")
 def test_snapshot_helper_script_passes_bash_syntax_check(tmp_path: Path) -> None:
-    """`bash -n` must accept snapshot_helper.sh as valid syntax."""
+    """`bash -n` must accept the bundled snapshot_helper.sh as valid syntax.
+
+    Also exercises the wheel's resource bundling end-to-end: if the
+    pyproject.toml `include` directive ever drops the .sh file, `_load_resource_text`
+    raises before we even get to the bash check.
+    """
     script_path = tmp_path / "snapshot_helper.sh"
     script_path.write_text(_load_resource_text("snapshot_helper.sh"))
     result = subprocess.run(
@@ -44,9 +30,10 @@ def test_snapshot_helper_script_passes_bash_syntax_check(tmp_path: Path) -> None
     assert result.returncode == 0, result.stderr
 
 
-def test_install_paths_are_well_known_absolute_paths() -> None:
-    """The outer install paths must be absolute (we use them in shell commands)."""
-    assert OUTER_HELPER_SCRIPT_PATH.is_absolute()
-    assert OUTER_HELPER_SERVICE_PATH.is_absolute()
-    assert str(OUTER_HELPER_SCRIPT_PATH).startswith("/usr/local/sbin/")
-    assert str(OUTER_HELPER_SERVICE_PATH).startswith("/etc/systemd/system/")
+def test_snapshot_helper_unit_is_loadable() -> None:
+    """The bundled systemd unit is loadable (pyproject `include` smoke test).
+
+    Combined with the bash-syntax test above, this ensures both resource
+    files survive the wheel build.
+    """
+    _load_resource_text("snapshot_helper.service")

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/cloud_init.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/cloud_init.py
@@ -19,6 +19,11 @@ def generate_cloud_init_user_data(
     by default so this is belt-and-suspenders on cloud-init backends;
     non-cloud-init backends (e.g. OVH) install it from their own
     bootstrap path.
+
+    ``inotify-tools`` and ``jq`` are needed by the per-host
+    ``snapshot_helper.sh`` (installed later, after the btrfs mount is
+    ready) -- pre-baked here so the helper install via SSH only needs
+    to drop files in place, no extra package install round-trips.
     """
     return f"""#cloud-config
 ssh_deletekeys: true
@@ -32,6 +37,8 @@ packages:
   - curl
   - ca-certificates
   - rsync
+  - inotify-tools
+  - jq
 runcmd:
   - curl -fsSL https://get.docker.com | sh
   - systemctl enable docker

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timezone
+from importlib import resources as importlib_resources
 from pathlib import Path
 from typing import Any
 from typing import Final
@@ -235,10 +236,37 @@ HOST_DIR_SUBPATH: Final[str] = "host_dir"
 # until SIGTERM arrives so `docker stop` (idle timeout, manual stop) exits cleanly.
 CONTAINER_ENTRYPOINT_CMD: Final[str] = "trap 'exit 0' TERM; tail -f /dev/null & wait"
 
+# In-container path the host_backup service writes / reads snapshot
+# request and result JSON to. Backed by the per-host docker volume
+# ``mngr-snapshot-trigger-<host_id_hex>`` which is also bind-mounted on the
+# outer at ``/var/lib/mngr-snapshot/`` so the outer-side snapshot helper
+# can watch it.
+SNAPSHOT_TRIGGER_MOUNT_PATH: Final[str] = "/mngr-snapshot"
+
+# In-container path that exposes the outer's <btrfs-mount>/snapshots/
+# directory read-only. host_backup reads ``<this>/current`` after the
+# outer helper produces a snapshot there.
+SNAPSHOT_READ_MOUNT_PATH: Final[str] = "/mngr-snapshots"
+
+# Outer-host paths for the snapshot-helper protocol files. Must match
+# what ``resources/snapshot_helper.sh`` watches.
+OUTER_SNAPSHOT_TRIGGER_DIR: Final[Path] = Path("/var/lib/mngr-snapshot")
+
+# Outer-host install paths for the helper script + systemd unit + env file.
+OUTER_HELPER_SCRIPT_PATH: Final[Path] = Path("/usr/local/sbin/snapshot_helper.sh")
+OUTER_HELPER_SERVICE_PATH: Final[Path] = Path("/etc/systemd/system/snapshot_helper.service")
+OUTER_HELPER_ENV_PATH: Final[Path] = Path("/etc/mngr-snapshot-helper.env")
+OUTER_HELPER_SERVICE_NAME: Final[str] = "snapshot_helper.service"
+
 
 def _host_volume_name_for(host_id: HostId) -> str:
     """Return the unified Docker volume name for a host."""
     return f"mngr-host-vol-{host_id.get_uuid().hex}"
+
+
+def _snapshot_trigger_volume_name_for(host_id: HostId) -> str:
+    """Return the per-host snapshot-trigger Docker volume name."""
+    return f"mngr-snapshot-trigger-{host_id.get_uuid().hex}"
 
 
 def _read_host_id_label_from_vps(outer: OuterHostInterface) -> HostId | None:
@@ -500,6 +528,73 @@ def _remove_container(outer: OuterHostInterface, container_name: str, force: boo
 def _remove_volume(outer: OuterHostInterface, volume_name: str) -> None:
     """Remove a Docker named volume (force)."""
     _run_docker(outer, ["volume", "rm", "-f", volume_name])
+
+
+def _load_resource_text(resource_name: str) -> str:
+    """Read a bundled package resource as text (e.g. snapshot_helper.sh)."""
+    return importlib_resources.files("imbue.mngr_vps_docker.resources").joinpath(resource_name).read_text()
+
+
+def _install_snapshot_helper_on_outer(
+    outer: OuterHostInterface,
+    *,
+    host_id: HostId,
+    btrfs_mount_path: Path,
+    subvolume_path: Path,
+) -> None:
+    """Install the snapshot helper systemd unit on the outer and enable+start it.
+
+    Idempotent: rewriting the script / unit / env file is harmless; the
+    ``systemctl enable --now`` re-runs are no-ops when the unit is already
+    enabled and active.
+
+    Assumes ``inotify-tools`` and ``jq`` are already installed (cloud-init
+    installs them; OVH installs them via ``_REQUIRED_OUTER_PACKAGES``).
+    """
+    helper_script = _load_resource_text("snapshot_helper.sh")
+    helper_service = _load_resource_text("snapshot_helper.service")
+    helper_env = (
+        f"MNGR_BTRFS_MOUNT_PATH={btrfs_mount_path}\n"
+        f"MNGR_HOST_SUBVOLUME={subvolume_path}\n"
+        f"MNGR_TRIGGER_DIR={OUTER_SNAPSHOT_TRIGGER_DIR}\n"
+    )
+
+    with log_span("Installing snapshot helper on outer (host_id={})", host_id):
+        _write_outer_file(outer, path=OUTER_HELPER_SCRIPT_PATH, content=helper_script, mode="0755")
+        _write_outer_file(outer, path=OUTER_HELPER_SERVICE_PATH, content=helper_service, mode="0644")
+        _write_outer_file(outer, path=OUTER_HELPER_ENV_PATH, content=helper_env, mode="0644")
+        _ensure_outer_dir(outer, OUTER_SNAPSHOT_TRIGGER_DIR)
+        # `daemon-reload` so systemd picks up edits to snapshot_helper.service
+        # if we ever change the unit definition in a future bake.
+        reload_result = outer.execute_idempotent_command("systemctl daemon-reload", timeout_seconds=10.0)
+        if not reload_result.success:
+            raise VpsProvisioningError(f"systemctl daemon-reload failed: stderr={reload_result.stderr.strip()!r}")
+        enable_result = outer.execute_idempotent_command(
+            f"systemctl enable --now {OUTER_HELPER_SERVICE_NAME}", timeout_seconds=15.0
+        )
+        if not enable_result.success:
+            raise VpsProvisioningError(
+                f"systemctl enable --now {OUTER_HELPER_SERVICE_NAME} failed: stderr={enable_result.stderr.strip()!r}"
+            )
+
+
+def _write_outer_file(
+    outer: OuterHostInterface,
+    *,
+    path: Path,
+    content: str,
+    mode: str,
+) -> None:
+    """Atomically write `content` to `path` on the outer with the given chmod."""
+    _ensure_outer_dir(outer, path.parent)
+    outer.write_file(path, content.encode("utf-8"), mode=mode, is_atomic=True)
+
+
+def _ensure_outer_dir(outer: OuterHostInterface, path: Path) -> None:
+    """`mkdir -p` on the outer; raises VpsProvisioningError on failure."""
+    result = outer.execute_idempotent_command(f"mkdir -p {shlex.quote(str(path))}", timeout_seconds=10.0)
+    if not result.success:
+        raise VpsProvisioningError(f"Failed to create outer dir {path}: stderr={result.stderr.strip()!r}")
 
 
 def _create_bind_volume_on_outer(
@@ -1349,11 +1444,36 @@ class VpsDockerProvider(BaseProviderInstance):
         later step in this method fails.
         """
         volume_name = _host_volume_name_for(host_id)
+        snapshot_trigger_volume_name = _snapshot_trigger_volume_name_for(host_id)
 
         with log_span("Provisioning unified host volume on btrfs subvolume"):
             subvolume_path = self._prepare_btrfs_on_outer(outer, host_id)
             _seed_host_volume_layout_on_outer(outer, subvolume_path)
             _create_bind_volume_on_outer(outer, volume_name=volume_name, device_path=subvolume_path)
+
+        # Snapshot helper: lets the in-container host_backup service request
+        # `btrfs subvolume snapshot` against the per-host subvolume via a
+        # request.json / result.json file protocol in a dedicated docker
+        # volume. Both the systemd unit on the outer and the docker volume
+        # mounted at /mngr-snapshot/ in the container need to exist before
+        # the agent boots.
+        with log_span("Provisioning host_backup snapshot helper + trigger volume"):
+            _ensure_outer_dir(outer, OUTER_SNAPSHOT_TRIGGER_DIR)
+            # The `snapshots/` dir holds `current/` (the live btrfs snapshot
+            # the helper creates). Pre-create it so the read-only bind mount
+            # into the container has something to point at on first boot.
+            _ensure_outer_dir(outer, self.config.btrfs_mount_path / "snapshots")
+            _install_snapshot_helper_on_outer(
+                outer,
+                host_id=host_id,
+                btrfs_mount_path=self.config.btrfs_mount_path,
+                subvolume_path=subvolume_path,
+            )
+            _create_bind_volume_on_outer(
+                outer,
+                volume_name=snapshot_trigger_volume_name,
+                device_path=OUTER_SNAPSHOT_TRIGGER_DIR,
+            )
 
         if docker_build_args:
             base_image = self._build_image_on_vps(outer, host_id, base_image, docker_build_args, git_depth)
@@ -1370,13 +1490,24 @@ class VpsDockerProvider(BaseProviderInstance):
             LABEL_TAGS: json.dumps(dict(tags) if tags else {}),
         }
         logger.log(LogLevel.BUILD.value, "Starting Docker container on VPS...", source="vps")
+        snapshots_dir_on_outer = self.config.btrfs_mount_path / "snapshots"
         with log_span("Starting Docker container"):
             container_id = _run_container(
                 outer,
                 image=base_image,
                 name=container_name,
                 port_mappings={f"0.0.0.0:{self.config.container_ssh_port}": "22"},
-                volumes=[f"{volume_name}:{HOST_VOLUME_MOUNT_PATH}:rw"],
+                volumes=[
+                    f"{volume_name}:{HOST_VOLUME_MOUNT_PATH}:rw",
+                    # Snapshot helper IPC volume (bind-shared with the outer
+                    # at OUTER_SNAPSHOT_TRIGGER_DIR via the named volume created
+                    # above; host_backup writes request.json / reads result.json).
+                    f"{snapshot_trigger_volume_name}:{SNAPSHOT_TRIGGER_MOUNT_PATH}:rw",
+                    # Read-only view of the outer's <btrfs-mount>/snapshots/
+                    # directory so restic-in-container can read the snapshot
+                    # the outer helper produced at <btrfs-mount>/snapshots/current.
+                    f"{snapshots_dir_on_outer}:{SNAPSHOT_READ_MOUNT_PATH}:ro",
+                ],
                 labels=labels,
                 extra_args=list(effective_start_args),
                 entrypoint_cmd=CONTAINER_ENTRYPOINT_CMD,
@@ -1769,6 +1900,14 @@ class VpsDockerProvider(BaseProviderInstance):
                     _remove_volume(outer, vps_config.volume_name)
                 except (HostConnectionError, MngrError) as e:
                     logger.warning("Failed to remove host volume: {}", e)
+
+                # Remove the per-host snapshot-trigger volume (the named entry;
+                # the bind source at OUTER_SNAPSHOT_TRIGGER_DIR is shared across
+                # all containers on this outer and is left alone).
+                try:
+                    _remove_volume(outer, _snapshot_trigger_volume_name_for(host_id))
+                except (HostConnectionError, MngrError) as e:
+                    logger.warning("Failed to remove snapshot trigger volume: {}", e)
 
         # Destroy the VPS instance
         with log_span("Destroying VPS instance"):

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -535,18 +535,33 @@ def _load_resource_text(resource_name: str) -> str:
     return importlib_resources.files("imbue.mngr_vps_docker.resources").joinpath(resource_name).read_text()
 
 
-def _install_snapshot_helper_on_outer(
+def _provision_snapshot_helper_on_outer(
     outer: OuterHostInterface,
+    cg: ConcurrencyGroup,
     *,
     host_id: HostId,
     btrfs_mount_path: Path,
     subvolume_path: Path,
+    trigger_volume_name: str,
 ) -> None:
-    """Install the snapshot helper systemd unit on the outer and enable+start it.
+    """Install the snapshot helper systemd unit + the trigger docker volume on the outer.
+
+    Two-phase pipeline (parallelized within each phase via ``cg`` so
+    independent SSH operations don't serialize, since each one round-trips
+    over the WAN):
+
+    1. Phase A -- 5 parallel ops: write the 3 helper files + ``mkdir -p``
+       the trigger dir + ``mkdir -p`` the snapshots dir.
+    2. Phase B -- 2 parallel ops: ``systemctl daemon-reload && systemctl
+       enable --now snapshot_helper.service`` (chained into one SSH RTT)
+       and ``docker volume create`` for the trigger volume (lazy bind, so
+       safe to run in parallel with the systemctl step now that the trigger
+       dir exists).
 
     Idempotent: rewriting the script / unit / env file is harmless; the
     ``systemctl enable --now`` re-runs are no-ops when the unit is already
-    enabled and active.
+    enabled and active; the ``docker volume create`` is no-op-with-warning
+    when the volume already exists.
 
     Assumes ``inotify-tools`` and ``jq`` are already installed (cloud-init
     installs them; OVH installs them via ``_REQUIRED_OUTER_PACKAGES``).
@@ -558,24 +573,77 @@ def _install_snapshot_helper_on_outer(
         f"MNGR_HOST_SUBVOLUME={subvolume_path}\n"
         f"MNGR_TRIGGER_DIR={OUTER_SNAPSHOT_TRIGGER_DIR}\n"
     )
+    snapshots_dir = btrfs_mount_path / "snapshots"
 
-    with log_span("Installing snapshot helper on outer (host_id={})", host_id):
-        _write_outer_file(outer, path=OUTER_HELPER_SCRIPT_PATH, content=helper_script, mode="0755")
-        _write_outer_file(outer, path=OUTER_HELPER_SERVICE_PATH, content=helper_service, mode="0644")
-        _write_outer_file(outer, path=OUTER_HELPER_ENV_PATH, content=helper_env, mode="0644")
-        _ensure_outer_dir(outer, OUTER_SNAPSHOT_TRIGGER_DIR)
-        # `daemon-reload` so systemd picks up edits to snapshot_helper.service
-        # if we ever change the unit definition in a future bake.
-        reload_result = outer.execute_idempotent_command("systemctl daemon-reload", timeout_seconds=10.0)
-        if not reload_result.success:
-            raise VpsProvisioningError(f"systemctl daemon-reload failed: stderr={reload_result.stderr.strip()!r}")
-        enable_result = outer.execute_idempotent_command(
-            f"systemctl enable --now {OUTER_HELPER_SERVICE_NAME}", timeout_seconds=15.0
+    with log_span("Provisioning snapshot helper on outer (host_id={})", host_id):
+        with ConcurrencyGroupExecutor(
+            parent_cg=cg,
+            name="snapshot_helper_phase_a",
+            max_workers=5,
+        ) as phase_a:
+            phase_a_futures = [
+                phase_a.submit(
+                    _write_outer_file,
+                    outer,
+                    path=OUTER_HELPER_SCRIPT_PATH,
+                    content=helper_script,
+                    mode="0755",
+                ),
+                phase_a.submit(
+                    _write_outer_file,
+                    outer,
+                    path=OUTER_HELPER_SERVICE_PATH,
+                    content=helper_service,
+                    mode="0644",
+                ),
+                phase_a.submit(
+                    _write_outer_file,
+                    outer,
+                    path=OUTER_HELPER_ENV_PATH,
+                    content=helper_env,
+                    mode="0644",
+                ),
+                phase_a.submit(_ensure_outer_dir, outer, OUTER_SNAPSHOT_TRIGGER_DIR),
+                phase_a.submit(_ensure_outer_dir, outer, snapshots_dir),
+            ]
+        for future in phase_a_futures:
+            future.result()
+
+        with ConcurrencyGroupExecutor(
+            parent_cg=cg,
+            name="snapshot_helper_phase_b",
+            max_workers=2,
+        ) as phase_b:
+            phase_b_futures = [
+                phase_b.submit(_enable_snapshot_helper_unit, outer),
+                phase_b.submit(
+                    _create_bind_volume_on_outer,
+                    outer,
+                    volume_name=trigger_volume_name,
+                    device_path=OUTER_SNAPSHOT_TRIGGER_DIR,
+                ),
+            ]
+        for future in phase_b_futures:
+            future.result()
+
+
+def _enable_snapshot_helper_unit(outer: OuterHostInterface) -> None:
+    """`systemctl daemon-reload && systemctl enable --now snapshot_helper.service`.
+
+    Chained into a single SSH round-trip so this step costs one RTT
+    instead of two. The combined command is idempotent: daemon-reload
+    re-reads unit files (no effect if nothing changed) and ``enable --now``
+    is a no-op when the unit is already enabled + active.
+    """
+    result = outer.execute_idempotent_command(
+        f"systemctl daemon-reload && systemctl enable --now {OUTER_HELPER_SERVICE_NAME}",
+        timeout_seconds=20.0,
+    )
+    if not result.success:
+        raise VpsProvisioningError(
+            f"systemctl daemon-reload && systemctl enable --now "
+            f"{OUTER_HELPER_SERVICE_NAME} failed: stderr={result.stderr.strip()!r}"
         )
-        if not enable_result.success:
-            raise VpsProvisioningError(
-                f"systemctl enable --now {OUTER_HELPER_SERVICE_NAME} failed: stderr={enable_result.stderr.strip()!r}"
-            )
 
 
 def _write_outer_file(
@@ -1456,25 +1524,18 @@ class VpsDockerProvider(BaseProviderInstance):
         # request.json / result.json file protocol in a dedicated docker
         # volume. Both the systemd unit on the outer and the docker volume
         # mounted at /mngr-snapshot/ in the container need to exist before
-        # the agent boots.
-        with log_span("Provisioning host_backup snapshot helper + trigger volume"):
-            # The `snapshots/` dir holds `current/` (the live btrfs snapshot
-            # the helper creates). Pre-create it so the read-only bind mount
-            # into the container has something to point at on first boot.
-            _ensure_outer_dir(outer, self.config.btrfs_mount_path / "snapshots")
-            # `_install_snapshot_helper_on_outer` ensures OUTER_SNAPSHOT_TRIGGER_DIR
-            # exists internally before starting the helper that watches it.
-            _install_snapshot_helper_on_outer(
-                outer,
-                host_id=host_id,
-                btrfs_mount_path=self.config.btrfs_mount_path,
-                subvolume_path=subvolume_path,
-            )
-            _create_bind_volume_on_outer(
-                outer,
-                volume_name=snapshot_trigger_volume_name,
-                device_path=OUTER_SNAPSHOT_TRIGGER_DIR,
-            )
+        # the agent boots. The helper provisioning is internally a 2-phase
+        # parallel pipeline (see _provision_snapshot_helper_on_outer) so
+        # the ~7 SSH round-trips it would otherwise serialize collapse to
+        # the latency of 2.
+        _provision_snapshot_helper_on_outer(
+            outer,
+            self.mngr_ctx.concurrency_group,
+            host_id=host_id,
+            btrfs_mount_path=self.config.btrfs_mount_path,
+            subvolume_path=subvolume_path,
+            trigger_volume_name=snapshot_trigger_volume_name,
+        )
 
         if docker_build_args:
             base_image = self._build_image_on_vps(outer, host_id, base_image, docker_build_args, git_depth)

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py
@@ -1458,11 +1458,12 @@ class VpsDockerProvider(BaseProviderInstance):
         # mounted at /mngr-snapshot/ in the container need to exist before
         # the agent boots.
         with log_span("Provisioning host_backup snapshot helper + trigger volume"):
-            _ensure_outer_dir(outer, OUTER_SNAPSHOT_TRIGGER_DIR)
             # The `snapshots/` dir holds `current/` (the live btrfs snapshot
             # the helper creates). Pre-create it so the read-only bind mount
             # into the container has something to point at on first boot.
             _ensure_outer_dir(outer, self.config.btrfs_mount_path / "snapshots")
+            # `_install_snapshot_helper_on_outer` ensures OUTER_SNAPSHOT_TRIGGER_DIR
+            # exists internally before starting the helper that watches it.
             _install_snapshot_helper_on_outer(
                 outer,
                 host_id=host_id,

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/snapshot_helper.service
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/snapshot_helper.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=mngr btrfs snapshot helper for the host_backup service
+After=local-fs.target
+Wants=local-fs.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/mngr-snapshot-helper.env
+ExecStart=/usr/local/sbin/snapshot_helper.sh
+Restart=always
+RestartSec=5
+# Helper must run as root to invoke `btrfs subvolume snapshot/delete`.
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/snapshot_helper.sh
+++ b/libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/snapshot_helper.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Outer-side btrfs snapshot helper for vps-docker hosts.
+#
+# Watches /var/lib/mngr-snapshot/request.json (the outer-host view of the
+# docker volume bind-mounted into the container at /mngr-snapshot/) and,
+# whenever a new request appears, runs the requested btrfs operation
+# against the per-host subvolume, then writes a result.json the inner
+# host_backup script can read.
+#
+# Request file format:
+#     {"request_id": "<uuid>", "operation": "snapshot" | "cleanup",
+#      "timestamp_iso": "..."}
+#
+# Result file format (atomically renamed from result.json.tmp):
+#     {"request_id": "<same uuid>", "operation": "...", "exit_code": int,
+#      "stdout": "...", "stderr": "...", "snapshot_path": "..."}
+#
+# Environment (set by the systemd unit, parameterized at host-create time
+# by the install template the mngr_vps_docker provider materializes):
+#     MNGR_BTRFS_MOUNT_PATH -- e.g. /mngr-btrfs
+#     MNGR_HOST_SUBVOLUME   -- e.g. /mngr-btrfs/<host_id_hex>
+#     MNGR_TRIGGER_DIR      -- e.g. /var/lib/mngr-snapshot
+set -euo pipefail
+
+# --- config defaults (overridable via env) ----------------------------------
+: "${MNGR_BTRFS_MOUNT_PATH:=/mngr-btrfs}"
+: "${MNGR_HOST_SUBVOLUME:?MNGR_HOST_SUBVOLUME must be set}"
+: "${MNGR_TRIGGER_DIR:=/var/lib/mngr-snapshot}"
+
+SNAPSHOT_PATH="${MNGR_BTRFS_MOUNT_PATH}/snapshots/current"
+REQUEST_PATH="${MNGR_TRIGGER_DIR}/request.json"
+RESULT_PATH="${MNGR_TRIGGER_DIR}/result.json"
+RESULT_TMP="${MNGR_TRIGGER_DIR}/result.json.tmp"
+
+# --- helpers ----------------------------------------------------------------
+
+# Emit a result.json. Args: request_id operation exit_code stdout stderr snapshot_path
+emit_result() {
+    local request_id="$1" operation="$2" exit_code="$3" stdout="$4" stderr="$5" snapshot_path="$6"
+    # Use jq for safe JSON encoding (handles quoting/escaping of stdout/stderr).
+    jq -n \
+        --arg request_id "$request_id" \
+        --arg operation "$operation" \
+        --argjson exit_code "$exit_code" \
+        --arg stdout "$stdout" \
+        --arg stderr "$stderr" \
+        --arg snapshot_path "$snapshot_path" \
+        '{request_id: $request_id, operation: $operation, exit_code: $exit_code, stdout: $stdout, stderr: $stderr, snapshot_path: $snapshot_path}' \
+        > "$RESULT_TMP"
+    mv "$RESULT_TMP" "$RESULT_PATH"
+}
+
+do_snapshot() {
+    local request_id="$1"
+    local stdout stderr exit_code
+
+    # Defensive cleanup: if a stale `current/` snapshot is present, delete
+    # it first so `btrfs subvolume snapshot` doesn't fail with "exists".
+    if [ -d "$SNAPSHOT_PATH" ]; then
+        btrfs subvolume delete "$SNAPSHOT_PATH" >/dev/null 2>&1 || true
+    fi
+    mkdir -p "$(dirname "$SNAPSHOT_PATH")"
+
+    local out_file err_file
+    out_file=$(mktemp)
+    err_file=$(mktemp)
+    set +e
+    btrfs subvolume snapshot -r "$MNGR_HOST_SUBVOLUME" "$SNAPSHOT_PATH" >"$out_file" 2>"$err_file"
+    exit_code=$?
+    set -e
+    stdout=$(cat "$out_file"); rm -f "$out_file"
+    stderr=$(cat "$err_file"); rm -f "$err_file"
+
+    local effective_snapshot_path=""
+    if [ "$exit_code" -eq 0 ]; then
+        effective_snapshot_path="$SNAPSHOT_PATH"
+    fi
+    emit_result "$request_id" "snapshot" "$exit_code" "$stdout" "$stderr" "$effective_snapshot_path"
+}
+
+do_cleanup() {
+    local request_id="$1"
+    local stdout="" stderr="" exit_code=0
+
+    if [ -d "$SNAPSHOT_PATH" ]; then
+        local out_file err_file
+        out_file=$(mktemp)
+        err_file=$(mktemp)
+        set +e
+        btrfs subvolume delete "$SNAPSHOT_PATH" >"$out_file" 2>"$err_file"
+        exit_code=$?
+        set -e
+        stdout=$(cat "$out_file"); rm -f "$out_file"
+        stderr=$(cat "$err_file"); rm -f "$err_file"
+    fi
+    emit_result "$request_id" "cleanup" "$exit_code" "$stdout" "$stderr" ""
+}
+
+handle_request() {
+    local payload request_id operation
+    payload=$(cat "$REQUEST_PATH" 2>/dev/null || echo "{}")
+    request_id=$(echo "$payload" | jq -r '.request_id // ""')
+    operation=$(echo "$payload" | jq -r '.operation // ""')
+    if [ -z "$request_id" ]; then
+        echo "snapshot_helper: request missing request_id; skipping" >&2
+        return
+    fi
+    case "$operation" in
+        snapshot) do_snapshot "$request_id" ;;
+        cleanup)  do_cleanup  "$request_id" ;;
+        *)
+            emit_result "$request_id" "$operation" 2 "" "unknown operation: $operation" ""
+            ;;
+    esac
+}
+
+# --- main loop --------------------------------------------------------------
+
+mkdir -p "$MNGR_TRIGGER_DIR"
+
+# Process any request that's already on disk at startup (covers the case
+# where the helper restarted while the inner script was waiting for a result).
+if [ -f "$REQUEST_PATH" ]; then
+    handle_request
+fi
+
+# inotifywait blocks until the file is modified or renamed-into-place. We
+# care about both because the inner script writes request.json.tmp then
+# renames; the rename surfaces as MOVED_TO.
+exec inotifywait -m -e close_write,moved_to --format '%f' "$MNGR_TRIGGER_DIR" |
+    while read -r filename; do
+        if [ "$filename" = "request.json" ]; then
+            handle_request
+        fi
+    done

--- a/libs/mngr_vps_docker/pyproject.toml
+++ b/libs/mngr_vps_docker/pyproject.toml
@@ -15,6 +15,13 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["imbue"]
 exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
+# Force-include the snapshot helper resources so they're bundled in the wheel
+# (hatchling would pick them up implicitly, but being explicit avoids any
+# surprise when a future build-config refactor narrows the include set).
+include = [
+    "imbue/mngr_vps_docker/resources/snapshot_helper.sh",
+    "imbue/mngr_vps_docker/resources/snapshot_helper.service",
+]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }

--- a/specs/host-backup/concise.md
+++ b/specs/host-backup/concise.md
@@ -1,0 +1,123 @@
+# Host-dir backup service (restic + R2)
+
+## Overview
+
+- A new long-running service inside every mind workspace continuously backs up the full `host_dir` (`/mngr/`) to a remote restic repository (Cloudflare R2 by default), using a per-tick btrfs subvolume snapshot on lima/vps-docker providers and a direct read on plain docker.
+- The service lives in a new `libs/host_backup/` library in the forever-claude-template repo, registered as `[services.host-backup]` in `services.toml` with `restart = "on-failure"`; the existing bootstrap service manager spawns the `svc-host-backup` tmux window via its normal reconcile loop — no new tmux mechanism, no changes to how services are launched.
+- All script-side config (frequency, retention, exclude patterns, snapshot method) lives in `runtime/backup.toml`; all restic secrets (R2 access keys, encryption password) live in `runtime/secrets/restic.env`. The bootstrap manager writes both files at first boot — the env file is an empty template the user must populate before backups actually run.
+- The script tolerates every error (loop never exits, all exceptions logged to loguru + jsonl with full traceback, hard 1-minute minimum gap between attempts), self-heals on missing secrets / missing repo (runs `restic init` on demand), and reacts immediately to config edits via a 15-second mtime poll on both config files.
+- The btrfs subvolume snapshot lives at `<btrfs-mount>/snapshots/current/` (single slot, no datetime suffix) so restic gets stable inode/path caching across runs; on vps-docker the inner script asks a small outer systemd helper (shipped via `mngr_vps_docker` cloud-init) to do the actual btrfs op via a single-slot `request.json` / `result.json` file protocol; on lima the script runs `sudo btrfs subvolume snapshot` directly. The existing `runtime-backup` (git push of `runtime/` to GitHub) is orthogonal and unchanged.
+
+## Expected Behavior
+
+### Service lifecycle
+
+- On container boot, `bootstrap/manager.py` runs a new pre-services init step that:
+  - Detects the snapshot method by probing the filesystem: `/mngr-snapshot/` volume present → `outer_trigger`; `findmnt -n -o FSTYPE /mngr` returns `btrfs` → `btrfs_local`; otherwise → `direct`.
+  - On every boot, rewrites `runtime/backup.toml`'s `snapshot.method` and its associated paths to match the detected environment (preserves user-customized fields like retention, excludes, repo URL via toml-merge so a migrated workspace recovers automatically; only the environment-derived `snapshot` section is overwritten).
+  - Writes `runtime/secrets/restic.env` only if it does not already exist — empty/comment-only template with placeholders for the three required keys.
+  - Completes before the services reconcile loop starts the `svc-host-backup` window.
+- `bootstrap/manager.py` already runs `_init_runtime_worktree` first, so `runtime/` is a worktree of `mindsbackup/$MNGR_AGENT_ID` by the time the new init step writes `backup.toml` into it; `backup.toml` therefore rides the runtime-backup git push to GitHub, while `runtime/secrets/restic.env` is excluded by the existing `secrets/` entry in `runtime/.gitignore`.
+- The `host-backup` service starts in tmux window `svc-host-backup`; if it ever exits unexpectedly, `restart = "on-failure"` brings it back.
+- The script writes structured events to `$MNGR_AGENT_STATE_DIR/events/backup/events.jsonl` with these types: `backup_started`, `snapshot_created`, `restic_backup_succeeded`, `restic_backup_failed`, `forget_completed`, `prune_completed`, `prune_skipped`, `config_reloaded`, `repo_init_attempted`, `repo_init_succeeded`, `tick_skipped_due_to_missing_secrets`, `tick_error`. Full stdout/stderr of every restic command is captured into the same stream for forensic debugging.
+- The script never writes a separate `backup-status.json` file — current state is derivable from the jsonl event log (or queried directly from restic on demand).
+
+### Tick loop
+
+- Each tick runs the following sequence, holding `backup_in_progress = True` for the duration:
+  1. Reload `backup.toml` (emit `config_reloaded`); confirm `restic.env` has non-empty values for `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (emit `tick_skipped_due_to_missing_secrets` and abort the tick otherwise).
+  2. Probe the remote repo with `restic snapshots --json`; on the specific "repository does not exist" / "unable to open config" error class, run `restic init` (emit `repo_init_attempted` then `repo_init_succeeded` on success); on any other error, log + abort tick.
+  3. Take a snapshot per the `snapshot.method` setting — always delete-then-create the `current/` slot (no startup special case; deletion-of-nonexistent is tolerated as a no-op):
+     - `btrfs_local`: `sudo btrfs subvolume delete <btrfs-mount>/snapshots/current` (best-effort), then `sudo btrfs subvolume snapshot -r <btrfs-mount>/<host-subvol> <btrfs-mount>/snapshots/current`.
+     - `outer_trigger`: write `/mngr-snapshot/request.json` with `operation = "cleanup"` and a fresh `request_id`; wait for matching `result.json`; then write a second `request.json` with `operation = "snapshot"` and another fresh `request_id`; wait for matching `result.json`. Inner polls `result.json`'s mtime every 1s up to a configurable hard timeout (default 120s) and verifies `request_id` matches before consuming.
+     - `direct`: no-op — restic reads `/mngr/` directly.
+     - Emit `snapshot_created` with `method`, `snapshot_path`, and outer-helper exit_code/stdout/stderr if applicable.
+  4. Run `restic backup <source-path> --tag <iso-timestamp> --exclude=<each pattern>`, with `<source-path>` being `/mngr-snapshots/current` (btrfs providers) or `/mngr` (direct). Capture stdout/stderr into a `restic_backup_succeeded` (with `snapshot_id`, `bytes_added`, `files_new` parsed from `--json` output) or `restic_backup_failed` (with `exit_code` + tail of stderr) event.
+  5. Delete the `current/` snapshot (same mechanism as step 3's delete — `sudo btrfs subvolume delete` for `btrfs_local`, second `cleanup` `request.json` for `outer_trigger`, no-op for `direct`).
+  6. Run `restic forget --keep-hourly N --keep-daily M --keep-weekly W --keep-monthly Mo` (values from `backup.toml`); emit `forget_completed`.
+  7. If `now - mtime(runtime/last-restic-prune) >= prune_interval_hours`, run `restic prune` and update the timestamp file; emit `prune_completed` or `prune_skipped` accordingly. The timestamp file is intentionally outside `runtime/secrets/` so it rides the runtime-backup git push and survives container loss.
+- Between ticks: the script polls both config files' mtimes every `config_poll_interval_seconds` (default 15). If either file changed since the last reload (or the wall-clock interval `backup_interval_seconds` has elapsed since the last tick start), kick off the next tick — but never start a tick within `minimum_backup_gap_seconds` (default 60) of the previous tick's end.
+- The outer service loop never exits. Every exception (expected or unexpected) is caught at the loop boundary, logged via `logger.error` with full traceback, recorded as a `tick_error` jsonl event, and the loop continues to the next sleep.
+
+### Manual trigger CLI
+
+- `uv run host-backup-now` is a thin CLI that:
+  1. Checks the service's `backup_in_progress` state (by reading the most-recent event of type `backup_started` / `restic_backup_succeeded`-or-`failed` in the jsonl — if the latest is `backup_started` without a corresponding completion, a backup is in progress).
+  2. If a backup is in progress, blocks until the next `restic_backup_succeeded` / `restic_backup_failed` event is observed.
+  3. Bumps `backup.toml`'s mtime (via `path.touch()`).
+  4. Tails events.jsonl from EOF, waits for the next `restic_backup_succeeded` / `restic_backup_failed` event, prints its JSON to stdout, and exits 0 (success) or 1 (failure).
+- A `--timeout` flag (default 30 min) caps how long the CLI waits.
+
+### Snapshot path / mount layout
+
+- On btrfs providers, the snapshot dir is at `<btrfs-mount>/snapshots/current/` and is bind-mounted into the agent container as `/mngr-snapshots/` (read-only):
+  - vps-docker: a new `--volume <btrfs-mount-path>/snapshots:/mngr-snapshots:ro` is appended to the container's `docker run` args by `mngr_vps_docker._setup_container_on_vps`.
+  - lima: the snapshot path lives inside the VM filesystem already; no extra mount needed (the script reads it at its absolute path).
+- On plain docker (no btrfs), the script passes `/mngr` to restic directly; no snapshot dir exists.
+
+### Outer-helper (vps-docker)
+
+- The outer helper is a small bash script + systemd unit shipped as resource files in `libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/` (`snapshot_helper.sh` + `snapshot_helper.service`); cloud-init's `write_files` block writes them to `/usr/local/sbin/snapshot_helper.sh` and `/etc/systemd/system/snapshot_helper.service` and `systemctl enable --now`s the unit at host-create time.
+- A new docker volume `mngr-snapshot-trigger-<host_id_hex>` is created at host-create time and mounted into the container at `/mngr-snapshot/`. The same volume is also bind-mounted on the VPS outer at `/var/lib/mngr-snapshot/` so the helper can watch it.
+- Helper protocol (single-slot files):
+  - Inner writes `/mngr-snapshot/request.json.tmp` then renames to `request.json`: `{"request_id": "<uuid>", "operation": "snapshot" | "cleanup", "timestamp_iso": "..."}`.
+  - Outer watches `request.json` via `inotifywait`; reads the file, dispatches to `btrfs subvolume snapshot -r <btrfs-mount>/<host_id_hex> <btrfs-mount>/snapshots/current` (for `snapshot`) or `btrfs subvolume delete <btrfs-mount>/snapshots/current` (for `cleanup`).
+  - Outer writes `/var/lib/mngr-snapshot/result.json.tmp` then renames to `result.json`: `{"request_id": "<same uuid>", "operation": "...", "exit_code": int, "stdout": "...", "stderr": "...", "snapshot_path": "..."}`.
+  - Inner polls `result.json`'s mtime every 1s; once mtime changes, reads the file and verifies `request_id` matches the request_id it wrote (skips stale results).
+
+### Provider matrix
+
+- `lima` (snapshot method = `btrfs_local`): script runs `sudo btrfs ...` directly inside the VM (agent user already has passwordless sudo, no new sudoers entry needed); reads from `<btrfs-mount>/snapshots/current/` at its absolute path.
+- `mngr_vps_docker` (vultr, ovh — snapshot method = `outer_trigger`): script writes to `/mngr-snapshot/request.json`, reads from `/mngr-snapshot/result.json`; restic reads from `/mngr-snapshots/current/` (the bind mount of the outer's snapshot dir).
+- `mngr_docker` (plain docker — snapshot method = `direct`): no snapshot; restic reads `/mngr/` directly. Suitable only for testing/dev because the on-disk state can shift mid-backup.
+- All other providers are out of scope for v1 (backup.toml's detection falls through to `direct`, which is correct only when /mngr is locally writable; treat any non-detected provider as user-responsibility).
+
+## Changes
+
+### New: `libs/host_backup/` in forever-claude-template
+
+- New library under `libs/host_backup/` with package `host_backup`, exposing two CLI entry points:
+  - `host-backup` — the long-running tick loop (called from `services.toml`).
+  - `host-backup-now` — the manual-trigger CLI.
+- `host_backup/data_types.py`: pydantic `FrozenModel` classes for `BackupConfig` (toml-loaded), `SnapshotMethod` enum (`BTRFS_LOCAL`, `OUTER_TRIGGER`, `DIRECT`), `BackupTickResult`, `SnapshotResult`, `OuterHelperRequest`, `OuterHelperResult`, etc.
+- `host_backup/interfaces.py`: `SnapshotTakerInterface` (abstract `take_snapshot()` / `delete_snapshot()`) with three concrete implementations under `host_backup/snapshot/` (one per method).
+- `host_backup/runner.py`: top-level tick loop (no class — just functions); reads config, detects in-flight state, drives the per-tick sequence.
+- `host_backup/events.py`: structured event types (subclass the existing `EventEnvelope` already used by `app_watcher`).
+- `host_backup/cli.py`: click entry points for both binaries.
+- Tests:
+  - Unit tests for pure logic (config parse, mtime poll, snapshot-method composition, exclude pattern composition, retention argument building, event envelope construction).
+  - Integration tests against a local `restic init -r /tmp/repo` covering the full backup → forget → prune cycle and the snapshot-method dispatch (mock SnapshotTaker implementations for non-direct methods).
+  - Real-R2 acceptance testing intentionally deferred to v2.
+
+### Modified: `libs/bootstrap/` in forever-claude-template
+
+- `bootstrap/manager.py` gains a new pre-services init step `_init_backup_config()` that runs after `_init_runtime_worktree()` and before the services reconcile loop:
+  - Detects `snapshot.method` from the filesystem.
+  - Loads any existing `runtime/backup.toml` and merges its user-customized fields (retention, excludes, intervals, repo URL template, R2 account/bucket) with a freshly-computed `[snapshot]` section (always overwritten).
+  - Writes `runtime/secrets/restic.env` only if absent — empty/comment-only template.
+- New constants near `INITIAL_CHAT_SIGNAL`: `BACKUP_CONFIG_FILE = Path("runtime/backup.toml")`, `RESTIC_ENV_FILE = Path("runtime/secrets/restic.env")`.
+
+### Modified: forever-claude-template root
+
+- `services.toml`: add `[services.host-backup]` with `command = "uv run host-backup"` and `restart = "on-failure"`.
+- `Dockerfile`: add `restic` to the `apt-get install` block alongside the existing tools.
+- `.mngr/settings.toml`: add `restic` to the lima `extra_provision_command__extend` `apt-get install` line.
+
+### Modified: `libs/mngr_vps_docker/` in this monorepo
+
+- New resource files under `libs/mngr_vps_docker/imbue/mngr_vps_docker/resources/`:
+  - `snapshot_helper.sh` — the outer bash script that watches `/var/lib/mngr-snapshot/request.json` via `inotifywait`, runs the requested btrfs op, writes `result.json` atomically.
+  - `snapshot_helper.service` — the systemd unit that runs `snapshot_helper.sh` under `Restart=always`.
+- `cloud_init.py`: add a `write_files` block that materializes those two files at `/usr/local/sbin/snapshot_helper.sh` and `/etc/systemd/system/snapshot_helper.service`, plus a `runcmd` line that `systemctl enable --now snapshot_helper.service`. The systemd unit depends on the btrfs mount existing, which `_prepare_btrfs_on_outer` already ensures.
+- `instance.py` (`_setup_container_on_vps`): create a docker volume `mngr-snapshot-trigger-<host_id_hex>` and pass it via `--volume mngr-snapshot-trigger-<host_id_hex>:/mngr-snapshot/` on the container `docker run`; bind-mount the same volume's data path at `/var/lib/mngr-snapshot/` on the outer (via `--driver=local --opt type=none --opt device=/var/lib/mngr-snapshot --opt o=bind`). Also append `--volume <btrfs-mount>/snapshots:/mngr-snapshots:ro` so the in-container restic can read the snapshot.
+- `destroy_host`: best-effort `docker volume rm mngr-snapshot-trigger-<host_id_hex>` alongside the existing volume cleanup.
+- `mngr_vps_docker/changelog/mngr-mind-backup.md` — new per-PR changelog entry describing the outer helper.
+
+### Out of scope for this PR
+
+- The FCT-side changes (new `libs/host_backup/`, `bootstrap/manager.py` edits, `services.toml`, `Dockerfile`, `.mngr/settings.toml`) live in a *separate repository* (forever-claude-template) and land as a separate PR there with its own changelog entry. This monorepo PR contains only the `mngr_vps_docker` changes plus `specs/host-backup/concise.md` (which gets a `dev/changelog/mngr-mind-backup.md` entry).
+- Acceptance testing against a real R2 bucket — deferred to v2.
+- Restore tooling (`host-backup-restore` CLI, UI for browsing past snapshots) — deferred; users can use `restic restore` manually with the env file they already maintain.
+- Per-workspace `backup.toml` customization UI in the minds desktop client — deferred.
+- The lima provider does not get any Python-side changes; if a future lima refactor requires inner-VM snapshot via a helper (rather than direct `sudo btrfs`), that's a separate spec.
+- Any change to the existing `runtime-backup` (git push to GitHub) service.


### PR DESCRIPTION
## Summary

- Adds a new continuous backup service for every mind workspace: an in-container `host_backup` (in [forever-claude-template PR #115](https://github.com/imbue-ai/forever-claude-template/pull/115)) sends `request.json` files to a per-host docker volume; this PR provisions the **outer-side** systemd helper on vps-docker hosts that watches that volume, runs `btrfs subvolume snapshot/delete`, and writes `result.json` back.
- See `specs/host-backup/concise.md` for the full design (committed in this branch's first commit, `53647031e`).

## Changes in this PR (monorepo side)

- **`libs/mngr_vps_docker/`**
  - New bundled resources `resources/snapshot_helper.sh` + `snapshot_helper.service`.
  - `_provision_snapshot_helper_on_outer()` writes the script + unit + per-host env file (`MNGR_HOST_SUBVOLUME`, ...) and `systemctl enable --now`s the unit after `_prepare_btrfs_on_outer`.
  - Two-phase parallel pipeline driven by `self.mngr_ctx.concurrency_group` (5 ops in phase A, 2 ops in phase B) so the ~9 SSH RTTs the provisioning would otherwise serialize collapse to ~2.
  - New per-host `mngr-snapshot-trigger-<host_id_hex>` docker volume.
  - Agent container gets two extra mounts: `/mngr-snapshot/` (RW, helper IPC) and `/mngr-snapshots/` (read-only view of `<btrfs-mount>/snapshots/`).
  - `destroy_host` cleans up the new volume.
  - Cloud-init pre-installs `inotify-tools` + `jq`.
- **`libs/mngr_ovh/`**: adds `inotify-tools` + `jq` to `_REQUIRED_OUTER_PACKAGES` so OVH outers (which install packages via the OVH bootstrap path, not cloud-init) match Vultr.
- Per-project changelog entries + an updated root `dev/changelog/mngr-mind-backup.md`.

## Test plan

- [x] `just test-quick` across `libs/mngr_vps_docker`, `libs/mngr_ovh`, `libs/mngr_vultr`, `libs/mngr_lima` (618 passed)
- [x] `test_meta_ratchets.py` (18 passed, with `GITHUB_BASE_REF=josh/pre_backups`)
- [x] `bash -n` syntax check on `snapshot_helper.sh`
- [ ] Live `mngr create @<workspace>.vultr` then exercise the helper end-to-end (manual; not yet performed)
- [ ] FCT-side PR #115 landed and an actual `host_backup` tick succeeds against R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)