### PR TITLE
fix bad merge

### DIFF
--- a/libs/mngr_mapreduce/changelog/mngr-fix-ty.md
+++ b/libs/mngr_mapreduce/changelog/mngr-fix-ty.md
@@ -1,0 +1,1 @@
+Removed the per-project `test_no_type_errors` and `test_no_ruff_errors` ratchet tests from `mngr_mapreduce`. These checks now run repo-wide from the root `test_meta_ratchets.py`, and the per-project copy imported `check_no_ruff_errors` (which was never centralized into `ratchet_testing.ratchets`), producing a ty `unresolved-import` error.

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/test_ratchets.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/test_ratchets.py
@@ -4,8 +4,6 @@ import pytest
 from inline_snapshot import snapshot
 
 from imbue.imbue_common.ratchet_testing import standard_ratchet_checks as rc
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_ruff_errors
-from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 
 _DIR = Path(__file__).parent.parent.parent
 
@@ -276,13 +274,3 @@ def test_prevent_assert_isinstance() -> None:
 
 def test_prevent_code_in_init_files() -> None:
     rc.check_code_in_init_files(_DIR, snapshot(0))
-
-
-def test_no_type_errors() -> None:
-    """Ensure the codebase has zero type errors."""
-    check_no_type_errors(_DIR)
-
-
-def test_no_ruff_errors() -> None:
-    """Ensure the codebase has zero ruff linting errors."""
-    check_no_ruff_errors(_DIR)


### PR DESCRIPTION
## Summary

`uv run ty check` reported an `unresolved-import` error in `libs/mngr_mapreduce/imbue/mngr_mapreduce/test_ratchets.py`:

```
error[unresolved-import]: Module `imbue.imbue_common.ratchet_testing.ratchets` has no member `check_no_ruff_errors`
```

`mngr_mapreduce` was the only project still carrying its own `test_no_type_errors` / `test_no_ruff_errors` ratchet tests (leftover from the `mngr_tmr` split). Both checks now run repo-wide from the root `test_meta_ratchets.py`, so the per-project copies are redundant. The ruff check in particular imported `check_no_ruff_errors`, which was never centralized into `ratchet_testing.ratchets` (only `check_no_type_errors` lives there), hence the ty failure.

## Change

- Delete `test_no_type_errors` and `test_no_ruff_errors` plus their imports from the per-project file. Repo-wide coverage is unchanged (still enforced by `test_meta_ratchets.py`).

## Verification

- `uv run ty check libs/mngr_mapreduce/imbue/mngr_mapreduce/test_ratchets.py` -> All checks passed.
- `uv run ty check` (repo-wide) -> only a pre-existing, unrelated `possibly-missing-submodule` warning in `mngr/utils/cel_utils.py` remains (a warning, not an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)