### PR TITLE
imbue_common: strengthen weak/misleading unit tests

### DIFF
--- a/libs/imbue_common/changelog/mngr-bad-tests-imbue-common-local.md
+++ b/libs/imbue_common/changelog/mngr-bad-tests-imbue-common-local.md
@@ -1,0 +1,8 @@
+Strengthened several weak or misleading unit tests in imbue_common:
+
+- `pytest_utils`: split the snapshot-flag parsing into a pure `is_updating_for_inline_snapshot_flags` helper and replaced the no-op "demo" test (whose assertion could never fail) with a parametrized test over real flag values.
+- `setup_logging` tests now assert the configured level actually filters/emits messages instead of only checking that no exception is raised.
+- `EventEnvelope` tests now verify that a missing field is rejected and that serialization emits the exact field values (not just key presence).
+- `primitives`: added pydantic-validation rejection cases for every constrained primitive (previously only happy-path values were tested).
+- `detect_branch` git fallback is now tested deterministically against a real repo on a unique branch instead of conditionally skipping its assertion.
+- Tightened ratchet-testing assertions (exact matched-content set, error-message matching), renamed undescriptive tests, and made the package-import smoke test meaningful.

--- a/libs/imbue_common/imbue/imbue_common/errors_test.py
+++ b/libs/imbue_common/imbue/imbue_common/errors_test.py
@@ -1,9 +1,12 @@
 """Tests for errors module."""
 
+import pytest
+
 from imbue.imbue_common.errors import SwitchError
 
 
-def test_switch_error_can_be_raised() -> None:
-    """SwitchError should be raisable as an exception."""
-    error = SwitchError("unexpected branch")
-    assert str(error) == "unexpected branch"
+def test_switch_error_is_raisable_and_catchable_with_message() -> None:
+    """SwitchError should behave as an Exception subclass carrying its message."""
+    assert issubclass(SwitchError, Exception)
+    with pytest.raises(SwitchError, match="unexpected branch"):
+        raise SwitchError("unexpected branch")

--- a/libs/imbue_common/imbue/imbue_common/event_envelope_test.py
+++ b/libs/imbue_common/imbue/imbue_common/event_envelope_test.py
@@ -19,7 +19,7 @@ _EID = EventId("evt-1234")
 _SRC = EventSource("test_source")
 
 
