### PR TITLE
Harden suspicious edge-case handling in mngr_usage

### DIFF
--- a/libs/mngr_usage/changelog/mngr-suspicious-edge-cases-mngr-usage-local.md
+++ b/libs/mngr_usage/changelog/mngr-suspicious-edge-cases-mngr-usage-local.md
@@ -1,0 +1,16 @@
+Hardened suspicious edge-case handling in `mngr usage`:
+
+- Config layering: removed `UsagePluginConfig.merge_with`, which re-derived the
+  merge incorrectly (its `x if x is not None` checks were no-ops on non-Optional
+  fields, so a higher config layer silently reset lower-layer `max_age_seconds` /
+  `since_seconds` back to defaults) and silently dropped a mismatched override.
+  `mngr usage` now inherits the canonical `PluginConfig.merge_with`, which merges
+  by explicitly-set fields like every other plugin.
+- Events with an unparseable `timestamp` are now dropped with a WARNING (naming
+  source + event_id) instead of vanishing silently, so a malformed timestamp can
+  no longer undercount cost without notice.
+- A `rate_limits` window whose value isn't a dict is now logged when skipped,
+  matching the existing per-window validation-error log.
+- `mngr usage wait` now raises on the impossible "neither matched nor timed out"
+  result for every output format (previously only the human format crashed; JSON
+  / JSONL silently emitted a self-contradictory record).

--- a/libs/mngr_usage/imbue/mngr_usage/api.py
+++ b/libs/mngr_usage/imbue/mngr_usage/api.py
@@ -142,6 +142,9 @@ def _windows_from_event(event: dict[str, Any]) -> dict[str, WindowSnapshot]:
     windows: dict[str, WindowSnapshot] = {}
     for window_key, window_value in rate_limits.items():
         if not isinstance(window_value, dict):
+            # A non-dict window value is the most blatant writer/reader drift;
+            # log it like the ValidationError path below rather than masking it.
+            logger.debug("Skipping window {}: value is not a dict ({})", window_key, type(window_value).__name__)
             continue
         try:
             windows[str(window_key)] = WindowSnapshot.model_validate(window_value)
@@ -237,10 +240,17 @@ def _sub_optional(current: int | float | None, baseline: int | float | None) -> 
     Treats a missing baseline as zero so the first session in a process
     (baseline = all-None CostSnapshot) just gets its own cumulative
     reading. A missing current field stays None (no delta to report).
-    Negative deltas are clamped to zero defensively -- they shouldn't
-    occur within a process (cost is monotonic) but if a writer ever emits
-    an out-of-order pair we'd rather show 0 than a misleading negative
-    spend.
+
+    Negative deltas are clamped to zero defensively. They cannot occur on
+    a well-formed stream: ``_finalize_process`` walks a process's sessions
+    in first-appearance order, which equals cumulative-reading order
+    *because sessions within one Claude Code process are sequential and
+    non-overlapping* (``/clear`` advances ``session_id`` forward and never
+    returns to a prior one; ``/resume`` is a fresh process). So each
+    session's cumulative reading is >= the prior session's, and every
+    field (cost, durations, line counts) is monotonic non-decreasing. The
+    clamp is purely a safety net for a writer emitting out-of-order events:
+    we'd rather show 0 than a misleading negative spend.
 
     Overloaded for ``int`` and ``float`` separately so the delta's typed
     field signature matches the per-session field type in CostSnapshot
@@ -362,6 +372,16 @@ def _walk_agent_events(events: list[dict[str, Any]], source_name: str) -> _Agent
     for event in events:
         ts = _parse_iso_timestamp(event.get("timestamp"))
         if ts is None:
+            # Drop the event but say so: an unparseable timestamp takes the
+            # event's cost contribution with it, so a silent skip would
+            # undercount spend. Mirrors the session_id drop below (writers are
+            # lockstep with the reader, so a miss is drift worth surfacing).
+            logger.warning(
+                "Dropping event with unparseable timestamp from source {} (event_id={}, timestamp={!r})",
+                source_name,
+                event.get("event_id"),
+                event.get("timestamp"),
+            )
             continue
         timed.append((ts, event))
     timed.sort(key=lambda pair: pair[0])

