### PR TITLE
Fix low-quality tests under minds/envs

### DIFF
--- a/apps/minds/changelog/mngr-bad-tests-minds-envs-local.md
+++ b/apps/minds/changelog/mngr-bad-tests-minds-envs-local.md
@@ -1,0 +1,7 @@
+Test-quality improvements under `imbue/minds/envs` (no user-visible behavior change):
+
+- `docker_cleanup_test.py`: the user-id-unresolved skip test now asserts the skip warning is logged (via `capture_loguru`) instead of only "does not raise", so it actually fails if the `cleanup_env_state_container` skip-guard is removed.
+- `health_check_test.py`: added coverage for `check_once`'s transport-exception branches (connect error / timeout are transient, other httpx errors are definitive) and for the public `await_apps_healthy` entry point (healthy, definitive-failure, and timeout paths) using `MockTransport` + the `client_factory` seam.
+- `generation_test.py` and `providers/cloudflare_tunnels_test.py`: the "not found / 404 is treated as success" tests now assert the underlying delete was actually attempted, not just that no exception was raised.
+- `provisioning_test.py`: the deploy re-run test was renamed to describe what it actually guards (one deploy pass per run, not resource-level idempotency), and the two no-inline-rollback failure tests now assert the no-`delete_*`/`wipe_*` invariant directly rather than pinning the exact full call list.
+- Consolidated the duplicated `_root_cg` and `_isolated_home` fixtures into a new `imbue/minds/envs/conftest.py`, dropping the redundant `HOME`/`chdir` setup already provided by the autouse isolation fixture.

