### PR TITLE
tabcomplete for plugin add/remove

### DIFF
--- a/libs/mngr/changelog/mngr-plugin-autocomplete.md
+++ b/libs/mngr/changelog/mngr-plugin-autocomplete.md
@@ -1,0 +1,1 @@
+Added shell tab-completion for the positional argument of `mngr plugin add`. Pressing TAB now suggests installable plugin package names (e.g. `imbue-mngr-claude`, `imbue-mngr-modal`) drawn from the plugin catalog -- the same set the `mngr extras` install wizard offers. Completion repeats for each package when adding several at once.

--- a/libs/mngr/changelog/mngr-plugin-autocomplete.md
+++ b/libs/mngr/changelog/mngr-plugin-autocomplete.md
@@ -1,1 +1,6 @@
-Added shell tab-completion for the positional argument of `mngr plugin add`. Pressing TAB now suggests installable plugin package names (e.g. `imbue-mngr-claude`, `imbue-mngr-modal`) drawn from the plugin catalog -- the same set the `mngr extras` install wizard offers. Completion repeats for each package when adding several at once.
+Added shell tab-completion for the positional arguments of `mngr plugin add` and `mngr plugin remove`.
+
+- `mngr plugin add <TAB>` suggests installable plugin package names (e.g. `imbue-mngr-claude`, `imbue-mngr-modal`) drawn from the plugin catalog -- the same set the `mngr extras` install wizard offers.
+- `mngr plugin remove <TAB>` suggests the plugin packages currently installed (from the uv-tool receipt), which is exactly what `remove` accepts.
+
+Both support prefix filtering and repeat the completion for each package when operating on several at once.

--- a/libs/mngr/changelog/mngr-plugin-autocomplete.md
+++ b/libs/mngr/changelog/mngr-plugin-autocomplete.md
@@ -1,6 +1,6 @@
 Added shell tab-completion for the positional arguments of `mngr plugin add` and `mngr plugin remove`.
 
 - `mngr plugin add <TAB>` suggests installable plugin package names (e.g. `imbue-mngr-claude`, `imbue-mngr-modal`) drawn from the plugin catalog -- the same set the `mngr extras` install wizard offers.
-- `mngr plugin remove <TAB>` suggests the plugin packages currently installed (from the uv-tool receipt), which is exactly what `remove` accepts.
+- `mngr plugin remove <TAB>` suggests the plugin packages currently installed (from the uv-tool receipt), filtered to packages that actually register `mngr` entry points -- so non-plugin dependencies installed alongside plugins (e.g. workspace libraries) are not offered.
 
 Both support prefix filtering and repeat the completion for each package when operating on several at once.

--- a/libs/mngr/imbue/mngr/cli/complete.py
+++ b/libs/mngr/imbue/mngr/cli/complete.py
@@ -313,8 +313,8 @@ def _resolve_sources(
 ) -> list[str]:
     """Resolve completion source identifiers to actual candidate values.
 
-    Source identifiers: "agent_names", "host_names", "plugin_names", "help_targets",
-    "config_keys", "config_value_for_key".
+    Source identifiers: "agent_names", "host_names", "plugin_names",
+    "catalog_packages", "help_targets", "config_keys", "config_value_for_key".
     """
     candidates: list[str] = []
     needs_agents = "agent_names" in sources
