### PR TITLE
Fix Minds App request refreshing

### DIFF
--- a/apps/minds/changelog/hynek-permission-request-notifications.md
+++ b/apps/minds/changelog/hynek-permission-request-notifications.md
@@ -1,0 +1,9 @@
+Fixed the desktop app's live permission-request notifications, which previously never updated: the requests badge, the requests-panel auto-open, and the in-panel list only refreshed after the user manually closed and reopened the panel.
+
+Two root causes:
+
+- The chrome SSE stream keyed its change detection off the bare pending-request *count*. Because latchkey requests are deduplicated by `(agent_id, scope, request_type)`, re-requesting the same scope (or resolving one request while another arrives) keeps the count constant while the contents change, so no update was emitted. The stream now diffs a content-based payload (`count` plus the ordered list of pending `request_ids`) and emits whenever the pending *set* changes. The SSE event was renamed from `request_count` to `requests` to reflect that it carries the id list, not just a count.
+
+- The Electron main-process SSE consumer (`runChromeSSELoop`) wedged permanently the first time the auth-cookie sync forced a reconnect: `req.abort()` does not emit a terminal event on Electron's `ClientRequest`, so the awaited connection promise never resolved and the live consumer died seconds after launch. The loop now resolves that promise directly on a forced reconnect (via a shared finish ref) instead of relying on `'abort'`/`'close'` events, the latter of which fired eagerly on healthy streaming responses and caused a reconnect storm that leaked backend SSE generators and exhausted the connection pool.
+
+In the Electron consumer, the requests panel now refreshes whenever the pending id set changes (not only on a count increase), and auto-open triggers when a genuinely new request id appears (so approving/denying never reopens a panel the user closed).

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -36,10 +36,18 @@ let hasCompletedInitialStart = false;
 const latestChromeState = {
   workspaces: null, // most recent workspaces payload
   authStatus: null, // most recent auth_status payload
-  requestCount: 0,  // most recent request_count value
+  requestCount: 0,  // most recent pending-request count
+  requestIds: [],   // most recent ordered list of pending request ids
 };
 
 const chromeSseAbortRef = { current: null };