--- a/apps/minds/imbue/minds/envs/conftest.py
+++ b/apps/minds/imbue/minds/envs/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for the ``minds.envs`` unit tests.
+
+CLAUDE.md requires fixtures to live in a ``conftest.py`` rather than being
+re-defined per ``_test.py`` file. These two were previously duplicated across
+``docker_cleanup_test.py``, ``generation_test.py``, ``provisioning_test.py`` and
+``local_store_test.py`` (and had drifted apart -- e.g. some entered the
+ConcurrencyGroup, some did not). They are consolidated here.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+
+
+@pytest.fixture
+def _root_cg() -> Iterator[ConcurrencyGroup]:
+    """An ACTIVE ConcurrencyGroup the tests can use as a subprocess parent.
+
+    Entered (via ``with``) so suites that spawn real subprocesses -- the
+    ``vault`` fake in ``generation_test`` and the ``docker`` CLI in
+    ``docker_cleanup_test`` -- have an active parent, which
+    ``run_process_to_completion`` requires. ``provisioning_test``'s fakes never
+    spawn anything, but an active group is a harmless superset for them.
+    """
+    cg = ConcurrencyGroup(name="envs-test-root")
+    with cg:
+        yield cg
+
+
+@pytest.fixture
+def _isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Layer the minds-specific tmp-home setup on top of the autouse isolation.
+
+    The autouse ``setup_test_mngr_env`` fixture (registered in
+    ``apps/minds/conftest.py``) already points ``HOME`` at this same ``tmp_path``
+    and chdirs into it via ``isolate_home``. Here we only add the minds-specific
+    bits:
+
+    * clear ``MINDS_ROOT_NAME`` so the dev-env-name path computations derive the
+      path purely from the ``DevEnvName``; and
+    * seed an ``apps/`` marker so ``find_monorepo_root`` (called by ``deploy_env``
+      to locate the recover-target file) resolves a root under the tmp tree
+      instead of the real repo. Harmless for tests that don't deploy.
+    """
+    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
+    (tmp_path / "apps").mkdir(exist_ok=True)
+    return tmp_path

--- a/apps/minds/imbue/minds/envs/docker_cleanup_test.py
+++ b/apps/minds/imbue/minds/envs/docker_cleanup_test.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterator
 from pathlib import Path
 from uuid import uuid4
 
@@ -13,13 +12,7 @@ from imbue.minds.envs.docker_cleanup import state_container_name
 from imbue.minds.envs.docker_cleanup import stop_active_env_state_container
 from imbue.minds.envs.docker_cleanup import stop_state_container
 from imbue.minds.envs.primitives import DevEnvName
-
-
-@pytest.fixture
-def _root_cg() -> Iterator[ConcurrencyGroup]:
-    cg = ConcurrencyGroup(name="docker-cleanup-test-root")
-    with cg:
-        yield cg
+from imbue.mngr.utils.testing import capture_loguru
 
 
 def _write_profile(mngr_host_dir: Path, *, profile_id: str, user_id: str) -> None:
@@ -69,13 +62,20 @@ def test_is_docker_daemon_unavailable_detects_daemon_errors() -> None:
     assert not _is_docker_daemon_unavailable("Error: No such container: minds-staging-docker-state-x")
 
 
-def test_cleanup_env_state_container_skips_when_user_id_unresolved(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
-) -> None:
-    # No mngr profile under HOME -> user_id can't be resolved -> no-op skip
-    # (never matches a broader target, never raises).
-    monkeypatch.setenv("HOME", str(tmp_path))
-    cleanup_env_state_container(DevEnvName("staging"), parent_concurrency_group=_root_cg)
+def test_cleanup_env_state_container_skips_when_user_id_unresolved(_root_cg: ConcurrencyGroup) -> None:
+    # No mngr profile under the (autouse-isolated) HOME -> user_id can't be
+    # resolved -> the function must take the skip branch and must NOT fall
+    # through to remove_state_container against a broader / None-typed target.
+    #
+    # Assert the *observable effect* of the skip branch -- the warning it logs --
+    # rather than just "did not raise". Without this, deleting the `if user_id is
+    # None: return` guard would still pass: the fall-through computes
+    # `...docker-state-None` and calls remove_state_container, which is a silent
+    # no-op when the container/daemon is absent. The warning only fires on the
+    # skip path, so it fails the test iff the guard is removed.
+    with capture_loguru(level="WARNING") as log_output:
+        cleanup_env_state_container(DevEnvName("staging"), parent_concurrency_group=_root_cg)
+    assert "skipping Docker state-container cleanup" in log_output.getvalue()
 
 
 def test_stop_active_env_state_container_skips_when_user_id_unresolved(

--- a/apps/minds/imbue/minds/envs/generation_test.py
+++ b/apps/minds/imbue/minds/envs/generation_test.py
@@ -8,7 +8,6 @@ kwarg, matching the pattern used in ``vault_reader_test.py``.
 import json
 import re
 import stat
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -70,16 +69,6 @@ def _make_fake_vault_binary(
     )
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return script
-
-
-@pytest.fixture
-def _root_cg() -> "Iterator[ConcurrencyGroup]":
-    """Yield an active ConcurrencyGroup so the spawned ``vault`` subprocess
-    can run under it (``cg.run_process_to_completion`` requires ACTIVE state).
-    """
-    cg = ConcurrencyGroup(name="generation-test-root")
-    with cg:
-        yield cg
 
 
 def _kv_get_payload(*, generation_id: str | None) -> str:
@@ -181,12 +170,18 @@ def test_delete_generation_id_is_idempotent_on_missing_entry(tmp_path: Path, _ro
         delete_exit_code=2,
         delete_stderr="No value found at secrets/metadata/minds/staging/generation",
     )
-    # Should not raise -- "not found" is treated as success.
+    # "not found" is treated as success (does not raise) -- but the delete must
+    # actually have been attempted. Without this argv assertion, a buggy
+    # early-return that never shelled out to vault would also "not raise" and so
+    # pass while exercising none of the not-found-is-success handling.
     delete_generation_id(
         "secrets/minds/staging",
         parent_concurrency_group=_root_cg,
         vault_binary=str(fake),
     )
+    calls = (tmp_path / "_calls.log").read_text()
+    assert "kv metadata delete" in calls
+    assert "minds/staging/generation" in calls
 
 
 def test_delete_generation_id_invokes_vault_metadata_delete(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:

--- a/apps/minds/imbue/minds/envs/health_check_test.py
+++ b/apps/minds/imbue/minds/envs/health_check_test.py
@@ -4,10 +4,15 @@ Uses ``httpx.MockTransport`` to inject controlled HTTP responses --
 no monkeypatching, no real network calls.
 """
 
+from collections.abc import Callable
+
 import httpx
+import pytest
+from pydantic import AnyUrl
 
 from imbue.minds.envs.health_check import HealthCheckFailedError
 from imbue.minds.envs.health_check import _is_transient_status