--- a/libs/mngr_usage/imbue/mngr_usage/cli.py
+++ b/libs/mngr_usage/imbue/mngr_usage/cli.py
@@ -1010,6 +1010,14 @@ def _emit_match_state_change(result: WaitForUsageResult, output_format: OutputFo
 
 def _output_wait_result(result: WaitForUsageResult, output_format: OutputFormat) -> None:
     """Render the final wait result. JSON/JSONL emit one final record; human writes a summary line."""
+    # ``wait_for_usage`` always returns with exactly one of is_matched / is_timed_out true.
+    # Check the invariant once, format-independently, so the impossible "neither" state crashes
+    # loudly for machine consumers (JSON/JSONL) too -- not only in the HUMAN branch below.
+    if not result.is_matched and not result.is_timed_out:
+        raise MngrError(
+            f"wait_for_usage returned both is_matched=False and is_timed_out=False "
+            f"(elapsed={result.elapsed_seconds:.2f}s)"
+        )
     payload = {
         "is_matched": result.is_matched,
         "is_timed_out": result.is_timed_out,

--- a/libs/mngr_usage/imbue/mngr_usage/cli_test.py
+++ b/libs/mngr_usage/imbue/mngr_usage/cli_test.py
@@ -347,6 +347,57 @@ def test_aggregate_drops_events_without_session_id() -> None:
     assert "claude" in warning_text
 
 
+def test_aggregate_drops_event_with_unparseable_timestamp_and_warns() -> None:
+    """An event whose ``timestamp`` won't parse is dropped (its cost would
+    otherwise undercount silently) and the reader warns, naming the event_id
+    so the data loss is visible. A valid sibling event still aggregates."""
+    events = [
+        {
+            "source": "claude/usage",
+            "type": "cost_snapshot",
+            "event_id": "evt-bad-ts",
+            "timestamp": "not-a-timestamp",
+            "session_id": "session-x",
+            "cost": {"total_cost_usd": 5.0},
+        },
+        _cost_event("2026-05-08T11:00:00.000000000Z", session_id="session-x", cost_usd=3.0),
+    ]
+    now = int(datetime(2026, 5, 8, 11, 1, 0, tzinfo=timezone.utc).timestamp())
+    captured: list[str] = []
+    sink_id = logger.add(lambda msg: captured.append(msg.record["message"]), level="WARNING", format="{message}")
+    try:
+        snapshots = aggregate_events_to_snapshots({"claude": {"agent-x": events}}, since_seconds=86400, now=now)
+    finally:
+        logger.remove(sink_id)
+    # Only the well-formed event contributes; the unparseable one is gone, not summed in.
+    assert len(snapshots) == 1
+    assert snapshots[0].sessions[0].cost.total_cost_usd == 3.0
+    warning_text = " ".join(captured)
+    assert "timestamp" in warning_text
+    assert "evt-bad-ts" in warning_text
+
+
+def test_aggregate_skips_non_dict_window_value() -> None:
+    """A window whose value isn't a dict (blatant writer drift) is skipped
+    while valid sibling windows in the same event survive."""
+    events = [
+        {
+            "source": "claude/usage",
+            "type": "cost_snapshot",
+            "timestamp": "2026-05-08T11:00:00.000000000Z",
+            "session_id": "session-x",
+            "rate_limits": {
+                "five_hour": {"used_percentage": 42.0, "resets_at": 9_999_999_999},
+                "seven_day": 0.5,
+            },
+        }
+    ]
+    snapshots = aggregate_events_to_snapshots({"claude": {"agent-x": events}}, since_seconds=86400, now=2_000_000_000)
+    assert len(snapshots) == 1
+    assert snapshots[0].windows["five_hour"].used_percentage == 42.0
+    assert "seven_day" not in snapshots[0].windows
+
+
 def test_aggregate_groups_per_session_and_computes_session_contribution_delta() -> None:
     """Within one Claude Code process, ``SessionCostRecord.cost`` is the
     session's *own* contribution -- delta from the prior session's

--- a/libs/mngr_usage/imbue/mngr_usage/data_types.py
+++ b/libs/mngr_usage/imbue/mngr_usage/data_types.py
@@ -73,18 +73,12 @@ class UsagePluginConfig(PluginConfig):
         "Set to False to discard usage data on destroy.",
     )
 
-    def merge_with(self, override: PluginConfig) -> UsagePluginConfig:
-        """Merge with override config (FrozenModel-style)."""
-        if not isinstance(override, UsagePluginConfig):
-            return self
-        return UsagePluginConfig(
-            enabled=override.enabled if override.enabled is not None else self.enabled,
-            max_age_seconds=override.max_age_seconds if override.max_age_seconds is not None else self.max_age_seconds,
-            since_seconds=override.since_seconds if override.since_seconds is not None else self.since_seconds,
-            preserve_on_destroy=(
-                override.preserve_on_destroy if override.preserve_on_destroy is not None else self.preserve_on_destroy
-            ),
-        )
+    # Intentionally no ``merge_with`` override: ``PluginConfig.merge_with``
+    # already merges subclass fields correctly via ``model_fields_set`` (only
+    # fields a layer explicitly set win), which is exactly the layering
+    # semantics we want. A hand-rolled override here would have to re-derive
+    # that and is easy to get wrong (e.g. ``override.x if x is not None`` is a
+    # no-op for non-Optional fields, silently clobbering the base layer).
 
 
 class CostSnapshot(FrozenModel):


### PR DESCRIPTION
Cleanup pass over `libs/mngr_usage` for over-defensive / suspicious edge-case handling (via the `identify-suspicious-edge-cases` skill), plus fixes.

## Findings fixed

1. **`UsagePluginConfig.merge_with` was both buggy and silently lossy.** Its `override.x if x is not None else self.x` checks were no-ops on the non-Optional `enabled` / `max_age_seconds` / `since_seconds` fields, so a merge always took the override's values — including unset defaults — silently resetting a lower config layer. It also `return self`-d on a non-`UsagePluginConfig` override, swallowing a wiring bug. Removed the override entirely; `mngr usage` now inherits the canonical `PluginConfig.merge_with` (merges by `model_fields_set`, like every other plugin).
2. **Events with an unparseable `timestamp` were dropped silently** (no log), unlike the sibling `session_id` drop (WARNING) and the window/cost drops (debug). Since a dropped event takes its cost with it, this could silently undercount spend. Now logged with a WARNING naming source + event_id.
3. **`mngr usage wait`'s impossible "neither matched nor timed out" state raised only in the HUMAN branch**; JSON/JSONL silently emitted a self-contradictory record. The invariant check is now format-independent.
4. **A non-dict `rate_limits` window value was skipped with no log**, inconsistent with the validation-error debug log two lines below. Now logged.
5. **Strengthened the `_sub_optional` negative-delta clamp comment** to state the actual load-bearing invariant (sessions within one Claude Code process are sequential and non-overlapping), rather than the weaker "cost is monotonic".

## Tests

Adds unit tests crystallizing the timestamp-drop warning and non-dict-window skip. Full `libs/mngr_usage` suite: 117 passed, coverage threshold (90%) held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)