-def test_event_envelope_requires_all_fields() -> None:
+def test_event_envelope_stores_all_envelope_fields() -> None:
     envelope = EventEnvelope(
         timestamp=_TS,
         type=EventType("test_event"),
@@ -32,6 +32,15 @@ def test_event_envelope_requires_all_fields() -> None:
     assert envelope.source == _SRC
 
 
+def test_event_envelope_rejects_missing_field() -> None:
+    with pytest.raises(ValidationError):
+        EventEnvelope(  # ty: ignore[missing-argument]
+            timestamp=_TS,
+            type=EventType("test_event"),
+            event_id=_EID,
+        )
+
+
 def test_event_envelope_serializes_all_fields() -> None:
     envelope = EventEnvelope(
         timestamp=_TS,
@@ -40,10 +49,12 @@ def test_event_envelope_serializes_all_fields() -> None:
         source=_SRC,
     )
     data = json.loads(envelope.model_dump_json())
-    assert "timestamp" in data
-    assert "type" in data
-    assert "event_id" in data
-    assert "source" in data
+    assert data == {
+        "timestamp": str(_TS),
+        "type": "test_event",
+        "event_id": str(_EID),
+        "source": str(_SRC),
+    }
 
 
 def test_event_envelope_is_frozen() -> None:

--- a/libs/imbue_common/imbue/imbue_common/logging_test.py
+++ b/libs/imbue_common/imbue/imbue_common/logging_test.py
@@ -8,6 +8,7 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
+import pytest
 from loguru import logger
 
 from imbue.imbue_common.logging import _build_flat_log_dict
@@ -51,15 +52,26 @@ def capture_logs() -> Iterator[LogCapture]:
         logger.remove(handler_id)
 
 
-def test_setup_logging_does_not_raise() -> None:
-    """setup_logging should configure logging without raising."""
-    setup_logging()
+def test_setup_logging_filters_messages_below_configured_level(capsys: pytest.CaptureFixture[str]) -> None:
+    """setup_logging should install a stderr sink that emits at/above the level and drops below it."""
+    setup_logging(level="WARNING")
+
+    logger.info("info_message_should_be_filtered")
+    logger.warning("warning_message_should_appear")
+
+    captured = capsys.readouterr()
+    assert "warning_message_should_appear" in captured.err
+    assert "info_message_should_be_filtered" not in captured.err
 
 
-def test_setup_logging_with_custom_level() -> None:
-    """setup_logging should accept custom log levels."""
-    setup_logging(level="DEBUG")
-    setup_logging(level="info")
+def test_setup_logging_normalizes_lowercase_level(capsys: pytest.CaptureFixture[str]) -> None:
+    """setup_logging should upper-case the level string so a lowercase 'debug' enables debug output."""
+    setup_logging(level="debug")
+
+    logger.debug("debug_message_should_appear")
+
+    captured = capsys.readouterr()
+    assert "debug_message_should_appear" in captured.err
 
 
 # =============================================================================

--- a/libs/imbue_common/imbue/imbue_common/primitives_test.py
+++ b/libs/imbue_common/imbue/imbue_common/primitives_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pydantic import BaseModel
+from pydantic import ValidationError
 
 from imbue.imbue_common.primitives import InvalidProbabilityError
 from imbue.imbue_common.primitives import NonEmptyStr
@@ -203,3 +204,74 @@ def test_probability_pydantic_schema() -> None:
     model = TestModel.model_validate({"value": 0.75})
     assert model.value == 0.75
     assert isinstance(model.value, Probability)
+
+
+def test_non_empty_str_pydantic_schema_accepts_and_strips() -> None:
+    """NonEmptyStr should validate and strip through model_validate."""
+
+    class TestModel(BaseModel):
+        value: NonEmptyStr
+
+    model = TestModel.model_validate({"value": "  hello  "})
+    assert model.value == "hello"
+    assert isinstance(model.value, NonEmptyStr)
+
+
+def test_non_empty_str_pydantic_schema_rejects_blank() -> None:
+    """NonEmptyStr's pydantic schema should reject empty/whitespace-only values."""
+
+    class TestModel(BaseModel):
+        value: NonEmptyStr
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": "   "})
+
+
+def test_non_negative_int_pydantic_schema_rejects_negative() -> None:
+    """NonNegativeInt's pydantic schema should reject negative values."""
+
+    class TestModel(BaseModel):
+        value: NonNegativeInt
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": -1})
+
+
+def test_positive_int_pydantic_schema_rejects_zero() -> None:
+    """PositiveInt's pydantic schema should reject zero."""
+
+    class TestModel(BaseModel):
+        value: PositiveInt
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": 0})
+
+
+def test_non_negative_float_pydantic_schema_rejects_negative() -> None:
+    """NonNegativeFloat's pydantic schema should reject negative values."""
+
+    class TestModel(BaseModel):
+        value: NonNegativeFloat
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": -0.01})
+
+
+def test_positive_float_pydantic_schema_rejects_zero() -> None:
+    """PositiveFloat's pydantic schema should reject zero."""
+
+    class TestModel(BaseModel):
+        value: PositiveFloat
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": 0.0})
+
+
+def test_probability_pydantic_schema_rejects_out_of_range() -> None:
+    """Probability's pydantic schema should reject values above 1.0."""
+
+    class TestModel(BaseModel):
+        value: Probability
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"value": 1.5})

--- a/libs/imbue_common/imbue/imbue_common/pure_test.py
+++ b/libs/imbue_common/imbue/imbue_common/pure_test.py
@@ -1,12 +1,12 @@
 from imbue.imbue_common.pure import pure
 
 
-def test_pure_decorator_returns_same_function() -> None:
-    @pure
+def test_pure_decorator_returns_the_same_function_object() -> None:
     def add(a: int, b: int) -> int:
         return a + b
 
-    assert add(1, 2) == 3
+    # pure is an advisory no-op decorator: it must return the original function unchanged.
+    assert pure(add) is add
 
 
 def test_pure_decorator_preserves_function_name() -> None:

--- a/libs/imbue_common/imbue/imbue_common/pytest_utils.py
+++ b/libs/imbue_common/imbue/imbue_common/pytest_utils.py
@@ -4,15 +4,25 @@ from imbue.imbue_common.pure import pure
 
 
 @pure
+def is_updating_for_inline_snapshot_flags(inline_snapshot_flags: str | None) -> bool:
+    """Return whether the given --inline-snapshot flag value means snapshots are being written.
+
+    ``inline_snapshot_flags`` is the raw value of ``config.option.inline_snapshot``: either
+    ``None`` (the option was not passed) or a comma-separated string of flag names. Snapshots
+    are being written when the ``create`` or ``fix`` flags are present.
+    """
+    if inline_snapshot_flags is None:
+        return False
+
+    flags = inline_snapshot_flags.split(",")
+    return "create" in flags or "fix" in flags
+
+
+@pure
 def inline_snapshot_is_updating(config: pytest.Config) -> bool:
     """Check if inline-snapshot is running with create or fix flags.
 
     This is useful for tests that need to behave differently when snapshots
     are being created or fixed vs when they are being validated.
     """
