### PR TITLE
Harden suspicious edge-case handling in desktop_client/latchkey

### DIFF
--- a/apps/minds/changelog/mngr-suspicious-edge-cases-minds-desktop-client-latchkey-local.md
+++ b/apps/minds/changelog/mngr-suspicious-edge-cases-minds-desktop-client-latchkey-local.md
@@ -1,0 +1,13 @@
+Hardened suspicious edge-case handling in the desktop client's latchkey package:
+
+- File-sharing access-mode rendering (`_access_human_label`) now branches on the
+  `FileSharingAccess` enum with `match`/`assert_never` instead of an if-chain
+  with a raw-string fallback. An unrecognized mode now crashes loudly rather than
+  silently splicing a raw token into the agent-facing grant/deny message.
+- The permission-requests stream parser now catches the precise
+  `pydantic.ValidationError` (not the broader `ValueError`) when a streamed line
+  has an unexpected shape, matching the catalog parser.
+- Documented the deliberate fail-closed handling when the gateway returns a
+  present-but-malformed `rules` body for a permissions lookup, and the
+  unreachable wrong-event-type guard in the file-sharing handler's
+  `display_name_for_event`.

--- a/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client.py
@@ -446,7 +446,7 @@ class LatchkeyGatewayClient(MutableModel):
                             continue
                         try:
                             yield StreamedPermissionRequest.model_validate(data)
-                        except ValueError as e:
+                        except ValidationError as e:
                             logger.warning(
                                 "permission-requests JSONL line had unexpected shape {!r}: {}",
                                 line,
@@ -605,6 +605,14 @@ class LatchkeyGatewayClient(MutableModel):
             raise LatchkeyGatewayClientError(f"GET {url} returned non-JSON body: {e}") from e
         if not isinstance(payload, dict):
             raise LatchkeyGatewayClientError(f"GET {url} returned non-object JSON: {payload!r}")
+        # The gateway extension owns every write to this file, so a 2xx body
+        # whose ``rules`` is absent or not a list (or whose entries are
+        # malformed) indicates gateway-side corruption that should not occur.
+        # We deliberately fail closed -- treat it as "no grants" so the dialog's
+        # pre-check is simply empty -- rather than crash the dialog render; a
+        # missing pre-check is recoverable (the user can still tick boxes),
+        # whereas a crash would block the grant entirely. The same fail-closed
+        # rationale covers the non-dict / non-list skips in the loop below.
         rules = payload.get("rules")
         if not isinstance(rules, list):
             return frozenset()

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -34,6 +34,7 @@ import json
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
+from typing import assert_never
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -116,15 +117,24 @@ def _normalize_share_path(raw_path: str, allowed_roots: Sequence[Path]) -> str:
 
 
 def _access_human_label(access: str) -> str:
-    """Lower-case human phrase for the access mode ("read-only" / "read & write")."""
-    if access == str(FileSharingAccess.READ):
-        return "read-only"
-    if access == str(FileSharingAccess.WRITE):
-        return "read & write"
-    # Unknown access values are unexpected but possible if the gateway
-    # ever grows a new mode -- surface the raw value rather than
-    # crashing so the dialog still renders.
-    return access
+    """Lower-case human phrase for the access mode ("read-only" / "read & write").
+
+    ``access`` is carried verbatim from a ``FileSharingAccess`` enum on the
+    request payload (it originates as ``str(payload.access)`` in
+    ``streamed_request_to_event``, and ``FileSharingRequestPayload.access`` is a
+    ``FileSharingAccess`` field), so it is always a valid member here -- a
+    gateway that emitted a new mode would fail ``StreamedPermissionRequest``
+    validation and be dropped upstream. We parse + ``match`` so the type checker
+    proves both modes are handled and any unexpected value crashes loudly rather
+    than silently splicing a raw token into the agent-facing grant/deny message.
+    """
+    match FileSharingAccess(access):
+        case FileSharingAccess.READ:
+            return "read-only"
+        case FileSharingAccess.WRITE:
+            return "read & write"
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def _format_granted_message(file_path: str, access: str) -> str:
@@ -203,6 +213,13 @@ class FileSharingGrantHandler(RequestEventHandler):
         return _KIND_LABEL
 
     def display_name_for_event(self, req_event: RequestEvent) -> str:
+        # The route layer guarantees ``req_event.request_type`` matches
+        # ``handles_request_type()`` before dispatching here (see
+        # ``RequestEventHandler``), and the request_type<->class mapping is fixed
+        # in ``streamed_request_to_event``, so this branch is unreachable. The
+        # isinstance check exists only to narrow the type for ``.path``; the
+        # empty-string fallback mirrors the no-handler card in ``app.py`` rather
+        # than crashing the whole requests panel for a state that cannot occur.
         if not isinstance(req_event, LatchkeyFileSharingPermissionRequestEvent):
             return ""
         return req_event.path


### PR DESCRIPTION
Output of `/identify-suspicious-edge-cases apps/minds/imbue/minds/desktop_client/latchkey`, followed by fixes for the accepted findings.

## Fixes

1. **`_access_human_label` (file_sharing.py)** had an if-chain over `READ`/`WRITE` with a raw-string fallback justified as "possible if the gateway grows a new mode". That fallback is unreachable: `access` is always carried from a validated `FileSharingAccess` enum, so a new mode would be rejected upstream by `StreamedPermissionRequest` validation. Replaced with `match FileSharingAccess(access)` + `assert_never`, so an unexpected value now crashes loudly instead of silently splicing a raw token into the agent-facing grant/deny message.

2. **`iter_permission_requests` (gateway_client.py)** caught the broad `ValueError` around a single `model_validate` call that can only raise `pydantic.ValidationError`. Tightened to `ValidationError`, matching the sibling `get_available_services`.

3. **Clarifying comments (over-report remedies)** for two correct-but-undocumented handlers: the fail-closed treatment of a present-but-malformed `rules` body in `get_granted_permissions_for_scopes`, and the unreachable wrong-event-type guard in the file-sharing handler's `display_name_for_event`.

Findings #5 (`_resolve_host_id` ValueError-to-detect-test-sentinel) and #6 (`ServicesCatalog` deny-only degradation) were reviewed and left as-is -- both are already documented and the behavior is justified.

## Testing

`just test-quick "apps/minds/imbue/minds/desktop_client/latchkey -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` -> 83 passed, 0 failed. `uv run ty check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)