### PR TITLE
Consolidate error hierarchy: all mngr errors inherit from MngrError

### DIFF
--- a/libs/mngr/changelog/mngr-fix-error-hierarchy-agent.md
+++ b/libs/mngr/changelog/mngr-fix-error-hierarchy-agent.md
@@ -1,0 +1,12 @@
+`AgentError` (and all of its subclasses, e.g. `NoCommandDefinedError`, `AgentNotFoundOnHostError`,
+`SendMessageError`, `AgentStartError`) now inherit from `MngrError` instead of `BaseMngrError`.
+The remaining `BaseMngrError`-only error types -- `PluginSpecifierError`,
+`DiscoverySchemaChangedError`, `MalformedJsonlLineError`, `TolerantPathError`, and
+`IssueSearchError` -- were moved the same way. This completes the consolidation of the error
+hierarchy under a single user-facing parent class: every mngr error is now a `ClickException`,
+so when one reaches the CLI it renders as a clean `Error: ...` message (plus any help text)
+instead of a Python traceback, and `except MngrError` handlers treat them as the user-facing
+errors they are.
+
+The now-redundant `MngrError` mix-in on `AgentNotFoundError` and `DuplicateAgentNameError`
+(which already reached `MngrError` via `AgentError`) was removed; both still behave identically.

--- a/libs/mngr/imbue/mngr/api/message_test.py
+++ b/libs/mngr/imbue/mngr/api/message_test.py
@@ -269,9 +269,9 @@ def test_send_message_one_agent_failure_does_not_prevent_other_agents(
 ) -> None:
     """One agent's SendMessageError must not kill the broadcast to other agents.
 
-    SendMessageError inherits from BaseMngrError (not MngrError). Before the switch
-    to concurrent sends, the serial loop only caught MngrError, so a SendMessageError
-    would propagate up and abort the entire broadcast.
+    SendMessageError is an AgentError, which inherits from MngrError. The per-agent
+    send is guarded by ``except BaseMngrError`` so that, in CONTINUE mode, one
+    agent's failure is recorded without aborting the broadcast to the others.
     """
     host = local_provider.create_host(HostName(LOCAL_HOST_NAME))
     assert isinstance(host, Host)

--- a/libs/mngr/imbue/mngr/cli/issue_reporting.py
+++ b/libs/mngr/imbue/mngr/cli/issue_reporting.py
@@ -19,7 +19,7 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ConcurrencyGroupError
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
-from imbue.mngr.errors import BaseMngrError
+from imbue.mngr.errors import MngrError
 
 GITHUB_REPO: Final[str] = "imbue-ai/mngr"
 GITHUB_BASE_URL: Final[str] = f"https://github.com/{GITHUB_REPO}"
@@ -32,7 +32,7 @@ _MAX_URL_LENGTH: Final[int] = 8000
 _TRUNCATION_SUFFIX: Final[str] = "\n\n_(truncated)_"
 
 
-class IssueSearchError(BaseMngrError):
+class IssueSearchError(MngrError):
     """Raised when searching for GitHub issues fails."""
 
 

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -120,15 +120,22 @@ class LockNotHeldError(HostError):
     """Raised when attempting to use a lock that is not held."""
 
 
-class AgentError(BaseMngrError):
-    """Base class for agent-related errors."""
+class AgentError(MngrError):
+    """Base class for agent-related errors.
+
+    Inherits from MngrError (not just BaseMngrError) so that agent errors are
+    ClickException instances: when they reach the CLI they render as a clean
+    ``Error: ...`` message (plus any user_help_text) instead of a traceback,
+    and ``except MngrError`` handlers treat them as the user-facing errors
+    they are.
+    """
 
 
 class NoCommandDefinedError(AgentError, ValueError):
     """Raised when no command is defined for an agent type."""
 
 
-class AgentNotFoundError(AgentError, MngrError):
+class AgentNotFoundError(AgentError):
     """No agent with this ID exists."""
 
     user_help_text = "Use 'mngr list' to see available agents."
@@ -158,7 +165,7 @@ class SendMessageError(AgentError):
         super().__init__(f"Failed to send message to agent {agent_name}: {reason}")
 
 