-    inline_snapshot_flags = config.option.inline_snapshot
-    if inline_snapshot_flags is None:
-        return False
-
-    flags = inline_snapshot_flags.split(",")
-    return "create" in flags or "fix" in flags
+    return is_updating_for_inline_snapshot_flags(config.option.inline_snapshot)

--- a/libs/imbue_common/imbue/imbue_common/pytest_utils_test.py
+++ b/libs/imbue_common/imbue/imbue_common/pytest_utils_test.py
@@ -1,43 +1,29 @@
 import pytest
 
 from imbue.imbue_common.pytest_utils import inline_snapshot_is_updating
+from imbue.imbue_common.pytest_utils import is_updating_for_inline_snapshot_flags
 
 
-def test_demonstrate_inline_snapshot_detection_works(request: pytest.FixtureRequest) -> None:
-    """Demonstrates that inline_snapshot_is_updating() correctly detects the flags.
+@pytest.mark.parametrize(
+    ("flags", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("create", True),
+        ("fix", True),
+        ("report", False),
+        ("update", False),
+        ("report,create,update", True),
+        ("report,fix", True),
+        ("report,update", False),
+    ],
+)
+def test_is_updating_for_inline_snapshot_flags_detects_create_and_fix(flags: str | None, expected: bool) -> None:
+    """Only the 'create' and 'fix' flags (alone or among others) mean snapshots are being written."""
+    assert is_updating_for_inline_snapshot_flags(flags) is expected
 
-    This is a demo test that shows the function working. Run it manually with
-    different flags to see the detection in action:
 
-    - Normal mode:
-      uv run pytest libs/imbue_common/imbue/imbue_common/pytest_utils_demo_test.py -n 0 -s --no-cov
-
-    - Create mode:
-      uv run pytest libs/imbue_common/imbue/imbue_common/pytest_utils_demo_test.py -n 0 -s --no-cov --inline-snapshot=create
-
-    - Fix mode:
-      uv run pytest libs/imbue_common/imbue/imbue_common/pytest_utils_demo_test.py -n 0 -s --no-cov --inline-snapshot=fix
-
-    - Multiple flags:
-      uv run pytest libs/imbue_common/imbue/imbue_common/pytest_utils_demo_test.py -n 0 -s --no-cov --inline-snapshot=report,create,update
-
-    Expected output:
-    - Normal: returns False
-    - Create/Fix: returns True
-    - Multiple with create or fix: returns True
-    - Multiple without create or fix: returns False
-    """
-    config = request.config
-    is_updating = inline_snapshot_is_updating(config)
-
-    print(f"\ninline_snapshot_is_updating() returned: {is_updating}")
-    print(f"config.option.inline_snapshot = {getattr(config.option, 'inline_snapshot', None)}")
-
-    if is_updating:
-        print("  -> Detected: Running in create or fix mode")
-        result = "updating"
-    else:
-        print("  -> Detected: Running in normal validation mode")
-        result = "normal"
-
-    assert result in ["updating", "normal"]
+def test_inline_snapshot_is_updating_reads_inline_snapshot_config_option(request: pytest.FixtureRequest) -> None:
+    """The public wrapper pulls the flag value off config.option.inline_snapshot and delegates."""
+    expected = is_updating_for_inline_snapshot_flags(request.config.option.inline_snapshot)
+    assert inline_snapshot_is_updating(request.config) is expected

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/core_test.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/core_test.py
@@ -56,12 +56,12 @@ def test_line_number_must_be_positive() -> None:
 
 
 def test_line_number_rejects_zero() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be > 0"):
         LineNumber(0)
 
 
 def test_line_number_rejects_negative() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must be > 0"):
         LineNumber(-1)
 
 
@@ -266,8 +266,7 @@ def test_get_ratchet_failures_finds_matches_in_git_repo(git_repo: Path) -> None:
     chunks = get_ratchet_failures(git_repo, FileExtension(".py"), pattern)
 
     assert len(chunks) == 2
