### PR TITLE
mngr/bad tests minds deployment tests local

### DIFF
--- a/apps/minds/changelog/mngr-bad-tests-minds-deployment-tests-local.md
+++ b/apps/minds/changelog/mngr-bad-tests-minds-deployment-tests-local.md
@@ -1,0 +1,6 @@
+Hardened the minds deployment/services test suite (`apps/minds/deployment_tests/`):
+
+- Fixed a flakiness bug in `test_deploy_new_version`: the `/version` poller no longer aborts on a transient 5xx during the expected `DeployStrategy.RECREATE` cold-boot window; it now polls past non-200 responses like the rollback test's poller already did.
+- Typed the previously-untyped `name` parameter of `_run_minds_env_destroy` in `test_deploy_round_trip` as `DevEnvName`.
+- Simplified the two still-skipped skeleton tests (`test_signup_tunnel`, `test_litellm_via_workspace`) to drop their unreachable `wait_for_env_ready` preamble and use `pytest.fail` so they fail loudly if unskipped before their drivers land.
+- Updated `deployment_tests/README.md`, which incorrectly claimed all tests were skipped, to reflect that four tests are now active.

--- a/apps/minds/deployment_tests/README.md
+++ b/apps/minds/deployment_tests/README.md
@@ -37,4 +37,6 @@ just minds-test-services-against dev-josh apps/minds/deployment_tests/test_logge
 
 ## Status
 
-All tests are currently `@pytest.mark.skip`ped while the orchestrator + fixture implementations land. The test bodies are skeleton-quality and document the planned assertions; iterating on them is the next step after the scaffolding ships.
+The `minds_deployment` tests (`test_deploy_round_trip.py`, `test_deploy_rollback.py`, `test_deploy_new_version.py`) and the `test_logged_in_smoke.py` `minds_services` test are implemented and active, with real assertions against live envs.
+
+Two `minds_services` tests remain `@pytest.mark.skip`ped pending their drivers: `test_signup_tunnel.py` (needs the mail.tm-backed signup / one-time-code / in-process desktop-client drivers) and `test_litellm_via_workspace.py` (needs the desktop-client workspace-create driver, a Neon DSN query helper, and a Docker daemon). Their bodies document the planned assertions and `pytest.fail` if the skip is ever removed before the drivers land.

