### PR TITLE
Solid migration: chrome + sidebar + permissions

### DIFF
--- a/apps/minds/changelog/gdenisov-solidjs-batch-c-chrome-sidebar-permissions.md
+++ b/apps/minds/changelog/gdenisov-solidjs-batch-c-chrome-sidebar-permissions.md
@@ -1,0 +1,30 @@
+# Solid migration: chrome + sidebar + permissions
+
+Migrates three of the desktop client's Jinja templates to Solid SSR
+bundles:
+
+- `chrome.html` + `chrome.js` (the persistent titlebar / sidebar / iframe
+  shell served at `/_chrome`) now render through a new `chrome` Vite
+  rollup entry. The component tree lives under
+  `frontend/src/components/chrome/{Titlebar,Sidebar,RequestsPanel,ProvidersPanel}.jsx`
+  and the route entry is `frontend/src/routes/chrome.jsx`.
+- `sidebar.html` + `sidebar.js` (the standalone sidebar
+  `WebContentsView` served at `/_chrome/sidebar`) now render through a
+  new `sidebar` Vite rollup entry that reuses the shared `Sidebar`
+  component.
+- `permissions.html`, `latchkey_predefined_permission.html`, and
+  `latchkey_file_sharing_permission.html` (the modal permission dialog
+  served at `/requests/<id>`) now render through new Solid routes under
+  `frontend/src/routes/permissions/{index,predefined,file_sharing}.jsx`
+  layered on the shared
+  `frontend/src/components/permissions/PermissionRequest.jsx` shell.
+
+The SSR sidecar's `/__ssr/render` endpoint now accepts a `bundle` field
+selecting which client bundle's route registry to use; the Python
+`SsrSidecar.render` shim and the `_render_ssr_or_fallback` helper carry
+the same `bundle` parameter through so the fallback client-render shell
+loads the matching entry script. The `_chrome` / `_chrome/sidebar`
+routes and the latchkey permission renderers all dispatch through the
+sidecar in production and fall back to the client-render shell when the
+sidecar is unhealthy. Existing Jinja templates and static JS files are
+left in place pending the Phase 8 cleanup pass.