+from imbue.minds.envs.health_check import await_apps_healthy
 from imbue.minds.envs.health_check import check_once
 from imbue.minds.errors import MindError
 
@@ -142,3 +147,111 @@ def test_check_once_5xx_after_cold_boot_with_body_is_definitive() -> None:
     assert ok is False
     assert reason is not None
     assert "after cold-boot window" in reason
+
+
+def _client_raising(exc: httpx.HTTPError) -> httpx.Client:
+    """Build an httpx.Client whose every request raises ``exc`` at the transport layer."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_check_once_connect_error_is_transient() -> None:
+    """A connection error (app still cold-booting / not yet routable) is transient."""
+    with _client_raising(httpx.ConnectError("connection refused")) as client:
+        ok, reason = check_once(
+            client=client,
+            url="https://example.com",
+            expected_substring=None,
+            per_attempt_timeout=1.0,
+            elapsed_seconds=0.0,
+        )
+    assert ok is False
+    assert reason is None
+
+
+def test_check_once_timeout_is_transient() -> None:
+    """A socket timeout is transient -- the poller keeps trying within its budget."""
+    with _client_raising(httpx.TimeoutException("slow")) as client:
+        ok, reason = check_once(
+            client=client,
+            url="https://example.com",
+            expected_substring=None,
+            per_attempt_timeout=1.0,
+            elapsed_seconds=0.0,
+        )
+    assert ok is False
+    assert reason is None
+
+
+def test_check_once_other_httpx_error_is_definitive() -> None:
+    """A non-timeout, non-connect httpx error surfaces as a definitive failure."""
+    with _client_raising(httpx.HTTPError("kaboom")) as client:
+        ok, reason = check_once(
+            client=client,
+            url="https://example.com",
+            expected_substring=None,
+            per_attempt_timeout=1.0,
+            elapsed_seconds=0.0,
+        )
+    assert ok is False
+    assert reason is not None
+    assert "httpx error" in reason
+
+
+def _factory_always(status: int, body: str = "") -> Callable[[], httpx.Client]:
+    """A ``client_factory`` whose client always returns the given response."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=status, text=body)
+
+    return lambda: httpx.Client(transport=httpx.MockTransport(handler))
+
+
+_CONNECTOR_URL = AnyUrl("https://connector.example")
+_LITELLM_URL = AnyUrl("https://litellm.example")
+
+
+def test_await_apps_healthy_returns_none_when_both_endpoints_healthy() -> None:
+    """Both endpoints answer 200 immediately -> the poller returns without raising."""
+    result = await_apps_healthy(
+        connector_url=_CONNECTOR_URL,
+        litellm_proxy_url=_LITELLM_URL,
+        max_seconds=1.0,
+        poll_interval=0.05,
+        per_attempt_timeout=1.0,
+        client_factory=_factory_always(200, '{"ok": true}'),
+    )
+    assert result is None
+
+
+def test_await_apps_healthy_raises_on_definitive_failure() -> None:
+    """A definitive failure (a 3xx redirect, e.g. a SuperTokens login page) fails fast.
+
+    A redirect is definitive regardless of the cold-boot window, so the poller
+    short-circuits to a HealthCheckFailedError instead of burning its budget.
+    """
+    with pytest.raises(HealthCheckFailedError, match="failed definitively"):
+        await_apps_healthy(
+            connector_url=_CONNECTOR_URL,
+            litellm_proxy_url=_LITELLM_URL,
+            max_seconds=1.0,
+            poll_interval=0.05,
+            per_attempt_timeout=1.0,
+            client_factory=_factory_always(302, "redirecting to login"),
+        )
+
+
+def test_await_apps_healthy_raises_on_timeout_when_never_healthy() -> None:
+    """A persistently-transient endpoint (503, empty body) exhausts the budget and fails."""
+    with pytest.raises(HealthCheckFailedError, match="did not return 200"):
+        await_apps_healthy(
+            connector_url=_CONNECTOR_URL,
+            litellm_proxy_url=_LITELLM_URL,
+            max_seconds=0.2,
+            poll_interval=0.05,
+            per_attempt_timeout=1.0,
+            client_factory=_factory_always(503, ""),
+        )

