### PR TITLE
mngr_imbue_cloud: fix bad tests (tautological column check, dead mock scaffolding, non-inheriting stub)

### DIFF
--- a/libs/mngr_imbue_cloud/changelog/mngr-bad-tests-mngr-imbue-cloud-local.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-bad-tests-mngr-imbue-cloud-local.md
@@ -1,0 +1,6 @@
+Test-quality fixes in the `imbue_cloud` plugin's test suite (no user-facing behavior change):
+
+- `pool_hosts` INSERT column check now compares against the parsed column tokens instead of raw substrings, so dropping a required column whose name is a substring of another (`id`, `ssh_port`) actually fails the test.
+- Removed dead, misleading `_make_client` test scaffolding in the connector-client tests and routed the remaining lease/auth tests through the shared `MockTransport` helper (cuts the `monkeypatch.setattr` count from 5 to 1).
+- The lease-release-on-failure test's recording client now inherits the real `ImbueCloudConnectorClient` interface (so `release_host` signature drift is caught), and the provider stub's cleanup recorder uses a per-instance `PrivateAttr` list instead of a shared class-level default.
+- Documented the `bucket`/`paid` CLI help-text tests as intentional wiring smoke tests.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin_test.py
@@ -86,6 +86,18 @@ def test_pool_create_requires_region() -> None:
     assert "Missing option" in result.output and "--region" in result.output
 
 
+def _insert_columns() -> list[str]:
+    """Parse the exact column tokens out of _INSERT_POOL_HOST_SQL's INTO clause.
+
+    Returns the standalone column names (e.g. ``id``, ``ssh_port``) so callers
+    can do *exact* membership checks rather than raw substring scans -- a bare
+    ``"id" in sql`` would spuriously match ``agent_id``/``host_id`` and a bare
+    ``"ssh_port" in sql`` would match ``container_ssh_port``.
+    """
+    columns_part = _INSERT_POOL_HOST_SQL.split("(", 1)[1].split(")", 1)[0]
+    return [c.strip() for c in columns_part.split(",")]
+
+
 def test_pool_hosts_insert_has_required_columns() -> None:
     """The INSERT must include every pool_hosts NOT-NULL column the schema requires.
 
@@ -95,7 +107,11 @@ def test_pool_hosts_insert_has_required_columns() -> None:
     the final DB write.
 
     Asserting the literal column list keeps this test cheap (no fake DB)
-    while still catching any future drop of a required column.
+    while still catching any future drop of a required column. We compare
+    against the *parsed* column tokens (not raw substrings) so dropping a
+    column whose name is a substring of another -- e.g. ``id`` (inside
+    ``agent_id``/``host_id``) or ``ssh_port`` (inside ``container_ssh_port``)
+    -- actually fails the test.
     """
     required_columns = (
         "id",
@@ -111,10 +127,11 @@ def test_pool_hosts_insert_has_required_columns() -> None:
         "attributes",
         "created_at",
     )
+    actual_columns = set(_insert_columns())
     for column in required_columns:
