### PR TITLE
Stop nested claude -p from being adopted into the parent agent's transcript

### DIFF
--- a/libs/mngr_claude/changelog/gabriel-claude-p-transcript.md
+++ b/libs/mngr_claude/changelog/gabriel-claude-p-transcript.md
@@ -1,0 +1,12 @@
+Fixed a bug where a nested `claude -p` (or any nested `claude`) run from inside
+a mngr-managed Claude agent's session would be adopted into the parent agent:
+the child session inherited `MAIN_CLAUDE_SESSION_ID`, so mngr's readiness and
+transcript hooks (all guarded on that variable) fired for it -- leaking the
+child's messages into the parent's transcript and flapping the parent's
+lifecycle-state files and session tracking.
+
+Each Claude agent now provisions a small `claude` shim onto its session PATH
+that strips `MAIN_CLAUDE_SESSION_ID` from nested invocations before exec-ing the
+real binary. The main agent launch resolves and runs the real binary directly,
+so its environment -- and therefore `/clear`, `/compact`, and session resume --
+are unaffected.

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -1103,6 +1103,36 @@ _CLAUDE_ALWAYS_PROVISIONED_SCRIPT_NAMES: Final[tuple[str, ...]] = (
     "sync_keychain_credentials.py",
 )
 
+# The per-agent `claude` shim. Installed as an executable named `claude` inside
+# _CLAUDE_SHIM_DIR_NAME, a directory that assemble_command prepends to PATH so
+# that *nested* `claude` invocations (e.g. `claude -p` run via the agent's Bash
+# tool) get MAIN_CLAUDE_SESSION_ID scrubbed -- making mngr's readiness/transcript
+# hooks (all guarded on that var) correctly no-op for those child sessions. The
+# shim lives in its own directory so prepending it to PATH shadows only `claude`,
+# not the other scripts in commands/. The main launch bypasses the shim via an
+# absolute path. See resources/claude_shim.sh.
+_CLAUDE_SHIM_RESOURCE_NAME: Final[str] = "claude_shim.sh"
+_CLAUDE_SHIM_DIR_NAME: Final[str] = "claude_shim"
+_CLAUDE_SHIM_INSTALLED_NAME: Final[str] = "claude"
+
+
+def _provision_claude_shim(
+    host: OnlineHostInterface,
+    agent_state_dir: Path,
+) -> None:
+    """Install the per-agent ``claude`` shim.
+
+    Writes ``resources/claude_shim.sh`` to
+    ``$MNGR_AGENT_STATE_DIR/claude_shim/claude`` (mode 0755). The shim scrubs
+    ``MAIN_CLAUDE_SESSION_ID`` from nested ``claude`` invocations so the parent
+    agent's readiness/transcript hooks do not adopt child sessions. See
+    :func:`ClaudeAgent.assemble_command` for how it is wired onto PATH.
+    """
+    shim_dir = agent_state_dir / _CLAUDE_SHIM_DIR_NAME
+    host.execute_idempotent_command(f"mkdir -p {shlex.quote(str(shim_dir))}", timeout_seconds=5.0)
+    content = _load_claude_resource_script(_CLAUDE_SHIM_RESOURCE_NAME)
+    host.write_file(shim_dir / _CLAUDE_SHIM_INSTALLED_NAME, content.encode(), "0755")
+
 
 def _provision_claude_always_on_scripts(
     host: OnlineHostInterface,
@@ -1602,6 +1632,34 @@ class ClaudeAgent(InteractiveTuiAgent[ClaudeAgentConfig], HasCommonTranscriptMix
             f' export MAIN_CLAUDE_SESSION_ID="${{_MNGR_READ_SID:-{agent_uuid}}}"'
         )
 
+        # Put the per-agent `claude` shim on PATH so that *nested* `claude`
+        # invocations spawned by this session (e.g. `claude -p` run via the Bash
+        # tool) get MAIN_CLAUDE_SESSION_ID scrubbed. Without it, a child session
+        # inherits that variable and mngr's readiness/transcript hooks (all
+        # guarded on it) wrongly attribute the child's messages and lifecycle
+        # state to this agent. See _provision_claude_shim / claude_shim.sh.
+        #
+        # The shim shadows only the bare name `claude`, so when `base` is the
+        # bare claude binary the *main* launch would hit the shim too. Resolve
+        # the real binary BEFORE the shim is on PATH and launch through its
+        # absolute path ($_MNGR_REAL_CLAUDE) so the main session's environment --
+        # and therefore /clear, /compact, and resume -- stay untouched. The PATH
+        # mutation lives in the launch command (not the shared env file), so it
+        # is scoped to this claude process tree; tmux does not propagate it to
+        # other agents (PATH is not in tmux's default update-environment).
+        shim_path_export = f'export PATH="$MNGR_AGENT_STATE_DIR/{_CLAUDE_SHIM_DIR_NAME}:$PATH"'
+        base_tokens = shlex.split(base)
+        if base_tokens and base_tokens[0] == _CLAUDE_SHIM_INSTALLED_NAME:
+            launch_rest = "".join(f" {shlex.quote(token)}" for token in base_tokens[1:])
+            launch_cmd = f'"$_MNGR_REAL_CLAUDE"{launch_rest}'
+            shim_prelude = f'_MNGR_REAL_CLAUDE="$(command -v {_CLAUDE_SHIM_INSTALLED_NAME})" && {shim_path_export}'
+        else:
+            # `base` is a custom binary / absolute path the shim does not shadow;
+            # launch it directly, but still prepend the shim so nested bare
+            # `claude` calls made by this session are scrubbed.
+            launch_cmd = base
+            shim_prelude = shim_path_export
+
         # Build both command variants using the dynamic session ID.
         # Use $CLAUDE_CONFIG_DIR (set in the agent's env file) to find session files
         # in the per-agent config dir rather than ~/.claude/. Session files on disk
@@ -1610,8 +1668,8 @@ class ClaudeAgent(InteractiveTuiAgent[ClaudeAgentConfig], HasCommonTranscriptMix
         # the end of assemble_command would spawn a fresh `claude --session-id
         # <agent_uuid>` without surfacing any error -- so an adopted session
         # would appear to do nothing.
-        resume_cmd = f'( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {base} --resume "$MAIN_CLAUDE_SESSION_ID"'
-        create_cmd = f"{base} --session-id {agent_uuid}"
+        resume_cmd = f'( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {launch_cmd} --resume "$MAIN_CLAUDE_SESSION_ID"'
+        create_cmd = f"{launch_cmd} --session-id {agent_uuid}"
 
         # Append additional args to both commands if present
         if args_str:
@@ -1626,9 +1684,13 @@ class ClaudeAgent(InteractiveTuiAgent[ClaudeAgentConfig], HasCommonTranscriptMix
         session_name = f"{self.mngr_ctx.config.prefix}{self.name}"
         background_cmd = self._build_background_tasks_command(session_name)
 
-        # Combine: start background tasks, export env (including session ID), then run the main command (and make sure we get rid of the session started marker on each run so that wait_for_ready_signal works correctly for both new and resumed sessions)
+        # Combine: start background tasks, resolve the real claude + install the
+        # shim on PATH, export env (including session ID), then run the main
+        # command (and make sure we get rid of the session started marker on each
+        # run so that wait_for_ready_signal works correctly for both new and
+        # resumed sessions)
         return CommandString(
-            f"{background_cmd} {env_exports} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( {resume_cmd} ) || {create_cmd}"
+            f"{background_cmd} {shim_prelude} && {env_exports} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( {resume_cmd} ) || {create_cmd}"
         )
 
     def on_before_provisioning(
@@ -2013,6 +2075,9 @@ class ClaudeAgent(InteractiveTuiAgent[ClaudeAgentConfig], HasCommonTranscriptMix
                 _provision_claude_always_on_scripts,
                 (host, self._get_agent_dir(), concurrency_group),
             )
+            # Install the per-agent `claude` shim that scrubs MAIN_CLAUDE_SESSION_ID
+            # from nested `claude` invocations (see assemble_command).
+            _provision_claude_shim(host, self._get_agent_dir())
             provision_raw_transcript_scripts(self, host, self._get_agent_dir(), concurrency_group)
             maybe_provision_common_transcript_scripts(self, host, self._get_agent_dir(), concurrency_group)
 

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -1652,7 +1652,18 @@ class ClaudeAgent(InteractiveTuiAgent[ClaudeAgentConfig], HasCommonTranscriptMix
         if base_tokens and base_tokens[0] == _CLAUDE_SHIM_INSTALLED_NAME:
             launch_rest = "".join(f" {shlex.quote(token)}" for token in base_tokens[1:])
             launch_cmd = f'"$_MNGR_REAL_CLAUDE"{launch_rest}'
-            shim_prelude = f'_MNGR_REAL_CLAUDE="$(command -v {_CLAUDE_SHIM_INSTALLED_NAME})" && {shim_path_export}'
+            # Resolve the real binary before the shim is on PATH. If `claude` is
+            # not found, abort with a clear message: without the explicit guard
+            # the failed assignment would short-circuit the `&&` chain straight
+            # into the trailing `|| create_cmd` fallback, which would then run
+            # with an empty $_MNGR_REAL_CLAUDE (a confusing ` --session-id ...`).
+            # The `;` (not `&&`) before the PATH export keeps the guard's failure
+            # from being swallowed by that same fallback.
+            shim_prelude = (
+                f'_MNGR_REAL_CLAUDE="$(command -v {_CLAUDE_SHIM_INSTALLED_NAME})" || '
+                '{ echo "mngr: could not find a claude binary on PATH; cannot start agent" >&2; exit 127; }; '
+                f"{shim_path_export}"
+            )
         else:
             # `base` is a custom binary / absolute path the shim does not shadow;
             # launch it directly, but still prepend the shim so nested bare

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -2,6 +2,7 @@ import importlib.resources
 import json
 import os
 import shlex
+import shutil
 import subprocess
 from contextlib import contextmanager
 from datetime import datetime
@@ -134,10 +135,13 @@ def _sid_export_for(uuid: UUID) -> str:
 
 
 # The shim prelude assemble_command emits when `base` is the bare `claude`
-# binary: resolve the real claude (before the shim is on PATH), then prepend the
-# per-agent shim dir so nested `claude` invocations get scrubbed.
+# binary: resolve the real claude (before the shim is on PATH, aborting cleanly
+# if it is absent), then prepend the per-agent shim dir so nested `claude`
+# invocations get scrubbed.
 _SHIM_PRELUDE_FOR_CLAUDE: str = (
-    '_MNGR_REAL_CLAUDE="$(command -v claude)" && export PATH="$MNGR_AGENT_STATE_DIR/claude_shim:$PATH"'
+    '_MNGR_REAL_CLAUDE="$(command -v claude)" || '
+    '{ echo "mngr: could not find a claude binary on PATH; cannot start agent" >&2; exit 127; }; '
+    'export PATH="$MNGR_AGENT_STATE_DIR/claude_shim:$PATH"'
 )
 # The shim prelude when `base` is a custom binary the shim does not shadow:
 # just prepend the shim dir (the main launch uses `base` directly).
@@ -639,6 +643,47 @@ def test_claude_agent_assemble_command_scrubs_session_id_for_nested_claude_only(
         "Expected the main launch to keep MAIN_CLAUDE_SESSION_ID and the nested "
         f"`claude` (via the shim) to have it scrubbed, got {recorded!r}."
     )
+
+
+def test_claude_agent_assemble_command_errors_clearly_when_claude_absent(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """When `claude` is not on PATH, the launch must fail with a clear message.
+
+    Without the explicit guard in the shim prelude, a failed `command -v claude`
+    would short-circuit into the trailing `|| create_cmd` fallback and run it
+    with an empty $_MNGR_REAL_CLAUDE (a confusing ` --session-id ...`). The guard
+    instead aborts with exit 127 and a diagnostic on stderr.
+    """
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
+
+    state_dir = tmp_path / "agent-state"
+    (state_dir / "commands").mkdir(parents=True)
+    bg_script = state_dir / "commands" / "claude_background_tasks.sh"
+    bg_script.write_text("#!/bin/bash\nexit 0\n")
+    bg_script.chmod(0o755)
+
+    # PATH with bash/env (so the pipeline can run) but deliberately no `claude`.
+    tools_dir = tmp_path / "tools_bin"
+    tools_dir.mkdir()
+    for tool in ("bash", "env"):
+        host_tool = shutil.which(tool)
+        assert host_tool is not None
+        os.symlink(host_tool, tools_dir / tool)
+
+    command = agent.assemble_command(host=host, agent_args=(), command_override=None)
+    env = {
+        "PATH": str(tools_dir),
+        "CLAUDE_CONFIG_DIR": str(tmp_path / "claude-config"),
+        "MNGR_AGENT_STATE_DIR": str(state_dir),
+        "HOME": str(tmp_path),
+    }
+    result = subprocess.run(["bash", "-c", str(command)], env=env, capture_output=True, text=True, timeout=30)
+
+    assert result.returncode == 127, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "could not find a claude binary on PATH" in result.stderr
+    # The empty-binary create fallback must NOT have been attempted.
+    assert "--session-id" not in result.stderr
 
 
 # =============================================================================

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -1,3 +1,4 @@
+import importlib.resources
 import json
 import os
 import shlex
@@ -130,6 +131,19 @@ def _sid_export_for(uuid: UUID) -> str:
         f'_MNGR_READ_SID=$(cat "$MNGR_AGENT_STATE_DIR/claude_session_id" 2>/dev/null || true);'
         f' export MAIN_CLAUDE_SESSION_ID="${{_MNGR_READ_SID:-{uuid}}}"'
     )
+
+
+# The shim prelude assemble_command emits when `base` is the bare `claude`
+# binary: resolve the real claude (before the shim is on PATH), then prepend the
+# per-agent shim dir so nested `claude` invocations get scrubbed.
+_SHIM_PRELUDE_FOR_CLAUDE: str = (
+    '_MNGR_REAL_CLAUDE="$(command -v claude)" && export PATH="$MNGR_AGENT_STATE_DIR/claude_shim:$PATH"'
+)
+# The shim prelude when `base` is a custom binary the shim does not shadow:
+# just prepend the shim dir (the main launch uses `base` directly).
+_SHIM_PRELUDE_FOR_CUSTOM: str = 'export PATH="$MNGR_AGENT_STATE_DIR/claude_shim:$PATH"'
+# How the main launch refers to the real binary when `base` is bare `claude`.
+_REAL_CLAUDE: str = '"$_MNGR_REAL_CLAUDE"'
 
 
 def _init_git_with_gitignore(work_dir: Path) -> None:
@@ -337,7 +351,7 @@ def test_claude_agent_assemble_command_with_no_args(
     sid_export = _sid_export_for(uuid)
     # Local hosts should NOT have IS_SANDBOX set
     assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" ) || claude --session-id {uuid}'
+        f'{background_cmd} {_SHIM_PRELUDE_FOR_CLAUDE} && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {_REAL_CLAUDE} --resume "$MAIN_CLAUDE_SESSION_ID" ) || {_REAL_CLAUDE} --session-id {uuid}'
     )
 
 
@@ -355,7 +369,7 @@ def test_claude_agent_assemble_command_with_agent_args(
     background_cmd = agent._build_background_tasks_command(session_name)
     sid_export = _sid_export_for(uuid)
     assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || claude --session-id {uuid} --model opus'
+        f'{background_cmd} {_SHIM_PRELUDE_FOR_CLAUDE} && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {_REAL_CLAUDE} --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || {_REAL_CLAUDE} --session-id {uuid} --model opus'
     )
 
 
@@ -378,7 +392,7 @@ def test_claude_agent_assemble_command_with_cli_args_and_agent_args(
     background_cmd = agent._build_background_tasks_command(session_name)
     sid_export = _sid_export_for(uuid)
     assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" --verbose --model opus ) || claude --session-id {uuid} --verbose --model opus'
+        f'{background_cmd} {_SHIM_PRELUDE_FOR_CLAUDE} && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {_REAL_CLAUDE} --resume "$MAIN_CLAUDE_SESSION_ID" --verbose --model opus ) || {_REAL_CLAUDE} --session-id {uuid} --verbose --model opus'
     )
 
 
@@ -400,7 +414,7 @@ def test_claude_agent_assemble_command_with_command_override(
     background_cmd = agent._build_background_tasks_command(session_name)
     sid_export = _sid_export_for(uuid)
     assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && custom-claude --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || custom-claude --session-id {uuid} --model opus'
+        f'{background_cmd} {_SHIM_PRELUDE_FOR_CUSTOM} && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && custom-claude --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || custom-claude --session-id {uuid} --model opus'
     )
 
 
@@ -440,7 +454,7 @@ def test_claude_agent_assemble_command_sets_is_sandbox_for_remote_host(
     sid_export = _sid_export_for(uuid)
     # Remote hosts SHOULD have IS_SANDBOX set
     assert command == CommandString(
-        f'{background_cmd} export IS_SANDBOX=1 && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" ) || claude --session-id {uuid}'
+        f'{background_cmd} {_SHIM_PRELUDE_FOR_CLAUDE} && export IS_SANDBOX=1 && {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {_REAL_CLAUDE} --resume "$MAIN_CLAUDE_SESSION_ID" ) || {_REAL_CLAUDE} --session-id {uuid}'
     )
 
 
@@ -541,6 +555,89 @@ def test_claude_agent_assemble_command_resume_branch_runs_when_session_jsonl_exi
     )
     assert target_session_id in invocation_args, (
         f"Expected adopted session id {target_session_id!r} in claude argv, got {invocation_args!r}."
+    )
+
+
+def test_claude_agent_assemble_command_scrubs_session_id_for_nested_claude_only(
+    local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """End-to-end: the main launch keeps MAIN_CLAUDE_SESSION_ID; nested `claude` loses it.
+
+    This is the core guarantee of the claude shim. A nested `claude -p` spawned
+    by an agent must NOT have its session adopted into the parent's transcript /
+    state, which mngr enforces by scrubbing MAIN_CLAUDE_SESSION_ID (the variable
+    every readiness hook is guarded on) from nested invocations -- while leaving
+    the main session's environment untouched.
+
+    The test executes the real assembled command against a stub `claude` that
+    (1) records whether MAIN_CLAUDE_SESSION_ID is set in its environment, and
+    (2) on its first (main) invocation, re-invokes bare `claude` once. The bare
+    re-invocation resolves the shim (prepended to PATH by the assembled command),
+    so the recorded environments must be:
+
+      - first line  (main launch, via the real binary): variable SET
+      - second line (nested launch, via the shim):       variable UNSET
+    """
+    agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
+
+    state_dir = tmp_path / "agent-state"
+    (state_dir / "commands").mkdir(parents=True)
+
+    # Make MAIN_CLAUDE_SESSION_ID resolve to a concrete value (not the uuid
+    # fallback) so the "SET" assertion is unambiguous.
+    main_sid = "main-session-abc123"
+    (state_dir / "claude_session_id").write_text(main_sid)
+
+    # Install the real shim (named `claude`) into the dir the assembled command
+    # prepends to PATH.
+    shim_dir = state_dir / "claude_shim"
+    shim_dir.mkdir()
+    shim_src = importlib.resources.files("imbue.mngr_claude.resources").joinpath("claude_shim.sh")
+    shim_installed = shim_dir / "claude"
+    shim_installed.write_text(shim_src.read_text())
+    shim_installed.chmod(0o755)
+
+    # Stub the background-tasks script (runs backgrounded; just needs to exist).
+    bg_script = state_dir / "commands" / "claude_background_tasks.sh"
+    bg_script.write_text("#!/bin/bash\nexit 0\n")
+    bg_script.chmod(0o755)
+
+    # Stub "real" claude: record MAIN_CLAUDE_SESSION_ID, then on the first
+    # invocation re-invoke bare `claude` exactly once (which resolves the shim).
+    env_log = tmp_path / "claude_env.log"
+    stub_dir = tmp_path / "stub_bin"
+    stub_dir.mkdir()
+    stub_claude = stub_dir / "claude"
+    stub_claude.write_text(
+        "#!/bin/bash\n"
+        f'printf "sid=%s\\n" "${{MAIN_CLAUDE_SESSION_ID:-UNSET}}" >> {shlex.quote(str(env_log))}\n'
+        'if [ -z "${STUB_NESTED:-}" ]; then\n'
+        "  export STUB_NESTED=1\n"
+        "  claude --print nested-call >/dev/null 2>&1 || true\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    stub_claude.chmod(0o755)
+
+    # No session jsonl is planted, so the resume guard's `find` fails and the
+    # `|| create` branch launches the stub via "$_MNGR_REAL_CLAUDE".
+    command = agent.assemble_command(host=host, agent_args=(), command_override=None)
+
+    env = {
+        "PATH": f"{stub_dir}:{os.environ.get('PATH', '')}",
+        "CLAUDE_CONFIG_DIR": str(tmp_path / "claude-config"),
+        "MNGR_AGENT_STATE_DIR": str(state_dir),
+        "HOME": str(tmp_path),
+    }
+    result = subprocess.run(["bash", "-c", str(command)], env=env, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"Assembled pipeline failed with exit {result.returncode}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    recorded = [line for line in env_log.read_text().splitlines() if line.strip()]
+    assert recorded == [f"sid={main_sid}", "sid=UNSET"], (
+        "Expected the main launch to keep MAIN_CLAUDE_SESSION_ID and the nested "
+        f"`claude` (via the shim) to have it scrubbed, got {recorded!r}."
     )
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/resources/claude_shim.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/claude_shim.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# mngr claude shim.
+#
+# Installed as `claude` in a dedicated directory that ClaudeAgent prepends to
+# PATH for the agent's interactive session. Its sole job is to strip
+# MAIN_CLAUDE_SESSION_ID from *nested* `claude` invocations (e.g. a `claude -p`
+# the agent runs through its Bash tool) before exec-ing the real binary.
+#
+# Why: mngr's readiness/transcript hooks are all guarded on
+# MAIN_CLAUDE_SESSION_ID (see claude_config.py SESSION_GUARD). A nested claude
+# process inherits that variable from the parent session, so without this shim
+# its SessionStart/UserPromptSubmit/Stop/... hooks would run and pollute the
+# parent agent's transcript, lifecycle-state files, and session tracking with
+# the child session. Unsetting the variable makes the guard fire so the child
+# session is ignored by the parent agent.
+#
+# The *main* agent launch invokes the real binary by absolute path (resolved
+# before this directory is on PATH) and never reaches this shim, so the main
+# session's environment -- and therefore /clear, /compact, and resume -- are
+# left completely untouched.
+
+set -u
+
+# Resolve the real `claude` by dropping our own directory from PATH and
+# re-resolving. This works regardless of where claude is installed and avoids
+# baking an absolute path in at provisioning time.
+#
+# Determine our own directory using bash parameter expansion (no external
+# `dirname`, so the shim has no PATH-resolved dependencies of its own). The
+# slashless case should never happen -- PATH resolution yields an absolute
+# argv[0] -- but bail loudly rather than risk re-resolving (and exec-ing)
+# ourselves.
+self_src="${BASH_SOURCE[0]}"
+case "$self_src" in
+    */*) self_dir=$(CDPATH= cd -- "${self_src%/*}" && pwd) ;;
+    *)
+        echo "mngr claude shim: cannot determine own location (BASH_SOURCE=$self_src)" >&2
+        exit 127
+        ;;
+esac
+
+new_path=""
+saved_ifs=$IFS
+IFS=:
+for entry in $PATH; do
+    [ "$entry" = "$self_dir" ] && continue
+    if [ -z "$new_path" ]; then
+        new_path=$entry
+    else
+        new_path="$new_path:$entry"
+    fi
+done
+IFS=$saved_ifs
+
+real_claude=$(PATH="$new_path" command -v claude 2>/dev/null || true)
+if [ -z "$real_claude" ]; then
+    echo "mngr claude shim: could not find the real 'claude' binary on PATH (excluding $self_dir)" >&2
+    exit 127
+fi
+
+unset MAIN_CLAUDE_SESSION_ID
+exec "$real_claude" "$@"

--- a/libs/mngr_claude/imbue/mngr_claude/resources/claude_shim_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/claude_shim_test.py
@@ -1,0 +1,99 @@
+"""Tests for claude_shim.sh.
+
+The shim is installed as an executable named ``claude`` on the agent's PATH. It
+exists to strip ``MAIN_CLAUDE_SESSION_ID`` from nested ``claude`` invocations
+(so mngr's readiness hooks, all guarded on that variable, no-op for child
+sessions) and then exec the real ``claude`` binary with the original args.
+
+Each test lays out a small bin directory tree:
+  - <shim_dir>/claude    -- the shim under test
+  - <real_dir>/claude    -- a stub standing in for the real binary
+and invokes the shim with PATH="<shim_dir>:<real_dir>".
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_SHIM_SOURCE = importlib.resources.files("imbue.mngr_claude.resources").joinpath("claude_shim.sh").read_text()
+
+
+def _install_shim(shim_dir: Path) -> Path:
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / "claude"
+    shim.write_text(_SHIM_SOURCE)
+    shim.chmod(0o755)
+    return shim
+
+
+def _install_stub_real_claude(real_dir: Path, body: str) -> Path:
+    real_dir.mkdir(parents=True, exist_ok=True)
+    stub = real_dir / "claude"
+    stub.write_text("#!/bin/bash\n" + body)
+    stub.chmod(0o755)
+    return stub
+
+
+def _run_shim(shim: Path, real_dir: Path, args: list[str], main_sid: str | None) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": f"{shim.parent}:{real_dir}:{os.environ.get('PATH', '')}"}
+    if main_sid is not None:
+        env["MAIN_CLAUDE_SESSION_ID"] = main_sid
+    return subprocess.run([str(shim), *args], env=env, capture_output=True, text=True, timeout=30)
+
+
+def test_shim_unsets_main_claude_session_id_for_nested_invocation(tmp_path: Path) -> None:
+    """The shim must scrub MAIN_CLAUDE_SESSION_ID before exec-ing the real binary."""
+    shim = _install_shim(tmp_path / "shim_bin")
+    real_dir = tmp_path / "real_bin"
+    _install_stub_real_claude(real_dir, 'printf "sid=%s\\n" "${MAIN_CLAUDE_SESSION_ID:-UNSET}"\n')
+
+    result = _run_shim(shim, real_dir, [], main_sid="should-be-removed")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "sid=UNSET", (
+        f"Expected MAIN_CLAUDE_SESSION_ID to be scrubbed, got stdout={result.stdout!r}"
+    )
+
+
+def test_shim_forwards_args_to_real_claude(tmp_path: Path) -> None:
+    """The shim must exec the real binary with the original argv intact."""
+    shim = _install_shim(tmp_path / "shim_bin")
+    real_dir = tmp_path / "real_bin"
+    # Print each arg on its own line so we can compare exactly (incl. spaces).
+    _install_stub_real_claude(real_dir, 'for a in "$@"; do printf "%s\\n" "$a"; done\n')
+
+    result = _run_shim(shim, real_dir, ["--print", "hello world", "-p"], main_sid="x")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["--print", "hello world", "-p"]
+
+
+def test_shim_errors_when_real_claude_is_absent(tmp_path: Path) -> None:
+    """When no real claude is on PATH (after dropping the shim dir), fail loudly.
+
+    The PATH still needs `bash`/`env` for the shebang to launch, so we provide a
+    tools dir with just those (symlinked from the host) and deliberately no
+    `claude` -- exercising the not-found branch rather than a launch failure.
+    """
+    shim = _install_shim(tmp_path / "shim_bin")
+    tools_dir = tmp_path / "tools_bin"
+    tools_dir.mkdir()
+    for tool in ("bash", "env"):
+        host_tool = shutil.which(tool)
+        assert host_tool is not None, f"{tool} must be available to run the shim"
+        os.symlink(host_tool, tools_dir / tool)
+
+    result = subprocess.run(
+        [str(shim)],
+        env={"PATH": f"{shim.parent}:{tools_dir}"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 127, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "could not find the real 'claude'" in result.stderr


### PR DESCRIPTION
## Problem

When a mngr-managed Claude agent runs a nested `claude -p` (or any nested `claude`) through its Bash tool, the child session was being adopted into the **parent** agent: its messages showed up in the parent's transcript, and the parent's lifecycle-state files / session tracking were corrupted.

Root cause: the nested process inherits `MAIN_CLAUDE_SESSION_ID` (and `CLAUDE_CONFIG_DIR`) from the parent session. mngr's readiness/transcript hooks are all guarded on `MAIN_CLAUDE_SESSION_ID` (the `SESSION_GUARD` in `claude_config.py`), so with that var non-empty the child's `SessionStart` hook appended its session id to `claude_session_id_history` — which `stream_transcript.sh` then streams into the parent's transcript — and `UserPromptSubmit`/`PermissionRequest`/`Stop` flipped the parent's state files.

The existing subagent-proxy already scrubs `MAIN_CLAUDE_SESSION_ID` for its Task-tool children, but a raw `claude -p` via Bash bypasses it entirely.

## Fix

Each Claude agent now provisions a small `claude` shim (`resources/claude_shim.sh`) into a dedicated dir (`$MNGR_AGENT_STATE_DIR/claude_shim/`) that `assemble_command` prepends to PATH. The shim unsets `MAIN_CLAUDE_SESSION_ID` before `exec`-ing the real binary, so the **existing** guard correctly no-ops for nested sessions across all hooks. `CLAUDE_CONFIG_DIR` is left intact, so the nested `claude -p` keeps the same credentials/config — it simply isn't streamed (the streamer is history-driven).

The **main** launch resolves the real binary via `command -v claude` *before* the shim is on PATH and runs it by absolute path, so the main session's environment — and therefore `/clear`, `/compact`, and resume — are untouched. No hook changes.

If `claude` is absent from PATH, the prelude now aborts with a clear message instead of falling through to a confusing empty-binary invocation.

## Test plan

- New `resources/claude_shim_test.py`: shim scrubs the var, forwards argv, and errors loudly when no real `claude` exists.
- New end-to-end test in `plugin_test.py` that executes the assembled command against a stub `claude` and asserts the main launch keeps `MAIN_CLAUDE_SESSION_ID` while a nested call (routed through the shim) has it scrubbed.
- New test asserting the clean `exit 127` + diagnostic when `claude` is absent.
- Updated the 5 existing `assemble_command` string-comparison tests.
- Headless agent is unaffected (it launches with `MAIN_CLAUDE_SESSION_ID` unset by design).

Locally: `plugin_test.py` + `claude_shim_test.py` (202), ratchets (55), subagent-proxy (166) all pass; ruff clean. Full offload suite runs in CI.