### PR TITLE
Fix bad tests under imbue/mngr/plugins

### DIFF
--- a/libs/mngr/changelog/mngr-bad-tests-mngr-plugins-local.md
+++ b/libs/mngr/changelog/mngr-bad-tests-mngr-plugins-local.md
@@ -1,0 +1,10 @@
+Improved the plugin test suite under `imbue/mngr/plugins/` (test-only changes, no user-visible behavior change):
+
+- Plugin CLI-command tests now drive the production `_register_plugin_commands()` wiring against the real `cli` group instead of re-implementing the registration loop in the test, so a regression in that function would actually be caught.
+- Replaced the module-global `_captured_values` dict with per-test capture dicts, removing shared state between tests.
+- "No commands added" tests now assert the real invariant (the cli command set is unchanged) rather than the absence of an unrelated command name.
+- Deleted a test that only exercised a decorator defined inside the test file (`with_plugin_cli_options`), since the underlying `apply_plugin_cli_options` is already covered directly.
+- Hoisted the duplicated "install a plugin manager and restore it" dance and the `LifecycleTracker` plugin into a shared `imbue/mngr/plugins/testing.py`, and moved the `lifecycle_tracker` fixture into `imbue/mngr/plugins/conftest.py`.
+- Catalog-iterating isolation tests now guard against vacuous success when a tier or the catalog becomes empty, and their stale "BASIC"/"EXTRA" tier naming was updated to "INDEPENDENT"/"DEPENDENT".
+- The plugin help-topics "returning no topics is harmless" test now asserts the topic registry is unchanged instead of only checking the exit code.
+- Added clarifying comments to the `is_blocked` tripwire tests noting they intentionally re-assert the fixture's blocking configuration.

--- a/libs/mngr/imbue/mngr/plugins/conftest.py
+++ b/libs/mngr/imbue/mngr/plugins/conftest.py
@@ -1,0 +1,14 @@
+import pluggy
+import pytest
+
+import imbue.mngr.main
+from imbue.mngr.plugins.testing import LifecycleTracker
+
+
+@pytest.fixture
+def lifecycle_tracker(plugin_manager: pluggy.PluginManager) -> LifecycleTracker:
+    """Register a lifecycle tracker plugin and install the plugin manager as the module singleton."""
+    tracker = LifecycleTracker()
+    plugin_manager.register(tracker)
+    imbue.mngr.main._plugin_manager_container["pm"] = plugin_manager
+    return tracker

