### PR TITLE
minds desktop: surface auto-update prompt and add dev-tools menu

### DIFF
--- a/apps/minds/changelog/mngr-extract-1.md
+++ b/apps/minds/changelog/mngr-extract-1.md
@@ -4,5 +4,4 @@ Desktop app auto-update and developer-tooling fixes (extracted from the larger m
 - Added a `Check for Updates...` item to the application menu that triggers a check and reports the result (update found / up to date / unavailable / error), with the unavailable message worded for the build type (dev vs unreleased draft).
 - Added a `View` menu with `Toggle Developer Tools` (Alt+Cmd+I), zoom controls, and fullscreen. The default Electron DevTools shortcut crashed because the app uses `BaseWindow` + `WebContentsView` rather than a `BrowserWindow`.
 - `MINDS_OPEN_DEVTOOLS=1` auto-opens detached DevTools on the content view at launch.
-- The workspace content `WebContentsView` now loads `preload.js`, on both its initial and its error-retry rebuild paths.
 - Startup env-setup failures are now logged to the console in addition to being shown in the error window.

--- a/apps/minds/changelog/mngr-extract-1.md
+++ b/apps/minds/changelog/mngr-extract-1.md
@@ -1,8 +1,8 @@
 Desktop app auto-update and developer-tooling fixes (extracted from the larger minds onboarding work for standalone review).
 
 - Auto-update: packaged builds now prompt to install a downloaded update. ToDesktop's runtime defaults `showInstallAndRestartPrompt` to `"never"`, so users saw "downloading in the background..." and were never prompted again; it is now set to `"always"`. ToDesktop is only initialized in packaged builds -- in dev its constructor threw on macOS (Squirrel is not linked in the unsigned binary), so dev launches now skip it.
-- Added a `File > Check for Updates...` menu item that triggers a check and reports the result (update found / up to date / unavailable in draft builds / error).
+- Added a `Check for Updates...` item to the application menu that triggers a check and reports the result (update found / up to date / unavailable / error), with the unavailable message worded for the build type (dev vs unreleased draft).
 - Added a `View` menu with `Toggle Developer Tools` (Alt+Cmd+I), zoom controls, and fullscreen. The default Electron DevTools shortcut crashed because the app uses `BaseWindow` + `WebContentsView` rather than a `BrowserWindow`.
 - `MINDS_OPEN_DEVTOOLS=1` auto-opens detached DevTools on the content view at launch.
-- The content `WebContentsView` now loads `preload.js`.
+- The workspace content `WebContentsView` now loads `preload.js`, on both its initial and its error-retry rebuild paths.
 - Startup env-setup failures are now logged to the console in addition to being shown in the error window.

--- a/apps/minds/changelog/mngr-extract-1.md
+++ b/apps/minds/changelog/mngr-extract-1.md
@@ -1,0 +1,8 @@
+Desktop app auto-update and developer-tooling fixes (extracted from the larger minds onboarding work for standalone review).
+
+- Auto-update: packaged builds now prompt to install a downloaded update. ToDesktop's runtime defaults `showInstallAndRestartPrompt` to `"never"`, so users saw "downloading in the background..." and were never prompted again; it is now set to `"always"`. ToDesktop is only initialized in packaged builds -- in dev its constructor threw on macOS (Squirrel is not linked in the unsigned binary), so dev launches now skip it.
+- Added a `File > Check for Updates...` menu item that triggers a check and reports the result (update found / up to date / unavailable in draft builds / error).
+- Added a `View` menu with `Toggle Developer Tools` (Alt+Cmd+I), zoom controls, and fullscreen. The default Electron DevTools shortcut crashed because the app uses `BaseWindow` + `WebContentsView` rather than a `BrowserWindow`.
+- `MINDS_OPEN_DEVTOOLS=1` auto-opens detached DevTools on the content view at launch.
+- The content `WebContentsView` now loads `preload.js`.
+- Startup env-setup failures are now logged to the console in addition to being shown in the error window.

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -6,27 +6,11 @@ const paths = require('./paths');
 const { runEnvSetup } = require('./env-setup');
 const { startBackend, shutdown, getBackendProcess } = require('./backend');
 
-// Use ToDesktop's default auto-update behavior: it checks on launch +
-// on an interval, downloads in the background, and shows its own
-// "Restart to update" prompt when a download completes. We previously
-// suppressed that prompt to build a custom titlebar pill, but the pill
-// renderer was never wired up -- leaving users with detection but no
-// way to install. Defaults are simpler and actually work.
-//
-// Only init when packaged: in dev (`pnpm start`), `electron.autoUpdater`
-// is undefined on macOS (Squirrel is not linked in the unsigned dev
-// binary), and todesktop's constructor throws trying to subscribe to
-// it. Skipping init keeps dev launches working; the auto-updater is
-// never useful in dev anyway.
+// Only init the auto-updater in packaged builds: in dev, electron.autoUpdater
+// is undefined on macOS, so todesktop's constructor throws.
 if (app.isPackaged) {
-  // @todesktop/runtime defaults `showInstallAndRestartPrompt: "never"`,
-  // which leaves a downloaded update silently staged on disk with no UI
-  // surfacing -- users see the initial "Update found. Downloading in
-  // the background. You will be prompted to restart when it is ready."
-  // dialog, the download completes, and they are never prompted again.
-  // Set to "always" so the runtime shows a native "Install on next
-  // launch / Install now and restart" dialog as soon as the staged
-  // bundle is ready.
+  // Default is "never", which stages a downloaded update without ever
+  // prompting the user to install it.
   todesktop.init({
     updateReadyAction: {
       showInstallAndRestartPrompt: 'always',
@@ -325,10 +309,7 @@ function createBundleWebContentsViews(win) {
   win.contentView.addChildView(chromeView);
   win.contentView.addChildView(contentView);
 
-  // Auto-open DevTools when MINDS_OPEN_DEVTOOLS=1 is set. The built-in
-  // cmd+opt+I shortcut hits an Electron menu handler that assumes a
-  // BrowserWindow (we use BaseWindow + WebContentsViews) and crashes;
-  // this env var is the escape hatch for dev-time inspection.
+  // Auto-open DevTools for dev-time inspection.
   if (process.env.MINDS_OPEN_DEVTOOLS === '1') {
     contentView.webContents.once('did-finish-load', () => {
       contentView.webContents.openDevTools({ mode: 'detach' });
@@ -1487,16 +1468,8 @@ async function onReady() {
 }
 
 // User-initiated update check from File > Check for Updates.
-//
-// Follows ToDesktop's documented API: `autoUpdater.checkForUpdates()`
-// returns a Promise resolving to `{ updateInfo }` -- `updateInfo` is the
-// release metadata when a newer version exists (ToDesktop then downloads
-// it in the background and shows its own "Restart to update" prompt via
-// the default updateReadyAction), or null/absent when already current.
-// We branch on that return value for the menu-click feedback rather
-// than listening for events -- events are ToDesktop's "granular control"
-// path and may not fire on every resolve, which is exactly what made an
-// earlier version of this function silent.
+// autoUpdater.checkForUpdates() resolves to { updateInfo }: present when a
+// newer version exists (then downloaded in the background), absent when current.
 async function triggerUpdateCheck() {
   const autoUpdater = todesktop.autoUpdater;
   if (!autoUpdater || typeof autoUpdater.checkForUpdates !== 'function') {
@@ -1585,10 +1558,8 @@ function installApplicationMenu() {
       submenu: [
         {
           label: 'Toggle Developer Tools',
-          // Default Electron binding (`role: 'toggleDevTools'`) targets the
-          // focused BrowserWindow's contents; we use BaseWindow with multiple
-          // WebContentsViews, so call toggleDevTools explicitly on the
-          // focused bundle's content view.
+          // role: 'toggleDevTools' targets a BrowserWindow; we use BaseWindow,
+          // so toggle the focused bundle's content view explicitly.
           accelerator: 'Alt+Cmd+I',
           click: () => {
             const bundle = getMostRecentWindow();

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1468,7 +1468,7 @@ async function onReady() {
   await runStartupSequence(initialBundle);
 }
 
-// User-initiated update check from File > Check for Updates.
+// User-initiated update check from the app menu's Check for Updates item.
 // autoUpdater.checkForUpdates() resolves to { updateInfo }: present when a
 // newer version exists (then downloaded in the background), absent when current.
 async function triggerUpdateCheck() {

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -6,7 +6,35 @@ const paths = require('./paths');
 const { runEnvSetup } = require('./env-setup');
 const { startBackend, shutdown, getBackendProcess } = require('./backend');
 
-todesktop.init();
+// Use ToDesktop's default auto-update behavior: it checks on launch +
+// on an interval, downloads in the background, and shows its own
+// "Restart to update" prompt when a download completes. We previously
+// suppressed that prompt to build a custom titlebar pill, but the pill
+// renderer was never wired up -- leaving users with detection but no
+// way to install. Defaults are simpler and actually work.
+//
+// Only init when packaged: in dev (`pnpm start`), `electron.autoUpdater`
+// is undefined on macOS (Squirrel is not linked in the unsigned dev
+// binary), and todesktop's constructor throws trying to subscribe to
+// it. Skipping init keeps dev launches working; the auto-updater is
+// never useful in dev anyway.
+if (app.isPackaged) {
+  // @todesktop/runtime defaults `showInstallAndRestartPrompt: "never"`,
+  // which leaves a downloaded update silently staged on disk with no UI
+  // surfacing -- users see the initial "Update found. Downloading in
+  // the background. You will be prompted to restart when it is ready."
+  // dialog, the download completes, and they are never prompted again.
+  // Set to "always" so the runtime shows a native "Install on next
+  // launch / Install now and restart" dialog as soon as the staged
+  // bundle is ready.
+  todesktop.init({
+    updateReadyAction: {
+      showInstallAndRestartPrompt: 'always',
+    },
+  });
+} else {
+  console.log('[update] Skipping ToDesktop init (dev build -- not packaged)');
+}
 
 // Redirect Electron's userData directory to ~/.<MINDS_ROOT_NAME>/ so that dev
 // and production installs are fully isolated (cookies, sessions, caches, etc.).
@@ -288,6 +316,7 @@ function createBundleWebContentsViews(win) {
   });
   const contentView = new WebContentsView({
     webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
       partition: CONTENT_PARTITION,
       contextIsolation: true,
       nodeIntegration: false,
@@ -295,6 +324,17 @@ function createBundleWebContentsViews(win) {
   });
   win.contentView.addChildView(chromeView);
   win.contentView.addChildView(contentView);
+
+  // Auto-open DevTools when MINDS_OPEN_DEVTOOLS=1 is set. The built-in
+  // cmd+opt+I shortcut hits an Electron menu handler that assumes a
+  // BrowserWindow (we use BaseWindow + WebContentsViews) and crashes;
+  // this env var is the escape hatch for dev-time inspection.
+  if (process.env.MINDS_OPEN_DEVTOOLS === '1') {
+    contentView.webContents.once('did-finish-load', () => {
+      contentView.webContents.openDevTools({ mode: 'detach' });
+    });
+  }
+
   return { chromeView, contentView };
 }
 
@@ -1446,6 +1486,53 @@ async function onReady() {
   await runStartupSequence(initialBundle);
 }
 
+// User-initiated update check from File > Check for Updates.
+//
+// Follows ToDesktop's documented API: `autoUpdater.checkForUpdates()`
+// returns a Promise resolving to `{ updateInfo }` -- `updateInfo` is the
+// release metadata when a newer version exists (ToDesktop then downloads
+// it in the background and shows its own "Restart to update" prompt via
+// the default updateReadyAction), or null/absent when already current.
+// We branch on that return value for the menu-click feedback rather
+// than listening for events -- events are ToDesktop's "granular control"
+// path and may not fire on every resolve, which is exactly what made an
+// earlier version of this function silent.
+async function triggerUpdateCheck() {
+  const autoUpdater = todesktop.autoUpdater;
+  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== 'function') {
+    dialog.showMessageBox({
+      type: 'info',
+      message: 'Update check unavailable.',
+      detail: 'This build is running in draft mode; the auto-updater is disabled until the build is released to the latest channel.',
+    });
+    return;
+  }
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    const updateInfo = result && result.updateInfo;
+    if (updateInfo) {
+      const v = updateInfo.version || updateInfo.releaseName;
+      dialog.showMessageBox({
+        type: 'info',
+        message: v ? `Update ${v} found.` : 'Update found.',
+        detail: 'Downloading in the background. You will be prompted to restart when it is ready.',
+      });
+    } else {
+      dialog.showMessageBox({
+        type: 'info',
+        message: "You're up to date.",
+        detail: 'No newer version is available.',
+      });
+    }
+  } catch (err) {
+    dialog.showMessageBox({
+      type: 'error',
+      message: 'Update check failed.',
+      detail: String(err && err.message ? err.message : err),
+    });
+  }
+}
+
 function installApplicationMenu() {
   if (!isMac || process.env.MINDS_HIDE_MENU === '1') {
     // On Windows/Linux the frame is custom-drawn; on macOS with MINDS_HIDE_MENU
@@ -1461,6 +1548,8 @@ function installApplicationMenu() {
       label: app.name || 'Minds',
       submenu: [
         { role: 'about' },
+        { type: 'separator' },
+        { label: 'Check for Updates...', click: triggerUpdateCheck },
         { type: 'separator' },
         { role: 'services' },
         { type: 'separator' },
@@ -1491,6 +1580,33 @@ function installApplicationMenu() {
       ],
     },
     { role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Toggle Developer Tools',
+          // Default Electron binding (`role: 'toggleDevTools'`) targets the
+          // focused BrowserWindow's contents; we use BaseWindow with multiple
+          // WebContentsViews, so call toggleDevTools explicitly on the
+          // focused bundle's content view.
+          accelerator: 'Alt+Cmd+I',
+          click: () => {
+            const bundle = getMostRecentWindow();
+            if (!bundle || bundle.window.isDestroyed()) return;
+            const cv = bundle.contentView;
+            if (cv && !cv.webContents.isDestroyed()) {
+              cv.webContents.toggleDevTools();
+            }
+          },
+        },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
     { role: 'windowMenu' },
   ];
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
@@ -1520,6 +1636,7 @@ async function runStartupSequence(bundle) {
       }
     });
   } catch (err) {
+    console.error('[startup] env-setup failed:', err.message);
     showErrorInAllWindows(
       'Setup failed -- you may not be connected to the internet',
       err.message,

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1476,7 +1476,9 @@ async function triggerUpdateCheck() {
     dialog.showMessageBox({
       type: 'info',
       message: 'Update check unavailable.',
-      detail: 'This build is running in draft mode; the auto-updater is disabled until the build is released to the latest channel.',
+      detail: app.isPackaged
+        ? 'The auto-updater is disabled until this build is released to the latest channel.'
+        : 'Updates are only available in installed builds.',
     });
     return;
   }

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -300,7 +300,6 @@ function createBundleWebContentsViews(win) {
   });
   const contentView = new WebContentsView({
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
       partition: CONTENT_PARTITION,
       contextIsolation: true,
       nodeIntegration: false,
@@ -878,7 +877,6 @@ function prepareAllWindowsForRetry() {
     if (!bundle.contentView) {
       const contentView = new WebContentsView({
         webPreferences: {
-          preload: path.join(__dirname, 'preload.js'),
           partition: CONTENT_PARTITION,
           contextIsolation: true,
           nodeIntegration: false,

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -878,6 +878,7 @@ function prepareAllWindowsForRetry() {
     if (!bundle.contentView) {
       const contentView = new WebContentsView({
         webPreferences: {
+          preload: path.join(__dirname, 'preload.js'),
           partition: CONTENT_PARTITION,
           contextIsolation: true,
           nodeIntegration: false,


### PR DESCRIPTION
## Summary

Standalone extraction from #1317 so the desktop app's auto-update and developer-tooling fixes can be reviewed and merged on their own, ahead of the larger Lima / packaging work. **Touches only `apps/minds/electron/main.js`** plus a changelog entry; every change is functional on its own and the branch merges cleanly into current `main`.

### Auto-update
- Set ToDesktop's `updateReadyAction.showInstallAndRestartPrompt` to `"always"`. The runtime default is `"never"`, so users saw the initial "downloading in the background..." dialog and were **never prompted to install** the staged update.
- Only call `todesktop.init()` in packaged builds. In dev on macOS the constructor throws because `electron.autoUpdater` is undefined (Squirrel is not linked in the unsigned dev binary); dev launches now log and skip it.
- Add a `Check for Updates...` item to the macOS **application menu** (alongside About / Services / Quit) backed by `triggerUpdateCheck()`, which reports the outcome via dialog: update found / up to date / unavailable / error. The "unavailable" message is worded per build type -- dev builds say updates are only available in installed builds; packaged-but-unreleased (draft) builds explain the auto-updater is disabled until released to the latest channel.

### Developer tooling
- Add a `View` menu with `Toggle Developer Tools` (Alt+Cmd+I), zoom controls, and fullscreen. The default Electron DevTools shortcut crashes because the app uses `BaseWindow` + `WebContentsView` rather than a `BrowserWindow`, so the handler calls `toggleDevTools()` on the focused bundle's content view explicitly.
- Honor `MINDS_OPEN_DEVTOOLS=1` to auto-open detached DevTools on the content view at launch.
- Log startup env-setup failures to the console in addition to the error window.

### Deliberately excluded from this extraction
- **Content-view preload.** #1317 also added `preload.js` (the privileged `window.minds` IPC bridge) to the workspace content view. That is intentionally **not** in this PR: #1875 has since landed on `main`, giving the content view a deliberately locked-down `content-relay-preload.js` because it hosts foreign, untrusted workspace content and must not receive the privileged bridge. `main` now owns the content-view preload; this PR leaves it alone (the trusted chrome/sidebar/requests/modal views keep `preload.js`). Note for #1317: its `preload.js`-on-content-view change now conflicts with #1875 and should be reconciled there.
- **About-panel git-SHA block.** Excluded because it reads `electron/build-info.json`, generated only by the `build.js` packaging changes that are not part of this PR. It would be inert (and log a warning in packaged builds) without that work, so it stays with the build/packaging extraction.

## Test plan
- `node --check apps/minds/electron/main.js` passes.
- Merges cleanly into current `main` (`git merge-tree` reports no conflicts).
- Symbols used (`getMostRecentWindow`, `dialog`, `app.isPackaged`, `todesktop.autoUpdater`) already exist / are valid on `main`; the bundle from `getMostRecentWindow()` has the `.window` / `.contentView` shape the View-menu handler relies on (same guard pattern as existing callers).
- This is an Electron-main-process change; the repo has no JS test runner and the Python suite does not exercise `main.js`. Relying on CI for the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)