--- a/apps/minds/imbue/minds/envs/local_store_test.py
+++ b/apps/minds/imbue/minds/envs/local_store_test.py
@@ -26,16 +26,6 @@ from imbue.minds.envs.primitives import DevEnvNotFoundError
 from imbue.minds.envs.primitives import InvalidDevEnvNameError
 
 
-@pytest.fixture
-def _isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Redirect ``Path.home()`` to ``tmp_path`` so writes land under tmp."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    # No MINDS_ROOT_NAME -- the dev-env-name path computations don't need it
-    # (env_root_dir derives the path purely from the DevEnvName).
-    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
-    return tmp_path
-
-
 def _make_client() -> ClientEnvConfig:
     return ClientEnvConfig(
         connector_url=AnyUrl("https://test-connector.modal.run"),

--- a/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels_test.py
+++ b/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels_test.py
@@ -193,7 +193,10 @@ def test_delete_tunnels_iterates_all_ids() -> None:
 
 
 def test_delete_tunnels_treats_404_as_success() -> None:
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(404, json={"errors": [{"message": "gone"}]})
 
     delete_tunnels(
@@ -202,6 +205,11 @@ def test_delete_tunnels_treats_404_as_success() -> None:
         api_token=SecretStr("t"),
         transport=httpx.MockTransport(handler),
     )
+    # 404 must be swallowed (no raise) AND the DELETE must actually have been
+    # issued -- a buggy skip that never sent the request would also "not raise".
+    assert len(requests) == 1
+    assert requests[0].method == "DELETE"
+    assert str(requests[0].url).rstrip("/").endswith("missing-tunnel")
 
 
 def test_delete_tunnels_raises_on_non_404_error() -> None:

--- a/apps/minds/imbue/minds/envs/provisioning_test.py
+++ b/apps/minds/imbue/minds/envs/provisioning_test.py
@@ -41,31 +41,6 @@ from imbue.minds.errors import MindError
 from imbue.minds.primitives import ServiceName
 from imbue.mngr_ovh.iam_tags import IamResource
 
-
-@pytest.fixture
-def _isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Sandbox $HOME + cwd so deploy/destroy/recover write to a tmp tree only.
-
-    Also seeds an ``apps/`` marker so :func:`find_monorepo_root` (called
-    by deploy_env to pick the recover-target file location) finds a
-    monorepo root under the tmp tree instead of the real repo.
-    """
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
-    (tmp_path / "apps").mkdir()
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
-
-
-@pytest.fixture
-def _root_cg() -> ConcurrencyGroup:
-    """Bare ConcurrencyGroup the fakes accept as their parent.
-
-    The fakes never spawn subprocesses, so we don't need to ``with`` it.
-    """
-    return ConcurrencyGroup(name="provisioning-test-root")
-
-
 # Fixed test workspace name used everywhere ``deploy_dev_env`` /
 # ``deploy_tier_env`` constructs an expected URL via ``per_env_*_url`` /
 # ``tier_*_url``. The fake deploy_litellm_proxy / deploy_remote_service_connector
@@ -416,8 +391,18 @@ def test_deploy_dev_env_writes_split_files(_isolated_home: Path, _root_cg: Concu
     assert result.secrets_path is not None and result.secrets_path.endswith("/.minds-dev-alice/secrets.toml")
 
 
-def test_deploy_dev_env_is_idempotent_on_re_run(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
-    """Re-running deploy for an existing env succeeds (overwrites in place)."""
+def test_deploy_dev_env_re_run_succeeds_with_one_deploy_pass_each_time(
+    _isolated_home: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    """Re-running deploy for an existing env succeeds and runs exactly one deploy pass each time.
+
+    This guards "no accidental second-pass redeploy within a single run", NOT
+    resource-level idempotency: the fake ``create_neon_project`` always creates,
+    so at the resource level a re-run is not a no-op. Adoption-vs-create dedup
+    (so a re-run reuses the existing Neon project instead of duplicating it) is
+    the F32 ``_select_one_or_raise_multi_match`` contract, covered in
+    ``providers/neon_db_test.py``.
+    """
     call_log = _make_call_log()
     providers = _build_fake_providers(call_log)
     deploy_env(
@@ -466,8 +451,14 @@ def test_deploy_env_dev_neon_failure_does_not_inline_rollback(
             parent_concurrency_group=_root_cg,
         )
     step_names = [c[0] for c in call_log["calls"]]
-    # No delete_* calls fire on failure -- recover is the rollback path.
-    assert step_names == ["ensure_modal_env", "create_neon_project"]
+    # The invariant under test is "no inline rollback": no delete_*/wipe_* step
+    # fires on failure (recover is the canonical rollback path). Assert that
+    # directly rather than pinning the exact full call list, so a future benign
+    # preflight step before create_neon_project wouldn't break this test.
+    assert not any(c[0].startswith("delete_") or c[0].startswith("wipe_") for c in call_log["calls"])
+    # Sanity: deploy did get as far as creating the Neon project (the failing step).
+    assert "ensure_modal_env" in step_names
+    assert "create_neon_project" in step_names
     # No client.toml / secrets.toml written for a failed deploy.
     assert not client_config_exists(DevEnvName("dev-carol"))
 
@@ -487,12 +478,15 @@ def test_deploy_env_dev_supertokens_failure_does_not_inline_rollback(
             parent_concurrency_group=_root_cg,
         )
     step_names = [c[0] for c in call_log["calls"]]
-    # No delete_* calls fire -- recover handles rollback in a later phase.
-    assert step_names == [
-        "ensure_modal_env",
-        "create_neon_project",
-        "create_supertokens_app",
-    ]
+    # The invariant under test is "no inline rollback": no delete_*/wipe_* step
+    # fires on failure (recover is the canonical rollback path). Assert that
+    # directly rather than pinning the exact full call list, so a future benign
+    # preflight step wouldn't break this test.
+    assert not any(c[0].startswith("delete_") or c[0].startswith("wipe_") for c in call_log["calls"])
+    # Sanity: deploy did get as far as creating the SuperTokens app (the failing step).
+    assert "ensure_modal_env" in step_names
+    assert "create_neon_project" in step_names
+    assert "create_supertokens_app" in step_names
 
 
 def test_deploy_dev_env_pushes_per_env_secrets_into_dev_modal_env(


### PR DESCRIPTION
Ran `/identify-bad-tests` scoped to `apps/minds/imbue/minds/envs` and then fixed every finding. Test-only changes plus one new `conftest.py`; no production code changed.

## What was wrong and what changed

1. **No-assertion skip test** (`docker_cleanup_test.py`): `test_cleanup_env_state_container_skips_when_user_id_unresolved` only checked "does not raise" — it passed even with the `user_id is None` skip-guard deleted (the fall-through is a silent no-op when docker is absent). Now asserts the skip warning is logged via `capture_loguru`. Mutation-verified: removing the guard now fails the test.

2. **Untested categorization + entry point** (`health_check_test.py`): added coverage for `check_once`'s transport-exception branches (connect error / timeout -> transient; other httpx error -> definitive) and for the public `await_apps_healthy` (healthy / definitive-failure / timeout paths) via `MockTransport` + the `client_factory` seam.

3. **Redundant isolation + duplicated fixtures** (findings 3 & 4): `_root_cg` was defined 3x and `_isolated_home` 2x, and the latter re-did the `HOME`/`chdir` isolation the autouse fixture already provides. Consolidated both into a new `imbue/minds/envs/conftest.py` and dropped the redundant setup.

4. **Misleading "idempotent" test** (`provisioning_test.py`): renamed `test_deploy_dev_env_is_idempotent_on_re_run` to describe what it actually guards (one deploy pass per run, not resource-level idempotency) and documented where resource dedup is really covered.

5. **"Does not raise" 404/idempotency tests** (`generation_test.py`, `providers/cloudflare_tunnels_test.py`): now assert the delete was actually attempted, not just that nothing raised.

6. **Brittle full-call-list assertions** (`provisioning_test.py`): the two no-inline-rollback failure tests now assert the no-`delete_*`/`wipe_*` invariant directly instead of pinning the entire ordered call list.

## Testing

- `just test-quick apps/minds/imbue/minds/envs` (unit subset): 136 passed.
- minds ratchets: 55 passed. `ty check` on touched files: clean.
- docker/acceptance tests under this path are unchanged in behavior and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)