--- a/apps/minds/frontend/src/components/chrome/ProvidersPanel.jsx
+++ b/apps/minds/frontend/src/components/chrome/ProvidersPanel.jsx
@@ -1,0 +1,42 @@
+import { For, Show } from 'solid-js';
+
+// Bottom-of-chrome status indicator listing provider blocks (e.g.
+// imbue_cloud accounts) and whether they are enabled.
+//
+// Props:
+//   providers     -- array of { name, enabled, status? } shapes; rendered
+//                    as a horizontal pill row.
+export function ProvidersPanel(props) {
+  const providers = () => props.providers || [];
+  return (
+    <div class="providers-panel flex items-center gap-2 px-3 py-1.5 border-t border-white/10 bg-zinc-900 text-xs">
+      <Show
+        when={providers().length > 0}
+        fallback={<span class="text-zinc-500">No providers configured</span>}
+      >
+        <For each={providers()}>
+          {(provider) => (
+            <span
+              class={
+                'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full border ' +
+                (provider.enabled
+                  ? 'bg-emerald-900/30 text-emerald-300 border-emerald-700/60'
+                  : 'bg-zinc-800 text-zinc-400 border-zinc-700')
+              }
+              title={provider.status || ''}
+            >
+              <span
+                class={
+                  'w-1.5 h-1.5 rounded-full ' +
+                  (provider.enabled ? 'bg-emerald-400' : 'bg-zinc-500')
+                }
+                aria-hidden="true"
+              />
+              {provider.name}
+            </span>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/chrome/ProvidersPanel.test.jsx
+++ b/apps/minds/frontend/src/components/chrome/ProvidersPanel.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { ProvidersPanel } from './ProvidersPanel.jsx';
+
+describe('ProvidersPanel', () => {
+  it('shows the fallback message when no providers are configured', () => {
+    const { getByText } = render(() => <ProvidersPanel providers={[]} />);
+    expect(getByText('No providers configured')).toBeInTheDocument();
+  });
+
+  it('renders a pill per provider with the enabled / disabled tint', () => {
+    const { getByText } = render(() => (
+      <ProvidersPanel
+        providers={[
+          { name: 'imbue-prod', enabled: true },
+          { name: 'imbue-dev', enabled: false },
+        ]}
+      />
+    ));
+    const enabledPill = getByText('imbue-prod').closest('span');
+    const disabledPill = getByText('imbue-dev').closest('span');
+    expect(enabledPill.className).toContain('emerald');
+    expect(disabledPill.className).toContain('zinc-800');
+  });
+});

--- a/apps/minds/frontend/src/components/chrome/RequestsPanel.jsx
+++ b/apps/minds/frontend/src/components/chrome/RequestsPanel.jsx
@@ -1,0 +1,41 @@
+import { For, Show } from 'solid-js';
+
+// Compact list of pending permission requests rendered inside the
+// chrome shell's optional requests panel. The chrome shell today opens
+// a separate WebContentsView (``/_chrome/requests-panel``) for this in
+// Electron, so the component is invoked from within that view -- it
+// just needs to render the list given an array.
+//
+// Props:
+//   requests        -- array of { id, label, agent_id? } shapes.
+//   onSelect        -- called with the request id when a row is clicked.
+//   emptyMessage    -- string shown when the list is empty.
+export function RequestsPanel(props) {
+  const items = () => props.requests || [];
+  const empty = () => props.emptyMessage || 'No pending requests';
+  return (
+    <div class="requests-panel divide-y divide-white/5">
+      <Show
+        when={items().length > 0}
+        fallback={
+          <div class="px-4 py-6 text-sm text-zinc-400 text-center">{empty()}</div>
+        }
+      >
+        <For each={items()}>
+          {(request) => (
+            <button
+              type="button"
+              class="block w-full text-left px-4 py-2.5 text-sm text-zinc-200 hover:bg-white/5 cursor-pointer"
+              onClick={() => props.onSelect?.(request.id)}
+            >
+              <div class="font-medium truncate">{request.label || request.id}</div>
+              <Show when={request.agent_id}>
+                <div class="text-[11px] text-zinc-500 truncate">{request.agent_id}</div>
+              </Show>
+            </button>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/chrome/RequestsPanel.test.jsx
+++ b/apps/minds/frontend/src/components/chrome/RequestsPanel.test.jsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@solidjs/testing-library';
+import { RequestsPanel } from './RequestsPanel.jsx';
+
+describe('RequestsPanel', () => {
+  it('renders an empty state when there are no pending requests', () => {
+    const { getByText } = render(() => <RequestsPanel requests={[]} />);
+    expect(getByText('No pending requests')).toBeInTheDocument();
+  });
+
+  it('renders each pending request as a clickable row', () => {
+    const handler = vi.fn();
+    const { getByText } = render(() => (
+      <RequestsPanel
+        requests={[
+          { id: 'req-1', label: 'Approve Slack' },
+          { id: 'req-2', label: 'Approve GitHub', agent_id: 'agent-x' },
+        ]}
+        onSelect={handler}
+      />
+    ));
+    fireEvent.click(getByText('Approve Slack'));
+    fireEvent.click(getByText('Approve GitHub'));
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, 'req-1');
+    expect(handler).toHaveBeenNthCalledWith(2, 'req-2');
+    expect(getByText('agent-x')).toBeInTheDocument();
+  });
+
+  it('uses a custom empty-state message when provided', () => {
+    const { getByText } = render(() => (
+      <RequestsPanel requests={[]} emptyMessage="Nothing waiting" />
+    ));
+    expect(getByText('Nothing waiting')).toBeInTheDocument();
+  });
+});

--- a/apps/minds/frontend/src/components/chrome/Sidebar.jsx
+++ b/apps/minds/frontend/src/components/chrome/Sidebar.jsx
@@ -1,0 +1,147 @@
+import { For, Show, createMemo, createSignal } from 'solid-js';
+import {
+  navigateContent,
+  openWorkspaceInNewWindow,
+  showWorkspaceContextMenu,
+} from '../../lib/electron_bridge.js';
+import { workspaceAccentCached } from '../../lib/workspace_accent.js';
+
+// Renders the grouped workspace list shown in the persistent shell's
+// left sidebar and the standalone Electron sidebar WebContentsView.
+//
+// Props:
+//   workspaces            -- array of { id, name, account?, accent? } shapes
+//                            emitted by the chrome SSE workspaces event.
+//   mngrForwardOrigin     -- bare origin of the mngr_forward plugin; the
+//                            sidebar builds /goto/<agent>/ URLs against it.
+//   currentWorkspaceId    -- workspace whose row should render with the
+//                            "current" highlight (only used by the
+//                            Electron-side sidebar bundle today).
+//   showOpenInNewWindow   -- true for the standalone sidebar bundle (the
+//                            row exposes a hover-revealed "open in new
+//                            window" affordance); false for the
+//                            chrome-embedded sidebar.
+
+function groupWorkspaces(workspaces) {
+  // Mirrors the legacy chrome.js grouping: "Private" first, then any
+  // account groups alphabetically.
+  const groups = new Map();
+  for (const workspace of workspaces) {
+    const key = workspace.account || 'Private';
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(workspace);
+  }
+  return [...groups.keys()]
+    .sort((a, b) => {
+      if (a === 'Private') return -1;
+      if (b === 'Private') return 1;
+      return a.localeCompare(b);
+    })
+    .map((key) => ({ key, workspaces: groups.get(key) }));
+}
+
+function accentForWorkspace(workspace) {
+  if (typeof workspace.accent === 'string') return workspace.accent;
+  return workspaceAccentCached(workspace.id);
+}
+
+function WorkspaceRow(props) {
+  const [isHovered, setIsHovered] = createSignal(false);
+  const accent = createMemo(() => accentForWorkspace(props.workspace));
+  const accentStyleString = createMemo(() => `--workspace-accent: ${accent()};`);
+  const baseClass =
+    'sidebar-item group cursor-pointer text-sm font-medium text-zinc-200 rounded-md mx-1.5 my-0.5 py-2.5 pl-4 pr-3 flex items-center justify-between gap-2 transition-colors hover:bg-white/5';
+  const rowClass = () =>
+    [baseClass, props.isCurrent ? 'is-current bg-white/5' : ''].filter(Boolean).join(' ');
+  const handleClick = (event) => {
+    if (event.defaultPrevented) return;
+    navigateContent(`${props.mngrForwardOrigin}/goto/${props.workspace.id}/`);
+  };
+  const handleOpenNew = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    openWorkspaceInNewWindow(props.workspace.id);
+  };
+  const handleContextMenu = (event) => {
+    event.preventDefault();
+    showWorkspaceContextMenu(props.workspace.id, event.clientX, event.clientY);
+  };
+  const openNewVisible = () => props.showOpenInNewWindow && isHovered() && !props.isCurrent;
+  return (
+    <div
+      class={rowClass()}
+      data-agent-id={props.workspace.id}
+      attr:style={accentStyleString()}
+      onClick={handleClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onContextMenu={handleContextMenu}
+    >
+      <span class="flex-1 whitespace-nowrap overflow-hidden text-ellipsis">
+        {props.workspace.name || props.workspace.id}
+      </span>
+      <Show when={props.showOpenInNewWindow}>
+        <button
+          type="button"
+          class={
+            'sidebar-open-new items-center justify-center bg-transparent border-none p-1 cursor-pointer text-zinc-400 rounded hover:text-zinc-200 hover:bg-white/5 ' +
+            (openNewVisible() ? 'inline-flex' : 'hidden')
+          }
+          title="Open in new window"
+          tabIndex={-1}
+          data-open-new={props.workspace.id}
+          onClick={handleOpenNew}
+        >
+          <svg
+            class="w-3.5 h-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M14 3h7v7" />
+            <path d="M10 14L21 3" />
+            <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
+          </svg>
+        </button>
+      </Show>
+    </div>
+  );
+}
+
+export function Sidebar(props) {
+  const groups = createMemo(() => groupWorkspaces(props.workspaces || []));
+  const hasWorkspaces = () => (props.workspaces || []).length > 0;
+  return (
+    <div id="sidebar-workspaces">
+      <Show
+        when={hasWorkspaces()}
+        fallback={
+          <div class="px-4 py-6 text-sm text-zinc-400 text-center">No projects</div>
+        }
+      >
+        <For each={groups()}>
+          {(group) => (
+            <>
+              <div class="px-3 pt-2 pb-0.5 text-[11px] text-zinc-400 tracking-wider">
+                {group.key === 'Private' ? 'PRIVATE' : group.key}
+              </div>
+              <For each={group.workspaces}>
+                {(workspace) => (
+                  <WorkspaceRow
+                    workspace={workspace}
+                    mngrForwardOrigin={props.mngrForwardOrigin || ''}
+                    isCurrent={workspace.id === props.currentWorkspaceId}
+                    showOpenInNewWindow={!!props.showOpenInNewWindow}
+                  />
+                )}
+              </For>
+            </>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/chrome/Sidebar.test.jsx
+++ b/apps/minds/frontend/src/components/chrome/Sidebar.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { Sidebar } from './Sidebar.jsx';
+
+const WORKSPACES = [
+  { id: 'agent-a', name: 'Apples', account: 'team@example.com' },
+  { id: 'agent-b', name: 'Bananas' },
+  { id: 'agent-c', name: 'Cherries', account: 'team@example.com' },
+];
+
+describe('Sidebar', () => {
+  it('renders an empty state when there are no workspaces', () => {
+    const { getByText } = render(() => <Sidebar workspaces={[]} mngrForwardOrigin="" />);
+    expect(getByText('No projects')).toBeInTheDocument();
+  });
+
+  it('groups workspaces by account with Private first', () => {
+    const { getAllByText, getByText, container } = render(() => (
+      <Sidebar workspaces={WORKSPACES} mngrForwardOrigin="http://forward" />
+    ));
+    // The "Private" header always renders first when present.
+    const headers = container.querySelectorAll('div.text-\\[11px\\]');
+    expect(headers[0].textContent).toBe('PRIVATE');
+    expect(headers[1].textContent).toBe('team@example.com');
+    // Each workspace label renders.
+    expect(getByText('Apples')).toBeInTheDocument();
+    expect(getByText('Bananas')).toBeInTheDocument();
+    expect(getByText('Cherries')).toBeInTheDocument();
+    // Workspace name renders exactly once per workspace.
+    expect(getAllByText('Apples')).toHaveLength(1);
+  });
+
+  it('highlights the current workspace row when showOpenInNewWindow is true', () => {
+    const { container } = render(() => (
+      <Sidebar
+        workspaces={WORKSPACES}
+        mngrForwardOrigin="http://forward"
+        currentWorkspaceId="agent-b"
+        showOpenInNewWindow
+      />
+    ));
+    const currentRow = container.querySelector('[data-agent-id="agent-b"]');
+    expect(currentRow).not.toBeNull();
+    expect(currentRow.classList.contains('is-current')).toBe(true);
+    const otherRow = container.querySelector('[data-agent-id="agent-a"]');
+    expect(otherRow.classList.contains('is-current')).toBe(false);
+  });
+
+  it('renders the open-in-new affordance only when showOpenInNewWindow is true', () => {
+    const { container, unmount } = render(() => (
+      <Sidebar
+        workspaces={[WORKSPACES[1]]}
+        mngrForwardOrigin="http://forward"
+        showOpenInNewWindow={false}
+      />
+    ));
+    expect(container.querySelector('button[data-open-new]')).toBeNull();
+    unmount();
+
+    const { container: container2 } = render(() => (
+      <Sidebar
+        workspaces={[WORKSPACES[1]]}
+        mngrForwardOrigin="http://forward"
+        showOpenInNewWindow
+      />
+    ));
+    expect(container2.querySelector('button[data-open-new]')).not.toBeNull();
+  });
+});

--- a/apps/minds/frontend/src/components/chrome/Titlebar.jsx
+++ b/apps/minds/frontend/src/components/chrome/Titlebar.jsx
@@ -1,0 +1,257 @@
+import { Show } from 'solid-js';
+import {
+  isElectron as isElectronBridge,
+  toggleSidebar,
+  toggleRequestsPanel,
+  minimizeWindow,
+  maximizeWindow,
+  closeWindow,
+  contentGoBack,
+  contentGoForward,
+  navigateContent,
+} from '../../lib/electron_bridge.js';
+
+// The macOS-style titlebar that sits across the top of the persistent
+// chrome shell. The full-window drag region, traffic-light padding, and
+// per-workspace accent stripe all live here. The container is non-drag
+// for buttons (-webkit-app-region: no-drag) but drag for everything
+// else so the user can grab any flat area to move the window.
+//
+// Props:
+//   isMac              -- toggles macOS traffic-light padding and hides
+//                         the Windows-style window controls on the right.
+//   isAuthenticated    -- selects the initial label of the "user" button
+//                         while waiting for the auth status SSE event.
+//   pageTitle          -- text rendered in the centered title slot.
+//   workspaceAccent    -- OKLCH stripe color or null; when null the
+//                         per-workspace swatch is hidden.
+//   requestCount       -- pending-request badge count; >0 shows the dot.
+//   onUserClick        -- called when the "Log in" / "Manage accounts"
+//                         button is clicked (parent navigates).
+//   userButtonLabel    -- label of the user button (computed by the
+//                         chrome route from auth state).
+
+const BUTTON_BASE =
+  'bg-transparent border-none text-zinc-400 cursor-pointer w-8 h-7 flex items-center justify-center rounded hover:text-zinc-200 hover:bg-white/5 active:bg-white/10';
+const WINDOW_CONTROL_BASE =
+  'bg-transparent border-none text-zinc-400 cursor-pointer w-9 h-[38px] flex items-center justify-center hover:bg-white/5 hover:text-zinc-200';
+
+export function Titlebar(props) {
+  const containerClass = () =>
+    [
+      'fixed top-0 left-0 right-0 h-[38px] bg-zinc-900 flex items-center select-none z-[100] border-b border-white/10 px-1',
+      props.isMac ? 'pl-[72px]' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  const handleHome = () => navigateContent('/');
+  return (
+    <div
+      id="minds-titlebar"
+      class={containerClass()}
+      attr:style={
+        props.workspaceAccent ? `--workspace-accent: ${props.workspaceAccent};` : undefined
+      }
+    >
+      <div class="flex gap-0.5">
+        <button
+          type="button"
+          id="sidebar-toggle"
+          title="Projects"
+          class={BUTTON_BASE}
+          onClick={() => toggleSidebar() || props.onToggleSidebar?.()}
+        >
+          <svg
+            class="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <line x1="9" y1="3" x2="9" y2="21" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          id="home-btn"
+          title="Home"
+          class={BUTTON_BASE}
+          onClick={handleHome}
+        >
+          <svg
+            class="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M3 12L12 3l9 9" />
+            <path d="M5 10v10a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1V10" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          id="back-btn"
+          title="Back"
+          class={BUTTON_BASE}
+          onClick={() => contentGoBack()}
+        >
+          <svg
+            class="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          id="forward-btn"
+          title="Forward"
+          class={BUTTON_BASE}
+          onClick={() => contentGoForward()}
+        >
+          <svg
+            class="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <polyline points="9 6 15 12 9 18" />
+          </svg>
+        </button>
+      </div>
+      <div class="flex-1 flex items-center justify-center gap-2 px-2 min-w-0">
+        <Show when={props.workspaceAccent}>
+          <span
+            id="title-swatch"
+            class="accent-swatch w-2.5 h-2.5 rounded-sm shrink-0"
+          />
+        </Show>
+        <span
+          id="page-title"
+          class="text-zinc-200 text-xs whitespace-nowrap overflow-hidden text-ellipsis"
+        >
+          {props.pageTitle || 'Minds'}
+        </span>
+      </div>
+      <div class="relative minds-user-area shrink-0">
+        <button
+          type="button"
+          id="user-btn"
+          class="!w-auto !h-auto !inline-block text-zinc-400 cursor-pointer px-2.5 py-1 rounded text-xs font-sans whitespace-nowrap hover:bg-white/5 hover:text-zinc-200"
+          title={props.userButtonTitle || 'Account'}
+          onClick={() => props.onUserClick?.()}
+        >
+          {props.userButtonLabel || (props.isAuthenticated ? 'Manage account(s)' : 'Log in')}
+        </button>
+      </div>
+      <button
+        type="button"
+        id="requests-toggle"
+        title="Requests"
+        class={'relative ' + BUTTON_BASE}
+        onClick={() => toggleRequestsPanel()}
+      >
+        <svg
+          class="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+        <Show when={(props.requestCount || 0) > 0}>
+          <span
+            id="requests-badge"
+            class="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-red-500"
+          />
+        </Show>
+      </button>
+      <Show when={!props.isMac}>
+        <div class="flex">
+          <button
+            type="button"
+            id="min-btn"
+            title="Minimize"
+            class={WINDOW_CONTROL_BASE}
+            attr:style="border-radius: 0;"
+            onClick={() => minimizeWindow()}
+          >
+            <svg
+              viewBox="0 0 12 12"
+              class="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="2" y1="6" x2="10" y2="6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            id="max-btn"
+            title="Maximize"
+            class={WINDOW_CONTROL_BASE}
+            attr:style="border-radius: 0;"
+            onClick={() => maximizeWindow()}
+          >
+            <svg
+              viewBox="0 0 12 12"
+              class="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="2" y="2" width="8" height="8" rx="0.5" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            id="close-btn"
+            title="Close"
+            class={'bg-transparent border-none text-zinc-400 cursor-pointer w-9 h-[38px] flex items-center justify-center hover:bg-red-600 hover:text-white'}
+            attr:style="border-radius: 0;"
+            onClick={() => closeWindow()}
+          >
+            <svg
+              viewBox="0 0 12 12"
+              class="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="2" y1="2" x2="10" y2="10" />
+              <line x1="10" y1="2" x2="2" y2="10" />
+            </svg>
+          </button>
+        </div>
+      </Show>
+    </div>
+  );
+}
+
+export function isElectron() {
+  return isElectronBridge();
+}

--- a/apps/minds/frontend/src/components/chrome/Titlebar.test.jsx
+++ b/apps/minds/frontend/src/components/chrome/Titlebar.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@solidjs/testing-library';
+import { Titlebar } from './Titlebar.jsx';
+
+describe('Titlebar', () => {
+  it('renders the basic toolbar buttons and page title', () => {
+    const { getByTitle, getByText } = render(() => (
+      <Titlebar pageTitle="My Workspace" />
+    ));
+    expect(getByTitle('Projects')).toBeInTheDocument();
+    expect(getByTitle('Home')).toBeInTheDocument();
+    expect(getByTitle('Back')).toBeInTheDocument();
+    expect(getByTitle('Forward')).toBeInTheDocument();
+    expect(getByTitle('Requests')).toBeInTheDocument();
+    expect(getByText('My Workspace')).toBeInTheDocument();
+  });
+
+  it('hides the Windows-style window controls in macOS mode', () => {
+    const { queryByTitle } = render(() => <Titlebar isMac />);
+    expect(queryByTitle('Minimize')).toBeNull();
+    expect(queryByTitle('Maximize')).toBeNull();
+    expect(queryByTitle('Close')).toBeNull();
+  });
+
+  it('shows the Windows-style window controls on non-macOS', () => {
+    const { getByTitle } = render(() => <Titlebar isMac={false} />);
+    expect(getByTitle('Minimize')).toBeInTheDocument();
+    expect(getByTitle('Maximize')).toBeInTheDocument();
+    expect(getByTitle('Close')).toBeInTheDocument();
+  });
+
+  it('renders the user-button label based on isAuthenticated', () => {
+    const { getByText, unmount } = render(() => <Titlebar isAuthenticated={false} />);
+    expect(getByText('Log in')).toBeInTheDocument();
+    unmount();
+    const { getByText: getByText2 } = render(() => <Titlebar isAuthenticated />);
+    expect(getByText2('Manage account(s)')).toBeInTheDocument();
+  });
+
+  it('shows the requests badge only when requestCount is positive', () => {
+    const { container, unmount } = render(() => <Titlebar requestCount={0} />);
+    expect(container.querySelector('#requests-badge')).toBeNull();
+    unmount();
+    const { container: c2 } = render(() => <Titlebar requestCount={3} />);
+    expect(c2.querySelector('#requests-badge')).not.toBeNull();
+  });
+
+  it('fires the user-click callback when the user button is pressed', () => {
+    const handler = vi.fn();
+    const { getByText } = render(() => (
+      <Titlebar onUserClick={handler} isAuthenticated={false} />
+    ));
+    fireEvent.click(getByText('Log in'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/minds/frontend/src/components/permissions/PermissionRequest.jsx
+++ b/apps/minds/frontend/src/components/permissions/PermissionRequest.jsx
@@ -1,0 +1,238 @@
+import { Show, createMemo, createSignal } from 'solid-js';
+import { Card } from '../ui/Card.jsx';
+import { Notice } from '../ui/Notice.jsx';
+import { closeModal } from '../../lib/electron_bridge.js';
+
+// Generic shell around a permission-request dialog. Mirrors the Jinja
+// templates/permissions.html base: full-screen backdrop, dialog card,
+// header / rationale / body / actions / progress / error blocks. Backend-
+// specific dialogs (the predefined and file-sharing permission flows)
+// supply the body via children, and customise visible state via props.
+//
+// Form-submission contract:
+//   * On submit, POSTs a FormData payload to /requests/<id>/grant.
+//   * Approve is enabled as soon as any ``permissions`` checkbox in the
+//     body is checked; the parent can hook in extra logic via
+//     ``onPermissionsChange``.
+//   * The grant response is parsed as JSON. ``outcome === "GRANTED"``
+//     closes the modal; ``NEEDS_MANUAL_CREDENTIALS`` shows the manual
+//     setup notice; anything else shows the generic error.
+export function PermissionRequest(props) {
+  const [errorMessage, setErrorMessage] = createSignal('');
+  const [manualMessage, setManualMessage] = createSignal('');
+  const [manualCommand, setManualCommand] = createSignal('');
+  const [showProgress, setShowProgress] = createSignal(false);
+  const [submitting, setSubmitting] = createSignal(false);
+  const [approveDisabled, setApproveDisabled] = createSignal(true);
+
+  const wsLabel = createMemo(() => props.wsName || props.agentId);
+  const accentStyle = createMemo(() =>
+    props.accent ? `--workspace-accent: ${props.accent};` : undefined,
+  );
+
+  const dismiss = () => {
+    if (!closeModal()) {
+      if (typeof window !== 'undefined') window.location.href = '/';
+    }
+  };
+
+  const onBackdropClick = (event) => {
+    if (event.target === event.currentTarget) dismiss();
+  };
+
+  const refreshApproveState = (form) => {
+    const checked = form.querySelector('input[name="permissions"]:checked') !== null;
+    setApproveDisabled(!checked);
+  };
+
+  const onFormInput = (event) => {
+    refreshApproveState(event.currentTarget);
+    props.onPermissionsChange?.(event);
+  };
+
+  const onMountForm = (form) => {
+    refreshApproveState(form);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    setApproveDisabled(true);
+    setSubmitting(true);
+    setErrorMessage('');
+    setManualMessage('');
+    setManualCommand('');
+    setShowProgress(true);
+    const data = new FormData(form);
+    try {
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: data,
+        credentials: 'same-origin',
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `HTTP ${response.status}`);
+      }
+      const payload = await response.json();
+      if (payload.outcome === 'GRANTED') {
+        dismiss();
+        return;
+      }
+      setShowProgress(false);
+      if (payload.outcome === 'NEEDS_MANUAL_CREDENTIALS') {
+        setManualCommand(payload.set_credentials_example || '');
+        setManualMessage(payload.message || '');
+        refreshApproveState(form);
+        setSubmitting(false);
+        return;
+      }
+      setErrorMessage(payload.message || 'Authorization failed.');
+      refreshApproveState(form);
+      setSubmitting(false);
+    } catch (err) {
+      setShowProgress(false);
+      setErrorMessage(err && err.message ? err.message : String(err));
+      refreshApproveState(form);
+      setSubmitting(false);
+    }
+  };
+
+  const handleDeny = () => {
+    setApproveDisabled(true);
+    // Fire-and-forget; matches the legacy behavior so the agent gets
+    // notified even after the dialog navigates away.
+    if (typeof fetch === 'function') {
+      fetch(`/requests/${props.requestId}/deny`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        keepalive: true,
+      }).catch(() => {});
+    }
+    dismiss();
+  };
+
+  const onKeyDown = (event) => {
+    if (event.key === 'Escape') dismiss();
+  };
+
+  return (
+    <div
+      class="bg-transparent text-zinc-900 font-sans antialiased min-h-screen"
+      attr:style={accentStyle()}
+      onKeyDown={onKeyDown}
+    >
+      <div
+        id="permissions-backdrop"
+        class="fixed inset-0 bg-black/40 flex items-center justify-center p-6"
+        onClick={onBackdropClick}
+      >
+        <div
+          id="permissions-dialog"
+          class="relative w-full max-w-[640px] max-h-full flex flex-col bg-white border border-zinc-200 rounded-2xl shadow-xl overflow-hidden"
+        >
+          <button
+            type="button"
+            id="permissions-close-btn"
+            aria-label="Close"
+            onClick={dismiss}
+            class="absolute top-3 right-3 z-10 inline-flex items-center justify-center w-8 h-8 rounded-md text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer"
+          >
+            <svg
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+              class="w-5 h-5"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M4.22 4.22a.75.75 0 0 1 1.06 0L10 8.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L11.06 10l4.72 4.72a.75.75 0 1 1-1.06 1.06L10 11.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L8.94 10 4.22 5.28a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </button>
+          <div class="overflow-y-auto min-h-0 p-6 sm:p-7">
+            <h1 class="text-2xl font-semibold text-zinc-900 leading-tight pr-8">
+              Permission request: {props.displayName || ''}
+            </h1>
+            <Card extra="mt-6">
+              <div>
+                <p class="text-base font-semibold text-zinc-900 mb-1">
+                  {wsLabel()} says:
+                </p>
+                <p class="text-sm italic whitespace-pre-wrap">{props.rationale || ''}</p>
+              </div>
+            </Card>
+            <form
+              id="permissions-form"
+              method="POST"
+              action={`/requests/${props.requestId}/grant`}
+              class="mt-6"
+              onSubmit={handleSubmit}
+              onInput={onFormInput}
+              onChange={onFormInput}
+              ref={(el) => el && onMountForm(el)}
+            >
+              {props.children}
+              <div class="flex gap-2 mt-5 justify-end">
+                <button
+                  type="button"
+                  onClick={handleDeny}
+                  disabled={submitting()}
+                  class="inline-flex items-center justify-center gap-1.5 px-3.5 py-2 rounded-md font-medium text-sm leading-tight transition-colors cursor-pointer no-underline whitespace-nowrap bg-red-50 text-red-600 border border-red-200 hover:bg-red-100"
+                >
+                  Deny
+                </button>
+                <button
+                  type="submit"
+                  id="permissions-approve-btn"
+                  disabled={approveDisabled() || submitting()}
+                  class="inline-flex items-center justify-center gap-1.5 px-3.5 py-2 rounded-md font-medium text-sm leading-tight transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer no-underline whitespace-nowrap bg-emerald-800 text-emerald-50 border border-transparent hover:bg-emerald-900"
+                >
+                  Approve
+                </button>
+              </div>
+            </form>
+            <Show when={showProgress()}>
+              <div id="permissions-progress" class="mt-4">
+                <Notice variant="info">
+                  <span class="font-medium">
+                    {props.progressLabel || 'Granting permission...'}
+                  </span>
+                  <Show when={props.progressDetail}>
+                    {' '}
+                    {props.progressDetail}
+                  </Show>
+                </Notice>
+              </div>
+            </Show>
+            <Show when={manualMessage() || manualCommand()}>
+              <div id="permissions-manual-credentials" class="mt-4">
+                <Notice variant="info">
+                  <p class="font-medium">Manual credential setup required</p>
+                  <p class="mt-1">{manualMessage()}</p>
+                  <p class="mt-2 text-sm">
+                    Obtain credentials from the provider, replace any{' '}
+                    <code>&lt;placeholders&gt;</code> below with them, run the command in
+                    a terminal, then click Approve again:
+                  </p>
+                  <pre class="mt-2 bg-zinc-900 text-zinc-100 rounded-md p-3 text-xs overflow-x-auto">
+                    <code>{manualCommand()}</code>
+                  </pre>
+                </Notice>
+              </div>
+            </Show>
+            <Show when={errorMessage()}>
+              <div id="permissions-error" class="mt-4">
+                <Notice variant="error">
+                  <p class="font-medium">Authorization failed</p>
+                  <p>{errorMessage()}</p>
+                </Notice>
+              </div>
+            </Show>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/components/permissions/PermissionRequest.test.jsx
+++ b/apps/minds/frontend/src/components/permissions/PermissionRequest.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@solidjs/testing-library';
+import { PermissionRequest } from './PermissionRequest.jsx';
+
+describe('PermissionRequest', () => {
+  it('renders the dialog scaffolding with header, rationale, and action buttons', () => {
+    const { container, getByText } = render(() => (
+      <PermissionRequest
+        agentId="agent-1"
+        requestId="req-1"
+        wsName="Demo workspace"
+        rationale="I need to read the channel"
+        displayName="Slack"
+      />
+    ));
+    expect(container.querySelector('#permissions-backdrop')).not.toBeNull();
+    expect(container.querySelector('#permissions-dialog')).not.toBeNull();
+    expect(container.querySelector('#permissions-close-btn')).not.toBeNull();
+    expect(getByText('Demo workspace says:')).toBeInTheDocument();
+    expect(getByText('I need to read the channel')).toBeInTheDocument();
+    expect(getByText('Approve')).toBeInTheDocument();
+    expect(getByText('Deny')).toBeInTheDocument();
+  });
+
+  it('falls back to the agent id in the rationale label when ws_name is empty', () => {
+    const { getByText } = render(() => (
+      <PermissionRequest
+        agentId="agent-fallback"
+        requestId="req-1"
+        wsName=""
+        rationale="reason"
+        displayName="Display"
+      />
+    ));
+    expect(getByText('agent-fallback says:')).toBeInTheDocument();
+  });
+
+  it('targets the right grant endpoint via the form action', () => {
+    const { container } = render(() => (
+      <PermissionRequest
+        agentId="agent-1"
+        requestId="req-99"
+        rationale=""
+        displayName="X"
+      />
+    ));
+    const form = container.querySelector('#permissions-form');
+    expect(form).not.toBeNull();
+    expect(form.getAttribute('action')).toBe('/requests/req-99/grant');
+  });
+});

--- a/apps/minds/frontend/src/lib/electron_bridge.js
+++ b/apps/minds/frontend/src/lib/electron_bridge.js
@@ -1,6 +1,7 @@
-// Thin wrapper around the Electron preload bridge. The preload script
-// exposes ``window.electron`` only inside the Electron app; in browsers
-// and under jsdom the bridge no-ops so Solid components stay testable.
+// Thin wrapper around the Electron preload bridges. The preload script
+// exposes ``window.minds`` (chrome / workspace IPC) and may expose
+// ``window.electron`` (focus/navigation hooks); in browsers and under
+// jsdom both bridges are absent so the Solid components stay testable.
 //
 // The migration plan keeps the Electron preload contract unchanged for
 // now; later phases may renegotiate it once the chrome+sidebar bundles
@@ -11,11 +12,21 @@ function safeBridge() {
   return window.electron || null;
 }
 
+function safeMinds() {
+  if (typeof window === 'undefined') return null;
+  return window.minds || null;
+}
+
 export function isElectron() {
-  return safeBridge() !== null;
+  return safeMinds() !== null || safeBridge() !== null;
 }
 
 export function navigateContent(url) {
+  const minds = safeMinds();
+  if (minds && typeof minds.navigateContent === 'function') {
+    minds.navigateContent(url);
+    return true;
+  }
   const bridge = safeBridge();
   if (bridge && typeof bridge.navigateContent === 'function') {
     bridge.navigateContent(url);
@@ -28,6 +39,148 @@ export function focusWorkspace(agentId) {
   const bridge = safeBridge();
   if (bridge && typeof bridge.focusWorkspace === 'function') {
     bridge.focusWorkspace(agentId);
+    return true;
+  }
+  return false;
+}
+
+// -- window.minds IPC helpers used by the chrome and sidebar bundles ----
+
+export function contentGoBack() {
+  const minds = safeMinds();
+  if (minds && typeof minds.contentGoBack === 'function') {
+    minds.contentGoBack();
+    return true;
+  }
+  return false;
+}
+
+export function contentGoForward() {
+  const minds = safeMinds();
+  if (minds && typeof minds.contentGoForward === 'function') {
+    minds.contentGoForward();
+    return true;
+  }
+  return false;
+}
+
+export function toggleSidebar() {
+  const minds = safeMinds();
+  if (minds && typeof minds.toggleSidebar === 'function') {
+    minds.toggleSidebar();
+    return true;
+  }
+  return false;
+}
+
+export function toggleRequestsPanel() {
+  const minds = safeMinds();
+  if (minds && typeof minds.toggleRequestsPanel === 'function') {
+    minds.toggleRequestsPanel();
+    return true;
+  }
+  return false;
+}
+
+export function minimizeWindow() {
+  const minds = safeMinds();
+  if (minds && typeof minds.minimize === 'function') {
+    minds.minimize();
+    return true;
+  }
+  return false;
+}
+
+export function maximizeWindow() {
+  const minds = safeMinds();
+  if (minds && typeof minds.maximize === 'function') {
+    minds.maximize();
+    return true;
+  }
+  return false;
+}
+
+export function closeWindow() {
+  const minds = safeMinds();
+  if (minds && typeof minds.close === 'function') {
+    minds.close();
+    return true;
+  }
+  return false;
+}
+
+export function openWorkspaceInNewWindow(agentId) {
+  const minds = safeMinds();
+  if (minds && typeof minds.openWorkspaceInNewWindow === 'function') {
+    minds.openWorkspaceInNewWindow(agentId);
+    return true;
+  }
+  return false;
+}
+
+export function showWorkspaceContextMenu(agentId, x, y) {
+  const minds = safeMinds();
+  if (minds && typeof minds.showWorkspaceContextMenu === 'function') {
+    minds.showWorkspaceContextMenu(agentId, x, y);
+    return true;
+  }
+  return false;
+}
+
+export function closeModal() {
+  const minds = safeMinds();
+  if (minds && typeof minds.closeModal === 'function') {
+    minds.closeModal();
+    return true;
+  }
+  return false;
+}
+
+// Subscription helpers. Each registers ``handler`` with the matching
+// window.minds IPC channel (if present) and returns a no-op when not in
+// Electron. They never throw -- if the channel is missing the call is
+// a quiet no-op so components can register unconditionally.
+
+export function onWindowTitleChange(handler) {
+  const minds = safeMinds();
+  if (minds && typeof minds.onWindowTitleChange === 'function') {
+    minds.onWindowTitleChange(handler);
+    return true;
+  }
+  return false;
+}
+
+export function onContentTitleChange(handler) {
+  const minds = safeMinds();
+  if (minds && typeof minds.onContentTitleChange === 'function') {
+    minds.onContentTitleChange(handler);
+    return true;
+  }
+  return false;
+}
+
+export function onContentURLChange(handler) {
+  const minds = safeMinds();
+  if (minds && typeof minds.onContentURLChange === 'function') {
+    minds.onContentURLChange(handler);
+    return true;
+  }
+  return false;
+}
+
+export function onCurrentWorkspaceChanged(handler) {
+  const minds = safeMinds();
+  if (minds && typeof minds.onCurrentWorkspaceChanged === 'function') {
+    minds.onCurrentWorkspaceChanged(handler);
+    return true;
+  }
+  return false;
+}
+
+export function onChromeEvent(handler) {
+  const minds = safeMinds();
+  if (minds && typeof minds.onChromeEvent === 'function') {
+    minds.onChromeEvent(handler);
     return true;
   }
   return false;

--- a/apps/minds/frontend/src/main/chrome.entry.jsx
+++ b/apps/minds/frontend/src/main/chrome.entry.jsx
@@ -1,0 +1,32 @@
+import { hydrate } from 'solid-js/web';
+import { getRouteComponent } from '../routes/registry.chrome.js';
+import '../styles/globals.css';
+
+// Client-side hydration entry for the "chrome" bundle (titlebar +
+// sidebar + content shell). Loaded by FastAPI at /_chrome and rendered
+// into the chrome WebContentsView in Electron. Same hydration contract
+// as app.entry.jsx -- reads {route, props} from __route__ and hydrates.
+
+function readBoot() {
+  const node = document.getElementById('__route__');
+  if (!node || !node.textContent) {
+    throw new Error('Missing #__route__ JSON payload on page');
+  }
+  return JSON.parse(node.textContent);
+}
+
+function mount() {
+  const { route, props } = readBoot();
+  const Component = getRouteComponent(route);
+  const target = document.getElementById('app');
+  if (!target) {
+    throw new Error('Missing #app mount target');
+  }
+  hydrate(() => <Component {...props} />, target);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount, { once: true });
+} else {
+  mount();
+}

--- a/apps/minds/frontend/src/main/server.jsx
+++ b/apps/minds/frontend/src/main/server.jsx
@@ -5,7 +5,7 @@
 //
 // Endpoints:
 //   GET  /__ssr/health      -> 200 {"status":"ok"} when the server is up
-//   POST /__ssr/render      body: {route, props}; returns rendered HTML
+//   POST /__ssr/render      body: {bundle, route, props}; returns rendered HTML
 //
 // Listening port:
 //   process.env.MINDS_SSR_PORT (required; the Python supervisor picks a
@@ -14,13 +14,13 @@
 // The Vite client manifest is read from the path in MINDS_VITE_MANIFEST
 // (relative paths land under the client build's outDir). When unset --
 // typical in dev when the bundle hasn't been built yet -- we emit
-// /src/main/app.entry.jsx as the script src so Vite's dev server serves
-// the source directly.
+// /src/main/<bundle>.entry.jsx as the script src so Vite's dev server
+// serves the source directly.
 
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { renderToStringAsync, generateHydrationScript } from 'solid-js/web';
-import { getRouteComponent } from '../routes/registry.js';
+import { getRouteComponentForBundle } from '../routes/registry.js';
 
 const PORT = Number(process.env.MINDS_SSR_PORT || 0);
 if (!PORT) {
@@ -30,6 +30,15 @@ if (!PORT) {
 
 const MANIFEST_PATH = process.env.MINDS_VITE_MANIFEST || null;
 const VITE_DEV_URL = process.env.MINDS_VITE_DEV_URL || null;
+
+// Per-bundle metadata. Each bundle name corresponds to a Vite rollup
+// input (vite.config.mjs:rollupOptions.input) and its on-disk source
+// entry path the manifest is keyed by.
+const BUNDLES = {
+  app: { manifestKey: 'src/main/app.entry.jsx', devEntry: 'src/main/app.entry.jsx' },
+  chrome: { manifestKey: 'src/main/chrome.entry.jsx', devEntry: 'src/main/chrome.entry.jsx' },
+  sidebar: { manifestKey: 'src/main/sidebar.entry.jsx', devEntry: 'src/main/sidebar.entry.jsx' },
+};
 
 let cachedManifest = null;
 async function getManifest() {
@@ -45,24 +54,28 @@ async function getManifest() {
   }
 }
 
-function resolveAssetTags(manifest) {
-  // Returns { scriptTag, linkTags } for the `app` entry. The convention
-  // matches Vite's manifest format -- look up the entry by its source
-  // path, read `file` for the hashed bundle name, and emit any `css`
-  // entries as preloaded stylesheets.
+function resolveAssetTags(manifest, bundle) {
+  // Returns { scriptTag, linkTags } for the bundle's entry. The
+  // convention matches Vite's manifest format -- look up the entry by
+  // its source path, read `file` for the hashed bundle name, and emit
+  // any `css` entries as preloaded stylesheets.
+  const meta = BUNDLES[bundle];
+  if (!meta) {
+    throw new Error(`Unknown bundle for asset resolution: ${bundle}`);
+  }
   if (!manifest) {
     const devSrc = VITE_DEV_URL
-      ? `${VITE_DEV_URL}/src/main/app.entry.jsx`
-      : '/_static/src/main/app.entry.jsx';
+      ? `${VITE_DEV_URL}/${meta.devEntry}`
+      : `/_static/${meta.devEntry}`;
     const devCss = VITE_DEV_URL ? `${VITE_DEV_URL}/src/styles/globals.css` : null;
     return {
       scriptTag: `<script type="module" src="${devSrc}"></script>`,
       linkTags: devCss ? `<link rel="stylesheet" href="${devCss}">` : '',
     };
   }
-  const entry = manifest['src/main/app.entry.jsx'];
+  const entry = manifest[meta.manifestKey];
   if (!entry) {
-    throw new Error('Vite manifest missing src/main/app.entry.jsx entry');
+    throw new Error(`Vite manifest missing ${meta.manifestKey} entry`);
   }
   const scriptTag = `<script type="module" src="/_static/_dist/${entry.file}"></script>`;
   const cssFiles = entry.css || [];
@@ -83,12 +96,12 @@ function escapeJsonForScript(value) {
     .replace(/\u2029/g, '\\u2029');
 }
 
-async function renderRoute({ route, props }) {
-  const Component = getRouteComponent(route);
+async function renderRoute({ bundle, route, props }) {
+  const Component = getRouteComponentForBundle(bundle, route);
   const body = await renderToStringAsync(() => <Component {...props} />);
   const hydrationScript = generateHydrationScript();
   const manifest = await getManifest();
-  const { scriptTag, linkTags } = resolveAssetTags(manifest);
+  const { scriptTag, linkTags } = resolveAssetTags(manifest, bundle);
   const payload = escapeJsonForScript({ route, props });
 
   return `<!doctype html>
@@ -142,6 +155,7 @@ const server = createServer(async (req, res) => {
         return;
       }
       const route = typeof request.route === 'string' ? request.route : null;
+      const bundle = typeof request.bundle === 'string' ? request.bundle : 'app';
       const props = request.props || {};
       if (!route) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -149,7 +163,7 @@ const server = createServer(async (req, res) => {
         return;
       }
       try {
-        const html = await renderRoute({ route, props });
+        const html = await renderRoute({ bundle, route, props });
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(html);
         return;

--- a/apps/minds/frontend/src/main/sidebar.entry.jsx
+++ b/apps/minds/frontend/src/main/sidebar.entry.jsx
@@ -1,0 +1,32 @@
+import { hydrate } from 'solid-js/web';
+import { getRouteComponent } from '../routes/registry.sidebar.js';
+import '../styles/globals.css';
+
+// Client-side hydration entry for the "sidebar" bundle (standalone
+// workspace list rendered into the Electron sidebar WebContentsView).
+// Same hydration contract as app.entry.jsx -- reads {route, props} from
+// __route__ and hydrates.
+
+function readBoot() {
+  const node = document.getElementById('__route__');
+  if (!node || !node.textContent) {
+    throw new Error('Missing #__route__ JSON payload on page');
+  }
+  return JSON.parse(node.textContent);
+}
+
+function mount() {
+  const { route, props } = readBoot();
+  const Component = getRouteComponent(route);
+  const target = document.getElementById('app');
+  if (!target) {
+    throw new Error('Missing #app mount target');
+  }
+  hydrate(() => <Component {...props} />, target);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount, { once: true });
+} else {
+  mount();
+}

--- a/apps/minds/frontend/src/routes/chrome.jsx
+++ b/apps/minds/frontend/src/routes/chrome.jsx
@@ -1,0 +1,228 @@
+import { Show, createSignal, onMount, onCleanup } from 'solid-js';
+import { Titlebar } from '../components/chrome/Titlebar.jsx';
+import { Sidebar } from '../components/chrome/Sidebar.jsx';
+import {
+  isElectron,
+  navigateContent,
+  onChromeEvent,
+  onContentTitleChange,
+  onContentURLChange,
+  onCurrentWorkspaceChanged,
+  onWindowTitleChange,
+} from '../lib/electron_bridge.js';
+import { workspaceAccentCached } from '../lib/workspace_accent.js';
+
+// The persistent chrome shell: titlebar across the top, optional
+// slide-in workspace sidebar on the left, and (in browser mode) the
+// content iframe filling the rest. In Electron the content + sidebar
+// are separate WebContentsViews -- the iframe and the slide-in panel
+// are hidden via the `isElectron()` check below.
+//
+// Props:
+//   isMac                   -- macOS-style traffic-light padding.
+//   isAuthenticated         -- initial state for the user button label
+//                              before /auth/api/status reports back.
+//   mngrForwardOrigin       -- bare origin of the mngr_forward plugin.
+//   initialWorkspaces       -- workspace list seeded from server-side
+//                              data; the SSE subscription replaces it.
+
+const RECOVERY_NAVIGATION = new Map();
+
+function buildRecoveryUrl(agentId, mngrForwardOrigin) {
+  const fallback = `${mngrForwardOrigin}/goto/${agentId}/`;
+  let returnTo = '';
+  try {
+    if (typeof document !== 'undefined') {
+      const frame = document.getElementById('content-frame');
+      if (frame && frame.contentWindow) {
+        returnTo = frame.contentWindow.location.href || '';
+      }
+    }
+  } catch {
+    returnTo = '';
+  }
+  if (!returnTo) returnTo = fallback;
+  return `/agents/${encodeURIComponent(agentId)}/recovery?return_to=${encodeURIComponent(returnTo)}`;
+}
+
+export function ChromeRoute(props) {
+  const [sidebarOpen, setSidebarOpen] = createSignal(false);
+  const [workspaces, setWorkspaces] = createSignal(props.initialWorkspaces || []);
+  const [pageTitle, setPageTitle] = createSignal('Minds');
+  const [currentWorkspaceId, setCurrentWorkspaceId] = createSignal(null);
+  const [requestCount, setRequestCount] = createSignal(0);
+  const [signedIn, setSignedIn] = createSignal(!!props.isAuthenticated);
+  const [userEmail, setUserEmail] = createSignal('');
+  const systemInterfaceStatus = new Map();
+  const mngrForwardOrigin = props.mngrForwardOrigin || '';
+
+  const accent = () => {
+    const aid = currentWorkspaceId();
+    return aid ? workspaceAccentCached(aid) : null;
+  };
+
+  const handleUserClick = () => {
+    if (signedIn()) navigateContent('/accounts');
+    else navigateContent('/auth/login');
+  };
+
+  const maybeRedirectToRecovery = (agentId) => {
+    if (!agentId) return;
+    if (systemInterfaceStatus.get(agentId) !== 'stuck') return;
+    if (RECOVERY_NAVIGATION.get(agentId)) return;
+    RECOVERY_NAVIGATION.set(agentId, true);
+    navigateContent(buildRecoveryUrl(agentId, mngrForwardOrigin));
+  };
+
+  const handleChromeEvent = (data) => {
+    if (!data || typeof data !== 'object') return;
+    if (data.type === 'workspaces' && Array.isArray(data.workspaces)) {
+      setWorkspaces(data.workspaces);
+      return;
+    }
+    if (data.type === 'auth_status') {
+      setSignedIn(!!data.signedIn);
+      setUserEmail(data.email || '');
+      return;
+    }
+    if (data.type === 'requests') {
+      setRequestCount(Number(data.count) || 0);
+      return;
+    }
+    if (data.type === 'system_interface_status') {
+      if (data.status === 'healthy') {
+        systemInterfaceStatus.delete(data.agent_id);
+        RECOVERY_NAVIGATION.delete(data.agent_id);
+        return;
+      }
+      systemInterfaceStatus.set(data.agent_id, data.status);
+      if (data.agent_id === currentWorkspaceId()) {
+        maybeRedirectToRecovery(data.agent_id);
+      }
+    }
+  };
+
+  const refreshAuthStatus = async () => {
+    try {
+      const response = await fetch('/auth/api/status');
+      if (!response.ok) return;
+      const data = await response.json();
+      setSignedIn(!!data.signedIn);
+      setUserEmail(data.email || '');
+    } catch {
+      // SSE-only mode (offline / dev); leave the cached state alone.
+    }
+  };
+
+  onMount(() => {
+    refreshAuthStatus();
+    // Title-tracking inside the iframe content (browser mode). In
+    // Electron the content WebContentsView pushes title changes over
+    // IPC instead.
+    if (isElectron()) {
+      const titleHandler = (title) => setPageTitle(title || 'Minds');
+      if (!onWindowTitleChange(titleHandler)) {
+        onContentTitleChange(titleHandler);
+      }
+      onContentURLChange(() => {
+        refreshAuthStatus();
+      });
+      onCurrentWorkspaceChanged((agentId) => {
+        const next = agentId || null;
+        if (next !== currentWorkspaceId()) {
+          RECOVERY_NAVIGATION.delete(next);
+        }
+        setCurrentWorkspaceId(next);
+        maybeRedirectToRecovery(next);
+      });
+    } else {
+      const interval = setInterval(() => {
+        try {
+          if (typeof document === 'undefined') return;
+          const frame = document.getElementById('content-frame');
+          if (!frame || !frame.contentWindow) return;
+          const innerDoc = frame.contentDocument;
+          if (innerDoc && innerDoc.title) setPageTitle(innerDoc.title);
+          const match = frame.contentWindow.location.pathname.match(/^\/goto\/([^/]+)/);
+          const next = match ? match[1] : null;
+          if (next !== currentWorkspaceId()) {
+            RECOVERY_NAVIGATION.delete(next);
+          }
+          setCurrentWorkspaceId(next);
+          maybeRedirectToRecovery(next);
+        } catch {
+          // cross-origin probes are expected during navigation; ignore.
+        }
+      }, 500);
+      onCleanup(() => clearInterval(interval));
+    }
+    // SSE wire-up. Electron uses window.minds.onChromeEvent to receive
+    // multiplexed envelopes; the browser path opens its own
+    // /_chrome/events stream.
+    if (!onChromeEvent(handleChromeEvent)) {
+      const Impl =
+        props.eventSourceImpl ||
+        (typeof EventSource !== 'undefined' ? EventSource : null);
+      if (!Impl) return;
+      let eventSource = new Impl(props.sseUrl || '/_chrome/events');
+      eventSource.onmessage = (event) => {
+        try {
+          handleChromeEvent(JSON.parse(event.data));
+        } catch {
+          // malformed payloads dropped silently
+        }
+      };
+      onCleanup(() => {
+        if (eventSource) {
+          eventSource.close();
+          eventSource = null;
+        }
+      });
+    }
+  });
+
+  const electronMode = isElectron();
+
+  return (
+    <div
+      class="font-sans antialiased bg-zinc-900 min-h-screen"
+      data-is-mac={props.isMac ? 'true' : 'false'}
+      data-is-authenticated={props.isAuthenticated ? 'true' : 'false'}
+      data-mngr-forward-origin={mngrForwardOrigin}
+    >
+      <Titlebar
+        isMac={!!props.isMac}
+        isAuthenticated={signedIn()}
+        pageTitle={pageTitle()}
+        workspaceAccent={accent()}
+        requestCount={requestCount()}
+        userButtonTitle={userEmail() || (signedIn() ? 'Manage accounts' : 'Sign in to your account')}
+        userButtonLabel={signedIn() ? 'Manage account(s)' : 'Log in'}
+        onUserClick={handleUserClick}
+        onToggleSidebar={() => setSidebarOpen((v) => !v)}
+      />
+      <Show when={!electronMode}>
+        <div
+          id="sidebar-panel"
+          class={
+            'fixed left-0 top-[38px] w-[260px] h-[calc(100%-38px)] bg-zinc-900 z-50 shadow-[4px_0_12px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-in-out overflow-y-auto border-r border-white/10 ' +
+            (sidebarOpen() ? '' : '-translate-x-full')
+          }
+        >
+          <Sidebar
+            workspaces={workspaces()}
+            mngrForwardOrigin={mngrForwardOrigin}
+            currentWorkspaceId={currentWorkspaceId()}
+            showOpenInNewWindow={false}
+          />
+        </div>
+        <iframe
+          id="content-frame"
+          src="/"
+          class="fixed left-[6px] top-[38px] border-0 rounded-xl bg-zinc-50"
+          attr:style="width: calc(100% - 12px); height: calc(100% - 44px); box-shadow: 0 1px 0 rgba(255,255,255,0.05) inset;"
+        />
+      </Show>
+    </div>
+  );
+}

--- a/apps/minds/frontend/src/routes/permissions/file_sharing.jsx
+++ b/apps/minds/frontend/src/routes/permissions/file_sharing.jsx
@@ -1,0 +1,52 @@
+import { PermissionRequest } from '../../components/permissions/PermissionRequest.jsx';
+
+// Latchkey file-sharing permission request dialog. Mirrors the
+// predefined dialog's chrome but offers no per-permission choice: the
+// request already names the (path, access) pair. A hidden checked
+// ``permissions`` input enables the Approve button on first paint.
+//
+// Props:
+//   agentId, requestId, wsName, rationale, accent  -- forwarded to
+//                                                     PermissionRequest.
+//   filePath          -- absolute host path the agent wants access to.
+//   access            -- raw access mode (``READ`` or ``WRITE``); drives
+//                       the badge color and the summary copy.
+//   accessHumanLabel  -- lower-case rendering shown in the badge body.
+export function PermissionsFileSharingRoute(props) {
+  const isWrite = props.access === 'WRITE';
+  const summary = isWrite ? (
+    <>
+      Approving will grant {props.wsName || props.agentId} and its sibling agents{' '}
+      <strong>read and write</strong> access (including delete) to the following
+      file/directory:
+    </>
+  ) : (
+    <>
+      Approving will grant {props.wsName || props.agentId} and its sibling agents{' '}
+      <strong>read-only</strong> access to the following file:
+    </>
+  );
+  const badgeClass = isWrite
+    ? 'shrink-0 text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-amber-50 text-amber-800 border border-amber-200'
+    : 'shrink-0 text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-800 border border-emerald-200';
+  return (
+    <PermissionRequest
+      agentId={props.agentId}
+      requestId={props.requestId}
+      wsName={props.wsName}
+      rationale={props.rationale}
+      displayName={props.filePath}
+      accent={props.accent}
+      progressLabel="Granting permission..."
+    >
+      <p class="text-sm text-zinc-700 mb-3">{summary}</p>
+      <div class="bg-white border border-zinc-200 rounded-xl p-4 flex items-center gap-3">
+        <code class="text-sm font-mono text-zinc-900 break-all flex-1 min-w-0">
+          {props.filePath}
+        </code>
+        <span class={badgeClass}>{props.accessHumanLabel}</span>
+      </div>
+      <input type="checkbox" name="permissions" value="file-sharing" checked hidden />
+    </PermissionRequest>
+  );
+}

--- a/apps/minds/frontend/src/routes/permissions/index.jsx
+++ b/apps/minds/frontend/src/routes/permissions/index.jsx
@@ -1,0 +1,18 @@
+import { PermissionRequest } from '../../components/permissions/PermissionRequest.jsx';
+
+// Generic permission-request shell with no backend-specific body. Used
+// as a fallback / default landing in routes that have no specialised
+// permission UI yet. The shell renders the rationale and approve/deny
+// chrome; the body is left empty.
+export function PermissionsIndexRoute(props) {
+  return (
+    <PermissionRequest
+      agentId={props.agentId}
+      requestId={props.requestId}
+      wsName={props.wsName}
+      rationale={props.rationale}
+      displayName={props.displayName}
+      accent={props.accent}
+    />
+  );
+}

--- a/apps/minds/frontend/src/routes/permissions/predefined.jsx
+++ b/apps/minds/frontend/src/routes/permissions/predefined.jsx
@@ -1,0 +1,142 @@
+import { For, Show, createSignal } from 'solid-js';
+import { Notice } from '../../components/ui/Notice.jsx';
+import { PermissionRequest } from '../../components/permissions/PermissionRequest.jsx';
+
+// Latchkey-backed predefined-permission request dialog. The simple view
+// summarizes which permissions Approve will grant; clicking "Adjust"
+// reveals the full checkbox editor. The hidden editor inputs always
+// exist in the DOM so the shared submit handler can read the checked
+// set in either view.
+//
+// Props:
+//   agentId, requestId, wsName, rationale, displayName, accent
+//                              -- forwarded to PermissionRequest.
+//   permissionSchemas          -- ordered list of schema names rendered
+//                                 as checkboxes (including the catch-all
+//                                 "any" if applicable).
+//   checkedPermissions         -- subset of schemas that should be
+//                                 pre-checked on first render.
+//   descriptionByPermissionName -- map of schema name -> plain-English
+//                                 summary; rendered alongside the row
+//                                 when present.
+//   willOpenBrowser            -- toggles the progress copy between
+//                                 "Authenticating..." (browser flow) and
+//                                 "Granting permission..." (no flow).
+export function PermissionsPredefinedRoute(props) {
+  const [editorVisible, setEditorVisible] = createSignal(false);
+  const checkedSet = new Set(props.checkedPermissions || []);
+  const schemas = props.permissionSchemas || [];
+  const descriptions = props.descriptionByPermissionName || {};
+  const grantedSchemas = schemas.filter((schema) => checkedSet.has(schema));
+  const wsLabel = props.wsName || props.agentId;
+
+  const progressLabel = props.willOpenBrowser ? 'Authenticating...' : 'Granting permission...';
+  const progressDetail = props.willOpenBrowser
+    ? `Latchkey is opening a browser window for you to sign in to ${props.displayName}. This dialog will close automatically when the flow completes.`
+    : '';
+
+  return (
+    <PermissionRequest
+      agentId={props.agentId}
+      requestId={props.requestId}
+      wsName={props.wsName}
+      rationale={props.rationale}
+      displayName={props.displayName}
+      accent={props.accent}
+      progressLabel={progressLabel}
+      progressDetail={progressDetail}
+    >
+      <div id="permissions-simple-view" class={editorVisible() ? 'hidden' : ''}>
+        <Show
+          when={grantedSchemas.length > 0}
+          fallback={
+            <>
+              <Notice variant="warn">
+                The agent did not request any specific permissions. Click{' '}
+                <span class="font-medium">Adjust</span> below to choose what to grant.
+              </Notice>
+              <div class="flex justify-end mt-3">
+                <button
+                  type="button"
+                  id="permissions-adjust-link"
+                  onClick={() => setEditorVisible(true)}
+                  class="text-xs text-blue-600 hover:underline cursor-pointer bg-transparent border-0 p-0"
+                >
+                  Adjust
+                </button>
+              </div>
+            </>
+          }
+        >
+          <p class="text-sm text-zinc-700 mb-3">
+            Approving will grant {wsLabel} and its sibling agents the following permissions:
+          </p>
+          <div class="bg-white border border-zinc-200 rounded-xl p-4 space-y-3">
+            <For each={grantedSchemas}>
+              {(permission) => (
+                <div>
+                  <div class="flex items-center gap-2.5">
+                    <svg
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      aria-hidden="true"
+                      class="w-4 h-4 shrink-0 text-emerald-600"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 1 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
+                      />
+                    </svg>
+                    <code class="text-sm font-mono text-zinc-900">{permission}</code>
+                  </div>
+                  <Show when={descriptions[permission]}>
+                    <span class="block text-sm text-zinc-600 mt-0.5 ml-[26px]">
+                      {descriptions[permission]}
+                    </span>
+                  </Show>
+                </div>
+              )}
+            </For>
+            <div class="flex justify-end border-t border-zinc-100 pt-2">
+              <button
+                type="button"
+                id="permissions-adjust-link"
+                onClick={() => setEditorVisible(true)}
+                class="text-xs text-blue-600 hover:underline cursor-pointer bg-transparent border-0 p-0"
+              >
+                Adjust
+              </button>
+            </div>
+          </div>
+        </Show>
+      </div>
+      <div id="permissions-editor-view" class={editorVisible() ? '' : 'hidden'}>
+        <h2 class="text-sm font-medium text-zinc-700 mb-2">Permissions to grant:</h2>
+        <div class="bg-white border border-zinc-200 rounded-xl p-4 space-y-3">
+          <For each={schemas}>
+            {(permission) => (
+              <label class="flex items-start gap-2.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="permissions"
+                  value={permission}
+                  class="mt-1 shrink-0"
+                  checked={checkedSet.has(permission)}
+                />
+                <span class="min-w-0">
+                  <code class="text-sm font-mono text-zinc-900">{permission}</code>
+                  <Show when={descriptions[permission]}>
+                    <span class="block text-sm text-zinc-600 mt-0.5">
+                      {descriptions[permission]}
+                    </span>
+                  </Show>
+                </span>
+              </label>
+            )}
+          </For>
+        </div>
+      </div>
+    </PermissionRequest>
+  );
+}

--- a/apps/minds/frontend/src/routes/registry.app.js
+++ b/apps/minds/frontend/src/routes/registry.app.js
@@ -1,0 +1,33 @@
+import { WelcomeRoute } from './welcome.jsx';
+import { LoginRoute } from './login.jsx';
+import { AuthErrorRoute } from './auth_error.jsx';
+import { LoginRedirectRoute } from './login_redirect.jsx';
+import { PermissionsIndexRoute } from './permissions/index.jsx';
+import { PermissionsPredefinedRoute } from './permissions/predefined.jsx';
+import { PermissionsFileSharingRoute } from './permissions/file_sharing.jsx';
+
+// Route registry for the "app" bundle (the main content WebContentsView).
+// Each entry maps a route key (the Python side picks the key by URL) to
+// its Solid component. The key is passed verbatim through the SSR sidecar
+// HTTP boundary, so it lives in one shared place.
+//
+// As pages migrate they get added to this map. Trying to render a key
+// that isn't here is a hard error -- caught by the sidecar before any
+// HTML is returned.
+export const ROUTES = {
+  welcome: WelcomeRoute,
+  login: LoginRoute,
+  auth_error: AuthErrorRoute,
+  login_redirect: LoginRedirectRoute,
+  'permissions/index': PermissionsIndexRoute,
+  'permissions/predefined': PermissionsPredefinedRoute,
+  'permissions/file_sharing': PermissionsFileSharingRoute,
+};
+
+export function getRouteComponent(key) {
+  const Component = ROUTES[key];
+  if (!Component) {
+    throw new Error(`Unknown route key: ${key}`);
+  }
+  return Component;
+}

--- a/apps/minds/frontend/src/routes/registry.chrome.js
+++ b/apps/minds/frontend/src/routes/registry.chrome.js
@@ -1,0 +1,15 @@
+import { ChromeRoute } from './chrome.jsx';
+
+// Route registry for the "chrome" bundle (titlebar + sidebar + content
+// iframe shell, served at /_chrome).
+export const ROUTES = {
+  chrome: ChromeRoute,
+};
+
+export function getRouteComponent(key) {
+  const Component = ROUTES[key];
+  if (!Component) {
+    throw new Error(`Unknown chrome route key: ${key}`);
+  }
+  return Component;
+}

--- a/apps/minds/frontend/src/routes/registry.js
+++ b/apps/minds/frontend/src/routes/registry.js
@@ -1,26 +1,28 @@
-import { WelcomeRoute } from './welcome.jsx';
-import { LoginRoute } from './login.jsx';
-import { AuthErrorRoute } from './auth_error.jsx';
-import { LoginRedirectRoute } from './login_redirect.jsx';
+import * as appRegistry from './registry.app.js';
+import * as chromeRegistry from './registry.chrome.js';
+import * as sidebarRegistry from './registry.sidebar.js';
 
-// Maps a "route key" (the Python side picks the key by URL) to its Solid
-// component. The key is passed verbatim through the SSR sidecar HTTP
-// boundary, so it lives in one shared place.
-//
-// As pages migrate they get added to this map. Trying to render a key
-// that isn't here is a hard error -- caught by the sidecar before any
-// HTML is returned.
-export const ROUTES = {
-  welcome: WelcomeRoute,
-  login: LoginRoute,
-  auth_error: AuthErrorRoute,
-  login_redirect: LoginRedirectRoute,
+// Top-level multi-bundle registry. Each bundle key matches a rollup
+// entry name in vite.config.mjs (app / chrome / sidebar) and carries its
+// own route -> component map. The SSR sidecar selects the right bundle
+// using the "bundle" field of the render request, then resolves the
+// route key inside that bundle.
+const BUNDLES = {
+  app: appRegistry,
+  chrome: chromeRegistry,
+  sidebar: sidebarRegistry,
 };
 
-export function getRouteComponent(key) {
-  const Component = ROUTES[key];
-  if (!Component) {
-    throw new Error(`Unknown route key: ${key}`);
+export function getRouteComponentForBundle(bundle, key) {
+  const registry = BUNDLES[bundle];
+  if (!registry) {
+    throw new Error(`Unknown bundle: ${bundle}`);
   }
-  return Component;
+  return registry.getRouteComponent(key);
+}
+
+// Legacy convenience export so the client app-bundle entry that imports
+// the bare app registry keeps working without an additional adapter.
+export function getRouteComponent(key) {
+  return appRegistry.getRouteComponent(key);
 }

--- a/apps/minds/frontend/src/routes/registry.sidebar.js
+++ b/apps/minds/frontend/src/routes/registry.sidebar.js
@@ -1,0 +1,15 @@
+import { SidebarRoute } from './sidebar.jsx';
+
+// Route registry for the "sidebar" bundle (standalone sidebar
+// WebContentsView, served at /_chrome/sidebar).
+export const ROUTES = {
+  sidebar: SidebarRoute,
+};
+
+export function getRouteComponent(key) {
+  const Component = ROUTES[key];
+  if (!Component) {
+    throw new Error(`Unknown sidebar route key: ${key}`);
+  }
+  return Component;
+}

--- a/apps/minds/frontend/src/routes/sidebar.jsx
+++ b/apps/minds/frontend/src/routes/sidebar.jsx
@@ -1,0 +1,70 @@
+import { createSignal, onMount, onCleanup } from 'solid-js';
+import { Sidebar } from '../components/chrome/Sidebar.jsx';
+import { onChromeEvent, onCurrentWorkspaceChanged } from '../lib/electron_bridge.js';
+
+// Route component for the standalone sidebar WebContentsView. Wraps
+// <Sidebar /> with the SSE subscription that keeps the workspace list
+// fresh (and, in Electron, the IPC subscription that highlights the
+// currently-active workspace).
+//
+// Props:
+//   mngrForwardOrigin       -- bare origin of the mngr_forward plugin.
+//   workspaces              -- initial workspace list from the server
+//                              (used both for SSR and as the seed before
+//                              the SSE pump catches up).
+//   sseUrl                  -- override for the SSE source URL (tests).
+export function SidebarRoute(props) {
+  const [workspaces, setWorkspaces] = createSignal(props.workspaces || []);
+  const [currentWorkspaceId, setCurrentWorkspaceId] = createSignal(null);
+
+  const updateFromChromeEvent = (data) => {
+    if (!data || typeof data !== 'object') return;
+    if (data.type === 'workspaces' && Array.isArray(data.workspaces)) {
+      setWorkspaces(data.workspaces);
+    }
+  };
+
+  onMount(() => {
+    // The standalone sidebar bundle uses window.minds.onChromeEvent
+    // (Electron-only IPC); in browser mode the chrome page hosts its
+    // own SSE, but we also fall back to direct SSE here so the sidebar
+    // remains useful when opened standalone (e.g. dev). Mirrors the
+    // logic in static/sidebar.js.
+    if (onChromeEvent(updateFromChromeEvent)) {
+      onCurrentWorkspaceChanged((agentId) => setCurrentWorkspaceId(agentId || null));
+      return;
+    }
+    const Impl =
+      props.eventSourceImpl ||
+      (typeof EventSource !== 'undefined' ? EventSource : null);
+    if (!Impl) return;
+    let eventSource = new Impl(props.sseUrl || '/_chrome/events');
+    eventSource.onmessage = (event) => {
+      try {
+        updateFromChromeEvent(JSON.parse(event.data));
+      } catch {
+        // malformed events are silently dropped, matching the legacy code
+      }
+    };
+    onCleanup(() => {
+      if (eventSource) {
+        eventSource.close();
+        eventSource = null;
+      }
+    });
+  });
+
+  return (
+    <div class="bg-zinc-900 font-sans antialiased overflow-y-auto min-h-screen">
+      <h2 class="text-sm text-zinc-200 p-3 m-0 border-b border-white/10 font-medium">
+        Projects
+      </h2>
+      <Sidebar
+        workspaces={workspaces()}
+        mngrForwardOrigin={props.mngrForwardOrigin || ''}
+        currentWorkspaceId={currentWorkspaceId()}
+        showOpenInNewWindow
+      />
+    </div>
+  );
+}

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1641,13 +1641,17 @@ def _handle_chrome_page(
         is_authenticated=authenticated,
         mngr_forward_origin=_get_mngr_forward_origin(request),
         initial_workspaces=initial_workspaces,
+        sidecar=request.app.state.ssr_sidecar,
     )
     return HTMLResponse(content=html)
 
 
 def _handle_chrome_sidebar(request: Request) -> Response:
     """Serve the standalone sidebar page for the Electron sidebar WebContentsView."""
-    html = render_sidebar_page(mngr_forward_origin=_get_mngr_forward_origin(request))
+    html = render_sidebar_page(
+        mngr_forward_origin=_get_mngr_forward_origin(request),
+        sidecar=request.app.state.ssr_sidecar,
+    )
     return HTMLResponse(content=html)
 
 
@@ -2821,6 +2825,7 @@ def _handle_request_page(
         req_event=req_event,
         backend_resolver=backend_resolver,
         mngr_forward_origin=_get_mngr_forward_origin(request),
+        sidecar=request.app.state.ssr_sidecar,
     )
 
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -50,6 +50,7 @@ from imbue.minds.desktop_client.request_events import RequestType
 from imbue.minds.desktop_client.request_events import append_response_event
 from imbue.minds.desktop_client.request_events import create_request_response_event
 from imbue.minds.desktop_client.request_handler import RequestEventHandler
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 from imbue.mngr.primitives import AgentId
 
 # Label shown on the requests-panel card (lower-case, short).
@@ -144,6 +145,7 @@ class FileSharingGrantHandler(RequestEventHandler):
         req_event: RequestEvent,
         backend_resolver: BackendResolverInterface,
         mngr_forward_origin: str,
+        sidecar: SsrSidecar | None = None,
     ) -> Response:
         if not isinstance(req_event, LatchkeyFileSharingPermissionRequestEvent):
             return HTMLResponse(content="<p>Unsupported request type</p>", status_code=500)
@@ -158,6 +160,7 @@ class FileSharingGrantHandler(RequestEventHandler):
             access=req_event.access,
             access_human_label=_access_human_label(req_event.access),
             mngr_forward_origin=mngr_forward_origin,
+            sidecar=sidecar,
         )
         return HTMLResponse(content=rendered)
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
@@ -27,6 +27,7 @@ from imbue.minds.desktop_client.request_events import RequestInbox
 from imbue.minds.desktop_client.request_events import RequestType
 from imbue.minds.desktop_client.request_events import create_latchkey_file_sharing_permission_request_event
 from imbue.minds.desktop_client.request_events import load_response_events
+from imbue.minds.desktop_client.testing import extract_ssr_route_payload
 from imbue.mngr.primitives import AgentId
 
 _HttpxHandler: Final = Callable[[httpx.Request], httpx.Response]
@@ -126,16 +127,14 @@ def test_render_request_page_shows_path_and_rationale(tmp_path: Path) -> None:
     )
     assert response.status_code == 200
     body = bytes(response.body).decode("utf-8")
-    assert "/home/user/important.txt" in body
-    assert "summarize the doc" in body
-    assert "Approve" in body and "Deny" in body
-    # The dialog must show the human-readable access label so the user
-    # knows what's being granted.
-    assert "read-only" in body
-    # The dialog must escape user-controlled values; ensure quoting
-    # uses HTML-safe attributes rather than raw interpolation.
-    # Presence of the form-submit JS tag confirms the dialog wired in.
-    assert "<script>" in body
+    payload = extract_ssr_route_payload(body)
+    assert payload["route"] == "permissions/file_sharing"
+    assert payload["props"]["filePath"] == "/home/user/important.txt"
+    assert payload["props"]["rationale"] == "summarize the doc"
+    # The dialog must surface the human-readable access label so the
+    # user knows what's being granted.
+    assert payload["props"]["accessHumanLabel"] == "read-only"
+    assert payload["props"]["access"] == "READ"
 
 
 def test_render_request_page_marks_write_grants_distinctly(tmp_path: Path) -> None:
@@ -153,10 +152,9 @@ def test_render_request_page_marks_write_grants_distinctly(tmp_path: Path) -> No
         mngr_forward_origin="",
     )
     body = bytes(response.body).decode("utf-8")
-    assert "read &amp; write" in body or "read & write" in body
-    # The read-only label must not appear when WRITE access is being
-    # requested, otherwise the dialog would be misleading.
-    assert "read-only" not in body
+    payload = extract_ssr_route_payload(body)
+    assert payload["props"]["access"] == "WRITE"
+    assert payload["props"]["accessHumanLabel"] == "read & write"
 
 
 def test_render_request_page_escapes_html_in_inputs(tmp_path: Path) -> None:
@@ -173,10 +171,17 @@ def test_render_request_page_escapes_html_in_inputs(tmp_path: Path) -> None:
         mngr_forward_origin="",
     )
     body = bytes(response.body).decode("utf-8")
-    # Raw HTML must not appear; entities must.
+    # Raw HTML payloads must not leak into the SSR-shell DOM. The Solid
+    # component renders user-controlled values as text, never as HTML;
+    # the JSON payload escapes ``<`` -> ``<`` so the embedded blob
+    # cannot terminate the surrounding <script> tag.
     assert "<script>alert(1)" not in body
-    assert "&lt;script&gt;alert(1)" in body
     assert "<img src=x" not in body
+    # The verbatim raw strings are carried in the SSR JSON payload so
+    # the client component receives them as data.
+    payload = extract_ssr_route_payload(body)
+    assert payload["props"]["filePath"] == "/tmp/<script>alert(1)</script>.txt"
+    assert payload["props"]["rationale"] == "<img src=x onerror=alert(2)>"
 
 
 # -- apply_grant_request --

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -50,6 +50,7 @@ from imbue.minds.desktop_client.latchkey.services_catalog import ServicesCatalog
 from imbue.minds.desktop_client.request_events import LatchkeyPredefinedPermissionRequestEvent
 from imbue.minds.desktop_client.request_events import RequestEvent
 from imbue.minds.desktop_client.request_events import RequestInbox
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 from imbue.minds.desktop_client.request_events import RequestResponseEvent
 from imbue.minds.desktop_client.request_events import RequestStatus
 from imbue.minds.desktop_client.request_events import RequestType
@@ -466,6 +467,7 @@ class LatchkeyPermissionGrantHandler(RequestEventHandler):
         req_event: RequestEvent,
         backend_resolver: BackendResolverInterface,
         mngr_forward_origin: str,
+        sidecar: SsrSidecar | None = None,
     ) -> Response:
         """Render the dialog HTML for a latchkey permission request.
 
@@ -509,6 +511,7 @@ class LatchkeyPermissionGrantHandler(RequestEventHandler):
             checked_permissions=pre_checked,
             will_open_browser=will_open_browser,
             mngr_forward_origin=mngr_forward_origin,
+            sidecar=sidecar,
         )
         return HTMLResponse(content=rendered)
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -50,13 +50,13 @@ from imbue.minds.desktop_client.latchkey.services_catalog import ServicesCatalog
 from imbue.minds.desktop_client.request_events import LatchkeyPredefinedPermissionRequestEvent
 from imbue.minds.desktop_client.request_events import RequestEvent
 from imbue.minds.desktop_client.request_events import RequestInbox
-from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 from imbue.minds.desktop_client.request_events import RequestResponseEvent
 from imbue.minds.desktop_client.request_events import RequestStatus
 from imbue.minds.desktop_client.request_events import RequestType
 from imbue.minds.desktop_client.request_events import append_response_event
 from imbue.minds.desktop_client.request_events import create_request_response_event
 from imbue.minds.desktop_client.request_handler import RequestEventHandler
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import HostId
 from imbue.mngr_latchkey.core import CredentialStatus

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/templates.py
@@ -24,13 +24,12 @@ out of the generic template module.
 
 from collections.abc import Sequence
 
-from imbue.imbue_common.pure import pure
 from imbue.minds.desktop_client.latchkey.services_catalog import ServicePermissionInfo
-from imbue.minds.desktop_client.templates import JINJA_ENV
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
+from imbue.minds.desktop_client.templates import _render_ssr_or_fallback
 from imbue.minds.desktop_client.templates import workspace_accent
 
 
-@pure
 def render_predefined_permission_dialog(
     agent_id: str,
     request_id: str,
@@ -40,6 +39,7 @@ def render_predefined_permission_dialog(
     checked_permissions: Sequence[str],
     will_open_browser: bool,
     mngr_forward_origin: str = "",
+    sidecar: SsrSidecar | None = None,
 ) -> str:
     """Render the predefined (catalog-backed) permission approval dialog.
 
@@ -51,24 +51,31 @@ def render_predefined_permission_dialog(
 
     ``mngr_forward_origin`` is the bare origin of the ``mngr forward`` plugin;
     the workspace link in the dialog points at ``{mngr_forward_origin}/goto/<agent>/``.
+
+    Implemented as a Solid component (``routes/permissions/predefined.jsx``);
+    this shim asks the SSR sidecar to render it and falls back to the
+    client-render shell when the sidecar isn't available.
     """
-    return JINJA_ENV.get_template("latchkey_predefined_permission.html").render(
-        agent_id=agent_id,
-        request_id=request_id,
-        ws_name=ws_name,
-        rationale=rationale,
-        display_name=service.display_name,
-        scope=service.scope,
-        permission_schemas=service.permission_schemas,
-        description_by_permission_name=service.description_by_permission_name,
-        checked_permissions=set(checked_permissions),
-        accent=workspace_accent(agent_id),
-        will_open_browser=will_open_browser,
-        mngr_forward_origin=mngr_forward_origin,
+    return _render_ssr_or_fallback(
+        sidecar=sidecar,
+        route="permissions/predefined",
+        props={
+            "agentId": agent_id,
+            "requestId": request_id,
+            "wsName": ws_name,
+            "rationale": rationale,
+            "displayName": service.display_name,
+            "scope": service.scope,
+            "permissionSchemas": list(service.permission_schemas),
+            "descriptionByPermissionName": dict(service.description_by_permission_name),
+            "checkedPermissions": sorted(set(checked_permissions)),
+            "accent": workspace_accent(agent_id),
+            "willOpenBrowser": will_open_browser,
+            "mngrForwardOrigin": mngr_forward_origin,
+        },
     )
 
 
-@pure
 def render_file_sharing_permission_dialog(
     agent_id: str,
     request_id: str,
@@ -78,13 +85,14 @@ def render_file_sharing_permission_dialog(
     access: str,
     access_human_label: str,
     mngr_forward_origin: str = "",
+    sidecar: SsrSidecar | None = None,
 ) -> str:
     """Render the file-sharing permission approval dialog.
 
     Mirrors the predefined dialog's chrome, header, rationale card, and
-    submission JS (via the shared ``templates/permissions.html`` base);
-    swaps the per-permission checkbox list for a short explanation of
-    what the agent will be allowed to do with the path.
+    submission JS (via the shared ``permissions/PermissionRequest`` Solid
+    component); swaps the per-permission checkbox list for a short
+    explanation of what the agent will be allowed to do with the path.
 
     ``access`` carries the agent's requested access mode (``READ`` or
     ``WRITE``) verbatim; ``access_human_label`` is the lower-case
@@ -94,15 +102,19 @@ def render_file_sharing_permission_dialog(
     ``mngr_forward_origin`` is the bare origin of the ``mngr forward`` plugin;
     the workspace link in the dialog points at ``{mngr_forward_origin}/goto/<agent>/``.
     """
-    return JINJA_ENV.get_template("latchkey_file_sharing_permission.html").render(
-        agent_id=agent_id,
-        request_id=request_id,
-        ws_name=ws_name,
-        rationale=rationale,
-        file_path=file_path,
-        access=access,
-        access_human_label=access_human_label,
-        display_name=file_path,
-        accent=workspace_accent(agent_id),
-        mngr_forward_origin=mngr_forward_origin,
+    return _render_ssr_or_fallback(
+        sidecar=sidecar,
+        route="permissions/file_sharing",
+        props={
+            "agentId": agent_id,
+            "requestId": request_id,
+            "wsName": ws_name,
+            "rationale": rationale,
+            "filePath": file_path,
+            "access": access,
+            "accessHumanLabel": access_human_label,
+            "displayName": file_path,
+            "accent": workspace_accent(agent_id),
+            "mngrForwardOrigin": mngr_forward_origin,
+        },
     )

--- a/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
+++ b/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
@@ -43,6 +43,8 @@ from imbue.minds.desktop_client.request_events import RequestType
 from imbue.minds.desktop_client.request_events import create_latchkey_predefined_permission_request_event
 from imbue.minds.desktop_client.request_events import create_request_response_event
 from imbue.minds.desktop_client.request_handler import RequestEventHandler
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
+from imbue.minds.desktop_client.testing import extract_ssr_route_payload
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import HostId
 from imbue.mngr_latchkey.core import Latchkey
@@ -279,37 +281,25 @@ def test_get_permission_request_page_pre_checks_agent_requested_permissions(tmp_
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
-    assert "Slack" in body
-    assert "I need to read" in body
-    # The agent-requested permission appears checked.
-    read_idx = body.find('value="slack-read-all"')
-    assert read_idx != -1
-    tag_start = body.rfind("<input", 0, read_idx)
-    tag_end = body.find(">", read_idx)
-    assert "checked" in body[tag_start:tag_end]
-    # ``any`` is offered as a checkbox but must not be pre-checked.
-    any_idx = body.find('value="any"')
-    assert any_idx != -1
-    any_tag_start = body.rfind("<input", 0, any_idx)
-    any_tag_end = body.find(">", any_idx)
-    assert "checked" not in body[any_tag_start:any_tag_end]
-    # Approve must be disabled in initial markup (JS enables it once the
-    # user confirms / interacts with the form).
-    assert 'id="permissions-approve-btn"' in body
-    assert "disabled" in body
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "permissions/predefined"
+    assert payload["props"]["displayName"] == "Slack"
+    assert "I need to read" in payload["props"]["rationale"]
+    # The agent-requested permission is pre-checked, the catch-all is not.
+    assert "slack-read-all" in payload["props"]["checkedPermissions"]
+    assert "any" not in payload["props"]["checkedPermissions"]
+    # The catch-all is still offered in the editor view.
+    assert "any" in payload["props"]["permissionSchemas"]
 
 
 def test_get_permission_request_page_renders_as_modal(tmp_path: Path) -> None:
-    """The request page is rendered as a dismissable modal overlay.
+    """The request page surfaces the SSR payload the Solid modal hydrates from.
 
-    The desktop client hosts it in a transparent full-window overlay view
-    stacked over the workspace, so the page provides a dim backdrop, a
-    centered dialog card, and a close affordance. Dismissal (close button,
-    backdrop click, Escape, or a completed grant/deny) must prefer the
-    Electron modal host (``window.minds.closeModal``) so the workspace view
-    is left untouched, falling back to navigating home only when no modal
-    host is present (page opened directly in a browser).
+    The Vitest tests for the PermissionRequest component assert on the
+    modal scaffolding (backdrop, dialog card, close affordance, Electron
+    closeModal preference). This test merely confirms the Python side
+    emits the right route key + props so the right Solid component
+    mounts.
     """
     agent_id = AgentId()
     request = create_latchkey_predefined_permission_request_event(
@@ -325,32 +315,13 @@ def test_get_permission_request_page_renders_as_modal(tmp_path: Path) -> None:
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
-    # Modal scaffolding: a dim backdrop, a dialog card, and a close button.
-    assert 'id="permissions-backdrop"' in body
-    assert 'id="permissions-dialog"' in body
-    assert 'id="permissions-close-btn"' in body
-    # The transparent body lets the overlay reveal the workspace behind it.
-    assert "bg-transparent" in body
-    # Dismissal prefers the Electron modal host over a home navigation.
-    assert "window.minds.closeModal" in body
-    closemodal_idx = body.find("window.minds.closeModal")
-    href_idx = body.find('window.location.href = "/"')
-    assert closemodal_idx != -1 and href_idx != -1
-    assert closemodal_idx < href_idx, "closeModal must be preferred over the home-nav fallback"
-    # Backdrop click and Escape are wired to the same dismissal helper.
-    assert "onBackdropClick" in body
-    assert 'e.key === "Escape"' in body
-    # Overflow scrolls inside the dialog card (capped at the viewport height
-    # with an inner scroll region), not down the full width of the app.
-    dialog_idx = body.find('id="permissions-dialog"')
-    dialog_tag_end = body.find(">", dialog_idx)
-    assert "max-h-full" in body[dialog_idx:dialog_tag_end]
-    assert "overflow-y-auto" in body
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "permissions/predefined"
+    assert payload["props"]["requestId"] == str(request.event_id)
 
 
 def test_get_permission_request_page_shows_descriptions_when_present(tmp_path: Path) -> None:
-    """detent's per-permission descriptions are rendered next to each permission when present."""
+    """detent's per-permission descriptions are threaded through SSR props."""
     agent_id = AgentId()
     request = create_latchkey_predefined_permission_request_event(
         agent_id=str(agent_id),
@@ -365,12 +336,11 @@ def test_get_permission_request_page_shows_descriptions_when_present(tmp_path: P
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
+    payload = extract_ssr_route_payload(response.text)
+    descriptions = payload["props"]["descriptionByPermissionName"]
     # The requested permission's summary comes from the catalog fixture's
     # per-permission ``description`` field.
-    assert "All read operations across the Slack API." in body
-    # The scope-level description is intentionally not surfaced on the dialog.
-    assert "Any interaction with the Slack API." not in body
+    assert descriptions.get("slack-read-all") == "All read operations across the Slack API."
 
 
 def test_get_permission_request_page_renders_no_pre_checks_when_request_and_existing_are_empty(
@@ -394,20 +364,11 @@ def test_get_permission_request_page_renders_no_pre_checks_when_request_and_exis
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
-    # No input element should carry the ``checked`` attribute.
-    for value_marker in ('value="any"', 'value="slack-read-all"', 'value="slack-write-all"'):
-        idx = body.find(value_marker)
-        assert idx != -1
-        tag_start = body.rfind("<input", 0, idx)
-        tag_end = body.find(">", idx)
-        assert "checked" not in body[tag_start:tag_end], (
-            f"unexpected pre-check on {value_marker}: {body[tag_start : tag_end + 1]}"
-        )
-    # Approve stays disabled in the initial markup -- the JS re-enables
-    # it as soon as the user ticks any checkbox.
-    assert 'id="permissions-approve-btn"' in body
-    assert "disabled" in body
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["props"]["checkedPermissions"] == []
+    # All three permission schemas remain offered so the user can opt in.
+    for schema in ("any", "slack-read-all", "slack-write-all"):
+        assert schema in payload["props"]["permissionSchemas"]
 
 
 def test_post_permission_grant_calls_handler_and_resolves_inbox(tmp_path: Path) -> None:
@@ -588,14 +549,8 @@ def test_get_permission_request_page_pre_checks_existing_grants(tmp_path: Path) 
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
-    # The previously-granted permission appears checked.
-    chat_read_idx = body.find('value="slack-chat-read"')
-    assert chat_read_idx != -1
-    # Find the surrounding <input ...> tag and assert it has 'checked'.
-    tag_start = body.rfind("<input", 0, chat_read_idx)
-    tag_end = body.find(">", chat_read_idx)
-    assert "checked" in body[tag_start:tag_end]
+    payload = extract_ssr_route_payload(response.text)
+    assert "slack-chat-read" in payload["props"]["checkedPermissions"]
 
 
 def test_get_permission_request_page_pre_checks_union_of_existing_and_requested(tmp_path: Path) -> None:
@@ -626,22 +581,16 @@ def test_get_permission_request_page_pre_checks_union_of_existing_and_requested(
     response = client.get(f"/requests/{request.event_id}")
 
     assert response.status_code == 200
-    body = response.text
-    for expected_checked in ("slack-chat-read", "slack-write-all"):
-        idx = body.find(f'value="{expected_checked}"')
-        assert idx != -1, f"checkbox for {expected_checked} missing from dialog"
-        tag_start = body.rfind("<input", 0, idx)
-        tag_end = body.find(">", idx)
-        assert "checked" in body[tag_start:tag_end], (
-            f"expected {expected_checked} to be pre-checked: {body[tag_start : tag_end + 1]}"
-        )
-    # ``slack-read-all`` is in the catalog but neither requested nor
-    # previously granted, so it must not be pre-checked.
-    read_all_idx = body.find('value="slack-read-all"')
-    assert read_all_idx != -1
-    read_all_tag_start = body.rfind("<input", 0, read_all_idx)
-    read_all_tag_end = body.find(">", read_all_idx)
-    assert "checked" not in body[read_all_tag_start:read_all_tag_end]
+    payload = extract_ssr_route_payload(response.text)
+    checked = set(payload["props"]["checkedPermissions"])
+    schemas = set(payload["props"]["permissionSchemas"])
+    # The existing grant + the newly-requested permission are both
+    # pre-checked.
+    assert {"slack-chat-read", "slack-write-all"}.issubset(checked)
+    # ``slack-read-all`` is offered but neither requested nor previously
+    # granted, so it must not be pre-checked.
+    assert "slack-read-all" in schemas
+    assert "slack-read-all" not in checked
 
 
 def test_post_permission_grant_returns_503_when_host_not_yet_discovered(tmp_path: Path) -> None:
@@ -726,6 +675,7 @@ class _StubOtherHandler(RequestEventHandler):
         req_event: RequestEvent,
         backend_resolver: BackendResolverInterface,
         mngr_forward_origin: str,
+        sidecar: SsrSidecar | None = None,
     ) -> Response:
         return Response(content="ok", status_code=200)
 

--- a/apps/minds/imbue/minds/desktop_client/request_handler.py
+++ b/apps/minds/imbue/minds/desktop_client/request_handler.py
@@ -22,6 +22,7 @@ from fastapi.responses import Response
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.request_events import RequestEvent
+from imbue.minds.desktop_client.ssr_sidecar import SsrSidecar
 
 
 class RequestEventHandler(MutableModel, ABC):
@@ -58,6 +59,7 @@ class RequestEventHandler(MutableModel, ABC):
         req_event: RequestEvent,
         backend_resolver: BackendResolverInterface,
         mngr_forward_origin: str,
+        sidecar: SsrSidecar | None = None,
     ) -> Response:
         """Render the request-detail page (``GET /requests/{id}``).
 
@@ -69,6 +71,12 @@ class RequestEventHandler(MutableModel, ABC):
         ``mngr forward`` plugin (e.g. ``"http://localhost:8421"``);
         handlers thread it into rendered templates so workspace links
         target the plugin's ``/goto/<agent>/`` route rather than minds.
+
+        ``sidecar`` is the SSR sidecar; when present, handlers that have
+        migrated to Solid render via the sidecar and fall back to the
+        client-render shell on failure. When ``None`` (legacy callers,
+        unit tests) handlers must still produce a working response --
+        the migrated paths fall back to the inline client-render shell.
         """
 
     @abstractmethod

--- a/apps/minds/imbue/minds/desktop_client/ssr_sidecar.py
+++ b/apps/minds/imbue/minds/desktop_client/ssr_sidecar.py
@@ -224,8 +224,13 @@ class SsrSidecar(MutableModel):
                 raise SsrSidecarError("SSR sidecar wait_ready interrupted by shutdown")
         raise SsrSidecarError(f"SSR sidecar did not become ready within {effective_timeout}s (last error: {last_exc})")
 
-    def render(self, *, route: str, props: dict[str, Any]) -> str:
+    def render(self, *, route: str, props: dict[str, Any], bundle: str = "app") -> str:
         """Render a route to an HTML string via the sidecar.
+
+        ``bundle`` selects which client bundle's route registry to use
+        (one of ``"app"`` / ``"chrome"`` / ``"sidebar"``). Defaults to
+        ``"app"`` so legacy callers that pre-date the multi-bundle split
+        keep working without changes.
 
         Raises :class:`SsrSidecarError` on any transport or render-side
         failure (including the brief window when the supervisor is
@@ -237,7 +242,7 @@ class SsrSidecar(MutableModel):
         try:
             response = client.post(
                 _RENDER_PATH,
-                json={"route": route, "props": props},
+                json={"bundle": bundle, "route": route, "props": props},
                 timeout=self.render_timeout_seconds,
             )
         except httpx.HTTPError as exc:

--- a/apps/minds/imbue/minds/desktop_client/ssr_sidecar_test.py
+++ b/apps/minds/imbue/minds/desktop_client/ssr_sidecar_test.py
@@ -48,7 +48,7 @@ def test_render_ssr_or_fallback_with_no_sidecar_returns_shell() -> None:
 class _BoomSidecar:
     """A fake SsrSidecar that always raises -- exercises the fallback path."""
 
-    def render(self, *, route: str, props: dict[str, object]) -> str:
+    def render(self, *, route: str, props: dict[str, object], bundle: str = "app") -> str:
         raise SsrSidecarError("sidecar exploded")
 
 
@@ -62,10 +62,10 @@ def test_render_ssr_or_fallback_with_failing_sidecar_returns_shell() -> None:
 
 class _SuccessSidecar:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.calls: list[tuple[str, dict[str, object], str]] = []
 
-    def render(self, *, route: str, props: dict[str, object]) -> str:
-        self.calls.append((route, props))
+    def render(self, *, route: str, props: dict[str, object], bundle: str = "app") -> str:
+        self.calls.append((route, props, bundle))
         return f"<html><body>SSR for {route}</body></html>"
 
 
@@ -73,4 +73,4 @@ def test_render_ssr_or_fallback_with_healthy_sidecar_returns_ssr_html() -> None:
     sidecar = _SuccessSidecar()
     html = _render_ssr_or_fallback(sidecar=sidecar, route="welcome", props={"a": 1})
     assert html == "<html><body>SSR for welcome</body></html>"
-    assert sidecar.calls == [("welcome", {"a": 1})]
+    assert sidecar.calls == [("welcome", {"a": 1}, "app")]

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -66,10 +66,13 @@ class _RendersHtml(Protocol):
     relationship.
     """
 
-    def render(self, *, route: str, props: dict[str, Any]) -> str: ...
+    def render(self, *, route: str, props: dict[str, Any], bundle: str = ...) -> str: ...
 
 
-def _client_render_shell(*, route: str, props: dict[str, Any]) -> str:
+_VALID_BUNDLES: Final[frozenset[str]] = frozenset({"app", "chrome", "sidebar"})
+
+
+def _client_render_shell(*, route: str, props: dict[str, Any], bundle: str = "app") -> str:
     """Inline shell HTML that boots the client bundle without SSR.
 
     Used when the SSR sidecar is unhealthy or in tests that don't spin up
@@ -77,32 +80,35 @@ def _client_render_shell(*, route: str, props: dict[str, Any]) -> str:
     SSR'd version once the client hydrates, except that the user sees an
     empty ``#app`` mount point for one tick before Solid takes over.
 
+    ``bundle`` selects which client entry to load (one of
+    ``"app"``/``"chrome"``/``"sidebar"``). The Vite build emits each
+    entry under a stable filename so the shim doesn't need the manifest.
+
     The route key and props are inlined as a JSON ``<script>`` blob; the
-    client entry (``frontend/src/main/app.entry.jsx``) reads it on boot.
+    matching client entry reads it on boot.
     """
+    if bundle not in _VALID_BUNDLES:
+        raise SsrSidecarError(f"Unknown bundle for fallback shell: {bundle!r}")
     payload = (
         json.dumps({"route": route, "props": props})
         .replace("<", "\\u003c")
         .replace(" ", "\\u2028")
         .replace(" ", "\\u2029")
     )
-    # We can't predict the hashed asset paths without the Vite manifest
-    # here (the sidecar normally reads it), so we emit a single module
-    # script pointing at a stable filename via Vite's manifest convention.
-    # The Vite build is configured to emit the entry as the import path
-    # below; in dev mode the user must run ``pnpm frontend:dev`` and set
-    # ``MINDS_VITE_DEV_URL`` so the SSR path is taken instead.
+    # All three bundles import ``globals.css`` so Vite emits one shared
+    # stylesheet under ``globals.css``; loading it works whichever bundle
+    # owns the page.
     return (
         "<!doctype html>\n"
         '<html lang="en">\n'
         "<head>\n"
         '<meta charset="UTF-8"><title>Minds</title>\n'
-        '<link rel="stylesheet" href="/_static/_dist/assets/app.css">\n'
+        '<link rel="stylesheet" href="/_static/_dist/assets/globals.css">\n'
         "</head>\n"
         '<body class="bg-zinc-50 text-zinc-900 font-sans antialiased">\n'
         '<div id="app"></div>\n'
         f'<script type="application/json" id="__route__">{payload}</script>\n'
-        '<script type="module" src="/_static/_dist/assets/app.js"></script>\n'
+        f'<script type="module" src="/_static/_dist/assets/{bundle}.js"></script>\n'
         "</body>\n"
         "</html>\n"
     )
@@ -113,6 +119,7 @@ def _render_ssr_or_fallback(
     sidecar: _RendersHtml | None,
     route: str,
     props: dict[str, Any],
+    bundle: str = "app",
 ) -> str:
     """Try SSR; fall back to the client-render shell on any failure.
 
@@ -122,12 +129,12 @@ def _render_ssr_or_fallback(
     standing up a Node sidecar.
     """
     if sidecar is None:
-        return _client_render_shell(route=route, props=props)
+        return _client_render_shell(route=route, props=props, bundle=bundle)
     try:
-        return sidecar.render(route=route, props=props)
+        return sidecar.render(route=route, props=props, bundle=bundle)
     except SsrSidecarError as exc:
         logger.warning("SSR sidecar render failed for route {!r}; using fallback shell: {}", route, exc)
-        return _client_render_shell(route=route, props=props)
+        return _client_render_shell(route=route, props=props, bundle=bundle)
 
 
 # -- Per-workspace identity color --
@@ -993,12 +1000,12 @@ def render_destroying_page(
 # -- Chrome (persistent shell) templates --
 
 
-@pure
 def render_chrome_page(
     is_mac: bool = False,
     is_authenticated: bool = False,
     mngr_forward_origin: str = "",
     initial_workspaces: Sequence[dict[str, str]] | None = None,
+    sidecar: SsrSidecar | None = None,
 ) -> str:
     """Render the persistent chrome page (title bar + sidebar + content iframe).
 
@@ -1011,17 +1018,28 @@ def render_chrome_page(
 
     In Electron mode, the iframe and browser sidebar are hidden via JS; the content
     and sidebar are handled by separate WebContentsViews.
+
+    The page is implemented as a Solid component (``routes/chrome.jsx``);
+    this shim asks the chrome SSR bundle to render it and falls back to
+    the client-render shell when the sidecar isn't available.
     """
-    return JINJA_ENV.get_template("chrome.html").render(
-        is_mac=is_mac,
-        is_authenticated=is_authenticated,
-        mngr_forward_origin=mngr_forward_origin,
-        initial_workspaces=initial_workspaces or [],
+    return _render_ssr_or_fallback(
+        sidecar=sidecar,
+        route="chrome",
+        props={
+            "isMac": bool(is_mac),
+            "isAuthenticated": bool(is_authenticated),
+            "mngrForwardOrigin": mngr_forward_origin,
+            "initialWorkspaces": list(initial_workspaces or []),
+        },
+        bundle="chrome",
     )
 
 
-@pure
-def render_sidebar_page(mngr_forward_origin: str = "") -> str:
+def render_sidebar_page(
+    mngr_forward_origin: str = "",
+    sidecar: SsrSidecar | None = None,
+) -> str:
     """Render the standalone sidebar page for the Electron sidebar WebContentsView.
 
     This page shows the workspace list and subscribes to SSE updates. In Electron,
@@ -1029,9 +1047,16 @@ def render_sidebar_page(mngr_forward_origin: str = "") -> str:
     the content WebContentsView. ``mngr_forward_origin`` is exposed via
     ``data-mngr-forward-origin`` so sidebar.js can build the cross-origin
     ``/goto/<agent>/`` URL the plugin serves.
+
+    Implemented as a Solid component (``routes/sidebar.jsx``); the shim
+    asks the sidebar SSR bundle to render it and falls back to the
+    client-render shell when the sidecar isn't available.
     """
-    return JINJA_ENV.get_template("sidebar.html").render(
-        mngr_forward_origin=mngr_forward_origin,
+    return _render_ssr_or_fallback(
+        sidecar=sidecar,
+        route="sidebar",
+        props={"mngrForwardOrigin": mngr_forward_origin},
+        bundle="sidebar",
     )
 
 

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -196,39 +196,36 @@ def test_render_login_page_emits_solid_route_payload() -> None:
     assert payload["props"] == {}
 
 
-def test_render_chrome_page_contains_titlebar() -> None:
+def test_render_chrome_page_emits_solid_route_payload() -> None:
+    """The chrome page is now a Solid component; the shim returns the
+    SSR-shell HTML carrying the route key and initial props for client
+    hydration. Per-element assertions live in the Vitest layer."""
     html = render_chrome_page()
-    assert "minds-titlebar" in html
-    assert "sidebar-toggle" in html
-    assert "home-btn" in html
-    assert "back-btn" in html
-    assert "content-frame" in html
+    payload = extract_ssr_route_payload(html)
+    assert payload["route"] == "chrome"
+    assert payload["props"]["isMac"] is False
+    assert payload["props"]["isAuthenticated"] is False
 
 
-def test_render_chrome_page_hides_window_controls_on_mac() -> None:
-    """On macOS, the window-controls row carries the 'hidden' Tailwind class
-    so the native traffic lights are used instead."""
+def test_render_chrome_page_passes_mac_flag_to_solid_props() -> None:
     html_mac = render_chrome_page(is_mac=True)
     html_other = render_chrome_page(is_mac=False)
-    # The 'hidden' class only appears on the window-controls wrapper in
-    # mac mode; on other platforms the same element is visible.
-    assert 'class="flex hidden"' in html_mac or 'class="flex  hidden"' in html_mac
-    assert 'class="flex hidden"' not in html_other and 'class="flex  hidden"' not in html_other
+    assert extract_ssr_route_payload(html_mac)["props"]["isMac"] is True
+    assert extract_ssr_route_payload(html_other)["props"]["isMac"] is False
 
 
-def test_render_chrome_page_shows_window_controls_on_non_mac() -> None:
-    html = render_chrome_page(is_mac=False)
-    assert "min-btn" in html
-    assert "max-btn" in html
-    assert "close-btn" in html
+def test_render_chrome_page_passes_initial_workspaces() -> None:
+    workspaces = [{"id": "agent-1", "name": "Demo"}]
+    html = render_chrome_page(initial_workspaces=workspaces)
+    payload = extract_ssr_route_payload(html)
+    assert payload["props"]["initialWorkspaces"] == workspaces
 
 
-def test_render_sidebar_page_contains_workspace_list() -> None:
-    html = render_sidebar_page()
-    assert "sidebar-workspaces" in html
-    # The interactivity (including the SSE EventSource fallback) now lives
-    # in the external /_static/sidebar.js file; the template should pull it in.
-    assert "/_static/sidebar.js" in html
+def test_render_sidebar_page_emits_solid_route_payload() -> None:
+    html = render_sidebar_page(mngr_forward_origin="http://forward:8421")
+    payload = extract_ssr_route_payload(html)
+    assert payload["route"] == "sidebar"
+    assert payload["props"]["mngrForwardOrigin"] == "http://forward:8421"
 
 
 def test_render_recovery_page_includes_agent_id_and_return_to() -> None:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -1235,33 +1235,36 @@ def test_unhandled_exception_returns_500_with_message(tmp_path: Path) -> None:
 
 
 def test_chrome_page_renders_without_auth(tmp_path: Path) -> None:
-    """The /_chrome route is unauthenticated and returns the chrome HTML."""
+    """The /_chrome route is unauthenticated and returns the chrome SSR shell."""
     client, _, _ = _setup_test_server(tmp_path)
 
     response = client.get("/_chrome")
     assert response.status_code == 200
-    assert "minds-titlebar" in response.text
-    assert "content-frame" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "chrome"
+    assert "isMac" in payload["props"]
 
 
-def test_chrome_page_includes_sidebar_toggle(tmp_path: Path) -> None:
+def test_chrome_page_includes_authentication_flag(tmp_path: Path) -> None:
     client, _, _ = _setup_test_server(tmp_path)
 
     response = client.get("/_chrome")
     assert response.status_code == 200
-    assert "sidebar-toggle" in response.text
-    assert "sidebar-panel" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    # Unauthenticated request reports isAuthenticated=False so the Solid
+    # titlebar shows the "Log in" affordance on first paint.
+    assert payload["props"]["isAuthenticated"] is False
 
 
 def test_chrome_sidebar_page_renders(tmp_path: Path) -> None:
-    """The /_chrome/sidebar route returns the standalone sidebar HTML."""
+    """The /_chrome/sidebar route returns the sidebar SSR shell."""
     client, _, _ = _setup_test_server(tmp_path)
 
     response = client.get("/_chrome/sidebar")
     assert response.status_code == 200
-    assert "sidebar-workspaces" in response.text
-    # Interactivity including the SSE fallback has moved to the external JS.
-    assert "/_static/sidebar.js" in response.text
+    payload = extract_ssr_route_payload(response.text)
+    assert payload["route"] == "sidebar"
+    assert "mngrForwardOrigin" in payload["props"]
 
 
 def test_chrome_events_sse_returns_auth_required_when_unauthenticated(tmp_path: Path) -> None:

--- a/apps/minds/vite.config.mjs
+++ b/apps/minds/vite.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig({
     rollupOptions: {
       input: {
         app: resolve(__dirname, 'frontend/src/main/app.entry.jsx'),
+        chrome: resolve(__dirname, 'frontend/src/main/chrome.entry.jsx'),
+        sidebar: resolve(__dirname, 'frontend/src/main/sidebar.entry.jsx'),
       },
       output: {
         // Stable filenames so still-Jinja templates can load the CSS by


### PR DESCRIPTION
## Summary

Migrates three Jinja templates to Solid SSR bundles as **Batch C** of
the Solid.js UI migration:

- **Chrome shell**: `chrome.html` + `chrome.js` (96 lines + 281 lines)
  -> `frontend/src/routes/chrome.jsx` (228 lines) + Titlebar / Sidebar /
  RequestsPanel / ProvidersPanel components (~480 lines combined).
  Served via a new `chrome` Vite rollup entry.
- **Standalone sidebar**: `sidebar.html` + `sidebar.js` (22 lines + 165
  lines) -> `frontend/src/routes/sidebar.jsx` (70 lines) reusing the
  same shared Sidebar component as the chrome shell. Served via a new
  `sidebar` Vite rollup entry.
- **Permissions dialogs**: `permissions.html` + the two latchkey
  permission templates (465 lines combined Jinja + inline JS) ->
  `frontend/src/routes/permissions/{index,predefined,file_sharing}.jsx`
  layered on the shared
  `frontend/src/components/permissions/PermissionRequest.jsx` shell.
  Mounted in the existing `app` bundle.

**Multi-entry SSR build**: `vite.config.mjs` now defines three rollup
entries (`app` / `chrome` / `sidebar`); each entry has its own route
registry under `frontend/src/routes/registry.<bundle>.js`. The SSR
sidecar's `/__ssr/render` HTTP boundary gains a `bundle` field that
selects which registry to dispatch through. The Python
`_render_ssr_or_fallback` helper carries the same `bundle` parameter so
the client-render shell loads the matching entry asset
(`/_static/_dist/assets/{app,chrome,sidebar}.js`).

The Electron preload bridge wrapper (`lib/electron_bridge.js`) gains
helpers for the `window.minds` IPC surface the chrome and sidebar
bundles use (navigation, window controls, workspace context menu, chrome
SSE multiplex). All helpers no-op when not running under Electron so
the Solid components stay testable under jsdom.

## Test results

- `pnpm --dir apps/minds frontend:build` -- builds all three client
  bundles + the SSR server bundle. Manifest registers
  `src/main/{app,chrome,sidebar}.entry.jsx`.
- `pnpm --dir apps/minds frontend:test` -- 39 / 39 passing
  (21 pre-existing + 18 new component tests).
- `PYTEST_MAX_DURATION_SECONDS=300 just test-quick apps/minds/imbue/minds/desktop_client`
  -- 676 / 681 passing. The 5 remaining failures (`webdav_test.py`) are
  pre-existing on `gdenisov/solidjs` (verified via `git stash`) and
  unrelated to this change.
- `just test-quick "test_meta_ratchets.py::test_no_ruff_errors test_meta_ratchets.py::test_no_type_errors"`
  -- 2 / 2 passing.

## Test plan

- [x] Vite builds all three entries.
- [x] Vitest tests cover the new chrome / sidebar / permissions components.
- [x] Python tests assert on SSR payload shape (parity gate).
- [x] No new ruff or type-check errors.
- [ ] CI offload tests pass.
- [ ] Acceptance tests pass.

## Scope notes

- Old Jinja templates and `static/*.js` files are left in place pending
  the Phase 8 cleanup pass per the migration plan.
- Touches `apps/minds/` only. Changelog entry at
  `apps/minds/changelog/gdenisov-solidjs-batch-c-chrome-sidebar-permissions.md`.

Generated with [Claude Code](https://claude.com/claude-code).