### PR TITLE
Fix bad tests under interfaces/ (tautological tests + MagicMock removal)

### DIFF
--- a/libs/mngr/changelog/mngr-bad-tests-mngr-interfaces-local.md
+++ b/libs/mngr/changelog/mngr-bad-tests-mngr-interfaces-local.md
@@ -1,0 +1,19 @@
+Test-quality cleanup under `imbue/mngr/interfaces` (no production-code changes):
+
+- Replaced tautological "constructor echo" unit tests (which only re-asserted the
+  values just passed in) with behavioral assertions: `SSHInfo` and `HostDetails`
+  now have JSON round-trip tests that exercise the real `Path`->str and enum->value
+  coercions, and `VolumeFile` is now checked via the `listdir` logic that derives
+  its `size` from actual file contents.
+- Tightened a loose `len(data) > 0` assertion in the scoped-volume listdir test to
+  assert exact file contents, so it can no longer pass if a scoped read resolved to
+  the wrong backing file.
+- Moved the in-memory `Volume` test double out of `volume_test.py` into a shared
+  `interfaces/mock_volume_test.py` (per the "mock implementations live in
+  `mock_*_test.py`" convention) and gave its `files` field a proper
+  `default_factory`.
+- Removed all `unittest.mock` usage from `provider_instance_test.py`: the host/agent
+  fallback, disconnect, and resilience tests now use concrete typed mock
+  implementations (`MockOnlineHost`, `MockAgent`) instead of `MagicMock`, asserting
+  observable effects (e.g. a `disconnect_count` counter, offline-derived agent
+  state) rather than coupling to call counts. The `unittest.mock` ratchet is now 0.

--- a/libs/mngr/imbue/mngr/interfaces/data_types_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/data_types_test.py
@@ -89,36 +89,13 @@ def test_relative_path_works_with_path_division() -> None:
 # =============================================================================
 
 
-def test_ssh_info_basic_creation() -> None:
-    """Test that SSHInfo can be created with required fields."""
-    ssh_info = SSHInfo(
-        user="root",
-        host="example.com",
-        port=22,
-        key_path=Path("/home/user/.ssh/id_rsa"),
-        command="ssh -i /home/user/.ssh/id_rsa -p 22 root@example.com",
-    )
-    assert ssh_info.user == "root"
-    assert ssh_info.host == "example.com"
-    assert ssh_info.port == 22
-    assert ssh_info.key_path == Path("/home/user/.ssh/id_rsa")
-    assert ssh_info.command == "ssh -i /home/user/.ssh/id_rsa -p 22 root@example.com"
+def test_ssh_info_json_round_trip_coerces_path() -> None:
+    """SSHInfo survives a JSON dump/load round-trip, coercing key_path Path<->str.
 
-
-def test_ssh_info_custom_port() -> None:
-    """Test SSHInfo with a custom port."""
-    ssh_info = SSHInfo(
-        user="deploy",
-        host="192.168.1.100",
-        port=2222,
-        key_path=Path("/keys/deploy.pem"),
-        command="ssh -i /keys/deploy.pem -p 2222 deploy@192.168.1.100",
-    )
-    assert ssh_info.port == 2222
-
-
-def test_ssh_info_serialization() -> None:
-    """Test that SSHInfo serializes to JSON correctly."""
+    The behavioral content here is the ``Path`` -> ``str`` coercion that
+    ``mode="json"`` performs (and its inverse on validation); a plain
+    field-by-field echo of the constructor inputs would catch no real bug.
+    """
     ssh_info = SSHInfo(
         user="root",
         host="example.com",
@@ -127,11 +104,13 @@ def test_ssh_info_serialization() -> None:
         command="ssh -i /home/user/.ssh/id_rsa -p 22 root@example.com",
     )
     data = ssh_info.model_dump(mode="json")
-    assert data["user"] == "root"
-    assert data["host"] == "example.com"
-    assert data["port"] == 22
+    # key_path is a Path on the model but must serialize to a plain string in JSON.
     assert data["key_path"] == "/home/user/.ssh/id_rsa"
-    assert data["command"] == "ssh -i /home/user/.ssh/id_rsa -p 22 root@example.com"
+    assert isinstance(data["key_path"], str)
+
+    restored = SSHInfo.model_validate(data)
+    assert restored == ssh_info
+    assert restored.key_path == Path("/home/user/.ssh/id_rsa")
 
 
 # =============================================================================
@@ -159,47 +138,15 @@ def test_host_details_minimal_creation() -> None:
     assert host_details.snapshots == []
 
 
-def test_host_details_with_extended_fields() -> None:
-    """Test that HostDetails can be created with all extended fields."""
-    boot_time = datetime.now(timezone.utc)
-    ssh_info = SSHInfo(
-        user="root",
-        host="example.com",
-        port=22,
-        key_path=Path("/home/user/.ssh/id_rsa"),
-        command="ssh -i /home/user/.ssh/id_rsa -p 22 root@example.com",
-    )
-    resources = HostResources(cpu=CpuResources(count=4), memory_gb=16.0, disk_gb=100.0)
+def test_host_details_json_round_trip_coerces_enum_and_nested_models() -> None:
+    """HostDetails survives a JSON dump/load round-trip with its extended fields.
 
-    host_details = HostDetails(
-        id=HostId.generate(),
-        name="test-host",
-        provider_name=ProviderInstanceName("docker"),
-        state=HostState.RUNNING,
-        image="ubuntu:22.04",
-        tags={"env": "production", "team": "infra"},
-        boot_time=boot_time,
-        uptime_seconds=3600.5,
-        resource=resources,
-        ssh=ssh_info,
-        # Note: not testing snapshots here as SnapshotInfo has complex ID requirements
-    )
-
-    assert host_details.state == HostState.RUNNING
-    assert host_details.image == "ubuntu:22.04"
-    assert host_details.tags == {"env": "production", "team": "infra"}
-    assert host_details.boot_time == boot_time
-    assert host_details.uptime_seconds == 3600.5
-    assert host_details.resource is not None
-    assert host_details.resource.memory_gb == 16.0
-    assert host_details.ssh is not None
-    assert host_details.ssh.user == "root"
-    # Snapshots should be empty by default
-    assert host_details.snapshots == []
-
-
-def test_host_details_serialization_with_extended_fields() -> None:
-    """Test that HostDetails with extended fields serializes correctly."""
+    The behavioral content is the coercion that ``mode="json"`` performs --
+    the ``HostState`` enum to its ``.value`` string, the ``boot_time``
+    datetime to an ISO string, and the nested ``SSHInfo`` (with its ``Path``)
+    to a plain dict -- plus the inverse on validation. A field-by-field echo
+    of the constructor inputs would catch none of that.
+    """
     boot_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
     ssh_info = SSHInfo(
         user="root",
@@ -208,7 +155,7 @@ def test_host_details_serialization_with_extended_fields() -> None:
         key_path=Path("/keys/id_rsa"),
         command="ssh -i /keys/id_rsa -p 22 root@example.com",
     )
-
+    resources = HostResources(cpu=CpuResources(count=4), memory_gb=16.0, disk_gb=100.0)
     host_details = HostDetails(
         id=HostId.generate(),
         name="test-host",
@@ -218,17 +165,18 @@ def test_host_details_serialization_with_extended_fields() -> None:
         tags={"key": "value"},
         boot_time=boot_time,
         uptime_seconds=7200.0,
+        resource=resources,
         ssh=ssh_info,
     )
 
     data = host_details.model_dump(mode="json")
-
+    # The enum must serialize to its string value, not the enum object.
     assert data["state"] == HostState.RUNNING.value
-    assert data["image"] == "custom-image:v1"
-    assert data["tags"] == {"key": "value"}
-    assert data["uptime_seconds"] == 7200.0
-    assert data["ssh"]["user"] == "root"
-    assert data["ssh"]["port"] == 22
+    # The nested SSHInfo's Path must be coerced to a string inside the dict.
+    assert data["ssh"]["key_path"] == "/keys/id_rsa"
+
+    restored = HostDetails.model_validate(data)
+    assert restored == host_details
 
 
 # =============================================================================
@@ -241,19 +189,6 @@ def test_certified_host_data_tmux_session_prefix_defaults_to_none() -> None:
     now = datetime.now(timezone.utc)
     data = CertifiedHostData(host_id="host-123", host_name="test-host", created_at=now, updated_at=now)
     assert data.tmux_session_prefix is None
-
-
-def test_certified_host_data_tmux_session_prefix_set() -> None:
-    """tmux_session_prefix should be settable."""
-    now = datetime.now(timezone.utc)
-    data = CertifiedHostData(
-        host_id="host-123",
-        host_name="test-host",
-        tmux_session_prefix="mngr-",
-        created_at=now,
-        updated_at=now,
-    )
-    assert data.tmux_session_prefix == "mngr-"
 
 
 def test_certified_host_data_tmux_session_prefix_serializes_to_json() -> None:
@@ -366,19 +301,6 @@ def test_certified_host_data_preserves_non_local_host_name() -> None:
 # =============================================================================
 
 
-def test_certified_host_data_created_at_and_updated_at_explicit() -> None:
-    """created_at and updated_at should be settable explicitly."""
-    now = datetime(2026, 2, 15, 12, 0, 0, tzinfo=timezone.utc)
-    data = CertifiedHostData(
-        host_id="host-ts-1",
-        host_name="ts-host",
-        created_at=now,
-        updated_at=now,
-    )
-    assert data.created_at == now
-    assert data.updated_at == now
-
-
 def test_certified_host_data_timestamps_backward_compat_from_json() -> None:
     """Old data.json without created_at/updated_at should deserialize with defaults."""
     old_json = {
@@ -412,19 +334,6 @@ def test_certified_host_data_timestamps_round_trip_through_json() -> None:
 
     assert restored.created_at == now
     assert restored.updated_at == now
-
-
-def test_certified_host_data_timestamps_are_utc() -> None:
-    """Timestamps should be timezone-aware UTC datetimes."""
-    now = datetime.now(timezone.utc)
-    data = CertifiedHostData(
-        host_id="host-utc-1",
-        host_name="utc-host",
-        created_at=now,
-        updated_at=now,
-    )
-    assert data.created_at.tzinfo is not None
-    assert data.updated_at.tzinfo is not None
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/interfaces/mock_agent_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/mock_agent_test.py
@@ -50,6 +50,9 @@ class MockAgent(AgentInterface[AgentTypeConfig]):
     def get_command(self) -> CommandString:
         return self.command
 
+    def set_command(self, command: CommandString) -> None:
+        self.command = command
+
     def get_labels(self) -> dict[str, str]:
         return dict(self.labels)
 

--- a/libs/mngr/imbue/mngr/interfaces/mock_agent_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/mock_agent_test.py
@@ -1,0 +1,173 @@
+"""Concrete, typed mock agent implementation for interface-layer unit tests.
+
+A real ``AgentInterface`` implementation (not a ``unittest.mock`` double) so
+that the provider-instance default methods exercise a typed contract: a
+renamed or re-typed abstract method makes the mock fail to instantiate rather
+than silently fabricating a return value.
+
+Only the methods reached while building ``AgentDetails`` from a live agent
+carry real behavior; the rest raise ``NotImplementedError``.
+"""
+
+from datetime import datetime
+from typing import Any
+from typing import Mapping
+from typing import Sequence
+
+from pydantic import Field
+
+from imbue.mngr.config.data_types import AgentTypeConfig
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import HostConnectionError
+from imbue.mngr.interfaces.agent import AgentInterface
+from imbue.mngr.interfaces.data_types import FileTransferSpec
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.primitives import ActivitySource
+from imbue.mngr.primitives import AgentLifecycleState
+from imbue.mngr.primitives import CommandString
+
+
+class MockAgent(AgentInterface[AgentTypeConfig]):
+    """A concrete ``AgentInterface`` whose reported values are set via fields.
+
+    Set ``raise_connection_error_on_reported_url`` to simulate the host's sshd
+    dropping mid-way through ``_build_agent_details_from_online_agent`` (the
+    error must surface *after* the earlier getters succeed), which the
+    provider should recover from by falling back to offline data.
+    """
+
+    command: CommandString = Field(default=CommandString("sleep 999"))
+    labels: dict[str, str] = Field(default_factory=dict)
+    lifecycle_state: AgentLifecycleState = Field(default=AgentLifecycleState.RUNNING)
+    is_start_on_boot: bool = Field(default=False)
+    created_branch_name: str | None = Field(default=None)
+    reported_url: str | None = Field(default=None)
+    raise_connection_error_on_reported_url: bool = Field(default=False)
+
+    # --- methods reached while building AgentDetails from a live agent ---
+
+    def get_command(self) -> CommandString:
+        return self.command
+
+    def get_labels(self) -> dict[str, str]:
+        return dict(self.labels)
+
+    def set_labels(self, labels: Mapping[str, str]) -> None:
+        self.labels = dict(labels)
+
+    def get_created_branch_name(self) -> str | None:
+        return self.created_branch_name
+
+    def get_is_start_on_boot(self) -> bool:
+        return self.is_start_on_boot
+
+    def set_is_start_on_boot(self, value: bool) -> None:
+        self.is_start_on_boot = value
+
+    def get_lifecycle_state(self) -> AgentLifecycleState:
+        return self.lifecycle_state
+
+    def get_reported_activity_time(self, activity_type: ActivitySource) -> datetime | None:
+        return None
+
+    def get_reported_url(self) -> str | None:
+        if self.raise_connection_error_on_reported_url:
+            raise HostConnectionError("SSH connection dropped")
+        return self.reported_url
+
+    @property
+    def runtime_seconds(self) -> float | None:
+        return None
+
+    # --- unused abstract methods ---
+
+    def get_host(self) -> OnlineHostInterface:
+        raise NotImplementedError()
+
+    def assemble_command(
+        self,
+        host: OnlineHostInterface,
+        agent_args: tuple[str, ...],
+        command_override: CommandString | None,
+        initial_message: str | None = None,
+    ) -> CommandString:
+        raise NotImplementedError()
+
+    def get_expected_process_name(self) -> str:
+        raise NotImplementedError()
+
+    def is_running(self) -> bool:
+        raise NotImplementedError()
+
+    def get_initial_message(self) -> str | None:
+        raise NotImplementedError()
+
+    def get_resume_message(self) -> str | None:
+        raise NotImplementedError()
+
+    def get_ready_timeout_seconds(self) -> float:
+        raise NotImplementedError()
+
+    def send_message(self, message: str) -> None:
+        raise NotImplementedError()
+
+    def capture_pane_content(self, include_scrollback: bool = False) -> str | None:
+        raise NotImplementedError()
+
+    def get_reported_start_time(self) -> datetime | None:
+        raise NotImplementedError()
+
+    def record_activity(self, activity_type: ActivitySource) -> None:
+        raise NotImplementedError()
+
+    def get_reported_activity_record(self, activity_type: ActivitySource) -> str | None:
+        raise NotImplementedError()
+
+    def get_plugin_data(self, plugin_name: str) -> dict[str, Any]:
+        raise NotImplementedError()
+
+    def set_plugin_data(self, plugin_name: str, data: dict[str, Any]) -> None:
+        raise NotImplementedError()
+
+    def get_reported_plugin_file(self, plugin_name: str, filename: str) -> str:
+        raise NotImplementedError()
+
+    def set_reported_plugin_file(self, plugin_name: str, filename: str, data: str) -> None:
+        raise NotImplementedError()
+
+    def list_reported_plugin_files(self, plugin_name: str) -> list[str]:
+        raise NotImplementedError()
+
+    def get_env_vars(self) -> dict[str, str]:
+        raise NotImplementedError()
+
+    def set_env_vars(self, env: Mapping[str, str]) -> None:
+        raise NotImplementedError()
+
+    def get_env_var(self, key: str) -> str | None:
+        raise NotImplementedError()
+
+    def set_env_var(self, key: str, value: str) -> None:
+        raise NotImplementedError()
+
+    def on_before_provisioning(
+        self, host: OnlineHostInterface, options: CreateAgentOptions, mngr_ctx: MngrContext
+    ) -> None:
+        raise NotImplementedError()
+
+    def get_provision_file_transfers(
+        self, host: OnlineHostInterface, options: CreateAgentOptions, mngr_ctx: MngrContext
+    ) -> Sequence[FileTransferSpec]:
+        raise NotImplementedError()
+
+    def provision(self, host: OnlineHostInterface, options: CreateAgentOptions, mngr_ctx: MngrContext) -> None:
+        raise NotImplementedError()
+
+    def on_after_provisioning(
+        self, host: OnlineHostInterface, options: CreateAgentOptions, mngr_ctx: MngrContext
+    ) -> None:
+        raise NotImplementedError()
+
+    def on_destroy(self, host: OnlineHostInterface) -> None:
+        raise NotImplementedError()

--- a/libs/mngr/imbue/mngr/interfaces/mock_host_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/mock_host_test.py
@@ -33,6 +33,7 @@ from imbue.mngr.interfaces.data_types import CpuResources
 from imbue.mngr.interfaces.data_types import HostResources
 from imbue.mngr.interfaces.data_types import PyinfraConnector
 from imbue.mngr.interfaces.data_types import SnapshotInfo
+from imbue.mngr.interfaces.data_types import VolumeFile
 from imbue.mngr.interfaces.host import CreateAgentOptions
 from imbue.mngr.interfaces.host import CreateWorkDirResult
 from imbue.mngr.interfaces.host import HostInterface
@@ -71,7 +72,7 @@ class MockOnlineHost(OnlineHostInterface):
     activity_config: ActivityConfig = Field(default_factory=lambda: ActivityConfig(idle_timeout_seconds=3600))
     agents: list[AgentInterface] = Field(default_factory=list)
     discovered_agents: list[DiscoveredAgent] = Field(default_factory=list)
-    ssh_connection_info: tuple[str, str, int, Path | None] | None = Field(default=None)
+    ssh_connection_info: tuple[str, str, int, Path] | None = Field(default=None)
     is_locked: bool = Field(default=False)
     provider_resources: HostResources = Field(default_factory=_default_resources)
     snapshots: list[SnapshotInfo] = Field(default_factory=list)
@@ -194,7 +195,10 @@ class MockOnlineHost(OnlineHostInterface):
     def get_file_mtime(self, path: Path) -> datetime | None:
         raise NotImplementedError()
 
-    def get_ssh_connection_info(self) -> tuple[str, str, int, Path | None] | None:
+    def list_directory(self, path: Path, *, recursive: bool = False) -> list[VolumeFile]:
+        raise NotImplementedError()
+
+    def get_ssh_connection_info(self) -> tuple[str, str, int, Path] | None:
         return self.ssh_connection_info
 
     # --- OnlineHostInterface ---
@@ -258,8 +262,8 @@ class MockOnlineHost(OnlineHostInterface):
     def get_boot_time(self) -> datetime | None:
         return None
 
-    def get_uptime_seconds(self) -> float | None:
-        return None
+    def get_uptime_seconds(self) -> float:
+        return 0.0
 
     def get_provider_resources(self) -> HostResources:
         return self.provider_resources
@@ -317,6 +321,9 @@ class MockOnlineHost(OnlineHostInterface):
         extra_args: str | None = None,
         exclude_git: bool = False,
     ) -> None:
+        raise NotImplementedError()
+
+    def copy_local_directory(self, source_path: Path, target_path: Path, extra_args: str | None) -> None:
         raise NotImplementedError()
 
     def save_agent_data(self, agent_id: AgentId, agent_data: Mapping[str, object]) -> None:

--- a/libs/mngr/imbue/mngr/interfaces/mock_host_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/mock_host_test.py
@@ -1,0 +1,323 @@
+"""Concrete, typed mock host implementations for interface-layer unit tests.
+
+These are real ``OnlineHostInterface`` implementations (not ``unittest.mock``
+doubles), so they catch interface drift -- a renamed or re-typed abstract
+method makes the mock fail to instantiate -- and they expose observable state
+(e.g. ``disconnect_count``) instead of requiring call-count assertions.
+
+Only the handful of methods exercised by the provider-instance default methods
+(``get_host_and_agent_details``, ``discover_hosts_and_agents``) carry real
+behavior; the remaining abstract methods raise ``NotImplementedError`` (the
+same convention used by ``providers/mock_provider_test.MockProviderInstance``).
+"""
+
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Iterator
+from typing import Mapping
+from typing import Sequence
+
+from pydantic import Field
+
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.errors import HostConnectionError
+from imbue.mngr.hosts.outer_host import create_local_pyinfra_host
+from imbue.mngr.interfaces.agent import AgentInterface
+from imbue.mngr.interfaces.data_types import ActivityConfig
+from imbue.mngr.interfaces.data_types import CertifiedHostData
+from imbue.mngr.interfaces.data_types import CommandResult
+from imbue.mngr.interfaces.data_types import CpuResources
+from imbue.mngr.interfaces.data_types import HostResources
+from imbue.mngr.interfaces.data_types import PyinfraConnector
+from imbue.mngr.interfaces.data_types import SnapshotInfo
+from imbue.mngr.interfaces.host import CreateAgentOptions
+from imbue.mngr.interfaces.host import CreateWorkDirResult
+from imbue.mngr.interfaces.host import HostInterface
+from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.primitives import ActivitySource
+from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import DiscoveredAgent
+from imbue.mngr.primitives import HostName
+from imbue.mngr.primitives import HostState
+
+
+def _default_connector() -> PyinfraConnector:
+    return PyinfraConnector(create_local_pyinfra_host())
+
+
+def _default_resources() -> HostResources:
+    return HostResources(cpu=CpuResources(count=1), memory_gb=1.0, disk_gb=10.0)
+
+
+class MockOnlineHost(OnlineHostInterface):
+    """A concrete ``OnlineHostInterface`` whose behavior is set via fields.
+
+    Configure ``agents`` / ``discovered_agents`` for the happy path, or set
+    ``raise_connection_error_on_get_agents`` /
+    ``raise_connection_error_on_discover_agents`` to simulate a host whose
+    sshd has died after it was discovered. ``disconnect`` increments
+    ``disconnect_count`` so tests can assert cleanup happened without
+    coupling to a mock's call record.
+    """
+
+    connector: PyinfraConnector = Field(default_factory=_default_connector, frozen=True)
+    host_name: HostName = Field(default=HostName("test-host"))
+    state: HostState = Field(default=HostState.RUNNING)
+    certified_data: CertifiedHostData = Field()
+    activity_config: ActivityConfig = Field(default_factory=lambda: ActivityConfig(idle_timeout_seconds=3600))
+    agents: list[AgentInterface] = Field(default_factory=list)
+    discovered_agents: list[DiscoveredAgent] = Field(default_factory=list)
+    ssh_connection_info: tuple[str, str, int, Path | None] | None = Field(default=None)
+    is_locked: bool = Field(default=False)
+    provider_resources: HostResources = Field(default_factory=_default_resources)
+    snapshots: list[SnapshotInfo] = Field(default_factory=list)
+    raise_connection_error_on_get_agents: bool = Field(default=False)
+    raise_connection_error_on_discover_agents: bool = Field(default=False)
+    disconnect_count: int = Field(default=0)
+
+    # --- HostInterface ---
+
+    @property
+    def is_local(self) -> bool:
+        return False
+
+    @property
+    def host_dir(self) -> Path:
+        return Path("/mngr")
+
+    def get_name(self) -> HostName:
+        return self.host_name
+
+    def get_activity_config(self) -> ActivityConfig:
+        return self.activity_config
+
+    def set_activity_config(self, config: ActivityConfig) -> None:
+        self.activity_config = config
+
+    def get_certified_data(self) -> CertifiedHostData:
+        return self.certified_data
+
+    def set_certified_data(self, data: CertifiedHostData) -> None:
+        self.certified_data = data
+
+    def get_plugin_data(self, plugin_name: str) -> dict[str, Any]:
+        return dict(self.certified_data.plugin.get(plugin_name, {}))
+
+    def get_seconds_since_stopped(self) -> float | None:
+        return None
+
+    def get_stop_time(self) -> datetime | None:
+        return None
+
+    def get_snapshots(self) -> list[SnapshotInfo]:
+        return list(self.snapshots)
+
+    def get_image(self) -> str | None:
+        return self.certified_data.image
+
+    def get_tags(self) -> dict[str, str]:
+        return dict(self.certified_data.user_tags)
+
+    def discover_agents(self) -> list[DiscoveredAgent]:
+        if self.raise_connection_error_on_discover_agents:
+            raise HostConnectionError("SSH error (Error reading SSH protocol banner)")
+        return list(self.discovered_agents)
+
+    def rename_agent(
+        self,
+        agent_ref: DiscoveredAgent,
+        new_name: AgentName,
+        labels_to_merge: Mapping[str, str] | None = None,
+    ) -> DiscoveredAgent:
+        raise NotImplementedError()
+
+    def get_state(self) -> HostState:
+        return self.state
+
+    def get_failure_reason(self) -> str | None:
+        return self.certified_data.failure_reason
+
+    def get_build_log(self) -> str | None:
+        return None
+
+    def disconnect(self) -> None:
+        self.disconnect_count += 1
+
+    # --- OuterHostInterface ---
+
+    def execute_idempotent_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        raise NotImplementedError()
+
+    def execute_stateful_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        raise NotImplementedError()
+
+    def execute_streaming_command(
+        self,
+        command: str,
+        on_line: Callable[[str], None],
+        *,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        raise NotImplementedError()
+
+    def read_file(self, path: Path) -> bytes:
+        raise NotImplementedError()
+
+    def write_file(self, path: Path, content: bytes, mode: str | None = None, is_atomic: bool = False) -> None:
+        raise NotImplementedError()
+
+    def read_text_file(self, path: Path, encoding: str = "utf-8") -> str:
+        raise NotImplementedError()
+
+    def write_text_file(self, path: Path, content: str, encoding: str = "utf-8", mode: str | None = None) -> None:
+        raise NotImplementedError()
+
+    def get_file_mtime(self, path: Path) -> datetime | None:
+        raise NotImplementedError()
+
+    def get_ssh_connection_info(self) -> tuple[str, str, int, Path | None] | None:
+        return self.ssh_connection_info
+
+    # --- OnlineHostInterface ---
+
+    def get_reported_activity_time(self, activity_type: ActivitySource) -> datetime | None:
+        return None
+
+    def record_activity(self, activity_type: ActivitySource) -> None:
+        raise NotImplementedError()
+
+    def get_reported_activity_content(self, activity_type: ActivitySource) -> str | None:
+        return None
+
+    @contextmanager
+    def lock_cooperatively(self, timeout_seconds: float = 30.0) -> Iterator[None]:
+        raise NotImplementedError()
+        yield
+
+    def get_reported_lock_time(self) -> datetime | None:
+        return None
+
+    def is_lock_held(self) -> bool:
+        return self.is_locked
+
+    def set_plugin_data(self, plugin_name: str, data: dict[str, Any]) -> None:
+        raise NotImplementedError()
+
+    def to_offline_host(self) -> HostInterface:
+        raise NotImplementedError()
+
+    def get_idle_seconds(self) -> float:
+        raise NotImplementedError()
+
+    def get_reported_plugin_state_file_data(self, plugin_name: str, filename: str) -> str:
+        raise NotImplementedError()
+
+    def set_reported_plugin_state_file_data(self, plugin_name: str, filename: str, data: str) -> None:
+        raise NotImplementedError()
+
+    def get_reported_plugin_state_files(self, plugin_name: str) -> list[str]:
+        raise NotImplementedError()
+
+    def get_host_env_path(self) -> Path:
+        raise NotImplementedError()
+
+    def get_env_vars(self) -> dict[str, str]:
+        raise NotImplementedError()
+
+    def set_env_vars(self, env: Mapping[str, str]) -> None:
+        raise NotImplementedError()
+
+    def get_env_var(self, key: str) -> str | None:
+        raise NotImplementedError()
+
+    def set_env_var(self, key: str, value: str) -> None:
+        raise NotImplementedError()
+
+    def build_source_env_prefix(self, agent: AgentInterface) -> str:
+        raise NotImplementedError()
+
+    def get_boot_time(self) -> datetime | None:
+        return None
+
+    def get_uptime_seconds(self) -> float | None:
+        return None
+
+    def get_provider_resources(self) -> HostResources:
+        return self.provider_resources
+
+    def set_tags(self, tags: Mapping[str, str]) -> None:
+        raise NotImplementedError()
+
+    def add_tags(self, tags: Mapping[str, str]) -> None:
+        raise NotImplementedError()
+
+    def remove_tags(self, keys: Sequence[str]) -> None:
+        raise NotImplementedError()
+
+    def get_agent_env_path(self, agent: AgentInterface) -> Path:
+        raise NotImplementedError()
+
+    def get_agents(self) -> list[AgentInterface]:
+        if self.raise_connection_error_on_get_agents:
+            raise HostConnectionError("SSH error")
+        return list(self.agents)
+
+    def create_agent_work_dir(
+        self,
+        host: OnlineHostInterface,
+        path: Path,
+        options: CreateAgentOptions,
+    ) -> CreateWorkDirResult:
+        raise NotImplementedError()
+
+    def create_agent_state(
+        self,
+        work_dir_path: Path,
+        options: CreateAgentOptions,
+        created_branch_name: str | None = None,
+    ) -> AgentInterface:
+        raise NotImplementedError()
+
+    def provision_agent(self, agent: AgentInterface, options: CreateAgentOptions, mngr_ctx: MngrContext) -> None:
+        raise NotImplementedError()
+
+    def destroy_agent(self, agent: AgentInterface) -> None:
+        raise NotImplementedError()
+
+    def start_agents(self, agent_ids: Sequence[AgentId]) -> None:
+        raise NotImplementedError()
+
+    def stop_agents(self, agent_ids: Sequence[AgentId], timeout_seconds: float = 5.0) -> None:
+        raise NotImplementedError()
+
+    def copy_directory(
+        self,
+        source_host: OnlineHostInterface,
+        source_path: Path,
+        target_path: Path,
+        extra_args: str | None = None,
+        exclude_git: bool = False,
+    ) -> None:
+        raise NotImplementedError()
+
+    def save_agent_data(self, agent_id: AgentId, agent_data: Mapping[str, object]) -> None:
+        raise NotImplementedError()

--- a/libs/mngr/imbue/mngr/interfaces/mock_volume_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/mock_volume_test.py
@@ -1,0 +1,62 @@
+from typing import Mapping
+
+from pydantic import Field
+
+from imbue.mngr.interfaces.data_types import FileType
+from imbue.mngr.interfaces.data_types import VolumeFile
+from imbue.mngr.interfaces.volume import BaseVolume
+
+
+class InMemoryVolume(BaseVolume):
+    """In-memory volume implementation for testing.
+
+    Backs the ``Volume`` interface with a plain ``{path: bytes}`` dict so tests
+    can exercise ``ScopedVolume`` / ``HostVolume`` behavior without touching a
+    real filesystem or remote host.
+    """
+
+    files: dict[str, bytes] = Field(default_factory=dict)
+
+    def listdir(self, path: str) -> list[VolumeFile]:
+        path = path.rstrip("/")
+        results: list[VolumeFile] = []
+        for file_path in sorted(self.files):
+            parent = file_path.rsplit("/", 1)[0] if "/" in file_path else ""
+            if parent == path or (not path and "/" not in file_path):
+                results.append(
+                    VolumeFile(path=file_path, file_type=FileType.FILE, mtime=0, size=len(self.files[file_path]))
+                )
+        return results
+
+    def path_exists(self, path: str) -> bool:
+        if path in self.files:
+            return True
+        prefix = path.rstrip("/") + "/"
+        return any(k.startswith(prefix) for k in self.files)
+
+    def read_file(self, path: str) -> bytes:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    def remove_file(self, path: str, *, recursive: bool = False) -> None:
+        if not recursive:
+            if path not in self.files:
+                raise FileNotFoundError(path)
+            del self.files[path]
+            return
+        prefix = path.rstrip("/") + "/"
+        to_delete = [k for k in self.files if k == path or k.startswith(prefix)]
+        if not to_delete:
+            raise FileNotFoundError(path)
+        for k in to_delete:
+            del self.files[k]
+
+    def remove_directory(self, path: str) -> None:
+        prefix = path.rstrip("/") + "/"
+        to_delete = [k for k in self.files if k.startswith(prefix) or k == path.rstrip("/")]
+        for k in to_delete:
+            del self.files[k]
+
+    def write_files(self, file_contents_by_path: Mapping[str, bytes]) -> None:
+        self.files.update(file_contents_by_path)

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
@@ -3,23 +3,24 @@
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
-from unittest.mock import MagicMock
+from typing import Any
 
 import pytest
 
+from imbue.mngr.config.data_types import AgentTypeConfig
 from imbue.mngr.config.data_types import MngrContext
-from imbue.mngr.errors import HostConnectionError
 from imbue.mngr.hosts.offline_host import OfflineHost
 from imbue.mngr.interfaces.data_types import CertifiedHostData
 from imbue.mngr.interfaces.data_types import HostDetails
-from imbue.mngr.interfaces.host import HostInterface
-from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.interfaces.mock_agent_test import MockAgent
+from imbue.mngr.interfaces.mock_host_test import MockOnlineHost
 from imbue.mngr.interfaces.provider_instance import _discover_agents_on_host
 from imbue.mngr.interfaces.provider_instance import build_agent_details_from_offline_ref
 from imbue.mngr.primitives import ActivitySource
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import DiscoveredHost
 from imbue.mngr.primitives import HostId
@@ -65,24 +66,34 @@ def _make_offline_host(host_id: HostId, provider: MockProviderInstance, mngr_ctx
     )
 
 
-def _make_mock_online_host(host_id: HostId) -> MagicMock:
-    """Create a MagicMock that passes isinstance(host, OnlineHostInterface) checks.
+def _make_mock_online_host(host_id: HostId, *, host_name: str = "test-host", **kwargs: Any) -> MockOnlineHost:
+    """Build a concrete online host whose behavior is set via fields.
 
-    Sets up the minimum return values needed by _build_host_details_from_host.
+    Pass ``agents=`` / ``discovered_agents=`` for the happy path or
+    ``raise_connection_error_on_get_agents=True`` /
+    ``raise_connection_error_on_discover_agents=True`` to simulate a host whose
+    sshd dies after discovery.
     """
-    host = MagicMock(spec=OnlineHostInterface)
-    host.id = host_id
-    host.get_name.return_value = "test-host"
-    host.get_state.return_value = HostState.RUNNING
-    host.get_ssh_connection_info.return_value = None
-    host.get_boot_time.return_value = None
-    host.get_uptime_seconds.return_value = 0.0
-    host.get_provider_resources.return_value = None
-    host.is_lock_held.return_value = False
-    host.get_certified_data.return_value = _make_certified_data(host_id)
-    host.get_snapshots.return_value = []
-    host.get_reported_activity_time.return_value = None
-    return host
+    return MockOnlineHost(
+        id=host_id,
+        host_name=HostName(host_name),
+        certified_data=_make_certified_data(host_id),
+        **kwargs,
+    )
+
+
+def _make_mock_agent(agent_id: AgentId, host_id: HostId, mngr_ctx: MngrContext, **kwargs: Any) -> MockAgent:
+    return MockAgent(
+        id=agent_id,
+        name=AgentName("test-agent"),
+        agent_type=AgentTypeName("generic"),
+        work_dir=Path("/tmp/test"),
+        create_time=datetime.now(timezone.utc),
+        host_id=host_id,
+        mngr_ctx=mngr_ctx,
+        agent_config=AgentTypeConfig(),
+        **kwargs,
+    )
 
 
 @pytest.fixture
@@ -103,9 +114,7 @@ def test_get_host_and_agent_details_disconnects_host(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
     """get_host_and_agent_details disconnects the host after collecting details."""
-    online_host = _make_mock_online_host(host_id)
-    online_host.get_agents.return_value = []
-
+    online_host = _make_mock_online_host(host_id, agents=[])
     provider.mock_hosts = [online_host]
 
     host_ref = DiscoveredHost(
@@ -113,20 +122,21 @@ def test_get_host_and_agent_details_disconnects_host(
         host_name=HostName("test-host"),
         provider_name=provider.name,
     )
-    agent_id = AgentId.generate()
-    agent_ref = _make_agent_ref(host_id, agent_id, provider.name)
+    agent_ref = _make_agent_ref(host_id, AgentId.generate(), provider.name)
 
-    provider.get_host_and_agent_details(host_ref, [agent_ref])
+    host_details, agent_details_list = provider.get_host_and_agent_details(host_ref, [agent_ref])
 
-    online_host.disconnect.assert_called_once()
+    assert online_host.disconnect_count == 1
+    # The collected details still come back (the disconnect happens in a finally).
+    assert host_details.name == "test-host"
+    assert len(agent_details_list) == 1
 
 
 def test_get_host_and_agent_details_disconnects_on_connection_error(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
     """get_host_and_agent_details disconnects the host even when HostConnectionError occurs."""
-    online_host = _make_mock_online_host(host_id)
-    online_host.get_agents.side_effect = HostConnectionError("SSH error")
+    online_host = _make_mock_online_host(host_id, raise_connection_error_on_get_agents=True)
 
     offline_host = _make_offline_host(host_id, provider, temp_mngr_ctx)
     provider.mock_hosts = [online_host, offline_host]
@@ -137,20 +147,24 @@ def test_get_host_and_agent_details_disconnects_on_connection_error(
         host_name=HostName("test-host"),
         provider_name=provider.name,
     )
-    agent_id = AgentId.generate()
-    agent_ref = _make_agent_ref(host_id, agent_id, provider.name)
+    agent_ref = _make_agent_ref(host_id, AgentId.generate(), provider.name)
 
-    provider.get_host_and_agent_details(host_ref, [agent_ref])
+    _host_details, agent_details_list = provider.get_host_and_agent_details(host_ref, [agent_ref])
 
-    online_host.disconnect.assert_called_once()
+    # The connection is released even on the error path...
+    assert online_host.disconnect_count == 1
+    # ...and the cleanup is tied to actual recovery: the agent comes back via the
+    # offline fallback and the per-host connection cache is cleared.
+    assert len(agent_details_list) == 1
+    assert agent_details_list[0].state == AgentLifecycleState.STOPPED
+    assert provider.connection_errors_cleared == [host_id]
 
 
 def test_connection_error_during_get_agents_falls_back_to_offline(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
     """HostConnectionError during host.get_agents() should fall back to offline data."""
-    online_host = _make_mock_online_host(host_id)
-    online_host.get_agents.side_effect = HostConnectionError("SSH error (Error reading SSH protocol banner)")
+    online_host = _make_mock_online_host(host_id, raise_connection_error_on_get_agents=True)
 
     offline_host = _make_offline_host(host_id, provider, temp_mngr_ctx)
     provider.mock_hosts = [online_host, offline_host]
@@ -161,39 +175,34 @@ def test_connection_error_during_get_agents_falls_back_to_offline(
         host_name=HostName("test-host"),
         provider_name=provider.name,
     )
-    agent_id = AgentId.generate()
-    agent_ref = _make_agent_ref(host_id, agent_id, provider.name)
+    agent_ref = _make_agent_ref(host_id, AgentId.generate(), provider.name)
 
-    # This should NOT raise -- it should fall back to offline data
+    # This should NOT raise -- it should fall back to offline data.
     host_details, agent_details_list = provider.get_host_and_agent_details(host_ref, [agent_ref])
 
     assert len(agent_details_list) == 1
     assert agent_details_list[0].name == "test-agent"
     assert agent_details_list[0].state == AgentLifecycleState.STOPPED
+    # The offline branch leaves idle_mode unset (distinct from a live agent).
+    assert agent_details_list[0].idle_mode is None
 
 
 def test_connection_error_during_agent_detail_building_falls_back_to_offline(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
-    """HostConnectionError during _build_agent_details_from_online_agent should fall back to offline data."""
+    """HostConnectionError raised mid-way through _build_agent_details_from_online_agent falls back to offline.
+
+    The live agent is enumerated successfully (get_agents returns it) and its
+    early getters (get_command, get_lifecycle_state, ...) all succeed; only
+    get_reported_url raises. So if the production code stopped calling
+    get_reported_url, the build would complete online and the agent would be
+    RUNNING -- this test would then fail on the STOPPED assertion, which is
+    exactly the regression protection a bare MagicMock could not provide.
+    """
     agent_id = AgentId.generate()
+    mock_agent = _make_mock_agent(agent_id, host_id, temp_mngr_ctx, raise_connection_error_on_reported_url=True)
 
-    # Create a mock agent that raises HostConnectionError when get_reported_url is called.
-    # Earlier methods (get_reported_activity_time, get_command, etc.) must succeed
-    # so the error occurs mid-way through _build_agent_details_from_online_agent.
-    mock_agent = MagicMock()
-    mock_agent.id = agent_id
-    mock_agent.name = AgentName("test-agent")
-    mock_agent.get_reported_activity_time.return_value = None
-    mock_agent.get_reported_url.side_effect = HostConnectionError("SSH connection dropped")
-
-    online_host = _make_mock_online_host(host_id)
-    online_host.get_agents.return_value = [mock_agent]
-    online_host.get_activity_config.return_value = MagicMock(
-        idle_mode=MagicMock(value="ssh"),
-        idle_timeout_seconds=3600,
-        activity_sources=(ActivitySource.SSH,),
-    )
+    online_host = _make_mock_online_host(host_id, agents=[mock_agent])
 
     offline_host = _make_offline_host(host_id, provider, temp_mngr_ctx)
     provider.mock_hosts = [online_host, offline_host]
@@ -206,20 +215,24 @@ def test_connection_error_during_agent_detail_building_falls_back_to_offline(
     )
     agent_ref = _make_agent_ref(host_id, agent_id, provider.name)
 
-    # This should NOT raise -- it should fall back to offline data
-    host_details, agent_details_list = provider.get_host_and_agent_details(host_ref, [agent_ref])
+    # This should NOT raise -- it should fall back to offline data.
+    _host_details, agent_details_list = provider.get_host_and_agent_details(host_ref, [agent_ref])
 
     assert len(agent_details_list) == 1
     assert agent_details_list[0].name == "test-agent"
+    # Offline-derived values prove we abandoned the half-built online details
+    # rather than surfacing a partially-populated (or live) agent.
     assert agent_details_list[0].state == AgentLifecycleState.STOPPED
+    assert agent_details_list[0].idle_mode is None
+    assert agent_details_list[0].url is None
+    assert online_host.disconnect_count == 1
 
 
 def test_offline_field_generators_populate_plugin_data_via_get_host_and_agent_details(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
     """When a host falls back to offline data, offline_field_generators populate plugin fields."""
-    online_host = _make_mock_online_host(host_id)
-    online_host.get_agents.side_effect = HostConnectionError("SSH error")
+    online_host = _make_mock_online_host(host_id, raise_connection_error_on_get_agents=True)
 
     offline_host = _make_offline_host(host_id, provider, temp_mngr_ctx)
     provider.mock_hosts = [online_host, offline_host]
@@ -248,34 +261,25 @@ def test_offline_field_generators_populate_plugin_data_via_get_host_and_agent_de
 
 def test_discover_agents_on_host_disconnects(host_id: HostId, provider: MockProviderInstance) -> None:
     """_discover_agents_on_host calls discover_agents then disconnect."""
-    mock_host = MagicMock(spec=HostInterface)
-    mock_host.id = host_id
-    mock_host.get_name.return_value = HostName("test-host")
-    mock_host.discover_agents.return_value = []
-
+    mock_host = _make_mock_online_host(host_id, discovered_agents=[])
     provider.mock_hosts = [mock_host]
 
     result = _discover_agents_on_host(provider, host_id)
 
     assert result == []
-    mock_host.disconnect.assert_called_once()
+    assert mock_host.disconnect_count == 1
 
 
 def test_discover_hosts_and_agents_disconnects_hosts(
     host_id: HostId, provider: MockProviderInstance, temp_mngr_ctx: MngrContext
 ) -> None:
     """discover_hosts_and_agents disconnects each host after fetching agents."""
-    mock_host = MagicMock(spec=HostInterface)
-    mock_host.id = host_id
-    mock_host.get_name.return_value = HostName("test-host")
-    mock_host.get_state.return_value = HostState.RUNNING
-    mock_host.discover_agents.return_value = []
-
+    mock_host = _make_mock_online_host(host_id, discovered_agents=[])
     provider.mock_hosts = [mock_host]
 
     provider.discover_hosts_and_agents(cg=temp_mngr_ctx.concurrency_group)
 
-    mock_host.disconnect.assert_called_once()
+    assert mock_host.disconnect_count == 1
 
 
 # =============================================================================
@@ -362,17 +366,12 @@ def test_discover_hosts_and_agents_tolerates_per_host_connection_error(
     healthy_agent_id = AgentId.generate()
     healthy_agent_ref = _make_agent_ref(healthy_host_id, healthy_agent_id, provider.name)
 
-    healthy_host = MagicMock(spec=HostInterface)
-    healthy_host.id = healthy_host_id
-    healthy_host.get_name.return_value = HostName("healthy-host")
-    healthy_host.get_state.return_value = HostState.RUNNING
-    healthy_host.discover_agents.return_value = [healthy_agent_ref]
-
-    broken_host = MagicMock(spec=HostInterface)
-    broken_host.id = broken_host_id
-    broken_host.get_name.return_value = HostName("broken-host")
-    broken_host.get_state.return_value = HostState.RUNNING
-    broken_host.discover_agents.side_effect = HostConnectionError("SSH error (Error reading SSH protocol banner)")
+    healthy_host = _make_mock_online_host(
+        healthy_host_id, host_name="healthy-host", discovered_agents=[healthy_agent_ref]
+    )
+    broken_host = _make_mock_online_host(
+        broken_host_id, host_name="broken-host", raise_connection_error_on_discover_agents=True
+    )
 
     provider.mock_hosts = [healthy_host, broken_host]
     # The broken host has an offline view (mock_agent_data is empty, so it
@@ -390,8 +389,8 @@ def test_discover_hosts_and_agents_tolerates_per_host_connection_error(
 
     # The connected_host context manager's finally must still run on the
     # failure path, so both hosts had disconnect() called.
-    healthy_host.disconnect.assert_called_once()
-    broken_host.disconnect.assert_called_once()
+    assert healthy_host.disconnect_count == 1
+    assert broken_host.disconnect_count == 1
 
     # The cache-invalidation hook must fire for the broken host so providers
     # that cache per-host state (docker/modal/lima/vps_docker) drop the
@@ -411,11 +410,9 @@ def test_discover_hosts_and_agents_falls_back_to_offline_on_connection_error(
     host_id = HostId.generate()
     agent_id = AgentId.generate()
 
-    broken_host = MagicMock(spec=HostInterface)
-    broken_host.id = host_id
-    broken_host.get_name.return_value = HostName("ssh-dead-host")
-    broken_host.get_state.return_value = HostState.RUNNING
-    broken_host.discover_agents.side_effect = HostConnectionError("Error reading SSH protocol banner")
+    broken_host = _make_mock_online_host(
+        host_id, host_name="ssh-dead-host", raise_connection_error_on_discover_agents=True
+    )
 
     offline_host = _make_offline_host(host_id, provider, temp_mngr_ctx)
     provider.mock_hosts = [broken_host]
@@ -441,5 +438,5 @@ def test_discover_hosts_and_agents_falls_back_to_offline_on_connection_error(
     assert offline_agents[0].labels == {"workspace": "ws-42", "is_primary": "true"}
 
     # The connected_host cleanup and on_connection_error hook still run.
-    broken_host.disconnect.assert_called_once()
+    assert broken_host.disconnect_count == 1
     assert provider.connection_errors_cleared == [host_id]

--- a/libs/mngr/imbue/mngr/interfaces/volume_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/volume_test.py
@@ -1,65 +1,11 @@
-from typing import Mapping
-
 import pytest
 
 from imbue.mngr.interfaces.data_types import FileType
-from imbue.mngr.interfaces.data_types import VolumeFile
-from imbue.mngr.interfaces.volume import BaseVolume
+from imbue.mngr.interfaces.mock_volume_test import InMemoryVolume
 from imbue.mngr.interfaces.volume import HostVolume
 from imbue.mngr.interfaces.volume import ScopedVolume
 from imbue.mngr.interfaces.volume import _scoped_path
 from imbue.mngr.primitives import AgentId
-
-
-class InMemoryVolume(BaseVolume):
-    """In-memory volume implementation for testing."""
-
-    files: dict[str, bytes] = {}
-
-    def listdir(self, path: str) -> list[VolumeFile]:
-        path = path.rstrip("/")
-        results: list[VolumeFile] = []
-        for file_path in sorted(self.files):
-            parent = file_path.rsplit("/", 1)[0] if "/" in file_path else ""
-            if parent == path or (not path and "/" not in file_path):
-                results.append(
-                    VolumeFile(path=file_path, file_type=FileType.FILE, mtime=0, size=len(self.files[file_path]))
-                )
-        return results
-
-    def path_exists(self, path: str) -> bool:
-        if path in self.files:
-            return True
-        prefix = path.rstrip("/") + "/"
-        return any(k.startswith(prefix) for k in self.files)
-
-    def read_file(self, path: str) -> bytes:
-        if path not in self.files:
-            raise FileNotFoundError(path)
-        return self.files[path]
-
-    def remove_file(self, path: str, *, recursive: bool = False) -> None:
-        if not recursive:
-            if path not in self.files:
-                raise FileNotFoundError(path)
-            del self.files[path]
-            return
-        prefix = path.rstrip("/") + "/"
-        to_delete = [k for k in self.files if k == path or k.startswith(prefix)]
-        if not to_delete:
-            raise FileNotFoundError(path)
-        for k in to_delete:
-            del self.files[k]
-
-    def remove_directory(self, path: str) -> None:
-        prefix = path.rstrip("/") + "/"
-        to_delete = [k for k in self.files if k.startswith(prefix) or k == path.rstrip("/")]
-        for k in to_delete:
-            del self.files[k]
-
-    def write_files(self, file_contents_by_path: Mapping[str, bytes]) -> None:
-        self.files.update(file_contents_by_path)
-
 
 # =============================================================================
 # _scoped_path tests
@@ -172,9 +118,12 @@ def test_scoped_volume_listdir(volume_with_files: InMemoryVolume) -> None:
     paths = [e.path for e in entries]
     assert "agents/a1.json" in paths
     assert "agents/a2.json" in paths
-    for entry in entries:
-        data = scoped.read_file(entry.path)
-        assert len(data) > 0
+    # Reading each listed entry must resolve to the correct backing file, so
+    # assert exact contents (matching volume_with_files) rather than just
+    # non-empty bytes -- the latter would still pass if a scoped read returned
+    # the wrong file's data.
+    assert scoped.read_file("agents/a1.json") == b'{"id": "a1"}'
+    assert scoped.read_file("agents/a2.json") == b'{"id": "a2"}'
 
 
 def test_scoped_volume_listdir_preserves_file_type(volume_with_files: InMemoryVolume) -> None:
@@ -222,12 +171,17 @@ def test_scoped_volume_path_exists_missing(volume_with_files: InMemoryVolume) ->
 # =============================================================================
 
 
-def test_volume_file_fields() -> None:
-    vf = VolumeFile(path="/test.txt", file_type=FileType.FILE, mtime=1000, size=42)
-    assert vf.path == "/test.txt"
-    assert vf.file_type == FileType.FILE
-    assert vf.mtime == 1000
-    assert vf.size == 42
+def test_volume_file_size_reflects_listed_file_contents() -> None:
+    """listdir derives VolumeFile.size from the actual file contents.
+
+    This ties the VolumeFile fields to the production listing logic rather than
+    to literals the test itself passed into the constructor.
+    """
+    vol = InMemoryVolume(files={"report.txt": b"hello world"})
+    (entry,) = vol.listdir("")
+    assert entry.path == "report.txt"
+    assert entry.file_type == FileType.FILE
+    assert entry.size == len(b"hello world")
 
 
 def test_volume_file_type_enum_values() -> None:

--- a/libs/mngr/imbue/mngr/utils/test_ratchets.py
+++ b/libs/mngr/imbue/mngr/utils/test_ratchets.py
@@ -229,7 +229,7 @@ def test_prevent_logger_exception() -> None:
 
 
 def test_prevent_unittest_mock_imports() -> None:
-    rc.check_unittest_mock_imports(_DIR, snapshot(1))
+    rc.check_unittest_mock_imports(_DIR, snapshot(0))
 
 
 def test_prevent_monkeypatch_setattr() -> None:


### PR DESCRIPTION
Acts on the findings from \`/identify-bad-tests libs/mngr/imbue/mngr/interfaces\`.

## What changed (test-only; no production code touched)

**Tautological / weak tests (data_types_test.py, volume_test.py)**
- Replaced "constructor echo" tests (which only re-asserted the values just passed to the constructor) with behavioral assertions:
  - \`SSHInfo\` and \`HostDetails\` now have JSON round-trip tests that exercise the real \`Path\`->str and enum->\`.value\` coercions.
  - \`VolumeFile\` is now checked through \`listdir\`, which derives \`size\` from actual file contents.
- Tightened a loose \`len(data) > 0\` assertion in the scoped-volume listdir test to assert exact file contents (so it can no longer pass if a scoped read resolved to the wrong backing file).
- Moved the in-memory \`Volume\` test double out of \`volume_test.py\` into a shared \`interfaces/mock_volume_test.py\` and gave \`files\` a proper \`default_factory\`.

**MagicMock removal (provider_instance_test.py)**
- Added \`MockOnlineHost\` / \`MockAgent\` -- real \`OnlineHostInterface\` / \`AgentInterface\` implementations -- so the fallback, disconnect, and resilience tests assert observable effects (a \`disconnect_count\` counter, offline-derived agent state like \`STOPPED\` / \`idle_mode is None\` / \`url is None\`) instead of \`MagicMock.assert_called_once()\` call-count coupling.
- The agent-detail-building fallback test now uses a concrete agent whose early getters succeed and whose \`get_reported_url\` raises, so it genuinely pins the offline fallback to a mid-build failure (a bare \`MagicMock()\` made that assertion vacuous).
- Removes the last \`unittest.mock\` import in the package; the \`unittest.mock\` ratchet is tightened from 1 to 0.

## Verification
- \`just test-quick libs/mngr/imbue/mngr/interfaces\`: 88 passed
- \`just test-quick libs/mngr/imbue/mngr/utils/test_ratchets.py\`: 55 passed
- \`uv run ty check\`: 0 errors (1 pre-existing unrelated warning in cel_utils.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)