### PR TITLE
Exclude Latchkey from the minimum age check.

### DIFF
--- a/apps/minds/changelog/hynek-exclude-latchkey-from-minimum-age.md
+++ b/apps/minds/changelog/hynek-exclude-latchkey-from-minimum-age.md
@@ -1,0 +1,1 @@
+Exclude the Latchkey dependency from the minimum age check (we are co-developing Latchkey together with Minds).

--- a/apps/minds/pnpm-workspace.yaml
+++ b/apps/minds/pnpm-workspace.yaml
@@ -11,4 +11,4 @@ onlyBuiltDependencies:
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
   - latchkey
-  - @imbue-ai/detent
+  - "@imbue-ai/detent"

--- a/apps/minds/pnpm-workspace.yaml
+++ b/apps/minds/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ onlyBuiltDependencies:
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
   - latchkey
+  - @imbue-ai/detent

--- a/apps/minds/pnpm-workspace.yaml
+++ b/apps/minds/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ onlyBuiltDependencies:
 # installs replay the existing lockfile unaffected. Available since pnpm
 # 10.16.0 (this app pins 10.33.4).
 minimumReleaseAge: 20160
+minimumReleaseAgeExclude:
+  - latchkey


### PR DESCRIPTION
Exclude the Latchkey from the minimum age check so that we can quickly bump Latchkey versions while developing.