### PR TITLE
Strengthen weak tests in mngr_claude_subagent_proxy suite

### DIFF
--- a/libs/mngr_claude_subagent_proxy/changelog/mngr-bad-tests-mngr-claude-subagent-proxy-local.md
+++ b/libs/mngr_claude_subagent_proxy/changelog/mngr-bad-tests-mngr-claude-subagent-proxy-local.md
@@ -1,0 +1,6 @@
+Strengthened several weak tests in the subagent-proxy test suite (no user-facing behavior change):
+
+- Marked the known-failing `test_plan_mode_propagates_to_subagent` release test `xfail(strict=True)` so it stops showing as an unexplained red and will flip to a real regression test the day plan-mode propagation is implemented.
+- Added execution-based tests for the generated wait-script (run under bash with a stub `uv`) covering the idempotent short-circuit, EXIT-trap secret cleanup on `mngr create` failure, the happy-path relay, and `--spawn-only` mode, plus a `bash -n` syntax check -- the prior tests only string-matched the generated shell source.
+- Factored the target-presence rate-limit decision into `_should_recheck_target_presence` and tested its cadence directly, replacing a test that only compared two module constants.
+- Added positive provisioning assertions (settings.local.json hooks actually written) and no-op side-effect assertions where they were missing, and broadened `extract_assistant_text` edge-case coverage.

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/hooks/guard_stop_hooks_test.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/hooks/guard_stop_hooks_test.py
@@ -58,7 +58,14 @@ def test_guard_stop_hooks_run_noop_when_state_dir_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SessionStart fires on plain Claude sessions without mngr context;
-    the hook must tolerate the missing-env case silently."""
+    the hook must tolerate the missing-env case silently.
+
+    There is intentionally no side-effect assertion here: when
+    MNGR_AGENT_STATE_DIR is unset, run() reads stdin and returns before it
+    has any path to act on (it never computes a state dir, so it cannot
+    create or write anything). The contract is purely "tolerate and return,"
+    so "does not raise" is the complete guarantee. The positive wrapping
+    behavior is covered by test_guard_stop_hooks_run_wraps_per_agent_plugin_cache.
+    """
     monkeypatch.delenv("MNGR_AGENT_STATE_DIR", raising=False)
-    # Should not raise.
     guard_stop_hooks.run(io.StringIO(""))

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/hooks_test.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/hooks_test.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import stat
+import subprocess
 from pathlib import Path
 from typing import Callable
 
@@ -223,6 +225,212 @@ def test_wait_script_traps_env_file_cleanup_on_failure() -> None:
         "EXIT trap must be installed BEFORE the env-capture redirect (and "
         "before mngr create) and cleared AFTER successful shred"
     )
