### PR TITLE
improve mngr_claude tests

### DIFF
--- a/libs/mngr_claude/changelog/mngr-bad-tests-mngr-claude-local.md
+++ b/libs/mngr_claude/changelog/mngr-bad-tests-mngr-claude-local.md
@@ -1,0 +1,11 @@
+Test-quality hardening across the mngr_claude test suite (no user-visible behavior change). Replaced assertions that passed without verifying correctness with ones that check real effects:
+
+- Seven `on_before_provisioning` tests that asserted nothing ("did not raise") now assert observable effects (config left untouched, missing-credentials warning present/absent, untrusted worktree rejected).
+- `does-not-extend-trust` provisioning tests now assert the exact set of trusted projects instead of the presence of a key the test itself wrote.
+- Transcript-converter truncation tests now assert exact lengths and the ellipsis marker (not just an upper bound), and the "skips event" tests now prove only the bad event is dropped (a known-good event survives) plus cover the missing-`timestamp` branch.
+- Command-assembly and install-command tests now assert on shlex-parsed tokens / load-bearing flags instead of hand-rebuilt exact shell strings.
+- Skill-install skip tests assert file content is unchanged instead of relying on mtime equality; added remote-install coverage. Custom-agent-type resolution test now sets a non-default field to prove it survives the merge.
+- Grace-period headless test asserts the poll actually re-checked; removed dead `_patch_agent_as_stopped` calls and a fragile wall-clock timing assertion.
+- claude_config no-op tests assert content is byte-for-byte unchanged; effort-callout check test isolated to the effort dialog.
+- Removed an introduced `unittest.mock.patch` of the function under test in favor of the real no-credentials environment, and a duplicate local `temp_source_dir` fixture (now inherited from the shared modal conftest).
+- Release/acceptance tests: the Modal provisioning test destroys the agent and asserts a non-empty preserved session JSONL; the adopt-session and modal tests drop brittle "Done." log-string checks; the no-dialog send_message test matches the specific downstream timeout; the background-tasks prefix-collision test asserts the script reached its gone-session exit; magic `sleep` literals replaced with a named constant.

--- a/libs/mngr_claude/imbue/mngr_claude/agent_registry_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/agent_registry_test.py
@@ -56,30 +56,32 @@ def test_resolve_agent_type_returns_claude_for_registered_type() -> None:
     assert resolved.agent_config.command == CommandString("claude")
 
 
-def _resolve_custom_claude_type(**config_overrides: Any) -> ResolvedAgentType:
-    """Helper to resolve a custom type with parent_type=claude and given overrides."""
+def _resolve_custom_claude_type(
+    parent_config: ClaudeAgentConfig | None = None,
+    **config_overrides: Any,
+) -> ResolvedAgentType:
+    """Helper to resolve a custom type with parent_type=claude and given overrides.
+
+    If parent_config is provided, it is registered as the user config for the
+    parent "claude" type, so its non-default fields participate in the merge.
+    """
     custom_config = AgentTypeConfig(
         parent_type=AgentTypeName("claude"),
         **config_overrides,
     )
-    config = MngrConfig(
-        agent_types={AgentTypeName("my_claude"): custom_config},
-    )
+    agent_types: dict[AgentTypeName, AgentTypeConfig] = {AgentTypeName("my_claude"): custom_config}
+    if parent_config is not None:
+        agent_types[AgentTypeName("claude")] = parent_config
+    config = MngrConfig(agent_types=agent_types)
     return resolve_agent_type(AgentTypeName("my_claude"), config)
 
 
-def test_resolve_agent_type_with_custom_type_uses_parent_class() -> None:
-    """A custom type with parent_type should use the parent's agent class."""
+def test_resolve_agent_type_with_custom_type_uses_parent_class_and_merges_cli_args() -> None:
+    """A custom type with parent_type should use the parent's agent class and merge its cli_args."""
     resolved = _resolve_custom_claude_type(cli_args=("--model", "opus"))
 
     assert resolved.agent_class == ClaudeAgent
     assert isinstance(resolved.agent_config, ClaudeAgentConfig)
-
-
-def test_resolve_agent_type_with_custom_type_merges_cli_args() -> None:
-    """A custom type should merge its cli_args onto the parent config."""
-    resolved = _resolve_custom_claude_type(cli_args=("--model", "opus"))
-
     assert resolved.agent_config.cli_args == ("--model", "opus")
 
 
@@ -91,11 +93,18 @@ def test_resolve_agent_type_with_custom_type_overrides_command() -> None:
 
 
 def test_resolve_agent_type_with_custom_type_preserves_parent_specific_fields() -> None:
-    """Custom type config should retain parent-specific fields like sync_home_settings."""
-    resolved = _resolve_custom_claude_type(cli_args=("--model", "opus"))
+    """A non-default parent-specific field (sync_home_settings) should survive the merge.
+
+    sync_home_settings defaults to True, so the parent config explicitly sets it to
+    False; if the merge dropped the field it would re-default to True and this would fail.
+    """
+    resolved = _resolve_custom_claude_type(
+        parent_config=ClaudeAgentConfig(sync_home_settings=False),
+        cli_args=("--model", "opus"),
+    )
 
     assert isinstance(resolved.agent_config, ClaudeAgentConfig)
-    assert resolved.agent_config.sync_home_settings is True
+    assert resolved.agent_config.sync_home_settings is False
 
 
 def test_resolve_agent_type_with_override_for_registered_type() -> None:

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -361,8 +361,11 @@ def test_remove_claude_trust_returns_false_when_no_config(tmp_path: Path) -> Non
     assert result is False
 
 
-def test_remove_claude_trust_returns_false_on_error(tmp_path: Path) -> None:
-    """Test that remove_claude_trust_for_path returns False on errors."""
+def test_remove_claude_trust_returns_false_on_invalid_json(tmp_path: Path) -> None:
+    """Test that remove_claude_trust_for_path returns False on invalid JSON.
+
+    The JSON-decode path is the only error the production code catches.
+    """
     config_file = find_user_claude_config()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
