### PR TITLE
mngr_tutor: fix low-quality tests found by identify-bad-tests

### DIFF
--- a/libs/mngr_tutor/changelog/mngr-bad-tests-mngr-tutor-local.md
+++ b/libs/mngr_tutor/changelog/mngr-bad-tests-mngr-tutor-local.md
@@ -1,0 +1,9 @@
+Strengthened the mngr-tutor test suite. Replaced tautological constructor tests in
+`data_types_test.py` with discriminated-union serialization round-trip tests; made the
+tutor CLI test assert the lesson selector is invoked with `ALL_LESSONS` rather than only
+checking the exit code; replaced weak `len(...) > 0` lesson assertions with structural
+invariants (create-first/destroy-last, consistent agent name per lesson); and tightened
+the TUI tests to assert the check alarm is scheduled at the correct interval with the
+correct callback and that the refreshed frame body actually contains the current step.
+Added integration tests (`test_checks.py`) covering the positive branches of every step
+check against a real agent.

--- a/libs/mngr_tutor/imbue/mngr_tutor/cli_test.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/cli_test.py
@@ -4,32 +4,32 @@ import pluggy
 import pytest
 from click.testing import CliRunner
 
-from imbue.mngr_tutor.cli import TutorCliOptions
 from imbue.mngr_tutor.cli import tutor
