### PR TITLE
Strengthen minds.utils logging/output unit tests

### DIFF
--- a/apps/minds/changelog/mngr-bad-tests-minds-utils-local.md
+++ b/apps/minds/changelog/mngr-bad-tests-minds-utils-local.md
@@ -1,0 +1,7 @@
+Strengthened the unit tests for `imbue.minds.utils` logging and output helpers:
+
+- `_format_user_message` tests now assert the exact colored format string (via inline-snapshot) for every level instead of loose substring checks, so a dropped/swapped DEBUG/TRACE/WARNING/ERROR color branch is now caught.
+- Added `setup_logging` cases that verify messages below the configured threshold are suppressed (e.g. DEBUG hidden at INFO, INFO hidden at WARN), covering the level-filtering behavior that was previously untested.
+- Replaced the fragile "no brace before the marker" heuristic with an exact stderr equality assertion for the human format.
+- Replaced the bespoke `_FakeLevel` record fake with `types.SimpleNamespace`.
+- `emit_event` HUMAN-without-message test now also asserts stderr stays empty.

--- a/apps/minds/imbue/minds/utils/logging_test.py
+++ b/apps/minds/imbue/minds/utils/logging_test.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from inline_snapshot import snapshot
 from loguru import logger
 
 from imbue.minds.utils.logging import ConsoleLogLevel
@@ -47,43 +49,34 @@ def test_quiet_overrides_verbose() -> None:
     assert level == ConsoleLogLevel.NONE
 
 
-class _FakeLevel:
-    """Fake loguru level object for testing format functions."""
-
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-
-def _make_fake_record(level_name: str) -> dict[str, _FakeLevel]:
+def _make_fake_record(level_name: str) -> dict[str, Any]:
     """Create a minimal dict matching the loguru record shape for _format_user_message."""
-    return {"level": _FakeLevel(level_name)}
+    return {"level": SimpleNamespace(name=level_name)}
 
 
 def test_format_user_message_info_returns_plain_format() -> None:
     result = _format_user_message(_make_fake_record("INFO"))
-    assert result == "{message}\n"
+    assert result == snapshot("{message}\n")
 
 
-def test_format_user_message_warning_includes_prefix() -> None:
+def test_format_user_message_warning_wraps_prefixed_message_in_color() -> None:
     result = _format_user_message(_make_fake_record("WARNING"))
-    assert "WARNING:" in result
-    assert "{message}" in result
+    assert result == snapshot("\x1b[1;38;5;178mWARNING: {message}\x1b[0m\n")
 
 
-def test_format_user_message_error_includes_prefix() -> None:
+def test_format_user_message_error_wraps_prefixed_message_in_color() -> None:
     result = _format_user_message(_make_fake_record("ERROR"))
-    assert "ERROR:" in result
-    assert "{message}" in result
+    assert result == snapshot("\x1b[1;38;5;196mERROR: {message}\x1b[0m\n")
 
 
-def test_format_user_message_debug_includes_message_placeholder() -> None:
+def test_format_user_message_debug_wraps_message_in_color() -> None:
     result = _format_user_message(_make_fake_record("DEBUG"))
-    assert "{message}" in result
+    assert result == snapshot("\x1b[38;5;33m{message}\x1b[0m\n")
 
 
-def test_format_user_message_trace_includes_message_placeholder() -> None:
+def test_format_user_message_trace_wraps_message_in_color() -> None:
     result = _format_user_message(_make_fake_record("TRACE"))
-    assert "{message}" in result
+    assert result == snapshot("\x1b[38;5;99m{message}\x1b[0m\n")
 
 
 @pytest.mark.usefixtures("_isolated_logger")
@@ -123,16 +116,41 @@ def test_setup_logging_shows_messages_at_configured_level(
 
 
 @pytest.mark.usefixtures("_isolated_logger")
+@pytest.mark.parametrize(
+    "configured_level, suppressed_loguru_level, marker",
+    [
+        (ConsoleLogLevel.INFO, "DEBUG", "below-info-marker-44910"),
+        (ConsoleLogLevel.INFO, "TRACE", "below-info-trace-marker-44911"),
+        (ConsoleLogLevel.DEBUG, "TRACE", "below-debug-marker-44912"),
+        (ConsoleLogLevel.WARN, "INFO", "below-warn-marker-44913"),
+        (ConsoleLogLevel.ERROR, "WARNING", "below-error-marker-44914"),
+    ],
+)
+def test_setup_logging_suppresses_messages_below_configured_level(
+    configured_level: ConsoleLogLevel,
+    suppressed_loguru_level: str,
+    marker: str,
+    capfd: Any,
+) -> None:
+    """Messages below the configured threshold must not reach stderr."""
+    setup_logging(configured_level)
+
+    logger.log(suppressed_loguru_level, marker)
+
+    captured = capfd.readouterr()
+    assert marker not in captured.err
+
+
+@pytest.mark.usefixtures("_isolated_logger")
 def test_setup_logging_always_uses_human_format_on_stderr(capfd: Any) -> None:
-    """Stderr output is always human-readable, never JSONL."""
+    """Stderr output is always the plain human format, never JSONL."""
     setup_logging(ConsoleLogLevel.INFO)
 
     logger.info("human-test-marker-71824")
 
     captured = capfd.readouterr()
-    assert "human-test-marker-71824" in captured.err
-    # Should not be JSON
-    assert "{" not in captured.err.split("human-test-marker-71824")[0]
+    # The INFO human format is exactly `{message}\n`, so stderr is just the marker line.
+    assert captured.err == "human-test-marker-71824\n"
 
 
 @pytest.mark.usefixtures("_isolated_logger")

--- a/apps/minds/imbue/minds/utils/output_test.py
+++ b/apps/minds/imbue/minds/utils/output_test.py
@@ -36,3 +36,4 @@ def test_emit_event_human_without_message_key_is_silent(capfd: Any) -> None:
 
     captured = capfd.readouterr()
     assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
Identified and fixed low-quality tests under \`apps/minds/imbue/minds/utils\` (via /identify-bad-tests). Findings recorded in \`apps/minds/_tasks/bad-tests/\` (gitignored).

## Fixes
- **`_format_user_message` color tests were tautological/weak.** The DEBUG/TRACE tests only asserted `"{message}" in result`, which every branch (including the default) satisfies, so a dropped color branch passed silently. WARNING/ERROR only checked a substring. All now assert the exact ANSI-colored format string via inline-snapshot.
- **`setup_logging` never verified level filtering.** Tests only logged *at* the configured level, so ignoring the level (or always using TRACE) would have passed. Added cases asserting below-threshold messages are suppressed (DEBUG hidden at INFO, INFO hidden at WARN, etc.).
- **Fragile "no brace before marker" human-format check** replaced with exact stderr equality.
- **Bespoke `_FakeLevel`** replaced with `types.SimpleNamespace`.
- **`emit_event` HUMAN-without-message test** now also asserts stderr stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)