### PR TITLE
Drop removed --use-snapshot flag from TMR GHA workflow

### DIFF
--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -46,9 +46,9 @@ jobs:
           mkdir -p tmr-report
           # The yolo agent type is synthesized inline (same as in tmr.yml).
           # The reintegrate path doesn't launch testing agents (it discovers
-          # already-launched ones by the tmr_run_name label), so --provider /
-          # --use-snapshot are unused. The integrator runs locally on the
-          # runner and uses ANTHROPIC_API_KEY directly.
+          # already-launched ones by the tmr_run_name label), so --provider
+          # is unused. The integrator runs locally on the runner and uses
+          # ANTHROPIC_API_KEY directly.
           uv run --project libs/mngr_tmr mngr tmr -vv \
             -S 'agent_types.yolo.parent_type="claude"' \
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -127,7 +127,6 @@ jobs:
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
             --agent-type yolo \
             --provider modal \
-            --use-snapshot \
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \

--- a/dev/changelog/mngr-fix-ci-invocation.md
+++ b/dev/changelog/mngr-fix-ci-invocation.md
@@ -1,0 +1,1 @@
+- Drop the now-removed `--use-snapshot` flag from the TMR GHA workflow (`.github/workflows/tmr.yml`) so the scheduled/manual TMR runs don't fail at invocation. Snapshot building on `--provider modal` is automatic now, so behavior is unchanged. Also refresh a stale comment in `.github/workflows/tmr-reintegrate.yml` that mentioned the same removed flag.


### PR DESCRIPTION
## Summary
- `mngr tmr` removed `--use-snapshot` (snapshot building is now automatic on providers that support it), but `.github/workflows/tmr.yml` was still passing the flag — every scheduled/manual TMR run now fails at invocation. Drop the flag.
- Refresh a stale comment in `.github/workflows/tmr-reintegrate.yml` that mentioned the same removed flag.

## Test plan
- [ ] Trigger a manual `tmr` workflow run and confirm it gets past the `mngr tmr` invocation step (previously failed with unknown-flag).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)