### PR TITLE
mngr_lima: strengthen low-value unit tests to verify behavior

### DIFF
--- a/libs/mngr_lima/changelog/mngr-bad-tests-mngr-lima-local.md
+++ b/libs/mngr_lima/changelog/mngr-bad-tests-mngr-lima-local.md
@@ -1,0 +1,21 @@
+Strengthened several low-value Lima provider unit tests so they actually verify
+behavior:
+
+- `LimaHostStore` cache test now mutates the on-disk record behind the cache and
+  asserts that a default read serves the stale value while a cache-bypass or
+  `clear_cache()` reflects the new disk state (previously it could not tell a
+  working cache from a no-op one).
+- Replaced the tautological `LimaSshConfig` constructor test with tests for the
+  `limactl show-ssh` output parser; extracted the parsing loop into a pure
+  `_parse_show_ssh_output` helper to make it unit-testable.
+- `LimaProviderConfig` custom-config test now asserts a JSON round trip
+  (verifying tuple/Path coercions) instead of echoing constructor arguments.
+- `reset_caches` test now asserts the caches are actually emptied; the provider
+  directory test pins the exact path; `get_volume_for_host` test asserts the
+  returned volume is rooted at the host's volume directory.
+- Default Lima YAML test asserts the arch-appropriate default image URL, and the
+  temp-file writer test verifies serialized content and cleans up via
+  `try/finally`.
+
+No user-facing behavior changes; `_parse_show_ssh_output` is a pure refactor of
+existing parsing logic.

--- a/libs/mngr_lima/imbue/mngr_lima/config_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/config_test.py
@@ -36,17 +36,24 @@ def test_run_as_root_with_exposed_volume_layout_is_rejected() -> None:
         LimaProviderConfig(is_run_as_root=True, is_host_data_volume_exposed=True)
 
 
-def test_custom_config() -> None:
+def test_custom_config_survives_json_round_trip() -> None:
+    # A custom config must serialize and deserialize without loss. This guards
+    # the non-obvious coercions the bare constructor does not: the tuple fields
+    # (default_start_args, minimum_lima_version) round-trip through JSON as
+    # lists and must come back as tuples, and host_dir as a Path.
     config = LimaProviderConfig(
         host_dir=Path("/custom/mngr"),
         default_idle_timeout=300,
         default_start_args=("--cpus=2",),
         minimum_lima_version=(1, 2, 0),
     )
-    assert config.host_dir == Path("/custom/mngr")
-    assert config.default_idle_timeout == 300
-    assert config.default_start_args == ("--cpus=2",)
-    assert config.minimum_lima_version == (1, 2, 0)
+
+    reloaded = LimaProviderConfig.model_validate_json(config.model_dump_json())
+
+    assert reloaded == config
+    assert reloaded.host_dir == Path("/custom/mngr")
+    assert reloaded.default_start_args == ("--cpus=2",)
+    assert reloaded.minimum_lima_version == (1, 2, 0)
 
 
 def test_config_backend_is_lima() -> None:

--- a/libs/mngr_lima/imbue/mngr_lima/host_store_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/host_store_test.py
@@ -112,7 +112,7 @@ def test_remove_persisted_agent_data(tmp_path: Path) -> None:
     assert len(store.list_persisted_agent_data_for_host(host_id)) == 0
 
 
-def test_cache_behavior(tmp_path: Path) -> None:
+def test_cache_serves_stale_value_until_bypassed_or_cleared(tmp_path: Path) -> None:
     store = _make_store(tmp_path)
     host_id = HostId.generate()
     certified_data = _make_certified_data(host_id)
@@ -120,16 +120,27 @@ def test_cache_behavior(tmp_path: Path) -> None:
     record = HostRecord(certified_host_data=certified_data, ssh_port=100)
     store.write_host_record(record)
 
-    # Should hit cache
+    # Mutate the on-disk record behind the cache's back so a cache hit and a
+    # disk read return distinguishable values. write_host_record already
+    # populated the in-memory cache with ssh_port=100.
+    mutated = HostRecord(certified_host_data=certified_data, ssh_port=200)
+    store.volume.write_files({f"host_state/{host_id}.json": mutated.model_dump_json(indent=2).encode("utf-8")})
+
+    # A default read is served from the cache, so it still sees the old port.
     cached = store.read_host_record(host_id)
     assert cached is not None
     assert cached.ssh_port == 100
 
-    # Clear cache and re-read from disk
+    # Bypassing the cache reads the freshly-written value from disk.
+    bypassed = store.read_host_record(host_id, use_cache=False)
+    assert bypassed is not None
+    assert bypassed.ssh_port == 200
+
+    # After clearing the cache, even a default read reflects the on-disk value.
     store.clear_cache()
-    from_disk = store.read_host_record(host_id)
-    assert from_disk is not None
-    assert from_disk.ssh_port == 100
+    after_clear = store.read_host_record(host_id)
+    assert after_clear is not None
+    assert after_clear.ssh_port == 200
 
 
 def test_lima_host_config_default_layout_is_bind_mount() -> None:

