### PR TITLE
Permission requests in modal view

### DIFF
--- a/apps/minds/changelog/hynek-permission-requests-in-modal-view.md
+++ b/apps/minds/changelog/hynek-permission-requests-in-modal-view.md
@@ -1,0 +1,3 @@
+Permission request dialogs now open in a modal overlay instead of replacing the main content window.
+
+When a user clicks a permission request card in the side panel, the request page (`/requests/<event_id>`) now opens in a transparent full-content-area overlay (`modalView`) stacked above the workspace, with a dim backdrop. The workspace view is never navigated away, so the user keeps the context of their work; dismissing the dialog (via Approve/Deny, the close button, a backdrop click, or Escape) returns them to exactly where they were. Opened directly in a browser with no modal host, the page degrades to a dimmed, centered card and dismissal navigates home.

--- a/apps/minds/docs/desktop-app.md
+++ b/apps/minds/docs/desktop-app.md
@@ -41,7 +41,7 @@ Closing an individual window just tears down that window's views -- the backend 
 
 ### Crash recovery
 
-If the backend exits unexpectedly, every open window switches to the error screen (chrome view expanded to fill the window, content/sidebar/requests-panel views torn down) with the last lines from the log file. Clicking "Retry" from any window restarts the backend once; on success every window reloads to its pre-error URL.
+If the backend exits unexpectedly, every open window switches to the error screen (chrome view expanded to fill the window, content/sidebar/requests-panel/modal views torn down) with the last lines from the log file. Clicking "Retry" from any window restarts the backend once; on success every window reloads to its pre-error URL.
 
 ### Keyboard shortcuts
 

--- a/apps/minds/docs/latchkey-permissions.md
+++ b/apps/minds/docs/latchkey-permissions.md
@@ -28,7 +28,14 @@ and how the agent receives the answer.
    request events file via `mngr events --follow`, adds a card to the
    right-side requests inbox panel, and surfaces a notification.
 5. **User opens the dialog.** Clicking the card opens
-   `/requests/<event_id>`, which renders a single-scope permission dialog:
+   `/requests/<event_id>` in a **modal overlay** over the current window
+   (a transparent full-content-area `WebContentsView` stacked above the
+   workspace, with a dim backdrop). The user's workspace view is never
+   navigated away, so dismissing the dialog -- via Approve/Deny, the close
+   button, a backdrop click, or Escape -- returns them to their work with
+   no context lost. (Opened directly in a browser, with no modal host, the
+   page degrades to a dimmed, centered card and dismissal navigates home.)
+   The page renders a single-scope permission dialog:
    * The dialog header names the service plainly (no monospace pill) and
      attributes the agent's rationale prominently as
      "`<workspace>` says:" -- this is the main place the requesting

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -107,7 +107,7 @@ function getBundleFromEvent(event) {
   const senderId = event.sender.id;
   for (const b of bundles) {
     if (b.window.isDestroyed()) continue;
-    const views = [b.chromeView, b.contentView, b.sidebarView, b.requestsPanelView];
+    const views = [b.chromeView, b.contentView, b.sidebarView, b.requestsPanelView, b.modalView];
     for (const v of views) {
       if (!v) continue;
       if (v.webContents.isDestroyed()) continue;
@@ -204,6 +204,19 @@ function updateBundleBounds(bundle) {
       height: height - TITLEBAR_HEIGHT,
     });
   }
+  // The modal overlays the entire content area (everything below the title
+  // bar, including the sidebar and requests panel). The title bar stays
+  // uncovered so window controls and the drag handle remain usable. The
+  // view is transparent, so the dialog's own dim backdrop shows the
+  // workspace behind it.
+  if (bundle.modalView && !bundle.modalView.webContents.isDestroyed()) {
+    bundle.modalView.setBounds({
+      x: 0,
+      y: TITLEBAR_HEIGHT,
+      width,
+      height: height - TITLEBAR_HEIGHT,
+    });
+  }
 }
 
 // -- Bundle lifecycle --
