### PR TITLE
telegram: fix low-quality tests and the issues they surfaced

### DIFF
--- a/apps/minds/changelog/mngr-bad-tests-minds-telegram-local.md
+++ b/apps/minds/changelog/mngr-bad-tests-minds-telegram-local.md
@@ -1,0 +1,8 @@
+Improved the test suite for the Telegram integration (`imbue/minds/telegram`) and fixed the issues those tests surfaced:
+
+- Refactored `credential_extractor.py` to split the localStorage parsing/validation out of the live-browser path into pure helpers (`_parse_dc_id_and_user_id`, `_parse_auth_key_hex`, `_parse_first_name`) and added unit tests covering every branch (missing/invalid data-center ID, unparseable `user_auth`, missing user ID, bare vs JSON-quoted auth key, wrong-length key, and best-effort first-name parsing). Previously only module constants were tested.
+- Extracted the `mngr exec` command construction in `injector.py` into a pure `build_inject_command` helper and added tests that pin the argv and verify shell-quoting of tokens containing spaces and metacharacters.
+- Removed the unreachable short-username padding branch in `generate_bot_username` (no input could ever produce a name shorter than 5 characters) and replaced the test that never exercised it.
+- Strengthened several weak Telegram tests: per-data-center session encoding is now decoded and checked (IP, port byte, dc byte, key bytes) instead of only the version prefix; the fallback API credentials are pinned to their exact known values; the orchestrator "already in progress" test no longer asserts on the private thread list; the `wait_for_all` test now verifies it returns promptly; and the error-hierarchy tests now exercise real raise/catch behavior.
+
+No user-facing behavior changes.

--- a/apps/minds/imbue/minds/telegram/bot_creator_test.py
+++ b/apps/minds/imbue/minds/telegram/bot_creator_test.py
@@ -1,4 +1,6 @@
 import base64
+import ipaddress
+import struct
 
 import pytest
 from inline_snapshot import snapshot
@@ -48,27 +50,23 @@ def test_dc_ips_covers_all_five_data_centers() -> None:
     assert set(DC_IPS.keys()) == snapshot({1, 2, 3, 4, 5})
 
 
-def test_auth_key_to_string_session_works_for_all_dc_ids() -> None:
+@pytest.mark.parametrize("dc_id", sorted(DC_IPS))
+def test_auth_key_to_string_session_encodes_dc_ip_port_and_key(dc_id: int) -> None:
+    """Verify the packed binary contains the right dc_id, IP, port, and key for each DC.
+
+    Asserting only the "1" version prefix would pass even if the IP for a DC
+    were packed wrong; this decodes the full layout
+    (dc_id[1] + ip[4] + port[2] + key[256]) and checks every field.
+    """
     auth_key_hex = "ff" * 256
-    for dc_id in DC_IPS:
-        result = auth_key_to_string_session(dc_id, auth_key_hex)
-        assert result.startswith("1")
-
-
-def test_auth_key_to_string_session_encodes_correct_dc_and_key() -> None:
-    """Verify the packed binary contains the correct dc_id and auth key bytes."""
-    dc_id = 1
-    auth_key_hex = "ab" * 256
     result = auth_key_to_string_session(dc_id, auth_key_hex)
 
     decoded = base64.urlsafe_b64decode(result[1:])
 
-    # First byte is dc_id
-    assert decoded[0] == 1
-
-    # Last 256 bytes are the auth key
-    auth_key_bytes = decoded[-256:]
-    assert auth_key_bytes == bytes.fromhex(auth_key_hex)
+    assert decoded[0] == dc_id
+    assert decoded[1:5] == ipaddress.ip_address(DC_IPS[dc_id]).packed
+    assert struct.unpack(">H", decoded[5:7])[0] == 443
+    assert decoded[7:] == bytes.fromhex(auth_key_hex)
 
 
 def test_bot_token_pattern_matches_valid_tokens() -> None:
@@ -85,6 +83,8 @@ def test_bot_username_pattern_matches_tme_links() -> None:
     assert _BOT_USERNAME_PATTERN.search("no link here") is None
 
 
-def test_fallback_api_credentials_are_valid() -> None:
-    assert _FALLBACK_API_ID > 0
-    assert len(_FALLBACK_API_HASH) == 32
+def test_fallback_api_credentials_match_known_telegram_web_values() -> None:
+    # These are the public Telegram Web application credentials used as a
+    # fallback when live extraction fails; pin the exact values so an
+    # accidental change is caught in review rather than silently shipped.
+    assert (_FALLBACK_API_ID, _FALLBACK_API_HASH) == snapshot((2496, "8da85b0d5bfe62527e5b244c209159c3"))

--- a/apps/minds/imbue/minds/telegram/credential_extractor.py
+++ b/apps/minds/imbue/minds/telegram/credential_extractor.py
@@ -75,7 +75,12 @@ def extract_telegram_credentials_from_browser(
 
 
 def _extract_credentials_from_page(page: Page) -> TelegramUserCredentials:
-    """Extract credentials from a logged-in Telegram Web page's localStorage."""
+    """Extract credentials from a logged-in Telegram Web page's localStorage.
+
+    This is a thin shell around the live Playwright ``Page``: it pulls the raw
+    localStorage strings out of the browser and delegates all parsing/validation
+    to the pure helpers below (which are unit-tested directly).
+    """
     # Extract dc and user_auth
     auth_data = page.evaluate(
         """(() => {
@@ -85,9 +90,31 @@ def _extract_credentials_from_page(page: Page) -> TelegramUserCredentials:
         })()"""
     )
 
-    dc_str = auth_data.get("dc")
-    user_auth_str = auth_data.get("userAuth")
+    dc_id, user_id = _parse_dc_id_and_user_id(auth_data.get("dc"), auth_data.get("userAuth"))
 
+    # Extract the auth_key for the active DC (the localStorage key depends on dc_id)
+    dc_key_name = f"dc{dc_id}_auth_key"
+    auth_key_raw = page.evaluate(f"localStorage.getItem('{dc_key_name}')")
+    auth_key_hex = _parse_auth_key_hex(auth_key_raw, dc_id)
+
+    account_data = page.evaluate("localStorage.getItem('account1')")
+    first_name = _parse_first_name(account_data)
+
+    return TelegramUserCredentials(
+        dc_id=dc_id,
+        auth_key_hex=auth_key_hex,
+        user_id=user_id,
+        first_name=first_name,
+    )
+
+
+def _parse_dc_id_and_user_id(dc_str: str | None, user_auth_str: str | None) -> tuple[int, str]:
+    """Parse the data-center ID and user ID out of the raw localStorage strings.
+
+    ``dc_str`` is the ``dc`` entry and ``user_auth_str`` is the ``user_auth``
+    JSON entry. Raises TelegramCredentialExtractionError if either is missing or
+    malformed, or if the user ID is absent.
+    """
     if not dc_str or not user_auth_str:
         raise TelegramCredentialExtractionError(
             "Could not find Telegram auth data in localStorage. "
@@ -108,13 +135,19 @@ def _extract_credentials_from_page(page: Page) -> TelegramUserCredentials:
     if not user_id:
         raise TelegramCredentialExtractionError("user_auth in localStorage does not contain a user ID")
 
-    # Extract the auth_key for the active DC
-    dc_key_name = f"dc{dc_id}_auth_key"
-    auth_key_raw = page.evaluate(f"localStorage.getItem('{dc_key_name}')")
+    return dc_id, user_id
 
+
+def _parse_auth_key_hex(auth_key_raw: str | None, dc_id: int) -> str:
+    """Validate and normalize the raw ``dc{dc_id}_auth_key`` localStorage value.
+
+    The stored value may be a bare hex string or a JSON-encoded string (wrapped
+    in extra quotes). Raises TelegramCredentialExtractionError if it is missing,
+    unparseable, or not exactly ``_AUTH_KEY_HEX_LENGTH`` hex characters.
+    """
     if not auth_key_raw:
         raise TelegramCredentialExtractionError(
-            f"Could not find auth key for DC {dc_id} in localStorage (key: {dc_key_name})"
+            f"Could not find auth key for DC {dc_id} in localStorage (key: dc{dc_id}_auth_key)"
         )
 
     # The value may be JSON-encoded (wrapped in extra quotes)
@@ -131,19 +164,20 @@ def _extract_credentials_from_page(page: Page) -> TelegramUserCredentials:
             f"Auth key has unexpected length: {len(auth_key_hex)} hex chars (expected {_AUTH_KEY_HEX_LENGTH})"
         )
 
-    # Extract first name from account data
-    first_name = ""
-    account_data = page.evaluate("localStorage.getItem('account1')")
-    if account_data:
-        try:
-            parsed_account = json.loads(account_data)
-            first_name = parsed_account.get("firstName", "")
-        except (json.JSONDecodeError, AttributeError) as exc:
-            logger.warning("Could not parse account1 data for first name: {}", exc)
+    return auth_key_hex
 
-    return TelegramUserCredentials(
-        dc_id=dc_id,
-        auth_key_hex=auth_key_hex,
-        user_id=user_id,
-        first_name=first_name,
-    )
+
+def _parse_first_name(account_data: str | None) -> str:
+    """Extract the user's first name from the raw ``account1`` localStorage value.
+
+    Returns an empty string (and logs a warning) if the value is absent or
+    cannot be parsed -- the first name is best-effort and never fatal.
+    """
+    if not account_data:
+        return ""
+    try:
+        parsed_account = json.loads(account_data)
+        return parsed_account.get("firstName", "")
+    except (json.JSONDecodeError, AttributeError) as exc:
+        logger.warning("Could not parse account1 data for first name: {}", exc)
+        return ""

--- a/apps/minds/imbue/minds/telegram/credential_extractor_test.py
+++ b/apps/minds/imbue/minds/telegram/credential_extractor_test.py
@@ -1,17 +1,108 @@
-"""Unit tests for credential_extractor constants and module-level attributes."""
+"""Unit tests for the pure localStorage-parsing helpers in credential_extractor.
 
+The live-browser entry point (``extract_telegram_credentials_from_browser``)
+requires Playwright and a real Telegram login, so it is not unit-tested here.
+Instead, all parsing/validation logic is factored into pure helpers that take the
+raw localStorage strings, and those are exercised exhaustively below.
+"""
+
+import json
+
+import pytest
+
+from imbue.minds.errors import TelegramCredentialExtractionError
 from imbue.minds.telegram.credential_extractor import _AUTH_KEY_HEX_LENGTH
-from imbue.minds.telegram.credential_extractor import _DEFAULT_LOGIN_TIMEOUT_SECONDS
-from imbue.minds.telegram.data_types import TELEGRAM_WEB_URL
+from imbue.minds.telegram.credential_extractor import _parse_auth_key_hex
+from imbue.minds.telegram.credential_extractor import _parse_dc_id_and_user_id
+from imbue.minds.telegram.credential_extractor import _parse_first_name
 
 
-def test_telegram_web_url_points_to_web_a() -> None:
-    assert TELEGRAM_WEB_URL == "https://web.telegram.org/a/"
+def test_parse_dc_id_and_user_id_extracts_both_from_valid_data() -> None:
+    dc_id, user_id = _parse_dc_id_and_user_id("2", json.dumps({"id": 12345}))
+    assert dc_id == 2
+    assert user_id == "12345"
 
 
-def test_auth_key_hex_length_is_512() -> None:
-    assert _AUTH_KEY_HEX_LENGTH == 512
+def test_parse_dc_id_and_user_id_raises_when_dc_missing() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="Could not find Telegram auth data"):
+        _parse_dc_id_and_user_id(None, json.dumps({"id": 1}))
 
 
-def test_default_login_timeout_is_five_minutes() -> None:
-    assert _DEFAULT_LOGIN_TIMEOUT_SECONDS == 300
+def test_parse_dc_id_and_user_id_raises_when_user_auth_missing() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="Could not find Telegram auth data"):
+        _parse_dc_id_and_user_id("2", None)
+
+
+def test_parse_dc_id_and_user_id_raises_when_dc_missing_and_empty_string() -> None:
+    # Empty strings are falsy and must be treated the same as None.
+    with pytest.raises(TelegramCredentialExtractionError, match="Could not find Telegram auth data"):
+        _parse_dc_id_and_user_id("", json.dumps({"id": 1}))
+
+
+def test_parse_dc_id_and_user_id_raises_on_non_integer_dc() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="Invalid data center ID in localStorage: 'abc'"):
+        _parse_dc_id_and_user_id("abc", json.dumps({"id": 1}))
+
+
+def test_parse_dc_id_and_user_id_raises_on_unparseable_user_auth() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="Could not parse user_auth from localStorage"):
+        _parse_dc_id_and_user_id("2", "not valid json {{{")
+
+
+def test_parse_dc_id_and_user_id_raises_when_user_id_absent() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="does not contain a user ID"):
+        _parse_dc_id_and_user_id("2", json.dumps({"first_name": "Alice"}))
+
+
+def test_parse_auth_key_hex_accepts_bare_hex_string() -> None:
+    bare = "ab" * 256
+    assert _parse_auth_key_hex(bare, dc_id=2) == bare
+
+
+def test_parse_auth_key_hex_unwraps_json_quoted_value() -> None:
+    bare = "cd" * 256
+    json_wrapped = json.dumps(bare)  # adds surrounding double quotes
+    assert json_wrapped.startswith('"')
+    # The bare and JSON-wrapped forms must normalize to the exact same hex.
+    assert _parse_auth_key_hex(json_wrapped, dc_id=2) == bare
+
+
+def test_parse_auth_key_hex_raises_when_missing() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match=r"Could not find auth key for DC 3 .*dc3_auth_key"):
+        _parse_auth_key_hex(None, dc_id=3)
+
+
+def test_parse_auth_key_hex_raises_on_unparseable_json_quoted_value() -> None:
+    with pytest.raises(TelegramCredentialExtractionError, match="Could not parse auth_key for DC 2"):
+        _parse_auth_key_hex('"unterminated', dc_id=2)
+
+
+def test_parse_auth_key_hex_raises_on_wrong_length() -> None:
+    too_short = "ab" * 100  # 200 hex chars, not 512
+    with pytest.raises(TelegramCredentialExtractionError, match="unexpected length: 200 hex chars"):
+        _parse_auth_key_hex(too_short, dc_id=2)
+
+
+def test_parse_auth_key_hex_validates_against_declared_length_constant() -> None:
+    # A value of exactly _AUTH_KEY_HEX_LENGTH must pass; one char short must fail.
+    valid = "f" * _AUTH_KEY_HEX_LENGTH
+    assert _parse_auth_key_hex(valid, dc_id=1) == valid
+    with pytest.raises(TelegramCredentialExtractionError, match="unexpected length"):
+        _parse_auth_key_hex("f" * (_AUTH_KEY_HEX_LENGTH - 1), dc_id=1)
+
+
+def test_parse_first_name_extracts_first_name_from_account_data() -> None:
+    assert _parse_first_name(json.dumps({"firstName": "Alice", "lastName": "Smith"})) == "Alice"
+
+
+def test_parse_first_name_returns_empty_string_when_account_data_missing() -> None:
+    assert _parse_first_name(None) == ""
+
+
+def test_parse_first_name_returns_empty_string_when_first_name_absent() -> None:
+    assert _parse_first_name(json.dumps({"lastName": "Smith"})) == ""
+
+
+def test_parse_first_name_returns_empty_string_on_malformed_account_data() -> None:
+    # Malformed account data is best-effort and must never raise.
+    assert _parse_first_name("not valid json {{{") == ""

