### PR TITLE
Fix bad tests in libs/mngr_tmr

### DIFF
--- a/libs/mngr_tmr/changelog/mngr-bad-tests-mngr-tmr-local.md
+++ b/libs/mngr_tmr/changelog/mngr-bad-tests-mngr-tmr-local.md
@@ -1,0 +1,21 @@
+Improved test quality in the test-mapreduce plugin's unit tests:
+
+- Fixed an order-dependent test-isolation bug: the report module's process-global
+  outcome caches (`_TESTING_OUTCOME_CACHE` / `_INTEGRATOR_OUTCOME_CACHE`) are keyed
+  only by agent name and ignore the output directory, so tests reusing an agent name
+  across distinct temp dirs could read each other's cached outcomes. Added a
+  `reset_outcome_caches()` helper and an autouse fixture that clears the caches
+  between tests.
+- Removed tautological model-construction tests and library-only tests (markdown
+  passthrough) that could not catch any real regression.
+- Rewrote the integrator-with-failures report test to assert on the rendered failure
+  marker instead of merely that the output file exists, and gave it a unique agent
+  name.
+- Replaced enum-value smoke tests with parse-contract tests on the JSON wire format
+  the agents actually rely on.
+- Tightened `_merged_status_html` assertions to check the full HTML entities
+  (`&#10003;` / `&#10007;`) and added coverage for the impl-priority-without-hash
+  branch.
+- Trimmed prompt and CLI help-text tests to assert only the values this plugin is
+  responsible for (interpolated prompt values; that the shared option decorators
+  stay wired onto `tmr`), rather than template prose or framework-owned behavior.

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
@@ -9,6 +9,7 @@ trick and the help-text surface contract.
 from typing import Any
 
 import click
+import pytest
 from click.testing import CliRunner
 from click.testing import Result
 
@@ -22,19 +23,28 @@ def test_cli_help(cli_runner: CliRunner) -> None:
     assert "PYTEST_ARGS" in result.output
 
 
-def test_cli_help_contains_options(cli_runner: CliRunner) -> None:
+@pytest.mark.parametrize(
+    "option",
+    [
+        "--agent-type",
+        "--poll-interval",
+        "--output-dir",
+        "--source",
+        "--provider",
+        "--env",
+        "--label",
+        "--timeout",
+        "--reducer-timeout",
+        "--max-parallel-agents",
+    ],
+)
+def test_cli_help_wires_in_shared_options(cli_runner: CliRunner, option: str) -> None:
+    """Guards that the shared mapreduce/common option decorators stay wired onto
+    ``tmr``. The options' own behavior is owned and tested by the framework
+    (imbue.mngr_mapreduce / imbue.mngr); this only asserts they are surfaced here.
+    """
     result = cli_runner.invoke(tmr, ["--help"])
-    assert "--agent-type" in result.output
-    assert "--poll-interval" in result.output
-    assert "--output-dir" in result.output
-    assert "--source" in result.output
-
-
-def test_cli_help_contains_provider_env_label_options(cli_runner: CliRunner) -> None:
-    result = cli_runner.invoke(tmr, ["--help"])
-    assert "--provider" in result.output
-    assert "--env" in result.output
-    assert "--label" in result.output
+    assert option in result.output
 
 
 def test_cli_help_drops_removed_options(cli_runner: CliRunner) -> None:
@@ -48,13 +58,6 @@ def test_cli_help_drops_removed_options(cli_runner: CliRunner) -> None:
     assert "--integrator-type" not in result.output
     assert "--integrator-template" not in result.output
     assert "--use-snapshot" not in result.output