@@ -277,7 +290,7 @@ function wireBundleWindowEvents(bundle) {
       clearTimeout(bundle.requestsPanelReloadTimer);
       bundle.requestsPanelReloadTimer = null;
     }
-    const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView];
+    const views = [bundle.chromeView, bundle.contentView, bundle.sidebarView, bundle.requestsPanelView, bundle.modalView];
     for (const view of views) {
       if (!view) continue;
       if (view.webContents.isDestroyed()) continue;
@@ -324,6 +337,8 @@ function createBundle() {
     requestsPanelView: null,
     requestsPanelVisible: false,
     requestsPanelReloadTimer: null,
+    modalView: null,
+    modalVisible: false,
     currentContentUrl: null,
     currentWorkspaceId: null,
     preErrorUrl: null,
@@ -571,6 +586,63 @@ function toggleRequestsPanel(bundle) {
   else openRequestsPanel(bundle);
 }
 
+// -- Modal overlay (per-bundle) --
+//
+// The modal is a full-content-area overlay used for transient dialogs (the
+// permission request page) that should not replace the user's workspace in
+// the content view. Like the sidebar / requests panel it is created lazily
+// and reused via setVisible(true/false). It uses the default session (so it
+// carries the auth cookie, like the chrome / requests-panel views) plus the
+// preload bridge, so the page inside can call `window.minds.closeModal()`.
+
+function openModal(bundle, url) {
+  if (!bundle || bundle.window.isDestroyed() || !url) return;
+  if (!bundle.modalView) {
+    const modal = new WebContentsView({
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+    // Transparent background so the dialog's own dim backdrop reveals the
+    // workspace underneath instead of an opaque rectangle.
+    modal.setBackgroundColor('#00000000');
+    bundle.modalView = modal;
+    bundle.window.contentView.addChildView(modal);
+    registerShortcutsFor(bundle, modal.webContents);
+    // Escape closes the modal even if the page's own key handling fails.
+    modal.webContents.on('before-input-event', (event, input) => {
+      if (input.type === 'keyDown' && input.key === 'Escape') {
+        event.preventDefault();
+        closeModal(bundle);
+      }
+    });
+  } else {
+    // Re-add to the parent to raise to the top of z-order, then make visible.
+    bundle.window.contentView.removeChildView(bundle.modalView);
+    bundle.window.contentView.addChildView(bundle.modalView);
+    bundle.modalView.setVisible(true);
+  }
+  bundle.modalVisible = true;
+  if (!bundle.modalView.webContents.isDestroyed()) {
+    bundle.modalView.webContents.loadURL(url);
+  }
+  updateBundleBounds(bundle);
+}
+
+function closeModal(bundle) {
+  if (!bundle || bundle.window.isDestroyed()) return;
+  if (!bundle.modalView || !bundle.modalVisible) return;
+  bundle.modalView.setVisible(false);
+  bundle.modalVisible = false;
+  // Drop the page so its websockets/timers stop and a stale dialog isn't
+  // briefly visible the next time the modal opens.
+  if (!bundle.modalView.webContents.isDestroyed()) {
+    bundle.modalView.webContents.loadURL('about:blank').catch(() => {});
+  }
+}
+
 function sendCurrentWorkspaceToBundleViews(bundle) {
   if (!bundle) return;
   // Both the titlebar (chrome view) and the sidebar key UI off the current
@@ -650,6 +722,7 @@ function showErrorInAllWindows(message, details) {
 
     if (bundle.sidebarView) closeSidebar(bundle);
     if (bundle.requestsPanelView) closeRequestsPanel(bundle);
+    if (bundle.modalView) closeModal(bundle);
 
     if (bundle.contentView && !bundle.contentView.webContents.isDestroyed()) {
       bundle.window.contentView.removeChildView(bundle.contentView);
@@ -1648,27 +1721,19 @@ ipcMain.on('open-workspace-in-new-window', (event, agentId) => {
   if (bundle) closeSidebar(bundle);
 });
 
-ipcMain.on('navigate-to-request', (event, agentId, eventId) => {
+ipcMain.on('navigate-to-request', (event, _agentId, eventId) => {
   if (!eventId) return;
   const url = toAbsoluteUrl('/requests/' + eventId);
+  // Open the request in a modal overlay in the window the user clicked from,
+  // rather than navigating its content view. This keeps the user's workspace
+  // exactly as they left it -- closing the dialog returns them to their work
+  // with no context lost, and no window switching.
   const sender = getBundleFromEvent(event);
-  // Route to the workspace's window when one is open so the request page
-  // lives alongside the workspace it's about, rather than wherever the user
-  // happened to click the request card from.
-  if (agentId) {
-    const existing = findBundleForWorkspace(agentId);
-    if (existing) {
-      focusBundle(existing);
-      if (existing.contentView && !existing.contentView.webContents.isDestroyed()) {
-        existing.contentView.webContents.loadURL(url);
-      }
-      return;
-    }
-  }
-  // Fallback: no window for this workspace -- open the request in the sender.
-  if (sender && sender.contentView && !sender.contentView.webContents.isDestroyed()) {
-    sender.contentView.webContents.loadURL(url);
-  }
+  if (sender) openModal(sender, url);
+});
+
+ipcMain.on('close-modal', (event) => {
+  closeModal(getBundleFromEvent(event));
 });
 
 ipcMain.on('show-workspace-context-menu', (event, agentId, x, y) => {

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -39,6 +39,9 @@ contextBridge.exposeInMainWorld('minds', {
   toggleRequestsPanel: () => ipcRenderer.send('toggle-requests-panel'),
   openRequestsPanel: () => ipcRenderer.send('open-requests-panel'),
 
+  // Modal overlay (e.g. permission request dialogs)
+  closeModal: () => ipcRenderer.send('close-modal'),
+
   // Multi-window workspace actions
   openWorkspaceInNewWindow: (agentId) =>
     ipcRenderer.send('open-workspace-in-new-window', agentId),

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -212,7 +212,7 @@ def _render_unknown_scope_page(request_id: str, scope: str) -> Response:
     escaped_scope = html_module.escape(scope)
     escaped_request_id = html_module.escape(request_id, quote=True)
     body = (
-        "<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
+        '<!DOCTYPE html><html><head><meta charset="UTF-8">'
         "<title>Unknown scope</title>"
         "<style>body{margin:0;font-family:-apple-system,sans-serif;background:transparent;}"
         ".backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.4);display:flex;"

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -205,14 +205,43 @@ def _render_unknown_scope_page(request_id: str, scope: str) -> Response:
     No catalog entry means we have no permissions to offer the user; the
     only sensible action is to send the request straight to deny.
     """
+    # Rendered inside the desktop client's transparent modal overlay (same as
+    # the catalog-backed dialog), so it uses a dim backdrop + centered card and
+    # a JS-driven Deny that closes the modal rather than a raw form post (which
+    # would render the deny endpoint's JSON response inside the overlay).
+    escaped_scope = html_module.escape(scope)
+    escaped_request_id = html_module.escape(request_id, quote=True)
     body = (
-        "<!DOCTYPE html><html><body><h1>Unknown scope</h1>"
-        f"<p>The agent requested permissions under scope <code>{html_module.escape(scope)}</code>, "
+        "<!DOCTYPE html><html><head><meta charset=\"UTF-8\">"
+        "<title>Unknown scope</title>"
+        "<style>body{margin:0;font-family:-apple-system,sans-serif;background:transparent;}"
+        ".backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.4);display:flex;"
+        "align-items:flex-start;justify-content:center;overflow-y:auto;padding:24px;}"
+        ".dialog{width:100%;max-width:640px;margin:auto;background:#fff;border:1px solid #e4e4e7;"
+        "border-radius:16px;box-shadow:0 10px 25px rgba(0,0,0,0.15);padding:28px;}"
+        "h1{font-size:22px;margin:0 0 12px;color:#18181b;}p{color:#3f3f46;line-height:1.5;}"
+        "code{background:#f4f4f5;padding:2px 5px;border-radius:4px;}"
+        ".actions{display:flex;justify-content:flex-end;margin-top:20px;}"
+        "button{padding:8px 14px;border-radius:6px;font-size:14px;font-weight:500;cursor:pointer;"
+        "background:#fef2f2;color:#dc2626;border:1px solid #fecaca;}button:hover{background:#fee2e2;}"
+        "</style></head><body>"
+        '<div class="backdrop" onclick="if(event.target.classList.contains(\'backdrop\'))closeDialog()">'
+        '<div class="dialog"><h1>Unknown scope</h1>'
+        f"<p>The agent requested permissions under scope <code>{escaped_scope}</code>, "
         "but this scope is not in the latchkey gateway's permission catalog. The request can only "
         "be denied from here.</p>"
-        f'<form method="POST" action="/requests/{html_module.escape(request_id, quote=True)}/deny">'
-        '<button type="submit">Deny</button></form>'
-        "</body></html>"
+        '<div class="actions"><button type="button" onclick="denyRequest()">Deny</button></div>'
+        "</div></div>"
+        "<script>"
+        "function closeDialog(){"
+        "if(window.minds&&window.minds.closeModal){window.minds.closeModal();}"
+        'else{window.location.href="/";}}'
+        "function denyRequest(){"
+        f'fetch("/requests/{escaped_request_id}/deny",'
+        '{method:"POST",credentials:"same-origin",keepalive:true}).catch(function(){});'
+        "closeDialog();}"
+        'document.addEventListener("keydown",function(e){if(e.key==="Escape")closeDialog();});'
+        "</script></body></html>"
     )
     return HTMLResponse(content=body, status_code=200)
 

--- a/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
+++ b/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
@@ -341,6 +341,12 @@ def test_get_permission_request_page_renders_as_modal(tmp_path: Path) -> None:
     # Backdrop click and Escape are wired to the same dismissal helper.
     assert "onBackdropClick" in body
     assert 'e.key === "Escape"' in body
+    # Overflow scrolls inside the dialog card (capped at the viewport height
+    # with an inner scroll region), not down the full width of the app.
+    dialog_idx = body.find('id="permissions-dialog"')
+    dialog_tag_end = body.find(">", dialog_idx)
+    assert "max-h-full" in body[dialog_idx:dialog_tag_end]
+    assert "overflow-y-auto" in body
 
 
 def test_get_permission_request_page_shows_descriptions_when_present(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
+++ b/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
@@ -300,6 +300,49 @@ def test_get_permission_request_page_pre_checks_agent_requested_permissions(tmp_
     assert "disabled" in body
 
 
+def test_get_permission_request_page_renders_as_modal(tmp_path: Path) -> None:
+    """The request page is rendered as a dismissable modal overlay.
+
+    The desktop client hosts it in a transparent full-window overlay view
+    stacked over the workspace, so the page provides a dim backdrop, a
+    centered dialog card, and a close affordance. Dismissal (close button,
+    backdrop click, Escape, or a completed grant/deny) must prefer the
+    Electron modal host (``window.minds.closeModal``) so the workspace view
+    is left untouched, falling back to navigating home only when no modal
+    host is present (page opened directly in a browser).
+    """
+    agent_id = AgentId()
+    request = create_latchkey_predefined_permission_request_event(
+        agent_id=str(agent_id),
+        scope="slack-api",
+        permissions=("slack-read-all",),
+        rationale="reason",
+    )
+    inbox = RequestInbox().add_request(request)
+    handler = _make_recording_handler(tmp_path)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    response = client.get(f"/requests/{request.event_id}")
+
+    assert response.status_code == 200
+    body = response.text
+    # Modal scaffolding: a dim backdrop, a dialog card, and a close button.
+    assert 'id="permissions-backdrop"' in body
+    assert 'id="permissions-dialog"' in body
+    assert 'id="permissions-close-btn"' in body
+    # The transparent body lets the overlay reveal the workspace behind it.
+    assert "bg-transparent" in body
+    # Dismissal prefers the Electron modal host over a home navigation.
+    assert "window.minds.closeModal" in body
+    closemodal_idx = body.find("window.minds.closeModal")
+    href_idx = body.find('window.location.href = "/"')
+    assert closemodal_idx != -1 and href_idx != -1
+    assert closemodal_idx < href_idx, "closeModal must be preferred over the home-nav fallback"
+    # Backdrop click and Escape are wired to the same dismissal helper.
+    assert "onBackdropClick" in body
+    assert 'e.key === "Escape"' in body
+
+
 def test_get_permission_request_page_shows_descriptions_when_present(tmp_path: Path) -> None:
     """detent's per-permission descriptions are rendered next to each permission when present."""
     agent_id = AgentId()

--- a/apps/minds/imbue/minds/desktop_client/templates/permissions.html
+++ b/apps/minds/imbue/minds/desktop_client/templates/permissions.html
@@ -44,19 +44,24 @@
 {% block body_class %}bg-transparent text-zinc-900 font-sans antialiased{% endblock %}
 {% block body_style %}--workspace-accent: {{ accent }};{% endblock %}
 {% block content %}
+  {# The backdrop only centers the dialog; it never scrolls. The dialog is
+     capped at the viewport height and its inner wrapper scrolls, so an
+     overflowing dialog (e.g. after "Adjust" reveals the editor) shows a
+     scrollbar inside the card rather than down the full width of the app. #}
   <div id="permissions-backdrop"
-       class="fixed inset-0 bg-black/40 flex items-start justify-center overflow-y-auto p-6"
+       class="fixed inset-0 bg-black/40 flex items-center justify-center p-6"
        onclick="onBackdropClick(event)">
     <div id="permissions-dialog"
-         class="relative w-full max-w-[640px] my-auto bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden p-6 sm:p-7">
+         class="relative w-full max-w-[640px] max-h-full flex flex-col bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden">
       <button type="button" id="permissions-close-btn" aria-label="Close"
               onclick="closePermissionDialog()"
-              class="absolute top-3 right-3 inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer">
+              class="absolute top-3 right-3 z-10 inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer">
         <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="w-5 h-5">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M4.22 4.22a.75.75 0 0 1 1.06 0L10 8.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L11.06 10l4.72 4.72a.75.75 0 1 1-1.06 1.06L10 11.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L8.94 10 4.22 5.28a.75.75 0 0 1 0-1.06Z" />
         </svg>
       </button>
+      <div class="overflow-y-auto min-h-0 p-6 sm:p-7">
     <h1 class="text-2xl font-semibold text-zinc-900 leading-tight pr-8">
       Permission request:
       {# Plain heading text: the display name (a service label like #}
@@ -114,6 +119,7 @@
         <p id="permissions-error-message"></p>
       {% endcall %}
     </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/apps/minds/imbue/minds/desktop_client/templates/permissions.html
+++ b/apps/minds/imbue/minds/desktop_client/templates/permissions.html
@@ -36,11 +36,28 @@
 {% extends 'base.html' %}
 {% import '_macros.html' as ui %}
 {% block title %}Permission request: {{ display_name }}{% endblock %}
-{% block body_class %}bg-zinc-50 text-zinc-900 font-sans antialiased page-workspace{% endblock %}
+{# Transparent body so the dialog reads as a modal: the desktop client hosts
+   this page in a transparent full-window overlay view stacked over the
+   workspace, and the dim backdrop below reveals the workspace behind it.
+   Opened directly in a browser (no modal host) it degrades to a dimmed,
+   centered card on the default surface. #}
+{% block body_class %}bg-transparent text-zinc-900 font-sans antialiased{% endblock %}
 {% block body_style %}--workspace-accent: {{ accent }};{% endblock %}
 {% block content %}
-  {% call ui.page_container() %}
-    <h1 class="text-2xl font-semibold text-zinc-900 leading-tight">
+  <div id="permissions-backdrop"
+       class="fixed inset-0 bg-black/40 flex items-start justify-center overflow-y-auto p-6"
+       onclick="onBackdropClick(event)">
+    <div id="permissions-dialog"
+         class="accent-spine relative w-full max-w-[640px] my-auto bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden p-6 sm:p-7">
+      <button type="button" id="permissions-close-btn" aria-label="Close"
+              onclick="closePermissionDialog()"
+              class="absolute top-3 right-3 inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer">
+        <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" class="w-5 h-5">
+          <path fill-rule="evenodd" clip-rule="evenodd"
+                d="M4.22 4.22a.75.75 0 0 1 1.06 0L10 8.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L11.06 10l4.72 4.72a.75.75 0 1 1-1.06 1.06L10 11.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L8.94 10 4.22 5.28a.75.75 0 0 1 0-1.06Z" />
+        </svg>
+      </button>
+    <h1 class="text-2xl font-semibold text-zinc-900 leading-tight pr-8">
       Permission request:
       {# Plain heading text: the display name (a service label like #}
       {# "Slack" or a file path) reads better without a boxed monospace #}
@@ -97,10 +114,32 @@
         <p id="permissions-error-message"></p>
       {% endcall %}
     </div>
-  {% endcall %}
+    </div>
+  </div>
 {% endblock %}
 {% block scripts %}
 <script>
+  // Dismiss the dialog: prefer the desktop client's modal host (which hides
+  // the overlay view and returns the user to their untouched workspace);
+  // fall back to navigating home when opened directly in a browser.
+  window.closePermissionDialog = function () {
+    if (window.minds && window.minds.closeModal) {
+      window.minds.closeModal();
+    } else {
+      window.location.href = "/";
+    }
+  };
+  // Only dismiss when the click lands on the backdrop itself, not inside the
+  // dialog card.
+  window.onBackdropClick = function (event) {
+    if (event.target && event.target.id === "permissions-backdrop") {
+      window.closePermissionDialog();
+    }
+  };
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") window.closePermissionDialog();
+  });
+
   (function () {
     const form = document.getElementById("permissions-form");
     const approveBtn = document.getElementById("permissions-approve-btn");
@@ -142,7 +181,7 @@
         }
         const data = await response.json();
         if (data.outcome === "GRANTED") {
-          window.location.href = "/";
+          window.closePermissionDialog();
           return;
         }
         if (progress) progress.classList.add("hidden");
@@ -183,7 +222,7 @@
         credentials: "same-origin",
         keepalive: true,
       }).catch(function () {});
-      window.location.href = "/";
+      window.closePermissionDialog();
     };
   })();
 </script>

--- a/apps/minds/imbue/minds/desktop_client/templates/permissions.html
+++ b/apps/minds/imbue/minds/desktop_client/templates/permissions.html
@@ -48,7 +48,7 @@
        class="fixed inset-0 bg-black/40 flex items-start justify-center overflow-y-auto p-6"
        onclick="onBackdropClick(event)">
     <div id="permissions-dialog"
-         class="accent-spine relative w-full max-w-[640px] my-auto bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden p-6 sm:p-7">
+         class="relative w-full max-w-[640px] my-auto bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden p-6 sm:p-7">
       <button type="button" id="permissions-close-btn" aria-label="Close"
               onclick="closePermissionDialog()"
               class="absolute top-3 right-3 inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer">


### PR DESCRIPTION
Render the permission request dialog in a modal window so that user doesn't lose the context of their work. (Requested by Kanjun and partially also by Gleb.)

<img width="1686" height="986" alt="modal_window" src="https://github.com/user-attachments/assets/f59a3479-8fe1-4e0e-befa-d5b58f62b1a7" />
