### PR TITLE
mngr_kanpan: harden suspicious edge-case handling

### DIFF
--- a/libs/mngr_kanpan/changelog/mngr-suspicious-edge-cases-mngr-kanpan-local.md
+++ b/libs/mngr_kanpan/changelog/mngr-suspicious-edge-cases-mngr-kanpan-local.md
@@ -1,0 +1,6 @@
+Hardened suspicious edge-case handling in the kanpan plugin:
+
+- `compute_section` now proves PR-state exhaustiveness with `assert_never` instead of a trailing `raise AssertionError`.
+- Field-cache save/load failures and unexpectedly-failed board refreshes now log at `warning` (with a traceback for the refresh case) so silently-discarded caches and fetch-pipeline bugs are visible; `save_field_cache` now catches only `OSError` so a serialization bug surfaces instead of being swallowed.
+- Malformed `[plugins.kanpan.commands.*]` entries are now logged instead of being silently dropped.
+- A degenerate GitHub remote that does not yield an `owner/repo` no longer produces a malformed/empty repo column.

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_source.py
@@ -219,5 +219,10 @@ def deserialize_fields(
         try:
             result[key] = adapter.validate_python(value)
         except ValidationError as e:
+            # Logged at debug (not warning) on purpose: this path is dominated by
+            # the expected one-time migration of legacy cache entries that predate
+            # the now-required `created` field, where a missing/invalid field is
+            # expected rather than alarming and warning-level noise on every load
+            # would be undesirable. Revisit once that migration window has passed.
             logger.debug("deserialize_fields: validation failed for key {!r}: {}", key, e)
     return result

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/github.py
@@ -354,6 +354,12 @@ def _parse_pr_node(node: dict[str, Any], unresolved_ignore_user: str | None) -> 
 @pure
 def _parse_pr_state(state_str: str) -> PrState:
     """Convert the GraphQL `PullRequestState` enum to `PrState`."""
+    # `PullRequestState` is a three-valued GraphQL enum (OPEN/CLOSED/MERGED). The
+    # final `return` is the genuine OPEN case; it also doubles as the safe default
+    # for any unexpected value (a future GitHub-side enum addition, a malformed
+    # response). OPEN is deliberately chosen as that default because it keeps the
+    # agent visible in review rather than mis-hiding it under Done/Cancelled --
+    # the same intentional-fallback stance as `CiStatus.from_rollup_state`.
     upper = state_str.upper()
     if upper == "MERGED":
         return PrState.MERGED

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/data_sources/repo_paths.py
@@ -38,7 +38,10 @@ def _parse_github_repo_path(remote_url: str) -> str | None:
         path = remote_url[len("git@github.com:") :]
         if path.endswith(".git"):
             path = path[:-4]
-        return path
+        # Require an owner/repo shape; a degenerate remote yielding no "/" is
+        # not a usable repo path, so treat it as "no repo" rather than emitting
+        # an empty/malformed RepoPathField downstream.
+        return path if "/" in path else None
 
     # HTTPS format: https://github.com/owner/repo.git
     parsed = urlparse(remote_url)
@@ -46,7 +49,7 @@ def _parse_github_repo_path(remote_url: str) -> str | None:
         path = parsed.path.lstrip("/")
         if path.endswith(".git"):
             path = path[:-4]
-        return path
+        return path if "/" in path else None
 
     return None
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -6,6 +6,7 @@ from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+from typing import assert_never
 
 from loguru import logger
 from pydantic import Field
@@ -217,7 +218,8 @@ def compute_section(fields: dict[str, FieldValue]) -> BoardSection:
             if pr.is_draft:
                 return BoardSection.PR_DRAFT
             return BoardSection.PR_BEING_REVIEWED
-    raise AssertionError(f"Unhandled PR state: {pr.state}")
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def toggle_agent_mute(mngr_ctx: MngrContext, agent_name: AgentName) -> bool:
@@ -273,8 +275,13 @@ def save_field_cache(
             json.dump(serialized, f)
         Path(tmp_path).rename(cache_path)
         tmp_path = None
-    except Exception as e:
-        logger.debug("Failed to save field cache: {}", e)
+    except OSError as e:
+        # Persisting the field cache is best-effort: a filesystem failure (e.g.
+        # a read-only profile dir) must not crash the refresh. We deliberately
+        # catch only OSError -- model_dump(mode="json") of typed FieldValues
+        # cannot raise OSError, so a serialization bug propagates loudly instead
+        # of being silently swallowed here.
+        logger.warning("Failed to save field cache: {}", e)
     finally:
         if tmp_path is not None:
             Path(tmp_path).unlink(missing_ok=True)
@@ -315,9 +322,12 @@ def load_field_cache(
         # Tolerate any read/parse/decode failure and behave as the docstring
         # promises ("returns empty dict if the cache file doesn't exist or
         # is corrupt"). The broad catch is intentional and covers
-        # UnicodeDecodeError from partial-write corruption alongside the
-        # narrower OSError / json.JSONDecodeError cases.
-        logger.debug("Failed to load field cache: {}", e)
+        # UnicodeDecodeError from partial-write corruption, the AttributeError
+        # from a non-dict top-level JSON value, and the InvalidName raised by
+        # AgentName(...) on a hand-edited key, alongside the narrower OSError /
+        # json.JSONDecodeError cases. Logged at warning (not debug) because a
+        # silently-reset corrupt cache should be visible per the style guide.
+        logger.warning("Failed to load field cache: {}", e)
         return {}
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher_test.py
@@ -65,6 +65,20 @@ def test_parse_non_github_url() -> None:
     assert _parse_github_repo_path("https://gitlab.com/org/repo.git") is None
 
 
+def test_parse_ssh_url_without_owner_returns_none() -> None:
+    # A degenerate SSH remote with no owner/repo (no "/") is not a usable repo
+    # path, so it must be treated as "absent" rather than yielding a malformed value.
+    assert _parse_github_repo_path("git@github.com:repo.git") is None
+
+
+def test_parse_https_url_without_owner_returns_none() -> None:
+    assert _parse_github_repo_path("https://github.com/repo") is None
+
+
+def test_parse_https_url_bare_host_returns_none() -> None:
+    assert _parse_github_repo_path("https://github.com/") is None
+
+
 def test_repo_path_from_labels_with_remote() -> None:
     assert repo_path_from_labels({"remote": "git@github.com:org/repo.git"}) == "org/repo"
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_ratchets.py
@@ -49,7 +49,7 @@ def test_prevent_bare_except() -> None:
 
 
 def test_prevent_broad_exception_catch() -> None:
-    rc.check_broad_exception_catch(_DIR, snapshot(7))
+    rc.check_broad_exception_catch(_DIR, snapshot(6))
 
 
 def test_prevent_base_exception_catch() -> None:
@@ -244,7 +244,7 @@ def test_prevent_bare_tmux_targets() -> None:
 
 
 def test_prevent_if_elif_without_else() -> None:
-    rc.check_if_elif_without_else(_DIR, snapshot(2))
+    rc.check_if_elif_without_else(_DIR, snapshot(1))
 
 
 def test_prevent_inline_functions() -> None:

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
@@ -723,6 +723,9 @@ def _on_batch_item_poll(
             else:
                 stderr = result.stderr.strip()
                 results.append(f"{label}: failed ({stderr})")
+        # Broad catch keeps the urwid event loop alive if the background work item
+        # raised (e.g. subprocess timeout); the failure is surfaced to the user in
+        # the batch results summary rather than crashing the board.
         except Exception as e:
             results.append(f"{label}: failed ({e})")
 
@@ -819,6 +822,9 @@ def _on_mute_persist_poll(loop: MainLoop, data: tuple[_KanpanState, Future[bool]
     if future.done():
         try:
             future.result()
+        # Broad catch keeps the urwid event loop alive if persisting the mute failed
+        # (mngr API error); the optimistic UI update is reverted and the failure is
+        # shown to the user rather than crashing the board.
         except Exception as e:
             # Revert the optimistic update
             _update_snapshot_mute(state, agent_name, not expected_muted)
@@ -895,6 +901,9 @@ def _on_custom_command_poll(
             else:
                 stderr = result.stderr.strip()
                 _show_transient_message(state, f"  {cmd.name} failed for {agent_name}: {stderr}")
+        # Broad catch keeps the urwid event loop alive if the custom command raised
+        # (e.g. subprocess timeout); the failure is shown to the user in the footer
+        # rather than crashing the board.
         except Exception as e:
             _show_transient_message(state, f"  {cmd.name} failed for {agent_name}: {e}")
         if cmd.refresh_afterwards:
@@ -1038,8 +1047,14 @@ def _finish_refresh(loop: MainLoop, state: _KanpanState) -> None:
             new_snapshot = _carry_forward_fields(state.snapshot, new_snapshot)
         state.snapshot = new_snapshot
     except Exception as e:
+        # Broad catch is intentional: this runs in an urwid alarm callback, so an
+        # uncaught exception would tear down the whole TUI event loop. fetch_*_snapshot
+        # captures per-source errors internally and returns them in the snapshot, so an
+        # exception escaping to here is genuinely unexpected (a fetch-pipeline bug) -- log
+        # it at warning with the traceback so it is diagnosable, and surface it to the user
+        # via snapshot.errors below.
         failed = True
-        logger.debug("Refresh failed: {}", e)
+        logger.opt(exception=e).warning("Refresh failed unexpectedly: {}", e)
         if state.snapshot is not None:
             state.snapshot = state.snapshot.model_copy_update(
                 to_update(
@@ -1543,6 +1558,11 @@ def _load_user_commands(mngr_ctx: MngrContext) -> dict[str, CustomCommand]:
             result[key] = value
         elif isinstance(value, dict):
             result[key] = CustomCommand(**value)
+        else:
+            # A value that is neither a CustomCommand nor a raw dict cannot be a
+            # valid command config; log so a malformed entry is visible to the
+            # user rather than silently dropped, but don't crash the whole board.
+            logger.warning("Ignoring malformed kanpan command {!r}: unexpected type {}", key, type(value).__name__)
     return result
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -1157,6 +1157,19 @@ def test_load_user_commands_rejects_builtin_kind_in_raw_dict() -> None:
         _load_user_commands(ctx)
 
 
+def test_load_user_commands_skips_malformed_non_dict_value() -> None:
+    # A config entry that is neither a CustomCommand nor a raw dict (e.g. a bare
+    # string from a malformed TOML config reaching us via model_construct) must be
+    # skipped, not silently coerced and not crash the whole command load.
+    config = KanpanPluginConfig.model_construct(
+        commands={"good": CustomCommand(name="ok", command="echo hi"), "bad": "not-a-command"},
+    )
+    ctx = make_mngr_ctx_with_config(config)
+    result = _load_user_commands(ctx)
+    assert "bad" not in result
+    assert result["good"].name == "ok"
+
+
 def test_build_command_map_includes_builtins() -> None:
     config = KanpanPluginConfig()
     ctx = make_mngr_ctx_with_config(config)


### PR DESCRIPTION
Cleanup pass from `/identify-suspicious-edge-cases` over `libs/mngr_kanpan`, then fixing the findings. The full findings report lives in `libs/mngr_kanpan/_tasks/suspicious-edge-cases/` (gitignored).

## Changes

- **`compute_section`** (`fetcher.py`): replaced the trailing `raise AssertionError(...)` after the `match pr.state` with `case _ as unreachable: assert_never(unreachable)`, so the type checker proves `PrState` exhaustiveness (and we stop raising a built-in exception).
- **`save_field_cache`** (`fetcher.py`): narrowed the catch from `except Exception` to `except OSError` (the only genuine best-effort-write failure mode) and bumped the log to `warning`, so a serialization bug propagates loudly instead of being swallowed.
- **`load_field_cache`** / **`_finish_refresh`**: kept the broad catches (both are intentional event-loop / corrupt-cache guards, and `load_field_cache`'s breadth is enforced by existing tests covering non-dict JSON and invalid agent names) but raised the log level to `warning` -- with a traceback via `logger.opt(exception=e)` for the unexpected-refresh-failure case.
- **`_load_user_commands`** (`tui.py`): a config entry that is neither a `CustomCommand` nor a raw dict is now logged instead of silently dropped.
- **`_parse_github_repo_path`** (`repo_paths.py`): a degenerate GitHub remote that yields no `owner/repo` now returns `None` instead of an empty/malformed `RepoPathField`.
- Documented the intentional handlers that are correct as-is: the broad catches in the three TUI background-poll callbacks, the deliberate `debug` level in `deserialize_fields` (legacy-migration noise), and the OPEN default in `_parse_pr_state`.
- Re-snapshotted ratchets: broad-exception `7 -> 6`, if/elif-without-else `2 -> 1`.

## Tests

`just test-quick "libs/mngr_kanpan -m 'not acceptance and not release'"` -> 388 passed, 0 failed (includes type checks and ratchets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)