### PR TITLE
Strengthen mngr_pair test suite (identify-bad-tests follow-up)

### DIFF
--- a/libs/mngr_pair/changelog/mngr-bad-tests-mngr-pair-local.md
+++ b/libs/mngr_pair/changelog/mngr-bad-tests-mngr-pair-local.md
@@ -1,0 +1,6 @@
+Strengthened the mngr-pair test suite. The `pair` CLI tests now assert on the
+specific error messages and the exact set of choice values rather than on
+near-tautological substrings, the `--source`/`--source-agent` conflict test now
+actually triggers (and verifies) the conflict, and the structured (JSONL/JSON)
+output of pair-start/stop events is checked. Internal-only changes; no
+user-facing behavior changed.

--- a/libs/mngr_pair/changelog/mngr-bad-tests-mngr-pair-local.md
+++ b/libs/mngr_pair/changelog/mngr-bad-tests-mngr-pair-local.md
@@ -1,6 +1,15 @@
-Strengthened the mngr-pair test suite. The `pair` CLI tests now assert on the
-specific error messages and the exact set of choice values rather than on
-near-tautological substrings, the `--source`/`--source-agent` conflict test now
-actually triggers (and verifies) the conflict, and the structured (JSONL/JSON)
-output of pair-start/stop events is checked. Internal-only changes; no
-user-facing behavior changed.
+Strengthened the mngr-pair test suite (test-only changes; no user-facing
+behavior changed):
+
+- The `pair` CLI tests now assert on specific error messages and the exact set
+  of choice values rather than near-tautological substrings, the
+  `--source`/`--source-agent` conflict test now actually triggers and verifies
+  the conflict, and the structured (JSONL/JSON) output of pair start/stop events
+  is checked.
+- The `UnisonSyncer` command-building tests assert the exact command and ignore
+  pairs instead of loose substring membership.
+- The crash-simulation test no longer uses a broad `pkill -f`; it locates the
+  specific unison PID with `pgrep` and kills that exact PID. The two dependency
+  tests use real PATH manipulation instead of faking `shutil.which`. The
+  symlink-sync test waits for both the symlink and its target, removing a race
+  (and its `flaky` marker).

--- a/libs/mngr_pair/imbue/mngr_pair/api_test.py
+++ b/libs/mngr_pair/imbue/mngr_pair/api_test.py
@@ -16,7 +16,12 @@ from imbue.mngr_pair.api import determine_git_sync_actions
 
 
 def test_unison_syncer_builds_basic_command(tmp_path: Path, cg: ConcurrencyGroup) -> None:
-    """Test that UnisonSyncer builds a valid unison command."""
+    """Test that UnisonSyncer builds a valid unison command for the default mode.
+
+    Asserts the exact command prefix (program, both paths, and the standard
+    watch/auto/batch/git-ignore flags in order) so a regression in any flag,
+    value, or its position is caught -- not just that tokens appear somewhere.
+    """
     source = tmp_path / "source"
     target = tmp_path / "target"
     source.mkdir()