--- a/libs/mngr_lima/imbue/mngr_lima/instance_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance_test.py
@@ -11,6 +11,7 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotId
 from imbue.mngr.primitives import SnapshotName
+from imbue.mngr.providers.local.volume import LocalVolume
 from imbue.mngr_lima.config import LimaProviderConfig
 from imbue.mngr_lima.errors import LimaHostRenameError
 from imbue.mngr_lima.host_store import HostRecord
@@ -86,9 +87,13 @@ def test_get_volume_for_nonexistent_host(lima_provider: LimaProviderInstance) ->
 
 def test_get_volume_for_existing_host(lima_provider: LimaProviderInstance) -> None:
     host_id = HostId.generate()
-    lima_provider._ensure_host_volume_dir(host_id)
+    volume_dir = lima_provider._ensure_host_volume_dir(host_id)
     volume = lima_provider.get_volume_for_host(host_id)
     assert volume is not None
+    # The returned volume must be rooted at this host's volume directory, not
+    # merely non-None (a bug returning some other host's dir would pass that).
+    assert isinstance(volume.volume, LocalVolume)
+    assert volume.volume.root_path == volume_dir
 
 
 def test_get_volume_for_host_returns_none_for_btrfs_mode_record(lima_provider: LimaProviderInstance) -> None:
@@ -128,16 +133,34 @@ def test_parse_size_to_gb() -> None:
     assert _parse_size_to_gb("invalid") == 4.0  # default fallback
 
 