--- a/apps/minds/imbue/minds/telegram/data_types_test.py
+++ b/apps/minds/imbue/minds/telegram/data_types_test.py
@@ -24,6 +24,8 @@ def test_telegram_bot_credentials_hides_token_in_repr() -> None:
         bot_token=SecretStr("123456:ABC-DEF"),
         bot_username="test_bot",
     )
+    # Guards that bot_token stays typed as SecretStr: a plain-str field would
+    # leak the token into repr()/logs.
     repr_str = repr(creds)
     assert "123456:ABC-DEF" not in repr_str
     assert creds.bot_token.get_secret_value() == "123456:ABC-DEF"

--- a/apps/minds/imbue/minds/telegram/errors_test.py
+++ b/apps/minds/imbue/minds/telegram/errors_test.py
@@ -1,4 +1,12 @@
-"""Tests for telegram error hierarchy."""
+"""Tests for the telegram error hierarchy.
+
+These assert the *catch* contracts callers rely on (e.g. that a credential
+error can be handled as a plain ValueError, or that any telegram error can be
+handled via the shared TelegramError / MindError base) by actually raising and
+catching, rather than only asserting issubclass relationships.
+"""
+
+import pytest
 
 from imbue.minds.errors import MindError
 from imbue.minds.errors import TelegramBotCreationError
