### PR TITLE
replace emit_final_json with public write_json_line

### DIFF
--- a/libs/mngr/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,3 @@
+Internal refactor with no user-visible behavior change. Removed the `emit_final_json` helper from `imbue.mngr.cli.output_helpers`, which was a one-line pass-through to the private `_write_json_line`. The underlying primitive is now public as `write_json_line` (sibling to the existing `write_human_line`), and all call sites use it directly.
+
+The old name was misleading: despite "final JSON" implying the single terminating object emitted in `--format=json` mode, it was also called from the streaming JSONL callbacks (e.g. `mngr list`). `write_json_line` honestly describes what it does -- write one JSON object as a line -- for both the JSON and JSONL paths.

--- a/libs/mngr/imbue/mngr/cli/ask.py
+++ b/libs/mngr/imbue/mngr/cli/ask.py
@@ -26,9 +26,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.help_formatter import get_all_help_metadata
 from imbue.mngr.cli.output_helpers import AbortError
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import MngrError
@@ -330,10 +330,10 @@ def _show_command_summary(output_format: OutputFormat) -> None:
             write_human_line('\nAsk a question: mngr ask "how do I create an agent?"')
         case OutputFormat.JSON:
             commands = {name: meta.one_line_description for name, meta in metadata.items()}
-            emit_final_json({"commands": commands})
+            write_json_line({"commands": commands})
         case OutputFormat.JSONL:
             commands = {name: meta.one_line_description for name, meta in metadata.items()}
-            emit_final_json({"event": "commands", "commands": commands})
+            write_json_line({"event": "commands", "commands": commands})
         case _ as unreachable:
             assert_never(unreachable)
 

--- a/libs/mngr/imbue/mngr/cli/cleanup.py
+++ b/libs/mngr/imbue/mngr/cli/cleanup.py
@@ -31,9 +31,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.urwid_utils import create_urwid_screen_preserving_terminal
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
@@ -563,7 +563,7 @@ def _emit_no_agents_found(output_opts: OutputOptions) -> None:
     """Output message when no agents are found."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"agents": [], "message": "No agents found"})
+            write_json_line({"agents": [], "message": "No agents found"})
         case OutputFormat.JSONL:
             emit_event("info", {"message": "No agents found"}, OutputFormat.JSONL)
         case OutputFormat.HUMAN:
@@ -599,7 +599,7 @@ def _emit_dry_run_output(
 
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"action": action.value.lower(), "dry_run": True, "agents": agent_data})
+            write_json_line({"action": action.value.lower(), "dry_run": True, "agents": agent_data})
         case OutputFormat.JSONL:
             emit_event("dry_run", {"action": action.value.lower(), "agents": agent_data}, OutputFormat.JSONL)
         case OutputFormat.HUMAN:
@@ -632,7 +632,7 @@ def _emit_result(
 
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("cleanup_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/config.py
+++ b/libs/mngr/imbue/mngr/cli/config.py
@@ -21,9 +21,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.help_formatter import show_help_with_pager
 from imbue.mngr.cli.output_helpers import AbortError
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import MngrConfig
@@ -361,14 +361,14 @@ def _emit_config_list(
                 output["scope"] = scope.value.lower()
             if config_path is not None:
                 output["path"] = str(config_path)
-            emit_final_json(output)
+            write_json_line(output)
         case OutputFormat.JSONL:
             output_jsonl: dict[str, object] = {"event": "config_list", "config": config_data}
             if scope is not None:
                 output_jsonl["scope"] = scope.value.lower()
             if config_path is not None:
                 output_jsonl["path"] = str(config_path)
-            emit_final_json(output_jsonl)
+            write_json_line(output_jsonl)
         case OutputFormat.HUMAN:
             if scope is not None and config_path is not None:
                 write_human_line("Config from {} ({}):", scope.value.lower(), config_path)
@@ -457,9 +457,9 @@ def _emit_config_value(key: str, value: Any, output_opts: OutputOptions) -> None
     """Emit a config value in the appropriate format."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"key": key, "value": value})
