### PR TITLE
harden minds/config suspicious edge-case handling

### DIFF
--- a/apps/minds/changelog/mngr-suspicious-edge-cases-minds-config-local.md
+++ b/apps/minds/changelog/mngr-suspicious-edge-cases-minds-config-local.md
@@ -1,0 +1,4 @@
+Hardened edge-case handling in `imbue/minds/config`:
+
+- `parse_agents_from_mngr_output` now raises `MalformedMngrOutputError` (instead of silently returning an empty list) when mngr's stdout is empty/blank, and raises it (instead of a bare `KeyError`) when the parsed JSON object lacks an `agents` key. Both cases indicate broken upstream output rather than "no agents".
+- The config loaders (`load_client_config` / `load_deploy_config`) now catch the precise `tomllib.TOMLDecodeError` and `pydantic.ValidationError` rather than the broad `ValueError`, so an unrelated `ValueError` bug is no longer mislabeled as a config parse/validation failure.

--- a/apps/minds/imbue/minds/config/data_types.py
+++ b/apps/minds/imbue/minds/config/data_types.py
@@ -327,9 +327,12 @@ def parse_agents_from_mngr_output(stdout: str) -> list[dict[str, object]]:
     """Extract agent records from the first JSON object line of ``mngr list --format json`` stdout.
 
     Raises ``MalformedMngrOutputError`` when the first non-empty line is not a
-    JSON object. stdout is reserved for JSON data; if log lines or SSH errors
+    JSON object, when stdout is empty/blank, or when the parsed object lacks an
+    ``agents`` key. stdout is reserved for JSON data; if log lines or SSH errors
     are leaking onto it, fix the underlying process rather than papering over
-    it here.
+    it here. ``mngr list --format json`` always serializes its result set as a
+    ``{"agents": [...]}`` object (zero agents is ``{"agents": []}``), so empty
+    stdout means the command produced no output at all rather than "no agents".
     """
     for line in stdout.splitlines():
         stripped = line.strip()
@@ -340,5 +343,7 @@ def parse_agents_from_mngr_output(stdout: str) -> list[dict[str, object]]:
                 f"Expected JSON object on first non-empty mngr output line, got: {stripped[:200]!r}"
             )
         data = json.loads(stripped)
+        if "agents" not in data:
+            raise MalformedMngrOutputError(f"mngr output JSON object missing 'agents' key: {stripped[:200]!r}")
         return data["agents"]
-    return []
+    raise MalformedMngrOutputError("Expected a JSON object in mngr output, but stdout was empty/blank")

--- a/apps/minds/imbue/minds/config/data_types_test.py
+++ b/apps/minds/imbue/minds/config/data_types_test.py
@@ -73,3 +73,17 @@ def test_parse_agents_from_mngr_output_raises_on_invalid_json_first_line() -> No
     output = "{invalid json here\n" + valid_json
     with pytest.raises(json.JSONDecodeError):
         parse_agents_from_mngr_output(output)
+
+
+@pytest.mark.parametrize("stdout", ["", "   ", "\n\n", "   \n  \n"])
+def test_parse_agents_from_mngr_output_raises_on_empty_stdout(stdout: str) -> None:
+    """Empty/blank stdout means mngr produced no output at all, not "no agents"."""
+    with pytest.raises(MalformedMngrOutputError, match="stdout was empty/blank"):
+        parse_agents_from_mngr_output(stdout)
+
+
+def test_parse_agents_from_mngr_output_raises_on_missing_agents_key() -> None:
+    """A JSON object lacking an 'agents' key is malformed output, not a bare KeyError."""
+    output = json.dumps({"not_agents": []})
+    with pytest.raises(MalformedMngrOutputError, match="missing 'agents' key"):
+        parse_agents_from_mngr_output(output)

--- a/apps/minds/imbue/minds/config/loader.py
+++ b/apps/minds/imbue/minds/config/loader.py
@@ -26,6 +26,8 @@ import tomllib
 from pathlib import Path
 from typing import Final
 
+from pydantic import ValidationError
+
 from imbue.minds.config.data_types import ClientEnvConfig
 from imbue.minds.config.data_types import DeployEnvConfig
 from imbue.minds.errors import MindError
@@ -74,11 +76,11 @@ def load_client_config(path: Path) -> ClientEnvConfig:
         raise EnvConfigError(f"Cannot read client config {path}: {exc}") from exc
     try:
         raw = tomllib.loads(text)
-    except ValueError as exc:
+    except tomllib.TOMLDecodeError as exc:
         raise EnvConfigError(f"Failed to parse client config {path}: {exc}") from exc
     try:
         return ClientEnvConfig.model_validate(raw)
-    except ValueError as exc:
+    except ValidationError as exc:
         raise EnvConfigError(f"Invalid client config at {path}: {exc}") from exc
 
 
@@ -93,9 +95,9 @@ def load_deploy_config(tier: str) -> DeployEnvConfig:
         raise EnvConfigError(f"Cannot read deploy config {path}: {exc}") from exc
     try:
         raw = tomllib.loads(text)
-    except ValueError as exc:
+    except tomllib.TOMLDecodeError as exc:
         raise EnvConfigError(f"Failed to parse deploy config {path}: {exc}") from exc
     try:
         return DeployEnvConfig.model_validate(raw)
-    except ValueError as exc:
+    except ValidationError as exc:
         raise EnvConfigError(f"Invalid deploy config at {path}: {exc}") from exc


### PR DESCRIPTION
not sure if we want this

---

## Summary

Cleanup pass (`/identify-suspicious-edge-cases`) over `apps/minds/imbue/minds/config`, then fixes for the findings.

- **`parse_agents_from_mngr_output`** (`config/data_types.py`): now raises `MalformedMngrOutputError` instead of (a) silently returning `[]` when mngr's stdout is empty/blank and (b) raising a bare `KeyError` when the parsed JSON object lacks an `agents` key. `mngr list --format json` always serializes its result as `{"agents": [...]}` (zero agents is `{"agents": []}`), so empty stdout signals broken upstream output, not "no agents" -- consistent with the function's existing non-JSON branch and documented philosophy.
- **`load_client_config` / `load_deploy_config`** (`config/loader.py`): catch the precise `tomllib.TOMLDecodeError` and `pydantic.ValidationError` rather than the broad `ValueError`, so an unrelated `ValueError` is no longer mislabeled as a config parse/validation failure.

Added unit tests for the new raising behavior.

## Test plan

- `just test-quick apps/minds/imbue/minds/config` -- 28 passed
- `just test-quick "apps/minds -k 'test_no_type_errors or ratchet'"` -- 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)