+from imbue.mngr_tutor.data_types import Lesson
+from imbue.mngr_tutor.lessons import ALL_LESSONS
 
 
-def test_tutor_cli_options_can_be_instantiated() -> None:
-    opts = TutorCliOptions(
-        output_format="human",
-        quiet=False,
-        verbose=0,
-        log_file=None,
-        log_commands=None,
-        plugin=(),
-        disable_plugin=(),
-    )
-    assert opts.output_format == "human"
-
-
-def test_tutor_command_calls_lesson_selector(
+def test_tutor_command_invokes_lesson_selector_with_all_lessons(
     cli_runner: CliRunner,
     plugin_manager: pluggy.PluginManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The tutor command should call run_lesson_selector."""
-    monkeypatch.setattr(
-        "imbue.mngr_tutor.cli.run_lesson_selector",
-        lambda lessons: None,  # Return None to exit the selector loop
-    )
+    """The tutor command should call run_lesson_selector with ALL_LESSONS.
+
+    run_lesson_selector launches a real urwid TUI, so it is replaced with a recorder
+    that captures its argument and returns None (which exits the selector loop). The
+    assertion checks the lessons actually handed to the selector, so passing the wrong
+    tuple (or dropping the call) would fail -- unlike asserting only the exit code.
+    """
+    received_lessons: list[tuple[Lesson, ...]] = []
+
+    def _record_and_exit(lessons: tuple[Lesson, ...]) -> None:
+        received_lessons.append(lessons)
+        return None
+
+    monkeypatch.setattr("imbue.mngr_tutor.cli.run_lesson_selector", _record_and_exit)
+
     result = cli_runner.invoke(tutor, [], obj=plugin_manager, catch_exceptions=False)
+
     assert result.exit_code == 0
+    assert received_lessons == [ALL_LESSONS]

--- a/libs/mngr_tutor/imbue/mngr_tutor/data_types_test.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/data_types_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentName
 from imbue.mngr_tutor.data_types import AgentExistsCheck
@@ -6,96 +8,95 @@ from imbue.mngr_tutor.data_types import AgentNotExistsCheck
 from imbue.mngr_tutor.data_types import FileExistsInAgentWorkDirCheck
 from imbue.mngr_tutor.data_types import Lesson
 from imbue.mngr_tutor.data_types import LessonStep
+from imbue.mngr_tutor.data_types import StepCheck
 from imbue.mngr_tutor.data_types import TmuxSessionHasClientsCheck
 
-
-def test_agent_exists_check_construction() -> None:
-    check = AgentExistsCheck(agent_name=AgentName("test-agent"))
-    assert check.check_type == "agent_exists"
-    assert check.agent_name == AgentName("test-agent")
-
-
-def test_agent_not_exists_check_construction() -> None:
-    check = AgentNotExistsCheck(agent_name=AgentName("test-agent"))
-    assert check.check_type == "agent_not_exists"
-    assert check.agent_name == AgentName("test-agent")
-
-
-def test_agent_in_state_check_construction() -> None:
-    check = AgentInStateCheck(
-        agent_name=AgentName("test-agent"),
-        expected_states=(AgentLifecycleState.RUNNING,),
-    )
-    assert check.check_type == "agent_in_state"
-    assert check.agent_name == AgentName("test-agent")
-    assert check.expected_states == (AgentLifecycleState.RUNNING,)
-
-
-def test_agent_in_state_check_accepts_multiple_states() -> None:
-    check = AgentInStateCheck(
-        agent_name=AgentName("test-agent"),
+# One instance of every member of the StepCheck union. The check_type literals
+# these carry are the contract the StepCheck Discriminator dispatches on, so the
+# round-trip tests below cover all five branches.
+ALL_CHECKS: tuple[StepCheck, ...] = (
+    AgentExistsCheck(agent_name=AgentName("agent-smith")),
+    AgentNotExistsCheck(agent_name=AgentName("agent-smith")),
+    AgentInStateCheck(
+        agent_name=AgentName("agent-smith"),
         expected_states=(AgentLifecycleState.RUNNING, AgentLifecycleState.WAITING),
+    ),
+    FileExistsInAgentWorkDirCheck(agent_name=AgentName("agent-smith"), file_path="hello.txt"),
+    TmuxSessionHasClientsCheck(agent_name=AgentName("agent-smith")),
+)
+
+
+@pytest.mark.parametrize("check", ALL_CHECKS, ids=lambda c: c.check_type)
+def test_lesson_step_round_trips_through_serialization_preserving_check_subtype(check: StepCheck) -> None:
+    """A LessonStep survives model_dump/model_validate with the StepCheck Discriminator
+    reconstructing the exact check subtype.
+
+    This is the only non-trivial behavior of these models. A wrong or duplicated
+    check_type literal (data_types.py), or a union member dropped from StepCheck, would
+    make the discriminator route to the wrong type (or fail), and this would catch it.
+    """
+    step = LessonStep(heading="Heading", details="Details", check=check)
+
+    reconstructed = LessonStep.model_validate(step.model_dump())
+
+    assert type(reconstructed.check) is type(check)
+    assert reconstructed == step
+
+
+def test_step_check_discriminator_dispatches_on_check_type_from_raw_dict() -> None:
+    """Validating a raw dict (as if loaded from persisted/transmitted data) routes to
+    the subtype named by its check_type field, not whatever was built in Python."""
+    step = LessonStep.model_validate(
+        {
+            "heading": "Stop the agent",
+            "details": "Run mngr stop agent-smith.",
+            "check": {
+                "check_type": "agent_in_state",
+                "agent_name": "agent-smith",
+                "expected_states": ["STOPPED"],
+            },
+        }
     )
-    assert len(check.expected_states) == 2
 
-
-def test_file_exists_check_construction() -> None:
-    check = FileExistsInAgentWorkDirCheck(
-        agent_name=AgentName("test-agent"),
-        file_path="hello.txt",
-    )
-    assert check.check_type == "file_exists_in_work_dir"
-    assert check.agent_name == AgentName("test-agent")
-    assert check.file_path == "hello.txt"
-
-
-def test_tmux_session_has_clients_check_construction() -> None:
-    check = TmuxSessionHasClientsCheck(agent_name=AgentName("test-agent"))
-    assert check.check_type == "tmux_session_has_clients"
-    assert check.agent_name == AgentName("test-agent")
-
-
-def test_lesson_step_with_agent_exists_check() -> None:
-    step = LessonStep(
-        heading="Create an agent",
-        details="Run `mngr create test-agent`.",
-        check=AgentExistsCheck(agent_name=AgentName("test-agent")),
-    )
-    assert step.heading == "Create an agent"
-    assert isinstance(step.check, AgentExistsCheck)
-
-
-def test_lesson_step_with_agent_in_state_check() -> None:
-    step = LessonStep(
-        heading="Stop the agent",
-        details="Run `mngr stop test-agent`.",
-        check=AgentInStateCheck(
-            agent_name=AgentName("test-agent"),
-            expected_states=(AgentLifecycleState.STOPPED,),
-        ),
-    )
     assert isinstance(step.check, AgentInStateCheck)
+    assert step.check.agent_name == AgentName("agent-smith")
     assert step.check.expected_states == (AgentLifecycleState.STOPPED,)
 
 
-def test_lesson_construction() -> None:
-    lesson = Lesson(
-        title="Test Lesson",
-        description="A test lesson.",
-        steps=(
-            LessonStep(
-                heading="Step 1",
-                details="Do step 1.",
-                check=AgentExistsCheck(agent_name=AgentName("agent-1")),
-            ),
-            LessonStep(
-                heading="Step 2",
-                details="Do step 2.",
-                check=AgentNotExistsCheck(agent_name=AgentName("agent-1")),
-            ),
-        ),
+def test_step_check_validation_rejects_unknown_check_type() -> None:
+    """The discriminated union must reject a check_type that is not one of its members,
+    rather than silently constructing some default."""
+    with pytest.raises(ValueError):
+        LessonStep.model_validate(
+            {
+                "heading": "Heading",
+                "details": "Details",
+                "check": {"check_type": "not_a_real_check", "agent_name": "agent-smith"},
+            }
+        )
+
+
+def test_check_type_literals_are_unique_across_the_step_check_union() -> None:
+    """The Discriminator requires distinct check_type values across the union; a
+    copy-paste duplicate would make dispatch ambiguous."""
+    check_types = [check.check_type for check in ALL_CHECKS]
+
+    assert sorted(check_types) == sorted(set(check_types))
+
+
+def test_lesson_construction_preserves_ordered_steps() -> None:
+    """Lesson keeps its steps in the order given (steps are ordered by contract)."""
+    first_step = LessonStep(
+        heading="Step 1",
+        details="Do step 1.",
+        check=AgentExistsCheck(agent_name=AgentName("agent-1")),
     )
-    assert lesson.title == "Test Lesson"
-    assert len(lesson.steps) == 2
-    assert isinstance(lesson.steps[0].check, AgentExistsCheck)
-    assert isinstance(lesson.steps[1].check, AgentNotExistsCheck)
+    second_step = LessonStep(
+        heading="Step 2",
+        details="Do step 2.",
+        check=AgentNotExistsCheck(agent_name=AgentName("agent-1")),
+    )
+
+    lesson = Lesson(title="Test Lesson", description="A test lesson.", steps=(first_step, second_step))
+
+    assert lesson.steps == (first_step, second_step)

--- a/libs/mngr_tutor/imbue/mngr_tutor/lessons_test.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/lessons_test.py
@@ -1,47 +1,48 @@
+import pytest
+
 from imbue.mngr_tutor.data_types import AgentExistsCheck
 from imbue.mngr_tutor.data_types import AgentNotExistsCheck
+from imbue.mngr_tutor.data_types import Lesson
 from imbue.mngr_tutor.lessons import ALL_LESSONS
 from imbue.mngr_tutor.lessons import LESSON_GETTING_STARTED
 from imbue.mngr_tutor.lessons import LESSON_REMOTE_AGENTS
 
 
-def test_all_lessons_tuple_contains_all_defined_lessons() -> None:
-    assert len(ALL_LESSONS) == 2
-    assert ALL_LESSONS[0] is LESSON_GETTING_STARTED
-    assert ALL_LESSONS[1] is LESSON_REMOTE_AGENTS
+def test_all_lessons_tuple_contains_the_defined_lessons_in_order() -> None:
+    assert ALL_LESSONS == (LESSON_GETTING_STARTED, LESSON_REMOTE_AGENTS)
 
 
-def test_getting_started_lesson_has_expected_structure() -> None:
-    assert LESSON_GETTING_STARTED.title == "Basic Local Agent"
-    assert len(LESSON_GETTING_STARTED.steps) == 5
+@pytest.mark.parametrize("lesson", ALL_LESSONS, ids=lambda lesson: lesson.title)
+def test_lesson_has_non_blank_title_description_and_step_text(lesson: Lesson) -> None:
+    """Every lesson and step carries real (non-whitespace) user-facing text.
 
-    # First step creates an agent
-    assert isinstance(LESSON_GETTING_STARTED.steps[0].check, AgentExistsCheck)
-
-    # Last step destroys the agent
-    assert isinstance(LESSON_GETTING_STARTED.steps[4].check, AgentNotExistsCheck)
-
-
-def test_remote_agents_lesson_has_expected_structure() -> None:
-    assert LESSON_REMOTE_AGENTS.title == "Remote Agents on Modal (WIP)"
-    assert len(LESSON_REMOTE_AGENTS.steps) == 5
-
-    # First step creates a remote agent
-    assert isinstance(LESSON_REMOTE_AGENTS.steps[0].check, AgentExistsCheck)
-
-    # Last step destroys the agent
-    assert isinstance(LESSON_REMOTE_AGENTS.steps[4].check, AgentNotExistsCheck)
+    Guards against an authoring slip that leaves a heading/detail blank or whitespace-only,
+    which `len(...) > 0` would miss.
+    """
+    assert lesson.title.strip()
+    assert lesson.description.strip()
+    assert len(lesson.steps) > 0
+    for step in lesson.steps:
+        assert step.heading.strip()
+        assert step.details.strip()
 
 
-def test_all_lessons_have_non_empty_steps() -> None:
-    for lesson in ALL_LESSONS:
-        assert len(lesson.steps) > 0
-        for step in lesson.steps:
-            assert len(step.heading) > 0
-            assert len(step.details) > 0
+@pytest.mark.parametrize("lesson", ALL_LESSONS, ids=lambda lesson: lesson.title)
+def test_lesson_starts_by_creating_and_ends_by_destroying_one_agent(lesson: Lesson) -> None:
+    """Each lesson's narrative arc is create-the-agent first, destroy-it last, and every
+    step in between operates on that same agent.
 
+    This catches a real authoring bug: a step whose check references the wrong agent name
+    (e.g. a copy-paste from the other lesson), which would make the tutor never detect
+    completion of that step.
+    """
+    first_check = lesson.steps[0].check
+    last_check = lesson.steps[-1].check
 
-def test_all_lessons_have_title_and_description() -> None:
-    for lesson in ALL_LESSONS:
-        assert len(lesson.title) > 0
-        assert len(lesson.description) > 0
+    assert isinstance(first_check, AgentExistsCheck)
+    assert isinstance(last_check, AgentNotExistsCheck)
+
+    agent_name = first_check.agent_name
+    assert last_check.agent_name == agent_name
+    for step in lesson.steps:
+        assert step.check.agent_name == agent_name

--- a/libs/mngr_tutor/imbue/mngr_tutor/test_checks.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/test_checks.py
@@ -1,0 +1,156 @@
+"""Integration tests for the tutor step checks against a real created agent.
+
+``checks_test.py`` covers the fast "agent/session not found" branches as unit tests.
+These exercise the *positive* branches -- the substantive logic in ``checks.py`` that
+the unit tests never reach (state matching, work-dir path joining, the tmux
+``list-clients`` parsing) -- which require a real agent and therefore tmux.
+"""
+
+from pathlib import Path
+from uuid import uuid4
+
+import pluggy
+import pytest
+from click.testing import CliRunner
+
+from imbue.mngr.api.list import list_agents
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.interfaces.data_types import AgentDetails
+from imbue.mngr.primitives import AgentLifecycleState
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.utils.testing import create_test_agent_via_cli
+from imbue.mngr.utils.testing import tmux_session_cleanup
+from imbue.mngr_tutor.checks import run_check
+from imbue.mngr_tutor.data_types import AgentExistsCheck
+from imbue.mngr_tutor.data_types import AgentInStateCheck
+from imbue.mngr_tutor.data_types import AgentNotExistsCheck
+from imbue.mngr_tutor.data_types import FileExistsInAgentWorkDirCheck
+from imbue.mngr_tutor.data_types import TmuxSessionHasClientsCheck
+
+
+def _get_agent_details(mngr_ctx: MngrContext, agent_name: AgentName) -> AgentDetails:
+    result = list_agents(mngr_ctx=mngr_ctx, is_streaming=False)
+    for agent in result.agents:
+        if agent.name == agent_name:
+            return agent
+    raise AssertionError(f"Expected agent {agent_name!r} to be listed, found: {[a.name for a in result.agents]}")
+
+
+@pytest.mark.tmux
+def test_agent_exists_checks_reflect_a_real_created_agent(
+    cli_runner: CliRunner,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+    mngr_test_prefix: str,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """AgentExistsCheck is True (and AgentNotExistsCheck False) once the agent really exists.
+
+    The unit tests only cover the missing-agent branch, so a bug that made
+    _check_agent_exists always return False would slip past them but fail here.
+    """
+    agent_name = f"tutor-exists-{uuid4().hex[:8]}"
+    session_name = f"{mngr_test_prefix}{agent_name}"
+
+    with tmux_session_cleanup(session_name):
+        create_test_agent_via_cli(
+            cli_runner, temp_git_repo, mngr_test_prefix, plugin_manager, agent_name, command="sleep 748213"
+        )
+
+        assert run_check(AgentExistsCheck(agent_name=AgentName(agent_name)), temp_mngr_ctx) is True
+        assert run_check(AgentNotExistsCheck(agent_name=AgentName(agent_name)), temp_mngr_ctx) is False
+
+
+@pytest.mark.tmux
+def test_agent_in_state_check_matches_the_agents_actual_state(
+    cli_runner: CliRunner,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+    mngr_test_prefix: str,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """AgentInStateCheck is True only when the agent's real state is in expected_states.
+
+    Covers the `agent.state in expected_states` comparison in _check_agent_in_state,
+    which the unit tests (missing agent -> False) never reach.
+    """
+    agent_name = f"tutor-state-{uuid4().hex[:8]}"
+    session_name = f"{mngr_test_prefix}{agent_name}"
+
+    with tmux_session_cleanup(session_name):
+        create_test_agent_via_cli(
+            cli_runner, temp_git_repo, mngr_test_prefix, plugin_manager, agent_name, command="sleep 837214"
+        )
+
+        actual_state = _get_agent_details(temp_mngr_ctx, AgentName(agent_name)).state
+        non_matching_state = (
+            AgentLifecycleState.STOPPED if actual_state != AgentLifecycleState.STOPPED else AgentLifecycleState.DONE
+        )
+
+        matching_check = AgentInStateCheck(agent_name=AgentName(agent_name), expected_states=(actual_state,))
+        non_matching_check = AgentInStateCheck(agent_name=AgentName(agent_name), expected_states=(non_matching_state,))
+
+        assert run_check(matching_check, temp_mngr_ctx) is True
+        assert run_check(non_matching_check, temp_mngr_ctx) is False
+
+
+@pytest.mark.tmux
+def test_file_exists_in_work_dir_check_detects_files_under_the_agents_work_dir(
+    cli_runner: CliRunner,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+    mngr_test_prefix: str,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """FileExistsInAgentWorkDirCheck resolves the path relative to the agent's work_dir.
+
+    Covers the `(agent.work_dir / file_path).exists()` logic in
+    _check_file_exists_in_work_dir, including the False case for an absent file.
+    """
+    agent_name = f"tutor-file-{uuid4().hex[:8]}"
+    session_name = f"{mngr_test_prefix}{agent_name}"
+
+    with tmux_session_cleanup(session_name):
+        create_test_agent_via_cli(
+            cli_runner, temp_git_repo, mngr_test_prefix, plugin_manager, agent_name, command="sleep 926351"
+        )
+
+        work_dir = _get_agent_details(temp_mngr_ctx, AgentName(agent_name)).work_dir
+        marker_name = f"tutor-marker-{uuid4().hex[:8]}.txt"
+        (work_dir / marker_name).write_text("present")
+
+        present_check = FileExistsInAgentWorkDirCheck(agent_name=AgentName(agent_name), file_path=marker_name)
+        absent_check = FileExistsInAgentWorkDirCheck(
+            agent_name=AgentName(agent_name), file_path=f"absent-{uuid4().hex[:8]}.txt"
+        )
+
+        assert run_check(present_check, temp_mngr_ctx) is True
+        assert run_check(absent_check, temp_mngr_ctx) is False
+
+
+@pytest.mark.tmux
+def test_tmux_session_has_clients_check_is_false_when_session_has_no_attached_client(
+    cli_runner: CliRunner,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+    mngr_test_prefix: str,
+    plugin_manager: pluggy.PluginManager,
+) -> None:
+    """With a live session but no attached client, the check returns False.
+
+    This reaches the `list-clients` succeeds (returncode 0) but empty-output branch of
+    _check_tmux_session_has_clients, distinct from the no-session (returncode != 0) case
+    in checks_test.py. The fully-positive path (a client attached) is not covered here
+    because attaching a real tmux client requires a controlling terminal.
+    """
+    agent_name = f"tutor-clients-{uuid4().hex[:8]}"
+    session_name = f"{mngr_test_prefix}{agent_name}"
+
+    with tmux_session_cleanup(session_name):
+        create_test_agent_via_cli(
+            cli_runner, temp_git_repo, mngr_test_prefix, plugin_manager, agent_name, command="sleep 615238"
+        )
+
+        check = TmuxSessionHasClientsCheck(agent_name=AgentName(agent_name))
+
+        assert run_check(check, temp_mngr_ctx) is False

--- a/libs/mngr_tutor/imbue/mngr_tutor/test_checks.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/test_checks.py
@@ -49,7 +49,7 @@ def test_agent_exists_checks_reflect_a_real_created_agent(
     The unit tests only cover the missing-agent branch, so a bug that made
     _check_agent_exists always return False would slip past them but fail here.
     """
-    agent_name = f"tutor-exists-{uuid4().hex[:8]}"
+    agent_name = f"tutor-exists-{uuid4().hex}"
     session_name = f"{mngr_test_prefix}{agent_name}"
 
     with tmux_session_cleanup(session_name):
@@ -74,7 +74,7 @@ def test_agent_in_state_check_matches_the_agents_actual_state(
     Covers the `agent.state in expected_states` comparison in _check_agent_in_state,
     which the unit tests (missing agent -> False) never reach.
     """
-    agent_name = f"tutor-state-{uuid4().hex[:8]}"
+    agent_name = f"tutor-state-{uuid4().hex}"
     session_name = f"{mngr_test_prefix}{agent_name}"
 
     with tmux_session_cleanup(session_name):
@@ -107,7 +107,7 @@ def test_file_exists_in_work_dir_check_detects_files_under_the_agents_work_dir(
     Covers the `(agent.work_dir / file_path).exists()` logic in
     _check_file_exists_in_work_dir, including the False case for an absent file.
     """
-    agent_name = f"tutor-file-{uuid4().hex[:8]}"
+    agent_name = f"tutor-file-{uuid4().hex}"
     session_name = f"{mngr_test_prefix}{agent_name}"
 
     with tmux_session_cleanup(session_name):
@@ -116,12 +116,12 @@ def test_file_exists_in_work_dir_check_detects_files_under_the_agents_work_dir(
         )
 
         work_dir = _get_agent_details(temp_mngr_ctx, AgentName(agent_name)).work_dir
-        marker_name = f"tutor-marker-{uuid4().hex[:8]}.txt"
+        marker_name = f"tutor-marker-{uuid4().hex}.txt"
         (work_dir / marker_name).write_text("present")
 
         present_check = FileExistsInAgentWorkDirCheck(agent_name=AgentName(agent_name), file_path=marker_name)
         absent_check = FileExistsInAgentWorkDirCheck(
-            agent_name=AgentName(agent_name), file_path=f"absent-{uuid4().hex[:8]}.txt"
+            agent_name=AgentName(agent_name), file_path=f"absent-{uuid4().hex}.txt"
         )
 
         assert run_check(present_check, temp_mngr_ctx) is True
@@ -143,7 +143,7 @@ def test_tmux_session_has_clients_check_is_false_when_session_has_no_attached_cl
     in checks_test.py. The fully-positive path (a client attached) is not covered here
     because attaching a real tmux client requires a controlling terminal.
     """
-    agent_name = f"tutor-clients-{uuid4().hex[:8]}"
+    agent_name = f"tutor-clients-{uuid4().hex}"
     session_name = f"{mngr_test_prefix}{agent_name}"
 
     with tmux_session_cleanup(session_name):

--- a/libs/mngr_tutor/imbue/mngr_tutor/tui_test.py
+++ b/libs/mngr_tutor/imbue/mngr_tutor/tui_test.py
@@ -6,7 +6,9 @@ from typing import Any
 import pytest
 from urwid.event_loop.abstract_loop import ExitMainLoop
 from urwid.widget.attr_map import AttrMap
+from urwid.widget.filler import Filler
 from urwid.widget.listbox import SimpleFocusListWalker
+from urwid.widget.pile import Pile
 from urwid.widget.text import Text
 from urwid.widget.wimp import SelectableIcon
 
@@ -16,6 +18,7 @@ from imbue.mngr_tutor.data_types import AgentExistsCheck
 from imbue.mngr_tutor.data_types import AgentNotExistsCheck
 from imbue.mngr_tutor.data_types import Lesson
 from imbue.mngr_tutor.data_types import LessonStep
+from imbue.mngr_tutor.tui import CHECK_INTERVAL_SECONDS
 from imbue.mngr_tutor.tui import _LessonRunnerInputHandler
 from imbue.mngr_tutor.tui import _LessonRunnerState
 from imbue.mngr_tutor.tui import _LessonSelectorInputHandler
@@ -31,20 +34,40 @@ from imbue.mngr_tutor.tui import _schedule_next_check
 # =============================================================================
 
 
-class _CallTracker:
-    """Lightweight call tracker to replace MagicMock.assert_called patterns."""
+class _AlarmRecorder:
+    """Records every call to a loop's set_alarm_in so tests can assert the exact
+    delay, callback, and arguments an alarm was scheduled with (not just the count)."""
 
     def __init__(self) -> None:
-        self.call_count: int = 0
+        self.calls: list[tuple[object, ...]] = []
 
-    def __call__(self, *args: object, **kwargs: object) -> None:
-        self.call_count += 1
+    def __call__(self, *args: object) -> None:
+        self.calls.append(args)
+
+    @property
+    def call_count(self) -> int:
+        return len(self.calls)
 
 
 def _make_mock_loop() -> Any:
-    """Create a lightweight loop substitute with a trackable set_alarm_in."""
-    tracker = _CallTracker()
-    return SimpleNamespace(set_alarm_in=tracker, _alarm_tracker=tracker)
+    """Create a lightweight loop substitute with a recording set_alarm_in.
+
+    A real urwid MainLoop opens a screen and an event loop, neither of which is
+    needed to test scheduling, so this records the set_alarm_in calls instead.
+    """
+    recorder = _AlarmRecorder()
+    return SimpleNamespace(set_alarm_in=recorder, _alarm_recorder=recorder)
+
+
+def _collect_text(widget: object) -> str:
+    """Recursively join the rendered text of a Text/Pile/Filler widget tree."""
+    if isinstance(widget, Text):
+        return str(widget.get_text()[0])
+    if isinstance(widget, Filler):
+        return _collect_text(widget.original_widget)
+    if isinstance(widget, Pile):
+        return " ".join(_collect_text(child) for child, _ in widget.contents)
+    return ""
 
 
 def _make_step(heading: str = "Step", details: str = "Do something") -> LessonStep:
@@ -75,6 +98,9 @@ def _make_runner_state(
         step_completed = [False] * len(lesson.steps)
     frame = SimpleNamespace(body=None)
     status_text = Text("")
+    # These widget/scheduling tests never read mngr_ctx (the check is only run via
+    # _on_check_alarm, which has its own real-context helper below), so we bypass
+    # validation with model_construct rather than spin up a real MngrContext.
     mngr_ctx = SimpleNamespace()
     return _LessonRunnerState.model_construct(
         lesson=lesson,
@@ -168,10 +194,13 @@ def test_build_step_widgets_all_complete_has_no_details() -> None:
 # =============================================================================
 
 
-def test_refresh_display_sets_frame_body() -> None:
+def test_refresh_display_populates_frame_body_with_current_step_content() -> None:
     state = _make_runner_state()
     _refresh_display(state)
-    assert state.frame.body is not None
+    assert isinstance(state.frame.body, Filler)
+    text_content = _collect_text(state.frame.body)
+    assert "Step 1" in text_content
+    assert "First step" in text_content
 
 
 # =============================================================================
@@ -259,10 +288,11 @@ def test_runner_input_handler_swallows_other_keys() -> None:
 # =============================================================================
 
 
-def test_schedule_next_check_sets_alarm() -> None:
+def test_schedule_next_check_schedules_on_check_alarm_at_the_check_interval() -> None:
     loop = _make_mock_loop()
-    _schedule_next_check(loop, _make_runner_state())
-    assert loop._alarm_tracker.call_count == 1
+    state = _make_runner_state()
+    _schedule_next_check(loop, state)
+    assert loop._alarm_recorder.calls == [(CHECK_INTERVAL_SECONDS, _on_check_alarm, state)]
 
 
 def test_on_check_alarm_all_complete_sets_status() -> None:
@@ -291,7 +321,8 @@ def _make_runner_state_with_ctx(
         step_completed = [False] * len(lesson.steps)
     frame = SimpleNamespace(body=None)
     status_text = Text("")
-    return _LessonRunnerState.model_construct(
+    # A real MngrContext is available here, so use the validating constructor.
+    return _LessonRunnerState(
         lesson=lesson,
         mngr_ctx=mngr_ctx,
         step_completed=step_completed,
@@ -304,7 +335,7 @@ def test_on_check_alarm_step_not_passed_schedules_next(temp_mngr_ctx: MngrContex
     state = _make_runner_state_with_ctx(temp_mngr_ctx, step_completed=[False, False], passing_check=False)
     loop = _make_mock_loop()
     _on_check_alarm(loop, state)
-    assert loop._alarm_tracker.call_count == 1
+    assert loop._alarm_recorder.call_count == 1
     assert state.step_completed[0] is False
 
 
@@ -313,7 +344,7 @@ def test_on_check_alarm_step_passed_advances(temp_mngr_ctx: MngrContext) -> None
     loop = _make_mock_loop()
     _on_check_alarm(loop, state)
     assert state.step_completed[0] is True
-    assert loop._alarm_tracker.call_count == 1
+    assert loop._alarm_recorder.call_count == 1
 
 
 def test_on_check_alarm_last_step_passed_shows_complete(temp_mngr_ctx: MngrContext) -> None:


### PR DESCRIPTION
Fixes the bad tests identified under \`libs/mngr_tutor\` (report in \`libs/mngr_tutor/_tasks/bad-tests/\`).

## What changed

- **checks (#1, most important):** \`checks_test.py\` only ever exercised the agent/session-not-found branches. Added \`test_checks.py\` (tmux-marked integration tests) that create a real agent and verify the positive paths: \`AgentExistsCheck\`/\`AgentNotExistsCheck\`, \`AgentInStateCheck\` state matching, \`FileExistsInAgentWorkDirCheck\` work-dir path joining, and the session-exists-but-no-clients branch of \`TmuxSessionHasClientsCheck\`.
- **cli_test (#2, #3):** the command test now asserts \`run_lesson_selector\` is invoked with \`ALL_LESSONS\` instead of only checking the exit code; dropped the tautological options-instantiation test.
- **data_types_test (#4):** replaced per-field constructor assertions with discriminated-union serialization round-trip tests (the only non-trivial behavior of these models), plus unknown-check-type rejection and discriminator-uniqueness.
- **lessons_test (#7):** replaced \`len(...) > 0\` checks with structural invariants (non-blank text, create-first/destroy-last, consistent agent name within a lesson).
- **tui_test (#5, #6, #8):** the scheduling test now asserts the alarm's interval and callback; the refresh test asserts the frame body actually contains the current step; the with-context helper uses the validating \`_LessonRunnerState\` constructor (and the no-context helper documents why it bypasses validation).

## Testing

- \`just test-quick "libs/mngr_tutor -m 'not tmux and not acceptance and not release'"\`: 101 passed.
- \`uv run pytest libs/mngr_tutor/imbue/mngr_tutor/test_checks.py -p no:xdist -m tmux\`: 4 passed.
- type-error + ratchet tests: 55 passed.

The full offload suite (incl. tmux/acceptance) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)