+            write_json_line({"key": key, "value": value})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "config_value", "key": key, "value": value})
+            write_json_line({"event": "config_value", "key": key, "value": value})
         case OutputFormat.HUMAN:
             write_human_line("{}", _format_value_for_display(value))
         case _ as unreachable:
@@ -488,9 +488,9 @@ def _emit_config_extend_value(key: str, extend_key: str, value: Any, output_opts
     """
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"key": extend_key, "value": value})
+            write_json_line({"key": extend_key, "value": value})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "config_value", "key": extend_key, "value": value})
+            write_json_line({"event": "config_value", "key": extend_key, "value": value})
         case OutputFormat.HUMAN:
             write_human_line("{}", _format_extend_sentinel(value))
         case _ as unreachable:
@@ -501,9 +501,9 @@ def _emit_key_not_found(key: str, output_opts: OutputOptions) -> None:
     """Emit a key not found error in the appropriate format."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"error": f"Key not found: {key}", "key": key})
+            write_json_line({"error": f"Key not found: {key}", "key": key})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "error", "message": f"Key not found: {key}", "key": key})
+            write_json_line({"event": "error", "message": f"Key not found: {key}", "key": key})
         case OutputFormat.HUMAN:
             logger.error("Key not found: {}", key)
         case _ as unreachable:
@@ -650,7 +650,7 @@ def _emit_config_extend_result(
     """Emit the result of a ``mngr config extend`` operation."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "key": extend_key,
                     "value": value,
@@ -659,7 +659,7 @@ def _emit_config_extend_result(
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "config_extend",
                     "key": extend_key,
@@ -690,7 +690,7 @@ def _emit_config_set_result(
     """Emit the result of a config set operation."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "key": key,
                     "value": value,
@@ -699,7 +699,7 @@ def _emit_config_set_result(
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "config_set",
                     "key": key,
@@ -773,7 +773,7 @@ def _emit_config_unset_result(
     """Emit the result of a config unset operation."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "key": key,
                     "scope": scope.value.lower(),
@@ -781,7 +781,7 @@ def _emit_config_unset_result(
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "config_unset",
                     "key": key,
@@ -854,14 +854,14 @@ def _config_edit_impl(ctx: click.Context, **kwargs: Any) -> None:
 
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "scope": scope.value.lower(),
                     "path": str(config_path),
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "config_edited",
                     "scope": scope.value.lower(),
@@ -982,9 +982,9 @@ def _emit_schema_rows(rows: list[dict[str, Any]], output_opts: OutputOptions) ->
         return
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"schema": rows})
+            write_json_line({"schema": rows})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "config_list_schema", "schema": rows})
+            write_json_line({"event": "config_list_schema", "schema": rows})
         case OutputFormat.HUMAN:
             for row in rows:
                 write_human_line(
@@ -1032,9 +1032,9 @@ def _config_path_impl(ctx: click.Context, **kwargs: Any) -> None:
         except ConfigNotFoundError as e:
             match output_opts.output_format:
                 case OutputFormat.JSON:
-                    emit_final_json({"error": str(e), "scope": scope.value.lower()})
+                    write_json_line({"error": str(e), "scope": scope.value.lower()})
                 case OutputFormat.JSONL:
-                    emit_final_json({"event": "error", "message": str(e), "scope": scope.value.lower()})
+                    write_json_line({"event": "error", "message": str(e), "scope": scope.value.lower()})
                 case OutputFormat.HUMAN:
                     logger.error("{}", e)
                 case _ as unreachable:
@@ -1069,7 +1069,7 @@ def _emit_single_path(scope: ConfigScope, config_path: Path, output_opts: Output
     """Emit a single config path."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "scope": scope.value.lower(),
                     "path": str(config_path),
@@ -1077,7 +1077,7 @@ def _emit_single_path(scope: ConfigScope, config_path: Path, output_opts: Output
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "config_path",
                     "scope": scope.value.lower(),
@@ -1095,9 +1095,9 @@ def _emit_all_paths(paths: list[dict[str, Any]], output_opts: OutputOptions) -> 
     """Emit all config paths."""
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"paths": paths})
+            write_json_line({"paths": paths})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "config_paths", "paths": paths})
+            write_json_line({"event": "config_paths", "paths": paths})
         case OutputFormat.HUMAN:
             for path_info in paths:
                 scope = path_info["scope"]

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -51,8 +51,8 @@ from imbue.mngr.cli.headless_runner import stream_or_accumulate_response
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CreateCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
@@ -1803,7 +1803,7 @@ def _output_result(result: CreateAgentResult, opts: OutputOptions) -> None:
     result_data = {"agent_id": str(result.agent.id), "host_id": str(result.host.id)}
     match opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("created", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/destroy.py
+++ b/libs/mngr/imbue/mngr/cli/destroy.py
@@ -27,9 +27,9 @@ from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -593,7 +593,7 @@ def _output_result(destroyed_agents: Sequence[AgentName], output_opts: OutputOpt
     result_data = {"destroyed_agents": [str(n) for n in destroyed_agents], "count": len(destroyed_agents)}
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("destroy_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/exec.py
+++ b/libs/mngr/imbue/mngr/cli/exec.py
@@ -20,10 +20,10 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_command_stdout_and_stderr
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -347,7 +347,7 @@ def _emit_json_outer_output(result: MultiExecResult) -> None:
         "total_skipped": len(result.skipped_agents),
         "total_failed": len(result.failed_agents),
     }
-    emit_final_json(output_data)
+    write_json_line(output_data)
 
 
 def _emit_jsonl_exec_result(result: ExecResult) -> None:
@@ -444,7 +444,7 @@ def _emit_json_output(result: MultiExecResult) -> None:
         "total_executed": len(result.successful_results),
         "total_failed": len(result.failed_agents),
     }
-    emit_final_json(output_data)
+    write_json_line(output_data)
 
 
 # Register help metadata for git-style help formatting

--- a/libs/mngr/imbue/mngr/cli/gc.py
+++ b/libs/mngr/imbue/mngr/cli/gc.py
@@ -17,10 +17,10 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import format_size
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
@@ -222,7 +222,7 @@ def _emit_json_summary(result: GcResult, dry_run: bool) -> None:
         "errors": result.errors,
         "dry_run": dry_run,
     }