+// Holds the in-flight connection's ``finish`` resolver so a forced reconnect
+// (e.g. after the auth cookie is synced) can resolve the awaited promise
+// directly. Electron's ``ClientRequest`` does not reliably emit a terminal
+// event on ``abort()``, and its ``'close'`` event fires eagerly on a healthy
+// streaming response (causing a reconnect storm), so neither can be relied on
+// to drive reconnection.
+const chromeSseFinishRef = { current: null };
 let chromeSseReconnectTick = 0; // bumped to interrupt the current wait
 
 function getSessionStatePath() {
@@ -536,7 +544,7 @@ function closeRequestsPanel(bundle) {
   updateBundleBounds(bundle);
 }
 
-// Coalesce rapid SSE-triggered reloads. A burst of request_count events
+// Coalesce rapid SSE-triggered reloads. A burst of requests events
 // (e.g. count 1 -> 2 -> 3 within a few ms) would otherwise restart the
 // panel load multiple times in flight, potentially preventing it from
 // ever settling on a rendered state, and multiplying backend HTTP load
@@ -865,28 +873,36 @@ function handleChromeSSEEvent(evt) {
     updateAllOsTitles();
   } else if (evt.type === 'auth_status') {
     latestChromeState.authStatus = evt;
-  } else if (evt.type === 'request_count') {
-    const prevCount = latestChromeState.requestCount;
+  } else if (evt.type === 'requests') {
+    const prevIds = latestChromeState.requestIds || [];
+    const newIds = Array.isArray(evt.request_ids) ? evt.request_ids.map(String) : [];
     const newCount = evt.count || 0;
-    // Backend defaults the setting to true, but treat a missing field the
-    // same way so older backends do not regress to no-auto-open.
+    // Backend defaults auto_open to true; treat a missing field the same way.
     const autoOpen = evt.auto_open !== false;
+    // Diff the pending *set* (ordered ids), not the count, so a swap at
+    // constant size still refreshes the panel. Auto-open keys off a
+    // genuinely new id appearing (not a count increase, which is blind to
+    // replacements), so approving/denying never reopens a panel the user
+    // closed.
+    const prevSet = new Set(prevIds);
+    const hasNewRequest = newIds.some((id) => !prevSet.has(id));
+    const idsChanged = newIds.length !== prevIds.length || hasNewRequest;
+    latestChromeState.requestIds = newIds;
     latestChromeState.requestCount = newCount;
-    // Auto-open only when the count actually went UP. Going down (e.g.
-    // user just approved/denied) should never reopen a panel the user
-    // closed, and equal counts mean nothing inbox-relevant changed.
-    const shouldAutoOpen = autoOpen && newCount > prevCount;
-    // Requests panel HTML is static at load time. Refresh visible panels
-    // so their cards reflect the new pending list, OR open hidden ones
-    // when shouldAutoOpen is set. ``openRequestsPanel`` reloads the panel
-    // itself for the visible-bundle case, so we never need to schedule a
-    // reload on top of an open call. Debounced per-bundle so a burst of
-    // count changes coalesces into one reload per panel.
-    for (const b of bundles) {
-      if (shouldAutoOpen && !b.requestsPanelVisible) {
-        openRequestsPanel(b);
-      } else {
-        scheduleRequestsPanelReload(b);
+    const shouldAutoOpen = autoOpen && hasNewRequest;
+    // Requests panel HTML is static at load time. Refresh visible panels so
+    // their cards reflect the new pending set whenever it changed, OR open
+    // hidden ones when shouldAutoOpen is set. ``openRequestsPanel`` reloads
+    // the panel itself for the visible-bundle case, so we never need to
+    // schedule a reload on top of an open call. Debounced per-bundle so a
+    // burst of changes coalesces into one reload per panel.
+    if (idsChanged || shouldAutoOpen) {
+      for (const b of bundles) {
+        if (shouldAutoOpen && !b.requestsPanelVisible) {
+          openRequestsPanel(b);
+        } else {
+          scheduleRequestsPanelReload(b);
+        }
       }
     }
   }
@@ -914,7 +930,11 @@ function primeViewWithCachedChromeState(wc) {
   if (latestChromeState.authStatus) {
     wc.send('chrome-event', latestChromeState.authStatus);
   }
-  wc.send('chrome-event', { type: 'request_count', count: latestChromeState.requestCount });
+  wc.send('chrome-event', {
+    type: 'requests',
+    count: latestChromeState.requestCount,
+    request_ids: latestChromeState.requestIds,
+  });
 }
 
 function kickChromeSSEReconnect() {
@@ -923,6 +943,11 @@ function kickChromeSSEReconnect() {
   if (req) {
     try { req.abort(); } catch { /* noop */ }
   }
+  // ``req.abort()`` does not reliably emit a terminal event on Electron's
+  // ClientRequest, so resolve the in-flight connection promise directly to
+  // guarantee the loop reconnects rather than wedging on an unresolved await.
+  const finish = chromeSseFinishRef.current;
+  if (finish) finish();
 }
 
 async function runChromeSSELoop() {
@@ -939,6 +964,7 @@ async function runChromeSSELoop() {
         if (finished) return;
         finished = true;
         chromeSseAbortRef.current = null;
+        chromeSseFinishRef.current = null;
         resolve();
       };
       let req;
@@ -953,12 +979,13 @@ async function runChromeSSELoop() {
         return;
       }
       chromeSseAbortRef.current = req;
+      chromeSseFinishRef.current = finish;
       req.setHeader('Accept', 'text/event-stream');
       req.on('response', (response) => {
         if (response.statusCode !== 200) {
           response.on('data', () => {});
-          response.on('end', finish);
-          response.on('error', finish);
+          response.on('end', () => finish());
+          response.on('error', () => finish());
           return;
         }
         let buffer = '';
@@ -976,10 +1003,11 @@ async function runChromeSSELoop() {
             } catch { /* ignore bad frames */ }
           }
         });
-        response.on('end', finish);
-        response.on('error', finish);
+        response.on('end', () => finish());
+        response.on('error', () => finish());
+        response.on('aborted', () => finish());
       });
-      req.on('error', finish);
+      req.on('error', () => finish());
       req.end();
     });
     // Brief backoff before reconnecting.

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1608,14 +1608,14 @@ async def _handle_chrome_events(
             last_providers_data = _build_providers_state_payload(backend_resolver)
             yield "data: {}\n\n".format(json.dumps({"type": "providers_state", **last_providers_data}))
             inbox: RequestInbox | None = request.app.state.request_inbox
-            last_request_count = inbox.get_pending_count() if inbox else 0
-            # ``auto_open`` is bundled with ``request_count`` (rather than its
-            # own SSE event) so the Electron shell sees both atomically when
-            # deciding whether to auto-open the panel on count increases.
+            last_requests_payload = _build_requests_payload(inbox)
+            # ``auto_open`` is bundled with the requests payload (rather than
+            # its own SSE event) so the Electron shell sees both atomically
+            # when deciding whether to auto-open the panel.
             minds_config: MindsConfig | None = request.app.state.minds_config
             auto_open = minds_config.get_auto_open_requests_panel() if minds_config else True
             yield "data: {}\n\n".format(
-                json.dumps({"type": "request_count", "count": last_request_count, "auto_open": auto_open})
+                json.dumps({"type": "requests", **last_requests_payload, "auto_open": auto_open})
             )
 
             if tracker is not None:
@@ -1688,12 +1688,15 @@ async def _handle_chrome_events(
                     yield "data: {}\n\n".format(json.dumps({"type": "providers_state", **current_providers_data}))
 
                 inbox = request.app.state.request_inbox
-                current_request_count = inbox.get_pending_count() if inbox else 0
-                if current_request_count != last_request_count:
-                    last_request_count = current_request_count
+                current_requests_payload = _build_requests_payload(inbox)
+                # Diff the full payload (count + ordered pending ids), not just
+                # the count, so a change to the pending *set* at constant size
+                # still pushes an update and the panel refreshes.
+                if current_requests_payload != last_requests_payload:
+                    last_requests_payload = current_requests_payload
                     auto_open = minds_config.get_auto_open_requests_panel() if minds_config else True
                     yield "data: {}\n\n".format(
-                        json.dumps({"type": "request_count", "count": current_request_count, "auto_open": auto_open})
+                        json.dumps({"type": "requests", **current_requests_payload, "auto_open": auto_open})
                     )
         finally:
             if isinstance(backend_resolver, MngrCliBackendResolver):
@@ -1821,6 +1824,26 @@ def _build_workspace_list(
                 entry["account"] = account.email
         workspaces.append(entry)
     return workspaces
+
+
+def _build_requests_payload(inbox: RequestInbox | None) -> dict[str, Any]:
+    """Build the content-based requests payload pushed over the chrome SSE.
+
+    The chrome's live request UI (badge, panel refresh, auto-open) must react
+    to any change in the *set* of pending requests, not merely its size. A
+    bare count is a lossy summary: if one request is resolved while another
+    arrives, or a request is replaced under the same dedup key, the count is
+    unchanged even though the inbox contents are not. Keying updates off the
+    count therefore silently drops those transitions.
+
+    To make change detection sound, we surface the actual pending request
+    ids (in a deterministic order) alongside the count. Consumers diff
+    ``request_ids`` to decide whether to refresh the panel and which ids are
+    newly arrived (for auto-open); the count remains for the badge.
+    """
+    pending = inbox.get_pending_requests() if inbox else []
+    request_ids = [str(req.event_id) for req in pending]
+    return {"count": len(request_ids), "request_ids": request_ids}
 
 
 # -- System-interface recovery / restart --
@@ -2673,7 +2696,7 @@ def _handle_request_event_callback(agent_id_str: str, raw_line: str) -> None:
     """Process an incoming request event and add it to the app's inbox.
 
     After mutating the inbox, fires the resolver's change notification so
-    the chrome SSE wakes up and pushes the new ``request_count`` immediately
+    the chrome SSE wakes up and pushes the new ``requests`` payload immediately
     (otherwise it would lag up to 30s for the next poll tick, breaking the
     requests panel auto-open and badge UX).
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -272,7 +272,7 @@ class FileSharingGrantHandler(RequestEventHandler):
 
         Without this the resolved card stays visible in the requests
         panel until the next desktop-client restart. Also wakes the
-        chrome SSE so the new ``request_count`` is pushed without
+        chrome SSE so the new ``requests`` payload is pushed without
         waiting for the 30s heartbeat.
         """
         inbox: RequestInbox | None = request.app.state.request_inbox

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -714,7 +714,7 @@ class LatchkeyPermissionGrantHandler(RequestEventHandler):
         is just so the requests panel doesn't show the resolved request as
         still pending until the next desktop-client restart.
 
-        Also wakes the chrome SSE so the new ``request_count`` is pushed
+        Also wakes the chrome SSE so the new ``requests`` payload is pushed
         right away -- otherwise the panel would keep showing the resolved
         card for up to 30s while the SSE poll waits for its next tick.
         """

--- a/apps/minds/imbue/minds/desktop_client/static/chrome.js
+++ b/apps/minds/imbue/minds/desktop_client/static/chrome.js
@@ -255,7 +255,7 @@
     try {
       if (data.type === 'workspaces') renderWorkspaces(data.workspaces);
       if (data.type === 'auth_status') updateAuthUI(data);
-      if (data.type === 'request_count') updateRequestsBadge(data.count);
+      if (data.type === 'requests') updateRequestsBadge(data.count);
       if (data.type === 'system_interface_status') handleSystemInterfaceStatus(data.agent_id, data.status);
     } catch (e) {}
   }

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -15,6 +15,7 @@ from imbue.minds.desktop_client.agent_creator import AgentCreationStatus
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.agent_creator import LOG_SENTINEL
 from imbue.minds.desktop_client.app import _build_mngr_exec_argv
+from imbue.minds.desktop_client.app import _build_requests_payload
 from imbue.minds.desktop_client.app import _build_workspace_list
 from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
@@ -33,7 +34,9 @@ from imbue.minds.desktop_client.imbue_cloud_cli import ImbueCloudCli
 from imbue.minds.desktop_client.minds_config import MindsConfig
 from imbue.minds.desktop_client.notification import NotificationDispatcher
 from imbue.minds.desktop_client.request_events import RequestInbox
+from imbue.minds.desktop_client.request_events import RequestStatus
 from imbue.minds.desktop_client.request_events import create_latchkey_predefined_permission_request_event
+from imbue.minds.desktop_client.request_events import create_request_response_event
 from imbue.minds.desktop_client.system_interface_health import AgentHealth
 from imbue.minds.desktop_client.system_interface_health import SystemInterfaceHealthTracker
 from imbue.minds.primitives import CreationId
@@ -1200,6 +1203,55 @@ def test_chrome_events_sse_returns_workspaces_when_authenticated(tmp_path: Path)
     workspaces = _build_workspace_list(backend_resolver)
     assert len(workspaces) == 1
     assert workspaces[0]["id"] == str(agent_id)
+
+
+def test_build_requests_payload_empty_inbox() -> None:
+    """An empty inbox yields a zero count and no pending ids."""
+    assert _build_requests_payload(None) == {"count": 0, "request_ids": []}
+    assert _build_requests_payload(RequestInbox()) == {"count": 0, "request_ids": []}
+
+
+def test_build_requests_payload_carries_pending_ids() -> None:
+    """A pending request surfaces its event_id alongside the count."""
+    agent_id = str(AgentId())
+    event = create_latchkey_predefined_permission_request_event(
+        agent_id=agent_id, scope="slack-api", rationale="post updates"
+    )
+    payload = _build_requests_payload(RequestInbox().add_request(event))
+    assert payload == {"count": 1, "request_ids": [str(event.event_id)]}
+
+
+def test_build_requests_payload_distinguishes_equal_count_different_contents() -> None:
+    """A swap of the pending set at constant size changes the payload.
+
+    This is the soundness property: keying live updates off the bare count
+    would miss this transition (count stays 1), so the payload must differ.
+    """
+    agent_id = str(AgentId())
+    request_a = create_latchkey_predefined_permission_request_event(
+        agent_id=agent_id, scope="slack-api", rationale="a"
+    )
+    request_b = create_latchkey_predefined_permission_request_event(
+        agent_id=agent_id, scope="github-api", rationale="b"
+    )
+
+    inbox_with_a = RequestInbox().add_request(request_a)
+    # Resolve A and add B: the pending set becomes {B}, same size as {A}.
+    inbox_with_b = inbox_with_a.add_response(
+        create_request_response_event(
+            request_event_id=str(request_a.event_id),
+            status=RequestStatus.GRANTED,
+            agent_id=agent_id,
+            request_type=request_a.request_type,
+            scope="slack-api",
+        )
+    ).add_request(request_b)
+
+    payload_a = _build_requests_payload(inbox_with_a)
+    payload_b = _build_requests_payload(inbox_with_b)
+    assert payload_a["count"] == payload_b["count"] == 1
+    assert payload_a != payload_b
+    assert payload_b["request_ids"] == [str(request_b.event_id)]
 
 
 # -- Tests for new account management and request routes --


### PR DESCRIPTION
The request side panel used to be stale - changes in permission requests wouldn't propagate until the panel was closed & reopened. Auto-opening didn't work and the red dot notification didn't work, either.