-class DuplicateAgentNameError(AgentError, MngrError):
+class DuplicateAgentNameError(AgentError):
     """An agent with this name already exists on the host."""
 
     user_help_text = (
@@ -388,7 +395,7 @@ class LocalHostNotDestroyableError(ProviderError):
         super().__init__(provider_name, "Cannot destroy the local host - it is your local computer")
 
 
-class PluginSpecifierError(BaseMngrError, ValueError):
+class PluginSpecifierError(MngrError, ValueError):
     """Raised when a plugin specifier is invalid or cannot be resolved."""
 
 
@@ -481,7 +488,7 @@ class BinaryNotInstalledError(MngrError):
         super().__init__(f"{binary} is required for {purpose} but was not found on PATH")
 
 
-class DiscoverySchemaChangedError(BaseMngrError, ValueError):
+class DiscoverySchemaChangedError(MngrError, ValueError):
     """Raised when a discovery event line cannot be validated against the current schema.
 
     This typically means a field was added, removed, or renamed in a discovery event
@@ -497,7 +504,7 @@ class DiscoverySchemaChangedError(BaseMngrError, ValueError):
         super().__init__(f"Discovery event of type {event_type!r} does not match current schema: {validation_error}")
 
 
-class MalformedJsonlLineError(BaseMngrError, ValueError):
+class MalformedJsonlLineError(MngrError, ValueError):
     """Raised when a JSONL line is structurally invalid (e.g. not a JSON object, missing required envelope fields).
 
     The right fix is to track down whichever process is producing the bad line and stop it

--- a/libs/mngr/imbue/mngr/errors_test.py
+++ b/libs/mngr/imbue/mngr/errors_test.py
@@ -4,10 +4,14 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from imbue.mngr.cli.issue_reporting import IssueSearchError
+from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import AgentNotFoundError
 from imbue.mngr.errors import AgentNotFoundOnHostError
 from imbue.mngr.errors import AgentStartError
 from imbue.mngr.errors import CommandTimeoutError
+from imbue.mngr.errors import DiscoverySchemaChangedError
+from imbue.mngr.errors import DuplicateAgentNameError
 from imbue.mngr.errors import HostConnectionError
 from imbue.mngr.errors import HostDataSchemaError
 from imbue.mngr.errors import HostError
@@ -17,7 +21,10 @@ from imbue.mngr.errors import HostNotRunningError
 from imbue.mngr.errors import HostNotStoppedError
 from imbue.mngr.errors import ImageNotFoundError
 from imbue.mngr.errors import LockNotHeldError
+from imbue.mngr.errors import MalformedJsonlLineError
 from imbue.mngr.errors import MngrError
+from imbue.mngr.errors import NoCommandDefinedError
+from imbue.mngr.errors import PluginSpecifierError
 from imbue.mngr.errors import ProviderError
 from imbue.mngr.errors import ProviderInstanceNotFoundError
 from imbue.mngr.errors import ProviderNotAuthorizedError
@@ -33,6 +40,7 @@ from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import ImageReference
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotId
+from imbue.mngr.utils.cel_utils import TolerantPathError
 from imbue.mngr.utils.testing import assert_init_first_param_is_provider_name
 from imbue.mngr.utils.testing import walk_concrete_subclasses
 
@@ -302,6 +310,72 @@ def test_host_connection_error_displays_single_error_prefix_via_click() -> None:
     assert result.output.startswith("Error: ")
     assert "Error: Error:" not in result.output
     assert "could not reach host" in result.output
+
+
+@pytest.mark.parametrize(
+    "agent_error_subclass",
+    [
+        AgentError,
+        NoCommandDefinedError,
+        AgentNotFoundError,
+        AgentNotFoundOnHostError,
+        SendMessageError,
+        DuplicateAgentNameError,
+        AgentStartError,
+    ],
+    ids=lambda c: c.__name__,
+)
+def test_agent_errors_are_mngr_errors(agent_error_subclass: type) -> None:
+    """AgentError and its subclasses are MngrError (and thus ClickException) subclasses.
+
+    This is the single-parent-class consolidation: every agent error is now a
+    user-facing MngrError, so `except MngrError` handlers catch it and the CLI
+    renders it cleanly instead of as a traceback.
+    """
+    assert issubclass(agent_error_subclass, MngrError)
+    assert issubclass(agent_error_subclass, click.ClickException)
+
+
+def test_agent_start_error_displays_single_error_prefix_via_click() -> None:
+    """An agent error raised inside a command renders as a clean 'Error: ' message.
+
+    Before agent errors inherited MngrError, an uncaught AgentStartError reached
+    Click as a non-ClickException and printed a full traceback. Now Click formats
+    it like any other user-facing error.
+    """
+
+    @click.command()
+    def cmd() -> None:
+        raise AgentStartError("my-agent", "session already exists")
+
+    runner = CliRunner()
+    result = runner.invoke(cmd)
+
+    assert result.exit_code == 1
+    assert result.output.startswith("Error: ")
+    assert "Error: Error:" not in result.output
+    assert "my-agent" in result.output
+
+
+@pytest.mark.parametrize(
+    "mngr_error_subclass",
+    [
+        PluginSpecifierError,
+        DiscoverySchemaChangedError,
+        MalformedJsonlLineError,
+        TolerantPathError,
+        IssueSearchError,
+    ],
+    ids=lambda c: c.__name__,
+)
+def test_consolidated_errors_are_mngr_errors(mngr_error_subclass: type) -> None:
+    """The remaining formerly-BaseMngrError-only types now inherit from MngrError.
+
+    Completes the consolidation so that every mngr error shares the single
+    user-facing MngrError parent (and thus is a ClickException).
+    """
+    assert issubclass(mngr_error_subclass, MngrError)
+    assert issubclass(mngr_error_subclass, click.ClickException)
 
 
 def test_host_data_schema_error_includes_path_and_fix() -> None:

--- a/libs/mngr/imbue/mngr/utils/cel_utils.py
+++ b/libs/mngr/imbue/mngr/utils/cel_utils.py
@@ -8,7 +8,6 @@ from celpy.evaluation import CELEvalError
 from loguru import logger
 
 from imbue.imbue_common.pure import pure
-from imbue.mngr.errors import BaseMngrError
 from imbue.mngr.errors import MngrError
 
 # Marker substring embedded in the CELEvalError message produced by
@@ -18,17 +17,17 @@ from imbue.mngr.errors import MngrError
 _TOLERANT_MISS_MARKER = "__tolerant_key_miss__"
 
 
-class TolerantPathError(BaseMngrError, TypeError):
+class TolerantPathError(MngrError, TypeError):
     """Raised by `with_tolerant_paths` when a path is misconfigured.
 
     Indicates a programming error in the caller's `paths` argument: a path
     segment is missing from its parent dict, or an ancestor/target is not a
-    dict-like (e.g. a MapType). Subclasses both `BaseMngrError` (the
-    library's package-base, per the project's exception-hierarchy style)
-    and `TypeError` (so existing callers that catch TypeError still see
-    it); the named subclass exists so call sites can distinguish a
-    tolerant-paths setup error from any other TypeError flowing through
-    the same code path.
+    dict-like (e.g. a MapType). Subclasses both `MngrError` (the single
+    user-facing parent for all mngr errors, so an uncaught instance renders
+    as a clean ``Error: ...`` at the CLI) and `TypeError` (so existing
+    callers that catch TypeError still see it); the named subclass exists so
+    call sites can distinguish a tolerant-paths setup error from any other
+    TypeError flowing through the same code path.
     """
 
 

--- a/libs/mngr_mapreduce/changelog/mngr-fix-error-hierarchy-agent.md
+++ b/libs/mngr_mapreduce/changelog/mngr-fix-error-hierarchy-agent.md
@@ -1,0 +1,3 @@
+Simplified exception handlers now that `AgentError` is a `MngrError` subclass: the redundant
+`AgentError` entry in the `except (MngrError, AgentError, ...)` guards in launching and the CLI
+has been removed. No behavior change -- agent errors are still caught and handled the same way.

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/cli.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/cli.py
@@ -28,7 +28,6 @@ from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
-from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UnknownBackendError
 from imbue.mngr.interfaces.host import AgentEnvironmentOptions
@@ -364,7 +363,7 @@ def _run_reducer_phase(
             run_name=ctx.run_name,
             output_dir=ctx.output_dir,
         )
-    except (MngrError, AgentError, OSError, BaseExceptionGroup) as exc:
+    except (MngrError, OSError, BaseExceptionGroup) as exc:
         logger.warning("Failed to launch reducer agent: {}", exc)
         return None
 

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching.py
@@ -15,7 +15,6 @@ from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.providers import get_provider_instance
 from imbue.mngr.api.rsync import rsync_to_remote
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import AgentError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.interfaces.host import AgentDataOptions
 from imbue.mngr.interfaces.host import AgentGitOptions
@@ -446,7 +445,7 @@ def launch_all_mappers(
                 info, host = future.result()
                 agents.append(info)
                 agent_hosts[str(info.agent_id)] = host
-            except (MngrError, AgentError, OSError, BaseExceptionGroup) as exc:
+            except (MngrError, OSError, BaseExceptionGroup) as exc:
                 logger.warning("Failed to launch agent for {}: {}", task.id, exc)
                 launch_failures.append(_make_launch_failure_metadata(task.id, agent_name, branch_name, exc))
 
@@ -507,7 +506,7 @@ def launch_mappers_up_to_limit(
                 )
             )
             continue
-        except (MngrError, AgentError, OSError, BaseExceptionGroup) as exc:
+        except (MngrError, OSError, BaseExceptionGroup) as exc:
             logger.warning("Failed to launch agent for {}: {}", task.id, exc)
             launch_failures.append(_make_launch_failure_metadata(task.id, agent_name, branch_name, exc))
             continue

--- a/libs/mngr_uncapped_claude/changelog/mngr-fix-error-hierarchy-agent.md
+++ b/libs/mngr_uncapped_claude/changelog/mngr-fix-error-hierarchy-agent.md
@@ -1,0 +1,5 @@
+`UncappedClaudeError` (the plugin's base error) now inherits from `MngrError` instead of
+`BaseMngrError`, matching the repo-wide consolidation of the error hierarchy under a single
+user-facing parent class. This also removes a prior inconsistency where its subclasses
+(`UnsupportedClaudeFlagError`, `InvalidStreamJsonInputError`, `MissingPromptError`) were already
+`MngrError` instances via `UserInputError` while the base was not. No behavior change.

--- a/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/errors.py
+++ b/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/errors.py
@@ -1,8 +1,8 @@
-from imbue.mngr.errors import BaseMngrError
+from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import UserInputError
 
 
-class UncappedClaudeError(BaseMngrError):
+class UncappedClaudeError(MngrError):
     """Base exception for the mngr_uncapped_claude plugin."""
 
 

--- a/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/errors_test.py
+++ b/libs/mngr_uncapped_claude/imbue/mngr_uncapped_claude/errors_test.py
@@ -1,0 +1,25 @@
+"""Tests for the mngr_uncapped_claude error hierarchy."""
+
+import click
+import pytest
+
+from imbue.mngr.errors import MngrError
+from imbue.mngr_uncapped_claude.errors import InvalidStreamJsonInputError
+from imbue.mngr_uncapped_claude.errors import MissingPromptError
+from imbue.mngr_uncapped_claude.errors import UncappedClaudeError
+from imbue.mngr_uncapped_claude.errors import UnsupportedClaudeFlagError
+
+
+@pytest.mark.parametrize(
+    "error_subclass",
+    [UncappedClaudeError, UnsupportedClaudeFlagError, InvalidStreamJsonInputError, MissingPromptError],
+    ids=lambda c: c.__name__,
+)
+def test_uncapped_claude_errors_are_mngr_errors(error_subclass: type) -> None:
+    """The plugin's base error and its subclasses are all MngrError (and ClickException) subclasses.
+
+    The base used to inherit only from BaseMngrError while its subclasses were already
+    user-facing via UserInputError; the consolidation makes the whole tree consistent.
+    """
+    assert issubclass(error_subclass, MngrError)
+    assert issubclass(error_subclass, click.ClickException)


### PR DESCRIPTION
## Summary

Completes the error-hierarchy consolidation (started with `HostError`) so that **every** mngr error inherits from `MngrError` as the single user-facing parent. Every error is now a `ClickException`: an uncaught instance renders as a clean `Error: ...` message instead of a Python traceback, and `except MngrError` handlers treat them as the user-facing errors they are.

Each formerly-`BaseMngrError`-only type was independently investigated (raise sites, catch sites, MRO, constructor/`ClickException` compatibility, CLI reachability, tests) and found safe to move.

### Types moved to `MngrError`
- **`AgentError`** and its subclasses `NoCommandDefinedError`, `AgentNotFoundOnHostError`, `SendMessageError`, `AgentStartError`. `AgentNotFoundError` / `DuplicateAgentNameError` already reached `MngrError` via an explicit mix-in, now dropped as redundant.
- `PluginSpecifierError`, `DiscoverySchemaChangedError`, `MalformedJsonlLineError` (`errors.py`)
- `TolerantPathError` (`utils/cel_utils.py`) — keeps its `TypeError` base
- `IssueSearchError` (`cli/issue_reporting.py`)
- `UncappedClaudeError` (`mngr_uncapped_claude`) — also fixes a prior inconsistency where its subclasses were already `MngrError` via `UserInputError` while the base was not

### Cleanups
- Dropped the now-redundant `AgentError` entry from the `except (MngrError, AgentError, ...)` guards in `mngr_mapreduce` launching/cli.
- Updated a stale comment in `message_test.py`.

### Behavioral notes
- Per discussion, **no** special re-raise carve-out was added for agent errors in the listing per-agent guard (unlike `HostConnectionError`).
- The only meaningful behavior change is at the CLI boundary (clean rendering) and in `list.py`'s ABORT path, where agent errors are now re-raised with their original type preserved instead of being wrapped in a fresh `MngrError`.

### Tests
- Added invariant tests asserting each moved type is a `MngrError`/`ClickException` (parametrized, mirroring the `HostError` tests), plus a CLI-render test for `AgentStartError`.
- Added `errors_test.py` for `mngr_uncapped_claude`.

Ran locally (all passing): `errors_test.py`, `message_test.py`, `list_test.py`, `discovery_events_test.py`, `cel_utils_test.py`, `issue_reporting_test.py`, `host_test.py`, full `mngr_mapreduce` and `mngr_uncapped_claude` suites, the affected `test_ratchets.py` files, and the import-layer meta ratchet. `ty` type check passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)