-def test_reset_caches(lima_provider: LimaProviderInstance) -> None:
-    # Should not raise
+def test_reset_caches_empties_the_host_store_cache(lima_provider: LimaProviderInstance) -> None:
+    host_id = HostId.generate()
+    now = datetime.now(timezone.utc)
+    record = HostRecord(
+        certified_host_data=CertifiedHostData(
+            host_id=str(host_id),
+            host_name="cache-host",
+            user_tags={},
+            snapshots=[],
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    # write_host_record populates the host-store read cache.
+    lima_provider._host_store.write_host_record(record)
+    assert lima_provider._host_store._cache != {}
+
     lima_provider.reset_caches()
 
+    # A no-op reset_caches (e.g. clearing the wrong dict) would leave these full.
+    assert lima_provider._host_store._cache == {}
+    assert lima_provider._host_by_id_cache == {}
 
-def test_provider_dir_structure(lima_provider: LimaProviderInstance) -> None:
-    # Verify the provider directory structure uses the provider name
-    assert "lima-test" in str(lima_provider._provider_dir)
-    assert "providers" in str(lima_provider._provider_dir)
-    assert "lima" in str(lima_provider._provider_dir)
+
+def test_provider_dir_uses_profile_dir_and_provider_name(lima_provider: LimaProviderInstance) -> None:
+    # Pin the full layout rather than asserting loose substrings: the provider
+    # state lives under <profile_dir>/providers/lima/<provider name>.
+    assert lima_provider._provider_dir == lima_provider.mngr_ctx.profile_dir / "providers" / "lima" / "lima-test"
 
 
 def test_ensure_host_keypair_creates_and_is_idempotent(lima_provider: LimaProviderInstance) -> None:

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 from imbue.mngr.errors import MngrError
+from imbue.mngr_lima.constants import DEFAULT_IMAGE_URL_AARCH64
+from imbue.mngr_lima.constants import DEFAULT_IMAGE_URL_X86_64
 from imbue.mngr_lima.lima_yaml import generate_default_lima_yaml
 from imbue.mngr_lima.lima_yaml import load_user_lima_yaml
 from imbue.mngr_lima.lima_yaml import merge_lima_yaml
@@ -40,8 +42,12 @@ def test_generate_default_lima_yaml(tmp_path: Path) -> None:
 
     assert "images" in config
     assert len(config["images"]) == 1
-    assert "location" in config["images"][0]
-    assert "arch" in config["images"][0]
+    # The default image must be the arch-appropriate constant, not just present:
+    # a regression shipping an empty or wrong default URL would otherwise pass.
+    arch = config["images"][0]["arch"]
+    assert arch in ("aarch64", "x86_64")
+    expected_location = DEFAULT_IMAGE_URL_AARCH64 if arch == "aarch64" else DEFAULT_IMAGE_URL_X86_64
+    assert config["images"][0]["location"] == expected_location
 
     assert "mounts" in config
     assert len(config["mounts"]) == 1
@@ -116,12 +122,19 @@ def test_write_lima_yaml(tmp_path: Path) -> None:
 
 
 def test_write_lima_yaml_temp_file() -> None:
+    # The no-path branch deliberately writes to a system temp location, so the
+    # file lives outside tmp_path; the try/finally guarantees cleanup even if an
+    # assertion fails first.
     config = {"images": [{"location": "test.qcow2"}]}
     result = write_lima_yaml(config)
-    assert result.exists()
-    assert result.suffix == ".yaml"
-    # Clean up
-    result.unlink()
+    try:
+        assert result.exists()
+        assert result.suffix == ".yaml"
+        # Verify the file actually holds the serialized config, not just that it
+        # exists with the right extension.
+        assert "test.qcow2" in result.read_text()
+    finally:
+        result.unlink()
 
 
 def test_load_user_lima_yaml(tmp_path: Path) -> None:

--- a/libs/mngr_lima/imbue/mngr_lima/limactl.py
+++ b/libs/mngr_lima/imbue/mngr_lima/limactl.py
@@ -344,13 +344,21 @@ def limactl_show_ssh(
     result = cg.run_process_to_completion(cmd, timeout=timeout)
     if result.returncode != 0:
         raise LimaCommandError("show-ssh", result.returncode, result.stderr)
+    return _parse_show_ssh_output(result.stdout)
 
+
+def _parse_show_ssh_output(stdout: str) -> LimaSshConfig:
+    """Parse `limactl show-ssh --format config` output into a LimaSshConfig.
+
+    Any field the output omits falls back to Lima's documented default
+    (loopback host, port 22, root user, the shared per-config identity file).
+    """
     hostname = "127.0.0.1"
     port = 22
     user = "root"
     identity_file = Path.home() / ".lima" / "_config" / "user"
 
-    for line in result.stdout.splitlines():
+    for line in stdout.splitlines():
         line = line.strip()
         if line.startswith("HostName "):
             hostname = _strip_ssh_config_quotes(line.split(None, 1)[1])

--- a/libs/mngr_lima/imbue/mngr_lima/limactl_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/limactl_test.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from imbue.mngr.primitives import HostName
 from imbue.mngr_lima.limactl import LimaSshConfig
+from imbue.mngr_lima.limactl import _parse_show_ssh_output
 from imbue.mngr_lima.limactl import _strip_ssh_config_quotes
 from imbue.mngr_lima.limactl import host_name_from_instance_name
 from imbue.mngr_lima.limactl import lima_instance_name
@@ -40,14 +41,33 @@ def test_strip_ssh_config_quotes() -> None:
     assert _strip_ssh_config_quotes("  60022  ") == "60022"
 
 
-def test_lima_ssh_config() -> None:
-    config = LimaSshConfig(
+def test_parse_show_ssh_output_extracts_all_fields() -> None:
+    # Shape of `limactl show-ssh --format config <instance>`: an indented,
+    # quote-wrapped SSH-config block. The parser must strip quotes, coerce the
+    # port to int, and map each directive to the right field.
+    stdout = (
+        "Host lima-mngr-my-host\n"
+        '  HostName "127.0.0.1"\n'
+        "  Port 60022\n"
+        '  User "josh"\n'
+        '  IdentityFile "/home/josh/.lima/_config/user"\n'
+    )
+
+    config = _parse_show_ssh_output(stdout)
+
+    assert config == LimaSshConfig(
         hostname="127.0.0.1",
         port=60022,
         user="josh",
         identity_file=Path("/home/josh/.lima/_config/user"),
     )
+
+
+def test_parse_show_ssh_output_falls_back_to_defaults_for_missing_directives() -> None:
+    # Only Port is present; the other fields must take Lima's documented
+    # defaults rather than being left unset or carrying a stale value.
+    config = _parse_show_ssh_output("Host lima-mngr-my-host\n  Port 50051\n")
+
+    assert config.port == 50051
     assert config.hostname == "127.0.0.1"
-    assert config.port == 60022
-    assert config.user == "josh"
-    assert config.identity_file == Path("/home/josh/.lima/_config/user")
+    assert config.user == "root"


### PR DESCRIPTION
Identifies and fixes low-quality tests under `libs/mngr_lima` flagged by `/identify-bad-tests`.

## What changed

Rewrites tests that passed without establishing correctness:

- **`LimaHostStore` cache test** now mutates the on-disk record behind the cache so a cache hit and a disk read return distinguishable values; asserts the default read is served from cache while `use_cache=False` and `clear_cache()` reflect disk. Previously it could not tell a working cache from a no-op one.
- **`LimaSshConfig`**: replaced the tautological constructor round-trip test with tests for the `limactl show-ssh` parser; extracted the parse loop into a pure `_parse_show_ssh_output` helper to make it unit-testable.
- **`LimaProviderConfig`** custom-config test now asserts a JSON round trip (verifying tuple/Path coercions) instead of echoing constructor arguments.
- **`reset_caches`** test asserts the caches are actually emptied; **provider-dir** test pins the exact path instead of loose substrings; **`get_volume_for_host`** test asserts the returned volume is rooted at the host's volume directory.
- **Default lima YAML** test asserts the arch-appropriate default image URL; **temp-file writer** test verifies serialized content and cleans up via `try/finally`.

One documented false positive (error-attribute assertions in `errors_test.py` actually guard hand-written `__init__` wiring) is left unchanged.

## Testing

`just test-quick "libs/mngr_lima -m 'not acceptance and not release and not lima'"` — 120 passed, 0 failed (includes ratchets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)