-    assert chunks[0].matched_content in ["# TODO: Fix this", "# TODO: And this"]
-    assert chunks[1].matched_content in ["# TODO: Fix this", "# TODO: And this"]
+    assert {chunk.matched_content for chunk in chunks} == {"# TODO: Fix this", "# TODO: And this"}
     assert all(chunk.file_path.name == "test.py" for chunk in chunks)
 
 
@@ -342,7 +341,7 @@ def test_get_ratchet_failures_raises_on_non_git_directory(tmp_path: Path) -> Non
         get_ratchet_failures(test_dir, FileExtension(".py"), pattern)
 
 
-def test_formatting(git_repo: Path):
+def test_format_ratchet_failure_message_includes_rule_name_and_matched_content(git_repo: Path) -> None:
     test_file = git_repo / "test.py"
     test_file.write_text("    suspicious_code_here()\n    another_bad_line()\n")
     subprocess.run(["git", "add", "."], cwd=git_repo, check=True, capture_output=True)

--- a/libs/imbue_common/imbue/imbue_common/test_profiles_test.py
+++ b/libs/imbue_common/imbue/imbue_common/test_profiles_test.py
@@ -1,4 +1,6 @@
+import subprocess
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
@@ -94,18 +96,28 @@ def test_detect_branch_ignores_empty_github_head_ref(monkeypatch: pytest.MonkeyP
     assert detect_branch() == "main"
 
 
-def test_detect_branch_falls_back_to_git(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_detect_branch_falls_back_to_git(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
     monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
 
-    branch = detect_branch()
+    # Create a real git repo on a uniquely-named branch and detect from inside it,
+    # so the fallback is exercised deterministically rather than depending on the
+    # ambient checkout (which may be in detached HEAD). An initial commit is needed
+    # so that `git rev-parse --abbrev-ref HEAD` resolves the branch (it fails on an
+    # unborn branch).
+    branch_name = "detect-branch-" + uuid4().hex
+    subprocess.run(["git", "init", "-b", branch_name], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(tmp_path)
 
-    # In most environments (local dev, CI with proper checkout), git can
-    # determine the branch. In some CI configurations (detached HEAD, isolated
-    # HOME), git rev-parse may fail and return None. Both are valid outcomes --
-    # the important thing is that detect_branch doesn't crash.
-    if branch is not None:
-        assert len(branch) > 0
+    assert detect_branch() == branch_name
 
 
 # -- resolve_active_profile ---------------------------------------------------

--- a/libs/imbue_common/tests/test_imbue_core_import.py
+++ b/libs/imbue_common/tests/test_imbue_core_import.py
@@ -1,5 +1,7 @@
 from imbue import imbue_common
 
 
-def test_import():
-    assert imbue_common
+def test_imbue_common_package_is_importable() -> None:
+    # The module-level import above fails at collection time if the imbue.imbue_common
+    # package cannot be imported; this asserts it resolved to the expected package.
+    assert imbue_common.__name__ == "imbue.imbue_common"


### PR DESCRIPTION
Ran `/identify-bad-tests libs/imbue_common` and fixed the findings.

## What was wrong
The scan found tests that passed without establishing correctness:
- `pytest_utils_test`: a "demo" test whose assertion (`result in ["updating","normal"]`) could never fail.
- `setup_logging` tests asserted only that no exception was raised.
- `EventEnvelope` tests checked key *presence* on serialization and never verified that fields are required.
- `primitives` pydantic tests covered only valid values, never the rejection branch.
- `detect_branch` git-fallback test had a conditional assertion that no-ops when the ambient checkout is detached.
- Various ratchet-testing / errors / pure / import tests had weak membership assertions, missing error-message matching, undescriptive names, or tautological asserts.

## Changes
- Extracted a pure `is_updating_for_inline_snapshot_flags` helper in `pytest_utils.py` and replaced the demo test with parametrized real-input cases.
- `setup_logging` tests now assert level filtering/emission via `capsys`.
- `EventEnvelope`: added a missing-field rejection test and made serialization assert exact values.
- `primitives`: added pydantic rejection cases for every constrained primitive (and the previously-untested `NonEmptyStr`/`NonNegativeInt`/`PositiveInt`).
- `detect_branch` fallback now runs deterministically against a real repo on a unique branch.
- Tightened ratchet-core assertions (exact matched-content set, error-message matching), renamed undescriptive tests, and made the package-import smoke test meaningful.

Full findings report (gitignored): `libs/imbue_common/_tasks/bad-tests/2026-06-04-15-01-09.md`.

Local: `just test-quick "libs/imbue_common -m 'not acceptance and not release'"` -> 236 passed, 0 failed. `ty check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)