@@ -32,13 +37,21 @@ def test_unison_syncer_builds_basic_command(tmp_path: Path, cg: ConcurrencyGroup
 
     cmd = syncer._build_unison_command()
 
-    assert "unison" in cmd
-    assert str(source) in cmd
-    assert str(target) in cmd
-    assert "-repeat" in cmd
-    assert "watch" in cmd
-    assert "-auto" in cmd
-    assert "-batch" in cmd
+    # NEWER conflict mode appends ["-prefer", "newer"]; BOTH direction adds no
+    # force flag, so this is the complete command for the default configuration.
+    assert cmd == [
+        "unison",
+        str(source),
+        str(target),
+        "-repeat",
+        "watch",
+        "-auto",
+        "-batch",
+        "-ignore",
+        "Name .git",
+        "-prefer",
+        "newer",
+    ]
 
 
 def test_unison_syncer_builds_command_with_forward_direction(tmp_path: Path, cg: ConcurrencyGroup) -> None:
@@ -103,10 +116,10 @@ def test_unison_syncer_builds_command_with_exclude_patterns(tmp_path: Path, cg: 
 
     cmd = syncer._build_unison_command()
 
-    # Check that exclude patterns are added
-    cmd_str = " ".join(cmd)
-    assert "*.pyc" in cmd_str
-    assert "__pycache__" in cmd_str
+    # Each exclude pattern must appear as a distinct ["-ignore", "Name <pattern>"] pair.
+    ignore_values = [cmd[i + 1] for i, arg in enumerate(cmd[:-1]) if arg == "-ignore"]
+    assert "Name *.pyc" in ignore_values
+    assert "Name __pycache__" in ignore_values
 
 
 def test_unison_syncer_always_excludes_git_directory(tmp_path: Path, cg: ConcurrencyGroup) -> None:
@@ -125,9 +138,11 @@ def test_unison_syncer_always_excludes_git_directory(tmp_path: Path, cg: Concurr
     )
 
     cmd = syncer._build_unison_command()
-    cmd_str = " ".join(cmd)
 
-    assert ".git" in cmd_str
+    # The .git directory must be excluded via the exact ["-ignore", "Name .git"] pair,
+    # not merely have ".git" appear somewhere (which any path component could supply).
+    ignore_values = [cmd[i + 1] for i, arg in enumerate(cmd[:-1]) if arg == "-ignore"]
+    assert "Name .git" in ignore_values
 
 
 def test_unison_syncer_is_not_running_initially(tmp_path: Path, cg: ConcurrencyGroup) -> None:
@@ -365,8 +380,14 @@ def test_unison_syncer_stop_is_noop_when_not_started(tmp_path: Path, cg: Concurr
     syncer.stop()
 
 
-def test_git_sync_action_default_values() -> None:
-    """Test that GitSyncAction has correct default values."""
+def test_git_sync_action_defaults_to_no_side_ahead() -> None:
+    """A GitSyncAction built with only branch names defaults to neither side ahead.
+
+    This default is what ``determine_git_sync_actions`` relies on for the
+    "no divergence" cases, so it is pinned here. The branch-name fields are not
+    asserted because echoing back a value just passed to the constructor is
+    tautological.
+    """
     action = GitSyncAction(
         agent_branch="main",
         local_branch="main",
@@ -374,5 +395,3 @@ def test_git_sync_action_default_values() -> None:
 
     assert action.agent_is_ahead is False
     assert action.local_is_ahead is False
-    assert action.agent_branch == "main"
-    assert action.local_branch == "main"

--- a/libs/mngr_pair/imbue/mngr_pair/cli_test.py
+++ b/libs/mngr_pair/imbue/mngr_pair/cli_test.py
@@ -1,5 +1,6 @@
 """Unit tests for the pair CLI command."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -7,93 +8,93 @@ from click.testing import CliRunner
 
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.primitives import OutputFormat
-from imbue.mngr_pair.cli import PairCliOptions
 from imbue.mngr_pair.cli import _emit_pair_started
 from imbue.mngr_pair.cli import _emit_pair_stopped
 from imbue.mngr_pair.cli import pair
 
 
-def test_pair_cli_options_has_all_fields() -> None:
-    """Test that PairCliOptions has all required fields."""
-    assert hasattr(PairCliOptions, "__annotations__")
-    annotations = PairCliOptions.__annotations__
-    assert "source" in annotations
-    assert "source_agent" in annotations
-    assert "source_host" in annotations
-    assert "sync_direction" in annotations
-    assert "conflict" in annotations
-    assert "exclude" in annotations
-    assert "require_git" in annotations
-    assert "uncommitted_changes" in annotations
-
-
-def test_pair_command_is_registered() -> None:
-    """Test that the pair command is properly registered."""
-    assert pair is not None
-    assert pair.name == "pair"
-
-
-def test_pair_command_help_shows_options() -> None:
-    """Test that --help shows all expected options."""
+def test_pair_command_help_shows_all_options() -> None:
+    """--help should list every option the command accepts."""
     runner = CliRunner()
     result = runner.invoke(pair, ["--help"])
     assert result.exit_code == 0
-    assert "--source" in result.output or "-s" in result.output
-    assert "--source-agent" in result.output
-    assert "--source-host" in result.output
-    assert "--sync-direction" in result.output
-    assert "--conflict" in result.output
-    assert "--exclude" in result.output
-    assert "--require-git" in result.output or "--no-require-git" in result.output
-    assert "--uncommitted-changes" in result.output
+    for option in (
+        "--source",
+        "--source-agent",
+        "--source-host",
+        "--source-path",
+        "--target",
+        "--sync-direction",
+        "--conflict",
+        "--uncommitted-changes",
+        "--include",
+        "--exclude",
+        "--require-git",
+        "--no-require-git",
+    ):
+        assert option in result.output
 
 
-def test_pair_sync_direction_choices() -> None:
-    """Test that direction option has expected choices."""
+@pytest.mark.parametrize(
+    ("option_name", "expected_choice_metavar"),
+    [
+        ("--sync-direction", "[both|forward|reverse]"),
+        ("--conflict", "[newer|source|target|ask]"),
+        ("--uncommitted-changes", "[stash|clobber|merge|fail]"),
+    ],
+)
+def test_pair_help_lists_every_choice_for_choice_options(option_name: str, expected_choice_metavar: str) -> None:
+    """Each choice option's help must list its full, exact set of allowed values.
+
+    Asserting the rendered ``[a|b|c]`` metavar (rather than just that the option
+    name appears) means dropping or misspelling any single choice in the
+    ``click.Choice(...)`` lists in cli.py fails this test.
+    """
     runner = CliRunner()
     result = runner.invoke(pair, ["--help"])
     assert result.exit_code == 0
-    assert "both" in result.output.lower() or "source" in result.output.lower()
-
-
-def test_pair_conflict_choices() -> None:
-    """Test that conflict option has expected choices."""
-    runner = CliRunner()
-    result = runner.invoke(pair, ["--help"])
-    assert result.exit_code == 0
-    assert "conflict" in result.output.lower()
-
-
-def test_pair_uncommitted_changes_choices() -> None:
-    """Test that uncommitted-changes option has expected choices."""
-    runner = CliRunner()
-    result = runner.invoke(pair, ["--help"])
-    assert result.exit_code == 0
-    assert "uncommitted" in result.output.lower()
+    assert expected_choice_metavar in result.output
 
 
 @pytest.mark.parametrize("output_format", [OutputFormat.HUMAN, OutputFormat.JSON, OutputFormat.JSONL])
-def test_emit_pair_started_exercises_all_format_branches(
+def test_emit_pair_started_emits_expected_output_for_each_format(
     output_format: OutputFormat,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """_emit_pair_started should handle all output formats without error."""
+    """_emit_pair_started should emit the right content for each output format."""
     output_opts = OutputOptions(output_format=output_format)
     _emit_pair_started(Path("/src"), Path("/dst"), output_opts)
     captured = capsys.readouterr()
-    if output_format == OutputFormat.HUMAN:
-        assert "/src" in captured.out
-        assert "/dst" in captured.out
+    match output_format:
+        case OutputFormat.HUMAN:
+            assert "/src" in captured.out
+            assert "/dst" in captured.out
+        case OutputFormat.JSONL:
+            event = json.loads(captured.out)
+            assert event["event"] == "pair_started"
+            assert event["source_path"] == "/src"
+            assert event["target_path"] == "/dst"
+        case OutputFormat.JSON:
+            # JSON mode defers all output until the command's final result, so
+            # an intermediate event emits nothing.
+            assert captured.out == ""
 
 
 @pytest.mark.parametrize("output_format", [OutputFormat.HUMAN, OutputFormat.JSON, OutputFormat.JSONL])
-def test_emit_pair_stopped_exercises_all_format_branches(
+def test_emit_pair_stopped_emits_expected_output_for_each_format(
     output_format: OutputFormat,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """_emit_pair_stopped should handle all output formats without error."""
+    """_emit_pair_stopped should emit the right content for each output format."""
     output_opts = OutputOptions(output_format=output_format)
     _emit_pair_stopped(output_opts)
     captured = capsys.readouterr()
-    if output_format == OutputFormat.HUMAN:
-        assert "stopped" in captured.out.lower()
+    match output_format:
+        case OutputFormat.HUMAN:
+            assert "stopped" in captured.out.lower()
+        case OutputFormat.JSONL:
+            event = json.loads(captured.out)
+            assert event["event"] == "pair_stopped"
+        case OutputFormat.JSON:
+            # JSON mode defers all output until the command's final result.
+            assert captured.out == ""

--- a/libs/mngr_pair/imbue/mngr_pair/test_api.py
+++ b/libs/mngr_pair/imbue/mngr_pair/test_api.py
@@ -1,3 +1,6 @@
+import os
+import signal
+import stat
 import subprocess
 from pathlib import Path
 from typing import cast
@@ -110,13 +113,64 @@ def test_sync_git_state_performs_pull_when_agent_is_ahead(pair_ctx: SyncTestCont
 # =============================================================================
 
 
-def test_pair_files_raises_when_unison_not_installed_and_mocked(
+def _make_executable_stub(directory: Path, name: str) -> None:
+    """Create an executable no-op stub named ``name`` in ``directory``.
+
+    Used to make a binary genuinely discoverable on PATH (so ``shutil.which``
+    runs for real) without faking ``shutil.which`` itself.
+    """
+    stub = directory / name
+    stub.write_text("#!/bin/sh\nexit 0\n")
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_path_excluding_binaries(directory: Path, excluded: set[str]) -> str:
+    """Populate ``directory`` with symlinks to every binary currently on PATH except ``excluded``.
+
+    Returns a PATH value pointing only at ``directory``. This makes the excluded
+    binaries genuinely undiscoverable by the real ``shutil.which`` while keeping
+    every other tool the test harness needs (e.g. ``tmux`` for teardown, ``git``)
+    available -- so we exercise the real dependency-resolution path rather than
+    faking ``shutil.which``. Earlier PATH entries win, mirroring lookup order.
+    """
+    linked: set[str] = set()
+    for path_entry in os.environ.get("PATH", "").split(os.pathsep):
+        entry_dir = Path(path_entry)
+        if not entry_dir.is_dir():
+            continue
+        for binary in entry_dir.iterdir():
+            name = binary.name
+            if name in excluded or name in linked:
+                continue
+            try:
+                if binary.is_dir() or not os.access(binary, os.X_OK):
+                    continue
+            except OSError:
+                # Some system binaries cannot be stat'd by this user; skip them.
+                continue
+            linked.add(name)
+            (directory / name).symlink_to(binary)
+    return str(directory)
+
+
+def test_pair_files_raises_when_unison_not_installed(
     pair_ctx: SyncTestContext,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     cg: ConcurrencyGroup,
 ) -> None:
-    """Test that pair_files raises BinaryNotInstalledError when unison is not available."""
-    monkeypatch.setattr("shutil.which", lambda _binary: None)
+    """Test that pair_files raises BinaryNotInstalledError when unison is not available.
+
+    Points PATH at a directory exposing every binary except unison/unison-fsmonitor,
+    so the real ``shutil.which`` genuinely cannot find unison -- exercising the
+    actual dependency-resolution path rather than monkeypatching ``shutil.which``.
+    """
+    path_without_unison = tmp_path / "bin_without_unison"
+    path_without_unison.mkdir()
+    monkeypatch.setenv(
+        "PATH",
+        _make_path_excluding_binaries(path_without_unison, {"unison", "unison-fsmonitor"}),
+    )
 
     with pytest.raises(BinaryNotInstalledError):
         with pair_files(
@@ -141,8 +195,14 @@ def test_pair_files_raises_when_git_required_but_not_present(
     cg: ConcurrencyGroup,
 ) -> None:
     """Test that pair_files raises MngrError when git is required but directories are not repos."""
-    # Make all system dependency checks (unison, etc.) pass so we reach the git check
-    monkeypatch.setattr("shutil.which", lambda binary: "/tmp/fake/path/" + binary)
+    # Make the unison binaries genuinely discoverable (via real stubs on PATH) so the
+    # dependency check passes and we reach the git check, while keeping the real `git`
+    # binary available by retaining the existing PATH entries.
+    stub_bin_dir = tmp_path / "stub_bin"
+    stub_bin_dir.mkdir()
+    _make_executable_stub(stub_bin_dir, "unison")
+    _make_executable_stub(stub_bin_dir, "unison-fsmonitor")
+    monkeypatch.setenv("PATH", f"{stub_bin_dir}{os.pathsep}{os.environ['PATH']}")
 
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
@@ -361,15 +421,14 @@ def test_unison_syncer_syncs_file_changes(tmp_path: Path, cg: ConcurrencyGroup) 
 
 
 @pytest.mark.unison
-@pytest.mark.flaky
 def test_unison_syncer_syncs_symlinks(tmp_path: Path, cg: ConcurrencyGroup) -> None:
     """Test that UnisonSyncer correctly syncs symlinks.
 
-    Marked flaky because the ``wait_for`` only waits for the symlink to appear in
-    ``target``, but the very next assertion checks that the symlink's target file
-    ``real_file.txt`` also exists. Unison gives no ordering guarantee between two
-    unrelated files in a single sync sweep, so the symlink can land in ``target``
-    before its real file does.
+    Unison gives no ordering guarantee between the symlink and its target file
+    within a single sync sweep, so the ``wait_for`` condition requires *both*
+    ``link_to_file.txt`` (as a symlink) and ``real_file.txt`` to be present
+    before asserting -- otherwise the test could observe the symlink before its
+    real file lands.
     """
     source = tmp_path / "source"
     target = tmp_path / "target"
@@ -391,10 +450,11 @@ def test_unison_syncer_syncs_symlinks(tmp_path: Path, cg: ConcurrencyGroup) -> N
     try:
         syncer.start()
 
-        # Wait for sync to complete
+        # Wait until both the symlink and its real target have synced. Waiting on
+        # the symlink alone races with its target landing in a later sweep.
         wait_for(
-            lambda: (target / "link_to_file.txt").exists(),
-            error_message="Symlink was not synced within timeout",
+            lambda: (target / "link_to_file.txt").is_symlink() and (target / "real_file.txt").exists(),
+            error_message="Symlink and its target were not both synced within timeout",
         )
 
         # Both files should exist in target
@@ -475,12 +535,18 @@ def test_unison_syncer_handles_process_crash(tmp_path: Path, cg: ConcurrencyGrou
         assert syncer._running_process is not None
 
         # Kill the unison process forcefully via SIGKILL (simulating a crash).
-        # Use pkill to find the actual unison process by its unique tmp_path args,
-        # since RunningProcess doesn't expose the underlying PID directly.
-        subprocess.run(
-            ["pkill", "-KILL", "-f", f"unison {source} {target}"],
+        # RunningProcess doesn't expose the underlying PID, so locate the specific
+        # process(es) by their unique tmp_path arguments with pgrep, verify we found
+        # at least one, and SIGKILL those exact PIDs -- never a broad pkill pattern.
+        pgrep_result = subprocess.run(
+            ["pgrep", "-f", f"unison {source} {target}"],
             capture_output=True,
+            text=True,
         )
+        unison_pids = [int(line) for line in pgrep_result.stdout.split()]
+        assert unison_pids, "Expected to find the running unison process to kill"
+        for pid in unison_pids:
+            os.kill(pid, signal.SIGKILL)
 
         # is_running should eventually become False
         wait_for(

--- a/libs/mngr_pair/imbue/mngr_pair/test_cli.py
+++ b/libs/mngr_pair/imbue/mngr_pair/test_cli.py
@@ -6,90 +6,102 @@ from click.testing import CliRunner
 from imbue.mngr_pair.cli import pair
 
 
-def test_pair_source_and_source_agent_conflict(
+def test_pair_source_and_source_agent_conflict_is_rejected(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that providing both --source and --source-agent shows error."""
+    """Specifying --source and --source-agent with different agents is rejected.
+
+    The conflict is only detected when --source actually carries an agent that
+    differs from --source-agent, so this passes two distinct agent names.
+    """
     result = cli_runner.invoke(
         pair,
-        ["agent-name", "--source", "/some/path", "--source-agent", "other-agent"],
+        ["--source", "agent-a", "--source-agent", "agent-b"],
         obj=plugin_manager,
     )
-    # Should fail because you can't provide both
     assert result.exit_code != 0
-    assert "cannot" in result.output.lower() or "error" in result.output.lower()
+    assert "Cannot specify both --source and --source-agent" in result.output
 
 
-def test_pair_source_as_path_raises_error(
+def test_pair_source_and_source_agent_agreeing_does_not_conflict(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that using --source with a path correctly requires the path to exist."""
+    """--source and --source-agent naming the same agent must NOT raise the conflict.
+
+    This pins the other branch of the equality check: when the two agree, the
+    command proceeds to agent resolution (and fails there, not on the conflict).
+    """
     result = cli_runner.invoke(
         pair,
-        ["agent-name", "--source", "/nonexistent/path/12345"],
+        ["--source", "agent-same", "--source-agent", "agent-same"],
         obj=plugin_manager,
     )
-    # Should fail because path doesn't exist
     assert result.exit_code != 0
+    assert "Cannot specify both --source and --source-agent" not in result.output
+    assert "Could not find agent with ID or name: agent-same" in result.output
+
+
+def test_pair_source_without_agent_requires_an_agent_to_be_specified(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """A path-only --source carries no agent, so the command reports a missing agent.
+
+    (Non-interactive invocation cannot prompt, so it errors rather than asking.)
+    """
+    result = cli_runner.invoke(
+        pair,
+        ["--source", "/nonexistent/path/12345"],
+        obj=plugin_manager,
+    )
+    assert result.exit_code != 0
+    assert "No agent specified" in result.output
 
 
 def test_pair_nonexistent_agent(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that pairing with nonexistent agent shows appropriate error."""
+    """Pairing with a nonexistent agent reports that the agent could not be found."""
     result = cli_runner.invoke(
         pair,
         ["nonexistent-agent-12345"],
         obj=plugin_manager,
     )
-    # Should fail because agent doesn't exist
     assert result.exit_code != 0
+    assert "Could not find agent with ID or name: nonexistent-agent-12345" in result.output
 
 
 def test_pair_source_host_nonexistent_host(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that --source-host with nonexistent host shows appropriate error."""
+    """--source-host with a nonexistent host reports that no host matched."""
     result = cli_runner.invoke(
         pair,
         ["some-agent", "--source-host", "nonexistent-host-12345"],
         obj=plugin_manager,
     )
-    # Should fail because host doesn't exist
     assert result.exit_code != 0
-    assert "no host found" in result.output.lower() or "error" in result.output.lower()
+    assert "No hosts found matching nonexistent-host-12345" in result.output
 
 
-def test_pair_source_host_with_local_host(
+def test_pair_source_host_localhost_resolves_then_fails_on_missing_agent(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
 ) -> None:
-    """Test that --source-host with 'localhost' (local host) works for filtering."""
+    """--source-host localhost resolves the host; the failure is about the agent.
+
+    This demonstrates that the local host filter works: the error is the
+    agent-not-found message, not a host-resolution error.
+    """
     result = cli_runner.invoke(
         pair,
         ["nonexistent-agent", "--source-host", "localhost"],
         obj=plugin_manager,
     )
-    # Should fail because the agent doesn't exist on the local host
-    # But NOT because the host doesn't exist
     assert result.exit_code != 0
-    # The error should be about the agent, not the host
-    assert "no agent found" in result.output.lower() or "error" in result.output.lower()
-
-
-def test_pair_source_host_agent_not_on_specified_host(
-    cli_runner: CliRunner,
-    plugin_manager: pluggy.PluginManager,
-) -> None:
-    """Test that --source-host shows error when agent doesn't exist on that host."""
-    result = cli_runner.invoke(
-        pair,
-        ["some-agent", "--source-host", "localhost"],
-        obj=plugin_manager,
-    )
-    # Should fail because agent doesn't exist on the specified host
-    assert result.exit_code != 0
+    assert "Could not find agent with ID or name: nonexistent-agent" in result.output
+    assert "No hosts found" not in result.output

--- a/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
+++ b/libs/mngr_pair/imbue/mngr_pair/test_ratchets.py
@@ -210,7 +210,7 @@ def test_prevent_unittest_mock_imports() -> None:
 
 
 def test_prevent_monkeypatch_setattr() -> None:
-    rc.check_monkeypatch_setattr(_DIR, snapshot(2))
+    rc.check_monkeypatch_setattr(_DIR, snapshot(0))
 
 
 def test_prevent_test_container_classes() -> None:


### PR DESCRIPTION
Fixes the 12 issues found by \`/identify-bad-tests libs/mngr_pair\` (report in \`libs/mngr_pair/_tasks/bad-tests/\`). Test-only changes; no production behavior changed.

## cli_test.py (unit)
- Drop \`test_pair_cli_options_has_all_fields\` (introspected \`__annotations__\`) and \`test_pair_command_is_registered\` (covered by help/plugin/entry-point tests).
- Assert the full \`[a|b|c]\` choice metavar for each \`Choice\` option instead of asserting the option name appears in its own help text.
- Assert structured JSONL output (event name + paths) and JSON-mode silence for \`_emit_pair_started\`/\`_emit_pair_stopped\`, not just the HUMAN branch.

## test_cli.py (integration)
- The \`--source\`/\`--source-agent\` conflict test now passes two *different* agent names so it actually reaches the conflict branch (it previously passed a path-only \`--source\`, never triggered the conflict, and passed only because "Error" appeared in an unrelated agent-not-found message). Added a same-agent case to pin the no-conflict branch.
- Replaced \`exit_code != 0 and (phrase or "error")\` assertions with the exact error string each test targets.
- Merged the two near-duplicate \`--source-host localhost\` tests into one that proves the host resolved.

## api_test.py (unit)
- Assert the exact unison command list and \`['-ignore', 'Name <x>']\` pairs instead of loose substring membership.
- Drop tautological branch-name assertions from the \`GitSyncAction\` defaults test.

## test_api.py (integration)
- Replace the forbidden broad \`pkill -KILL -f\` with \`pgrep\` to find the specific unison PID(s) then SIGKILL those exact PIDs.
- Replace \`monkeypatch.setattr("shutil.which", ...)\` with real PATH manipulation (ratchet \`test_prevent_monkeypatch_setattr\` trimmed 2 -> 0).
- Fix the \`syncs_symlinks\` race by waiting for both the symlink and its target; drop \`@pytest.mark.flaky\`.

Local: \`just test-quick libs/mngr_pair\` -> 104 passed, 0 failed; \`ty check\` on changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)