### PR TITLE
Harden suspicious edge-case handling in mngr_latchkey

### DIFF
--- a/libs/mngr_latchkey/changelog/mngr-suspicious-edge-cases-mngr-latchkey-local.md
+++ b/libs/mngr_latchkey/changelog/mngr-suspicious-edge-cases-mngr-latchkey-local.md
@@ -1,0 +1,20 @@
+Hardened suspicious edge-case handling across the latchkey package:
+
+- `DiscoveryStreamConsumer` now subscripts `_provider_by_agent_id` directly
+  (rather than defaulting to `"unknown"`) so a broken host/provider tracking
+  invariant surfaces loudly instead of injecting a synthetic provider name.
+- `link_opaque_permissions_to_host` now refuses to overwrite the canonical
+  host permissions path when it is unexpectedly a symlink, instead of silently
+  clobbering it.
+- The `services.json` generator (`generate_services_json.py`) now raises on a
+  detent schema whose `required`/`properties` field is present but wrong-typed,
+  rather than coercing it to empty and skewing the scope/permission catalog.
+- Added clarifying comments documenting why several deliberately-defensive
+  handlers behave as they do (broad callback-isolation catch in the discovery
+  stream, the gateway-start log-and-continue path, malformed-record recovery in
+  `load_forward_info`, the stderr-substring auth-browser retry gate, the
+  re-checked latchkey binary guard, and the type-narrowing `isinstance` filter
+  in `_parse_auth_options`).
+
+No user-facing behavior change in normal flows; the new raises only fire on
+previously-silent "shouldn't happen" states.

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/core.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/core.py
@@ -273,6 +273,11 @@ def _parse_auth_options(payload: Mapping[str, object], service_name: str) -> fro
             raw_options,
         )
         return frozenset()
+    # The guard above already proves every element is a ``str`` at runtime, but
+    # ty cannot propagate the ``all(isinstance(...))`` check into the element
+    # type (``raw_options`` stays ``list[object]``). The per-element
+    # ``isinstance`` filter is what narrows it back to ``str`` for the type
+    # checker; it is a no-op at runtime, not dead defensive code.
     return frozenset(option for option in raw_options if isinstance(option, str))
 
 
@@ -839,6 +844,13 @@ class Latchkey(MutableModel):
         )
         if is_success:
             return True, ""
