### PR TITLE
skitwright: strengthen tests from bad-tests review

### DIFF
--- a/libs/skitwright/changelog/mngr-bad-tests-skitwright-local.md
+++ b/libs/skitwright/changelog/mngr-bad-tests-skitwright-local.md
@@ -1,0 +1,6 @@
+Strengthened the skitwright test suite after a bad-tests review: added unit tests that
+verify the runner keeps real subprocess stdout/stderr separate and records both streams
+in `output_lines`, and that `Session` honors its `cwd`, `env`, and `comment` arguments
+(previously passed but never asserted to take effect). Removed a tautological exit-code
+assertion, made `expect()` dispatch tests assert the returned expectation type, and gave
+the timeout test a unique sleep duration.

--- a/libs/skitwright/imbue/skitwright/expect_test.py
+++ b/libs/skitwright/imbue/skitwright/expect_test.py
@@ -1,6 +1,8 @@
 import pytest
 
 from imbue.skitwright.data_types import CommandResult
+from imbue.skitwright.expect import ResultExpectation
+from imbue.skitwright.expect import StringExpectation
 from imbue.skitwright.expect import expect
 
 
@@ -13,6 +15,10 @@ def _fail(exit_code: int = 1, stdout: str = "", stderr: str = "") -> CommandResu
 
 
 # --- ResultExpectation ---
+
+# For these assertion helpers, "does not raise on a passing input" IS the behavior under
+# test, so the pass-path tests below intentionally have no explicit assertion. Each is
+# paired with a *_fails_* test that verifies the raising branch and its message.
 
 
 def test_to_succeed_passes_on_zero_exit() -> None:
@@ -111,13 +117,11 @@ def test_to_be_empty_fails_on_nonempty() -> None:
 
 
 def test_expect_dispatches_to_result_expectation() -> None:
-    expectation = expect(_ok())
-    expectation.to_succeed()
+    assert isinstance(expect(_ok()), ResultExpectation)
 
 
 def test_expect_dispatches_to_string_expectation() -> None:
-    expectation = expect("hello")
-    expectation.to_contain("hello")
+    assert isinstance(expect("hello"), StringExpectation)
 
 
 def test_expect_raises_on_unsupported_type() -> None:

--- a/libs/skitwright/imbue/skitwright/session_test.py
+++ b/libs/skitwright/imbue/skitwright/session_test.py
@@ -1,5 +1,9 @@
+import os
 from pathlib import Path
+from uuid import uuid4
 
+from imbue.skitwright.data_types import OutputLine
+from imbue.skitwright.data_types import OutputSource
 from imbue.skitwright.session import Session
 
 
@@ -14,13 +18,56 @@ def test_session_run_captures_exit_code(tmp_path: Path) -> None:
     session = Session(cwd=tmp_path)
     result = session.run("exit 42")
     assert result.exit_code == 42
-    assert result.exit_code != 0
 
 
 def test_session_run_captures_stderr(tmp_path: Path) -> None:
     session = Session(cwd=tmp_path)
     result = session.run("echo err >&2")
     assert "err" in result.stderr
+
+
+def test_session_run_separates_and_records_both_stdout_and_stderr(tmp_path: Path) -> None:
+    session = Session(cwd=tmp_path)
+
+    result = session.run("printf 'out1\\nout2\\n'; printf 'err1\\n' >&2")
+
+    # The runner must keep the two streams separate when reconstructing them.
+    assert result.stdout == "out1\nout2\n"
+    assert result.stderr == "err1\n"
+    # Every produced line must be recorded in output_lines tagged with its real source.
+    # The cross-stream ordering depends on the OS scheduler, so assert on contents, not order.
+    assert OutputLine(source=OutputSource.STDOUT, text="out1") in result.output_lines
+    assert OutputLine(source=OutputSource.STDOUT, text="out2") in result.output_lines
+    assert OutputLine(source=OutputSource.STDERR, text="err1") in result.output_lines
+    assert len(result.output_lines) == 3
+
+
+def test_session_run_honors_cwd(tmp_path: Path) -> None:
+    session = Session(cwd=tmp_path)
+
+    result = session.run("pwd")
+
+    # resolve() tolerates the macOS /private symlink in front of temp dirs.
+    assert Path(result.stdout.strip()).resolve() == tmp_path.resolve()
+
+
+def test_session_run_honors_env(tmp_path: Path) -> None:
+    env_var_name = f"SKITWRIGHT_TEST_VAR_{uuid4().hex}"
+    env_var_value = uuid4().hex
+    session = Session(env={**os.environ, env_var_name: env_var_value}, cwd=tmp_path)
+
+    result = session.run(f"echo ${env_var_name}")
+
+    assert result.stdout.strip() == env_var_value
+
+
+def test_session_run_records_comment_in_transcript(tmp_path: Path) -> None:
+    session = Session(cwd=tmp_path)
+    comment = f"setup step {uuid4().hex}"
+
+    session.run("echo hi", comment=comment)
+
+    assert f"# {comment}" in session.transcript
 
 
 def test_session_transcript_records_all_commands(tmp_path: Path) -> None:
@@ -36,6 +83,6 @@ def test_session_transcript_records_all_commands(tmp_path: Path) -> None:
 
 def test_session_run_timeout(tmp_path: Path) -> None:
     session = Session(cwd=tmp_path)
-    result = session.run("sleep 60", timeout=0.1)
+    result = session.run("sleep 38217", timeout=0.1)
     assert result.exit_code == 124
     assert "timed out" in result.stderr


### PR DESCRIPTION
Ran `/identify-bad-tests libs/skitwright` and fixed the actionable findings.

## Changes
- **Runner stream separation/recording (new test):** add `test_session_run_separates_and_records_both_stdout_and_stderr`. The threaded interleaving in `runner.py` (the riskiest code) was only exercised with hand-built `OutputLine` tuples in `transcript_test`; now a real subprocess emitting to both streams verifies `stdout`/`stderr` separation and the `output_lines` contents.
- **Session cwd/env/comment (new tests):** every prior `session_test` passed `cwd=tmp_path` but nothing depended on it taking effect, and `env`/`comment` were untested. Added `test_session_run_honors_cwd`, `test_session_run_honors_env`, and `test_session_run_records_comment_in_transcript`.
- **Tautological assertion removed:** dropped the redundant `result.exit_code != 0` in `test_session_run_captures_exit_code` (the `== 42` check fully covers it).
- **expect() dispatch tests:** now assert `isinstance(...)` on the returned expectation instead of indirectly relying on an `AttributeError`.
- **Unique constant:** timeout test uses `sleep 38217` instead of `sleep 60` per the test-quality convention.
- Added a clarifying comment explaining why the `expect()` pass-path tests intentionally have no explicit assertion.

Local run: `just test-quick "libs/skitwright -m 'not acceptance and not release'"` -> 96 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)