### PR TITLE
minds cli: fix low-quality tests found by identify-bad-tests

### DIFF
--- a/apps/minds/changelog/mngr-bad-tests-minds-cli-local.md
+++ b/apps/minds/changelog/mngr-bad-tests-minds-cli-local.md
@@ -1,0 +1,13 @@
+Improved test quality under `imbue/minds/cli`:
+
+- `test_pool_create_derives_production_from_default_root_name` now drives the real
+  `MINDS_ROOT_NAME=minds` -> `production` resolution via `require_activated_env_name()`
+  instead of hardcoding the env name, so a regression in that mapping is actually caught.
+- Consolidated the duplicated, divergent `_isolated_env` fixtures from `env_test.py` and
+  `pool_test.py` into a single `isolated_activation_env` fixture in `conftest.py` that strips
+  the superset of activation vars (`MINDS_ROOT_NAME`, `MODAL_PROFILE`, `MODAL_CONFIG_PATH`).
+- Dropped redundant `HOME`/`chdir` setup that the autouse `isolate_mind_tests` already provides.
+- `test_wipe_teardown_is_noop_without_profile_or_agents` now asserts the observable no-op
+  (no "Destroyed ... mngr agent(s)" log line) via a loguru sink instead of only "did not raise".
+- `test_validate_modal_profile_rejects_non_table_section` now pins the failure to the
+  "no profile named ..." branch by asserting on the message text.

--- a/apps/minds/imbue/minds/cli/_activated_env_test.py
+++ b/apps/minds/imbue/minds/cli/_activated_env_test.py
@@ -49,7 +49,6 @@ def test_tier_for_env_name_dev_prefixed_with_ci_substring_still_dev() -> None:
 
 
 def test_validate_modal_profile_accepts_matching_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