+
+
+# The structural tests above pin the *shape* of the generated wait-script.
+# The tests below pin its *behavior* by actually running it under bash with
+# a stub `uv` on PATH, so a behavior-preserving refactor of the template
+# (renamed vars, reordered statements) doesn't break them and -- more
+# importantly -- a script that is syntactically valid but functionally broken
+# (inverted guard, mis-scoped trap, dropped sentinel) is caught.
+_STUB_UV: str = (
+    "#!/usr/bin/env bash\n"
+    "# Stub `uv`: record each invocation and emulate the two real subcommands\n"
+    "# the wait-script issues (`uv run mngr create ...` and\n"
+    "# `uv run python -m ...subagent_wait ...`).\n"
+    'printf \'%s\\n\' "$*" >> "$UV_STUB_LOG"\n'
+    'if [ "${2:-}" = "mngr" ] && [ "${3:-}" = "create" ]; then\n'
+    '    exit "${STUB_MNGR_CREATE_EXIT:-0}"\n'
+    "fi\n"
+    'if [ "${2:-}" = "python" ]; then\n'
+    "    printf 'END_TURN:stub-subagent-reply'\n"
+    "    exit 0\n"
+    "fi\n"
+    "exit 0\n"
+)
+
+
+def _make_stub_uv(bin_dir: Path) -> None:
+    """Drop an executable stub `uv` into ``bin_dir`` (created if needed)."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    uv_path = bin_dir / "uv"
+    uv_path.write_text(_STUB_UV)
+    uv_path.chmod(0o755)
+
+
+def _run_generated_wait_script(
+    script_text: str,
+    state_dir: Path,
+    stub_bin: Path,
+    *,
+    mngr_create_exit: int = 0,
+    args: tuple[str, ...] = (),
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Write the generated wait-script to disk and run it under bash with the
+    stub `uv` first on PATH. Returns (completed_process, uv_invocation_log)."""
+    script_file = state_dir / "wait.sh"
+    script_file.write_text(script_text)
+    script_file.chmod(0o755)
+    uv_log = state_dir / "uv_stub.log"
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["MNGR_AGENT_STATE_DIR"] = str(state_dir)
+    env["UV_STUB_LOG"] = str(uv_log)
+    env["STUB_MNGR_CREATE_EXIT"] = str(mngr_create_exit)
+    completed = subprocess.run(
+        ["bash", str(script_file), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return completed, uv_log
+
+
+def _seed_live_sidefiles(state_dir: Path, tool_use_id: str) -> None:
+    """Create the per-tool_use_id state subdirs plus prompt/map files so the
+    wait-script's idempotent guard passes and the init branch runs."""
+    for sub in ("subagent_prompts", "subagent_map", "proxy_commands", "subagent_results"):
+        (state_dir / sub).mkdir(parents=True, exist_ok=True)
+    (state_dir / "subagent_prompts" / f"{tool_use_id}.md").write_text("do the thing")
+    (state_dir / "subagent_map" / f"{tool_use_id}.json").write_text("{}")
+
+
+def test_wait_script_is_syntactically_valid_bash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`bash -n` must accept the generated script. A bad shlex.quote round-trip
+    (e.g. a parent_cwd containing quotes/spaces) or a malformed template edit
+    would produce a script that the shape-matching tests still pass but that
+    bash refuses to parse."""
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+    script = spawn_hook.build_wait_script(
+        tool_use_id="toolu_syntax",
+        target_name="parent--subagent-foo",
+        parent_cwd="/tmp/some dir/with'a quote",
+    )
+    script_file = tmp_path / "wait.sh"
+    script_file.write_text(script)
+    completed = subprocess.run(["bash", "-n", str(script_file)], capture_output=True, text=True, timeout=30)
+    assert completed.returncode == 0, f"bash -n rejected the generated script:\n{completed.stderr}"
+
+
+def test_wait_script_short_circuits_without_invoking_uv_when_sidefiles_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behavioral check of the idempotent prelude: with PROMPT_FILE / MAP_FILE
+    absent (PostToolUse already cleaned up), running the script emits the
+    sentinel, exits 0, and never reaches `uv run mngr create`."""
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+    stub_bin = tmp_path / "bin"
+    _make_stub_uv(stub_bin)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    script = spawn_hook.build_wait_script(
+        tool_use_id="toolu_exec_guard",
+        target_name="parent--subagent-foo",
+        parent_cwd="/tmp/somewhere",
+    )
+
+    completed, uv_log = _run_generated_wait_script(script, state_dir, stub_bin)
+
+    assert completed.returncode == 0, completed.stderr
+    assert "MNGR_PROXY_END_OF_OUTPUT" in completed.stdout
+    # uv was never invoked: the prelude short-circuited before mngr create.
+    assert not uv_log.exists(), f"uv should not run on the cleaned-up path; log: {uv_log.read_text()}"
+
+
+def test_wait_script_trap_shreds_env_file_when_mngr_create_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Behavioral check of the EXIT trap: when `mngr create` exits non-zero,
+    `set -e` aborts the script but the EXIT trap still removes the env-file
+    holding the parent's captured secrets, and the init flag is NOT set (so a
+    retry re-runs create)."""
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+    stub_bin = tmp_path / "bin"
+    _make_stub_uv(stub_bin)
+    state_dir = tmp_path / "state"
+    tid = "toolu_exec_trap"
+    _seed_live_sidefiles(state_dir, tid)
+    script = spawn_hook.build_wait_script(
+        tool_use_id=tid,
+        target_name="parent--subagent-foo",
+        parent_cwd="/tmp/somewhere",
+    )
+
+    completed, uv_log = _run_generated_wait_script(script, state_dir, stub_bin, mngr_create_exit=1)
+
+    # The failed create aborts the script under set -e.
+    assert completed.returncode != 0
+    # We actually reached the create call (so the env-file had been written)...
+    assert uv_log.exists() and "mngr create" in uv_log.read_text()
+    # ...and the EXIT trap shredded it: no parent secrets left on disk.
+    assert not (state_dir / "proxy_commands" / f"env-{tid}.env").exists()
+    # Init flag untouched -> a subsequent invocation will retry create.
+    assert not (state_dir / "proxy_commands" / f"initialized-{tid}").exists()
+
+
+def test_wait_script_happy_path_relays_subagent_reply_and_cleans_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end behavioral check of the success path: create succeeds,
+    subagent_wait returns END_TURN, and the script writes the result file,
+    prints the body plus the sentinel, shreds the env-file, and marks
+    initialization done."""
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+    stub_bin = tmp_path / "bin"
+    _make_stub_uv(stub_bin)
+    state_dir = tmp_path / "state"
+    tid = "toolu_exec_ok"
+    _seed_live_sidefiles(state_dir, tid)
+    script = spawn_hook.build_wait_script(
+        tool_use_id=tid,
+        target_name="parent--subagent-foo",
+        parent_cwd="/tmp/somewhere",
+    )
+
+    completed, uv_log = _run_generated_wait_script(script, state_dir, stub_bin)
+
+    assert completed.returncode == 0, completed.stderr
+    # The subagent's reply is relayed verbatim, followed by the sentinel.
+    assert "stub-subagent-reply" in completed.stdout
+    assert "MNGR_PROXY_END_OF_OUTPUT" in completed.stdout
+    # Result file captured the body; env-file shredded; init flag set.
+    assert (state_dir / "subagent_results" / f"{tid}.txt").read_text() == "stub-subagent-reply"
+    assert not (state_dir / "proxy_commands" / f"env-{tid}.env").exists()
+    assert (state_dir / "proxy_commands" / f"initialized-{tid}").exists()
+    # Both subcommands ran: create, then the wait module.
+    log = uv_log.read_text()
+    assert "mngr create" in log
+    assert "subagent_wait" in log
+
+
+def test_wait_script_spawn_only_skips_wait_after_create(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """In --spawn-only (background) mode the script creates the child and exits
+    0 immediately, WITHOUT blocking on subagent_wait -- so no result file is
+    written and the wait module is never invoked."""
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+    stub_bin = tmp_path / "bin"
+    _make_stub_uv(stub_bin)
+    state_dir = tmp_path / "state"
+    tid = "toolu_exec_bg"
+    _seed_live_sidefiles(state_dir, tid)
+    script = spawn_hook.build_wait_script(
+        tool_use_id=tid,
+        target_name="parent--subagent-foo",
+        parent_cwd="/tmp/somewhere",
+    )
+
+    completed, uv_log = _run_generated_wait_script(script, state_dir, stub_bin, args=("--spawn-only",))
+
+    assert completed.returncode == 0, completed.stderr
+    log = uv_log.read_text()
+    assert "mngr create" in log
+    # The blocking wait module must not be invoked in spawn-only mode.
+    assert "subagent_wait" not in log
+    assert not (state_dir / "subagent_results" / f"{tid}.txt").exists()
+    # Initialization still completed (env shredded, flag set).
+    assert (state_dir / "proxy_commands" / f"initialized-{tid}").exists()
+    assert not (state_dir / "proxy_commands" / f"env-{tid}.env").exists()
 
 
 def test_spawn_prepends_resolved_agent_definition_body_to_prompt_file(
@@ -444,9 +652,9 @@ def test_rewrite_substitutes_output_and_cleans_up(
     # updatedToolOutput is MCP-only. The hook now emits no JSON; the
     # subagent end-turn text reaches the parent via Haiku's own final
     # reply (see hooks/spawn.py wait-script + mngr-proxy.agent.md).
-    # Result file remains on disk for diagnostics? No: the hook still
-    # cleans up side files because they are no longer needed once Haiku
-    # has captured the content from the wait-script's stdout.
+    # PostToolUse removes all per-tool_use_id sidefiles once Haiku has
+    # captured the content from the wait-script's stdout; nothing is
+    # retained for diagnostics on the success path.
     assert not map_file.exists()
     assert not result_file.exists()
     assert not prompt_file.exists()
@@ -828,5 +1036,13 @@ def test_guard_per_agent_plugin_cache_noop_when_cache_missing(tmp_path: Path) ->
     """
     state_dir = tmp_path / "agent-state-no-plugins"
     state_dir.mkdir()
-    # Should not raise.
+
     _stop_hook_guard.guard_per_agent_plugin_cache(state_dir)
+
+    # The contract is "tolerate a missing cache and do nothing": it must not
+    # raise AND must not materialize the cache tree it was looking for (a
+    # regression that did `mkdir(parents=True)` before checking would pass a
+    # bare "did not raise" assertion).
+    cache_root = state_dir / "plugin" / "claude" / "anthropic" / "plugins"
+    assert not cache_root.exists()
+    assert list(state_dir.iterdir()) == []

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/plugin_test.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/plugin_test.py
@@ -247,6 +247,14 @@ def test_plugin_allows_guarded_project_stop_hook(work_dir: Path, fake_host: Fake
 
     _provision(agent, fake_host, None)
 
+    # Provisioning must not just avoid raising -- it must actually install
+    # the PROXY hooks. A silent no-op would also "not raise" but would mean
+    # the guarded project hook was never honored.
+    settings = json.loads((work_dir / ".claude" / "settings.local.json").read_text())
+    hooks = settings["hooks"]
+    assert any(entry.get("matcher") == "Agent" for entry in hooks["PreToolUse"])
+    assert "imbue.mngr_claude_subagent_proxy.hooks.spawn" in hooks["PreToolUse"][0]["hooks"][0]["command"]
+
 
 def test_plugin_project_stop_hook_check_can_be_bypassed_via_env(
     work_dir: Path, fake_host: FakeHost, monkeypatch: pytest.MonkeyPatch
@@ -257,6 +265,13 @@ def test_plugin_project_stop_hook_check_can_be_bypassed_via_env(
     agent = FakeAgent(AgentId.generate(), work_dir, ClaudeAgentConfig(), name=AgentName("reviewer"))
 
     _provision(agent, fake_host, None)
+
+    # The bypass must still produce a fully-provisioned agent, not a silent
+    # no-op that merely skipped the un-guarded check.
+    settings = json.loads((work_dir / ".claude" / "settings.local.json").read_text())
+    hooks = settings["hooks"]
+    assert any(entry.get("matcher") == "Agent" for entry in hooks["PreToolUse"])
+    assert "imbue.mngr_claude_subagent_proxy.hooks.spawn" in hooks["PreToolUse"][0]["hooks"][0]["command"]
 
 
 def test_plugin_skips_non_claude_agents(work_dir: Path, fake_host: FakeHost) -> None:
@@ -528,6 +543,12 @@ def test_deny_mode_skips_project_stop_hook_check(
 
     # Must NOT raise -- the project-stop-hook check is gated behind PROXY mode.
     _provision(agent, fake_host, ctx)
+
+    # And it must still install the DENY-mode hook, not silently no-op.
+    settings = json.loads((work_dir / ".claude" / "settings.local.json").read_text())
+    hooks = settings["hooks"]
+    assert any(entry.get("matcher") == "Agent" for entry in hooks["PreToolUse"])
+    assert "imbue.mngr_claude_subagent_proxy.hooks.deny" in hooks["PreToolUse"][0]["hooks"][0]["command"]
 
 
 def test_deny_mode_does_not_strip_subagent_user_hooks(

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait.py
@@ -513,6 +513,21 @@ def _has_target_disappeared_past_grace(runtime: _WaitRuntime, now: float) -> boo
     return False
 
 
+def _should_recheck_target_presence(last_check_at: float, now: float) -> bool:
+    """Return True if enough time has elapsed since the last `mngr list`
+    presence check to issue another one.
+
+    `mngr list` is expensive, so the wait loop rate-limits its
+    target-disappearance check to once per ``_TARGET_PRESENCE_RECHECK_SECONDS``
+    even though the loop polls roughly every ``_POLL_INTERVAL_SECONDS``.
+    Pulling the cadence decision into a pure function lets it be tested
+    directly -- a regression that fired the check on every poll (or never
+    fired it) is observable here, which a constant-relationship assertion
+    could not catch.
+    """
+    return now - last_check_at >= _TARGET_PRESENCE_RECHECK_SECONDS
+
+
 def resolve_destroyed_result(target_name: str, location: AgentLocation) -> str:
     """Build the END_TURN payload for an agent that was destroyed before completing."""
     preserved_dir = get_preserved_agent_dir(location.host_dir, AgentName(target_name), AgentId(location.agent_id))
@@ -648,7 +663,7 @@ def wait_for_subagent(target_name: str, watermark_file: Path | None = None) -> s
                 _delete_watermark_file(watermark_file)
             return f"END_TURN:{truncated}"
 
-        if now - runtime.last_presence_check_at >= _TARGET_PRESENCE_RECHECK_SECONDS:
+        if _should_recheck_target_presence(runtime.last_presence_check_at, now):
             runtime.last_presence_check_at = now
             if _has_target_disappeared_past_grace(runtime, now):
                 destroyed_text = resolve_destroyed_result(target_name, location)

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait_test.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/subagent_wait_test.py
@@ -175,6 +175,36 @@ def test_extract_assistant_text_concatenates_text_blocks_only() -> None:
     assert extract_assistant_text(multi_text_event) == "hello world"
 
 
+# extract_assistant_text feeds the body relayed to the parent, so a
+# malformed event must yield "" rather than raise -- otherwise the relay
+# wedges. These mirror the boundary coverage the sibling predicates
+# (is_end_turn_event, is_real_user_event) already have.
+_EXTRACT_EMPTY_CASES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("empty_content_list", {"type": "assistant", "message": {"content": []}}),
+    ("missing_message", {"type": "assistant"}),
+    ("non_dict_message", {"type": "assistant", "message": "not-a-dict"}),
+    ("content_not_a_list", {"type": "assistant", "message": {"content": "just a string"}}),
+    ("content_missing", {"type": "assistant", "message": {"stop_reason": "end_turn"}}),
+    (
+        "only_non_text_blocks",
+        {"type": "assistant", "message": {"content": [{"type": "thinking", "thinking": "x"}]}},
+    ),
+    (
+        "empty_string_text_block",
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": ""}]}},
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [case[1] for case in _EXTRACT_EMPTY_CASES],
+    ids=[case[0] for case in _EXTRACT_EMPTY_CASES],
+)
+def test_extract_assistant_text_returns_empty_on_malformed_or_empty(event: dict[str, Any]) -> None:
+    assert extract_assistant_text(event) == ""
+
+
 # is_real_user_event must accept only plain-text human prompts and reject
 # tool_result blocks plus the synthetic hook-feedback messages Claude
 # Code emits as type=user. Hook-feedback prefixes are matched after a
@@ -395,20 +425,42 @@ def test_permission_gate_suppresses_until_transcript_advances(tmp_path: Path) ->
     assert _check_permissions_newly_waiting(runtime) is True
 
 
-def test_target_presence_recheck_is_rate_limited() -> None:
-    """The wait loop's `mngr list` calls for target-presence checks must be
-    rate-limited via _TARGET_PRESENCE_RECHECK_SECONDS so the 5x/s polling
-    cadence does not flood the host with concurrent `mngr list` runs.
+# The wait loop's `mngr list` target-presence check must be rate-limited:
+# the loop polls ~5x/s but the disappearance check must fire only once per
+# _TARGET_PRESENCE_RECHECK_SECONDS. Found live: a nested verify-and-fix
+# subagent stalled when many parents made `mngr list` slow -- the loop fired
+# the check every 200ms, each call timing out after 30s, queueing faster
+# than they finished and starving the rest of the loop.
+#
+# These cases pin the actual cadence decision (the pure helper the loop
+# uses), not just a relationship between two constants. A regression that
+# fired the check on every poll -- e.g. deleting the elapsed-time guard, or
+# failing to advance last_presence_check_at -- would make the within-interval
+# cases below return True and fail, which the old constants-only assertion
+# could not catch.
+_RECHECK_INTERVAL: float = subagent_wait._TARGET_PRESENCE_RECHECK_SECONDS
+_RECHECK_CADENCE_CASES: tuple[tuple[str, float, float, bool], ...] = (
+    ("just_checked_zero_elapsed", 100.0, 100.0, False),
+    ("one_poll_later", 100.0, 100.0 + subagent_wait._POLL_INTERVAL_SECONDS, False),
+    ("just_under_interval", 100.0, 100.0 + _RECHECK_INTERVAL - 0.001, False),
+    ("exactly_at_interval", 100.0, 100.0 + _RECHECK_INTERVAL, True),
+    ("well_past_interval", 100.0, 100.0 + _RECHECK_INTERVAL * 3, True),
+)
 
-    Found live: a nested verify-and-fix subagent stalled when many parent
-    agents made `mngr list` slow. The wait loop fired its disappearance
-    check on every poll iteration (every 200ms), each call timing out
-    after 30s, queueing up faster than they finished and starving the
-    rest of the loop.
-    """
-    # The rate-limit interval must be substantially larger than the poll
-    # interval; otherwise the rate-limiting is effectively a no-op.
-    assert subagent_wait._TARGET_PRESENCE_RECHECK_SECONDS > subagent_wait._POLL_INTERVAL_SECONDS * 5
-    # The interval must also be at least a few seconds in absolute terms,
-    # since a single mngr-list call commonly takes >1s on busy hosts.
-    assert subagent_wait._TARGET_PRESENCE_RECHECK_SECONDS >= 2.0
+
+@pytest.mark.parametrize(
+    ("last_check_at", "now", "expected"),
+    [(case[1], case[2], case[3]) for case in _RECHECK_CADENCE_CASES],
+    ids=[case[0] for case in _RECHECK_CADENCE_CASES],
+)
+def test_should_recheck_target_presence_cadence(last_check_at: float, now: float, expected: bool) -> None:
+    assert subagent_wait._should_recheck_target_presence(last_check_at, now) is expected
+
+
+def test_target_presence_recheck_interval_is_sane() -> None:
+    """Secondary sanity check on the chosen interval: it must be both
+    substantially larger than the poll interval (or the rate-limiting is a
+    no-op) and at least a couple seconds absolute (a single mngr-list call
+    commonly takes >1s on busy hosts)."""
+    assert _RECHECK_INTERVAL > subagent_wait._POLL_INTERVAL_SECONDS * 5
+    assert _RECHECK_INTERVAL >= 2.0

--- a/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_real_claude_subagent.py
+++ b/libs/mngr_claude_subagent_proxy/imbue/mngr_claude_subagent_proxy/test_real_claude_subagent.py
@@ -814,6 +814,14 @@ _PLAN_MODE_PROMPT: Final[str] = (
 )
 
 
+@pytest.mark.xfail(
+    reason="plan-mode propagation is not yet implemented -- see README 'Deferred / "
+    "out-of-scope'. The spawn hook does not forward --permission-mode plan to the "
+    "child's mngr-create call (hooks/spawn.py:build_wait_script), so the child never "
+    "inherits plan mode. strict=True makes this XPASS-and-fail the day the feature "
+    "lands, prompting removal of the marker.",
+    strict=True,
+)
 @pytest.mark.release
 @pytest.mark.tmux
 @pytest.mark.rsync


### PR DESCRIPTION
Fixes the findings from the `identify-bad-tests` scan of `libs/mngr_claude_subagent_proxy`. Test-only changes plus one small production refactor (extracted a pure helper); no user-facing behavior change.

## Findings addressed

1. **`test_plan_mode_propagates_to_subagent` was a known-failing release test with no marker.** Plan-mode propagation is documented as not implemented (README "Deferred / out-of-scope"; `hooks/spawn.py` forwards no `--permission-mode`). Marked `xfail(strict=True)` so it stops reading as an unexplained red and flips to a real regression test (XPASS-fail) the day the feature lands.

2. **Wait-script tests asserted on generated shell source, not behavior.** Added execution-based tests that run the generated script under `bash` with a stub `uv` on PATH: idempotent short-circuit when sidefiles are absent (no `mngr create`), EXIT-trap secret cleanup when `mngr create` fails, happy-path relay of the subagent reply + sentinel, and `--spawn-only` mode skipping the blocking wait. Plus a `bash -n` syntax check. The existing structural string-match tests are retained.

3. **`test_target_presence_recheck_is_rate_limited` only compared two constants.** Extracted `_should_recheck_target_presence(last_check_at, now)` in `subagent_wait.py`, used it in the poll loop, and replaced the test with a parametrized cadence test that would catch a deleted/forgotten rate-limit guard. Kept an absolute-floor sanity check as a secondary assertion.

4. **Provisioning "allowed path" tests asserted only "no exception."** Added positive assertions that `settings.local.json` is written with the expected PreToolUse:Agent hook (spawn for PROXY, deny for DENY).

5. **`noop_when_*_missing` guard tests asserted only "does not raise."** Added a side-effect assertion for the missing-cache case (cache tree not materialized); for the missing-state-dir hook, documented that there is genuinely no reachable side effect (the function returns before computing any path) rather than faking one.

6. **`extract_assistant_text` had thin edge coverage.** Added a parametrized companion covering empty/missing/non-list content.

7. **Confusing self-dialogue comment** in `test_rewrite_substitutes_output_and_cleans_up` replaced with a single declarative sentence.

## Testing

`just test-quick libs/mngr_claude_subagent_proxy` (excluding tmux/modal/docker/acceptance/release/rsync): 183 passed. Ratchets: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)