-
-
-def test_cli_help_contains_timeout_options(cli_runner: CliRunner) -> None:
-    result = cli_runner.invoke(tmr, ["--help"])
-    assert "--timeout" in result.output
-    assert "--reducer-timeout" in result.output
-    assert "--max-parallel-agents" in result.output
 
 
 def _invoke_tmr_command(

--- a/libs/mngr_tmr/imbue/mngr_tmr/conftest.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/conftest.py
@@ -4,6 +4,8 @@ Uses shared plugin test fixtures from mngr for common setup (plugin manager,
 environment isolation, git repos, etc.) and defines test-mapreduce-specific fixtures below.
 """
 
+from collections.abc import Iterator
+
 import pytest
 
 from imbue.mngr.api.find import ensure_host_started
@@ -12,8 +14,22 @@ from imbue.mngr.primitives import HostName
 from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr.utils.plugin_testing import register_plugin_test_fixtures
+from imbue.mngr_tmr.report import reset_outcome_caches
 
 register_plugin_test_fixtures(globals())
+
+
+@pytest.fixture(autouse=True)
+def _reset_report_outcome_caches() -> Iterator[None]:
+    """Isolate the report module's process-global outcome caches per test.
+
+    The caches key parsed outcomes by ``AgentName`` and ignore ``output_dir``,
+    so without this fixture tests that reuse an agent name (across distinct temp
+    dirs) would read each other's cached outcomes in an order-dependent way.
+    """
+    reset_outcome_caches()
+    yield
+    reset_outcome_caches()
 
 
 @pytest.fixture

--- a/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
@@ -13,31 +13,17 @@ from imbue.mngr_tmr.recipe import CollectTestsError
 from imbue.mngr_tmr.recipe import collect_tests
 
 
-def test_build_agent_prompt_contains_test_id() -> None:
+def test_build_agent_prompt_interpolates_test_id_and_outcome_filename() -> None:
+    """build_test_agent_prompt is responsible for interpolating the run command
+    (containing the test node id) and the outcome filename into the template."""
     prompt = build_test_agent_prompt("tests/test_foo.py::test_bar", ())
     assert "tests/test_foo.py::test_bar" in prompt
     assert TESTING_AGENT_OUTCOME_FILENAME in prompt
-    assert "IMPROVE_TEST" in prompt
-    assert "FIX_TEST" in prompt
-    assert "FIX_IMPL" in prompt
-    assert "tests_passing_before" in prompt
-    assert "tests_passing_after" in prompt
-    assert "summary_markdown" in prompt
 
 
 def test_build_agent_prompt_includes_pytest_flags() -> None:
     prompt = build_test_agent_prompt("tests/test_x.py::test_y", ("-m", "release"))
     assert "-m release" in prompt
-
-
-def test_build_agent_prompt_requests_markdown() -> None:
-    prompt = build_test_agent_prompt("t::t", ())
-    assert "markdown" in prompt.lower()
-
-
-def test_build_agent_prompt_instructs_one_entry_per_kind() -> None:
-    prompt = build_test_agent_prompt("t::t", ())
-    assert "do not duplicate kinds" in prompt.lower()
 
 
 def test_collect_tests_with_real_pytest(tmp_path: Path, cg: ConcurrencyGroup) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -161,6 +161,19 @@ _EXTRACTED_TEST_OUTPUT_DIR = "test_output"
 _TESTING_OUTCOME_CACHE: dict[AgentName, TestResult] = {}
 _INTEGRATOR_OUTCOME_CACHE: dict[AgentName, IntegratorResult] = {}
 
+
+def reset_outcome_caches() -> None:
+    """Clear the process-global outcome caches.
+
+    These caches key parsed outcomes by ``AgentName`` and ignore
+    ``output_dir`` on a hit (safe in production, where one process maps to a
+    single output_dir). Tests reuse agent names across distinct temp dirs, so
+    they must reset the caches between tests to avoid cross-test contamination.
+    """
+    _TESTING_OUTCOME_CACHE.clear()
+    _INTEGRATOR_OUTCOME_CACHE.clear()
+
+
 _SECTION_ORDER: list[ReportSection] = [
     ReportSection.NON_IMPL_FIXES,
     ReportSection.IMPL_FIXES,

--- a/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
@@ -16,7 +16,6 @@ from imbue.mngr_tmr.report import ReportSection
 from imbue.mngr_tmr.report import TestMapReduceResult
 from imbue.mngr_tmr.report import TestResult
 from imbue.mngr_tmr.report import _merged_status_html
-from imbue.mngr_tmr.report import _render_markdown
 from imbue.mngr_tmr.report import _report_section_of
 from imbue.mngr_tmr.report import generate_html_report
 
@@ -110,66 +109,26 @@ def make_metadata_and_outcome(
     return metadata
 
 
-# --- enum + dataclass smoke tests ---
+# --- outcome JSON parse-contract tests ---
+#
+# The string values of ChangeKind/ChangeStatus are the JSON wire format that
+# agents write and that _parse_outcome_json reads back. These tests guard the
+# parse-from-string direction production relies on, rather than restating the
+# enum definitions. (ReportSection is purely internal and never serialized, so
+# it has no analogous contract to guard.)
 
 
-def test_change_kind_values() -> None:
-    assert ChangeKind.IMPROVE_TEST == "IMPROVE_TEST"
-    assert ChangeKind.FIX_TEST == "FIX_TEST"
-    assert ChangeKind.FIX_IMPL == "FIX_IMPL"
-    assert ChangeKind.FIX_TUTORIAL == "FIX_TUTORIAL"
+def test_change_kind_parses_wire_strings() -> None:
+    assert ChangeKind("IMPROVE_TEST") is ChangeKind.IMPROVE_TEST
+    assert ChangeKind("FIX_TEST") is ChangeKind.FIX_TEST
+    assert ChangeKind("FIX_IMPL") is ChangeKind.FIX_IMPL
+    assert ChangeKind("FIX_TUTORIAL") is ChangeKind.FIX_TUTORIAL
 
 
-def test_change_status_values() -> None:
-    assert ChangeStatus.SUCCEEDED == "SUCCEEDED"
-    assert ChangeStatus.FAILED == "FAILED"
-    assert ChangeStatus.BLOCKED == "BLOCKED"
-
-
-def test_report_section_values() -> None:
-    assert ReportSection.NON_IMPL_FIXES == "NON_IMPL_FIXES"
-    assert ReportSection.IMPL_FIXES == "IMPL_FIXES"
-    assert ReportSection.BLOCKED == "BLOCKED"
-    assert ReportSection.CLEAN_PASS == "CLEAN_PASS"
-    assert ReportSection.RUNNING == "RUNNING"
-
-
-def test_test_result_empty() -> None:
-    result = TestResult(tests_passing_before=True, tests_passing_after=True, summary_markdown="All good")
-    assert result.changes == {}
-    assert result.errored is False
-
-
-def test_test_result_with_changes() -> None:
-    changes = {
-        ChangeKind.FIX_TEST: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="Fixed"),
-        ChangeKind.IMPROVE_TEST: Change(status=ChangeStatus.BLOCKED, summary_markdown="Needs work"),
-    }
-    result = TestResult(changes=changes, tests_passing_before=False, tests_passing_after=True)
-    assert len(result.changes) == 2
-
-
-def test_test_map_reduce_result_with_branch() -> None:
-    result = TestMapReduceResult(
-        test_node_id="tests/test_foo.py::test_baz",
-        agent_name=AgentName("tmr-test-baz"),
-        changes={ChangeKind.FIX_IMPL: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="Fixed null check")},
-        tests_passing_before=False,
-        tests_passing_after=True,
-        summary_markdown="Fixed missing null check",
-        branch_name="tmr/20260101000000/test-baz",
-    )
-    assert result.branch_name == "tmr/20260101000000/test-baz"
-
-
-def test_test_map_reduce_result_without_branch() -> None:
-    result = TestMapReduceResult(
-        test_node_id="tests/test_foo.py::test_ok",
-        agent_name=AgentName("tmr-test-ok"),
-        tests_passing_before=True,
-        tests_passing_after=True,
-    )
-    assert result.branch_name is None
+def test_change_status_parses_wire_strings() -> None:
+    assert ChangeStatus("SUCCEEDED") is ChangeStatus.SUCCEEDED
+    assert ChangeStatus("FAILED") is ChangeStatus.FAILED
+    assert ChangeStatus("BLOCKED") is ChangeStatus.BLOCKED
 
 
 # --- report_section_of tests ---
@@ -219,17 +178,9 @@ def test_report_section_blocked_no_changes_tests_failing() -> None:
     assert _report_section_of(make_test_result(before=False, after=False)) == ReportSection.BLOCKED
 
 
-# --- render_markdown tests ---
-
-
-def test_render_markdown_bold() -> None:
-    result = _render_markdown("**bold**")
-    assert "<strong>bold</strong>" in result
-
-
-def test_render_markdown_plain_text() -> None:
-    result = _render_markdown("plain text")
-    assert "plain text" in result
+# Markdown rendering is a thin passthrough to the markdown-it library and is
+# exercised end-to-end by the generate_html_report tests (summaries flow through
+# _render_markdown), so it has no dedicated unit test here.
 
 
 # --- _merged_status tests ---
@@ -256,7 +207,21 @@ def test_merged_status_squashed() -> None:
         changes=SUCCEEDED_FIX,
     )
     integrator = IntegratorResult(squashed_branches=("mngr-tmr/a",))
-    assert "10003" in _merged_status_html(r, integrator)
+    assert "&#10003;" in _merged_status_html(r, integrator)
+
+
+def test_merged_status_impl_priority_without_hash() -> None:
+    """A branch in impl_priority but missing from impl_commit_hashes renders a checkmark."""
+    r = TestMapReduceResult(
+        test_node_id="t::t",
+        agent_name=AgentName("a"),
+        branch_name="mngr-tmr/b",
+        tests_passing_before=False,
+        tests_passing_after=True,
+        changes={ChangeKind.FIX_IMPL: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="fixed")},
+    )
+    integrator = IntegratorResult(impl_priority=("mngr-tmr/b",))
+    assert _merged_status_html(r, integrator) == "&#10003;"
 
 
 def test_merged_status_impl_priority() -> None:
@@ -284,7 +249,7 @@ def test_merged_status_failed() -> None:
         changes=SUCCEEDED_FIX,
     )
     integrator = IntegratorResult(failed=("mngr-tmr/c",))
-    assert "10007" in _merged_status_html(r, integrator)
+    assert "&#10007;" in _merged_status_html(r, integrator)
 
 
 def test_merged_status_not_in_integrator() -> None:
@@ -411,19 +376,34 @@ def test_generate_html_report_with_integrator(tmp_path: Path) -> None:
 
 def test_generate_html_report_integrator_with_failures(tmp_path: Path) -> None:
     output_dir = tmp_path / "out"
-    agents = [make_metadata_and_outcome(output_dir, "a", tests_passing_before=True, tests_passing_after=True)]
+    # The failed branch must belong to a rendered mapper row for the failure
+    # marker to appear, so give the mapper agent the branch the integrator failed
+    # to merge.
+    agents = [
+        make_metadata_and_outcome(
+            output_dir,
+            "agent-failed-merge",
+            branch_name="mngr-tmr/b",
+            changes=SUCCEEDED_FIX,
+            tests_passing_before=False,
+            tests_passing_after=True,
+        )
+    ]
     integrator_meta = AgentMetadata(
         kind=AgentKind.REDUCER,
-        agent_name=AgentName("tmr-integrator-abc123"),
-        branch_name="mngr-tmr/integrated-abc123",
+        agent_name=AgentName("tmr-integrator-with-failures"),
+        branch_name="mngr-tmr/integrated-with-failures",
     )
     write_integrator_outcome(
         output_dir,
         integrator_meta.agent_name,
-        {"squashed_branches": ["mngr-tmr/a"], "failed": ["mngr-tmr/b"]},
+        {"squashed_branches": [], "failed": ["mngr-tmr/b"]},
     )
     result_path = generate_html_report(agents, output_dir, integrator_metadata=integrator_meta)
-    assert result_path.exists()
+    content = result_path.read_text()
+    assert "Merged?" in content
+    # The failed branch renders the X marker (&#10007;) in its merged-status cell.
+    assert "&#10007;" in content
 
 
 def test_generate_html_report_without_integrator(tmp_path: Path) -> None:


### PR DESCRIPTION
Addresses the bad-tests review findings for `libs/mngr_tmr` (report in `libs/mngr_tmr/_tasks/bad-tests/2026-06-04-10-27-38.md`).

## Changes

**Production / fixture (finding 1 — order-dependent isolation bug):**
- `report.py`'s process-global outcome caches are keyed only by `AgentName` and ignore `output_dir` on a hit. Tests reusing an agent name across distinct temp dirs could read each other's cached outcomes order-dependently. Added `reset_outcome_caches()` and an autouse fixture in `conftest.py` clearing the caches before/after each test.

**Test quality (findings 2-8):**
- Deleted tautological model-construction tests and markdown-passthrough tests (exercised only pydantic / markdown-it).
- Replaced enum-value smoke tests with parse-contract tests on the JSON wire format; dropped the internal-only `ReportSection` one.
- Rewrote `test_generate_html_report_integrator_with_failures` to assert the rendered failure marker (and use a unique agent name) instead of only `result_path.exists()`.
- Tightened `_merged_status_html` tests to assert full HTML entities (`&#10003;` / `&#10007;`) and added the impl-priority-without-hash branch case.
- Trimmed prompt and CLI help-text tests to the interpolated/wiring facts this plugin owns rather than template prose or framework-owned options.

## Testing

`just test-quick "libs/mngr_tmr -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'"` — 105 passed, 0 failed (ratchets: 55 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)