@@ -58,7 +57,6 @@ def test_validate_modal_profile_accepts_matching_section(tmp_path: Path, monkeyp
 
 
 def test_validate_modal_profile_rejects_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     with pytest.raises(click.ClickException) as excinfo:
         validate_modal_profile_exists_in_modal_toml("minds-staging")
@@ -69,7 +67,6 @@ def test_validate_modal_profile_rejects_missing_file(tmp_path: Path, monkeypatch
 
 
 def test_validate_modal_profile_rejects_missing_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
@@ -81,7 +78,6 @@ def test_validate_modal_profile_rejects_missing_section(tmp_path: Path, monkeypa
 
 
 def test_validate_modal_profile_rejects_unparseable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     modal_toml.write_text("this is not valid toml = = =")
@@ -94,21 +90,22 @@ def test_validate_modal_profile_rejects_unparseable_file(tmp_path: Path, monkeyp
 
 def test_validate_modal_profile_rejects_non_table_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A bare scalar at the workspace key is not a valid profile."""
-    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
     modal_toml = tmp_path / ".modal.toml"
     # A top-level scalar key collides namespace-wise with the workspace
     # name but does not satisfy "section named workspace".
     modal_toml.write_text('"minds-dev" = "not a table"\n')
-    with pytest.raises(click.ClickException):
+    with pytest.raises(click.ClickException) as excinfo:
         validate_modal_profile_exists_in_modal_toml("minds-dev")
+    # Pin the non-table case to the "missing profile" branch specifically, so a
+    # regression that misrouted it to the "could not read" branch is caught.
+    assert "no profile named 'minds-dev'" in str(excinfo.value)
 
 
 def test_validate_modal_profile_honors_modal_config_path_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When MODAL_CONFIG_PATH is set, validation must read that file (matching the Modal SDK)."""
-    monkeypatch.setenv("HOME", str(tmp_path))
     # Profile lives in the override path, NOT in ~/.modal.toml.
     override_path = tmp_path / "alt-modal-config.toml"
     override_path.write_text('[minds-dev]\ntoken_id = "ak-1"\ntoken_secret = "as-1"\n')
@@ -121,7 +118,6 @@ def test_validate_modal_profile_rejects_when_override_lacks_profile_even_if_home
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """With MODAL_CONFIG_PATH set, ~/.modal.toml is ignored entirely (mirrors Modal SDK)."""
-    monkeypatch.setenv("HOME", str(tmp_path))
     # Profile present in HOME but not the override -- validation must
     # still fail, because Modal SDK would read the override and miss it.
     home_toml = tmp_path / ".modal.toml"

--- a/apps/minds/imbue/minds/cli/conftest.py
+++ b/apps/minds/imbue/minds/cli/conftest.py
@@ -34,3 +34,20 @@ def isolate_mind_tests(
 
     with isolate_git(monkeypatch), isolate_tmux_server(monkeypatch):
         yield
+
+
+@pytest.fixture
+def isolated_activation_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Strip every activation env var so tests opt in to a specific env explicitly.
+
+    The autouse ``isolate_mind_tests`` already points HOME (and the cwd) at
+    ``tmp_path``; this fixture layers on top by clearing the activation vars
+    that leak in from the operator's shell (``MINDS_ROOT_NAME``,
+    ``MODAL_PROFILE``) plus ``MODAL_CONFIG_PATH``, which would otherwise
+    redirect deploy-mode validation away from the test's ``~/.modal.toml``.
+    Returns ``tmp_path`` (== HOME) for tests that need to drop fixture files there.
+    """
+    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
+    monkeypatch.delenv("MODAL_PROFILE", raising=False)
+    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
+    return tmp_path

--- a/apps/minds/imbue/minds/cli/env_test.py
+++ b/apps/minds/imbue/minds/cli/env_test.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from loguru import logger
 
 from imbue.minds.cli._activated_env import MODAL_PROFILE_ENV_VAR
 from imbue.minds.cli.env import _destroy_agents_and_state_container_for_wipe
@@ -27,32 +28,31 @@ from imbue.minds.cli.env import env
 from imbue.minds.envs.primitives import InvalidDevEnvNameError
 
 
-def test_wipe_teardown_is_noop_without_profile_or_agents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_wipe_teardown_is_noop_without_profile_or_agents() -> None:
     # With no mngr profile + no agents under the env root, there is nothing to
     # destroy and the state-container cleanup skips on an unresolved user_id --
-    # a pure no-op that does not raise (no Docker daemon is even contacted).
-    monkeypatch.setenv("HOME", str(tmp_path))
-    _destroy_agents_and_state_container_for_wipe("staging")
+    # a pure no-op (no Docker daemon is even contacted). HOME is already
+    # redirected to tmp_path by the autouse isolate_mind_tests fixture.
+    #
+    # The production code logs a "Destroyed N mngr agent(s)" line only when it
+    # actually tears something down, so the absence of any such line is the
+    # observable proof that the teardown was a genuine no-op (rather than, say,
+    # spuriously destroying an agent or contacting Docker). Capture loguru
+    # output via a sink, since loguru does not propagate to pytest's caplog.
+    log_lines: list[str] = []
+    sink_id = logger.add(lambda msg: log_lines.append(msg.record["message"]), level="INFO", format="{message}")
+    try:
+        _destroy_agents_and_state_container_for_wipe("staging")
+    finally:
+        logger.remove(sink_id)
+    assert not any("Destroyed" in line for line in log_lines), log_lines
 
 
-def test_wipe_teardown_raises_on_invalid_env_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_wipe_teardown_raises_on_invalid_env_name() -> None:
     # Errors are surfaced, not swallowed: a bad env name must raise so the
     # operator sees the problem rather than silently leaking resources.
-    monkeypatch.setenv("HOME", str(tmp_path))
     with pytest.raises(InvalidDevEnvNameError):
         _destroy_agents_and_state_container_for_wipe("not a valid env name!!")
-
-
-@pytest.fixture
-def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Strip activation env vars; tests opt in to a specific env explicitly."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
-    monkeypatch.delenv(MODAL_PROFILE_ENV_VAR, raising=False)
-    # Make sure no inherited MODAL_CONFIG_PATH redirects deploy-mode
-    # validation away from the test's ~/.modal.toml fixture file.
-    monkeypatch.delenv("MODAL_CONFIG_PATH", raising=False)
-    return tmp_path
 
 
 def _write_modal_toml_with_profile(home: Path, workspace: str) -> None:
@@ -63,7 +63,7 @@ def _write_modal_toml_with_profile(home: Path, workspace: str) -> None:
 # -- activate: use-only mode --
 
 
-def test_activate_dev_env_use_only_omits_modal_profile_export(_isolated_env: Path) -> None:
+def test_activate_dev_env_use_only_omits_modal_profile_export(isolated_activation_env: Path) -> None:
     """Plain ``activate --create`` emits no ``export MODAL_PROFILE=`` line."""
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
@@ -76,7 +76,7 @@ def test_activate_dev_env_use_only_omits_modal_profile_export(_isolated_env: Pat
     assert "export MODAL_PROFILE=" not in result.output
 
 
-def test_activate_dev_env_use_only_emits_unset_modal_profile(_isolated_env: Path) -> None:
+def test_activate_dev_env_use_only_emits_unset_modal_profile(isolated_activation_env: Path) -> None:
     """Plain ``activate`` emits ``unset MODAL_PROFILE`` so a deploy-mode shell flips back cleanly."""
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
@@ -84,10 +84,10 @@ def test_activate_dev_env_use_only_emits_unset_modal_profile(_isolated_env: Path
     assert "unset MODAL_PROFILE" in result.output
 
 
-def test_activate_dev_env_use_only_does_not_validate_modal_toml(_isolated_env: Path) -> None:
+def test_activate_dev_env_use_only_does_not_validate_modal_toml(isolated_activation_env: Path) -> None:
     """A missing ``~/.modal.toml`` is fine for use-only activation."""
     runner = CliRunner()
-    assert not (_isolated_env / ".modal.toml").exists()
+    assert not (isolated_activation_env / ".modal.toml").exists()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
     assert result.exit_code == 0, result.output
 
@@ -95,9 +95,9 @@ def test_activate_dev_env_use_only_does_not_validate_modal_toml(_isolated_env: P
 # -- activate: deploy mode --
 
 
-def test_activate_dev_env_deploy_mode_exports_modal_profile(_isolated_env: Path) -> None:
+def test_activate_dev_env_deploy_mode_exports_modal_profile(isolated_activation_env: Path) -> None:
     """``--deploy`` exports ``MODAL_PROFILE`` pinned to the dev tier's modal_workspace."""
-    _write_modal_toml_with_profile(_isolated_env, "minds-dev")
+    _write_modal_toml_with_profile(isolated_activation_env, "minds-dev")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
     assert result.exit_code == 0, result.output
@@ -106,7 +106,7 @@ def test_activate_dev_env_deploy_mode_exports_modal_profile(_isolated_env: Path)
     assert "unset MODAL_PROFILE" not in result.output
 
 
-def test_activate_use_only_header_omits_deploy_flag(_isolated_env: Path) -> None:
+def test_activate_use_only_header_omits_deploy_flag(isolated_activation_env: Path) -> None:
     """The 'Source via:' header should omit --deploy when the user did not pass it."""
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
@@ -115,16 +115,16 @@ def test_activate_use_only_header_omits_deploy_flag(_isolated_env: Path) -> None
     assert "--deploy" not in result.output
 
 
-def test_activate_deploy_mode_header_includes_deploy_flag(_isolated_env: Path) -> None:
+def test_activate_deploy_mode_header_includes_deploy_flag(isolated_activation_env: Path) -> None:
     """The 'Source via:' header should include --deploy so re-sourcing preserves the mode."""
-    _write_modal_toml_with_profile(_isolated_env, "minds-dev")
+    _write_modal_toml_with_profile(isolated_activation_env, "minds-dev")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
     assert result.exit_code == 0, result.output
     assert 'eval "$(uv run minds env activate --deploy dev-foo)"' in result.output
 
 
-def test_activate_deploy_mode_refuses_when_modal_toml_lacks_profile(_isolated_env: Path) -> None:
+def test_activate_deploy_mode_refuses_when_modal_toml_lacks_profile(isolated_activation_env: Path) -> None:
     """No matching ``~/.modal.toml`` profile = clean refusal with a ``modal token set`` hint."""
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
@@ -132,9 +132,9 @@ def test_activate_deploy_mode_refuses_when_modal_toml_lacks_profile(_isolated_en
     assert "modal token set --profile minds-dev" in result.output
 
 
-def test_activate_deploy_mode_refuses_when_modal_toml_has_wrong_profile(_isolated_env: Path) -> None:
+def test_activate_deploy_mode_refuses_when_modal_toml_has_wrong_profile(isolated_activation_env: Path) -> None:
     """A ``~/.modal.toml`` with a different profile still trips the refusal."""
-    _write_modal_toml_with_profile(_isolated_env, "some-other-workspace")
+    _write_modal_toml_with_profile(isolated_activation_env, "some-other-workspace")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "--deploy", "dev-foo"])
     assert result.exit_code != 0, result.output
@@ -145,17 +145,17 @@ def test_activate_deploy_mode_refuses_when_modal_toml_has_wrong_profile(_isolate
 
 
 def test_activate_allows_when_only_this_envs_recover_target_exists(
-    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A pending recover-target for the env being activated must NOT block activation.
 
     Otherwise `minds env recover` (which requires an activated env) could
     never run to clear it -- the activate/recover catch-22.
     """
-    monkeypatch.chdir(_isolated_env)
+    monkeypatch.chdir(isolated_activation_env)
     # monorepo-root marker for find_monorepo_root
-    (_isolated_env / "apps").mkdir()
-    (_isolated_env / ".minds-deploy-recover-target-dev-foo.json").write_text("{}")
+    (isolated_activation_env / "apps").mkdir()
+    (isolated_activation_env / ".minds-deploy-recover-target-dev-foo.json").write_text("{}")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
     assert result.exit_code == 0, result.output
@@ -163,30 +163,32 @@ def test_activate_allows_when_only_this_envs_recover_target_exists(
 
 
 def test_activate_refuses_when_another_envs_recover_target_exists(
-    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A recover-target for a DIFFERENT env still blocks activating an unaffected env.
 
     This surfaces a forgotten failed deploy rather than letting the operator
     silently proceed past it.
     """
-    monkeypatch.chdir(_isolated_env)
-    (_isolated_env / "apps").mkdir()
-    (_isolated_env / ".minds-deploy-recover-target-dev-other.json").write_text("{}")
+    monkeypatch.chdir(isolated_activation_env)
+    (isolated_activation_env / "apps").mkdir()
+    (isolated_activation_env / ".minds-deploy-recover-target-dev-other.json").write_text("{}")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
     assert result.exit_code != 0, result.output
     assert "dev-other" in result.output
 
 
-def test_activate_succeeds_when_run_outside_the_monorepo(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_activate_succeeds_when_run_outside_the_monorepo(
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Activation works from outside the monorepo: the recover-target guard is
     skipped (no monorepo root means no recover-target file can exist there)
     rather than erroring on NotInMonorepoError.
     """
     # Deliberately do NOT create an `apps/` marker, so find_monorepo_root
     # raises NotInMonorepoError from this cwd and the guard tolerates it.
-    monkeypatch.chdir(_isolated_env)
+    monkeypatch.chdir(isolated_activation_env)
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
     assert result.exit_code == 0, result.output
@@ -194,14 +196,14 @@ def test_activate_succeeds_when_run_outside_the_monorepo(_isolated_env: Path, mo
 
 
 def test_activate_allowed_for_affected_env_even_when_another_target_exists(
-    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Activating an affected env is allowed even when another env also has a
     pending recover-target; the other is surfaced as a warning, not a block."""
-    monkeypatch.chdir(_isolated_env)
-    (_isolated_env / "apps").mkdir()
-    (_isolated_env / ".minds-deploy-recover-target-dev-foo.json").write_text("{}")
-    (_isolated_env / ".minds-deploy-recover-target-dev-other.json").write_text("{}")
+    monkeypatch.chdir(isolated_activation_env)
+    (isolated_activation_env / "apps").mkdir()
+    (isolated_activation_env / ".minds-deploy-recover-target-dev-foo.json").write_text("{}")
+    (isolated_activation_env / ".minds-deploy-recover-target-dev-other.json").write_text("{}")
     runner = CliRunner()
     result = runner.invoke(env, ["activate", "--create", "dev-foo"])
     assert result.exit_code == 0, result.output
@@ -211,7 +213,9 @@ def test_activate_allowed_for_affected_env_even_when_another_target_exists(
 # -- env deploy / destroy gate --
 
 
-def test_env_deploy_refuses_without_deploy_activation(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_deploy_refuses_without_deploy_activation(
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``minds env deploy`` requires deploy-mode activation; refuses otherwise."""
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
     runner = CliRunner()
@@ -222,7 +226,7 @@ def test_env_deploy_refuses_without_deploy_activation(_isolated_env: Path, monke
 
 
 def test_env_deploy_refuses_with_mismatched_modal_profile(
-    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A ``MODAL_PROFILE`` that does not match the tier is a hard error."""
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
@@ -234,7 +238,9 @@ def test_env_deploy_refuses_with_mismatched_modal_profile(
     assert "minds-dev" in result.output
 
 
-def test_env_destroy_refuses_without_deploy_activation(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_destroy_refuses_without_deploy_activation(
+    isolated_activation_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``minds env destroy`` shares the same deploy-mode gate as deploy."""
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-foo")
     runner = CliRunner()
@@ -246,7 +252,7 @@ def test_env_destroy_refuses_without_deploy_activation(_isolated_env: Path, monk
 # -- deactivate --
 
 
-def test_deactivate_unsets_modal_profile(_isolated_env: Path) -> None:
+def test_deactivate_unsets_modal_profile(isolated_activation_env: Path) -> None:
     """A deactivated shell drops every var either activation mode might have exported."""
     runner = CliRunner()
     result = runner.invoke(env, ["deactivate"])

--- a/apps/minds/imbue/minds/cli/pool_test.py
+++ b/apps/minds/imbue/minds/cli/pool_test.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
+from imbue.minds.cli._activated_env import require_activated_env_name
 from imbue.minds.cli.pool import _SECRET_BEARING_FLAGS
 from imbue.minds.cli.pool import build_create_admin_args
 from imbue.minds.cli.pool import build_destroy_admin_args
@@ -24,14 +25,6 @@ from imbue.minds.cli.pool import merge_ovh_env_into_subprocess_env
 from imbue.minds.cli.pool import pool
 from imbue.minds.cli.pool import resolved_management_public_key_path
 from imbue.minds.utils.secret_redaction import redact_secret_flag_values
-
-
-@pytest.fixture
-def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    """Strip activation env vars by default; tests opt in to a specific env."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
-    return tmp_path
 
 
 def test_database_url_is_redacted_from_the_loggable_admin_command() -> None:
@@ -172,10 +165,10 @@ def test_build_destroy_admin_args_skip_vps_cancel() -> None:
     )
 
 
-def test_pool_create_requires_activated_env(_isolated_env: Path) -> None:
+def test_pool_create_requires_activated_env(isolated_activation_env: Path) -> None:
     """With no MINDS_ROOT_NAME set, the click command must refuse early."""
     runner = CliRunner()
-    key_file = _isolated_env / "mgmt.pub"
+    key_file = isolated_activation_env / "mgmt.pub"
     key_file.write_text("ssh-ed25519 AAAA... operator@host\n")
     result = runner.invoke(
         pool,
@@ -188,7 +181,7 @@ def test_pool_create_requires_activated_env(_isolated_env: Path) -> None:
             "--attributes",
             "{}",
             "--workspace-dir",
-            str(_isolated_env),
+            str(isolated_activation_env),
             "--management-public-key-file",
             str(key_file),
             "--database-url",
@@ -200,19 +193,25 @@ def test_pool_create_requires_activated_env(_isolated_env: Path) -> None:
 
 
 def test_pool_create_derives_production_from_default_root_name(
-    _isolated_env: Path,
+    isolated_activation_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``MINDS_ROOT_NAME=minds`` resolves to the ``production`` env name in the tag."""
+    """``MINDS_ROOT_NAME=minds`` resolves to the ``production`` env name in the tag.
+
+    Drives the real resolution the click command uses
+    (``require_activated_env_name`` -> ``env_name_from_root_name``) rather than
+    hardcoding the env name, so a regression in that mapping (e.g. ``minds``
+    resolving to anything other than ``production``) is actually caught.
+    """
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds")
-    # Pure-function check: the tag injection logic is the same path the click
-    # command uses, so verifying it here covers the end-to-end behaviour.
+    resolved_env_name = require_activated_env_name()
+    assert resolved_env_name == "production"
     args = build_create_admin_args(
-        env_name="production",
+        env_name=resolved_env_name,
         count=1,
         region="US-EAST-VA",
         attributes_json="{}",
-        workspace_dir=str(_isolated_env),
+        workspace_dir=str(isolated_activation_env),
         management_public_key_file="/k.pub",
         database_url="postgres://example",
         mngr_source=None,
@@ -222,14 +221,14 @@ def test_pool_create_derives_production_from_default_root_name(
     assert args[tag_index + 1] == "minds_env=production"
 
 
-def test_pool_list_requires_activated_env(_isolated_env: Path) -> None:
+def test_pool_list_requires_activated_env(isolated_activation_env: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(pool, ["list", "--database-url", "postgres://example"])
     assert result.exit_code != 0
     assert "No minds env is activated" in result.output
 
 
-def test_pool_destroy_requires_activated_env(_isolated_env: Path) -> None:
+def test_pool_destroy_requires_activated_env(isolated_activation_env: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(pool, ["destroy", "abc-123", "--database-url", "postgres://example"])
     assert result.exit_code != 0
@@ -303,10 +302,17 @@ def test_derive_public_key_from_private_rejects_garbage() -> None:
 
 
 def test_resolved_management_public_key_path_explicit_override_yields_path_unchanged(
-    _isolated_env: Path,
+    isolated_activation_env: Path,
 ) -> None:
-    """Operator override path bypasses Vault entirely and yields the operator's file as-is."""
-    pub_path = _isolated_env / "operator-key.pub"
+    """Operator override path bypasses Vault entirely and yields the operator's file as-is.
+
+    This deliberately only pins the explicit-override (early-return) arm. The
+    Vault-backed default arm -- which derives the key, writes a temp file, and
+    cleans it up on exit -- needs a real Vault and so is not unit-testable here;
+    it currently has no automated coverage (a known gap to fill with an
+    acceptance test).
+    """
+    pub_path = isolated_activation_env / "operator-key.pub"
     pub_path.write_text("ssh-ed25519 AAAA... operator@host\n")
     with resolved_management_public_key_path("dev-x", explicit_path=str(pub_path)) as yielded:
         assert yielded == str(pub_path)


### PR DESCRIPTION
Address all six findings from the identify-bad-tests sweep of
apps/minds/imbue/minds/cli:

1. Make test_pool_create_derives_production_from_default_root_name drive
   the real MINDS_ROOT_NAME=minds -> production resolution via
   require_activated_env_name() instead of hardcoding the env name.
2. Consolidate the duplicated/divergent _isolated_env fixtures into a
   single isolated_activation_env fixture in conftest.py.
3. Drop redundant HOME/chdir setup the autouse isolate_mind_tests provides.
4. test_wipe_teardown_is_noop_without_profile_or_agents now asserts the
   observable no-op (no "Destroyed ..." loguru line) rather than only
   "did not raise".
5. test_validate_modal_profile_rejects_non_table_section now asserts the
   specific "no profile named ..." message to pin the right error branch.
6. Document the deliberate explicit-override-only coverage of
   resolved_management_public_key_path (Vault arm is a known gap).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