@@ -7,18 +15,28 @@ from imbue.minds.errors import TelegramCredentialExtractionError
 from imbue.minds.errors import TelegramError
 
 
-def test_telegram_error_inherits_from_mind_error() -> None:
-    assert issubclass(TelegramError, MindError)
+def test_telegram_error_is_catchable_as_mind_error() -> None:
+    with pytest.raises(MindError):
+        raise TelegramError("boom")
 
 
-def test_telegram_credential_error_inherits_from_telegram_error_and_value_error() -> None:
-    assert issubclass(TelegramCredentialError, TelegramError)
-    assert issubclass(TelegramCredentialError, ValueError)
+def test_telegram_credential_error_is_catchable_as_value_error() -> None:
+    # Callers that validate inputs catch ValueError; the credential error must
+    # be handled by such a handler.
+    with pytest.raises(ValueError):
+        raise TelegramCredentialError("invalid credentials")
 
 
-def test_telegram_extraction_error_inherits_from_telegram_error() -> None:
-    assert issubclass(TelegramCredentialExtractionError, TelegramError)
+def test_telegram_credential_error_is_catchable_as_telegram_error() -> None:
+    with pytest.raises(TelegramError):
+        raise TelegramCredentialError("invalid credentials")
 
 
-def test_telegram_bot_creation_error_inherits_from_telegram_error() -> None:
-    assert issubclass(TelegramBotCreationError, TelegramError)
+def test_telegram_extraction_error_is_catchable_as_telegram_error() -> None:
+    with pytest.raises(TelegramError):
+        raise TelegramCredentialExtractionError("extraction failed")
+
+
+def test_telegram_bot_creation_error_is_catchable_as_telegram_error() -> None:
+    with pytest.raises(TelegramError):
+        raise TelegramBotCreationError("botfather rejected")

