### PR TITLE
improve mngr_antigravity tests

### DIFF
--- a/libs/mngr_antigravity/changelog/mngr-bad-tests-mngr-antigravity-local.md
+++ b/libs/mngr_antigravity/changelog/mngr-bad-tests-mngr-antigravity-local.md
@@ -1,0 +1,5 @@
+Strengthened the two-space-indent assertions in `antigravity_config_test.py`. The
+previous `assert "  " in serialized` checks could not distinguish two-space from
+four-space (or wider) indentation, so they did not actually verify the format the
+serializers promise. They now assert that a top-level key line begins with exactly
+two spaces.

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
@@ -47,7 +47,10 @@ def test_serialize_round_trips_to_two_space_indented_json() -> None:
 
     assert json.loads(serialized) == settings
     # Two-space indent, no trailing newline -- mirrors what agy itself writes.
-    assert "  " in serialized
+    # A top-level key must be indented by exactly two spaces (not four, which a
+    # bare ``"  " in serialized`` check could not distinguish).
+    color_scheme_line = next(line for line in serialized.splitlines() if '"colorScheme"' in line)
+    assert color_scheme_line.startswith("  ") and not color_scheme_line.startswith("   ")
     assert not serialized.endswith("\n")
 
 
@@ -283,4 +286,7 @@ def test_serialize_antigravity_hooks_round_trips() -> None:
     config = build_antigravity_hooks_config()
     serialized = serialize_antigravity_hooks(config)
     assert json.loads(serialized) == config
-    assert "  " in serialized
+    # Two-space indent: the top-level key must start with exactly two spaces,
+    # which a bare ``"  " in serialized`` check could not distinguish from four.
+    mngr_key_line = next(line for line in serialized.splitlines() if '"mngr"' in line)
+    assert mngr_key_line.startswith("  ") and not mngr_key_line.startswith("   ")


### PR DESCRIPTION
## Summary

Ran `/identify-bad-tests libs/mngr_antigravity` and fixed the one clear-cut finding.

The round-trip serialization tests in `antigravity_config_test.py` claimed to verify two-space-indented JSON but asserted only `assert "  " in serialized`. Two consecutive spaces appear in JSON serialized at *any* indent width >= 2 (e.g. `indent=4` lines contain `"  "` too), so the check could not distinguish two-space from four-space indentation and would not catch the regression its name describes.

Both assertions (in `test_serialize_round_trips_to_two_space_indented_json` and `test_serialize_antigravity_hooks_round_trips`) now assert that a top-level key line begins with *exactly* two spaces, which discriminates `indent=2` from `indent=4`.

## Findings reviewed but not changed

The remaining candidates (structural `issubclass`/constant change-detector tests, the `_send_enter_and_validate` not-abstract check, and the `isolated_home` fixture's partial HOME re-isolation) were left as-is: they match the established testing style of the sibling `mngr_claude` plugin, act as tripwires for external-contract values / safety-relevant defaults, or serve a real purpose. Full rationale is in the gitignored findings file under `_tasks/bad-tests/`.

## Testing

`just test-quick "libs/mngr_antigravity -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` -- 137 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)