@@ -327,6 +327,8 @@ def _resolve_sources(
             candidates.extend(host_names)
     if "plugin_names" in sources:
         candidates.extend(cache.plugin_names)
+    if "catalog_packages" in sources:
+        candidates.extend(cache.catalog_package_names)
     if "help_targets" in sources:
         candidates.extend(cache.help_targets)
     if "config_keys" in sources:

--- a/libs/mngr/imbue/mngr/cli/complete.py
+++ b/libs/mngr/imbue/mngr/cli/complete.py
@@ -314,7 +314,8 @@ def _resolve_sources(
     """Resolve completion source identifiers to actual candidate values.
 
     Source identifiers: "agent_names", "host_names", "plugin_names",
-    "catalog_packages", "help_targets", "config_keys", "config_value_for_key".
+    "catalog_packages", "installed_packages", "help_targets", "config_keys",
+    "config_value_for_key".
     """
     candidates: list[str] = []
     needs_agents = "agent_names" in sources
@@ -329,6 +330,8 @@ def _resolve_sources(
         candidates.extend(cache.plugin_names)
     if "catalog_packages" in sources:
         candidates.extend(cache.catalog_package_names)
+    if "installed_packages" in sources:
+        candidates.extend(cache.installed_plugin_package_names)
     if "help_targets" in sources:
         candidates.extend(cache.help_targets)
     if "config_keys" in sources:

--- a/libs/mngr/imbue/mngr/cli/complete_test.py
+++ b/libs/mngr/imbue/mngr/cli/complete_test.py
@@ -395,6 +395,63 @@ def test_get_completions_subcommand_agent_names(
     assert result == ["my-agent", "other-agent"]
 
 
+def test_get_completions_plugin_add_catalog_packages(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """Completing catalog package names for `mngr plugin add <TAB>`."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "enable", "disable"]},
+        positional_completions={"plugin.add": [["catalog_packages"]]},
+        catalog_package_names=["imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+    set_comp_env("mngr plugin add ", "3")
+
+    result = _get_completions()
+
+    assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
+def test_get_completions_plugin_add_catalog_packages_with_prefix(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """Completing catalog package names for `mngr plugin add` with a prefix filter."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "enable", "disable"]},
+        positional_completions={"plugin.add": [["catalog_packages"]]},
+        catalog_package_names=["imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+    set_comp_env("mngr plugin add imbue-mngr-m", "3")
+
+    result = _get_completions()
+
+    assert result == ["imbue-mngr-modal"]
+
+
+def test_get_completions_plugin_add_is_variadic(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """`plugin add` takes multiple packages, so completion repeats for later positions."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "enable", "disable"]},
+        positional_completions={"plugin.add": [["catalog_packages"]]},
+        catalog_package_names=["imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+    set_comp_env("mngr plugin add imbue-mngr-claude ", "4")
+
+    result = _get_completions()
+
+    assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
 def test_get_completions_subcommand_agent_names_with_prefix(
     completion_cache_dir: Path,
     set_comp_env: Callable[[str, str], None],

--- a/libs/mngr/imbue/mngr/cli/complete_test.py
+++ b/libs/mngr/imbue/mngr/cli/complete_test.py
@@ -452,6 +452,68 @@ def test_get_completions_plugin_add_is_variadic(
     assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
 
 
+def test_get_completions_plugin_remove_installed_packages(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """Completing installed plugin packages for `mngr plugin remove <TAB>`."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "remove", "enable"]},
+        positional_completions={"plugin.remove": [["installed_packages"]]},
+        installed_plugin_package_names=["imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+    set_comp_env("mngr plugin remove ", "3")
+
+    result = _get_completions()
+
+    assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
+def test_get_completions_plugin_remove_installed_packages_with_prefix(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """`plugin remove` completion respects a prefix filter."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "remove", "enable"]},
+        positional_completions={"plugin.remove": [["installed_packages"]]},
+        installed_plugin_package_names=["imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+    set_comp_env("mngr plugin remove imbue-mngr-c", "3")
+
+    result = _get_completions()
+
+    assert result == ["imbue-mngr-claude"]
+
+
+def test_get_completions_plugin_remove_distinct_from_add(
+    completion_cache_dir: Path,
+    set_comp_env: Callable[[str, str], None],
+) -> None:
+    """`remove` completes installed packages while `add` completes the full catalog."""
+    data = CompletionCacheData(
+        commands=["plugin"],
+        subcommand_by_command={"plugin": ["add", "remove"]},
+        positional_completions={
+            "plugin.add": [["catalog_packages"]],
+            "plugin.remove": [["installed_packages"]],
+        },
+        catalog_package_names=["imbue-mngr-claude", "imbue-mngr-modal", "imbue-mngr-vultr"],
+        installed_plugin_package_names=["imbue-mngr-claude"],
+    )
+    _write_command_cache(completion_cache_dir, data)
+
+    set_comp_env("mngr plugin add ", "3")
+    assert _get_completions() == ["imbue-mngr-claude", "imbue-mngr-modal", "imbue-mngr-vultr"]
+
+    set_comp_env("mngr plugin remove ", "3")
+    assert _get_completions() == ["imbue-mngr-claude"]
+
+
 def test_get_completions_subcommand_agent_names_with_prefix(
     completion_cache_dir: Path,
     set_comp_env: Callable[[str, str], None],

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -45,6 +45,7 @@ from imbue.mngr.utils.cel_utils import evaluate_cel_sort_key
 from imbue.mngr.utils.terminal import ANSI_DIM_GRAY
 from imbue.mngr.utils.terminal import ANSI_ERASE_LINE
 from imbue.mngr.utils.terminal import ANSI_RESET
+from imbue.mngr.uv_tool import get_installed_plugin_package_names
 
 _DEFAULT_HUMAN_DISPLAY_FIELDS: Final[tuple[str, ...]] = (
     "name",
@@ -203,6 +204,7 @@ def _list_impl(ctx: click.Context, **kwargs) -> None:
         cli_group = ctx.parent.command
         registered_agent_types = list_registered_agent_types()
         topic_names = sorted(get_all_topics().keys())
+        installed_plugin_packages = get_installed_plugin_package_names()
         mngr_ctx.concurrency_group.start_new_thread(
             target=write_cli_completions_cache,
             kwargs={
@@ -210,6 +212,7 @@ def _list_impl(ctx: click.Context, **kwargs) -> None:
                 "mngr_ctx": mngr_ctx,
                 "registered_agent_types": registered_agent_types,
                 "topic_names": topic_names,
+                "installed_plugin_packages": installed_plugin_packages,
             },
             name="completion-cache-writer",
             is_checked=False,

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import json
 import os
 import sys
@@ -44,6 +43,7 @@ from imbue.mngr.utils.toml_config import set_plugin_enabled
 from imbue.mngr.uv_tool import ToolRequirement
 from imbue.mngr.uv_tool import build_uv_tool_install_add_requirements
 from imbue.mngr.uv_tool import build_uv_tool_install_remove_multiple
+from imbue.mngr.uv_tool import has_mngr_entry_points
 from imbue.mngr.uv_tool import read_receipt
 from imbue.mngr.uv_tool import require_uv_tool_receipt
 
@@ -267,19 +267,6 @@ def _read_package_name_from_pyproject(local_path: str) -> str:
     if not name:
         raise PluginSpecifierError(f"pyproject.toml at '{resolved}' does not have a project.name field")
     return name
-
-
-def _check_for_mngr_entry_points(package_name: str) -> bool:
-    """Check whether an installed package registered any mngr entry points.
-
-    Returns True if entry points were found, False otherwise.
-    """
-    try:
-        dist = importlib.metadata.distribution(package_name)
-    except importlib.metadata.PackageNotFoundError:
-        return False
-    entry_points = dist.entry_points
-    return any(ep.group == "mngr" for ep in entry_points)
 
 
 def _emit_plugin_add_result(
@@ -645,7 +632,7 @@ def _plugin_add_impl(ctx: click.Context) -> None:
 
     # Report results for each source
     for specifier, resolved_package_name, _ in source_info:
-        has_entry_points = _check_for_mngr_entry_points(resolved_package_name)
+        has_entry_points = has_mngr_entry_points(resolved_package_name)
         _emit_plugin_add_result(specifier, resolved_package_name, has_entry_points, output_opts)
 
 

--- a/libs/mngr/imbue/mngr/config/completion_cache.py
+++ b/libs/mngr/imbue/mngr/config/completion_cache.py
@@ -51,6 +51,10 @@ class CompletionCacheData(NamedTuple):
     host_name_options: list[str] = []
     plugin_name_options: list[str] = []
     plugin_names: list[str] = []
+    # PyPI package names from the plugin catalog, used to complete the positional
+    # argument of `mngr plugin add` (which takes installable package specifiers,
+    # not the entry-point names of already-installed plugins in `plugin_names`).
+    catalog_package_names: list[str] = []
     config_keys: list[str] = []
     positional_nargs_by_command: dict[str, int | None] = {}
     positional_completions: dict[str, list[list[str]]] = {}

--- a/libs/mngr/imbue/mngr/config/completion_cache.py
+++ b/libs/mngr/imbue/mngr/config/completion_cache.py
@@ -51,9 +51,8 @@ class CompletionCacheData(NamedTuple):
     host_name_options: list[str] = []
     plugin_name_options: list[str] = []
     plugin_names: list[str] = []
-    # PyPI package names from the plugin catalog, used to complete the positional
-    # argument of `mngr plugin add` (which takes installable package specifiers,
-    # not the entry-point names of already-installed plugins in `plugin_names`).
+    # Installable plugin package names (PyPI) for completing `mngr plugin add`,
+    # distinct from `plugin_names` (entry-point names of installed plugins).
     catalog_package_names: list[str] = []
     config_keys: list[str] = []
     positional_nargs_by_command: dict[str, int | None] = {}

--- a/libs/mngr/imbue/mngr/config/completion_cache.py
+++ b/libs/mngr/imbue/mngr/config/completion_cache.py
@@ -54,6 +54,10 @@ class CompletionCacheData(NamedTuple):
     # Installable plugin package names (PyPI) for completing `mngr plugin add`,
     # distinct from `plugin_names` (entry-point names of installed plugins).
     catalog_package_names: list[str] = []
+    # Currently-installed plugin package names (uv-tool receipt extras) for
+    # completing `mngr plugin remove`, which only accepts already-installed
+    # packages.
+    installed_plugin_package_names: list[str] = []
     config_keys: list[str] = []
     positional_nargs_by_command: dict[str, int | None] = {}
     positional_completions: dict[str, list[list[str]]] = {}

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -470,5 +470,5 @@ def write_cli_completions_cache(
 
         cache_path = get_completion_cache_dir() / COMPLETION_CACHE_FILENAME
         atomic_write(cache_path, json.dumps(cache_data._asdict()))
-    except OSError:
-        logger.debug("Failed to write CLI completions cache")
+    except OSError as e:
+        logger.warning("Failed to write CLI completions cache: {}", e)

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -25,7 +25,7 @@ from imbue.mngr.utils.pydantic_utils import unwrap_optional
 # Each inner list contains source names for that position (empty = freeform).
 # For variadic commands (nargs=None), the last entry repeats.
 # Source identifiers: "agent_names", "host_names", "plugin_names",
-# "catalog_packages", "config_keys", "help_targets"
+# "catalog_packages", "installed_packages", "config_keys", "help_targets"
 _POSITIONAL_COMPLETION_SPEC: Final[dict[str, list[list[str]]]] = {
     "archive": [["agent_names"]],
     "capture": [["agent_names"]],
@@ -53,6 +53,7 @@ _POSITIONAL_COMPLETION_SUBCOMMAND_SPEC: Final[dict[str, list[list[str]]]] = {
     "snapshot.destroy": [["agent_names"]],
     "snapshot.list": [["agent_names"]],
     "plugin.add": [["catalog_packages"]],
+    "plugin.remove": [["installed_packages"]],
     "plugin.enable": [["plugin_names"]],
     "plugin.disable": [["plugin_names"]],
     "config.get": [["config_keys"]],
@@ -326,6 +327,7 @@ def write_cli_completions_cache(
     mngr_ctx: MngrContext | None = None,
     registered_agent_types: list[str] | None = None,
     topic_names: list[str] | None = None,
+    installed_plugin_packages: list[str] | None = None,
 ) -> None:
     """Write all CLI commands, options, and choices to the completions cache (best-effort).
 
@@ -345,6 +347,12 @@ def write_cli_completions_cache(
     command names they form the completion candidates for the ``mngr help``
     positional argument. The caller passes these because help topics live in the
     cli layer, which this (config-layer) writer must not import.
+
+    installed_plugin_packages are the package names currently installed as
+    plugins (uv-tool receipt extras); they are the completion candidates for the
+    ``mngr plugin remove`` positional argument. The caller passes these for the
+    same layering reason as topic_names: the uv-tool receipt helper transitively
+    imports the cli layer, which this writer must not depend on.
 
     Catches OSError from cache writes so filesystem failures do not break
     CLI commands. Other exceptions are allowed to propagate.
@@ -452,6 +460,7 @@ def write_cli_completions_cache(
             plugin_name_options=sorted(set(plugin_name_opts)),
             plugin_names=dynamic.plugin_names if dynamic is not None else [],
             catalog_package_names=catalog_package_names,
+            installed_plugin_package_names=sorted(set(installed_plugin_packages or [])),
             config_keys=dynamic.config_keys if dynamic is not None else [],
             positional_nargs_by_command=positional_nargs_by_command,
             positional_completions=positional_completions,

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -13,6 +13,7 @@ from imbue.mngr.config.completion_cache import CompletionCacheData
 from imbue.mngr.config.completion_cache import get_completion_cache_dir
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.provider_config_registry import list_registered_provider_backend_names
+from imbue.mngr.plugin_catalog import get_installable_packages
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.utils.click_utils import detect_alias_to_canonical
@@ -23,8 +24,8 @@ from imbue.mngr.utils.pydantic_utils import unwrap_optional
 # Maps command name -> list of source identifier lists per position.
 # Each inner list contains source names for that position (empty = freeform).
 # For variadic commands (nargs=None), the last entry repeats.
-# Source identifiers: "agent_names", "host_names", "plugin_names", "config_keys",
-# "help_targets"
+# Source identifiers: "agent_names", "host_names", "plugin_names",
+# "catalog_packages", "config_keys", "help_targets"
 _POSITIONAL_COMPLETION_SPEC: Final[dict[str, list[list[str]]]] = {
     "archive": [["agent_names"]],
     "capture": [["agent_names"]],
@@ -51,6 +52,7 @@ _POSITIONAL_COMPLETION_SUBCOMMAND_SPEC: Final[dict[str, list[list[str]]]] = {
     "snapshot.create": [["agent_names"]],
     "snapshot.destroy": [["agent_names"]],
     "snapshot.list": [["agent_names"]],
+    "plugin.add": [["catalog_packages"]],
     "plugin.enable": [["plugin_names"]],
     "plugin.disable": [["plugin_names"]],
     "config.get": [["config_keys"]],
@@ -433,6 +435,11 @@ def write_cli_completions_cache(
                 if cmd_name in canonical_names and data_key in dynamic_as_dict:
                     option_choices[opt_key] = dynamic_as_dict[data_key]
 
+        # Static catalog package names for `mngr plugin add` completion. Sourced
+        # from the plugin catalog (the same store the `mngr extras` install wizard
+        # uses), not from the runtime context, so it is always available.
+        catalog_package_names = sorted({entry.package_name for entry in get_installable_packages()})
+
         cache_data = CompletionCacheData(
             commands=all_command_names,
             aliases=alias_to_canonical,
@@ -444,6 +451,7 @@ def write_cli_completions_cache(
             host_name_options=sorted(host_name_opts),
             plugin_name_options=sorted(set(plugin_name_opts)),
             plugin_names=dynamic.plugin_names if dynamic is not None else [],
+            catalog_package_names=catalog_package_names,
             config_keys=dynamic.config_keys if dynamic is not None else [],
             positional_nargs_by_command=positional_nargs_by_command,
             positional_completions=positional_completions,

--- a/libs/mngr/imbue/mngr/config/completion_writer_test.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer_test.py
@@ -197,6 +197,7 @@ def test_write_cli_completions_cache_includes_positional_completions_for_plugin(
     assert data["positional_completions"]["plugin.enable"] == [["plugin_names"]]
     assert data["positional_completions"]["plugin.disable"] == [["plugin_names"]]
     assert data["positional_completions"]["plugin.add"] == [["catalog_packages"]]
+    assert data["positional_completions"]["plugin.remove"] == [["installed_packages"]]
 
 
 def test_write_cli_completions_cache_includes_catalog_package_names(
@@ -217,6 +218,34 @@ def test_write_cli_completions_cache_includes_catalog_package_names(
     # PyPI package name is, so completion must offer the latter.
     assert "imbue-mngr-claude" in catalog_packages
     assert "claude" not in catalog_packages
+
+
+def test_write_cli_completions_cache_includes_installed_plugin_packages(
+    completion_cache_dir: Path,
+) -> None:
+    """Cache should record the installed plugin packages passed by the caller for `plugin remove`."""
+    group = click.Group(name="test", commands={"list": click.Command("list")})
+
+    write_cli_completions_cache(
+        cli_group=group,
+        installed_plugin_packages=["imbue-mngr-modal", "imbue-mngr-claude", "imbue-mngr-modal"],
+    )
+    data = _read_cache(completion_cache_dir)
+
+    # Deduplicated and sorted.
+    assert data["installed_plugin_package_names"] == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
+def test_write_cli_completions_cache_installed_plugin_packages_defaults_empty(
+    completion_cache_dir: Path,
+) -> None:
+    """When the caller passes no installed packages, the field is empty (not an error)."""
+    group = click.Group(name="test", commands={"list": click.Command("list")})
+
+    write_cli_completions_cache(cli_group=group)
+    data = _read_cache(completion_cache_dir)
+
+    assert data["installed_plugin_package_names"] == []
 
 
 def test_write_cli_completions_cache_includes_positional_completions_for_config(

--- a/libs/mngr/imbue/mngr/config/completion_writer_test.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer_test.py
@@ -196,6 +196,27 @@ def test_write_cli_completions_cache_includes_positional_completions_for_plugin(
 
     assert data["positional_completions"]["plugin.enable"] == [["plugin_names"]]
     assert data["positional_completions"]["plugin.disable"] == [["plugin_names"]]
+    assert data["positional_completions"]["plugin.add"] == [["catalog_packages"]]
+
+
+def test_write_cli_completions_cache_includes_catalog_package_names(
+    completion_cache_dir: Path,
+) -> None:
+    """Cache should include installable catalog package names for `plugin add` completion."""
+    group = click.Group(name="test", commands={"list": click.Command("list")})
+
+    write_cli_completions_cache(cli_group=group)
+    data = _read_cache(completion_cache_dir)
+
+    catalog_packages = data["catalog_package_names"]
+    assert catalog_packages == sorted(set(catalog_packages))
+    # Every catalog package is an installable PyPI distribution with the shared prefix.
+    assert catalog_packages
+    assert all(name.startswith("imbue-mngr-") for name in catalog_packages)
+    # The entry-point name (e.g. "claude") is not what `plugin add` takes; the
+    # PyPI package name is, so completion must offer the latter.
+    assert "imbue-mngr-claude" in catalog_packages
+    assert "claude" not in catalog_packages
 
 
 def test_write_cli_completions_cache_includes_positional_completions_for_config(

--- a/libs/mngr/imbue/mngr/config/completion_writer_test.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer_test.py
@@ -62,8 +62,9 @@ def test_get_completion_cache_dir_ignores_double_underscore_form(
     assert result == tmp_path / "default_host"
 
 
+@pytest.mark.allow_warnings(match=r"Failed to write CLI completions cache")
 def test_write_cli_completions_cache_handles_oserror(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """write_cli_completions_cache should silently handle OSError."""
+    """write_cli_completions_cache should handle OSError without raising (logs a warning)."""
     # Monkeypatch atomic_write to simulate a write failure. We can't use chmod
     # because Modal sandboxes run as root, which bypasses permission checks.
     monkeypatch.setenv("MNGR_COMPLETION_CACHE_DIR", str(tmp_path))

--- a/libs/mngr/imbue/mngr/uv_tool.py
+++ b/libs/mngr/imbue/mngr/uv_tool.py
@@ -106,6 +106,28 @@ def read_receipt(receipt_path: Path) -> ToolReceipt:
     return ToolReceipt(base=base, extras=extras)
 
 
+def get_installed_plugin_package_names(receipt_path: Path | None = None) -> list[str]:
+    """Return installed plugin package names from the uv-tool receipt, best-effort.
+
+    These are exactly the package names ``mngr plugin remove`` accepts (the
+    receipt extras). Returns an empty list when mngr was not installed via
+    ``uv tool`` or the receipt cannot be read -- callers (e.g. the tab
+    completion cache writer) must never fail on a missing/garbled receipt.
+
+    ``receipt_path`` defaults to the live uv-tool receipt; callers may pass an
+    explicit path (mainly for testing).
+    """
+    if receipt_path is None:
+        receipt_path = get_receipt_path()
+    if receipt_path is None:
+        return []
+    try:
+        receipt = read_receipt(receipt_path)
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    return sorted({requirement.name for requirement in receipt.extras})
+
+
 @pure
 def build_base_specifier(base: ToolRequirement) -> str:
     """Build the positional specifier for ``uv tool install <specifier>``.

--- a/libs/mngr/imbue/mngr/uv_tool.py
+++ b/libs/mngr/imbue/mngr/uv_tool.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 from typing import Final
 
+from loguru import logger
 from pydantic import Field
 
 from imbue.imbue_common.frozen_model import FrozenModel
@@ -152,7 +153,11 @@ def get_installed_plugin_package_names(
         is_plugin_package = has_mngr_entry_points
     try:
         receipt = read_receipt(receipt_path)
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        # The receipt is machine-written by uv; a parse/read failure means it is
+        # corrupt or unreadable. Degrade gracefully (no completions) but surface
+        # the corruption rather than swallowing it silently.
+        logger.warning("Could not read uv-tool receipt at {} for plugin completion: {}", receipt_path, e)
         return []
     return sorted({requirement.name for requirement in receipt.extras if is_plugin_package(requirement.name)})
 

--- a/libs/mngr/imbue/mngr/uv_tool.py
+++ b/libs/mngr/imbue/mngr/uv_tool.py
@@ -7,8 +7,10 @@ builds ``uv tool install`` commands that preserve existing dependencies
 while adding or removing plugins.
 """
 
+import importlib.metadata
 import sys
 import tomllib
+from collections.abc import Callable
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -106,26 +108,53 @@ def read_receipt(receipt_path: Path) -> ToolReceipt:
     return ToolReceipt(base=base, extras=extras)
 
 
-def get_installed_plugin_package_names(receipt_path: Path | None = None) -> list[str]:
+def has_mngr_entry_points(package_name: str) -> bool:
+    """Return whether an installed package registers any ``mngr`` entry points.
+
+    This is what distinguishes an actual mngr plugin from a plain library: the
+    uv-tool receipt's extras include every ``--with`` dependency (e.g. workspace
+    libraries like ``imbue-common`` or ``concurrency-group``), but only packages
+    that declare ``mngr``-group entry points are plugins. Returns False if the
+    package is not installed.
+    """
+    try:
+        dist = importlib.metadata.distribution(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return any(entry_point.group == "mngr" for entry_point in dist.entry_points)
+
+
+def get_installed_plugin_package_names(
+    receipt_path: Path | None = None,
+    is_plugin_package: Callable[[str], bool] | None = None,
+) -> list[str]:
     """Return installed plugin package names from the uv-tool receipt, best-effort.
 
-    These are exactly the package names ``mngr plugin remove`` accepts (the
-    receipt extras). Returns an empty list when mngr was not installed via
-    ``uv tool`` or the receipt cannot be read -- callers (e.g. the tab
-    completion cache writer) must never fail on a missing/garbled receipt.
+    These are the package names ``mngr plugin remove`` accepts. The receipt's
+    extras list every ``--with`` dependency, including non-plugin libraries
+    pulled in alongside editable plugins; this filters those out, keeping only
+    packages that actually register ``mngr`` entry points (see
+    ``has_mngr_entry_points``).
 
-    ``receipt_path`` defaults to the live uv-tool receipt; callers may pass an
-    explicit path (mainly for testing).
+    Returns an empty list when mngr was not installed via ``uv tool`` or the
+    receipt cannot be read -- callers (e.g. the tab completion cache writer)
+    must never fail on a missing/garbled receipt.
+
+    ``receipt_path`` defaults to the live uv-tool receipt and
+    ``is_plugin_package`` to ``has_mngr_entry_points``; callers may pass either
+    explicitly (mainly for testing).
     """
     if receipt_path is None:
         receipt_path = get_receipt_path()
     if receipt_path is None:
         return []
+    if is_plugin_package is None:
+        is_plugin_package = has_mngr_entry_points
     try:
         receipt = read_receipt(receipt_path)
     except (OSError, tomllib.TOMLDecodeError):
         return []
-    return sorted({requirement.name for requirement in receipt.extras})
+    return sorted({requirement.name for requirement in receipt.extras if is_plugin_package(requirement.name)})
 
 
 @pure

--- a/libs/mngr/imbue/mngr/uv_tool_test.py
+++ b/libs/mngr/imbue/mngr/uv_tool_test.py
@@ -15,6 +15,7 @@ from imbue.mngr.uv_tool import build_uv_tool_install_add_path
 from imbue.mngr.uv_tool import build_uv_tool_install_add_requirements
 from imbue.mngr.uv_tool import build_uv_tool_install_remove
 from imbue.mngr.uv_tool import build_uv_tool_install_remove_multiple
+from imbue.mngr.uv_tool import get_installed_plugin_package_names
 from imbue.mngr.uv_tool import get_receipt_path
 from imbue.mngr.uv_tool import read_receipt
 from imbue.mngr.uv_tool import require_uv_tool_receipt
@@ -481,3 +482,36 @@ def test_build_uv_tool_install_remove_multiple_all_deps() -> None:
     )
     cmd = build_uv_tool_install_remove_multiple(receipt, {"dep-a", "dep-b"})
     assert cmd == ("uv", "tool", "install", "imbue-mngr", "--reinstall")
+
+
+# =============================================================================
+# Tests for get_installed_plugin_package_names
+# =============================================================================
+
+
+def test_get_installed_plugin_package_names_returns_empty_in_dev_mode() -> None:
+    """Best-effort: returns empty when mngr was not installed via uv tool (no receipt)."""
+    assert get_installed_plugin_package_names() == []
+
+
+def test_get_installed_plugin_package_names_sorted_and_deduped(tmp_path: Path) -> None:
+    """Returns the receipt extras' package names, sorted and deduplicated."""
+    receipt_path = tmp_path / "uv-receipt.toml"
+    receipt_path.write_text(
+        "[tool]\nrequirements = [\n"
+        '  { name = "imbue-mngr" },\n'
+        '  { name = "imbue-mngr-modal" },\n'
+        '  { name = "imbue-mngr-claude" },\n'
+        '  { name = "imbue-mngr-modal" },\n'
+        "]\n"
+    )
+
+    assert get_installed_plugin_package_names(receipt_path) == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
+def test_get_installed_plugin_package_names_handles_malformed_receipt(tmp_path: Path) -> None:
+    """Best-effort: a garbled receipt yields an empty list rather than raising."""
+    receipt_path = tmp_path / "uv-receipt.toml"
+    receipt_path.write_text("this is not valid toml = = =\n")
+
+    assert get_installed_plugin_package_names(receipt_path) == []

--- a/libs/mngr/imbue/mngr/uv_tool_test.py
+++ b/libs/mngr/imbue/mngr/uv_tool_test.py
@@ -17,6 +17,7 @@ from imbue.mngr.uv_tool import build_uv_tool_install_remove
 from imbue.mngr.uv_tool import build_uv_tool_install_remove_multiple
 from imbue.mngr.uv_tool import get_installed_plugin_package_names
 from imbue.mngr.uv_tool import get_receipt_path
+from imbue.mngr.uv_tool import has_mngr_entry_points
 from imbue.mngr.uv_tool import read_receipt
 from imbue.mngr.uv_tool import require_uv_tool_receipt
 
@@ -489,6 +490,17 @@ def test_build_uv_tool_install_remove_multiple_all_deps() -> None:
 # =============================================================================
 
 
+def test_has_mngr_entry_points_false_for_missing_package() -> None:
+    """A package that is not installed has no mngr entry points."""
+    assert has_mngr_entry_points("definitely-not-installed-package-zzz") is False
+
+
+def test_has_mngr_entry_points_false_for_non_plugin_library() -> None:
+    """An installed library that declares no mngr entry points is not a plugin."""
+    # pytest is always installed in the test environment and is not an mngr plugin.
+    assert has_mngr_entry_points("pytest") is False
+
+
 def test_get_installed_plugin_package_names_returns_empty_in_dev_mode() -> None:
     """Best-effort: returns empty when mngr was not installed via uv tool (no receipt)."""
     assert get_installed_plugin_package_names() == []
@@ -506,7 +518,30 @@ def test_get_installed_plugin_package_names_sorted_and_deduped(tmp_path: Path) -
         "]\n"
     )
 
-    assert get_installed_plugin_package_names(receipt_path) == ["imbue-mngr-claude", "imbue-mngr-modal"]
+    # Inject a deterministic plugin predicate so the test does not depend on
+    # which packages happen to be installed in the test environment.
+    result = get_installed_plugin_package_names(receipt_path, is_plugin_package=lambda name: True)
+    assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
+
+
+def test_get_installed_plugin_package_names_filters_non_plugin_extras(tmp_path: Path) -> None:
+    """Non-plugin extras (libraries with no mngr entry points) are excluded."""
+    receipt_path = tmp_path / "uv-receipt.toml"
+    # Mirrors a real editable dev install: plugins plus workspace libraries.
+    receipt_path.write_text(
+        "[tool]\nrequirements = [\n"
+        '  { name = "imbue-mngr" },\n'
+        '  { name = "concurrency-group" },\n'
+        '  { name = "imbue-common" },\n'
+        '  { name = "modal-proxy" },\n'
+        '  { name = "imbue-mngr-modal" },\n'
+        '  { name = "imbue-mngr-claude" },\n'
+        "]\n"
+    )
+
+    is_plugin = {"imbue-mngr-modal", "imbue-mngr-claude"}.__contains__
+    result = get_installed_plugin_package_names(receipt_path, is_plugin_package=is_plugin)
+    assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
 
 
 def test_get_installed_plugin_package_names_handles_malformed_receipt(tmp_path: Path) -> None:

--- a/libs/mngr/imbue/mngr/uv_tool_test.py
+++ b/libs/mngr/imbue/mngr/uv_tool_test.py
@@ -544,8 +544,9 @@ def test_get_installed_plugin_package_names_filters_non_plugin_extras(tmp_path: 
     assert result == ["imbue-mngr-claude", "imbue-mngr-modal"]
 
 
+@pytest.mark.allow_warnings(match=r"Could not read uv-tool receipt")
 def test_get_installed_plugin_package_names_handles_malformed_receipt(tmp_path: Path) -> None:
-    """Best-effort: a garbled receipt yields an empty list rather than raising."""
+    """Best-effort: a garbled receipt yields an empty list (and warns) rather than raising."""
     receipt_path = tmp_path / "uv-receipt.toml"
     receipt_path.write_text("this is not valid toml = = =\n")
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/2f0b20f8-383b-4e5f-8f98-d2d0e16d8874


https://github.com/user-attachments/assets/a05f533b-446d-445e-97cb-ee68a63a8748


i noticed that `mngr plugin remove concurrency-group` will run. should i make it validate that the thing being removed actually is a mngr plugin?

---

> [!NOTE]
> **Follow-up worth considering (not addressed here):** this PR only filters the tab-*completion* source for `mngr plugin remove` to real plugins. The `remove` **command itself** still validates against the raw uv-tool receipt extras (`_plugin_remove_impl`), so manually typing `mngr plugin remove imbue-common` would still "succeed" and could break the install. Tightening `remove`'s own validation to reject non-plugin packages (reusing `has_mngr_entry_points`) would close that footgun, but it's a behavior change to the command, so it's left out of this PR.

## Summary

Adds shell tab-completion for the positional arguments of `mngr plugin add` and `mngr plugin remove`.

- **`mngr plugin add <TAB>`** suggests installable plugin **package names** (e.g. `imbue-mngr-claude`, `imbue-mngr-modal`), drawn from the plugin catalog -- the same store the `mngr extras` install wizard uses.
- **`mngr plugin remove <TAB>`** suggests the plugin packages **currently installed** (from the uv-tool receipt), filtered to packages that actually register `mngr` entry points -- so non-plugin dependencies installed alongside plugins (e.g. workspace libraries like `imbue-common`, `concurrency-group`, `modal-proxy`) are not offered.

Both support prefix filtering and repeat the completion for each package when operating on several at once.

### Why these sources?

`add` and `remove` operate on PyPI **package names** (`imbue-mngr-modal`), whereas `enable`/`disable` operate on registered **plugin names** (`modal`). The existing `plugin_names` source is therefore wrong for `add`/`remove`:

- `add` takes installable packages you don't have yet -> draws from `plugin_catalog.get_installable_packages()`.
- `remove` takes packages you *do* have, and only ones that are actually plugins -> draws from the uv-tool receipt extras, filtered by `has_mngr_entry_points`.

## Implementation

Fits the existing cache-based completer (no per-keypress Click invocation):
- New `catalog_package_names` and `installed_plugin_package_names` fields on `CompletionCacheData`, with `catalog_packages` / `installed_packages` completion sources resolved in the lightweight `complete.py`.
- Positional spec entries `"plugin.add"` and `"plugin.remove"` in the writer.
- The installed-package list is computed by the cli-layer caller (`list.py`) and passed into the config-layer writer, mirroring how `topic_names` is threaded in, so the writer does not import the cli layer (which would break the import-linter layers contract).
- Promoted the mngr-entry-point check from a private helper in `cli/plugin.py` to a shared `uv_tool.has_mngr_entry_points` (single source of truth; the `plugin add` warning path now uses it too).

## Testing

- Unit tests in `completion_writer_test.py`, `complete_test.py`, and `uv_tool_test.py` (full list, prefix filter, variadic repeat, non-plugin filtering, best-effort receipt handling).
- Manually verified the real `complete.py` entrypoint with `COMP_WORDS`/`COMP_CWORD` set as the shell would, against the actual uv-tool receipt -- confirmed `remove` offers only real plugins and excludes `imbue-common` / `concurrency-group` / `modal-proxy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)