-    emit_final_json(output_data)
+    write_json_line(output_data)
 
 
 def _emit_human_summary(result: GcResult, dry_run: bool) -> None:

--- a/libs/mngr/imbue/mngr/cli/headless_runner.py
+++ b/libs/mngr/imbue/mngr/cli/headless_runner.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from imbue.mngr.api.create import create as api_create
 from imbue.mngr.api.providers import get_provider_instance
-from imbue.mngr.cli.output_helpers import emit_final_json
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.agent_config_registry import resolve_agent_type
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
@@ -210,9 +210,9 @@ def stream_or_accumulate_response(chunks: Iterator[str], output_format: OutputFo
             sys.stdout.flush()
         case OutputFormat.JSON:
             response = accumulate_chunks(chunks)
-            emit_final_json({"response": response})
+            write_json_line({"response": response})
         case OutputFormat.JSONL:
             response = accumulate_chunks(chunks)
-            emit_final_json({"event": "response", "response": response})
+            write_json_line({"event": "response", "response": response})
         case _ as unreachable:
             assert_never(unreachable)

--- a/libs/mngr/imbue/mngr/cli/label.py
+++ b/libs/mngr/imbue/mngr/cli/label.py
@@ -17,8 +17,8 @@ from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -70,7 +70,7 @@ def _output_result(
     result_data = {"changes": changes, "count": len(changes)}
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("label_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/limit.py
+++ b/libs/mngr/imbue/mngr/cli/limit.py
@@ -21,8 +21,8 @@ from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -87,7 +87,7 @@ def _output_result(
     result_data = {"changes": changes, "count": len(changes)}
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("limit_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -30,9 +30,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.help_topics import get_all_topics
 from imbue.mngr.cli.output_helpers import AbortError
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import render_format_template
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.completion_writer import write_cli_completions_cache
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
@@ -715,7 +715,7 @@ def _run_list_iteration(params: _ListIterationParams, ctx: click.Context) -> Non
         elif params.output_opts.output_format == OutputFormat.HUMAN:
             write_human_line("No agents found")
         elif params.output_opts.output_format == OutputFormat.JSON:
-            emit_final_json({"agents": [], "errors": result.errors})
+            write_json_line({"agents": [], "errors": result.errors})
         else:
             # JSONL is handled above with streaming, so this should be unreachable
             raise AssertionError(f"Unexpected output format: {params.output_opts.output_format}")
@@ -748,19 +748,19 @@ def _emit_json_output(agents: list[AgentDetails], errors: list[ErrorInfo]) -> No
         "agents": agents_data,
         "errors": errors_data,
     }
-    emit_final_json(output_data)
+    write_json_line(output_data)
 
 
 def _emit_jsonl_agent(agent: AgentDetails) -> None:
     """Emit a single agent as a JSONL line (streaming callback)."""
     agent_data = agent.model_dump(mode="json")
-    emit_final_json(agent_data)
+    write_json_line(agent_data)
 
 
 def _emit_jsonl_error(error: ErrorInfo) -> None:
     """Emit a single error as a JSONL line (streaming callback)."""
     error_data = {"event": "error", **error.model_dump(mode="json")}
-    emit_final_json(error_data)
+    write_json_line(error_data)
 
 
 def _emit_human_output(

--- a/libs/mngr/imbue/mngr/cli/message.py
+++ b/libs/mngr/imbue/mngr/cli/message.py
@@ -16,8 +16,8 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -283,7 +283,7 @@ def _emit_json_output(result: MessageResult) -> None:
         "total_sent": len(result.successful_agents),
         "total_failed": len(result.failed_agents),
     }
-    emit_final_json(output_data)
+    write_json_line(output_data)
 
 
 # Register help metadata for git-style help formatting

--- a/libs/mngr/imbue/mngr/cli/output_helpers.py
+++ b/libs/mngr/imbue/mngr/cli/output_helpers.py
@@ -14,11 +14,12 @@ from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import OutputFormat
 
 
-def _write_json_line(data: Mapping[str, Any]) -> None:
+def write_json_line(data: Mapping[str, Any]) -> None:
     """Write a JSON object as a line to stdout.
 
-    This is used for JSON and JSONL output formats where we need raw JSON
-    without any logger formatting.
+    Used for both JSON output (a single terminating object) and JSONL output
+    (one object per line, streamed) where we need raw JSON without any logger
+    formatting. Sibling to ``write_human_line``.
     """
     sys.stdout.write(json.dumps(data) + "\n")
     sys.stdout.flush()
@@ -114,7 +115,7 @@ def emit_info(message: str, output_format: OutputFormat) -> None:
             write_human_line(message)
         case OutputFormat.JSONL:
             event = {"event": "info", "message": message}
-            _write_json_line(event)
+            write_json_line(event)
         case OutputFormat.JSON:
             # JSON mode: silent until final output
             pass
@@ -136,7 +137,7 @@ def emit_event(
                 write_human_line(str(data["message"]))
         case OutputFormat.JSONL:
             event = {"event": event_type, **data}
-            _write_json_line(event)
+            write_json_line(event)
         case OutputFormat.JSON:
             # JSON mode: silent until final output
             pass
@@ -159,7 +160,7 @@ def on_error(
             logger.error(error_msg)
         case OutputFormat.JSONL:
             event = {"event": "error", "message": error_msg}
-            _write_json_line(event)
+            write_json_line(event)
         case OutputFormat.JSON:
             # JSON mode: errors collected and shown in final output
             pass
@@ -169,11 +170,6 @@ def on_error(
     # Abort if requested
     if error_behavior == ErrorBehavior.ABORT:
         raise AbortError(error_msg, original_exception=exc)
-
-
-def emit_final_json(data: Mapping[str, Any]) -> None:
-    """Emit final JSON output (for JSON format only)."""
-    _write_json_line(data)
 
 
 @pure
@@ -232,7 +228,7 @@ def output_rsync_result(
 
     match output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("rsync_complete", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:
@@ -258,7 +254,7 @@ def _output_git_sync_success(
     """
     match output_format:
         case OutputFormat.JSON:
-            emit_final_json({"success": True})
+            write_json_line({"success": True})
         case OutputFormat.JSONL:
             emit_event(event_name, {"success": True}, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/output_helpers_test.py
+++ b/libs/mngr/imbue/mngr/cli/output_helpers_test.py
@@ -6,9 +6,7 @@ import pytest
 
 from imbue.mngr.api.rsync import RsyncResult
 from imbue.mngr.cli.output_helpers import AbortError
-from imbue.mngr.cli.output_helpers import _write_json_line
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import format_size
@@ -18,6 +16,7 @@ from imbue.mngr.cli.output_helpers import output_git_push_success
 from imbue.mngr.cli.output_helpers import output_rsync_result
 from imbue.mngr.cli.output_helpers import render_format_template
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.errors import MngrError
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import OutputFormat
@@ -153,20 +152,6 @@ def test_on_error_stores_original_exception() -> None:
     with pytest.raises(AbortError) as exc_info:
         on_error("test error", ErrorBehavior.ABORT, OutputFormat.HUMAN, exc=original)
     assert exc_info.value.original_exception is original
-
-
-# =============================================================================
-# Tests for emit_final_json
-# =============================================================================
-
-
-def test_emit_final_json_outputs_json(capsys: pytest.CaptureFixture[str]) -> None:
-    """emit_final_json should output JSON data."""
-    emit_final_json({"status": "success", "count": 5})
-    captured = capsys.readouterr()
-    output = json.loads(captured.out.strip())
-    assert output["status"] == "success"
-    assert output["count"] == 5
 
 
 # =============================================================================
@@ -432,13 +417,13 @@ def test_write_human_line_with_args(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 # =============================================================================
-# Tests for _write_json_line
+# Tests for write_json_line
 # =============================================================================
 
 
 def test_write_json_line_outputs_json(capsys: pytest.CaptureFixture[str]) -> None:
-    """_write_json_line should output valid JSON followed by newline."""
-    _write_json_line({"key": "value", "number": 42})
+    """write_json_line should output valid JSON followed by newline."""
+    write_json_line({"key": "value", "number": 42})
     captured = capsys.readouterr()
     output = json.loads(captured.out.strip())
     assert output["key"] == "value"
@@ -446,8 +431,8 @@ def test_write_json_line_outputs_json(capsys: pytest.CaptureFixture[str]) -> Non
 
 
 def test_write_json_line_terminates_with_newline(capsys: pytest.CaptureFixture[str]) -> None:
-    """_write_json_line should terminate output with newline."""
-    _write_json_line({"a": 1})
+    """write_json_line should terminate output with newline."""
+    write_json_line({"a": 1})
     captured = capsys.readouterr()
     assert captured.out.endswith("\n")
 

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -27,9 +27,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.help_formatter import show_help_with_pager
 from imbue.mngr.cli.output_helpers import AbortError
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.plugin_install_wizard import install_wizard
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import ConfigScope
@@ -211,13 +211,13 @@ def _emit_plugin_list_human(plugins: list[PluginInfo], fields: tuple[str, ...]) 
 def _emit_plugin_list_json(plugins: list[PluginInfo], fields: tuple[str, ...]) -> None:
     """Emit plugin list in JSON format."""
     plugin_dicts = [{f: _get_field_value(p, f) for f in fields} for p in plugins]
-    emit_final_json({"plugins": plugin_dicts})
+    write_json_line({"plugins": plugin_dicts})
 
 
 def _emit_plugin_list_jsonl(plugins: list[PluginInfo], fields: tuple[str, ...]) -> None:
     """Emit plugin list in JSONL format (one line per plugin)."""
     for p in plugins:
-        emit_final_json({f: _get_field_value(p, f) for f in fields})
+        write_json_line({f: _get_field_value(p, f) for f in fields})
 
 
 @pure
@@ -297,7 +297,7 @@ def _emit_plugin_add_result(
                     "Package installed but no mngr entry points found -- this package may not be a mngr plugin"
                 )
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "specifier": specifier,
                     "package": package_name,
@@ -305,7 +305,7 @@ def _emit_plugin_add_result(
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "plugin_added",
                     "specifier": specifier,
@@ -326,13 +326,13 @@ def _emit_plugin_remove_result(
         case OutputFormat.HUMAN:
             write_human_line("Removed plugin package '{}'", package_name)
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "package": package_name,
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "plugin_removed",
                     "package": package_name,
@@ -800,7 +800,7 @@ def _emit_plugin_toggle_result(
             action = "Enabled" if is_enabled else "Disabled"
             write_human_line("{} plugin '{}' in {} ({})", action, name, scope.value.lower(), config_path)
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "plugin": name,
                     "enabled": is_enabled,
@@ -809,7 +809,7 @@ def _emit_plugin_toggle_result(
                 }
             )
         case OutputFormat.JSONL:
-            emit_final_json(
+            write_json_line(
                 {
                     "event": "plugin_toggled",
                     "plugin": name,

--- a/libs/mngr/imbue/mngr/cli/rename.py
+++ b/libs/mngr/imbue/mngr/cli/rename.py
@@ -17,8 +17,8 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.label import parse_label_string
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import UserInputError
@@ -60,7 +60,7 @@ def _output_result(
     }
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("rename_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/snapshot.py
+++ b/libs/mngr/imbue/mngr/cli/snapshot.py
@@ -21,12 +21,12 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import AbortError
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import format_size
 from imbue.mngr.cli.output_helpers import on_error
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -236,7 +236,7 @@ def _emit_create_result(
             if errors:
                 data["errors"] = errors
                 data["error_count"] = len(errors)
-            emit_final_json(data)
+            write_json_line(data)
         case OutputFormat.JSONL:
             event_data: dict[str, Any] = {"count": len(created)}
             if errors:
@@ -281,7 +281,7 @@ def _emit_list_snapshots(
                 }
                 for host_id, snap in all_snapshots
             ]
-            emit_final_json({"snapshots": data, "count": len(data)})
+            write_json_line({"snapshots": data, "count": len(data)})
         case OutputFormat.JSONL:
             for host_id, snap in all_snapshots:
                 emit_event(
@@ -330,7 +330,7 @@ def _emit_destroy_result(
         return
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"snapshots_destroyed": destroyed, "count": len(destroyed)})
+            write_json_line({"snapshots_destroyed": destroyed, "count": len(destroyed)})
         case OutputFormat.JSONL:
             emit_event("destroy_result", {"count": len(destroyed)}, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/start.py
+++ b/libs/mngr/imbue/mngr/cli/start.py
@@ -24,9 +24,9 @@ from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -70,7 +70,7 @@ def _output_result(started_agents: Sequence[str], output_opts: OutputOptions, *,
     result_data = {"started_agents": started_agents, "count": len(started_agents)}
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("start_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr/imbue/mngr/cli/stop.py
+++ b/libs/mngr/imbue/mngr/cli/stop.py
@@ -21,9 +21,9 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.label import apply_labels
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_format_template_lines
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.stdin_utils import STDIN_PLACEHOLDER
 from imbue.mngr.cli.stdin_utils import expand_stdin_placeholder
 from imbue.mngr.config.data_types import CommonCliOptions
@@ -66,7 +66,7 @@ def _output_result(stopped_agents: Sequence[str], output_opts: OutputOptions) ->
     result_data = {"stopped_agents": stopped_agents, "count": len(stopped_agents)}
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("stop_result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr_file/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr_file/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,1 @@
+Internal refactor with no user-visible behavior change. Updated the JSON output call sites to use the renamed `write_json_line` helper from `imbue.mngr.cli.output_helpers` (formerly `emit_final_json`, now removed).

--- a/libs/mngr_file/imbue/mngr_file/cli/get.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/get.py
@@ -12,7 +12,7 @@ from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.primitives import AgentOrHostAddress
@@ -45,7 +45,7 @@ def _emit_get_result(
     }
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"event": "file_read", **data})
+            write_json_line({"event": "file_read", **data})
         case OutputFormat.JSONL:
             emit_event("file_read", data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr_file/imbue/mngr_file/cli/list.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/list.py
@@ -19,10 +19,10 @@ from imbue.imbue_common.pure import pure
 from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import format_size
 from imbue.mngr.cli.output_helpers import render_format_template
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import MngrError
@@ -304,7 +304,7 @@ def _emit_list_result(
             table = tabulate(rows, headers=headers, tablefmt="plain")
             write_human_line(table)
         case OutputFormat.JSON:
-            emit_final_json(
+            write_json_line(
                 {
                     "count": len(entries),
                     "files": [_entry_to_json_dict(e) for e in entries],

--- a/libs/mngr_file/imbue/mngr_file/cli/put.py
+++ b/libs/mngr_file/imbue/mngr_file/cli/put.py
@@ -12,8 +12,8 @@ from imbue.mngr.cli.address_params import AGENT_OR_HOST_ADDRESS
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import UserInputError
@@ -47,7 +47,7 @@ def _emit_put_result(
     }
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json({"event": "file_written", **data})
+            write_json_line({"event": "file_written", **data})
         case OutputFormat.JSONL:
             emit_event("file_written", data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr_latchkey/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr_latchkey/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,1 @@
+Internal refactor with no user-visible behavior change. Updated the JSON output call sites to use the renamed `write_json_line` helper from `imbue.mngr.cli.output_helpers` (formerly `emit_final_json`, now removed).

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/cli.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/cli.py
@@ -40,8 +40,8 @@ from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import AgentId
@@ -259,10 +259,10 @@ def _create_agent_env_command(ctx: click.Context, **kwargs: Any) -> None:
         "env": dict(setup.env),
         "opaque_permissions_path": str(setup.opaque_permissions_path),
     }
-    # ``emit_final_json`` is the project's standard helper for emitting
+    # ``write_json_line`` is the project's standard helper for emitting
     # a single JSON object on stdout (used by every ``mngr`` command
     # that supports ``--format=json`` final output).
-    emit_final_json(payload)
+    write_json_line(payload)
 
 
 _add_common_latchkey_options(_create_agent_env_command)
@@ -755,7 +755,7 @@ def _gateway_info_command(ctx: click.Context, **kwargs: Any) -> None:
     except LatchkeyError as e:
         raise click.ClickException(f"Failed to derive gateway password: {e}") from e
 
-    emit_final_json(
+    write_json_line(
         {
             "url": f"http://{latchkey.listen_host}:{info.gateway_port}",
             "password": password,

--- a/libs/mngr_schedule/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr_schedule/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,1 @@
+Internal refactor with no user-visible behavior change. Updated the JSON/JSONL output call sites to use the renamed `write_json_line` helper from `imbue.mngr.cli.output_helpers` (formerly `emit_final_json`, now removed).

--- a/libs/mngr_schedule/imbue/mngr_schedule/cli/list.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/cli/list.py
@@ -10,8 +10,8 @@ from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.logging import log_span
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr_modal.instance import ModalProviderInstance
@@ -159,10 +159,10 @@ def _emit_schedule_list_json(records: list[ScheduleCreationRecord]) -> None:
     data = {
         "schedules": [record.model_dump(mode="json") for record in records],
     }
-    emit_final_json(data)
+    write_json_line(data)
 
 
 def _emit_schedule_list_jsonl(records: list[ScheduleCreationRecord]) -> None:
     """Emit JSONL output for schedule list."""
     for record in records:
-        emit_final_json(record.model_dump(mode="json"))
+        write_json_line(record.model_dump(mode="json"))

--- a/libs/mngr_schedule/imbue/mngr_schedule/cli/run.py
+++ b/libs/mngr_schedule/imbue/mngr_schedule/cli/run.py
@@ -9,8 +9,8 @@ from loguru import logger
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import MngrError
 from imbue.mngr.primitives import OutputFormat
@@ -85,9 +85,9 @@ def _emit_output(output: str, output_format: OutputFormat) -> None:
     """
     match output_format:
         case OutputFormat.JSON:
-            emit_final_json({"output": output})
+            write_json_line({"output": output})
         case OutputFormat.JSONL:
-            emit_final_json({"event": "output", "output": output})
+            write_json_line({"event": "output", "output": output})
         case OutputFormat.HUMAN:
             if output:
                 write_human_line("{}", output.rstrip("\n"))

--- a/libs/mngr_usage/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr_usage/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,1 @@
+Internal refactor with no user-visible behavior change. Updated the JSON output call sites to use the renamed `write_json_line` helper from `imbue.mngr.cli.output_helpers` (formerly `emit_final_json`, now removed).

--- a/libs/mngr_usage/imbue/mngr_usage/cli.py
+++ b/libs/mngr_usage/imbue/mngr_usage/cli.py
@@ -21,10 +21,10 @@ from imbue.mngr.cli.filter_opts import build_agent_filter_cel
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import render_format_template
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UserInputError
@@ -588,7 +588,7 @@ def _emit_output(
                 "since_seconds": since_seconds,
                 "sources": [_render_one_source_for_json(model, now, detail) for _, model in snapshots_with_models],
             }
-            emit_final_json(payload)
+            write_json_line(payload)
         case OutputFormat.HUMAN:
             if not snapshots_with_models:
                 return
@@ -999,7 +999,7 @@ def _output_wait_result(result: WaitForUsageResult, output_format: OutputFormat)
     }
     match output_format:
         case OutputFormat.JSON:
-            emit_final_json(payload)
+            write_json_line(payload)
         case OutputFormat.JSONL:
             emit_event("result", payload, OutputFormat.JSONL)
         case OutputFormat.HUMAN:

--- a/libs/mngr_wait/changelog/gabriel-remove-emit-final-json.md
+++ b/libs/mngr_wait/changelog/gabriel-remove-emit-final-json.md
@@ -1,0 +1,1 @@
+Internal refactor with no user-visible behavior change. Updated the JSON output call site to use the renamed `write_json_line` helper from `imbue.mngr.cli.output_helpers` (formerly `emit_final_json`, now removed).

--- a/libs/mngr_wait/imbue/mngr_wait/cli.py
+++ b/libs/mngr_wait/imbue/mngr_wait/cli.py
@@ -15,9 +15,9 @@ from imbue.mngr.cli.exit_codes import EXIT_CODE_TIMEOUT
 from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.cli.output_helpers import emit_event
-from imbue.mngr.cli.output_helpers import emit_final_json
 from imbue.mngr.cli.output_helpers import emit_info
 from imbue.mngr.cli.output_helpers import write_human_line
+from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import UserInputError
@@ -114,7 +114,7 @@ def _output_result(result: WaitResult, output_opts: OutputOptions) -> None:
 
     match output_opts.output_format:
         case OutputFormat.JSON:
-            emit_final_json(result_data)
+            write_json_line(result_data)
         case OutputFormat.JSONL:
             emit_event("result", result_data, OutputFormat.JSONL)
         case OutputFormat.HUMAN:


### PR DESCRIPTION
## What

`emit_final_json` (in `imbue.mngr.cli.output_helpers`) was a one-line pass-through to the private `_write_json_line`. Its name was also misleading: despite "final JSON" implying the single terminating object emitted in `--format=json` mode, it was called from streaming JSONL callbacks too (e.g. `mngr list`'s `_emit_jsonl_agent` / `_emit_jsonl_error`).

This makes the primitive public as `write_json_line` (sibling to the existing `write_human_line`), removes `emit_final_json`, and updates all ~74 call sites + imports across 6 packages (`mngr`, `mngr_wait`, `mngr_usage`, `mngr_schedule`, `mngr_latchkey`, `mngr_file`).

`write_json_line` honestly describes what it does -- write one JSON object as a line -- for both the JSON (single terminating object) and JSONL (streamed) paths. The thin `list.py` wrappers (`_emit_json_output`, `_emit_jsonl_agent`, `_emit_jsonl_error`) are intentionally left in place; only their inner call is renamed.

No user-visible behavior change -- the byte output is identical.

## Testing

- `just test-quick libs/mngr/imbue/mngr/cli/output_helpers_test.py` -- 49 passed, 0 failed (dropped the now-redundant `test_emit_final_json_outputs_json`).
- Smoke-imported all 26 changed modules; confirmed `write_json_line` present and `emit_final_json` gone.
- Full suite via CI.