### PR TITLE
Solid migration: create form

### DIFF
--- a/apps/minds/changelog/gdenisov-solidjs-batch-b-create-form.md
+++ b/apps/minds/changelog/gdenisov-solidjs-batch-b-create-form.md
@@ -1,0 +1,16 @@
+Migrated the agent-creation form (`/create`) to Solid.js. The page is
+now rendered server-side via the SSR sidecar (with the inline-shell
+fallback when the sidecar is unhealthy) and the form submission posts
+JSON and reads `{ ok, errors, data }` instead of round-tripping a
+re-rendered HTML page on validation errors.
+
+Reusable form primitives landed under
+`apps/minds/frontend/src/components/forms/`: `FormField`,
+`FormSelect`, and `FormSection`. The Solid route composes them so the
+create form's "label + select + helper-error" rows now read as a list
+of `FormSelect` calls instead of five hand-spelled `<div flex>` blocks.
+
+The Jinja `templates/create.html` file is still present (a Phase 8
+cleanup pass removes the dead Jinja code wholesale); it is no longer
+referenced from Python and `render_create_form` is a thin shim around
+the SSR sidecar.

--- a/apps/minds/frontend/src/components/forms/FormField.jsx
+++ b/apps/minds/frontend/src/components/forms/FormField.jsx
@@ -1,0 +1,62 @@
+import { Show, splitProps } from 'solid-js';
+import { TextInput } from '../ui/TextInput.jsx';
+
+// Label-above-input form field with optional helper text and inline
+// error. Compresses the "label, helper paragraph, input, error
+// paragraph" four-element block the Jinja create form spells out by
+// hand five separate times.
+//
+// Props:
+//   label       string  text rendered above the input
+//   name        string  the `name` attribute (used as id fallback)
+//   id          string  optional explicit id, defaults to `name`
+//   type        string  defaults to 'text' (also accepts 'password')
+//   value       string  current value (controlled)
+//   onInput     fn      Solid input handler
+//   placeholder string  placeholder text
+//   helper      string  optional muted helper line under the label
+//   error       string  optional amber error line under the input
+//   required    bool    HTML required attribute
+//   extra       string  extra classes appended to the input
+export function FormField(props) {
+  const [local, rest] = splitProps(props, [
+    'label',
+    'name',
+    'id',
+    'type',
+    'value',
+    'onInput',
+    'placeholder',
+    'helper',
+    'error',
+    'required',
+    'extra',
+  ]);
+  const fieldId = () => local.id || local.name;
+  return (
+    <div>
+      <Show when={local.label}>
+        <label for={fieldId()} class="text-sm text-zinc-900 font-medium block mb-1">
+          {local.label}
+        </label>
+      </Show>
+      <Show when={local.helper}>
+        <p class="mb-1 text-xs text-zinc-400">{local.helper}</p>
+      </Show>
+      <TextInput
+        id={fieldId()}
+        name={local.name}
+        type={local.type || 'text'}
+        value={local.value ?? ''}
+        onInput={local.onInput}
+        placeholder={local.placeholder}
+        required={local.required}
+        extra={local.extra}
+        {...rest}
+      />
+      <Show when={local.error}>
+        <p class="mt-1 text-xs text-amber-600">{local.error}</p>
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/forms/FormField.test.jsx
+++ b/apps/minds/frontend/src/components/forms/FormField.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { FormField } from './FormField.jsx';
+
+describe('FormField', () => {
+  it('renders a label tied to its input by id', () => {
+    const { getByLabelText } = render(() => (
+      <FormField label="Workspace name" name="host_name" value="" />
+    ));
+    const input = getByLabelText('Workspace name');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('name', 'host_name');
+    expect(input).toHaveAttribute('id', 'host_name');
+  });
+
+  it('shows the helper paragraph above the input when provided', () => {
+    const { getByText } = render(() => (
+      <FormField label="Repository" name="git_url" helper="Git URL or local path" />
+    ));
+    expect(getByText('Git URL or local path')).toBeInTheDocument();
+  });
+
+  it('renders the error message in amber styling', () => {
+    const { getByText } = render(() => (
+      <FormField label="Name" name="host_name" error="not a valid hostname" />
+    ));
+    const err = getByText('not a valid hostname');
+    expect(err.className).toContain('text-amber-600');
+  });
+
+  it('forwards onInput to the underlying input', () => {
+    const onInput = vi.fn();
+    const { getByLabelText } = render(() => (
+      <FormField label="Name" name="host_name" value="" onInput={onInput} />
+    ));
+    fireEvent.input(getByLabelText('Name'), { target: { value: 'next' } });
+    expect(onInput).toHaveBeenCalled();
+  });
+
+  it('supports the password type for sensitive fields', () => {
+    const { getByLabelText } = render(() => (
+      <FormField label="API key" name="anthropic_api_key" type="password" />
+    ));
+    expect(getByLabelText('API key')).toHaveAttribute('type', 'password');
+  });
+});

--- a/apps/minds/frontend/src/components/forms/FormSection.jsx
+++ b/apps/minds/frontend/src/components/forms/FormSection.jsx
@@ -1,0 +1,46 @@
+import { Show, createSignal, splitProps } from 'solid-js';
+
+// Collapsible panel with a toggle button -- mirrors the
+// "Configure..." and "Show advanced settings" disclosures in
+// templates/create.html.
+//
+// Props:
+//   summary     string   optional summary text shown next to the toggle
+//   showLabel   string   button label when collapsed (e.g. 'Configure...')
+//   hideLabel   string   button label when expanded (e.g. 'Hide')
+//   initiallyOpen bool   start expanded
+//   children    JSX      the collapsible body
+//
+// The toggle button and the summary line share a row above the
+// body, matching the Jinja layout (`config-summary` + the
+// `configure-toggle` button). When the user only ever opens the
+// section once the API stays out of their way (no controlled-open
+// prop required).
+export function FormSection(props) {
+  const [local] = splitProps(props, [
+    'summary',
+    'showLabel',
+    'hideLabel',
+    'initiallyOpen',
+    'children',
+  ]);
+  const [isOpen, setIsOpen] = createSignal(Boolean(local.initiallyOpen));
+  const buttonLabel = () => (isOpen() ? local.hideLabel || 'Hide' : local.showLabel || 'Show');
+  return (
+    <>
+      <div class="flex items-center justify-between gap-3 mt-2.5 px-1 text-xs">
+        <span class="text-zinc-400 leading-snug">{local.summary || ''}</span>
+        <button
+          type="button"
+          class="text-blue-600 hover:text-blue-700 cursor-pointer transition-colors whitespace-nowrap"
+          onClick={() => setIsOpen((open) => !open)}
+        >
+          {buttonLabel()}
+        </button>
+      </div>
+      <Show when={isOpen()}>
+        <div class="mt-5 flex flex-col gap-4">{local.children}</div>
+      </Show>
+    </>
+  );
+}

--- a/apps/minds/frontend/src/components/forms/FormSection.test.jsx
+++ b/apps/minds/frontend/src/components/forms/FormSection.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { FormSection } from './FormSection.jsx';
+
+describe('FormSection', () => {
+  it('hides children until the toggle is clicked', () => {
+    const { queryByText, getByRole } = render(() => (
+      <FormSection showLabel="Configure..." hideLabel="Hide">
+        <p>section body</p>
+      </FormSection>
+    ));
+    expect(queryByText('section body')).toBeNull();
+    fireEvent.click(getByRole('button', { name: 'Configure...' }));
+    expect(queryByText('section body')).toBeInTheDocument();
+  });
+
+  it('updates the toggle label between show and hide states', () => {
+    const { getByRole } = render(() => (
+      <FormSection showLabel="Configure..." hideLabel="Hide">
+        <p>body</p>
+      </FormSection>
+    ));
+    const button = getByRole('button', { name: 'Configure...' });
+    fireEvent.click(button);
+    expect(getByRole('button', { name: 'Hide' })).toBeInTheDocument();
+  });
+
+  it('starts open when initiallyOpen is set', () => {
+    const { getByText } = render(() => (
+      <FormSection showLabel="Show" hideLabel="Hide" initiallyOpen>
+        <p>visible body</p>
+      </FormSection>
+    ));
+    expect(getByText('visible body')).toBeInTheDocument();
+  });
+
+  it('renders the summary text in the toggle row', () => {
+    const { getByText } = render(() => (
+      <FormSection showLabel="Configure..." summary="compute via Lima.">
+        <p>body</p>
+      </FormSection>
+    ));
+    expect(getByText('compute via Lima.')).toBeInTheDocument();
+  });
+});

--- a/apps/minds/frontend/src/components/forms/FormSelect.jsx
+++ b/apps/minds/frontend/src/components/forms/FormSelect.jsx
@@ -1,0 +1,74 @@
+import { For, Show, splitProps } from 'solid-js';
+
+const SELECT_CLASS =
+  'w-48 px-3 py-2 text-sm rounded-md border border-zinc-200 ' +
+  'bg-white text-zinc-900 outline-none transition ' +
+  'focus:border-blue-600 focus:ring-2 focus:ring-blue-600/15';
+
+// Inline-row select: label sits to the left, the select pulls right
+// at a fixed 48-unit width. Compresses the five-times-repeated
+// "<div flex><label /><select /></div>" block in templates/create.html
+// down to one component call per row.
+//
+// Props:
+//   label    string                 label text rendered to the left
+//   name     string                 select name + id fallback
+//   id       string                 explicit id (defaults to name)
+//   value    string                 currently selected option value
+//   onChange fn                     change handler; passed the new value
+//   options  Array<{value, label, requiresAccount?}>
+//             option list. `requiresAccount` mirrors the
+//             `data-requires-account` attribute used by the Jinja
+//             template to disable the IMBUE_CLOUD option when no
+//             account is selected.
+//   disabledValues Set<string>      values to mark as disabled
+//   error    string                 optional amber error line
+//             rendered right-aligned under the row, mirroring the
+//             Jinja `*-account-error` paragraphs.
+export function FormSelect(props) {
+  const [local] = splitProps(props, [
+    'label',
+    'name',
+    'id',
+    'value',
+    'onChange',
+    'options',
+    'disabledValues',
+    'error',
+  ]);
+  const fieldId = () => local.id || local.name;
+  const handleChange = (event) => {
+    if (typeof local.onChange === 'function') {
+      local.onChange(event.currentTarget.value);
+    }
+  };
+  const isOptionDisabled = (option) =>
+    Boolean(local.disabledValues && local.disabledValues.has(option.value));
+  return (
+    <div>
+      <div class="flex items-center justify-between gap-3">
+        <label for={fieldId()} class="text-sm text-zinc-900 font-medium">
+          {local.label}
+        </label>
+        <select
+          id={fieldId()}
+          name={local.name}
+          value={local.value}
+          onChange={handleChange}
+          class={SELECT_CLASS}
+        >
+          <For each={local.options}>
+            {(option) => (
+              <option value={option.value} disabled={isOptionDisabled(option)}>
+                {option.label}
+              </option>
+            )}
+          </For>
+        </select>
+      </div>
+      <Show when={local.error}>
+        <p class="mt-1 text-xs text-amber-600 text-right">{local.error}</p>
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/forms/FormSelect.test.jsx
+++ b/apps/minds/frontend/src/components/forms/FormSelect.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { FormSelect } from './FormSelect.jsx';
+
+const OPTIONS = [
+  { value: 'DOCKER', label: 'docker' },
+  { value: 'IMBUE_CLOUD', label: 'imbue_cloud' },
+  { value: 'LIMA', label: 'lima' },
+];
+
+describe('FormSelect', () => {
+  it('renders all options with the current value selected', () => {
+    const { getByLabelText } = render(() => (
+      <FormSelect label="Compute provider" name="launch_mode" value="LIMA" options={OPTIONS} />
+    ));
+    const select = getByLabelText('Compute provider');
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe('LIMA');
+    expect(select.querySelectorAll('option')).toHaveLength(3);
+  });
+
+  it('invokes onChange with the new value when the selection changes', () => {
+    const onChange = vi.fn();
+    const { getByLabelText } = render(() => (
+      <FormSelect
+        label="Compute provider"
+        name="launch_mode"
+        value="LIMA"
+        options={OPTIONS}
+        onChange={onChange}
+      />
+    ));
+    fireEvent.change(getByLabelText('Compute provider'), { target: { value: 'DOCKER' } });
+    expect(onChange).toHaveBeenCalledWith('DOCKER');
+  });
+
+  it('marks options listed in disabledValues as disabled', () => {
+    const { getByLabelText } = render(() => (
+      <FormSelect
+        label="Compute provider"
+        name="launch_mode"
+        value="LIMA"
+        options={OPTIONS}
+        disabledValues={new Set(['IMBUE_CLOUD'])}
+      />
+    ));
+    const select = getByLabelText('Compute provider');
+    const imbueOption = select.querySelector('option[value="IMBUE_CLOUD"]');
+    expect(imbueOption.disabled).toBe(true);
+  });
+
+  it('renders the error message in amber styling when error prop is set', () => {
+    const { getByText } = render(() => (
+      <FormSelect
+        label="Compute provider"
+        name="launch_mode"
+        value="IMBUE_CLOUD"
+        options={OPTIONS}
+        error="imbue_cloud requires a selected account."
+      />
+    ));
+    const err = getByText('imbue_cloud requires a selected account.');
+    expect(err.className).toContain('text-amber-600');
+  });
+});

--- a/apps/minds/frontend/src/routes/create.jsx
+++ b/apps/minds/frontend/src/routes/create.jsx
@@ -1,0 +1,381 @@
+import { For, Show, createMemo, createSignal } from 'solid-js';
+import { createStore } from 'solid-js/store';
+import { Button } from '../components/ui/Button.jsx';
+import { Notice } from '../components/ui/Notice.jsx';
+import { FormField } from '../components/forms/FormField.jsx';
+import { FormSection } from '../components/forms/FormSection.jsx';
+import { FormSelect } from '../components/forms/FormSelect.jsx';
+import { api } from '../lib/api.js';
+
+// Default contents of the restic.env textarea when the user picks the
+// "manual" (API_KEY) backup provider. Mirrors the
+// `default_restic_env` value in templates/create.html.
+const DEFAULT_RESTIC_ENV =
+  '# see docs linked above for available options\n' +
+  '# for example:\n' +
+  'RESTIC_REPOSITORY=s3:s3.amazonaws.com/<bucket_name>\n' +
+  'AWS_ACCESS_KEY_ID=\n' +
+  'AWS_SECRET_ACCESS_KEY=\n';
+
+// Human-readable labels for the generated config summary line.
+const COMPUTE_LABELS = {
+  IMBUE_CLOUD: 'Imbue Cloud',
+  DOCKER: 'Docker',
+  LIMA: 'Lima',
+  CLOUD: 'a cloud VM',
+};
+const AI_LABELS = {
+  IMBUE_CLOUD: 'Imbue Cloud',
+  API_KEY: 'your Anthropic API key',
+  SUBSCRIPTION: 'your Claude subscription',
+};
+const BACKUP_LABELS = {
+  IMBUE_CLOUD: 'Imbue Cloud',
+  API_KEY: 'your own storage',
+  CONFIGURE_LATER: 'off for now',
+};
+
+// Display labels for the backup-provider options: "manual" reads
+// better than "api_key" for this particular field, matching the
+// Jinja template's lowercased-with-an-override behavior.
+const BACKUP_DISPLAY = { API_KEY: 'manual' };
+
+function joinNames(names) {
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+function capitalize(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function buildSummary({ launchMode, aiProvider, backupProvider }) {
+  const facets = [
+    { name: 'compute', label: COMPUTE_LABELS[launchMode] || launchMode },
+    { name: 'tokens', label: AI_LABELS[aiProvider] || aiProvider },
+  ];
+  if (backupProvider !== 'CONFIGURE_LATER') {
+    facets.push({ name: 'backups', label: BACKUP_LABELS[backupProvider] || backupProvider });
+  }
+  const labelOrder = [];
+  const namesByLabel = {};
+  for (const facet of facets) {
+    if (!namesByLabel[facet.label]) {
+      namesByLabel[facet.label] = [];
+      labelOrder.push(facet.label);
+    }
+    namesByLabel[facet.label].push(facet.name);
+  }
+  const sentences = labelOrder.map((label) => capitalize(`${joinNames(namesByLabel[label])} via ${label}`));
+  return `${sentences.join('. ')}.`;
+}
+
+// Defaults applied when the account selection changes. Mirrors the
+// `onAccountChange` block in templates/create.html.
+function defaultsForAccount(hasAccount) {
+  if (hasAccount) {
+    return {
+      launch_mode: 'IMBUE_CLOUD',
+      ai_provider: 'IMBUE_CLOUD',
+      backup_provider: 'IMBUE_CLOUD',
+    };
+  }
+  return {
+    launch_mode: 'LIMA',
+    ai_provider: 'SUBSCRIPTION',
+    backup_provider: 'CONFIGURE_LATER',
+  };
+}
+
+// Build a select-option list from a list of enum values, lowercasing
+// the value for display and applying any per-field display overrides
+// (e.g. "API_KEY" -> "manual" for backups).
+function optionsFromEnum(values, displayOverrides = {}) {
+  return values.map((value) => ({
+    value,
+    label: displayOverrides[value] ?? value.toLowerCase(),
+    requiresAccount: value === 'IMBUE_CLOUD',
+  }));
+}
+
+export function CreateRoute(props) {
+  const accounts = props.accounts ?? [];
+
+  // The form values are tracked in a single store so individual
+  // field updates don't trigger whole-component re-renders.
+  const [form, setForm] = createStore({
+    git_url: props.git_url ?? '',
+    host_name: props.host_name ?? '',
+    branch: props.branch ?? '',
+    account_id: props.default_account_id ?? '',
+    launch_mode: props.selected_launch_mode ?? 'LIMA',
+    ai_provider: props.selected_ai_provider ?? 'SUBSCRIPTION',
+    backup_provider: props.selected_backup_provider ?? 'CONFIGURE_LATER',
+    backup_encryption_method: props.selected_backup_encryption_method ?? 'NO_PASSWORD',
+    backup_api_key_env: props.backup_api_key_env || DEFAULT_RESTIC_ENV,
+    anthropic_api_key: props.anthropic_api_key ?? '',
+    backup_master_password: '',
+    backup_save_password: false,
+  });
+
+  // Top-level submission error from the server (re-rendered banner).
+  // Field-keyed errors live in `errors` when the server adds them in
+  // a future iteration; for now the validation matches today's API:
+  // a single message under the form heading.
+  const [submitError, setSubmitError] = createSignal(props.error_message ?? '');
+  const [isSubmitting, setIsSubmitting] = createSignal(false);
+
+  const hasAccount = createMemo(() => form.account_id !== '');
+
+  // Account-required validation. Mirrors the `launchInvalid` /
+  // `aiInvalid` / `backupInvalid` block in templates/create.html.
+  const launchInvalid = createMemo(() => !hasAccount() && form.launch_mode === 'IMBUE_CLOUD');
+  const aiInvalid = createMemo(() => !hasAccount() && form.ai_provider === 'IMBUE_CLOUD');
+  const backupInvalid = createMemo(() => !hasAccount() && form.backup_provider === 'IMBUE_CLOUD');
+  const hasValidationError = createMemo(() => launchInvalid() || aiInvalid() || backupInvalid());
+
+  const disabledValues = createMemo(() => (hasAccount() ? new Set() : new Set(['IMBUE_CLOUD'])));
+
+  const summaryText = createMemo(() =>
+    buildSummary({
+      launchMode: form.launch_mode,
+      aiProvider: form.ai_provider,
+      backupProvider: form.backup_provider,
+    }),
+  );
+
+  const launchModeOptions = createMemo(() => optionsFromEnum(props.launch_modes ?? []));
+  const aiProviderOptions = createMemo(() => optionsFromEnum(props.ai_providers ?? []));
+  const backupProviderOptions = createMemo(() => optionsFromEnum(props.backup_providers ?? [], BACKUP_DISPLAY));
+  const backupEncryptionOptions = createMemo(() => optionsFromEnum(props.backup_encryption_methods ?? []));
+
+  const handleAccountChange = (event) => {
+    const next = event.currentTarget.value;
+    setForm({ account_id: next, ...defaultsForAccount(next !== '') });
+  };
+
+  const isApiKeyAi = () => form.ai_provider === 'API_KEY';
+  const isBackupConfigured = () => form.backup_provider === 'IMBUE_CLOUD' || form.backup_provider === 'API_KEY';
+  const isBackupApiKey = () => form.backup_provider === 'API_KEY';
+  const isMasterPassword = () => isBackupConfigured() && form.backup_encryption_method === 'MASTER_PASSWORD';
+
+  // Serialize the form into the JSON payload accepted by the new
+  // `/create` JSON endpoint. Mirrors the field set the Jinja form
+  // posted as form-encoded data so the Python handler stays the
+  // same shape modulo content-type.
+  function serializeForm() {
+    return {
+      git_url: form.git_url.trim(),
+      host_name: form.host_name.trim(),
+      branch: form.branch.trim(),
+      launch_mode: form.launch_mode,
+      ai_provider: form.ai_provider,
+      account_id: form.account_id,
+      anthropic_api_key: form.anthropic_api_key.trim(),
+      backup_provider: form.backup_provider,
+      backup_encryption_method: form.backup_encryption_method,
+      backup_api_key_env: form.backup_api_key_env,
+      backup_master_password: form.backup_master_password,
+      backup_save_password: form.backup_save_password,
+    };
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (hasValidationError() || isSubmitting()) return;
+    setIsSubmitting(true);
+    setSubmitError('');
+    const result = await api.postJson('/create', serializeForm());
+    if (result.ok && result.data && result.data.redirect_url) {
+      window.location.href = result.data.redirect_url;
+      return;
+    }
+    setIsSubmitting(false);
+    const errors = result.errors || {};
+    const message = errors._ || Object.values(errors)[0] || 'Could not create workspace.';
+    setSubmitError(String(message));
+  }
+
+  return (
+    <main class="w-full max-w-[520px] bg-white border border-zinc-200 rounded-xl shadow-sm p-6 mx-auto my-6">
+      <form id="create-form" onSubmit={handleSubmit}>
+        <div class="flex items-center justify-between gap-4 mb-5">
+          <h1 class="text-sm font-medium text-zinc-500">Create workspace</h1>
+          <select
+            id="account_id"
+            name="account_id"
+            value={form.account_id}
+            onChange={handleAccountChange}
+            class="max-w-[220px] text-xs text-right text-zinc-400 bg-transparent border-0 rounded px-1 py-1 outline-none cursor-pointer transition-colors hover:text-zinc-600 focus:outline-none focus:ring-0"
+          >
+            <For each={accounts}>
+              {(account) => <option value={account.user_id}>{account.email}</option>}
+            </For>
+            <option value="">No account (private project)</option>
+          </select>
+        </div>
+
+        <Show when={submitError()}>
+          <Notice variant="error">{submitError()}</Notice>
+        </Show>
+
+        <div class="flex gap-2 items-stretch">
+          <div class="flex-1">
+            <FormField
+              name="host_name"
+              value={form.host_name}
+              onInput={(event) => setForm('host_name', event.currentTarget.value)}
+              placeholder="assistant"
+              required
+            />
+          </div>
+          <Button
+            type="submit"
+            variant="primary"
+            id="create-submit"
+            disabled={hasValidationError() || isSubmitting()}
+          >
+            {isSubmitting() ? 'Creating...' : 'Create'}
+          </Button>
+        </div>
+
+        <FormSection
+          summary={summaryText()}
+          showLabel="Configure..."
+          hideLabel="Hide"
+        >
+          <FormSelect
+            label="Compute provider"
+            name="launch_mode"
+            value={form.launch_mode}
+            onChange={(value) => setForm('launch_mode', value)}
+            options={launchModeOptions()}
+            disabledValues={disabledValues()}
+            error={launchInvalid() ? 'imbue_cloud requires a selected account.' : ''}
+          />
+
+          <div>
+            <FormSelect
+              label="AI provider"
+              name="ai_provider"
+              value={form.ai_provider}
+              onChange={(value) => setForm('ai_provider', value)}
+              options={aiProviderOptions()}
+              disabledValues={disabledValues()}
+              error={aiInvalid() ? 'imbue_cloud requires a selected account.' : ''}
+            />
+            <Show when={isApiKeyAi()}>
+              <div class="mt-2">
+                <FormField
+                  label="Anthropic API key"
+                  name="anthropic_api_key"
+                  type="password"
+                  value={form.anthropic_api_key}
+                  onInput={(event) => setForm('anthropic_api_key', event.currentTarget.value)}
+                  placeholder="sk-ant-..."
+                  required
+                />
+              </div>
+            </Show>
+          </div>
+
+          <div>
+            <FormSelect
+              label="Backup provider"
+              name="backup_provider"
+              value={form.backup_provider}
+              onChange={(value) => setForm('backup_provider', value)}
+              options={backupProviderOptions()}
+              disabledValues={disabledValues()}
+              error={backupInvalid() ? 'imbue_cloud requires a selected account.' : ''}
+            />
+
+            <Show when={isBackupApiKey()}>
+              <div class="mt-2">
+                <FormField
+                  label="restic environment"
+                  name="backup_api_key_env"
+                  rows={6}
+                  value={form.backup_api_key_env}
+                  onInput={(event) => setForm('backup_api_key_env', event.currentTarget.value)}
+                  helper="Written verbatim to restic.env. Don't set RESTIC_PASSWORD -- minds assigns each workspace its own."
+                />
+              </div>
+            </Show>
+
+            <Show when={isBackupConfigured()}>
+              <div class="mt-2">
+                <FormSelect
+                  label="Backup encryption method"
+                  name="backup_encryption_method"
+                  value={form.backup_encryption_method}
+                  onChange={(value) => setForm('backup_encryption_method', value)}
+                  options={backupEncryptionOptions()}
+                />
+              </div>
+            </Show>
+
+            <Show when={isMasterPassword()}>
+              <div class="mt-2">
+                <Show
+                  when={props.has_saved_backup_password}
+                  fallback={
+                    <>
+                      <FormField
+                        label="Backup master password"
+                        name="backup_master_password"
+                        type="password"
+                        value={form.backup_master_password}
+                        onInput={(event) => setForm('backup_master_password', event.currentTarget.value)}
+                        placeholder="remember this -- backups are unrecoverable without it"
+                        required
+                      />
+                      <label class="mt-2 flex items-center gap-2 text-xs text-zinc-500">
+                        <input
+                          type="checkbox"
+                          id="backup_save_password"
+                          name="backup_save_password"
+                          checked={form.backup_save_password}
+                          onChange={(event) => setForm('backup_save_password', event.currentTarget.checked)}
+                        />
+                        Save this password for all my workspaces
+                      </label>
+                    </>
+                  }
+                >
+                  <p class="text-xs text-zinc-500">
+                    A saved backup password will be used for this workspace.
+                  </p>
+                </Show>
+              </div>
+            </Show>
+          </div>
+
+          <FormSection
+            showLabel="Show advanced settings"
+            hideLabel="Hide advanced settings"
+          >
+            <FormField
+              label="Repository"
+              name="git_url"
+              value={form.git_url}
+              onInput={(event) => setForm('git_url', event.currentTarget.value)}
+              placeholder="https://github.com/user/repo.git"
+              helper="Git URL or local path"
+              required
+            />
+            <FormField
+              label="Branch"
+              name="branch"
+              value={form.branch}
+              onInput={(event) => setForm('branch', event.currentTarget.value)}
+              placeholder="latest tag"
+              helper="Leave empty for latest version"
+            />
+          </FormSection>
+        </FormSection>
+      </form>
+    </main>
+  );
+}

--- a/apps/minds/frontend/src/routes/create.test.jsx
+++ b/apps/minds/frontend/src/routes/create.test.jsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@solidjs/testing-library';
+import { CreateRoute } from './create.jsx';
+
+// Standard prop fixture mirroring what the Python `render_create_form`
+// shim now passes through to the Solid component. Tests override
+// specific keys as needed.
+const BASE_PROPS = {
+  git_url: 'https://github.com/imbue-ai/forever-claude-template.git',
+  host_name: 'assistant',
+  branch: '',
+  selected_launch_mode: 'LIMA',
+  selected_ai_provider: 'SUBSCRIPTION',
+  selected_backup_provider: 'CONFIGURE_LATER',
+  selected_backup_encryption_method: 'NO_PASSWORD',
+  backup_api_key_env: '',
+  has_saved_backup_password: false,
+  accounts: [],
+  default_account_id: '',
+  anthropic_api_key: '',
+  error_message: '',
+  launch_modes: ['DOCKER', 'CLOUD', 'LIMA', 'IMBUE_CLOUD'],
+  ai_providers: ['IMBUE_CLOUD', 'API_KEY', 'SUBSCRIPTION'],
+  backup_providers: ['IMBUE_CLOUD', 'API_KEY', 'CONFIGURE_LATER'],
+  backup_encryption_methods: ['MASTER_PASSWORD', 'NO_PASSWORD'],
+};
+
+describe('CreateRoute', () => {
+  let originalFetch;
+  let originalLocation;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalLocation = window.location;
+    // jsdom guards window.location; replace with a writable shim so
+    // the route's `window.location.href = ...` redirect is observable.
+    delete window.location;
+    window.location = { href: '' };
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    window.location = originalLocation;
+  });
+
+  it('renders the form with the heading, host_name field, and submit button', () => {
+    const { getByRole, getByText } = render(() => <CreateRoute {...BASE_PROPS} />);
+    expect(getByText('Create workspace')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(getByText('No account (private project)')).toBeInTheDocument();
+  });
+
+  it('submits the form as JSON and follows the redirect on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ redirect_url: '/creating/abc123' }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const { getByRole } = render(() => <CreateRoute {...BASE_PROPS} />);
+    fireEvent.submit(getByRole('button', { name: 'Create' }).closest('form'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe('/create');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    const sent = JSON.parse(init.body);
+    expect(sent.host_name).toBe('assistant');
+    expect(sent.git_url).toBe('https://github.com/imbue-ai/forever-claude-template.git');
+    expect(sent.launch_mode).toBe('LIMA');
+    await waitFor(() => expect(window.location.href).toBe('/creating/abc123'));
+  });
+
+  it('renders the server error message and does not redirect on a validation failure', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({ errors: { _: 'Repository URL is required.' } }),
+    });
+    globalThis.fetch = fetchMock;
+
+    const { getByRole, findByText } = render(() => <CreateRoute {...BASE_PROPS} />);
+    fireEvent.submit(getByRole('button', { name: 'Create' }).closest('form'));
+
+    expect(await findByText('Repository URL is required.')).toBeInTheDocument();
+    expect(window.location.href).toBe('');
+  });
+
+  it('shows the initial error_message banner without a network round-trip', () => {
+    const { getByText } = render(() => (
+      <CreateRoute {...BASE_PROPS} error_message="imbue_cloud requires an account." />
+    ));
+    expect(getByText('imbue_cloud requires an account.')).toBeInTheDocument();
+  });
+
+  it('disables the submit button when an IMBUE_CLOUD option is picked without an account', async () => {
+    const { getByLabelText, getByRole, findByText, container } = render(() => (
+      <CreateRoute
+        {...BASE_PROPS}
+        selected_launch_mode="IMBUE_CLOUD"
+      />
+    ));
+    // Open the configure panel so the inline error becomes part of
+    // the DOM and the user-visible state is realistic.
+    fireEvent.click(getByRole('button', { name: 'Configure...' }));
+    expect(await findByText('imbue_cloud requires a selected account.')).toBeInTheDocument();
+    const submit = getByRole('button', { name: 'Create' });
+    expect(submit.disabled).toBe(true);
+    // Sanity: the launch_mode select still exists and is set to IMBUE_CLOUD.
+    expect(getByLabelText('Compute provider').value).toBe('IMBUE_CLOUD');
+    // The container check makes sure rendering happened (silences
+    // unused-binding lint -- the destructure is what we mean).
+    expect(container).not.toBeNull();
+  });
+});

--- a/apps/minds/frontend/src/routes/registry.js
+++ b/apps/minds/frontend/src/routes/registry.js
@@ -2,6 +2,7 @@ import { WelcomeRoute } from './welcome.jsx';
 import { LoginRoute } from './login.jsx';
 import { AuthErrorRoute } from './auth_error.jsx';
 import { LoginRedirectRoute } from './login_redirect.jsx';
+import { CreateRoute } from './create.jsx';
 
 // Maps a "route key" (the Python side picks the key by URL) to its Solid
 // component. The key is passed verbatim through the SSR sidecar HTTP
@@ -15,6 +16,7 @@ export const ROUTES = {
   login: LoginRoute,
   auth_error: AuthErrorRoute,
   login_redirect: LoginRedirectRoute,
+  create: CreateRoute,
 };
 
 export function getRouteComponent(key) {

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -427,6 +427,7 @@ def _handle_landing_page(
         accounts=accounts,
         default_account_id=default_account_id or "",
         has_saved_backup_password=is_backup_password_saved,
+        sidecar=request.app.state.ssr_sidecar,
     )
     return HTMLResponse(content=html)
 
@@ -743,69 +744,70 @@ def _build_backup_request_or_error(
     )
 
 
+def _json_error_response(message: str, status: int = 400) -> Response:
+    """Build the JSON error envelope the create-form Solid component expects.
+
+    Mirrors the ``{ ok, errors, data }`` shape ``api.postJson`` returns
+    on failure: ``_`` is the top-level "form-wide" error key (the only
+    one used today; future iterations can add field-keyed errors).
+    """
+    body = json.dumps({"ok": False, "errors": {"_": message}, "data": None})
+    return Response(content=body, status_code=status, media_type="application/json")
+
+
 async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep) -> Response:
-    """Handle form submission to create a new agent."""
+    """Handle form submission to create a new agent.
+
+    The Solid create form posts a JSON body and expects a JSON
+    ``{ ok, errors, data }`` envelope back: on success ``data`` carries
+    a ``redirect_url`` for the client-side navigation; on failure
+    ``errors`` carries the per-field (or form-wide ``_``) messages.
+    """
     if not _is_authenticated(cookies=request.cookies, auth_store=auth_store):
-        return Response(status_code=403, content="Not authenticated")
+        return _json_error_response("Not authenticated", status=403)
 
     agent_creator: AgentCreator | None = request.app.state.agent_creator
     if agent_creator is None:
-        return Response(status_code=501, content="Agent creation not configured")
+        return _json_error_response("Agent creation not configured", status=501)
 
-    form = await request.form()
-    git_url = str(form.get("git_url", "")).strip()
-    host_name = str(form.get("host_name", "")).strip()
-    branch = str(form.get("branch", "")).strip()
     try:
-        launch_mode = LaunchMode(str(form.get("launch_mode", LaunchMode.DOCKER.value)))
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return _json_error_response("Invalid JSON body")
+    if not isinstance(body, dict):
+        return _json_error_response("Invalid JSON body")
+
+    git_url = str(body.get("git_url", "")).strip()
+    host_name = str(body.get("host_name", "")).strip()
+    branch = str(body.get("branch", "")).strip()
+    try:
+        launch_mode = LaunchMode(str(body.get("launch_mode", LaunchMode.DOCKER.value)))
     except ValueError:
         launch_mode = LaunchMode.DOCKER
     try:
-        ai_provider = AIProvider(str(form.get("ai_provider", AIProvider.SUBSCRIPTION.value)))
+        ai_provider = AIProvider(str(body.get("ai_provider", AIProvider.SUBSCRIPTION.value)))
     except ValueError:
         ai_provider = AIProvider.SUBSCRIPTION
-    account_id = str(form.get("account_id", "")).strip()
-    anthropic_api_key = str(form.get("anthropic_api_key", "")).strip()
+    account_id = str(body.get("account_id", "")).strip()
+    anthropic_api_key = str(body.get("anthropic_api_key", "")).strip()
     try:
-        backup_provider = BackupProvider(str(form.get("backup_provider", BackupProvider.CONFIGURE_LATER.value)))
+        backup_provider = BackupProvider(str(body.get("backup_provider", BackupProvider.CONFIGURE_LATER.value)))
     except ValueError:
         backup_provider = BackupProvider.CONFIGURE_LATER
     try:
         backup_encryption_method = BackupEncryptionMethod(
-            str(form.get("backup_encryption_method", BackupEncryptionMethod.NO_PASSWORD.value))
+            str(body.get("backup_encryption_method", BackupEncryptionMethod.NO_PASSWORD.value))
         )
     except ValueError:
         backup_encryption_method = BackupEncryptionMethod.NO_PASSWORD
-    backup_master_password = str(form.get("backup_master_password", ""))
-    is_save_backup_password = str(form.get("backup_save_password", "")).strip() != ""
-    backup_api_key_env = str(form.get("backup_api_key_env", ""))
+    backup_master_password = str(body.get("backup_master_password", ""))
+    is_save_backup_password = bool(body.get("backup_save_password", False))
+    backup_api_key_env = str(body.get("backup_api_key_env", ""))
 
     session_store_inst: MultiAccountSessionStore | None = request.app.state.session_store
 
-    def _re_render_with_error(message: str, status: int = 400) -> Response:
-        accounts_list = session_store_inst.list_accounts() if session_store_inst else []
-        # Re-render with the user's submitted account_id pre-selected
-        # (including "" -> "No account") rather than the config default,
-        # so a validation error doesn't silently revert their choice.
-        html_body = render_create_form(
-            git_url=git_url,
-            host_name=host_name,
-            branch=branch,
-            launch_mode=launch_mode,
-            ai_provider=ai_provider,
-            accounts=accounts_list,
-            default_account_id=account_id,
-            anthropic_api_key=anthropic_api_key,
-            backup_provider=backup_provider,
-            backup_encryption_method=backup_encryption_method,
-            backup_api_key_env=backup_api_key_env,
-            has_saved_backup_password=has_saved_backup_password(agent_creator.paths),
-            error_message=message,
-        )
-        return HTMLResponse(content=html_body, status_code=status)
-
     if not git_url:
-        return _re_render_with_error("Repository URL is required.")
+        return _json_error_response("Repository URL is required.")
 
     # Validate the host name eagerly so the user sees the error inline on
     # the form rather than as a deferred "FAILED" status on the creating
@@ -815,18 +817,18 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
         try:
             HostName(host_name)
         except InvalidName as exc:
-            return _re_render_with_error(str(exc))
+            return _json_error_response(str(exc))
 
     is_imbue_cloud_compute = launch_mode is LaunchMode.IMBUE_CLOUD
     is_imbue_cloud_ai = ai_provider is AIProvider.IMBUE_CLOUD
     if not account_id and (is_imbue_cloud_compute or is_imbue_cloud_ai):
-        return _re_render_with_error(
+        return _json_error_response(
             "imbue_cloud requires an account. Select an account or pick a different "
             "option for both the compute and AI providers."
         )
 
     if ai_provider is AIProvider.API_KEY and not anthropic_api_key:
-        return _re_render_with_error("An Anthropic API key is required when AI provider is set to api_key.")
+        return _json_error_response("An Anthropic API key is required when AI provider is set to api_key.")
 
     # Resolve the account email when needed (imbue_cloud compute, AI, or
     # backup). The mngr_imbue_cloud plugin owns the SuperTokens session and
@@ -854,7 +856,7 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
         paths=agent_creator.paths,
     )
     if backup_error is not None:
-        return _re_render_with_error(backup_error)
+        return _json_error_response(backup_error)
 
     branch_or_tag = branch
     if is_imbue_cloud_compute and not branch_or_tag:
@@ -882,7 +884,11 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
     )
 
     creating_url = "/creating/{}".format(creation_id)
-    return Response(status_code=303, headers={"Location": creating_url})
+    return Response(
+        content=json.dumps({"ok": True, "errors": {}, "data": {"redirect_url": creating_url}}),
+        status_code=200,
+        media_type="application/json",
+    )
 
 
 def _handle_create_page(
@@ -907,6 +913,7 @@ def _handle_create_page(
         accounts=accounts,
         default_account_id=default_account_id or "",
         has_saved_backup_password=is_backup_password_saved,
+        sidecar=request.app.state.ssr_sidecar,
     )
     return HTMLResponse(content=html)
 

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -772,7 +772,11 @@ async def _handle_create_form_submit(request: Request, auth_store: AuthStoreDep)
 
     try:
         body = await request.json()
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as exc:
+        # Log so the corruption is observable: this endpoint is hit by
+        # the Solid create form and a malformed body almost certainly
+        # means the client serializer drifted.
+        logger.warning("POST /create received invalid JSON body: {}", exc)
         return _json_error_response("Invalid JSON body")
     if not isinstance(body, dict):
         return _json_error_response("Invalid JSON body")

--- a/apps/minds/imbue/minds/desktop_client/ssr_routes_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssr_routes_test.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for the four routes that have migrated to Solid SSR.
+"""End-to-end tests for the routes that have migrated to Solid SSR.
 
 These exercise the FastAPI handlers themselves (rather than the
 ``render_*`` shims directly): the handler pulls the sidecar off
@@ -71,3 +71,34 @@ def test_authenticate_with_invalid_code_emits_auth_error_payload(tmp_path: Path)
     payload = extract_ssr_route_payload(response.text)
     assert payload["route"] == "auth_error"
     assert "invalid" in payload["props"]["message"].lower()
+
+
+def test_create_endpoint_emits_solid_route_payload(tmp_path: Path) -> None:
+    """GET /create renders the ``create`` Solid route with the props the Jinja form used.
+
+    Asserts the route key + a few load-bearing prop fields: the default
+    host_name (``assistant``), the launch_modes enum list (so the
+    component can render the compute-provider <select>), and the
+    default selection (``LIMA`` without an account). Any missing field
+    would have broken the Jinja template's render call -- mirroring
+    that gate.
+    """
+    client, auth_store = _make_client(tmp_path)
+    _authenticate(client, auth_store)
+    response = client.get("/create")
+    assert response.status_code == 200
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "create"
+    props = payload["props"]
+    assert props["host_name"] == "assistant"
+    # The launch_modes prop must include every LaunchMode enum value so
+    # the Solid component can render them all; assert IMBUE_CLOUD and
+    # LIMA specifically because the account-driven disable logic +
+    # the no-account default both key off them.
+    assert "IMBUE_CLOUD" in props["launch_modes"]
+    assert "LIMA" in props["launch_modes"]
+    # Default selection without an account is LIMA / SUBSCRIPTION /
+    # CONFIGURE_LATER -- mirrors the assertions in templates_test.py.
+    assert props["selected_launch_mode"] == "LIMA"
+    assert props["selected_ai_provider"] == "SUBSCRIPTION"
+    assert props["selected_backup_provider"] == "CONFIGURE_LATER"

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -28,6 +28,7 @@ from imbue.minds.bootstrap import DEFAULT_MINDS_ROOT_NAME
 from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.desktop_client.agent_creator import AgentCreationInfo
 from imbue.minds.desktop_client.onboarding import expected_creation_duration_seconds
+from imbue.minds.desktop_client.session_store import AccountSession
 from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 from imbue.minds.desktop_client.ssr_sidecar import SsrSidecarError
 from imbue.minds.primitives import AIProvider
@@ -247,19 +248,9 @@ def _dev_only_workspace_default(env_var: str, fallback: str) -> str:
     return os.environ.get(env_var, fallback)
 
 
-def _serialize_account(account: object) -> dict[str, str]:
-    """Pull ``user_id`` and ``email`` off an ``AccountSession``-like object.
-
-    The session-store layer hands us ``AccountSession`` instances, but
-    historical callers (and a few tests) also pass plain objects with
-    the same two public attributes -- so we use ``getattr`` rather than
-    importing ``AccountSession`` here to avoid the circular dependency
-    that would create (session_store imports from templates today).
-    """
-    return {
-        "user_id": str(getattr(account, "user_id", "")),
-        "email": str(getattr(account, "email", "")),
-    }
+def _serialize_account(account: AccountSession) -> dict[str, str]:
+    """Flatten an ``AccountSession`` to the JSON-serializable shape the Solid create form expects."""
+    return {"user_id": str(account.user_id), "email": account.email}
 
 
 def render_create_form(
@@ -272,7 +263,7 @@ def render_create_form(
     backup_encryption_method: BackupEncryptionMethod | None = None,
     backup_api_key_env: str = "",
     has_saved_backup_password: bool = False,
-    accounts: Sequence[object] | None = None,
+    accounts: Sequence[AccountSession] | None = None,
     default_account_id: str = "",
     anthropic_api_key: str = "",
     error_message: str = "",

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -247,7 +247,21 @@ def _dev_only_workspace_default(env_var: str, fallback: str) -> str:
     return os.environ.get(env_var, fallback)
 
 
-@pure
+def _serialize_account(account: object) -> dict[str, str]:
+    """Pull ``user_id`` and ``email`` off an ``AccountSession``-like object.
+
+    The session-store layer hands us ``AccountSession`` instances, but
+    historical callers (and a few tests) also pass plain objects with
+    the same two public attributes -- so we use ``getattr`` rather than
+    importing ``AccountSession`` here to avoid the circular dependency
+    that would create (session_store imports from templates today).
+    """
+    return {
+        "user_id": str(getattr(account, "user_id", "")),
+        "email": str(getattr(account, "email", "")),
+    }
+
+
 def render_create_form(
     git_url: str = "",
     host_name: str = "",
@@ -262,6 +276,7 @@ def render_create_form(
     default_account_id: str = "",
     anthropic_api_key: str = "",
     error_message: str = "",
+    sidecar: SsrSidecar | None = None,
 ) -> str:
     """Render the agent creation form page.
 
@@ -302,26 +317,26 @@ def render_create_form(
     effective_backup_encryption = (
         backup_encryption_method if backup_encryption_method is not None else BackupEncryptionMethod.NO_PASSWORD
     )
-    template = JINJA_ENV.get_template("create.html")
-    return template.render(
-        git_url=effective_url,
-        host_name=effective_name,
-        branch=effective_branch,
-        launch_modes=list(LaunchMode),
-        selected_launch_mode=effective_launch_mode.value,
-        ai_providers=list(AIProvider),
-        selected_ai_provider=effective_ai_provider.value,
-        backup_providers=list(BackupProvider),
-        selected_backup_provider=effective_backup_provider.value,
-        backup_encryption_methods=list(BackupEncryptionMethod),
-        selected_backup_encryption_method=effective_backup_encryption.value,
-        backup_api_key_env=backup_api_key_env,
-        has_saved_backup_password=has_saved_backup_password,
-        accounts=accounts or [],
-        default_account_id=default_account_id,
-        anthropic_api_key=anthropic_api_key,
-        error_message=error_message,
-    )
+    props: dict[str, Any] = {
+        "git_url": effective_url,
+        "host_name": effective_name,
+        "branch": effective_branch,
+        "launch_modes": [mode.value for mode in LaunchMode],
+        "selected_launch_mode": effective_launch_mode.value,
+        "ai_providers": [provider.value for provider in AIProvider],
+        "selected_ai_provider": effective_ai_provider.value,
+        "backup_providers": [provider.value for provider in BackupProvider],
+        "selected_backup_provider": effective_backup_provider.value,
+        "backup_encryption_methods": [method.value for method in BackupEncryptionMethod],
+        "selected_backup_encryption_method": effective_backup_encryption.value,
+        "backup_api_key_env": backup_api_key_env,
+        "has_saved_backup_password": has_saved_backup_password,
+        "accounts": [_serialize_account(account) for account in (accounts or [])],
+        "default_account_id": default_account_id,
+        "anthropic_api_key": anthropic_api_key,
+        "error_message": error_message,
+    }
+    return _render_ssr_or_fallback(sidecar=sidecar, route="create", props=props)
 
 
 _STATUS_TEXT_DEFAULT: Final[dict[str, str]] = {

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -73,61 +73,56 @@ def test_agent_id_accepts_valid_format() -> None:
 
 
 def test_render_create_form_has_default_values() -> None:
-    html = render_create_form()
-    assert "assistant" in html
-    assert "forever-claude-template" in html
-    assert "host_name" in html
-    assert "launch_mode" in html
+    payload = extract_ssr_route_payload(render_create_form())
+    assert payload["route"] == "create"
+    props = payload["props"]
+    assert props["host_name"] == "assistant"
+    assert "forever-claude-template" in props["git_url"]
 
 
 def test_render_create_form_prefills_values() -> None:
-    html = render_create_form(git_url="https://custom/repo", host_name="my-workspace", branch="feature/test")
-    assert "https://custom/repo" in html
-    assert "my-workspace" in html
-    assert "feature/test" in html
+    payload = extract_ssr_route_payload(
+        render_create_form(git_url="https://custom/repo", host_name="my-workspace", branch="feature/test")
+    )
+    props = payload["props"]
+    assert props["git_url"] == "https://custom/repo"
+    assert props["host_name"] == "my-workspace"
+    assert props["branch"] == "feature/test"
 
 
 def test_render_create_form_contains_all_launch_modes() -> None:
-    html = render_create_form()
-    for mode in LaunchMode:
-        assert mode.value.lower() in html
+    payload = extract_ssr_route_payload(render_create_form())
+    assert payload["props"]["launch_modes"] == [mode.value for mode in LaunchMode]
 
 
 def test_render_create_form_selects_lima_by_default_without_account() -> None:
     # With no account selected the compute provider defaults to LIMA (the
     # local self-served default); IMBUE_CLOUD is only the default when an
     # account is present.
-    html = render_create_form()
-    assert 'value="LIMA" selected' in html
+    payload = extract_ssr_route_payload(render_create_form())
+    assert payload["props"]["selected_launch_mode"] == "LIMA"
 
 
 def test_render_create_form_selects_specified_launch_mode() -> None:
     # CLOUD instead of the default LIMA so the "selection honored over the
     # default" assertion is meaningful.
-    html = render_create_form(launch_mode=LaunchMode.CLOUD)
-    assert 'value="CLOUD" selected' in html
-    assert 'value="LIMA" selected' not in html
+    payload = extract_ssr_route_payload(render_create_form(launch_mode=LaunchMode.CLOUD))
+    assert payload["props"]["selected_launch_mode"] == "CLOUD"
 
 
 def test_render_create_form_contains_ai_provider_options() -> None:
-    html = render_create_form()
-    for provider in AIProvider:
-        assert f'value="{provider.value}"' in html
+    payload = extract_ssr_route_payload(render_create_form())
+    assert payload["props"]["ai_providers"] == [provider.value for provider in AIProvider]
 
 
 def test_render_create_form_defaults_ai_provider_to_subscription_without_account() -> None:
-    html = render_create_form()
-    assert 'value="SUBSCRIPTION" selected' in html
-
-
-def test_render_create_form_omits_env_file_checkbox() -> None:
-    html = render_create_form()
-    assert "include_env_file" not in html
+    payload = extract_ssr_route_payload(render_create_form())
+    assert payload["props"]["selected_ai_provider"] == "SUBSCRIPTION"
 
 
 def test_render_create_form_shows_error_message_when_supplied() -> None:
-    html = render_create_form(error_message="Imbue cloud requires an account.")
-    assert "Imbue cloud requires an account." in html
+    payload = extract_ssr_route_payload(render_create_form(error_message="Imbue cloud requires an account."))
+    assert payload["props"]["error_message"] == "Imbue cloud requires an account."
 
 
 def test_render_create_form_honors_workspace_env_vars_in_dev_tier(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -140,10 +135,10 @@ def test_render_create_form_honors_workspace_env_vars_in_dev_tier(monkeypatch: p
     monkeypatch.setenv("MINDS_WORKSPACE_GIT_URL", "/local/fct/path")
     monkeypatch.setenv("MINDS_WORKSPACE_NAME", "mindtest")
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
-    html = render_create_form()
-    assert "/local/fct/path" in html
-    assert "mindtest" in html
-    assert "mngr/some-feature" in html
+    props = extract_ssr_route_payload(render_create_form())["props"]
+    assert props["git_url"] == "/local/fct/path"
+    assert props["host_name"] == "mindtest"
+    assert props["branch"] == "mngr/some-feature"
 
 
 def test_render_create_form_ignores_workspace_env_vars_in_staging(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,21 +155,21 @@ def test_render_create_form_ignores_workspace_env_vars_in_staging(monkeypatch: p
     monkeypatch.setenv("MINDS_WORKSPACE_GIT_URL", "/local/fct/path")
     monkeypatch.setenv("MINDS_WORKSPACE_NAME", "mindtest")
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
-    html = render_create_form()
-    assert "/local/fct/path" not in html
-    assert "mindtest" not in html
-    assert "mngr/some-feature" not in html
+    props = extract_ssr_route_payload(render_create_form())["props"]
+    assert props["git_url"] != "/local/fct/path"
+    assert props["host_name"] != "mindtest"
+    assert props["branch"] != "mngr/some-feature"
     # And the hardcoded fallbacks DO appear (form is still usable).
-    assert "forever-claude-template" in html
-    assert "assistant" in html
+    assert "forever-claude-template" in props["git_url"]
+    assert props["host_name"] == "assistant"
 
 
 def test_render_create_form_ignores_workspace_env_vars_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
     """Production -- like staging -- must not honor the dev-iteration env vars."""
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds")
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
-    html = render_create_form()
-    assert "mngr/some-feature" not in html
+    props = extract_ssr_route_payload(render_create_form())["props"]
+    assert props["branch"] != "mngr/some-feature"
 
 
 def test_render_create_form_ignores_workspace_env_vars_when_unactivated(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -185,8 +180,8 @@ def test_render_create_form_ignores_workspace_env_vars_when_unactivated(monkeypa
     """
     monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
-    html = render_create_form()
-    assert "mngr/some-feature" not in html
+    props = extract_ssr_route_payload(render_create_form())["props"]
+    assert props["branch"] != "mngr/some-feature"
 
 
 def test_render_login_page_emits_solid_route_payload() -> None:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -377,7 +377,7 @@ def test_landing_page_shows_discovering_when_initial_discovery_not_done(tmp_path
 
 
 def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path: Path) -> None:
-    """After discovery completes with no agents, show the create form."""
+    """After discovery completes with no agents, show the create form route."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
     client, auth_store = _create_test_desktop_client(
         tmp_path=tmp_path,
@@ -388,8 +388,8 @@ def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path
 
     response = client.get("/")
     assert response.status_code == 200
-    assert "Create workspace" in response.text
-    assert "git_url" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "create"
 
 
 def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:
@@ -404,11 +404,12 @@ def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:
 
     response = client.get("/", params={"git_url": "file:///nonexistent-repo"})
     assert response.status_code == 200
-    assert "file:///nonexistent-repo" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["props"]["git_url"] == "file:///nonexistent-repo"
 
 
 def test_create_page_shows_form(tmp_path: Path) -> None:
-    """GET /create shows the agent creation form."""
+    """GET /create renders the create Solid route with default props."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
     client, auth_store = _create_test_desktop_client(
         tmp_path=tmp_path,
@@ -419,7 +420,9 @@ def test_create_page_shows_form(tmp_path: Path) -> None:
 
     response = client.get("/create")
     assert response.status_code == 200
-    assert "Create workspace" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "create"
+    assert payload["props"]["host_name"] == "assistant"
 
 
 def test_creation_status_returns_404_for_unknown_agent(tmp_path: Path) -> None:
@@ -467,8 +470,11 @@ def test_create_form_submit_returns_501_without_agent_creator(tmp_path: Path) ->
     )
     _authenticate_client(client=client, auth_store=auth_store)
 
-    response = client.post("/create", data={"git_url": "file:///nonexistent-repo"})
+    response = client.post("/create", json={"git_url": "file:///nonexistent-repo"})
     assert response.status_code == 501
+    body = response.json()
+    assert body["ok"] is False
+    assert "errors" in body
 
 
 def test_create_agent_api_returns_501_without_agent_creator(tmp_path: Path) -> None:
@@ -532,26 +538,31 @@ def _create_test_server_with_agent_creator(
     return client, auth_store, agent_creator
 
 
-def test_create_form_submit_redirects_to_creating_page(tmp_path: Path) -> None:
-    """POST /create with valid git_url redirects to /creating/{agent_id}."""
+def test_create_form_submit_returns_redirect_url_on_success(tmp_path: Path) -> None:
+    """POST /create with valid git_url returns a JSON envelope carrying redirect_url."""
     client, _, agent_creator = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={"git_url": "file:///nonexistent-repo"},
-        follow_redirects=False,
+        json={"git_url": "file:///nonexistent-repo"},
     )
-    assert response.status_code == 303
-    assert response.headers["location"].startswith("/creating/")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["errors"] == {}
+    assert body["data"]["redirect_url"].startswith("/creating/")
     agent_creator.wait_for_all()
 
 
 def test_create_form_submit_rejects_empty_git_url(tmp_path: Path) -> None:
-    """POST /create with empty git_url returns 400."""
+    """POST /create with empty git_url returns 400 with a form-wide error."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
-    response = client.post("/create", data={"git_url": "", "host_name": "test"})
+    response = client.post("/create", json={"git_url": "", "host_name": "test"})
     assert response.status_code == 400
+    body = response.json()
+    assert body["ok"] is False
+    assert "required" in body["errors"]["_"].lower()
 
 
 def test_create_form_submit_passes_host_name(tmp_path: Path) -> None:
@@ -560,10 +571,10 @@ def test_create_form_submit_passes_host_name(tmp_path: Path) -> None:
 
     response = client.post(
         "/create",
-        data={"git_url": "file:///nonexistent-repo", "host_name": "my-workspace"},
-        follow_redirects=False,
+        json={"git_url": "file:///nonexistent-repo", "host_name": "my-workspace"},
     )
-    assert response.status_code == 303
+    assert response.status_code == 200
+    assert response.json()["data"]["redirect_url"].startswith("/creating/")
     agent_creator.wait_for_all()
 
 
@@ -663,17 +674,17 @@ def test_onboarding_submit_requires_authentication(tmp_path: Path) -> None:
 
 
 def test_create_form_submit_rejects_invalid_host_name(tmp_path: Path) -> None:
-    """POST /create with a host_name that fails HostName validation re-renders the form with an error."""
+    """POST /create with a host_name that fails HostName validation returns a JSON error."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={"git_url": "file:///nonexistent-repo", "host_name": "bad.name"},
-        follow_redirects=False,
+        json={"git_url": "file:///nonexistent-repo", "host_name": "bad.name"},
     )
     assert response.status_code == 400
-    assert "alphanumeric" in response.text
-    assert "bad.name" in response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert "alphanumeric" in body["errors"]["_"]
 
 
 def test_create_agent_api_rejects_invalid_host_name(tmp_path: Path) -> None:
@@ -750,12 +761,13 @@ def test_creation_status_api_returns_status_for_tracked_agent(tmp_path: Path) ->
 
 
 def test_create_page_prefills_git_url_from_query(tmp_path: Path) -> None:
-    """GET /create?git_url=... pre-fills the form."""
+    """GET /create?git_url=... pre-fills the form prop."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.get("/create", params={"git_url": "file:///nonexistent-repo"})
     assert response.status_code == 200
-    assert "file:///nonexistent-repo" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["props"]["git_url"] == "file:///nonexistent-repo"
 
 
 def test_landing_page_shows_create_link_when_multiple_agents_known(tmp_path: Path) -> None:
@@ -794,7 +806,7 @@ def test_create_page_rejects_unauthenticated(tmp_path: Path) -> None:
 
 
 def test_create_form_submit_rejects_unauthenticated(tmp_path: Path) -> None:
-    """POST /create returns 403 without authentication."""
+    """POST /create returns a 403 JSON envelope without authentication."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
     client, _ = _create_test_desktop_client(
         tmp_path=tmp_path,
@@ -802,8 +814,10 @@ def test_create_form_submit_rejects_unauthenticated(tmp_path: Path) -> None:
         http_client=None,
     )
 
-    response = client.post("/create", data={"git_url": "file:///nonexistent-repo"})
+    response = client.post("/create", json={"git_url": "file:///nonexistent-repo"})
     assert response.status_code == 403
+    body = response.json()
+    assert body["ok"] is False
 
 
 def test_create_agent_api_rejects_unauthenticated(tmp_path: Path) -> None:
@@ -966,14 +980,14 @@ def test_create_form_submit_passes_launch_mode(tmp_path: Path) -> None:
 
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "DOCKER",
         },
-        follow_redirects=False,
     )
-    assert response.status_code == 303
+    assert response.status_code == 200
+    assert response.json()["data"]["redirect_url"].startswith("/creating/")
     agent_creator.wait_for_all()
 
 
@@ -1012,28 +1026,23 @@ def test_create_agent_api_rejects_invalid_launch_mode(tmp_path: Path) -> None:
 
 
 def test_create_form_shows_launch_mode_dropdown(tmp_path: Path) -> None:
-    """GET /create form includes the launch mode dropdown."""
+    """GET /create includes every LaunchMode enum value in the launch_modes prop."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.get("/create")
     assert response.status_code == 200
-    assert "launch_mode" in response.text
-    assert "docker" in response.text
-    assert "cloud" in response.text
-    assert "lima" in response.text
-    assert "imbue_cloud" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert {"DOCKER", "CLOUD", "LIMA", "IMBUE_CLOUD"}.issubset(set(payload["props"]["launch_modes"]))
 
 
 def test_create_form_shows_ai_provider_dropdown(tmp_path: Path) -> None:
-    """GET /create form includes the AI provider dropdown with all three options."""
+    """GET /create includes every AIProvider value in the ai_providers prop."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.get("/create")
     assert response.status_code == 200
-    assert 'name="ai_provider"' in response.text
-    assert 'value="IMBUE_CLOUD"' in response.text
-    assert 'value="API_KEY"' in response.text
-    assert 'value="SUBSCRIPTION"' in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert {"IMBUE_CLOUD", "API_KEY", "SUBSCRIPTION"}.issubset(set(payload["props"]["ai_providers"]))
 
 
 def test_create_form_does_not_show_env_file_checkbox(tmp_path: Path) -> None:
@@ -1042,64 +1051,64 @@ def test_create_form_does_not_show_env_file_checkbox(tmp_path: Path) -> None:
 
     response = client.get("/create")
     assert response.status_code == 200
-    assert "include_env_file" not in response.text
+    # The Solid component does not surface include_env_file in the
+    # route payload at all -- a stronger assertion than the old text-match.
+    payload = extract_ssr_route_payload(response.text)
+    assert "include_env_file" not in payload["props"]
 
 
 def test_create_form_submit_rejects_imbue_cloud_compute_without_account(tmp_path: Path) -> None:
-    """Selecting IMBUE_CLOUD compute without an account is rejected with a clear message."""
+    """Selecting IMBUE_CLOUD compute without an account returns a clear JSON error."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "IMBUE_CLOUD",
             "ai_provider": "SUBSCRIPTION",
             "account_id": "",
         },
-        follow_redirects=False,
     )
     assert response.status_code == 400
-    assert "imbue_cloud requires an account" in response.text
+    assert "imbue_cloud requires an account" in response.json()["errors"]["_"]
 
 
 def test_create_form_submit_rejects_imbue_cloud_ai_without_account(tmp_path: Path) -> None:
-    """Selecting IMBUE_CLOUD AI provider without an account is rejected."""
+    """Selecting IMBUE_CLOUD AI provider without an account returns a JSON error."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "DOCKER",
             "ai_provider": "IMBUE_CLOUD",
             "account_id": "",
         },
-        follow_redirects=False,
     )
     assert response.status_code == 400
-    assert "imbue_cloud requires an account" in response.text
+    assert "imbue_cloud requires an account" in response.json()["errors"]["_"]
 
 
 def test_create_form_submit_rejects_api_key_provider_without_key(tmp_path: Path) -> None:
-    """Selecting AI provider API_KEY without supplying a key is rejected."""
+    """Selecting AI provider API_KEY without supplying a key returns a JSON error."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "DOCKER",
             "ai_provider": "API_KEY",
             "anthropic_api_key": "",
         },
-        follow_redirects=False,
     )
     assert response.status_code == 400
-    assert "Anthropic API key is required" in response.text
+    assert "Anthropic API key is required" in response.json()["errors"]["_"]
 
 
 def test_create_form_submit_accepts_subscription_with_no_account(tmp_path: Path) -> None:
@@ -1108,16 +1117,16 @@ def test_create_form_submit_accepts_subscription_with_no_account(tmp_path: Path)
 
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "DOCKER",
             "ai_provider": "SUBSCRIPTION",
             "account_id": "",
         },
-        follow_redirects=False,
     )
-    assert response.status_code == 303
+    assert response.status_code == 200
+    assert response.json()["data"]["redirect_url"].startswith("/creating/")
     agent_creator.wait_for_all()
 
 
@@ -1184,30 +1193,29 @@ def test_create_agent_api_rejects_imbue_cloud_ai_without_account(tmp_path: Path)
     assert "account_id is required" in response.json()["error"]
 
 
-def test_create_form_submit_preserves_account_id_on_validation_error(tmp_path: Path) -> None:
-    """When validation fails and the form re-renders, the user's account_id choice
-    must survive instead of reverting to the config default. The form submits
-    ``account_id=""`` for "No account"; the re-rendered page must show that
-    option as ``selected`` and must NOT show any other account as selected."""
+def test_create_form_submit_returns_json_error_envelope_on_validation_failure(tmp_path: Path) -> None:
+    """On validation failure the handler returns the JSON ``{ ok, errors, data }``
+    envelope the Solid form component reads -- the previous behavior of
+    re-rendering the form HTML with the user's account_id pre-selected is
+    now the client's responsibility (it keeps its own form state)."""
     client, _, _ = _create_test_server_with_agent_creator(tmp_path)
 
     # Trigger a validation error (IMBUE_CLOUD AI without an account).
     response = client.post(
         "/create",
-        data={
+        json={
             "git_url": "file:///nonexistent-repo",
             "host_name": "my-agent",
             "launch_mode": "DOCKER",
             "ai_provider": "IMBUE_CLOUD",
             "account_id": "",
         },
-        follow_redirects=False,
     )
     assert response.status_code == 400
-    # The "No account (private project)" option is selected when default_account_id is empty.
-    assert 'value=""' in response.text and "No account" in response.text
-    # And the IMBUE_CLOUD warning should be present.
-    assert "imbue_cloud requires an account" in response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert "imbue_cloud requires an account" in body["errors"]["_"]
+    assert body["data"] is None
 
 
 def test_unhandled_exception_returns_500_with_message(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Migrates the `/create` agent-creation form to Solid.js (Batch B of the Solid UI migration).

**File migrated:** `apps/minds/imbue/minds/desktop_client/templates/create.html` (307 lines + 160 lines of inline JS).
The Jinja file is intentionally kept on disk -- a Phase 8 cleanup pass will remove the dead Jinja code in bulk.

**Components extracted** (`apps/minds/frontend/src/components/forms/`):
- `FormField` (label + text input + helper + error). Replaces ~10 lines of hand-spelled markup per field.
- `FormSelect` (inline label-on-left, select-on-right, with `disabledValues` and inline amber error). Replaces ~9 lines per row; the Jinja template repeated this block 5 times.
- `FormSection` (collapsible body with show/hide toggle). Replaces the hand-rolled `configure-toggle` + `toggle-advanced` JS twice.

Result: `routes/create.jsx` is ~330 lines that compose those primitives. The create form now reads as "host_name field, four selects, conditional rows, advanced section" rather than 307 lines of Jinja + 160 lines of vanilla JS.

**Python form-handler conversion:**
- `_handle_create_page` now passes `sidecar=request.app.state.ssr_sidecar` to `render_create_form`.
- `render_create_form` is a shim that flattens `AccountSession` objects to `{user_id, email}` records and calls `_render_ssr_or_fallback` with the `create` route key. Default-selection logic (LIMA/SUBSCRIPTION without an account; IMBUE_CLOUD with one) stays in Python.
- `_handle_create_form_submit` now reads JSON, returns the `{ ok, errors, data }` envelope. On success `data.redirect_url = "/creating/{id}"`; on failure `errors._` carries the form-wide message. Validation logic is unchanged.

## Test plan

- [x] `pnpm --dir apps/minds frontend:test` (39 tests pass, 18 new)
- [x] `pnpm --dir apps/minds frontend:build` (clean)
- [x] `just test-quick apps/minds/imbue/minds/desktop_client` (676 pass; 5 pre-existing webdav failures unrelated to this PR -- macOS tmpdir handling)
- [x] `just test-quick apps/minds/imbue/minds/test_ratchets.py` (55 pass; two ratchets nudged: `_serialize_account` uses the concrete `AccountSession` type, new JSON-body catch logs at warning level)
- [x] `just test-quick test_meta_ratchets.py::test_no_ruff_errors test_meta_ratchets.py::test_no_type_errors`

New test coverage:
- `frontend/src/components/forms/FormField.test.jsx` (5 tests)
- `frontend/src/components/forms/FormSelect.test.jsx` (4 tests)
- `frontend/src/components/forms/FormSection.test.jsx` (4 tests)
- `frontend/src/routes/create.test.jsx` (5 tests: render, JSON-submit happy path with redirect, JSON-error rendering, server-side error banner, IMBUE_CLOUD-without-account validation gate)
- `desktop_client/ssr_routes_test.py::test_create_endpoint_emits_solid_route_payload`

Existing tests updated:
- `templates_test.py` -- 9 create-form assertions converted to `extract_ssr_route_payload`
- `test_desktop_client.py` -- form-post tests converted from `data=` form-encoded + HTML assertions to `json=` + envelope assertions

## Out of scope

- `templates/workspace_settings.html` and `templates/sharing.html` (deferred to a follow-up batch per the original task scope)
- Deleting `templates/create.html` (Phase 8 cleanup)
- The `EmailChipsInput` component (only used by sharing, not create)