--- a/apps/minds/imbue/minds/telegram/injector.py
+++ b/apps/minds/imbue/minds/telegram/injector.py
@@ -18,6 +18,22 @@ from imbue.mngr.primitives import AgentId
 _SECRETS_FILE: Final[str] = "runtime/secrets/telegram.env"
 
 
+def build_inject_command(agent_id: AgentId, bot_token: SecretStr) -> list[str]:
+    """Build the ``mngr exec`` argv that writes the bot token into the agent.
+
+    The token is ``shlex.quote``-escaped before interpolation into the remote
+    shell snippet so that a token containing spaces or shell metacharacters
+    cannot break out of the ``printf`` or inject additional commands.
+    """
+    safe_token = shlex.quote(bot_token.get_secret_value())
+    return [
+        MNGR_BINARY,
+        "exec",
+        str(agent_id),
+        f"mkdir -p runtime/secrets && printf 'export TELEGRAM_BOT_TOKEN=%s\\n' {safe_token} > {_SECRETS_FILE}",
+    ]
+
+
 def inject_telegram_bot_token(
     agent_id: AgentId,
     bot_token: SecretStr,
@@ -29,16 +45,10 @@ def inject_telegram_bot_token(
 
     Raises MngrCommandError if the mngr exec command fails.
     """
-    safe_token = shlex.quote(bot_token.get_secret_value())
     with log_span("Injecting Telegram bot token into agent {}", agent_id):
         cg = ConcurrencyGroup(name="mngr-exec-telegram-token")
         with cg:
-            command = [
-                MNGR_BINARY,
-                "exec",
-                str(agent_id),
-                f"mkdir -p runtime/secrets && printf 'export TELEGRAM_BOT_TOKEN=%s\\n' {safe_token} > {_SECRETS_FILE}",
-            ]
+            command = build_inject_command(agent_id, bot_token)
             result = cg.run_process_to_completion(
                 command=command,
                 is_checked_after=False,

--- a/apps/minds/imbue/minds/telegram/injector_test.py
+++ b/apps/minds/imbue/minds/telegram/injector_test.py
@@ -1,7 +1,65 @@
-"""Unit tests for injector constants."""
+"""Unit tests for the Telegram bot-token injector command construction.
 
+The full ``inject_telegram_bot_token`` flow spawns a real ``mngr exec``
+subprocess, so it is not unit-tested here. The bug-prone part -- assembling the
+remote shell snippet and shell-quoting the token -- is factored into
+``build_inject_command`` and tested directly.
+"""
+
+import shlex
+
+from pydantic import SecretStr
+
+from imbue.minds.config.data_types import MNGR_BINARY
 from imbue.minds.telegram.injector import _SECRETS_FILE
+from imbue.minds.telegram.injector import build_inject_command
+from imbue.mngr.primitives import AgentId
 
 
-def test_secrets_file_path_is_in_runtime_directory() -> None:
-    assert _SECRETS_FILE == "runtime/secrets/telegram.env"
+def test_build_inject_command_targets_mngr_exec_for_the_agent() -> None:
+    agent_id = AgentId()
+    command = build_inject_command(agent_id, SecretStr("123456:ABCdef"))
+
+    assert command[0] == MNGR_BINARY
+    assert command[1] == "exec"
+    assert command[2] == str(agent_id)
+
+
+def test_build_inject_command_writes_token_to_per_secret_env_file() -> None:
+    command = build_inject_command(AgentId(), SecretStr("123456:ABCdef"))
+    shell_snippet = command[3]
+
+    assert "mkdir -p runtime/secrets" in shell_snippet
+    assert f"> {_SECRETS_FILE}" in shell_snippet
+    assert "export TELEGRAM_BOT_TOKEN=" in shell_snippet
+    # A simple token needs no quoting and appears verbatim.
+    assert "123456:ABCdef" in shell_snippet
+
+
+def test_build_inject_command_shell_quotes_token_with_spaces() -> None:
+    token_with_space = "abc def"
+    command = build_inject_command(AgentId(), SecretStr(token_with_space))
+    shell_snippet = command[3]
+
+    # A token with a space must be wrapped (shlex.quote adds surrounding single
+    # quotes) so it stays a single printf argument rather than splitting in two.
+    quoted = shlex.quote(token_with_space)
+    assert quoted == "'abc def'"
+    assert quoted in shell_snippet
+    # The token only ever appears inside that quoted region -- never bare.
+    assert shell_snippet.count(token_with_space) == 1
+    assert f"%s\\n' {quoted} >" in shell_snippet
+
+
+def test_build_inject_command_neutralizes_shell_metacharacters_in_token() -> None:
+    malicious_token = "x$(touch /tmp/pwned);echo"
+    command = build_inject_command(AgentId(), SecretStr(malicious_token))
+    shell_snippet = command[3]
+
+    quoted = shlex.quote(malicious_token)
+    # shlex.quote wraps the whole token in single quotes, so the dangerous
+    # substitution/command-separator is inert data, not executable shell.
+    assert quoted == "'x$(touch /tmp/pwned);echo'"
+    assert quoted in shell_snippet
+    # Outside the single-quoted token there is no unescaped command substitution.
+    assert "$(touch" not in shell_snippet.replace(quoted, "")

--- a/apps/minds/imbue/minds/telegram/setup.py
+++ b/apps/minds/imbue/minds/telegram/setup.py
@@ -38,8 +38,6 @@ from imbue.mngr.primitives import AgentId
 
 _MAX_BOT_USERNAME_LENGTH: Final[int] = 32
 
-_MIN_BOT_USERNAME_LENGTH: Final[int] = 5
-
 
 class TelegramSetupStatus(UpperCaseStrEnum):
     """Status of a background Telegram setup operation."""
@@ -65,7 +63,9 @@ def generate_bot_username(agent_name: str) -> str:
     """Generate a valid Telegram bot username from an agent name.
 
     Bot usernames must be 5-32 characters, alphanumeric with underscores,
-    and end in 'bot'.
+    and end in 'bot'. The 5-character minimum is satisfied automatically: an
+    empty/blank name falls back to "workspace", and any non-empty sanitized
+    name yields at least one character plus the 4-character "_bot" suffix.
     """
     # Sanitize: lowercase, replace non-alphanumeric with underscore
     sanitized = re.sub(r"[^a-z0-9_]", "_", agent_name.lower())
@@ -80,10 +80,6 @@ def generate_bot_username(agent_name: str) -> str:
     if len(username) > _MAX_BOT_USERNAME_LENGTH:
         prefix_length = _MAX_BOT_USERNAME_LENGTH - len("_bot")
         username = f"{sanitized[:prefix_length].rstrip('_')}_bot"
-
-    # Pad if too short
-    if len(username) < _MIN_BOT_USERNAME_LENGTH:
-        username = f"workspace_{username}"
 
     return username
 

--- a/apps/minds/imbue/minds/telegram/setup_test.py
+++ b/apps/minds/imbue/minds/telegram/setup_test.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 from inline_snapshot import snapshot
@@ -31,10 +32,13 @@ def test_generate_bot_username_truncates_long_names() -> None:
     assert result.endswith("_bot")
 
 
-def test_generate_bot_username_pads_short_names() -> None:
-    result = generate_bot_username("ab")
-    assert len(result) >= 5
-    assert result.endswith("_bot")
+def test_generate_bot_username_meets_minimum_length_for_shortest_inputs() -> None:
+    # The shortest possible non-empty name is a single character; with the
+    # "_bot" suffix that is exactly the 5-character Telegram minimum. An empty
+    # name falls back to "workspace_bot". Neither needs padding.
+    assert generate_bot_username("x") == snapshot("x_bot")
+    assert len(generate_bot_username("x")) == 5
+    assert len(generate_bot_username("")) >= 5
 
 
 def test_generate_bot_display_name() -> None:
@@ -102,18 +106,16 @@ def test_orchestrator_start_setup_skips_when_setup_already_in_progress(tmp_path:
     agent_id = AgentId()
     aid = str(agent_id)
 
-    # Simulate an in-progress setup by setting the status directly
+    # Seed an in-progress status directly: there is no public API to drive the
+    # orchestrator into CREATING_BOT without launching a real background browser
+    # flow, so seeding the status dict is the only available test seam.
     with orchestrator._lock:
         orchestrator._statuses[aid] = TelegramSetupStatus.CREATING_BOT
 
-    thread_count_before = len(orchestrator._threads)
     orchestrator.start_setup(agent_id=agent_id, agent_name="test")
-    thread_count_after = len(orchestrator._threads)
 
-    # No new thread should have been started
-    assert thread_count_after == thread_count_before
-
-    # Status should remain unchanged (not reset to CHECKING_CREDENTIALS)
+    # Re-entrant start_setup must be a no-op: the observable status stays
+    # CREATING_BOT rather than being clobbered back to CHECKING_CREDENTIALS.
     info = orchestrator.get_setup_info(agent_id)
     assert info is not None
     assert info.status == TelegramSetupStatus.CREATING_BOT
@@ -123,4 +125,11 @@ def test_orchestrator_wait_for_all_returns_immediately_when_no_threads(tmp_path:
     paths = WorkspacePaths(data_dir=tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
 
-    orchestrator.wait_for_all(timeout=0.1)
+    # Pass a deliberately huge timeout: with no registered threads the call must
+    # return at once rather than blocking on (or anywhere near) the timeout. A
+    # regression that blocked would blow far past this generous bound.
+    start = time.monotonic()
+    orchestrator.wait_for_all(timeout=3600.0)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0

--- a/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
+++ b/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
@@ -114,9 +114,13 @@ def test_telegram_setup_returns_done_immediately_when_already_configured(tmp_pat
     response = client.post(f"/api/agents/{agent_id}/telegram/setup")
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "CHECKING_CREDENTIALS"
+    # The POST status field is a fixed "request accepted" acknowledgement
+    # (the handler always returns CHECKING_CREDENTIALS), so it is not a
+    # behavioral signal -- only assert the request was accepted for this agent.
+    assert data["agent_id"] == str(agent_id)
 
-    # Status should show DONE immediately since credentials exist
+    # The real behavioral check: because credentials already exist, the status
+    # endpoint must report DONE immediately rather than running setup.
     status_response = client.get(f"/api/agents/{agent_id}/telegram/status")
     assert status_response.status_code == 200
     status_data = status_response.json()


### PR DESCRIPTION
Acts on the `identify-bad-tests` findings for `apps/minds/imbue/minds/telegram`, fixing each one: editing code where needed, then strengthening or replacing the tests.

## Fixes
1. **credential_extractor** — split the localStorage parsing out of the live-browser path into pure helpers (`_parse_dc_id_and_user_id`, `_parse_auth_key_hex`, `_parse_first_name`) and added branch coverage (missing/invalid DC, unparseable `user_auth`, missing user id, bare vs JSON-quoted key, wrong length, best-effort first name). Previously only module constants were tested.
2. **injector** — extracted `build_inject_command`; tests now pin the `mngr exec` argv and verify `shlex` quoting of tokens with spaces and shell metacharacters.
3. **setup** — removed the unreachable `len(username) < 5` padding branch in `generate_bot_username` (the `_bot` suffix already guarantees the minimum) and the unused constant; replaced the test that never exercised it.
4. **setup** — `wait_for_all` no-thread test now asserts it returns promptly instead of having no assertion.
5. **endpoints** — replaced an assertion on a hardcoded response constant with an `agent_id` round-trip check, keeping the real `status -> DONE` behavioral check.
6. **bot_creator** — per-DC session test now decodes and checks dc byte, IP, port, and key bytes for every data center instead of only the version prefix.
7. **bot_creator** — fallback API credentials pinned to their exact known values.
8. **setup** — in-progress skip test no longer couples to the private `_threads` list; keeps the observable status assertion.
9. **errors / data_types** — error-hierarchy tests now exercise real raise/catch contracts; the repr test is commented as a `SecretStr`-typing guard.

No user-facing behavior changes.

## Verification
- `just test-quick apps/minds/imbue/minds/telegram`: 67 passed, 0 failed
- Snapshots validated without xdist (inline-snapshot active): no diffs
- `uv run ty check imbue/minds/telegram/`: all checks passed

Note: opened against `mngr/review-more-tests` (the session base) rather than `main` so the diff is just these 5 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)