--- a/apps/minds/deployment_tests/test_deploy_new_version.py
+++ b/apps/minds/deployment_tests/test_deploy_new_version.py
@@ -123,10 +123,15 @@ def _poll_for_deploy_id_change(*, connector_url: str, baseline_deploy_id: str, t
     with httpx.Client(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
         while time.monotonic() < deadline:
             resp = client.get(f"{connector_url}/version")
-            resp.raise_for_status()
-            seen = resp.json().get("deploy_id", "")
-            if seen and seen != baseline_deploy_id:
-                return seen
-            last_seen = seen
+            # With DeployStrategy.RECREATE the first /version GET cold-boots a
+            # fresh container, so a transient 5xx during Modal's swap window is
+            # expected -- treat it as "keep polling" rather than aborting the
+            # test (mirrors _poll_for_deploy_id in test_deploy_rollback.py).
+            if resp.status_code == 200:
+                seen = resp.json().get("deploy_id", "")
+                if seen and seen != baseline_deploy_id:
+                    return seen
+                if seen:
+                    last_seen = seen
             time.sleep(_VERSION_POLL_INTERVAL_SECONDS)
     return last_seen

--- a/apps/minds/deployment_tests/test_deploy_round_trip.py
+++ b/apps/minds/deployment_tests/test_deploy_round_trip.py
@@ -29,6 +29,7 @@ from imbue.minds.deployment_tests.helpers import supertokens_app_exists
 from imbue.minds.envs.paths import client_config_file
 from imbue.minds.envs.paths import env_root_dir
 from imbue.minds.envs.paths import secrets_file
+from imbue.minds.envs.primitives import DevEnvName
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -72,7 +73,10 @@ def test_deploy_then_destroy_round_trip(ephemeral_env: EphemeralEnvHandle) -> No
         f"Modal env {ephemeral_env.name!r} not found in `modal environment list` after deploy."
     )
 
-    # Both Modal apps reachable.
+    # Both Modal apps reachable. A single GET (no polling) is sufficient here:
+    # the ephemeral_env fixture's `minds env deploy` already awaited
+    # `await_apps_healthy`, so the containers are warm by the time we reach
+    # this line.
     connector_url = str(ephemeral_env.connector_url).rstrip("/")
     litellm_url = str(ephemeral_env.litellm_proxy_url).rstrip("/")
     with httpx.Client(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
@@ -117,7 +121,7 @@ def test_deploy_then_destroy_round_trip(ephemeral_env: EphemeralEnvHandle) -> No
     # ephemeral_env fixture teardown's destroy will no-op (env root gone).
 
 
-def _run_minds_env_destroy(name) -> None:
+def _run_minds_env_destroy(name: DevEnvName) -> None:
     """Shell out to ``uv run minds env destroy`` for ``name`` and assert success."""
     sub_env = build_minds_env_subprocess_env(name)
     completed = subprocess.run(

--- a/apps/minds/deployment_tests/test_litellm_via_workspace.py
+++ b/apps/minds/deployment_tests/test_litellm_via_workspace.py
@@ -18,7 +18,6 @@ import pytest
 from imbue.minds.deployment_tests.data_types import FctTemplateRef
 from imbue.minds.deployment_tests.data_types import SharedEnvHandle
 from imbue.minds.deployment_tests.data_types import VerifiedUserHandle
-from imbue.minds.deployment_tests.helpers import wait_for_env_ready
 
 pytestmark = pytest.mark.minds_services
 
@@ -65,6 +64,8 @@ def test_litellm_spend_tracking_via_local_workspace(
     to offload, the future ``offload-modal-minds-services.toml`` will
     enable Docker-in-Docker (mirroring ``offload-modal-acceptance.toml``).
     """
-    wait_for_env_ready(shared_env("default"))
-    _ = (verified_user, fct_template_ref)
-    raise AssertionError("not implemented yet -- see skip reason")
+    # Body intentionally unimplemented (the test is @pytest.mark.skip above);
+    # the docstring is the design record. Fail loudly if the skip is ever
+    # removed before the drivers land.
+    _ = (shared_env, verified_user, fct_template_ref)
+    pytest.fail("not implemented yet -- see skip reason")

--- a/apps/minds/deployment_tests/test_signup_tunnel.py
+++ b/apps/minds/deployment_tests/test_signup_tunnel.py
@@ -19,7 +19,6 @@ import pytest
 from imbue.minds.deployment_tests._mailtm import MailtmInbox
 from imbue.minds.deployment_tests.data_types import FctTemplateRef
 from imbue.minds.deployment_tests.data_types import SharedEnvHandle
-from imbue.minds.deployment_tests.helpers import wait_for_env_ready
 
 pytestmark = pytest.mark.minds_services
 
@@ -76,6 +75,8 @@ def test_realistic_signup_verify_signin_create_tunnel_signout(
        Cloudflare), destroy the workspace, sign out, assert subsequent
        requests with the same session token return 401.
     """
-    wait_for_env_ready(shared_env("default"))
-    _ = (signup_email, fct_template_ref)
-    raise AssertionError("not implemented yet -- see skip reason")
+    # Body intentionally unimplemented (the test is @pytest.mark.skip above);
+    # the docstring is the design record. Fail loudly if the skip is ever
+    # removed before the drivers land.
+    _ = (shared_env, signup_email, fct_template_ref)
+    pytest.fail("not implemented yet -- see skip reason")


### PR DESCRIPTION
- **Add identify-suspicious-edge-cases skill**
- **Strengthen suspicion bar: justify the specific handling, not just that some handling is needed**
- **Fix typo and correct misleading style-guide claims in non_issues.md**
- **Add Something | None callout to identify-suspicious-edge-cases skill**
- **Drop ratchet/linter exclusion note from skill**
- **Allow identify-suspicious-edge-cases to target a subdir, not just a library**
- **Generalize the other identify-* skills to take a target path, not a library name**
- **Fix over-defensive edge-case handlers found by identify-suspicious-edge-cases**
- **Trim ResourceGuardMisconfiguration docstring to one line**
- **Fix import-layer violation: move build_user_ssh_command to primitives**
- **Add identify-bad-tests skill**
- **Tighten identify-bad-tests context paragraph**
- **Trim style-guide duplication from identify-bad-tests checklist**
- **Make external-resource use the test-promotion criterion**
- **Drop duplicative realism-vs-resources sentence**
- **Remove contradictory commit instruction**
- **Fix same commit contradiction in sibling identify-* skills**
- **Condense identify-bad-tests; defer the catalog to the style guide**
- **Clarify wording, add autouse-fixture scan, drop flaky-test emphasis**
- **Add fixture-reuse/conftest checks (sourced from CLAUDE.md, not style guide)**
- **Calibrate fixture guidance and clarify the Decision field**
- **Strengthen modal_proxy tests flagged by identify-bad-tests**
- **Strengthen mngr_wait tests flagged by identify-bad-tests**
- **Strengthen mngr/utils tests flagged by identify-bad-tests**
- **Address verify-architecture findings on the mngr test fixes**
- **Strengthen name-generator variability assertion**
- **Drop 1e-10 reference from name-generator test comment**
- **Parametrize the name-generator variability tests**
- **Drop change-detector state-set tests; trim a redundant comment**
- **Ratchet stale coverage floors up to match measured coverage**
- **Drop stale minds coverage-floor comment**
- **Refresh stale 'initial threshold' coverage comments**
- **Remove stale offload coverage-drift comments**
- **Ignore *.local.sh scratch scripts in .gitignore**
- **Ignore _tasks/ output at any depth (incl. dev/_tasks/)**
- **Harden suspicious edge-case handling in scripts/ (+ fix stale see_also refs)**
- **Fix test-isolation leak: make_cli_docs_test leaked MNGR_LOAD_ALL_PLUGINS**
- **Make the plugin-blocking test a leak tripwire instead of silently clearing**
- **Revert the coordinator.py catch-all removal**
- **release.py: let PyPI checks blow up; fix git-diff exit-code misread**
- **Harden minds deployment/services tests**