+        # The prepare-and-retry path is gated on latchkey's stderr wording: the
+        # upstream CLI exposes no structured "preparation required" signal, so
+        # we sniff for its suggested ``latchkey auth browser-prepare`` command in
+        # the error text. This is a soft contract -- if upstream rewords the
+        # message we degrade to "surface the original error, no auto-retry"
+        # (never to incorrect behaviour). Prefer a machine-readable marker here
+        # if latchkey ever grows one.
         if "latchkey auth browser-prepare" not in detail.lower():
             return False, detail
         logger.info(
@@ -983,6 +995,12 @@ class Latchkey(MutableModel):
         then spawns. Does not mutate ``_info`` or persist the info -- the
         caller is responsible for committing both under the lock.
         """
+        # ``initialize()`` already validated the binary's presence, so this
+        # re-check only covers the narrow race where the binary is removed
+        # between ``initialize()`` and this spawn. Without it the failure still
+        # surfaces -- ``run_process_in_background`` below would raise an
+        # ``OSError`` that we wrap into ``LatchkeyError`` -- but this gives the
+        # cleaner, more specific ``LatchkeyBinaryNotFoundError`` instead.
         if shutil.which(self.latchkey_binary) is None and not Path(self.latchkey_binary).is_file():
             raise LatchkeyBinaryNotFoundError(f"Latchkey binary not found: {self.latchkey_binary}")
 

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/discovery.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/discovery.py
@@ -148,6 +148,13 @@ class LatchkeyDiscoveryHandler(MutableModel):
         try:
             host_side_port = self.latchkey.start_gateway(self.concurrency_group)
         except LatchkeyError as e:
+            # Log-and-return rather than raise: this runs on the discovery
+            # dispatch thread, and ``start_gateway`` is idempotently re-ensured
+            # on every subsequent discovery fire, so a transient failure
+            # self-heals on the next event without us killing the stream. A
+            # truly broken gateway is caught loudly by the eager
+            # ``start_gateway`` call in ``_forward_command`` at startup; here we
+            # only need to not wedge the dispatch loop.
             logger.warning("Failed to start shared Latchkey gateway for agent {}: {}", agent_id, e)
             return
 

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/discovery_stream.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/discovery_stream.py
@@ -251,8 +251,15 @@ class DiscoveryStreamConsumer(MutableModel):
         host_id_str = str(event.host_id)
         with self._lock:
             self._ssh_by_host_id[host_id_str] = ssh_info
+            # ``_host_id_by_agent_id`` and ``_provider_by_agent_id`` are always
+            # mutated together under ``_lock`` (set together in
+            # ``_handle_agent_discovered`` / ``_handle_full_snapshot``, popped
+            # together in ``_destroy_agent``), so every key here is guaranteed
+            # to be in ``_provider_by_agent_id``. Subscript directly so a future
+            # edit that breaks that invariant crashes loudly instead of
+            # injecting a synthetic provider name downstream.
             agents_on_host = [
-                (AgentId(aid_str), self._provider_by_agent_id.get(aid_str, "unknown"))
+                (AgentId(aid_str), self._provider_by_agent_id[aid_str])
                 for aid_str, hid_str in self._host_id_by_agent_id.items()
                 if hid_str == host_id_str
             ]
@@ -294,6 +301,17 @@ class DiscoveryStreamConsumer(MutableModel):
                 return None
             return self._ssh_by_host_id.get(host_id)
 
+    # The two ``_safely_call_*`` dispatchers run on the single observe-output
+    # thread, so an exception escaping a callback would kill the entire
+    # discovery stream -- after which no further agent comes or goes events are
+    # processed for the lifetime of the supervisor. We deliberately isolate
+    # each callback: a misbehaving handler must not take the stream down with
+    # it. The caught set covers the failure modes a lifecycle handler can
+    # realistically hit -- SSH / filesystem I/O (``OSError``), concurrency-group
+    # state errors raised as ``RuntimeError`` (e.g. ``LatchkeyDiscoveryHandler``
+    # re-raises these from a failed ``start_new_thread`` after rolling back its
+    # pending flag), and ``ValueError`` from event/model construction. Anything
+    # outside this set is treated as a genuine bug and allowed to propagate.
     def _safely_call_discovered(
         self,
         agent_id: AgentId,

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/store.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/store.py
@@ -154,7 +154,15 @@ def update_forward_info_gateway_port(data_dir: Path, gateway_port: int) -> None:
 
 
 def load_forward_info(data_dir: Path) -> LatchkeyForwardInfo | None:
-    """Read the forward supervisor info, or None if missing or malformed."""
+    """Read the forward supervisor info, or None if missing or malformed.
+
+    A malformed / unreadable record is deliberately collapsed into the same
+    ``None`` ("no supervisor") result as an absent one: callers respond to
+    ``None`` by spawning a fresh supervisor, which is the correct recovery for
+    a corrupted record -- a bad on-disk file must not permanently wedge the
+    supervisor. The warning log is the breadcrumb that distinguishes corruption
+    from a normal first-run absence.
+    """
     path = forward_info_path(data_dir)
     if not path.is_file():
         return None
@@ -346,8 +354,18 @@ def link_opaque_permissions_to_host(
     """
     host_path = permissions_path_for_host(data_dir, host_id)
     host_path.parent.mkdir(parents=True, exist_ok=True)
+    # The canonical host path is only ever a real file (written here via
+    # ``os.replace`` or by the gateway's permission writer) or absent. A symlink
+    # there is a "shouldn't happen" state -- refuse to silently clobber it (which
+    # ``os.replace`` in the else-branch would do) so the anomaly surfaces instead
+    # of being papered over.
+    if host_path.is_symlink():
+        raise LatchkeyStoreError(
+            f"Canonical host permissions path {host_path} is unexpectedly a symlink; "
+            f"refusing to overwrite it while linking opaque handle {opaque_path}."
+        )
     try:
-        if host_path.is_file() and not host_path.is_symlink():
+        if host_path.is_file():
             # Re-use case: another agent on the same host already has a
             # permissions file with prior grants. Keep them and discard
             # the freshly-created baseline.

--- a/libs/mngr_latchkey/scripts/generate_services_json.py
+++ b/libs/mngr_latchkey/scripts/generate_services_json.py
@@ -165,10 +165,21 @@ def _is_scope_schema(schema_name: str, schema: Mapping[str, object], file_name: 
     """Whether a detent schema identifies a whole service (a scope) vs. a narrower permission."""
     if file_name == _AWS_SCHEMA_FILE:
         return schema_name in _AWS_SCOPE_SCHEMAS
+    # Distinguish "field absent" (legitimate: no required fields / no
+    # properties) from "field present but wrong-typed" (corrupt detent schema).
+    # Coercing the malformed case to empty would silently flip a schema's
+    # scope/permission classification and skew the generated catalog, so we
+    # raise on it instead of papering over it.
     required = schema.get("required")
-    required_fields = required if isinstance(required, list) else []
+    if required is not None and not isinstance(required, list):
+        raise GenerateServicesError(f"Schema {schema_name!r} in {file_name} has a non-list ``required``: {required!r}")
+    required_fields = required if required is not None else []
     properties = schema.get("properties")
-    property_names = properties if isinstance(properties, dict) else {}
+    if properties is not None and not isinstance(properties, dict):
+        raise GenerateServicesError(
+            f"Schema {schema_name!r} in {file_name} has a non-object ``properties``: {properties!r}"
+        )
+    property_names = properties if properties is not None else {}
     return "domain" in required_fields and "method" not in property_names
 
 


### PR DESCRIPTION
Output of `/identify-suspicious-edge-cases libs/mngr_latchkey`, followed by fixes for the findings.

## Structural fixes (behavior change only in previously-silent "shouldn't happen" states)

1. **`discovery_stream._handle_host_ssh_info`** — replaced `_provider_by_agent_id.get(aid_str, "unknown")` with a direct subscript. The two tracking dicts are always mutated together under `_lock`, so the `"unknown"` default was dead; the subscript now crashes loudly if a future edit breaks that invariant instead of injecting a synthetic provider name downstream.
2. **`store.link_opaque_permissions_to_host`** — raises `LatchkeyStoreError` if the canonical host permissions path is unexpectedly a symlink, instead of letting the else-branch `os.replace` silently clobber it.
3. **`generate_services_json._is_scope_schema`** — distinguishes "field absent" (legitimate) from "field present but wrong-typed" (corrupt detent schema) and raises on the latter, rather than coercing to empty and silently flipping a schema's scope/permission classification.

## Clarifying comments (no behavior change) for deliberately-defensive handlers

- Broad `(OSError, RuntimeError, ValueError)` callback-isolation catch in `_safely_call_*`.
- `LatchkeyDiscoveryHandler.__call__` log-and-continue on gateway-start failure.
- `load_forward_info` treating malformed records as absent (crash-recovery).
- `auth_browser` retry gated on latchkey's stderr wording (soft upstream contract).
- `_spawn_gateway` re-checking the binary (covers the removed-after-`initialize()` race).
- `_parse_auth_options` per-element `isinstance` filter (load-bearing for `ty`, not dead defense — an over-report kept and documented).

The full findings report lives in the gitignored `libs/mngr_latchkey/_tasks/suspicious-edge-cases/`.

## Testing
- `just test-quick "libs/mngr_latchkey -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 260 passed, 0 failed.
- `uv run ty check` on all modified files — all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)