@@ -455,9 +458,13 @@ def test_dismiss_effort_callout_is_noop_when_already_set() -> None:
     backup_file = find_user_claude_config().with_suffix(".json.bak")
     config = {"effortCalloutDismissed": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
+    content_before = config_file.read_text()
 
     dismiss_effort_callout(config_file)
 
+    # The config file content must be byte-for-byte unchanged across the no-op call.
+    assert config_file.read_text() == content_before
+    # Secondary check: a no-op write would have created a .bak backup; it must not exist.
     assert not backup_file.exists()
 
 
@@ -506,9 +513,13 @@ def test_acknowledge_cost_threshold_is_noop_when_already_set() -> None:
     backup_file = find_user_claude_config().with_suffix(".json.bak")
     config = {"hasAcknowledgedCostThreshold": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
+    content_before = config_file.read_text()
 
     acknowledge_cost_threshold(config_file)
 
+    # The config file content must be byte-for-byte unchanged across the no-op call.
+    assert config_file.read_text() == content_before
+    # Secondary check: a no-op write would have created a .bak backup; it must not exist.
     assert not backup_file.exists()
 
 
@@ -558,8 +569,12 @@ def test_check_claude_dialogs_dismissed_checks_effort_callout(tmp_path: Path) ->
     source_path = tmp_path / "source"
     source_path.mkdir()
 
-    # Config has trust but NOT effort dismissed
+    # Trust and onboarding are both set, so the effort callout is the ONLY
+    # remaining undismissed dialog. This isolates the effort check: the raised
+    # error type is genuinely attributable to the effort callout rather than
+    # being correct only by the trust -> effort -> onboarding check ordering.
     config = {
+        "hasCompletedOnboarding": True,
         "projects": {
             str(source_path): {"hasTrustDialogAccepted": True},
         },

--- a/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/headless_claude_agent_test.py
@@ -172,10 +172,10 @@ def test_assemble_command_includes_print_and_redirect(
     agent, host = _make_headless_agent(local_provider, tmp_path)
     cmd = agent.assemble_command(host, agent_args=(), command_override=None)
     assert "--print" in cmd
-    assert "$MNGR_AGENT_STATE_DIR/stdout.jsonl" in cmd
-    assert ">" in cmd
-    assert "$MNGR_AGENT_STATE_DIR/stderr.log" in cmd
-    assert "2>" in cmd
+    # Assert the full redirect suffix as a single substring so a broken stdout
+    # redirect (or transposed stdout/stderr targets) cannot pass: a lone "2>"
+    # membership check would be satisfied even if stdout redirect were dropped.
+    assert str(cmd).endswith('> "$MNGR_AGENT_STATE_DIR/stdout.jsonl" 2> "$MNGR_AGENT_STATE_DIR/stderr.log"')
 
 
 def test_assemble_command_includes_agent_args(
@@ -189,10 +189,13 @@ def test_assemble_command_includes_agent_args(
         agent_args=("--system-prompt", "test", "--output-format", "stream-json"),
         command_override=None,
     )
-    assert "--system-prompt" in cmd
-    assert "test" in cmd
-    assert "--output-format" in cmd
-    assert "stream-json" in cmd
+    # Parse with shlex and assert the flags appear in order, each immediately
+    # followed by its value. Independent "X in cmd" membership checks would
+    # pass even if flags and values were transposed (e.g.
+    # "--system-prompt --output-format test stream-json").
+    cmd_before_redirect = str(cmd).split(" >", 1)[0]
+    tokens = shlex.split(cmd_before_redirect)
+    assert tokens[-4:] == ["--system-prompt", "test", "--output-format", "stream-json"]
 
 
 def test_assemble_command_no_session_resumption(
@@ -473,7 +476,6 @@ def test_stream_output_yields_text_deltas(
 def test_stream_output_raises_when_empty_file(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """stream_output should raise MngrError when stdout file exists but is empty.
 
@@ -486,9 +488,10 @@ def test_stream_output_raises_when_empty_file(
     Uses _AlwaysFinishedHeadlessClaude instead of _patch_agent_as_stopped to
     keep the startup-grace window short: the tail loop now gates on file
     content during the grace window, so an empty stdout means the loop
-    polls until grace expires.
+    polls until grace expires. The always-finished subclass's
+    _is_agent_finished returns True directly, which is what terminates the
+    tail loop, so no lifecycle patch is needed.
     """
-    _patch_agent_as_stopped(monkeypatch)
     agent, host = _make_headless_agent(local_provider, tmp_path, agent_cls=_AlwaysFinishedHeadlessClaude)
 
     _write_fake_agent_output(host, agent)
@@ -634,7 +637,6 @@ def test_stream_output_combines_stderr_and_stdout_errors(
 def test_stream_output_raises_with_stderr_content(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """stream_output should surface stderr.log content in the error when stdout is empty.
 
@@ -643,9 +645,10 @@ def test_stream_output_raises_with_stderr_content(
     `tmux capture-pane` via the host interface.
 
     Uses _AlwaysFinishedHeadlessClaude for the short grace window (stdout is
-    empty, so _authoritatively_finished polls until grace elapses).
+    empty, so _authoritatively_finished polls until grace elapses). Its
+    _is_agent_finished returns True directly, which terminates the tail loop,
+    so no lifecycle patch is needed.
     """
-    _patch_agent_as_stopped(monkeypatch)
     agent, host = _make_headless_agent(local_provider, tmp_path, agent_cls=_AlwaysFinishedHeadlessClaude)
 
     _write_fake_agent_output(host, agent, stderr="stderr-f7g8h9i0\n")
@@ -721,6 +724,11 @@ def test_grace_period_ignores_lifecycle_state(
     result = agent._wait_for_stdout_file(stdout_path)
 
     assert result is True
+    # Phase 1 must have re-polled: the file only appears on the 2nd poll, so a
+    # count >= 2 proves phase 1 ignored the (always-finished) lifecycle state
+    # and kept polling instead of bailing after a single check.
+    assert isinstance(agent, _CreatesFileOnSecondPollAgent)
+    assert agent._stdout_poll_count >= 2
 
 
 def test_phase2_trusts_lifecycle_after_grace_period(
@@ -738,13 +746,9 @@ def test_phase2_trusts_lifecycle_after_grace_period(
     # Do NOT create the stdout file -- agent is "finished" and file never appeared
     stdout_path.parent.mkdir(parents=True, exist_ok=True)
 
-    start = time.monotonic()
     result = agent._wait_for_stdout_file(stdout_path)
-    elapsed = time.monotonic() - start
 
     assert result is False
-    # Should have waited at least the grace period before trusting lifecycle state
-    assert elapsed >= agent._startup_grace_seconds * 0.9
 
 
 def test_file_during_grace_period_returns_true_immediately(

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -59,6 +59,7 @@ from imbue.mngr.providers.docker.instance import DockerProviderInstance
 from imbue.mngr.providers.docker.testing import make_docker_provider_with_local_volume
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
+from imbue.mngr.utils.testing import capture_loguru
 from imbue.mngr.utils.testing import init_git_repo
 from imbue.mngr.utils.testing import make_mngr_ctx
 from imbue.mngr_claude.claude_config import ClaudeDirectoryNotTrustedError
@@ -66,6 +67,7 @@ from imbue.mngr_claude.claude_config import ClaudeEffortCalloutNotDismissedError
 from imbue.mngr_claude.claude_config import build_credential_sync_hooks_config
 from imbue.mngr_claude.claude_config import build_readiness_hooks_config
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
+from imbue.mngr_claude.plugin import CLAUDE_INSTALL_PATH
 from imbue.mngr_claude.plugin import ClaudeAgent
 from imbue.mngr_claude.plugin import ClaudeAgentConfig
 from imbue.mngr_claude.plugin import CostThresholdDialogIndicator
@@ -76,6 +78,7 @@ from imbue.mngr_claude.plugin import _build_settings_json
 from imbue.mngr_claude.plugin import _check_settings_local_gitignored
 from imbue.mngr_claude.plugin import _claude_json_has_primary_api_key
 from imbue.mngr_claude.plugin import _claude_preserved_items
+from imbue.mngr_claude.plugin import _compute_keychain_label_suffix
 from imbue.mngr_claude.plugin import _generate_installed_plugins_content
 from imbue.mngr_claude.plugin import _generate_known_marketplaces_content
 from imbue.mngr_claude.plugin import _get_claude_version
@@ -332,6 +335,58 @@ def test_claude_agent_config_merge_uses_override_cli_args_when_base_empty() -> N
 # =============================================================================
 
 
+class _ParsedAssembleCommand:
+    """Structural view of an assembled claude command, parsed via shlex.
+
+    The assembled command has the shape::
+
+        <bg> <exports> && rm -rf .../session_started
+            && ( ( find ... | grep . ) && <base> --resume "$SID" <args> )
+            || <base> --session-id <uuid> <args>
+
+    shlex.split tokenizes shell operators (``&&``, ``||``) as their own tokens,
+    so we split on the single top-level ``||`` to separate the resume branch from
+    the create branch, then read the base command and trailing args from each.
+    This lets the assemble-command tests assert on meaningful tokens (which base
+    command, the resume/session-id flags, the trailing args) without pinning the
+    exact whitespace or ``&&`` chain layout.
+    """
+
+    def __init__(self, command: str) -> None:
+        self.tokens = shlex.split(command)
+        # The resume/create split is the LAST top-level `||`. (An earlier `||`
+        # appears inside the SID export's `... 2>/dev/null || true` fallback, so
+        # splitting on the first `||` would be wrong.)
+        split_idx = len(self.tokens) - 1 - self.tokens[::-1].index("||")
+        resume_tokens = self.tokens[:split_idx]
+        create_tokens = self.tokens[split_idx + 1 :]
+
+        # Resume branch: <base> --resume $MAIN_CLAUDE_SESSION_ID <args...>.
+        # The resume command is wrapped in a `( ... )` subshell, so a trailing
+        # `)` group token follows the args; drop it before reading the args.
+        resume_idx = resume_tokens.index("--resume")
+        self.resume_base = resume_tokens[resume_idx - 1]
+        assert resume_tokens[resume_idx + 1] == "$MAIN_CLAUDE_SESSION_ID"
+        resume_arg_tokens = resume_tokens[resume_idx + 2 :]
+        if resume_arg_tokens and resume_arg_tokens[-1] == ")":
+            resume_arg_tokens = resume_arg_tokens[:-1]
+        self.resume_args = resume_arg_tokens
+
+        # Create branch: <base> --session-id <uuid> <args...>
+        session_idx = create_tokens.index("--session-id")
+        self.create_base = create_tokens[session_idx - 1]
+        self.create_session_id = create_tokens[session_idx + 1]
+        self.create_args = create_tokens[session_idx + 2 :]
+
+    @property
+    def has_is_sandbox(self) -> bool:
+        return "IS_SANDBOX=1" in self.tokens
+
+    @property
+    def has_background_script(self) -> bool:
+        return any("claude_background_tasks.sh" in token for token in self.tokens)
+
+
 def test_claude_agent_assemble_command_with_no_args(
     local_provider: LocalProviderInstance, tmp_path: Path, temp_mngr_ctx: MngrContext
 ) -> None:
@@ -341,14 +396,15 @@ def test_claude_agent_assemble_command_with_no_args(
     command = agent.assemble_command(host=host, agent_args=(), command_override=None)
 
     uuid = agent.id.get_uuid()
-    prefix = temp_mngr_ctx.config.prefix
-    session_name = f"{prefix}test-agent"
-    background_cmd = agent._build_background_tasks_command(session_name)
-    sid_export = _sid_export_for(uuid)
+    parsed = _ParsedAssembleCommand(str(command))
+    assert parsed.has_background_script
+    assert parsed.resume_base == "claude"
+    assert parsed.resume_args == []
+    assert parsed.create_base == "claude"
+    assert parsed.create_session_id == str(uuid)
+    assert parsed.create_args == []
     # Local hosts should NOT have IS_SANDBOX set
-    assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" ) || claude --session-id {uuid}'
-    )
+    assert not parsed.has_is_sandbox
 
 
 def test_claude_agent_assemble_command_with_agent_args(
@@ -360,13 +416,13 @@ def test_claude_agent_assemble_command_with_agent_args(
     command = agent.assemble_command(host=host, agent_args=("--model", "opus"), command_override=None)
 
     uuid = agent.id.get_uuid()
-    prefix = temp_mngr_ctx.config.prefix
-    session_name = f"{prefix}test-agent"
-    background_cmd = agent._build_background_tasks_command(session_name)
-    sid_export = _sid_export_for(uuid)
-    assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || claude --session-id {uuid} --model opus'
-    )
+    parsed = _ParsedAssembleCommand(str(command))
+    # agent_args appended to both variants, in order.
+    assert parsed.resume_base == "claude"
+    assert parsed.resume_args == ["--model", "opus"]
+    assert parsed.create_base == "claude"
+    assert parsed.create_session_id == str(uuid)
+    assert parsed.create_args == ["--model", "opus"]
 
 
 def test_claude_agent_assemble_command_with_cli_args_and_agent_args(
@@ -383,13 +439,11 @@ def test_claude_agent_assemble_command_with_cli_args_and_agent_args(
     command = agent.assemble_command(host=host, agent_args=("--model", "opus"), command_override=None)
 
     uuid = agent.id.get_uuid()
-    prefix = temp_mngr_ctx.config.prefix
-    session_name = f"{prefix}test-agent"
-    background_cmd = agent._build_background_tasks_command(session_name)
-    sid_export = _sid_export_for(uuid)
-    assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && claude --resume "$MAIN_CLAUDE_SESSION_ID" --verbose --model opus ) || claude --session-id {uuid} --verbose --model opus'
-    )
+    parsed = _ParsedAssembleCommand(str(command))
+    # cli_args precede agent_args in both variants.
+    assert parsed.resume_args == ["--verbose", "--model", "opus"]
+    assert parsed.create_session_id == str(uuid)
+    assert parsed.create_args == ["--verbose", "--model", "opus"]
 
 
 def test_claude_agent_assemble_command_with_command_override(
@@ -405,13 +459,13 @@ def test_claude_agent_assemble_command_with_command_override(
     )
 
     uuid = agent.id.get_uuid()
-    prefix = temp_mngr_ctx.config.prefix
-    session_name = f"{prefix}test-agent"
-    background_cmd = agent._build_background_tasks_command(session_name)
-    sid_export = _sid_export_for(uuid)
-    assert command == CommandString(
-        f'{background_cmd} {sid_export} && rm -rf $MNGR_AGENT_STATE_DIR/session_started && ( ( find "$CLAUDE_CONFIG_DIR" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && custom-claude --resume "$MAIN_CLAUDE_SESSION_ID" --model opus ) || custom-claude --session-id {uuid} --model opus'
-    )
+    parsed = _ParsedAssembleCommand(str(command))
+    # The override replaces the base command in both variants.
+    assert parsed.resume_base == "custom-claude"
+    assert parsed.resume_args == ["--model", "opus"]
+    assert parsed.create_base == "custom-claude"
+    assert parsed.create_session_id == str(uuid)
+    assert parsed.create_args == ["--model", "opus"]
 
 
 def test_claude_agent_assemble_command_raises_when_no_command(
@@ -594,8 +648,17 @@ def test_on_before_provisioning_skips_check_when_disabled(
 
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
 
-    # Should not raise and should complete without error
+    # on_before_provisioning is a read-only preflight: it must not mutate the
+    # user's ~/.claude.json. Snapshot the config and assert it is byte-for-byte
+    # unchanged after the call (this is the strongest cleanly-observable effect
+    # for the disabled-check path; with check_installation=False the function
+    # returns before any install/version probe, leaving config untouched).
+    config_path = Path.home() / ".claude.json"
+    config_before = config_path.read_text()
+
     agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    assert config_path.read_text() == config_before
 
 
 def test_get_provision_file_transfers_returns_empty_when_no_local_settings(
@@ -1656,12 +1719,13 @@ def test_provision_does_not_extend_trust_for_non_worktree(
 
     # Trust was written by _write_all_dialogs_dismissed, but the provision could
     # not extend trust from a source directory because _find_git_source_path
-    # returns None (work_dir is not a git worktree).
-    # The global config should only contain what _write_all_dialogs_dismissed wrote.
+    # returns None (work_dir is not a git worktree). Assert the negative: the
+    # global config's projects must contain ONLY the pre-existing work_dir entry,
+    # so a regression that erroneously extended trust (adding the source path or
+    # other entries) would fail here.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
-    # Only the work_dir trust entry from _write_all_dialogs_dismissed should exist
-    assert str(agent.work_dir.resolve()) in config["projects"]
+    assert set(config["projects"].keys()) == {str(agent.work_dir.resolve())}
 
 
 def test_provision_does_not_extend_trust_when_no_git_options(
@@ -1676,11 +1740,12 @@ def test_provision_does_not_extend_trust_when_no_git_options(
 
     agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
-    # Trust should NOT have been extended since no git options provided.
-    # The global config should only contain what _write_all_dialogs_dismissed wrote.
+    # Trust should NOT have been extended since no git options were provided.
+    # The projects map must contain ONLY the pre-existing work_dir entry; an extra
+    # key would mean provision wrongly extended trust.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
-    assert str(agent.work_dir.resolve()) in config["projects"]
+    assert set(config["projects"].keys()) == {str(agent.work_dir.resolve())}
 
 
 def test_provision_skips_trust_when_git_common_dir_is_none(
@@ -1695,10 +1760,10 @@ def test_provision_skips_trust_when_git_common_dir_is_none(
     agent.provision(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=temp_mngr_ctx)
 
     # Trust should NOT have been extended from a source since there's no git common dir.
-    # The global config should only contain what _write_all_dialogs_dismissed wrote.
+    # The projects map must contain ONLY the pre-existing work_dir entry.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
-    assert str(agent.work_dir.resolve()) in config["projects"]
+    assert set(config["projects"].keys()) == {str(agent.work_dir.resolve())}
 
 
 def test_provision_trusts_working_directory_when_enabled(
@@ -1730,11 +1795,12 @@ def test_provision_does_not_auto_dismiss_dialogs_when_disabled(
 
     agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
-    # The global config should only contain what _write_all_dialogs_dismissed wrote.
     # auto_dismiss_dialogs=False (default) means no additional trust was added.
+    # The projects map must contain ONLY the pre-existing work_dir entry; an extra
+    # key would mean a dialog/trust entry was auto-dismissed despite the flag.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
-    assert str(agent.work_dir.resolve()) in config["projects"]
+    assert set(config["projects"].keys()) == {str(agent.work_dir.resolve())}
 
 
 def test_auto_dismiss_dialogs_defaults_to_false() -> None:
@@ -1757,8 +1823,38 @@ def test_on_before_provisioning_validates_trust_for_worktree(
         is_source_trusted=True,
     )
 
-    # Should succeed without error because the source directory is trusted
+    # Should succeed without error because the source directory is trusted.
+    # The trust entry must survive (and remain the work_dir's source trust) --
+    # a non-interactive preflight that does not see trust would raise below.
     agent.on_before_provisioning(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=temp_mngr_ctx)
+    config = json.loads((Path.home() / ".claude.json").read_text())
+    assert config["projects"][str(source_path.resolve())]["hasTrustDialogAccepted"] is True
+
+
+def test_on_before_provisioning_rejects_untrusted_worktree(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    setup_git_config: None,
+) -> None:
+    """on_before_provisioning must reject an untrusted worktree in non-interactive mode.
+
+    Sibling to test_on_before_provisioning_validates_trust_for_worktree: the
+    trusted case proves the happy path doesn't raise, and this case proves the
+    gate actually fires (raising ClaudeDirectoryNotTrustedError) when the source
+    directory has no trust entry.
+    """
+    source_path, worktree_path, agent, host = _setup_worktree_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        is_source_trusted=False,
+    )
+
+    with pytest.raises(ClaudeDirectoryNotTrustedError) as exc_info:
+        agent.on_before_provisioning(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=temp_mngr_ctx)
+    # The error must name the specific untrusted source directory (not the worktree).
+    assert str(source_path.resolve()) in str(exc_info.value)
 
 
 def test_on_before_provisioning_skips_dialog_check_when_interactive(
@@ -1774,8 +1870,17 @@ def test_on_before_provisioning_skips_dialog_check_when_interactive(
         interactive_mngr_ctx,
     )
 
-    # Should NOT raise even though dialogs are not dismissed -- interactive defers to provision()
+    # No ~/.claude.json was written, so the source is NOT trusted and no dialogs
+    # are dismissed. A non-interactive preflight would raise here; the interactive
+    # path defers to provision() and must NOT raise.
+    config_path = Path.home() / ".claude.json"
+    assert not config_path.exists()
+
     agent.on_before_provisioning(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=interactive_mngr_ctx)
+
+    # The read-only preflight must not have written/dismissed anything in the
+    # interactive path (provision() owns that). The user's config stays absent.
+    assert not config_path.exists()
 
 
 def test_on_before_provisioning_skips_trust_check_when_git_common_dir_is_none(
@@ -1786,8 +1891,15 @@ def test_on_before_provisioning_skips_trust_check_when_git_common_dir_is_none(
     agent, host = make_claude_agent(local_provider, tmp_path, temp_mngr_ctx)
     _write_all_dialogs_dismissed(agent.work_dir)
 
-    # Should succeed without error because find_git_common_dir returns None
+    # find_git_common_dir returns None, so the trust check falls back to work_dir,
+    # which _write_all_dialogs_dismissed already trusts -- so the preflight passes.
+    # It is read-only, so the config must be byte-for-byte unchanged afterward.
+    config_path = Path.home() / ".claude.json"
+    config_before = config_path.read_text()
+
     agent.on_before_provisioning(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=temp_mngr_ctx)
+
+    assert config_path.read_text() == config_before
 
 
 def test_on_before_provisioning_shared_mode_succeeds_without_dialog_checks(
@@ -1804,12 +1916,18 @@ def test_on_before_provisioning_shared_mode_succeeds_without_dialog_checks(
         temp_mngr_ctx,
         agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
     )
-    # Deliberately leave ~/.claude.json with no dialogs dismissed -- a non-shared
-    # agent would fail here.
+    # Deliberately leave ~/.claude.json absent (no dialogs dismissed, no trust) --
+    # a non-shared agent would raise during the dialog-dismissal check here.
+    config_path = Path.home() / ".claude.json"
+    assert not config_path.exists()
 
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
 
     agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    # Shared mode skips the dialog check entirely and writes nothing to the user's
+    # config, so the file must still be absent.
+    assert not config_path.exists()
 
 
 def test_on_before_provisioning_shared_mode_raises_for_remote_host(
@@ -1855,8 +1973,14 @@ def test_on_before_provisioning_shared_mode_passes_when_env_unset(
 
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
 
-    # Should not raise.
+    # Shared mode does not touch the user's config; with no ~/.claude.json present
+    # it must neither raise nor create one (the "don't touch the config" path).
+    config_path = Path.home() / ".claude.json"
+    assert not config_path.exists()
+
     agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    assert not config_path.exists()
 
 
 def test_on_destroy_removes_trust(
@@ -2059,10 +2183,14 @@ def test_on_destroy_still_calls_keychain_cleanup_in_default_mode(
     ):
         agent.on_destroy(host)
 
-    # Two labels: API key and OAuth credentials.
-    assert len(delete_calls) == 2
-    assert any(label.startswith("Claude Code-") for label in delete_calls)
-    assert any(label.startswith("Claude Code-credentials-") for label in delete_calls)
+    # User-visible effect: both per-agent credential kinds (API key and OAuth
+    # credentials) are targeted for deletion under the suffix Claude Code derives
+    # from the per-agent config dir. We assert the exact target labels (rather
+    # than a raw call count) because they form the OS-keychain contract that must
+    # match what Claude Code itself wrote -- a wrong suffix or kind would leave a
+    # stale credential behind.
+    suffix = _compute_keychain_label_suffix(agent.get_claude_config_dir())
+    assert set(delete_calls) == {f"Claude Code{suffix}", f"Claude Code-credentials{suffix}"}
 
 
 @pytest.mark.rsync
@@ -2156,17 +2284,16 @@ def test_provision_prompts_for_all_dialogs_when_interactive(
         interactive_mngr_ctx,
     )
 
-    with _mock_all_dialog_prompts() as mocks:
+    with _mock_all_dialog_prompts():
         agent.provision(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=interactive_mngr_ctx)
 
-    mocks["trust"].assert_called_once_with(source_path)
-    mocks["effort"].assert_called_once()
-    mocks["onboarding"].assert_called_once()
-
-    # Verify dialogs were resolved in the global config (user intent)
+    # Verify dialogs were resolved in the global config (user intent). We assert
+    # on the on-disk end state rather than the internal prompt-call counts so a
+    # behavior-preserving refactor (e.g. consolidating the three prompts) doesn't
+    # break the test; the declined-prompt cases are covered separately.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
-    assert str(source_path.resolve()) in config["projects"]
+    assert config["projects"][str(source_path.resolve())]["hasTrustDialogAccepted"] is True
     assert config["effortCalloutDismissed"] is True
     assert config["hasCompletedOnboarding"] is True
 
@@ -2470,13 +2597,23 @@ def test_has_api_credentials_returns_false_primary_api_key_remote_no_sync(
     )
 
 
+_NO_CREDENTIALS_WARNING_SUBSTRING = "No API credentials detected for Claude Code"
+
+
+@pytest.mark.usefixtures("_no_api_key_in_env")
 @pytest.mark.usefixtures("_no_api_key_in_env")
 def test_on_before_provisioning_does_not_raise_when_no_credentials(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """on_before_provisioning should not raise when no API credentials are detected."""
+    """on_before_provisioning should warn (not raise) when no API credentials are detected.
+
+    The autouse env isolation redirects HOME to a temp dir (so no ~/.claude.json or
+    credentials file exists) and the _no_api_key_in_env fixture clears the env var, so
+    the real _has_api_credentials_available genuinely returns False here -- the same
+    setup the direct test_has_api_credentials_returns_false_when_no_credentials relies on.
+    """
     agent, host = make_claude_agent(
         local_provider,
         tmp_path,
@@ -2485,8 +2622,12 @@ def test_on_before_provisioning_does_not_raise_when_no_credentials(
     )
     _write_all_dialogs_dismissed(agent.work_dir)
 
-    # Should complete without raising (logs a warning instead)
-    agent.on_before_provisioning(host=host, options=_DEFAULT_CREDENTIAL_CHECK_OPTIONS, mngr_ctx=temp_mngr_ctx)
+    with capture_loguru() as log_output:
+        agent.on_before_provisioning(host=host, options=_DEFAULT_CREDENTIAL_CHECK_OPTIONS, mngr_ctx=temp_mngr_ctx)
+
+    # It must not raise, and it must emit the missing-credentials warning so the
+    # user is told the agent may fail to start.
+    assert _NO_CREDENTIALS_WARNING_SUBSTRING in log_output.getvalue()
 
 
 def test_on_before_provisioning_succeeds_with_credentials(
@@ -2495,7 +2636,7 @@ def test_on_before_provisioning_succeeds_with_credentials(
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """on_before_provisioning should succeed without warning when credentials are available."""
+    """on_before_provisioning should succeed WITHOUT the missing-credentials warning when creds exist."""
     agent, host = make_claude_agent(
         local_provider,
         tmp_path,
@@ -2506,7 +2647,12 @@ def test_on_before_provisioning_succeeds_with_credentials(
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
 
-    agent.on_before_provisioning(host=host, options=_DEFAULT_CREDENTIAL_CHECK_OPTIONS, mngr_ctx=temp_mngr_ctx)
+    with capture_loguru() as log_output:
+        agent.on_before_provisioning(host=host, options=_DEFAULT_CREDENTIAL_CHECK_OPTIONS, mngr_ctx=temp_mngr_ctx)
+
+    # With a real credential available, the missing-credentials warning must NOT
+    # be emitted (a flipped warn/no-warn branch would be caught here).
+    assert _NO_CREDENTIALS_WARNING_SUBSTRING not in log_output.getvalue()
 
 
 # =============================================================================
@@ -2631,16 +2777,15 @@ def test_provision_prompts_for_dialog_dismissal_when_interactive(
     # Write trust but without effortCalloutDismissed or hasCompletedOnboarding
     _write_claude_trust_without_dialog_dismissed(source_path)
 
-    with _mock_all_dialog_prompts() as mocks:
+    with _mock_all_dialog_prompts():
         agent.provision(host=host, options=_WORKTREE_OPTIONS, mngr_ctx=interactive_mngr_ctx)
 
-    # Trust was already set, so trust prompt should not fire
-    mocks["trust"].assert_not_called()
-    mocks["effort"].assert_called_once()
-    mocks["onboarding"].assert_called_once()
-
+    # Assert on the on-disk end state: the previously-undismissed dialogs are now
+    # dismissed, while the already-set trust entry is preserved. This captures the
+    # real effect without coupling to which/how-many prompt helpers were invoked.
     config_path = Path.home() / ".claude.json"
     config = json.loads(config_path.read_text())
+    assert config["projects"][str(source_path.resolve())]["hasTrustDialogAccepted"] is True
     assert config["effortCalloutDismissed"] is True
     assert config["hasCompletedOnboarding"] is True
 
@@ -3159,37 +3304,34 @@ def _make_command_tracking_host() -> tuple[OnlineHostInterface, list[str]]:
 
 def test_get_claude_version_returns_version_on_success() -> None:
     """_get_claude_version should return the version string when claude --version succeeds."""
-    host = cast(
-        OnlineHostInterface,
-        SimpleNamespace(
-            execute_idempotent_command=lambda cmd, *args, **kwargs: SimpleNamespace(
-                success=True,
-                stdout="2.1.50 (Claude Code)\n",
-                stderr="",
-            ),
-        ),
-    )
+    issued_commands: list[str] = []
+
+    def _execute(cmd: str, *args: object, **kwargs: object) -> SimpleNamespace:
+        issued_commands.append(cmd)
+        return SimpleNamespace(success=True, stdout="2.1.50 (Claude Code)\n", stderr="")
+
+    host = cast(OnlineHostInterface, SimpleNamespace(execute_idempotent_command=_execute))
 
     assert _get_claude_version(host) == "2.1.50"
+    # The version must be probed via `claude --version`; a bug invoking a
+    # different command (e.g. `claude --ver`) would otherwise go undetected.
+    assert issued_commands == ["claude --version"]
 
 
 def test_get_claude_version_returns_none_on_failure() -> None:
     """_get_claude_version should return None when claude --version fails."""
-    host = cast(
-        OnlineHostInterface,
-        SimpleNamespace(
-            execute_idempotent_command=lambda cmd, *args, **kwargs: SimpleNamespace(
-                success=False,
-                stdout="",
-                stderr="command not found",
-            ),
-        ),
-    )
+    issued_commands: list[str] = []
+
+    def _execute(cmd: str, *args: object, **kwargs: object) -> SimpleNamespace:
+        issued_commands.append(cmd)
+        return SimpleNamespace(success=False, stdout="", stderr="command not found")
+
+    host = cast(OnlineHostInterface, SimpleNamespace(execute_idempotent_command=_execute))
 
     assert _get_claude_version(host) is None
+    assert issued_commands == ["claude --version"]
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 def test_provision_raises_on_version_mismatch(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
@@ -3213,6 +3355,18 @@ def test_provision_raises_on_version_mismatch(
         )
 
         # Simulate a host where claude is installed but at a different version.
+        # FakeHost executes commands as real subprocesses, so it cannot return a
+        # canned `claude --version`; we keep a SimpleNamespace for the controlled
+        # version output but give write_file a real implementation that writes to
+        # disk. This lets the background-script provisioning threads (which call
+        # host.write_file) complete cleanly instead of silently swallowing the
+        # write, which previously left a thread raising an unhandled exception
+        # (the reason the PytestUnhandledThreadExceptionWarning filter was needed).
+        def _real_write_file(path: Path, content: bytes, mode: str | None = None) -> None:
+            del mode
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+
         host_with_wrong_version = cast(
             OnlineHostInterface,
             SimpleNamespace(
@@ -3222,7 +3376,7 @@ def test_provision_raises_on_version_mismatch(
                     stdout="2.1.50 (Claude Code)\n",
                     stderr="",
                 ),
-                write_file=lambda *args, **kwargs: None,
+                write_file=_real_write_file,
             ),
         )
 
@@ -3235,6 +3389,19 @@ def test_provision_raises_on_version_mismatch(
         assert "Claude version mismatch" in str(exc_info.value.main_exception)
 
 
+def _install_clause_tokens(install_command: str, marker: str) -> list[str]:
+    """Return the shlex-parsed tokens of the `&&`-joined clause containing ``marker``.
+
+    _install_claude builds a single string of clauses joined by ` && `. Parsing
+    the relevant clause into tokens lets the install-command tests assert on the
+    semantically load-bearing arguments (e.g. presence/absence of a version arg)
+    without pinning the exact whitespace or clause ordering of the full string.
+    """
+    clauses = [clause for clause in install_command.split(" && ") if marker in clause]
+    assert len(clauses) == 1, f"Expected exactly one clause containing {marker!r}, got {clauses!r}"
+    return shlex.split(clauses[0])
+
+
 def test_install_claude_passes_version_to_command() -> None:
     """_install_claude should pass the version as a positional arg to the install script."""
     host, executed_commands = _make_command_tracking_host()
@@ -3242,7 +3409,11 @@ def test_install_claude_passes_version_to_command() -> None:
     _install_claude(host, version="2.1.50")
 
     assert len(executed_commands) == 1
-    assert "install_claude.sh 2.1.50" in executed_commands[0]
+    tokens = _install_clause_tokens(executed_commands[0], "bash /tmp/install_claude.sh")
+    # bash <script> <version>: the version must follow the install script path.
+    script_index = tokens.index("/tmp/install_claude.sh")
+    assert tokens[:script_index] == ["bash"]
+    assert tokens[script_index + 1 :] == ["2.1.50"]
 
 
 def test_install_claude_without_version() -> None:
@@ -3252,8 +3423,9 @@ def test_install_claude_without_version() -> None:
     _install_claude(host, version=None)
 
     assert len(executed_commands) == 1
-    # The bash invocation should have no version arg after the script name
-    assert "bash /tmp/install_claude.sh &&" in executed_commands[0]
+    tokens = _install_clause_tokens(executed_commands[0], "bash /tmp/install_claude.sh")
+    # bash <script> with no trailing positional version argument.
+    assert tokens == ["bash", "/tmp/install_claude.sh"]
 
 
 def test_install_claude_verifies_binary_exists() -> None:
@@ -3263,7 +3435,10 @@ def test_install_claude_verifies_binary_exists() -> None:
     _install_claude(host, version=None)
 
     assert len(executed_commands) == 1
-    assert "test -x $HOME/.local/bin/claude" in executed_commands[0]
+    # The installer must verify the binary it placed under CLAUDE_INSTALL_PATH is
+    # executable; anchor to the imported constant rather than a hand-typed literal.
+    tokens = _install_clause_tokens(executed_commands[0], "test -x")
+    assert tokens == ["test", "-x", f"{CLAUDE_INSTALL_PATH}/claude"]
 
 
 # =============================================================================
@@ -4618,10 +4793,11 @@ def test_modify_env_vars_sets_claude_config_dirs(
     agent.modify_env_vars(host, env_vars)
 
     assert env_vars["CLAUDE_CONFIG_DIR"] == str(agent.get_claude_config_dir())
-    # ORIGINAL_CLAUDE_CONFIG_DIR points at the user's real ~/.claude dir -- we
-    # only assert it is set to a non-empty string; the exact path depends on
-    # the running user's $HOME and is not load-bearing for this test.
-    assert env_vars["ORIGINAL_CLAUDE_CONFIG_DIR"]
+    # ORIGINAL_CLAUDE_CONFIG_DIR points at the user's real ~/.claude dir. The
+    # autouse home-isolation fixture redirects $HOME to a temp dir and clears
+    # $CLAUDE_CONFIG_DIR / $ORIGINAL_CLAUDE_CONFIG_DIR, so the resolved value is
+    # known: it must be exactly ~/.claude (not, e.g., the per-agent config dir).
+    assert env_vars["ORIGINAL_CLAUDE_CONFIG_DIR"] == str(Path.home() / ".claude")
 
 
 def test_modify_env_vars_omits_claude_config_dir_in_shared_mode(

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -2601,7 +2601,6 @@ _NO_CREDENTIALS_WARNING_SUBSTRING = "No API credentials detected for Claude Code
 
 
 @pytest.mark.usefixtures("_no_api_key_in_env")
-@pytest.mark.usefixtures("_no_api_key_in_env")
 def test_on_before_provisioning_does_not_raise_when_no_credentials(
     local_provider: LocalProviderInstance,
     tmp_path: Path,

--- a/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 # -- Helpers --
 
@@ -182,7 +183,8 @@ def test_empty_input_file_produces_no_output(tmp_path: Path, stub_mngr_log_sh: s
 
 def test_converts_user_text_message(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    runner.write_input([_make_user_event("uuid-1", "2026-01-01T00:00:00Z", text="Hello")])
+    user_uuid = uuid4().hex
+    runner.write_input([_make_user_event(user_uuid, "2026-01-01T00:00:00Z", text="Hello")])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -191,13 +193,14 @@ def test_converts_user_text_message(tmp_path: Path, stub_mngr_log_sh: str) -> No
     assert len(events) == 1
     assert events[0]["type"] == "user_message"
     assert events[0]["content"] == "Hello"
-    assert events[0]["event_id"] == "uuid-1-user"
+    assert events[0]["event_id"] == f"{user_uuid}-user"
     assert events[0]["source"] == "claude/common_transcript"
 
 
 def test_converts_assistant_message(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    runner.write_input([_make_assistant_event("uuid-2", "2026-01-01T00:00:01Z", text="Hi there!")])
+    assistant_uuid = uuid4().hex
+    runner.write_input([_make_assistant_event(assistant_uuid, "2026-01-01T00:00:01Z", text="Hi there!")])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -207,19 +210,20 @@ def test_converts_assistant_message(tmp_path: Path, stub_mngr_log_sh: str) -> No
     assert events[0]["type"] == "assistant_message"
     assert events[0]["text"] == "Hi there!"
     assert events[0]["model"] == "claude-opus-4.6"
-    assert events[0]["event_id"] == "uuid-2-assistant"
+    assert events[0]["event_id"] == f"{assistant_uuid}-assistant"
     assert events[0]["stop_reason"] == "end_turn"
     assert events[0]["usage"]["input_tokens"] == 100
 
 
 def test_converts_tool_calls(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
     runner.write_input(
         [
             _make_assistant_event(
-                "uuid-3",
+                uuid4().hex,
                 "2026-01-01T00:00:02Z",
-                tool_calls=[{"id": "toolu_1", "name": "Read", "input": {"file": "test.txt"}}],
+                tool_calls=[{"id": tool_call_id, "name": "Read", "input": {"file": "test.txt"}}],
                 stop_reason="tool_use",
             )
         ]
@@ -232,21 +236,22 @@ def test_converts_tool_calls(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     assert len(events) == 1
     assert len(events[0]["tool_calls"]) == 1
     assert events[0]["tool_calls"][0]["tool_name"] == "Read"
-    assert events[0]["tool_calls"][0]["tool_call_id"] == "toolu_1"
+    assert events[0]["tool_calls"][0]["tool_call_id"] == tool_call_id
 
 
 def test_converts_tool_results(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
     assistant = _make_assistant_event(
-        "uuid-4",
+        uuid4().hex,
         "2026-01-01T00:00:03Z",
-        tool_calls=[{"id": "toolu_2", "name": "Bash"}],
+        tool_calls=[{"id": tool_call_id, "name": "Bash"}],
         stop_reason="tool_use",
     )
     user = _make_user_event(
-        "uuid-5",
+        uuid4().hex,
         "2026-01-01T00:00:04Z",
-        tool_results=[{"tool_use_id": "toolu_2", "content": "output text", "is_error": False}],
+        tool_results=[{"tool_use_id": tool_call_id, "content": "output text", "is_error": False}],
     )
     runner.write_input([assistant, user])
 
@@ -257,7 +262,7 @@ def test_converts_tool_results(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     assert len(events) == 2
     tool_results = [e for e in events if e["type"] == "tool_result"]
     assert len(tool_results) == 1
-    assert tool_results[0]["tool_call_id"] == "toolu_2"
+    assert tool_results[0]["tool_call_id"] == tool_call_id
     assert tool_results[0]["tool_name"] == "Bash"
     assert tool_results[0]["output"] == "output text"
     assert tool_results[0]["is_error"] is False
@@ -265,12 +270,13 @@ def test_converts_tool_results(tmp_path: Path, stub_mngr_log_sh: str) -> None:
 
 def test_deduplicates_by_event_id(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    runner.write_input([_make_user_event("uuid-1", "2026-01-01T00:00:00Z", text="Hello")])
+    user_uuid = uuid4().hex
+    runner.write_input([_make_user_event(user_uuid, "2026-01-01T00:00:00Z", text="Hello")])
 
     # Pre-populate output with the same event_id
     runner.output_file.parent.mkdir(parents=True, exist_ok=True)
     runner.output_file.write_text(
-        json.dumps({"event_id": "uuid-1-user", "type": "user_message", "content": "Hello"}) + "\n"
+        json.dumps({"event_id": f"{user_uuid}-user", "type": "user_message", "content": "Hello"}) + "\n"
     )
 
     result = runner.run_single_pass()
@@ -282,25 +288,33 @@ def test_deduplicates_by_event_id(tmp_path: Path, stub_mngr_log_sh: str) -> None
 
 
 def test_skips_progress_events(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A progress event is dropped while a sibling user message in the same input survives."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
     progress = json.dumps(
         {
             "type": "progress",
-            "uuid": "prog-1",
+            "uuid": uuid4().hex,
             "timestamp": "2026-01-01T00:00:00Z",
             "data": {"type": "bash_progress"},
         }
     )
-    runner.write_input([progress])
+    good_uuid = uuid4().hex
+    good = _make_user_event(good_uuid, "2026-01-01T00:00:01Z", text="kept")
+    runner.write_input([progress, good])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert runner.get_output_events() == []
+
+    events = runner.get_output_events()
+    assert len(events) == 1
+    assert events[0]["type"] == "user_message"
+    assert events[0]["content"] == "kept"
+    assert events[0]["event_id"] == f"{good_uuid}-user"
 
 
 def test_handles_malformed_json(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    valid = _make_user_event("uuid-1", "2026-01-01T00:00:00Z", text="valid")
+    valid = _make_user_event(uuid4().hex, "2026-01-01T00:00:00Z", text="valid")
     runner.write_input(["not json", valid])
 
     result = runner.run_single_pass()
@@ -312,34 +326,64 @@ def test_handles_malformed_json(tmp_path: Path, stub_mngr_log_sh: str) -> None:
 
 
 def test_skips_events_without_uuid(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """An event missing uuid is dropped while a sibling valid event survives."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
     no_uuid = json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z", "message": {"content": "hi"}})
-    runner.write_input([no_uuid])
+    good_uuid = uuid4().hex
+    good = _make_user_event(good_uuid, "2026-01-01T00:00:01Z", text="kept")
+    runner.write_input([no_uuid, good])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert runner.get_output_events() == []
+
+    events = runner.get_output_events()
+    assert len(events) == 1
+    assert events[0]["type"] == "user_message"
+    assert events[0]["content"] == "kept"
+    assert events[0]["event_id"] == f"{good_uuid}-user"
+
+
+def test_skips_events_without_timestamp(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """An event missing timestamp is dropped while a sibling valid event survives.
+
+    This exercises the timestamp branch of the `if not uuid or not timestamp` guard.
+    """
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    no_timestamp = json.dumps({"type": "user", "uuid": uuid4().hex, "message": {"content": "hi"}})
+    good_uuid = uuid4().hex
+    good = _make_user_event(good_uuid, "2026-01-01T00:00:01Z", text="kept")
+    runner.write_input([no_timestamp, good])
+
+    result = runner.run_single_pass()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    events = runner.get_output_events()
+    assert len(events) == 1
+    assert events[0]["type"] == "user_message"
+    assert events[0]["content"] == "kept"
+    assert events[0]["event_id"] == f"{good_uuid}-user"
 
 
 def test_user_with_text_and_tool_results(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     """A user message with both text and tool results should emit both."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
     assistant = _make_assistant_event(
-        "uuid-a",
+        uuid4().hex,
         "2026-01-01T00:00:01Z",
-        tool_calls=[{"id": "toolu_3", "name": "Edit"}],
+        tool_calls=[{"id": tool_call_id, "name": "Edit"}],
         stop_reason="tool_use",
     )
     user = json.dumps(
         {
             "type": "user",
-            "uuid": "uuid-u",
+            "uuid": uuid4().hex,
             "timestamp": "2026-01-01T00:00:02Z",
             "message": {
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "Continue please"},
-                    {"type": "tool_result", "tool_use_id": "toolu_3", "content": "done", "is_error": False},
+                    {"type": "tool_result", "tool_use_id": tool_call_id, "content": "done", "is_error": False},
                 ],
             },
         }
@@ -362,9 +406,9 @@ def test_truncates_tool_input_preview(tmp_path: Path, stub_mngr_log_sh: str) -> 
     runner.write_input(
         [
             _make_assistant_event(
-                "uuid-long",
+                uuid4().hex,
                 "2026-01-01T00:00:00Z",
-                tool_calls=[{"id": "toolu_long", "name": "Read", "input": long_input}],
+                tool_calls=[{"id": f"toolu_{uuid4().hex}", "name": "Read", "input": long_input}],
             )
         ]
     )
@@ -375,22 +419,52 @@ def test_truncates_tool_input_preview(tmp_path: Path, stub_mngr_log_sh: str) -> 
     events = runner.get_output_events()
     assert len(events) == 1
     input_preview = events[0]["tool_calls"][0]["input_preview"]
-    assert len(input_preview) <= 203
+    # Production truncates the compact JSON serialization to exactly _MAX_INPUT_PREVIEW_LENGTH
+    # (200) chars and appends "..." -> 203 chars total.
+    expected_full = json.dumps(long_input, separators=(",", ":"))
+    assert len(input_preview) == 203
+    assert input_preview.endswith("...")
+    assert input_preview[:200] == expected_full[:200]
+
+
+def test_does_not_truncate_short_tool_input_preview(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A short tool input is emitted verbatim with no truncation marker."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    short_input = {"file": "test.txt"}
+    runner.write_input(
+        [
+            _make_assistant_event(
+                uuid4().hex,
+                "2026-01-01T00:00:00Z",
+                tool_calls=[{"id": f"toolu_{uuid4().hex}", "name": "Read", "input": short_input}],
+            )
+        ]
+    )
+
+    result = runner.run_single_pass()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    events = runner.get_output_events()
+    assert len(events) == 1
+    input_preview = events[0]["tool_calls"][0]["input_preview"]
+    assert input_preview == json.dumps(short_input, separators=(",", ":"))
+    assert not input_preview.endswith("...")
 
 
 def test_truncates_long_tool_output(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
     assistant = _make_assistant_event(
-        "uuid-tr",
+        uuid4().hex,
         "2026-01-01T00:00:01Z",
-        tool_calls=[{"id": "toolu_tr", "name": "Read"}],
+        tool_calls=[{"id": tool_call_id, "name": "Read"}],
         stop_reason="tool_use",
     )
     long_output = "x" * 5000
     user = _make_user_event(
-        "uuid-tr2",
+        uuid4().hex,
         "2026-01-01T00:00:02Z",
-        tool_results=[{"tool_use_id": "toolu_tr", "content": long_output, "is_error": False}],
+        tool_results=[{"tool_use_id": tool_call_id, "content": long_output, "is_error": False}],
     )
     runner.write_input([assistant, user])
 
@@ -399,29 +473,61 @@ def test_truncates_long_tool_output(tmp_path: Path, stub_mngr_log_sh: str) -> No
 
     events = runner.get_output_events()
     tool_results = [e for e in events if e["type"] == "tool_result"]
-    assert len(tool_results[0]["output"]) <= 2003
+    output = tool_results[0]["output"]
+    # Production truncates to exactly _MAX_OUTPUT_LENGTH (2000) chars plus "..." -> 2003.
+    assert len(output) == 2003
+    assert output.endswith("...")
+    assert output[:2000] == long_output[:2000]
+
+
+def test_does_not_truncate_short_tool_output(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A short tool output is emitted verbatim with no truncation marker."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
+    assistant = _make_assistant_event(
+        uuid4().hex,
+        "2026-01-01T00:00:01Z",
+        tool_calls=[{"id": tool_call_id, "name": "Read"}],
+        stop_reason="tool_use",
+    )
+    short_output = "all good"
+    user = _make_user_event(
+        uuid4().hex,
+        "2026-01-01T00:00:02Z",
+        tool_results=[{"tool_use_id": tool_call_id, "content": short_output, "is_error": False}],
+    )
+    runner.write_input([assistant, user])
+
+    result = runner.run_single_pass()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    events = runner.get_output_events()
+    tool_results = [e for e in events if e["type"] == "tool_result"]
+    assert tool_results[0]["output"] == short_output
+    assert not tool_results[0]["output"].endswith("...")
 
 
 def test_tool_result_with_list_content(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     """Tool result content can be a list of text blocks."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    tool_call_id = f"toolu_{uuid4().hex}"
     assistant = _make_assistant_event(
-        "uuid-lc",
+        uuid4().hex,
         "2026-01-01T00:00:01Z",
-        tool_calls=[{"id": "toolu_lc", "name": "Read"}],
+        tool_calls=[{"id": tool_call_id, "name": "Read"}],
         stop_reason="tool_use",
     )
     user = json.dumps(
         {
             "type": "user",
-            "uuid": "uuid-lc2",
+            "uuid": uuid4().hex,
             "timestamp": "2026-01-01T00:00:02Z",
             "message": {
                 "role": "user",
                 "content": [
                     {
                         "type": "tool_result",
-                        "tool_use_id": "toolu_lc",
+                        "tool_use_id": tool_call_id,
                         "content": [{"type": "text", "text": "part 1"}, {"type": "text", "text": "part 2"}],
                         "is_error": False,
                     }
@@ -442,8 +548,8 @@ def test_tool_result_with_list_content(tmp_path: Path, stub_mngr_log_sh: str) ->
 def test_sorts_by_timestamp(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     """Events should be output sorted by timestamp."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    later = _make_user_event("uuid-later", "2026-01-01T00:00:02Z", text="Later")
-    earlier = _make_user_event("uuid-earlier", "2026-01-01T00:00:01Z", text="Earlier")
+    later = _make_user_event(uuid4().hex, "2026-01-01T00:00:02Z", text="Later")
+    earlier = _make_user_event(uuid4().hex, "2026-01-01T00:00:01Z", text="Earlier")
     runner.write_input([later, earlier])
 
     result = runner.run_single_pass()
@@ -461,7 +567,7 @@ def test_cache_read_and_write_tokens(tmp_path: Path, stub_mngr_log_sh: str) -> N
     runner.write_input(
         [
             _make_assistant_event(
-                "uuid-cache",
+                uuid4().hex,
                 "2026-01-01T00:00:00Z",
                 text="Hello",
                 usage={
@@ -487,9 +593,9 @@ def test_unknown_tool_name_defaults(tmp_path: Path, stub_mngr_log_sh: str) -> No
     """Tool results for unknown tool_call_ids should get tool_name='unknown'."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
     user = _make_user_event(
-        "uuid-unk",
+        uuid4().hex,
         "2026-01-01T00:00:01Z",
-        tool_results=[{"tool_use_id": "toolu_unknown", "content": "result", "is_error": False}],
+        tool_results=[{"tool_use_id": f"toolu_{uuid4().hex}", "content": "result", "is_error": False}],
     )
     runner.write_input([user])
 
@@ -504,7 +610,7 @@ def test_unknown_tool_name_defaults(tmp_path: Path, stub_mngr_log_sh: str) -> No
 def test_output_writes_to_correct_path(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     """Output should go to events/claude/common_transcript/events.jsonl."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    runner.write_input([_make_user_event("uuid-1", "2026-01-01T00:00:00Z", text="Hello")])
+    runner.write_input([_make_user_event(uuid4().hex, "2026-01-01T00:00:00Z", text="Hello")])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -522,10 +628,11 @@ def test_meta_user_message_classified_as_meta(tmp_path: Path, stub_mngr_log_sh: 
     human typed it.
     """
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    meta_uuid = uuid4().hex
     feedback = (
         "Stop hook feedback:\n[./scripts/main_claude_stop_hook.sh]: Everything up-to-date\nERROR: Some checks failed"
     )
-    runner.write_input([_make_meta_event("uuid-stop", "2026-01-01T00:00:00Z", text=feedback)])
+    runner.write_input([_make_meta_event(meta_uuid, "2026-01-01T00:00:00Z", text=feedback)])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -534,16 +641,16 @@ def test_meta_user_message_classified_as_meta(tmp_path: Path, stub_mngr_log_sh: 
     assert len(events) == 1
     assert events[0]["type"] == "tool_result"
     assert events[0]["tool_name"] == "meta"
-    assert events[0]["tool_call_id"] == "meta-uuid-stop"
+    assert events[0]["tool_call_id"] == f"meta-{meta_uuid}"
     assert events[0]["output"] == feedback
     assert events[0]["is_error"] is False
-    assert events[0]["event_id"] == "uuid-stop-meta"
+    assert events[0]["event_id"] == f"{meta_uuid}-meta"
 
 
 def test_meta_user_message_truncates_long_output(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
     feedback = "Stop hook feedback:\n" + "x" * 5000
-    runner.write_input([_make_meta_event("uuid-stop2", "2026-01-01T00:00:00Z", text=feedback)])
+    runner.write_input([_make_meta_event(uuid4().hex, "2026-01-01T00:00:00Z", text=feedback)])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -551,7 +658,27 @@ def test_meta_user_message_truncates_long_output(tmp_path: Path, stub_mngr_log_s
     events = runner.get_output_events()
     assert len(events) == 1
     assert events[0]["type"] == "tool_result"
-    assert len(events[0]["output"]) <= 2003
+    output = events[0]["output"]
+    # Production truncates to exactly _MAX_OUTPUT_LENGTH (2000) chars plus "..." -> 2003.
+    assert len(output) == 2003
+    assert output.endswith("...")
+    assert output[:2000] == feedback[:2000]
+
+
+def test_meta_user_message_does_not_truncate_short_output(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A short meta message is emitted verbatim with no truncation marker."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    feedback = "Stop hook feedback:\nEverything up-to-date"
+    runner.write_input([_make_meta_event(uuid4().hex, "2026-01-01T00:00:00Z", text=feedback)])
+
+    result = runner.run_single_pass()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    events = runner.get_output_events()
+    assert len(events) == 1
+    assert events[0]["type"] == "tool_result"
+    assert events[0]["output"] == feedback
+    assert not events[0]["output"].endswith("...")
 
 
 def test_meta_user_message_with_list_content(tmp_path: Path, stub_mngr_log_sh: str) -> None:
@@ -560,7 +687,7 @@ def test_meta_user_message_with_list_content(tmp_path: Path, stub_mngr_log_sh: s
     user = json.dumps(
         {
             "type": "user",
-            "uuid": "uuid-stop-list",
+            "uuid": uuid4().hex,
             "timestamp": "2026-01-01T00:00:00Z",
             "isMeta": True,
             "message": {
@@ -617,7 +744,7 @@ def test_user_text_quoting_stop_hook_marker_without_is_meta_stays_user(tmp_path:
     runner.write_input(
         [
             _make_user_event(
-                "uuid-quote",
+                uuid4().hex,
                 "2026-01-01T00:00:00Z",
                 text="Stop hook feedback:\nplease explain what this means",
             )
@@ -635,14 +762,14 @@ def test_user_text_quoting_stop_hook_marker_without_is_meta_stays_user(tmp_path:
 def test_incremental_conversion(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     """Running twice with new input should append without duplicates."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
-    runner.write_input([_make_user_event("uuid-1", "2026-01-01T00:00:00Z", text="First")])
+    runner.write_input([_make_user_event(uuid4().hex, "2026-01-01T00:00:00Z", text="First")])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"
     assert len(runner.get_output_events()) == 1
 
     # Append a new event to input
-    runner.append_input([_make_user_event("uuid-2", "2026-01-01T00:00:01Z", text="Second")])
+    runner.append_input([_make_user_event(uuid4().hex, "2026-01-01T00:00:01Z", text="Second")])
 
     result = runner.run_single_pass()
     assert result.returncode == 0, f"stderr: {result.stderr}"

--- a/libs/mngr_claude/imbue/mngr_claude/resources/stream_transcript_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/stream_transcript_test.py
@@ -433,11 +433,14 @@ def test_duplicate_session_id_in_history(tmp_path: Path, stub_mngr_log_sh: str, 
     assert runner.get_output_uuids() == uuids
 
 
-@pytest.mark.parametrize("line_count", [1, 10, 50])
+# The empty-file (0-line) boundary is covered by test_empty_session_file, so this
+# only exercises a single representative non-zero size; 10/50 walked the identical
+# code path and were redundant.
+@pytest.mark.parametrize("line_count", [10])
 def test_various_file_sizes(
     tmp_path: Path, stub_mngr_log_sh: str, mngr_transcript_lib_sh: str, line_count: int
 ) -> None:
-    """The script should handle session files of various sizes."""
+    """The script should handle a multi-line session file."""
     runner = ScriptRunner(tmp_path, stub_mngr_log_sh, mngr_transcript_lib_sh)
     uuids = [uuid4().hex for _ in range(line_count)]
     lines = [_make_jsonl_line(u) for u in uuids]

--- a/libs/mngr_claude/imbue/mngr_claude/skill_agent_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/skill_agent_test.py
@@ -1,17 +1,23 @@
 """Tests for skill-provisioned agent types (code-guardian, fixme-fairy)."""
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pluggy
 import pytest
+from pydantic import Field
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.agents.agent_registry import list_registered_agent_types
+from imbue.mngr.api.testing import FakeHost
 from imbue.mngr.config.agent_class_registry import get_agent_class
 from imbue.mngr.config.agent_config_registry import get_agent_config_class
 from imbue.mngr.config.agent_config_registry import resolve_agent_type
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.interfaces.data_types import CommandResult
+from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import CommandString
 from imbue.mngr.utils.testing import make_mngr_ctx
@@ -28,6 +34,7 @@ from imbue.mngr_claude.plugin import ClaudeAgentConfig
 from imbue.mngr_claude.skill_agent import SkillProvisionedAgent
 from imbue.mngr_claude.skill_agent import SkillProvisionedAgentConfig
 from imbue.mngr_claude.skill_agent import _install_skill_locally
+from imbue.mngr_claude.skill_agent import _install_skill_remotely
 
 # Each tuple: (type_name, agent_class, config_class, skill_name, skill_content)
 _SKILL_AGENTS = [
@@ -181,15 +188,29 @@ def test_skill_content_has_valid_frontmatter(
 
 
 @pytest.mark.parametrize("type_name,agent_class,config_class,skill_name,skill_content", _SKILL_AGENTS)
-def test_skill_content_is_substantial(
+def test_skill_content_has_instructional_body(
     type_name: str,
     agent_class: type,
     config_class: type,
     skill_name: str,
     skill_content: str,
 ) -> None:
-    """The skill content should be a meaningful set of instructions."""
-    assert len(skill_content) > 100
+    """The skill content should have an instructional body beyond its frontmatter."""
+    second_separator = skill_content.index("---", 4)
+    body = skill_content[second_separator + 3 :]
+    # A real skill body has at least one markdown section heading of instructions.
+    assert "## " in body
+
+
+@pytest.mark.parametrize("type_name,agent_class,config_class,skill_name,skill_content", _SKILL_AGENTS)
+def test_skill_name_matches_registered_type_name(
+    type_name: str,
+    agent_class: type,
+    config_class: type,
+    skill_name: str,
+    skill_content: str,
+) -> None:
+    """The installed skill name should match the registered agent type name."""
     assert skill_name == type_name
 
 
@@ -277,16 +298,15 @@ def test_install_skill_locally_skips_when_content_unchanged(
     skill_content: str,
     temp_mngr_ctx: MngrContext,
 ) -> None:
-    """When skill content is already up to date, installation should be skipped."""
+    """When skill content is already up to date, installation should leave the file untouched."""
     skill_path = Path.home() / ".claude" / "skills" / skill_name / "SKILL.md"
     skill_path.parent.mkdir(parents=True, exist_ok=True)
     skill_path.write_text(skill_content)
-    original_mtime = skill_path.stat().st_mtime
 
     _install_skill_locally(skill_name, skill_content, temp_mngr_ctx)
 
-    # File should not have been rewritten (mtime unchanged)
-    assert skill_path.stat().st_mtime == original_mtime
+    # The file content must be exactly the already-installed content (not rewritten).
+    assert skill_path.read_text() == skill_content
 
 
 @pytest.mark.parametrize("skill_name,skill_content", _SKILL_CONTENTS)
@@ -332,24 +352,44 @@ def test_skill_provisioned_agent_config_accepts_custom_command() -> None:
     assert config.command == CommandString("custom-agent")
 
 
-# -- Direct _install_skill_locally tests --
+# -- Remote skill installation tests --
 
 
-def test_install_skill_locally_skips_when_content_matches(
-    temp_mngr_ctx: MngrContext,
-) -> None:
-    """_install_skill_locally should skip writing when the existing content matches.
+class _RecordingFakeHost(FakeHost):
+    """FakeHost that records skill writes and idempotent commands without touching disk.
 
-    Note: Path.home() is isolated to a temp directory by the autouse
-    setup_test_mngr_env fixture, so this test writes to tmp_path/.claude/,
-    not the real home directory.
+    _install_skill_remotely writes to a relative ``.claude/skills/...`` path; recording
+    the calls (instead of letting FakeHost write to the process cwd) keeps the test
+    hermetic while still asserting the exact path and content that would be written.
     """
-    skill_path = Path.home() / ".claude" / "skills" / "skip-test-skill" / "SKILL.md"
-    skill_path.parent.mkdir(parents=True, exist_ok=True)
-    skill_path.write_text("same content")
-    original_mtime = skill_path.stat().st_mtime
 
-    _install_skill_locally("skip-test-skill", "same content", temp_mngr_ctx)
+    written_files: list[tuple[Path, str]] = Field(default_factory=list, description="(path, content) writes")
+    idempotent_commands: list[str] = Field(default_factory=list, description="Recorded idempotent commands")
 
-    assert skill_path.stat().st_mtime == original_mtime
-    assert skill_path.read_text() == "same content"
+    def execute_idempotent_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        self.idempotent_commands.append(command)
+        return CommandResult(stdout="", stderr="", success=True)
+
+    def write_text_file(self, path: Path, content: str, encoding: str = "utf-8", mode: str | None = None) -> None:
+        self.written_files.append((path, content))
+
+
+@pytest.mark.parametrize("skill_name,skill_content", _SKILL_CONTENTS)
+def test_install_skill_remotely_writes_skill_file_and_creates_dir(
+    skill_name: str,
+    skill_content: str,
+) -> None:
+    """_install_skill_remotely should write the skill to the host's .claude/skills path and mkdir it."""
+    host = _RecordingFakeHost()
+
+    _install_skill_remotely(skill_name, skill_content, cast(OnlineHostInterface, host))
+
+    assert host.written_files == [(Path(f".claude/skills/{skill_name}/SKILL.md"), skill_content)]
+    assert any(f"mkdir -p ~/.claude/skills/{skill_name}" == command for command in host.idempotent_commands)

--- a/libs/mngr_claude/imbue/mngr_claude/test_adopt_session.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_adopt_session.py
@@ -342,7 +342,12 @@ def _verify_adopted_context(
     with ``mngr message`` after startup. ``mngr destroy`` is invoked on the
     way out regardless of success.
     """
-    create_result = _run(
+    # ``_run`` defaults to ``check=True``, so a non-zero ``mngr create`` exit
+    # already fails the test with full stdout/stderr -- create-success is
+    # verified structurally here, without coupling to mngr's "Done." log
+    # wording. The load-bearing behavioral check is the secret recall in the
+    # destination agent's pane below.
+    _run(
         [
             "uv",
             "run",
@@ -364,9 +369,6 @@ def _verify_adopted_context(
         ],
         env=env,
         timeout=float(_PROVISION_TIMEOUT_SECONDS),
-    )
-    assert "Done." in create_result.stdout, (
-        f"Expected 'Done.' in mngr create stdout. stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
     )
     try:
         _run(

--- a/libs/mngr_claude/imbue/mngr_claude/test_background_tasks_prefix_collision.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_background_tasks_prefix_collision.py
@@ -115,3 +115,19 @@ def test_claude_background_tasks_exits_when_target_session_is_gone_despite_prefi
         f"Background script exited non-zero: returncode={result.returncode}\n"
         f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
     )
+
+    # returncode == 0 alone cannot distinguish "exited because the target
+    # session is gone (correct)" from "exited 0 for an unrelated early reason"
+    # (e.g. a pidfile-collision early-exit at the top of the script). The
+    # final ``log_info "... (session ended)"`` is only reached after the
+    # polling loop's exact-match ``has-session`` check fails and the loop body
+    # never runs, so its presence proves the script took the gone-session path
+    # rather than short-circuiting earlier. ``log_info`` writes JSONL to the
+    # events log (not stdout), so we assert against that file.
+    events_log = state_dir_with_log_lib / "events" / "logs" / "claude_background_tasks" / "events.jsonl"
+    assert events_log.exists(), f"Expected background-tasks events log at {events_log}"
+    events_text = events_log.read_text()
+    assert "(session ended)" in events_text, (
+        "Expected the script to reach its gone-session exit log line "
+        f"'... (session ended)'. Events log contents:\n{events_text}"
+    )

--- a/libs/mngr_claude/imbue/mngr_claude/test_claude_agent_dialog.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_claude_agent_dialog.py
@@ -10,6 +10,11 @@ from imbue.mngr.utils.testing import cleanup_tmux_session
 from imbue.mngr_claude.plugin import DialogDetectedError
 from imbue.mngr_claude.plugin_test import make_claude_agent
 
+# The fake tmux sessions these tests drive just need to stay alive long enough
+# for the assertions to run; the exact duration is irrelevant. A large value
+# keeps the session from exiting mid-test (the ``finally`` blocks kill it).
+_KEEP_ALIVE_SLEEP_SECONDS = 847601
+
 
 @pytest.mark.acceptance
 @pytest.mark.tmux
@@ -22,7 +27,7 @@ def test_send_message_raises_dialog_detected_when_dialog_visible(
 
     try:
         agent.host.execute_idempotent_command(
-            f"tmux new-session -d -s '{session_name}' 'echo \"Yes, I trust this folder\"; sleep 847601'",
+            f"tmux new-session -d -s '{session_name}' 'echo \"Yes, I trust this folder\"; sleep {_KEEP_ALIVE_SLEEP_SECONDS}'",
             timeout_seconds=5.0,
         )
 
@@ -56,7 +61,7 @@ def test_send_message_does_not_raise_dialog_detected_when_no_dialog(
 
     try:
         agent.host.execute_idempotent_command(
-            f"tmux new-session -d -s '{session_name}' 'echo \"Normal output here\"; sleep 847602'",
+            f"tmux new-session -d -s '{session_name}' 'echo \"Normal output here\"; sleep {_KEEP_ALIVE_SLEEP_SECONDS}'",
             timeout_seconds=5.0,
         )
 
@@ -66,9 +71,21 @@ def test_send_message_does_not_raise_dialog_detected_when_no_dialog(
             error_message="Content not visible in pane",
         )
 
-        # Should NOT raise DialogDetectedError. Will raise SendMessageError
-        # because there's no real Claude Code process to handle the input.
-        with pytest.raises(SendMessageError) as exc_info:
+        # The dialog preflight must clear (no dialog is present), after which
+        # send_message proceeds to the paste/submit phase. With no real Claude
+        # process, that phase deterministically times out -- either
+        # wait_for_paste_visible ("Timeout waiting for pasted content to
+        # appear") or the per-session submit hook in _send_enter_and_validate
+        # ("Timeout waiting for message submission signal"). Both raise the
+        # base SendMessageError with a "Timeout waiting for" reason, which a
+        # DialogDetectedError ("A dialog is blocking the agent's input ...")
+        # never contains. Matching that substring therefore proves the failure
+        # came from the downstream send path, not the dialog gate or some
+        # unrelated SendMessageError. We do NOT positively assert that "hello"
+        # reached the pane: the keep-alive session runs a bare `sleep` with no
+        # input handler, so whether the typed text echoes back is not reliable
+        # enough to assert on here.
+        with pytest.raises(SendMessageError, match="Timeout waiting for") as exc_info:
             agent.send_message("hello")
         assert not isinstance(exc_info.value, DialogDetectedError)
     finally:

--- a/libs/mngr_claude/imbue/mngr_claude/test_claude_agent_modal.py
+++ b/libs/mngr_claude/imbue/mngr_claude/test_claude_agent_modal.py
@@ -17,15 +17,11 @@ from imbue.mngr.utils.polling import poll_for_value
 from imbue.mngr.utils.testing import ModalSubprocessTestEnv
 from imbue.mngr.utils.testing import get_short_random_string
 
-
-@pytest.fixture
-def temp_source_dir(tmp_path: Path) -> Path:
-    """Create a temporary source directory for tests."""
-    source_dir = tmp_path / "source"
-    source_dir.mkdir()
-    # Create a simple file so the directory isn't empty
-    (source_dir / "test.txt").write_text("test content")
-    return source_dir
+# The ``temp_source_dir`` fixture is inherited from
+# ``imbue.mngr_modal.conftest`` (registered via ``pytest_plugins``); it
+# creates ``tmp_path/source`` with a ``test.txt`` containing "test content".
+# Do not redefine it here -- a local copy would only duplicate maintenance
+# surface and risk silent drift from the shared definition.
 
 
 def _setup_claude_gitignore(source_dir: Path) -> None:
@@ -263,20 +259,32 @@ def test_claude_agent_provisioning_on_modal(
     4. The agent is created and started successfully
 
     The test uses --dangerously-skip-permissions -p "just say 'hello'" to run
-    a quick, non-interactive claude session. The actual output goes to tmux,
-    so we only verify that the agent was created successfully.
+    a quick, non-interactive claude session, then destroys the agent and
+    asserts a non-empty session JSONL was preserved -- proving claude actually
+    ran on Modal, not merely that provisioning logged the expected strings.
     """
     agent_name = f"test-claude-modal-{get_short_random_string()}"
     _setup_claude_gitignore(temp_source_dir)
 
     result = _create_modal_agent(agent_name, temp_source_dir, modal_subprocess_env)
 
-    # Check that the command succeeded
+    # Check that the command succeeded.
     assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}\nstdout: {result.stdout}"
-    assert "Done." in result.stdout, f"Expected 'Done.' in output: {result.stdout}"
 
-    # Verify that Claude was installed (this message appears in the provisioning output)
-    # This confirms that the claude plugin provisioning hook ran correctly
+    # Destroy the agent so its session files are preserved to the local
+    # host_dir, then assert a non-empty session JSONL exists. This is the
+    # load-bearing check: it can only pass if claude actually started a
+    # session and wrote to it on the Modal host. The provisioning-log
+    # substring below is a secondary, best-effort sanity check.
+    destroy_result = _destroy_modal_agent(agent_name, modal_subprocess_env)
+    assert destroy_result.returncode == 0, (
+        f"Destroy failed with stderr: {destroy_result.stderr}\nstdout: {destroy_result.stdout}"
+    )
+    _assert_sessions_preserved(modal_subprocess_env.host_dir, agent_name)
+
+    # Secondary sanity check: provisioning installed claude. This is an
+    # implementation-detail log string (a reword would break it), so it is
+    # deliberately not the primary assertion.
     combined_output = result.stdout + result.stderr
     assert "Claude installed successfully" in combined_output or "Claude is already installed" in combined_output, (
         f"Expected Claude installation message in output.\nstdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
## Summary

Output of `/identify-bad-tests libs/mngr_claude` followed by fixing the findings. Reviewed all 11 test files in `libs/mngr_claude` against the style guide's testing bar and rewrote tests that passed without establishing correctness. Full findings recorded in `libs/mngr_claude/_tasks/bad-tests/` (gitignored).

Key fixes:
- **Seven `on_before_provisioning` tests asserted nothing** ("did not raise") -- now assert observable effects: config left untouched, missing-credentials warning present/absent (via `capture_loguru`), untrusted worktree rejected.
- **`does-not-extend-trust` tests** asserted the presence of a key the test itself wrote -- now assert the exact set of trusted projects.
- **Transcript truncation tests** used `<=` upper bounds -- now assert exact length + the `...` ellipsis marker, plus short-input non-truncation cases; "skips event" tests now prove only the bad event is dropped and cover the missing-`timestamp` branch.
- **Command-assembly / install-command tests** compared hand-rebuilt exact shell strings -- now assert shlex-parsed tokens / load-bearing flags.
- **Skill-install skip tests** relied on mtime equality (can false-pass) -- now assert file content unchanged; added remote-install coverage. Custom-type resolution test now sets a non-default field to prove it survives the merge.
- **Headless grace-period test** now asserts the poll actually re-checked; removed dead `_patch_agent_as_stopped` calls and a fragile wall-clock timing assertion.
- **claude_config no-op tests** assert content is byte-for-byte unchanged; effort-callout test isolated to the effort dialog.
- **Release/acceptance tests** assert real effects (preserved session JSONL, gone-session exit log) instead of brittle `"Done."` log strings; removed a duplicate `temp_source_dir` fixture; replaced magic `sleep` literals with a named constant.

Also removed an introduced `unittest.mock.patch` of the function under test (used the real no-credentials environment instead, consistent with the sibling unit test).

## Test plan
- `just test-quick libs/mngr_claude` (non-infra markers): **486 passed**.
- Ratchets: **55 passed** (no mock/monkeypatch count increase).
- `ty check` + `ruff`: clean.
- Release/acceptance/tmux tests edited conservatively from production code (cannot run locally); will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)