--- a/libs/mngr/imbue/mngr/plugins/plugin_isolation/all_agent_types/all_agent_types_test.py
+++ b/libs/mngr/imbue/mngr/plugins/plugin_isolation/all_agent_types/all_agent_types_test.py
@@ -14,6 +14,11 @@ def test_all_specified_agent_types_registered(plugin_manager: pluggy.PluginManag
 
 
 def test_non_agent_extras_still_blocked(plugin_manager: pluggy.PluginManager) -> None:
-    """Plugins not in the enabled set should remain blocked."""
+    """Plugins not in the enabled set should remain blocked.
+
+    ttyd and kanpan are not agent types, so they have no `list_registered_agent_types`
+    effect to assert on; this re-asserts the fixture's blocking decision directly as a
+    cheap tripwire for the non-agent plugins.
+    """
     assert plugin_manager.is_blocked("ttyd")
     assert plugin_manager.is_blocked("kanpan")

--- a/libs/mngr/imbue/mngr/plugins/plugin_isolation/no_plugins/no_plugins_test.py
+++ b/libs/mngr/imbue/mngr/plugins/plugin_isolation/no_plugins/no_plugins_test.py
@@ -15,5 +15,7 @@ def test_no_external_agent_types_registered(plugin_manager: pluggy.PluginManager
 
 def test_all_cataloged_plugins_are_blocked(plugin_manager: pluggy.PluginManager) -> None:
     """Every cataloged plugin should be blocked."""
+    # Guard against vacuous success if the catalog is ever emptied.
+    assert PLUGIN_CATALOG, "Expected a non-empty plugin catalog"
     for entry in PLUGIN_CATALOG:
         assert plugin_manager.is_blocked(entry.entry_point_name), f"Plugin {entry.entry_point_name} should be blocked"

--- a/libs/mngr/imbue/mngr/plugins/plugin_isolation/single_plugin/single_plugin_test.py
+++ b/libs/mngr/imbue/mngr/plugins/plugin_isolation/single_plugin/single_plugin_test.py
@@ -12,6 +12,11 @@ def test_only_claude_loaded(plugin_manager: pluggy.PluginManager) -> None:
     assert "opencode" not in registered
 
 
+# The two checks below intentionally re-assert the block/unblock decision the
+# `plugin_manager` fixture made (it calls `set_blocked` for everything outside
+# `enabled_plugins`). They are cheap tripwires on that wiring; the observable
+# effect of the decision -- which agent types end up registered -- is covered by
+# `test_only_claude_loaded` above.
 def test_claude_is_not_blocked(plugin_manager: pluggy.PluginManager) -> None:
     assert not plugin_manager.is_blocked("claude")
 

--- a/libs/mngr/imbue/mngr/plugins/plugin_isolation_test.py
+++ b/libs/mngr/imbue/mngr/plugins/plugin_isolation_test.py
@@ -12,22 +12,25 @@ from imbue.mngr.plugin_catalog import get_independent_entry_point_names
 from imbue.mngr.primitives import PluginTier
 
 # =============================================================================
-# Default configuration (BASIC tier)
+# Default configuration (INDEPENDENT tier)
 # =============================================================================
 
 
-def test_default_config_loads_basic_tier_agent_types(plugin_manager: pluggy.PluginManager) -> None:
-    """With default config, BASIC-tier agent types should be registered."""
+def test_default_config_loads_independent_tier_agent_types(plugin_manager: pluggy.PluginManager) -> None:
+    """With default config, INDEPENDENT-tier agent types should be registered."""
     registered = list_registered_agent_types()
     assert "claude" in registered
     assert "opencode" in registered
 
 
-def test_default_config_blocks_extra_tier_plugins(plugin_manager: pluggy.PluginManager) -> None:
-    """With default config, EXTRA-tier plugins should be blocked."""
-    extra_names = {e.entry_point_name for e in PLUGIN_CATALOG if e.tier == PluginTier.DEPENDENT}
-    for name in extra_names:
-        assert plugin_manager.is_blocked(name), f"EXTRA plugin {name} should be blocked by default"
+def test_default_config_blocks_dependent_tier_plugins(plugin_manager: pluggy.PluginManager) -> None:
+    """With default config, DEPENDENT-tier plugins should be blocked."""
+    dependent_names = {e.entry_point_name for e in PLUGIN_CATALOG if e.tier == PluginTier.DEPENDENT}
+    # Guard against vacuous success: if the catalog ever has no DEPENDENT-tier
+    # entries, the loop below would assert nothing. Fail loudly instead.
+    assert dependent_names, "Expected at least one DEPENDENT-tier plugin in the catalog"
+    for name in dependent_names:
+        assert plugin_manager.is_blocked(name), f"DEPENDENT plugin {name} should be blocked by default"
 
 
 # =============================================================================
@@ -36,7 +39,9 @@ def test_default_config_blocks_extra_tier_plugins(plugin_manager: pluggy.PluginM
 
 
 def test_get_independent_entry_point_names_matches_catalog() -> None:
-    """get_independent_entry_point_names should return exactly the BASIC-tier entries."""
-    basic_names = get_independent_entry_point_names()
+    """get_independent_entry_point_names should return exactly the INDEPENDENT-tier entries."""
+    independent_names = get_independent_entry_point_names()
     expected = {e.entry_point_name for e in PLUGIN_CATALOG if e.tier == PluginTier.INDEPENDENT}
-    assert basic_names == expected
+    # Guard against both sides being empty (which would make the equality vacuous).
+    assert independent_names, "Expected at least one INDEPENDENT-tier plugin in the catalog"
+    assert independent_names == expected

--- a/libs/mngr/imbue/mngr/plugins/test_lifecycle_hooks.py
+++ b/libs/mngr/imbue/mngr/plugins/test_lifecycle_hooks.py
@@ -2,46 +2,13 @@ from typing import Any
 
 import click
 import pluggy
-import pytest
 from click.testing import CliRunner
 
 import imbue.mngr.main
 from imbue.mngr import hookimpl
 from imbue.mngr.errors import AgentNotFoundError
 from imbue.mngr.main import cli
-
-
-class _LifecycleTracker:
-    """A test plugin that records lifecycle hook invocations."""
-
-    def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-
-    @hookimpl
-    def on_startup(self) -> None:
-        self.calls.append(("on_startup", {}))
-
-    @hookimpl
-    def on_shutdown(self) -> None:
-        self.calls.append(("on_shutdown", {}))
-
-    @hookimpl
-    def on_before_command(self, command_name: str, command_params: dict[str, Any]) -> None:
-        self.calls.append(("on_before_command", {"command_name": command_name, "command_params": command_params}))
-
-    @hookimpl
-    def on_after_command(self, command_name: str, command_params: dict[str, Any]) -> None:
-        self.calls.append(("on_after_command", {"command_name": command_name, "command_params": command_params}))
-
-    @hookimpl
-    def on_error(self, command_name: str, command_params: dict[str, Any], error: BaseException) -> None:
-        self.calls.append(
-            ("on_error", {"command_name": command_name, "command_params": command_params, "error": error})
-        )
-
-    @property
-    def hook_names(self) -> list[str]:
-        return [name for name, _ in self.calls]
+from imbue.mngr.plugins.testing import LifecycleTracker
 
 
 class _AbortingPlugin:
@@ -52,19 +19,10 @@ class _AbortingPlugin:
         raise click.Abort()
 
 
-@pytest.fixture()
-def lifecycle_tracker(plugin_manager: pluggy.PluginManager) -> _LifecycleTracker:
-    """Register a lifecycle tracker plugin and install the plugin manager as the module singleton."""
-    tracker = _LifecycleTracker()
-    plugin_manager.register(tracker)
-    imbue.mngr.main._plugin_manager_container["pm"] = plugin_manager
-    return tracker
-
-
 # --- Success path (mngr list) ---
 
 
-def test_hooks_fire_on_successful_command(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_hooks_fire_on_successful_command(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """All lifecycle hooks fire in the correct order on a successful command."""
     cli_runner.invoke(cli, ["list"])
 
@@ -77,7 +35,7 @@ def test_hooks_fire_on_successful_command(lifecycle_tracker: _LifecycleTracker, 
 
 
 def test_on_before_command_receives_correct_command_name(
-    lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner
+    lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner
 ) -> None:
     """on_before_command receives the canonical command name."""
     cli_runner.invoke(cli, ["list"])
@@ -87,9 +45,7 @@ def test_on_before_command_receives_correct_command_name(
     assert before_calls[0][1]["command_name"] == "list"
 
 
-def test_on_before_command_receives_correct_params(
-    lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner
-) -> None:
+def test_on_before_command_receives_correct_params(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """on_before_command receives the resolved command parameters dict."""
     cli_runner.invoke(cli, ["list", "--format", "json"])
 
@@ -99,7 +55,7 @@ def test_on_before_command_receives_correct_params(
 
 
 def test_on_after_command_receives_correct_command_name(
-    lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner
+    lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner
 ) -> None:
     """on_after_command receives the canonical command name on success."""
     cli_runner.invoke(cli, ["list"])
@@ -109,7 +65,7 @@ def test_on_after_command_receives_correct_command_name(
     assert after_calls[0][1]["command_name"] == "list"
 
 
-def test_alias_resolves_to_canonical_command_name(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_alias_resolves_to_canonical_command_name(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """Invoking via alias (ls) still reports the canonical command name (list) to hooks."""
     cli_runner.invoke(cli, ["ls"])
 
@@ -121,7 +77,7 @@ def test_alias_resolves_to_canonical_command_name(lifecycle_tracker: _LifecycleT
 # --- Error path (mngr destroy nonexistent) ---
 
 
-def test_on_error_fires_on_command_failure(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_on_error_fires_on_command_failure(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """on_error fires (and on_after_command does not) when a command raises."""
     cli_runner.invoke(cli, ["destroy", "nonexistent-agent-xyz"])
 
@@ -133,7 +89,7 @@ def test_on_error_fires_on_command_failure(lifecycle_tracker: _LifecycleTracker,
     ]
 
 
-def test_on_error_receives_correct_command_name(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_on_error_receives_correct_command_name(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """on_error receives the canonical command name."""
     cli_runner.invoke(cli, ["destroy", "nonexistent-agent-xyz"])
 
@@ -142,7 +98,7 @@ def test_on_error_receives_correct_command_name(lifecycle_tracker: _LifecycleTra
     assert error_calls[0][1]["command_name"] == "destroy"
 
 
-def test_on_error_receives_exception(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_on_error_receives_exception(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """on_error receives the actual exception that was raised."""
     cli_runner.invoke(cli, ["destroy", "nonexistent-agent-xyz"])
 
@@ -151,7 +107,7 @@ def test_on_error_receives_exception(lifecycle_tracker: _LifecycleTracker, cli_r
     assert isinstance(error_calls[0][1]["error"], AgentNotFoundError)
 
 
-def test_on_after_command_not_called_on_error(lifecycle_tracker: _LifecycleTracker, cli_runner: CliRunner) -> None:
+def test_on_after_command_not_called_on_error(lifecycle_tracker: LifecycleTracker, cli_runner: CliRunner) -> None:
     """on_after_command does NOT fire when a command raises."""
     cli_runner.invoke(cli, ["destroy", "nonexistent-agent-xyz"])
 
@@ -162,7 +118,7 @@ def test_on_after_command_not_called_on_error(lifecycle_tracker: _LifecycleTrack
 
 
 def test_plugin_can_abort_via_on_before_command(
-    lifecycle_tracker: _LifecycleTracker,
+    lifecycle_tracker: LifecycleTracker,
     plugin_manager: pluggy.PluginManager,
     cli_runner: CliRunner,
 ) -> None:
@@ -183,8 +139,8 @@ def test_multiple_plugin_hooks_all_fire(
     cli_runner: CliRunner,
 ) -> None:
     """When multiple tracker plugins are registered, both record all hooks."""
-    tracker1 = _LifecycleTracker()
-    tracker2 = _LifecycleTracker()
+    tracker1 = LifecycleTracker()
+    tracker2 = LifecycleTracker()
     plugin_manager.register(tracker1)
     plugin_manager.register(tracker2)
     imbue.mngr.main._plugin_manager_container["pm"] = plugin_manager
@@ -209,7 +165,7 @@ def test_blocked_plugin_hooks_do_not_fire(
     cli_runner: CliRunner,
 ) -> None:
     """Hooks from a plugin that has been blocked via pm.set_blocked() should not fire."""
-    tracker = _LifecycleTracker()
+    tracker = LifecycleTracker()
     plugin_manager.register(tracker, name="test-blocked-plugin")
 
     # Block the plugin -- this simulates what create_plugin_manager does

--- a/libs/mngr/imbue/mngr/plugins/test_plugin_cli_commands.py
+++ b/libs/mngr/imbue/mngr/plugins/test_plugin_cli_commands.py
@@ -1,34 +1,38 @@
-"""Tests for plugin CLI commands hook."""
+"""Tests for plugin CLI commands hook.
 
-from collections.abc import Generator
+These drive the production ``_register_plugin_commands()`` wiring (via the shared
+``plugin_commands_registered`` helper) against the real ``cli`` group, so a
+regression in that function would actually be caught. Each test plugin records
+the values it observes into a per-test dict passed to its constructor, avoiding
+shared module-level state between tests.
+"""
+
 from collections.abc import Sequence
-from contextlib import contextmanager
 from typing import Any
 
 import click
-import pluggy
 from click.testing import CliRunner
 
-import imbue.mngr.main
 from imbue.mngr import hookimpl
-from imbue.mngr.main import reset_plugin_manager
-from imbue.mngr.plugins import hookspecs
-
-# Module-level containers to capture values from test commands.
-# This avoids using disallowed output methods (see ratchet tests).
-_captured_values: dict[str, Any] = {}
+from imbue.mngr.main import cli
+from imbue.mngr.plugins.testing import plugin_commands_registered
 
 
 class _PluginWithSimpleCommand:
     """A test plugin that adds a simple command."""
 
+    def __init__(self, captured: dict[str, Any]) -> None:
+        self._captured = captured
+
     @hookimpl
     def register_cli_commands(self) -> Sequence[click.Command] | None:
+        captured = self._captured
+
         @click.command()
         @click.option("--name", default="World", help="Name to greet")
         def greet(name: str) -> None:
             """Greet someone."""
-            _captured_values["greet_name"] = name
+            captured["greet_name"] = name
 
         return [greet]
 
@@ -36,17 +40,22 @@ class _PluginWithSimpleCommand:
 class _PluginWithMultipleCommands:
     """A test plugin that adds multiple commands."""
 
+    def __init__(self, captured: dict[str, Any]) -> None:
+        self._captured = captured
+
     @hookimpl
     def register_cli_commands(self) -> Sequence[click.Command] | None:
+        captured = self._captured
+
         @click.command()
         def cmd_alpha() -> None:
             """Alpha command."""
-            _captured_values["alpha_called"] = True
+            captured["alpha_called"] = True
 
         @click.command()
         def cmd_beta() -> None:
             """Beta command."""
-            _captured_values["beta_called"] = True
+            captured["beta_called"] = True
 
         return [cmd_alpha, cmd_beta]
 
@@ -70,170 +79,121 @@ class _PluginWithEmptyList:
 class _PluginWithContextCommand:
     """A test plugin that adds a command using click context."""
 
+    def __init__(self, captured: dict[str, Any]) -> None:
+        self._captured = captured
+
     @hookimpl
     def register_cli_commands(self) -> Sequence[click.Command] | None:
+        captured = self._captured
+
         @click.command()
         @click.pass_context
         def ctxcmd(ctx: click.Context) -> None:
             """Command that uses context."""
-            _captured_values["ctx_obj_type"] = type(ctx.obj).__name__
+            captured["ctx_obj_type"] = type(ctx.obj).__name__
 
         return [ctxcmd]
 
 
-@contextmanager
-def _test_cli_with_plugin(
-    plugin: Any,
-) -> Generator[click.Group, None, None]:
-    """Create a test CLI group with a plugin registered, restoring state on exit."""
-    with _test_cli_with_plugins([plugin]) as test_cli:
-        yield test_cli
+def test_plugin_registers_simple_command(cli_runner: CliRunner) -> None:
+    """A plugin command registered via the production wiring is reachable on the real cli."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithSimpleCommand(captured)]) as added:
+        assert [c.name for c in added] == ["greet"]
 
-
-@contextmanager
-def _test_cli_with_plugins(
-    plugins: Sequence[Any],
-) -> Generator[click.Group, None, None]:
-    """Create a test CLI group with multiple plugins registered, restoring state on exit."""
-    reset_plugin_manager()
-    pm = pluggy.PluginManager("mngr")
-    pm.add_hookspecs(hookspecs)
-    for plugin in plugins:
-        pm.register(plugin)
-
-    old_pm = imbue.mngr.main._plugin_manager_container["pm"]
-    imbue.mngr.main._plugin_manager_container["pm"] = pm
-
-    @click.group()
-    @click.pass_context
-    def test_cli(ctx: click.Context) -> None:
-        ctx.obj = pm
-
-    all_command_lists = pm.hook.register_cli_commands()
-    for command_list in all_command_lists:
-        if command_list is None:
-            continue
-        for command in command_list:
-            if command.name is None:
-                continue
-            test_cli.add_command(command)
-
-    try:
-        yield test_cli
-    finally:
-        imbue.mngr.main._plugin_manager_container["pm"] = old_pm
-
-
-def test_plugin_registers_simple_command() -> None:
-    """Test that a plugin can register a simple command."""
-    _captured_values.clear()
-    with _test_cli_with_plugin(_PluginWithSimpleCommand()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["greet"])
+        result = cli_runner.invoke(cli, ["greet"])
 
         assert result.exit_code == 0
-        assert _captured_values.get("greet_name") == "World"
+        assert captured.get("greet_name") == "World"
 
 
-def test_plugin_command_with_option() -> None:
-    """Test that a plugin command's options work correctly."""
-    _captured_values.clear()
-    with _test_cli_with_plugin(_PluginWithSimpleCommand()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["greet", "--name", "Plugin"])
+def test_plugin_command_with_option(cli_runner: CliRunner) -> None:
+    """A plugin command's options work correctly when invoked on the real cli."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithSimpleCommand(captured)]):
+        result = cli_runner.invoke(cli, ["greet", "--name", "Plugin"])
 
         assert result.exit_code == 0
-        assert _captured_values.get("greet_name") == "Plugin"
+        assert captured.get("greet_name") == "Plugin"
 
 
-def test_plugin_registers_multiple_commands() -> None:
-    """Test that a plugin can register multiple commands."""
-    _captured_values.clear()
-    with _test_cli_with_plugin(_PluginWithMultipleCommands()) as test_cli:
-        runner = CliRunner()
+def test_plugin_registers_multiple_commands(cli_runner: CliRunner) -> None:
+    """A plugin can register multiple commands, all reachable on the real cli."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithMultipleCommands(captured)]) as added:
+        assert {c.name for c in added} == {"cmd-alpha", "cmd-beta"}
 
-        # Test cmd_alpha
-        result_alpha = runner.invoke(test_cli, ["cmd-alpha"])
+        result_alpha = cli_runner.invoke(cli, ["cmd-alpha"])
         assert result_alpha.exit_code == 0
-        assert _captured_values.get("alpha_called") is True
+        assert captured.get("alpha_called") is True
 
-        # Test cmd_beta
-        result_beta = runner.invoke(test_cli, ["cmd-beta"])
+        result_beta = cli_runner.invoke(cli, ["cmd-beta"])
         assert result_beta.exit_code == 0
-        assert _captured_values.get("beta_called") is True
+        assert captured.get("beta_called") is True
 
 
-def test_plugin_returning_none_does_not_add_commands() -> None:
-    """Test that a plugin returning None doesn't break anything."""
-    with _test_cli_with_plugin(_PluginWithNoCommands()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["--help"])
-
-        assert result.exit_code == 0
-        # The help should work, but no extra commands should be added
-        assert "greet" not in result.output
+def test_plugin_returning_none_does_not_add_commands(cli_runner: CliRunner) -> None:
+    """A plugin returning None registers no commands and leaves the cli command set unchanged."""
+    commands_before = set(cli.commands)
+    with plugin_commands_registered([_PluginWithNoCommands()]) as added:
+        assert added == []
+        assert set(cli.commands) == commands_before
 
 
-def test_plugin_returning_empty_list_does_not_add_commands() -> None:
-    """Test that a plugin returning an empty list doesn't break anything."""
-    with _test_cli_with_plugin(_PluginWithEmptyList()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["--help"])
-
-        assert result.exit_code == 0
-        assert "greet" not in result.output
+def test_plugin_returning_empty_list_does_not_add_commands(cli_runner: CliRunner) -> None:
+    """A plugin returning an empty list registers no commands and leaves the cli command set unchanged."""
+    commands_before = set(cli.commands)
+    with plugin_commands_registered([_PluginWithEmptyList()]) as added:
+        assert added == []
+        assert set(cli.commands) == commands_before
 
 
-def test_multiple_plugins_can_register_commands() -> None:
-    """Test that multiple plugins can each register commands."""
-    _captured_values.clear()
-    plugins = [_PluginWithSimpleCommand(), _PluginWithMultipleCommands()]
-    with _test_cli_with_plugins(plugins) as test_cli:
-        runner = CliRunner()
+def test_multiple_plugins_can_register_commands(cli_runner: CliRunner) -> None:
+    """Multiple plugins can each register commands, all reachable on the real cli."""
+    captured: dict[str, Any] = {}
+    plugins = [_PluginWithSimpleCommand(captured), _PluginWithMultipleCommands(captured)]
+    with plugin_commands_registered(plugins) as added:
+        assert {c.name for c in added} == {"greet", "cmd-alpha", "cmd-beta"}
 
-        # Test greet from _PluginWithSimpleCommand
-        result_greet = runner.invoke(test_cli, ["greet"])
+        result_greet = cli_runner.invoke(cli, ["greet"])
         assert result_greet.exit_code == 0
-        assert _captured_values.get("greet_name") == "World"
+        assert captured.get("greet_name") == "World"
 
-        # Test cmd_alpha from _PluginWithMultipleCommands
-        result_alpha = runner.invoke(test_cli, ["cmd-alpha"])
+        result_alpha = cli_runner.invoke(cli, ["cmd-alpha"])
         assert result_alpha.exit_code == 0
-        assert _captured_values.get("alpha_called") is True
+        assert captured.get("alpha_called") is True
 
-        # Test cmd_beta from _PluginWithMultipleCommands
-        result_beta = runner.invoke(test_cli, ["cmd-beta"])
+        result_beta = cli_runner.invoke(cli, ["cmd-beta"])
         assert result_beta.exit_code == 0
-        assert _captured_values.get("beta_called") is True
+        assert captured.get("beta_called") is True
 
 
-def test_plugin_commands_appear_in_help() -> None:
-    """Test that plugin commands appear in the CLI help."""
-    with _test_cli_with_plugin(_PluginWithSimpleCommand()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["--help"])
+def test_plugin_commands_appear_in_help(cli_runner: CliRunner) -> None:
+    """Plugin commands appear in the real cli's help output."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithSimpleCommand(captured)]):
+        result = cli_runner.invoke(cli, ["--help"])
 
         assert result.exit_code == 0
         assert "greet" in result.output
 
 
-def test_plugin_command_help_shows_description() -> None:
-    """Test that plugin command help shows the command's docstring."""
-    with _test_cli_with_plugin(_PluginWithSimpleCommand()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["greet", "--help"])
+def test_plugin_command_help_shows_description(cli_runner: CliRunner) -> None:
+    """Plugin command help shows the command's docstring and options."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithSimpleCommand(captured)]):
+        result = cli_runner.invoke(cli, ["greet", "--help"])
 
         assert result.exit_code == 0
         assert "Greet someone" in result.output
         assert "--name" in result.output
 
 
-def test_plugin_command_with_context() -> None:
-    """Test that a plugin command can access the click context."""
-    _captured_values.clear()
-    with _test_cli_with_plugin(_PluginWithContextCommand()) as test_cli:
-        runner = CliRunner()
-        result = runner.invoke(test_cli, ["ctxcmd"])
+def test_plugin_command_with_context(cli_runner: CliRunner) -> None:
+    """A plugin command can access the click context (which holds the plugin manager)."""
+    captured: dict[str, Any] = {}
+    with plugin_commands_registered([_PluginWithContextCommand(captured)]):
+        result = cli_runner.invoke(cli, ["ctxcmd"])
 
         assert result.exit_code == 0
-        assert _captured_values.get("ctx_obj_type") == "PluginManager"
+        assert captured.get("ctx_obj_type") == "PluginManager"

--- a/libs/mngr/imbue/mngr/plugins/test_plugin_cli_commands.py
+++ b/libs/mngr/imbue/mngr/plugins/test_plugin_cli_commands.py
@@ -132,7 +132,7 @@ def test_plugin_registers_multiple_commands(cli_runner: CliRunner) -> None:
         assert captured.get("beta_called") is True
 
 
-def test_plugin_returning_none_does_not_add_commands(cli_runner: CliRunner) -> None:
+def test_plugin_returning_none_does_not_add_commands() -> None:
     """A plugin returning None registers no commands and leaves the cli command set unchanged."""
     commands_before = set(cli.commands)
     with plugin_commands_registered([_PluginWithNoCommands()]) as added:
@@ -140,7 +140,7 @@ def test_plugin_returning_none_does_not_add_commands(cli_runner: CliRunner) -> N
         assert set(cli.commands) == commands_before
 
 
-def test_plugin_returning_empty_list_does_not_add_commands(cli_runner: CliRunner) -> None:
+def test_plugin_returning_empty_list_does_not_add_commands() -> None:
     """A plugin returning an empty list registers no commands and leaves the cli command set unchanged."""
     commands_before = set(cli.commands)
     with plugin_commands_registered([_PluginWithEmptyList()]) as added:

--- a/libs/mngr/imbue/mngr/plugins/test_plugin_cli_options.py
+++ b/libs/mngr/imbue/mngr/plugins/test_plugin_cli_options.py
@@ -1,11 +1,7 @@
 """Tests for plugin CLI options hook."""
 
-from collections.abc import Generator
 from collections.abc import Mapping
-from collections.abc import Sequence
-from contextlib import contextmanager
 from typing import Any
-from typing import Callable
 
 import click
 import pluggy
@@ -14,46 +10,14 @@ from click_option_group import GroupedOption
 from click_option_group import OptionGroup
 from click_option_group import optgroup
 
-import imbue.mngr.main
 from imbue.mngr import hookimpl
-from imbue.mngr.cli.common_opts import TCommand
 from imbue.mngr.cli.common_opts import _apply_plugin_option_overrides
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.main import apply_plugin_cli_options
-from imbue.mngr.main import reset_plugin_manager
-from imbue.mngr.plugins import hookspecs
 from imbue.mngr.plugins.hookspecs import OptionStackItem
-
-
-@contextmanager
-def _plugin_manager_with_plugins(
-    plugins: Sequence[Any],
-) -> Generator[pluggy.PluginManager, None, None]:
-    """Create a plugin manager with registered plugins, restoring state on exit."""
-    reset_plugin_manager()
-    pm = pluggy.PluginManager("mngr")
-    pm.add_hookspecs(hookspecs)
-    for plugin in plugins:
-        pm.register(plugin)
-
-    old_pm = imbue.mngr.main._plugin_manager_container["pm"]
-    imbue.mngr.main._plugin_manager_container["pm"] = pm
-
-    try:
-        yield pm
-    finally:
-        imbue.mngr.main._plugin_manager_container["pm"] = old_pm
-
-
-@contextmanager
-def _plugin_manager_with_plugin(
-    plugin: Any,
-) -> Generator[pluggy.PluginManager, None, None]:
-    """Create a plugin manager with a single plugin, restoring state on exit."""
-    with _plugin_manager_with_plugins([plugin]) as pm:
-        yield pm
+from imbue.mngr.plugins.testing import plugin_manager_installed
 
 
 class _PluginWithStringOption:
@@ -133,7 +97,7 @@ class _PluginWithMultipleOptions:
 
 def test_apply_plugin_cli_options_adds_string_option() -> None:
     """Test that apply_plugin_cli_options adds a string option from a plugin."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command()
         def test_cmd() -> None:
@@ -153,7 +117,7 @@ def test_apply_plugin_cli_options_adds_string_option() -> None:
 
 def test_apply_plugin_cli_options_adds_flag_option() -> None:
     """Test that apply_plugin_cli_options adds a flag option from a plugin."""
-    with _plugin_manager_with_plugin(_PluginWithFlagOption()):
+    with plugin_manager_installed([_PluginWithFlagOption()]):
 
         @click.command()
         def test_cmd() -> None:
@@ -173,7 +137,7 @@ def test_apply_plugin_cli_options_adds_flag_option() -> None:
 
 def test_apply_plugin_cli_options_adds_multiple_options() -> None:
     """Test that apply_plugin_cli_options adds multiple options from a plugin."""
-    with _plugin_manager_with_plugin(_PluginWithMultipleOptions()):
+    with plugin_manager_installed([_PluginWithMultipleOptions()]):
 
         @click.command()
         def test_cmd() -> None:
@@ -198,7 +162,7 @@ def test_apply_plugin_cli_options_adds_multiple_options() -> None:
 
 def test_apply_plugin_cli_options_no_options_for_unknown_command() -> None:
     """Test that apply_plugin_cli_options does nothing for unknown commands."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command()
         def test_cmd() -> None:
@@ -211,24 +175,11 @@ def test_apply_plugin_cli_options_no_options_for_unknown_command() -> None:
         assert len(test_cmd.params) == initial_param_count
 
 
-def test_with_plugin_cli_options_decorator() -> None:
-    """Test the with_plugin_cli_options decorator."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
-
-        @with_plugin_cli_options("create")
-        @click.command()
-        def decorated_cmd() -> None:
-            pass
-
-        param_names = [p.name for p in decorated_cmd.params]
-        assert "test_plugin_option" in param_names
-
-
 def test_plugin_options_are_parsed_correctly() -> None:
     """Test that plugin options are correctly parsed when the command is invoked."""
     captured_value: str | None = None
 
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command()
         @click.pass_context
@@ -249,7 +200,7 @@ def test_plugin_flag_option_default_false() -> None:
     """Test that plugin flag options default to False when not specified."""
     captured_value: bool | None = None
 
-    with _plugin_manager_with_plugin(_PluginWithFlagOption()):
+    with plugin_manager_installed([_PluginWithFlagOption()]):
 
         @click.command()
         @click.pass_context
@@ -270,7 +221,7 @@ def test_plugin_flag_option_set_to_true() -> None:
     """Test that plugin flag options are True when specified."""
     captured_value: bool | None = None
 
-    with _plugin_manager_with_plugin(_PluginWithFlagOption()):
+    with plugin_manager_installed([_PluginWithFlagOption()]):
 
         @click.command()
         @click.pass_context
@@ -290,7 +241,7 @@ def test_plugin_flag_option_set_to_true() -> None:
 def test_multiple_plugins_can_add_options() -> None:
     """Test that multiple plugins can add options to the same command in different groups."""
     plugins = [_PluginWithStringOption(), _PluginWithMultipleOptions()]
-    with _plugin_manager_with_plugins(plugins):
+    with plugin_manager_installed(plugins):
 
         @click.command()
         def test_cmd() -> None:
@@ -315,7 +266,7 @@ def test_multiple_plugins_can_add_options() -> None:
 
 def test_apply_plugin_cli_options_with_no_name() -> None:
     """Test that apply_plugin_cli_options handles commands with no name."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command(name=None)
         def test_cmd() -> None:
@@ -434,7 +385,7 @@ def test_option_stack_item_to_grouped_option() -> None:
 
 def test_plugin_creates_title_fake_option_for_new_group() -> None:
     """Test that applying plugin options creates a title fake option for the group."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command()
         def test_cmd() -> None:
@@ -472,7 +423,7 @@ class _PluginAddingToExistingGroup:
 
 def test_plugin_adds_options_to_existing_group() -> None:
     """Test that a plugin can add options to an existing option group."""
-    with _plugin_manager_with_plugin(_PluginAddingToExistingGroup()):
+    with plugin_manager_installed([_PluginAddingToExistingGroup()]):
 
         @click.command()
         @optgroup.group("Behavior")
@@ -532,7 +483,7 @@ class _PluginB:
 def test_multiple_plugins_can_add_to_same_new_group() -> None:
     """Test that multiple plugins can add options to the same new group."""
     plugins = [_PluginA(), _PluginB()]
-    with _plugin_manager_with_plugins(plugins):
+    with plugin_manager_installed(plugins):
 
         @click.command()
         def test_cmd() -> None:
@@ -551,7 +502,7 @@ def test_multiple_plugins_can_add_to_same_new_group() -> None:
 
 def test_plugin_options_show_in_help_with_group_header() -> None:
     """Test that plugin options appear in help output under their group header."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()):
+    with plugin_manager_installed([_PluginWithStringOption()]):
 
         @click.command()
         def test_cmd(**kwargs: Any) -> None:
@@ -643,7 +594,7 @@ class _DummyCommandClass:
 
 def test_override_command_options_modifies_params_in_place() -> None:
     """Test that override_command_options modifies params dict in place."""
-    with _plugin_manager_with_plugin(_PluginOverridingOption()) as pm:
+    with plugin_manager_installed([_PluginOverridingOption()]) as pm:
         params = {"my_option": "original_value", "other_option": "unchanged"}
 
         pm.hook.override_command_options(
@@ -658,7 +609,7 @@ def test_override_command_options_modifies_params_in_place() -> None:
 
 def test_override_command_options_only_applies_to_matching_command() -> None:
     """Test that override_command_options only applies to the specified command."""
-    with _plugin_manager_with_plugin(_PluginOverridingOption()) as pm:
+    with plugin_manager_installed([_PluginOverridingOption()]) as pm:
         params = {"my_option": "original_value"}
 
         pm.hook.override_command_options(
@@ -673,7 +624,7 @@ def test_override_command_options_only_applies_to_matching_command() -> None:
 def test_override_command_options_chains_multiple_plugins() -> None:
     """Test that multiple plugins can chain their modifications."""
     plugins = [_PluginOverrideChainA(), _PluginOverrideChainB()]
-    with _plugin_manager_with_plugins(plugins) as pm:
+    with plugin_manager_installed(plugins) as pm:
         params: dict[str, Any] = {}
 
         pm.hook.override_command_options(
@@ -689,7 +640,7 @@ def test_override_command_options_chains_multiple_plugins() -> None:
 
 def test_override_command_options_receives_command_class() -> None:
     """Test that plugins receive the command_class and can use it."""
-    with _plugin_manager_with_plugin(_PluginUsingCommandClass()) as pm:
+    with plugin_manager_installed([_PluginUsingCommandClass()]) as pm:
         params: dict[str, Any] = {}
 
         pm.hook.override_command_options(
@@ -704,18 +655,13 @@ def test_override_command_options_receives_command_class() -> None:
 
 def test_apply_plugin_option_overrides_function() -> None:
     """Test the _apply_plugin_option_overrides helper function."""
-    with _plugin_manager_with_plugin(_PluginOverridingOption()) as pm:
+    with plugin_manager_installed([_PluginOverridingOption()]) as pm:
         params = {"my_option": "original_value", "other_option": "unchanged"}
 
         _apply_plugin_option_overrides(pm, "test_override", _DummyCommandClass, params)
 
         assert params["my_option"] == "overridden_value"
         assert params["other_option"] == "unchanged"
-
-
-def with_plugin_cli_options(command_name: str) -> Callable[[TCommand], TCommand]:
-    """Decorator to apply plugin-registered CLI options to a click command."""
-    return lambda cmd: apply_plugin_cli_options(cmd, command_name=command_name)
 
 
 # =============================================================================
@@ -727,7 +673,7 @@ def test_setup_command_context_does_not_crash_with_plugin_params(
     plugin_manager: pluggy.PluginManager,
 ) -> None:
     """setup_command_context should not crash when plugin-registered options are in ctx.params."""
-    with _plugin_manager_with_plugin(_PluginWithStringOption()) as pm:
+    with plugin_manager_installed([_PluginWithStringOption()]) as pm:
         captured_plugin_params: dict[str, Any] = {}
 
         @click.command("test-create")
@@ -756,7 +702,7 @@ def test_setup_command_context_stores_plugin_params_in_ctx_meta(
     plugin_manager: pluggy.PluginManager,
 ) -> None:
     """setup_command_context should store plugin params in ctx.meta['plugin_cli_params']."""
-    with _plugin_manager_with_plugin(_PluginWithMultipleOptions()) as pm:
+    with plugin_manager_installed([_PluginWithMultipleOptions()]) as pm:
         captured_plugin_params: dict[str, Any] = {}
 
         @click.command("test-create")

--- a/libs/mngr/imbue/mngr/plugins/test_plugin_help_topics.py
+++ b/libs/mngr/imbue/mngr/plugins/test_plugin_help_topics.py
@@ -10,7 +10,6 @@ import pluggy
 import pytest
 from click.testing import CliRunner
 
-import imbue.mngr.main
 from imbue.mngr import hookimpl
 from imbue.mngr.cli.help import load_help_topics_from_plugins
 from imbue.mngr.cli.help_topics import _topic_alias_to_canonical
@@ -20,8 +19,7 @@ from imbue.mngr.interfaces.help_topic import DocFile
 from imbue.mngr.interfaces.help_topic import InlineContent
 from imbue.mngr.interfaces.help_topic import TopicHelpPage
 from imbue.mngr.main import cli
-from imbue.mngr.main import reset_plugin_manager
-from imbue.mngr.plugins import hookspecs
+from imbue.mngr.plugins.testing import plugin_manager_installed
 
 
 @contextmanager
@@ -116,20 +114,10 @@ class _PluginWithDocBackedTopic:
 @contextmanager
 def _registered_plugin_topics(plugin: Any) -> Generator[pluggy.PluginManager, None, None]:
     """Register a plugin's help topics, restoring the global registry on exit."""
-    reset_plugin_manager()
-    pm = pluggy.PluginManager("mngr")
-    pm.add_hookspecs(hookspecs)
-    pm.register(plugin)
-
-    old_pm = imbue.mngr.main._plugin_manager_container["pm"]
-    imbue.mngr.main._plugin_manager_container["pm"] = pm
-
-    try:
+    with plugin_manager_installed([plugin]) as pm:
         with preserve_topic_registry():
             load_help_topics_from_plugins(pm)
             yield pm
-    finally:
-        imbue.mngr.main._plugin_manager_container["pm"] = old_pm
 
 
 def test_plugin_topic_is_registered() -> None:
@@ -165,8 +153,12 @@ def test_plugin_topic_page_is_viewable() -> None:
 
 
 def test_plugin_returning_no_topics_is_harmless() -> None:
-    """A plugin returning None contributes no topics and does not error."""
+    """A plugin returning None contributes no topics: the registry is unchanged and help still works."""
+    topics_before = set(_topic_registry)
     with _registered_plugin_topics(_PluginWithNoTopics()) as pm:
+        # The None-returning plugin must not add, remove, or alter any topic keys.
+        assert set(_topic_registry) == topics_before
+
         result = CliRunner().invoke(cli, ["help"], obj=pm, catch_exceptions=False)
         assert result.exit_code == 0
 

--- a/libs/mngr/imbue/mngr/plugins/testing.py
+++ b/libs/mngr/imbue/mngr/plugins/testing.py
@@ -1,0 +1,99 @@
+"""Shared test helpers for the plugin test modules.
+
+These centralize the "build a fresh plugin manager, install it as the module
+singleton, restore the previous one on exit" dance that the individual plugin
+test files used to re-implement independently (each copy diverging subtly in
+what it restored).
+"""
+
+from collections.abc import Generator
+from collections.abc import Sequence
+from contextlib import contextmanager
+from typing import Any
+
+import click
+import pluggy
+
+import imbue.mngr.main
+from imbue.mngr import hookimpl
+from imbue.mngr.main import _register_plugin_commands
+from imbue.mngr.main import cli
+from imbue.mngr.main import reset_plugin_manager
+from imbue.mngr.plugins import hookspecs
+
+
+@contextmanager
+def plugin_manager_installed(plugins: Sequence[Any]) -> Generator[pluggy.PluginManager, None, None]:
+    """Create a fresh plugin manager with ``plugins`` registered and install it as the module singleton.
+
+    Resets the module-level plugin manager, builds a new ``pluggy.PluginManager``
+    with the mngr hookspecs and the given plugins registered, swaps it into
+    ``imbue.mngr.main._plugin_manager_container``, and restores the previous
+    manager on exit.
+    """
+    reset_plugin_manager()
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+    for plugin in plugins:
+        pm.register(plugin)
+
+    old_pm = imbue.mngr.main._plugin_manager_container["pm"]
+    imbue.mngr.main._plugin_manager_container["pm"] = pm
+    try:
+        yield pm
+    finally:
+        imbue.mngr.main._plugin_manager_container["pm"] = old_pm
+
+
+@contextmanager
+def plugin_commands_registered(plugins: Sequence[Any]) -> Generator[list[click.Command], None, None]:
+    """Install ``plugins`` and run the production command-registration wiring against the real ``cli``.
+
+    This drives the actual ``_register_plugin_commands()`` function (rather than a
+    test-local copy of its loop), so a regression in that function -- dropping
+    commands, skipping the hook, mishandling the ``command.name is None`` guard --
+    would be caught. Yields the list of commands the production wiring added to
+    ``cli`` and removes exactly those again on exit, leaving the shared ``cli``
+    group unchanged.
+    """
+    with plugin_manager_installed(plugins):
+        commands_before = set(cli.commands)
+        added_commands = _register_plugin_commands()
+        try:
+            yield added_commands
+        finally:
+            for name in set(cli.commands) - commands_before:
+                del cli.commands[name]
+
+
+class LifecycleTracker:
+    """A test plugin that records lifecycle hook invocations."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @hookimpl
+    def on_startup(self) -> None:
+        self.calls.append(("on_startup", {}))
+
+    @hookimpl
+    def on_shutdown(self) -> None:
+        self.calls.append(("on_shutdown", {}))
+
+    @hookimpl
+    def on_before_command(self, command_name: str, command_params: dict[str, Any]) -> None:
+        self.calls.append(("on_before_command", {"command_name": command_name, "command_params": command_params}))
+
+    @hookimpl
+    def on_after_command(self, command_name: str, command_params: dict[str, Any]) -> None:
+        self.calls.append(("on_after_command", {"command_name": command_name, "command_params": command_params}))
+
+    @hookimpl
+    def on_error(self, command_name: str, command_params: dict[str, Any], error: BaseException) -> None:
+        self.calls.append(
+            ("on_error", {"command_name": command_name, "command_params": command_params, "error": error})
+        )
+
+    @property
+    def hook_names(self) -> list[str]:
+        return [name for name, _ in self.calls]


### PR DESCRIPTION
Addresses the 8 findings from `/identify-bad-tests libs/mngr/imbue/mngr/plugins`. Test-only changes; no user-visible behavior change.

## Findings fixed
1. **CLI-command tests re-implemented production wiring.** `test_plugin_cli_commands.py` now drives the real `_register_plugin_commands()` against the actual `cli` group via a new shared `plugin_commands_registered` helper, instead of hand-copying the registration loop. A regression in that function would now be caught.
2. **`test_with_plugin_cli_options_decorator` tested a test-file-local decorator.** Deleted it and the `with_plugin_cli_options` helper; `apply_plugin_cli_options` is already covered directly.
3. **Module-global `_captured_values` shared state.** Replaced with per-test capture dicts passed to each test plugin's constructor.
4. **"No commands added" tests asserted an unrelated command name.** Now assert the real invariant: the `cli` command set is unchanged (and the production wiring returned no commands).
5. **`is_blocked` assertions re-assert fixture config.** Added clarifying comments noting they are intentional pluggy-level tripwires; the observable effect is covered by the `list_registered_agent_types()` tests.
6. **Helpers/fixtures duplicated across test files.** Hoisted the "install a plugin manager and restore it" dance and `LifecycleTracker` into a new `imbue/mngr/plugins/testing.py`, and moved the `lifecycle_tracker` fixture into a new `imbue/mngr/plugins/conftest.py`. All four test files use the shared helper.
7. **Catalog-iterating assertions pass vacuously if a tier/subset is empty.** Added non-emptiness guards; updated stale `BASIC`/`EXTRA` naming to `INDEPENDENT`/`DEPENDENT`.
8. **`test_plugin_returning_no_topics_is_harmless` only checked exit code.** Now asserts the topic registry is unchanged.

## Testing
`just test-quick "libs/mngr/imbue/mngr/plugins -p no:randomly"` -> 64 passed. Type-error and ratchet tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)