-        assert column in _INSERT_POOL_HOST_SQL, (
+        assert column in actual_columns, (
             f"Pool host INSERT is missing required column {column!r}; this is the same drift "
-            f"class as the host_name regression. SQL: {_INSERT_POOL_HOST_SQL!r}"
+            f"class as the host_name regression. Columns present: {sorted(actual_columns)}"
         )
 
 
@@ -126,8 +143,7 @@ def _insert_column_to_value(values: tuple[object, ...]) -> dict[str, object]:
     with ``values`` -- so a test can assert "this column got that value"
     robustly even if the column order changes.
     """
-    columns_part = _INSERT_POOL_HOST_SQL.split("(", 1)[1].split(")", 1)[0]
-    columns = [c.strip() for c in columns_part.split(",")]
+    columns = _insert_columns()
     values_part = _INSERT_POOL_HOST_SQL.split("VALUES (", 1)[1].rsplit(")", 1)[0]
     value_tokens = [t.strip() for t in values_part.split(",")]
     placeholder_columns = [col for col, tok in zip(columns, value_tokens, strict=False) if "%s" in tok]

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/buckets_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/buckets_test.py
@@ -2,6 +2,12 @@ from click.testing import CliRunner
 
 from imbue.mngr_imbue_cloud.cli.buckets import bucket
 
+# These are deliberate *wiring* smoke tests: they assert only that the click
+# groups register subcommands of the expected names, not that those subcommands
+# behave correctly (the per-command behavior needs the connector and is covered
+# by client_test.py). Their job is to catch an accidentally-unregistered or
+# renamed subcommand.
+
 
 def test_bucket_group_lists_subcommands() -> None:
     result = CliRunner().invoke(bucket, ["--help"])

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/paid_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/paid_test.py
@@ -5,6 +5,10 @@ from imbue.mngr_imbue_cloud.cli.paid import _resolve_admin_api_key
 from imbue.mngr_imbue_cloud.cli.paid import paid
 
 
+# test_paid_group_lists_* and test_paid_subgroups_* are deliberate *wiring*
+# smoke tests: they assert only that the click groups register subgroups/commands
+# of the expected names, not their behavior. Behavioral validation lives in the
+# _resolve_admin_api_key and test_domain_add_requires_connector_url tests below.
 def test_paid_group_lists_domain_and_email_subgroups() -> None:
     result = CliRunner().invoke(paid, ["--help"])
     assert result.exit_code == 0

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/client_test.py
@@ -26,12 +26,30 @@ from imbue.mngr_imbue_cloud.errors import ImbueCloudConnectorError
 from imbue.mngr_imbue_cloud.errors import ImbueCloudLeaseUnavailableError
 
 
-def _make_client(handler) -> tuple[ImbueCloudConnectorClient, httpx.MockTransport]:
+def _install_mock_httpx(
+    monkeypatch: pytest.MonkeyPatch,
+    handler,
+) -> ImbueCloudConnectorClient:
+    """Route the client's module-level ``httpx.*`` verb calls through a MockTransport.
+
+    The client issues requests via module-level ``httpx.post``/``httpx.get``/etc
+    (see ``client.py``), so the network boundary is intercepted by pointing each
+    verb at a ``MockTransport``-backed ``httpx.Client``. Patching through a single
+    loop keeps the monkeypatch ratchet at one occurrence regardless of how many
+    HTTP verbs a given route exercises.
+    """
     transport = httpx.MockTransport(handler)
 
-    # Patch httpx module-level functions to use the transport for the duration of the test.
-    # The client uses module-level httpx.* calls; intercept them via monkeypatch in tests.
-    return ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com")), transport
+    def _make(method_name: str):
+        def _call(*args, **kwargs):
+            with httpx.Client(transport=transport) as inner:
+                return inner.request(method_name, *args, **kwargs)
+
+        return _call
+
+    for method_name in ("POST", "GET", "DELETE", "PUT"):
+        monkeypatch.setattr(httpx, method_name.lower(), _make(method_name))
+    return ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
 
 
 def test_lease_host_503_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -42,14 +60,7 @@ def test_lease_host_503_raises_unavailable(monkeypatch: pytest.MonkeyPatch) -> N
         assert "region" not in body
         return httpx.Response(503, json={"detail": "no match"})
 
-    transport = httpx.MockTransport(handler)
-
-    def fake_post(*args, **kwargs):
-        with httpx.Client(transport=transport) as inner:
-            return inner.post(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, "post", fake_post)
-    client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
+    client = _install_mock_httpx(monkeypatch, handler)
     with pytest.raises(ImbueCloudLeaseUnavailableError):
         client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=2), "ssh-ed25519 AAAA", "my-host")
 
@@ -77,14 +88,7 @@ def test_lease_host_success_parses_response(monkeypatch: pytest.MonkeyPatch) -> 
             },
         )
 
-    transport = httpx.MockTransport(handler)
-
-    def fake_post(*args, **kwargs):
-        with httpx.Client(transport=transport) as inner:
-            return inner.post(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, "post", fake_post)
-    client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
+    client = _install_mock_httpx(monkeypatch, handler)
     result = client.lease_host(
         SecretStr("tok"),
         LeaseAttributes(cpus=2),
@@ -102,14 +106,7 @@ def test_unauthenticated_responses_raise_auth_error(monkeypatch: pytest.MonkeyPa
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"detail": "no token"})
 
-    transport = httpx.MockTransport(handler)
-
-    def fake_get(*args, **kwargs):
-        with httpx.Client(transport=transport) as inner:
-            return inner.get(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, "get", fake_get)
-    client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
+    client = _install_mock_httpx(monkeypatch, handler)
     with pytest.raises(ImbueCloudAuthError):
         client.list_hosts(SecretStr("tok"))
 
@@ -118,14 +115,7 @@ def test_500_lease_raises_connector_error(monkeypatch: pytest.MonkeyPatch) -> No
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="boom")
 
-    transport = httpx.MockTransport(handler)
-
-    def fake_post(*args, **kwargs):
-        with httpx.Client(transport=transport) as inner:
-            return inner.post(*args, **kwargs)
-
-    monkeypatch.setattr(httpx, "post", fake_post)
-    client = ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
+    client = _install_mock_httpx(monkeypatch, handler)
     with pytest.raises(ImbueCloudConnectorError):
         client.lease_host(SecretStr("tok"), LeaseAttributes(cpus=1), "ssh-ed25519 X", "my-host")
 
@@ -201,28 +191,6 @@ def test_parse_auth_policy_ignores_unknown_include_types() -> None:
 
 
 # -- R2 buckets --
-#
-# Same MockTransport approach as above, but patched through a single loop so the
-# monkeypatch ratchet counts one occurrence regardless of how many HTTP verbs
-# the bucket routes exercise.
-
-
-def _install_mock_httpx(
-    monkeypatch: pytest.MonkeyPatch,
-    handler,
-) -> ImbueCloudConnectorClient:
-    transport = httpx.MockTransport(handler)
-
-    def _make(method_name: str):
-        def _call(*args, **kwargs):
-            with httpx.Client(transport=transport) as inner:
-                return inner.request(method_name, *args, **kwargs)
-
-        return _call
-
-    for method_name in ("POST", "GET", "DELETE", "PUT"):
-        monkeypatch.setattr(httpx, method_name.lower(), _make(method_name))
-    return ImbueCloudConnectorClient(base_url=AnyUrl("https://example.com"))
 
 
 def _bucket_create_response() -> dict:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance_test.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 
 import pytest
+from pydantic import AnyUrl
+from pydantic import Field
+from pydantic import PrivateAttr
 from pydantic import SecretStr
 
 from imbue.mngr.primitives import AgentId
@@ -13,6 +16,7 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr_imbue_cloud.client import ImbueCloudConnectorClient
 from imbue.mngr_imbue_cloud.config import ImbueCloudProviderConfig
 from imbue.mngr_imbue_cloud.data_types import LeasedHostInfo
 from imbue.mngr_imbue_cloud.instance import ImbueCloudProvider
@@ -53,9 +57,13 @@ from imbue.mngr_imbue_cloud.primitives import LeaseDbId
 def test_map_docker_status_to_host_state(status: str, exit_code: int, expected_state: HostState) -> None:
     state, note = _map_docker_status_to_host_state(status, exit_code)
     assert state == expected_state
-    # Every mapping returns a non-empty diagnostic note that gets folded
-    # into HostDetails.failure_reason; assert it's at least populated so
-    # the user sees *something* in the listing.
+    # The state mapping is the contract this matrix pins. The note assertion is
+    # intentionally only a populated-ness check (every mapping must fold *some*
+    # diagnostic into HostDetails.failure_reason so the user sees something in
+    # the listing); the specific note *content* for the cases that carry
+    # debugging info is pinned by the dedicated tests below
+    # (test_map_docker_status_running_note_mentions_inner_ssh and
+    # test_map_docker_status_exited_nonzero_note_includes_exit_code).
     assert note is not None
     assert note != ""
 
@@ -270,32 +278,36 @@ def test_build_pool_host_wipe_script_renders_safe_host_id_inline() -> None:
 # =============================================================================
 
 
-class _RecordingReleaseClient:
-    """Stub connector client that records release_host calls (and reports success)."""
+class _RecordingReleaseClient(ImbueCloudConnectorClient):
+    """Concrete connector-client mock that records release_host calls.
 
-    def __init__(self) -> None:
-        self.release_calls: list[str] = []
+    Inherits the real ``ImbueCloudConnectorClient`` interface so that a future
+    signature change to ``release_host`` fails this test (rather than silently
+    passing against a stale hand-rolled stub).
+    """
 
-    def release_host(self, access_token: SecretStr, host_db_id: str) -> bool:
+    release_calls: list[str] = Field(default_factory=list)
+
+    def release_host(self, access_token: SecretStr, host_db_id: str) -> None:
         self.release_calls.append(host_db_id)
-        return True
 
 
 class _ReleaseGuardProvider(ImbueCloudProvider):
     """Provider stub that records local-state cleanup instead of touching disk."""
 
-    _cleanup_calls: list[HostId] = []
+    # PrivateAttr(default_factory=...) gives each instance its own list, so the
+    # recorder can never leak state across tests via a shared class-level default.
+    _cleanup_calls: list[HostId] = PrivateAttr(default_factory=list)
 
     def _cleanup_local_host_state(self, host_id: HostId) -> None:
         self._cleanup_calls.append(host_id)
 
 
 def _make_release_guard_provider() -> tuple[_ReleaseGuardProvider, _RecordingReleaseClient]:
-    client = _RecordingReleaseClient()
+    client = _RecordingReleaseClient(base_url=AnyUrl("https://example.com"))
     provider = _ReleaseGuardProvider.model_construct(
         name=ProviderInstanceName("imbue-cloud-test"),
         client=client,
-        _cleanup_calls=[],
     )
     return provider, client
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/test_ratchets.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/test_ratchets.py
@@ -210,7 +210,7 @@ def test_prevent_unittest_mock_imports() -> None:
 
 
 def test_prevent_monkeypatch_setattr() -> None:
-    rc.check_monkeypatch_setattr(_DIR, snapshot(5))
+    rc.check_monkeypatch_setattr(_DIR, snapshot(1))
 
 
 def test_prevent_test_container_classes() -> None:


### PR DESCRIPTION
Fixes the `identify-bad-tests` findings for `libs/mngr_imbue_cloud`.

- **admin_test**: the `pool_hosts` INSERT column check compared raw substrings, so `id` (inside `agent_id`/`host_id`/`vps_instance_id`) and `ssh_port` (inside `container_ssh_port`) could be dropped without failing the test — exactly the schema-drift class it claims to guard. Now compares against the parsed column tokens.
- **client_test**: removed the dead, misleading `_make_client` helper (built a `MockTransport` then discarded it, so any user of it would hit the real network) and routed the lease/auth tests through the shared `_install_mock_httpx` seam. Drops the `monkeypatch.setattr` ratchet 5 → 1.
- **instance_test**: the release-recording client now inherits the real `ImbueCloudConnectorClient` (it had already drifted to `release_host(...) -> bool` vs the real `-> None`, undetected); the provider stub's `_cleanup_calls` recorder is now a per-instance `PrivateAttr(default_factory=list)` instead of a shared class-level mutable default.
- **buckets_test / paid_test**: documented the help-text tests as intentional wiring smoke tests.
- **instance_test**: clarified that the parametrized docker-status `note` assertion is a populated-ness check, with content pinned by dedicated tests.

Test-only; no user-facing behavior change. Full `mngr_imbue_cloud` suite (169) + ratchets (55) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)