### PR TITLE
Harden suspicious edge cases in concurrency_group

### DIFF
--- a/libs/concurrency_group/changelog/mngr-suspicious-edge-cases-concurrency-group-local.md
+++ b/libs/concurrency_group/changelog/mngr-suspicious-edge-cases-concurrency-group-local.md
@@ -1,0 +1,6 @@
+Hardened several suspicious edge-case handlers in the concurrency_group library:
+
+- `ShutdownEvent.wait` now reports the event's true state when it cannot acquire the internal busy-wait lock within the timeout, instead of always returning `False` (which could tell a caller "not shutting down" while a shutdown was already in progress).
+- `run_local_command_modern_version` only labels a process as timed-out when it was actually killed for exceeding its deadline; a process that exits on its own near the deadline boundary is no longer mislabeled (which previously could surface a spurious `ProcessTimeoutError`).
+- The subprocess initialization-success callback is no longer inside the broad failure-reporting `try`, removing a latent double-notification path.
+- Replaced an unreachable `ProcessSetupError` fallback in `RunningProcess.wait` with an assertion, and added clarifying comments to a few intentional defensive branches.

--- a/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
+++ b/libs/concurrency_group/imbue/concurrency_group/concurrency_group.py
@@ -307,6 +307,11 @@ class ConcurrencyGroup(MutableModel, AbstractContextManager):
         ancestor_exception = self._maybe_get_closest_ancestor_exception()
         if ancestor_exception is not None:
             if not isinstance(ancestor_exception, Exception):
+                # A non-Exception BaseException ancestor (e.g. KeyboardInterrupt/SystemExit) means
+                # the whole process is being torn down, so we honor the interrupt immediately. The
+                # local strand failures gathered above are intentionally abandoned here: there is no
+                # caller left to surface them to once the interrupt propagates. (`_exit`, by
+                # contrast, is the final teardown point and so preserves siblings via __context__.)
                 raise ancestor_exception
             exceptions.append(AncestorConcurrentFailure(ancestor_exception))
         if len(exceptions) > 0:
@@ -610,6 +615,8 @@ def _deduplicate_exceptions(exceptions: tuple[Exception, ...]) -> tuple[Exceptio
         if len(with_traceback) > 0:
             deduplicated_process_errors.append(with_traceback[0])
         else:
+            # No error in this bucket carries a traceback (none was raised before being collected).
+            # The duplicates are equivalent for reporting purposes, so any representative will do.
             deduplicated_process_errors.append(bucket[0])
     return tuple(other_exceptions + deduplicated_process_errors)
 

--- a/libs/concurrency_group/imbue/concurrency_group/event_utils.py
+++ b/libs/concurrency_group/imbue/concurrency_group/event_utils.py
@@ -45,7 +45,11 @@ class ShutdownEvent(MutableModel):
         # Don't busy-wait if another thread is already doing so for us.
         acquired = self._wait_lock.acquire(timeout=timeout if timeout is not None else -1)
         if not acquired:
-            return False
+            # We could not get the busy-wait lock within the timeout because another thread is
+            # already polling. That says nothing about whether the event is set, so report the
+            # actual current state rather than an unconditional False (which would let a caller
+            # conclude "not shutting down" while a shutdown is in fact already in progress).
+            return self.is_set()
         try:
             # Use a dummy event for polling instead of time.sleep
             poll_event = Event()

--- a/libs/concurrency_group/imbue/concurrency_group/local_process.py
+++ b/libs/concurrency_group/imbue/concurrency_group/local_process.py
@@ -88,13 +88,11 @@ class RunningProcess:
             stderr = self.read_stderr()
             raise TimeoutExpired(self._command, timeout if timeout is not None else 0.0, stdout, stderr)
         result = self.poll()
-        if result is None:
-            raise ProcessSetupError(
-                command=tuple(self._command),
-                stdout="",
-                stderr="Process exited before being started!",
-                is_output_already_logged=True,
-            )
+        # The thread is no longer alive here (the is_alive guard above would have raised
+        # TimeoutExpired otherwise), so poll() either returns the completed return code or raises
+        # ProcessInvariantError -- it cannot return None. The assert documents that and narrows the
+        # type from `int | None` to `int` for the return below.
+        assert result is not None
         if self._is_checked:
             self.check()
         return result

--- a/libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py
+++ b/libs/concurrency_group/imbue/concurrency_group/subprocess_utils.py
@@ -223,11 +223,14 @@ def run_local_command_modern_version(
                 # Popen failed, so no output was ever streamed regardless of trace_output.
                 is_output_already_logged=False,
             ) from e
-
-        on_initialization_complete(None)
     except BaseException as e:
         on_initialization_complete(e)
         raise
+
+    # Notify success only on the happy path, and outside the try above: if it lived inside the try,
+    # a raise from this call would be caught by the broad handler above and report initialization
+    # twice (the caller's single-slot queue would then raise on the second put).
+    on_initialization_complete(None)
 
     if trace_output:
         assert trace_on_line_callback, "Must pass trace_on_line_callback"
@@ -251,11 +254,13 @@ def run_local_command_modern_version(
 
         timeout_time = time.time() + timeout if timeout is not None else None
 
+        is_completed_normally = False
         while not shutdown_event.wait(poll_time) and not _is_timeout(timeout_time):
             maybe_exit_code = process.poll()
             gatherer.gather_output()
             if maybe_exit_code is not None:
                 exit_code = maybe_exit_code
+                is_completed_normally = True
                 break
         else:
             exit_code = _shutdown_popen(process, command_as_string, shutdown_timeout_sec)
@@ -276,7 +281,10 @@ def run_local_command_modern_version(
             stdout=stdout.decode("utf-8", errors="replace"),
             stderr=stderr.decode("utf-8", errors="replace"),
             command=tuple(command),
-            is_timed_out=_is_timeout(timeout_time),
+            # Only a process we actually killed for running past its deadline is "timed out". A
+            # process that exited on its own (the break path) is never timed out, even if the clock
+            # happens to have crossed timeout_time by the time we build the result here.
+            is_timed_out=_is_timeout(timeout_time) and not is_completed_normally,
             is_output_already_logged=trace_output,
         )
         if is_checked:

--- a/libs/concurrency_group/imbue/concurrency_group/thread_utils.py
+++ b/libs/concurrency_group/imbue/concurrency_group/thread_utils.py
@@ -39,7 +39,7 @@ class ObservableThread(threading.Thread):
         """Initialize ObservableThread."""
         super().__init__(name=name, daemon=daemon)
         self._target = target
-        self._target_name = getattr(target, "__name__", None) if target else None
+        self._target_name = getattr(target, "__name__", None)
         self._args = args
         self._kwargs = kwargs or {}
         self._exception: BaseException | None = None


### PR DESCRIPTION
Cleanup pass from the `identify-suspicious-edge-cases` skill over `libs/concurrency_group`. Each change either fixes a handler that could silently produce a wrong result or documents an intentional defensive branch.

## Fixes
- **`ShutdownEvent.wait`**: when it cannot acquire the internal busy-wait lock within the timeout, it now returns the event's true `is_set()` state instead of an unconditional `False`. Previously a single-shot waiter could be told "not shutting down" while a shutdown was already in progress and another thread held the lock.
- **`run_local_command_modern_version`**: `is_timed_out` is now true only when the process was actually killed for exceeding its deadline. A process that exits on its own right at the deadline boundary is no longer mislabeled as timed-out (which could surface a spurious `ProcessTimeoutError`).
- **subprocess init callback**: `on_initialization_complete(None)` moved out of the broad `BaseException` try, removing a latent double-notification path (which would hit the caller's single-slot queue).
- **`RunningProcess.wait`**: replaced an unreachable `ProcessSetupError` fallback with an `assert` (the thread is already known dead, so `poll()` cannot return `None`); this also narrows the return type to `int`.

## Clarity / docs
- Dropped a redundant `if target` guard in `ObservableThread` (`target` is a required, truthy callable).
- Added comments documenting the intentional defensive branches in `_deduplicate_exceptions` (no-traceback fallback) and `_raise_if_any_strands_or_ancestors_failed` (interrupting-ancestor re-raise).

All 162 local `libs/concurrency_group` tests pass and `ty` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)