### PR TITLE
Fix low-quality tests under scripts/

### DIFF
--- a/dev/changelog/mngr-bad-tests-scripts-local.md
+++ b/dev/changelog/mngr-bad-tests-scripts-local.md
@@ -1,0 +1,6 @@
+Improved test quality under `scripts/`:
+
+- Rewrote `scripts/josh/coordinator_test.py`: flattened the `Test*` classes into descriptively-named module-level test functions; replaced tests that no longer exercised production code (a handler test that only ran `echo` via the shell, an "update detection" test that only round-tripped JSON, and an initial-sync test that reimplemented `process_tasks`) with tests that drive the real `ProcessManager.spawn_handler` and `process_tasks` paths; and gave the long-lived handler-termination test a unique sleep duration.
+- `scripts/open_issue.py` now accepts an injectable `open_url` callable instead of the test replacing `webbrowser.open` at runtime; the test asserts the title and body land in the correct URL query parameters (catching a title/body swap or missing encoding).
+- Tightened `scripts/sync_common_ratchets_test.py` to cross-check discovered `test_ratchets.py` files against the independent project discovery instead of asserting hand-guessed `>= N` floors.
+- Documented why `scripts/version_sync_test.py::test_package_graph_matches_pyproject_files` asserts by raising.

--- a/scripts/josh/coordinator_test.py
+++ b/scripts/josh/coordinator_test.py
@@ -1,6 +1,5 @@
 """Tests for the coordinator script."""
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -15,84 +14,79 @@ from scripts.josh.coordinator import process_tasks
 from scripts.josh.coordinator import read_json_file
 from scripts.josh.coordinator import write_json_file
 
-
-class TestNormalizeTaskName:
-    """Tests for task name normalization."""
-
-    def test_already_normalized(self):
-        """Test name that's already in correct format."""
-        assert normalize_task_name("first-task") == "first-task"
-
-    def test_spaces_to_hyphens(self):
-        """Test that spaces are converted to hyphens."""
-        assert normalize_task_name("even easier task") == "even-easier-task"
-
-    def test_long_name_with_spaces(self):
-        """Test normalization of long names with spaces."""
-        assert (
-            normalize_task_name("another task to demonstrate that spaces are ok in task names")
-            == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
-        )
-
-    def test_mixed_case_to_lowercase(self):
-        """Test that mixed case is converted to lowercase."""
-        assert normalize_task_name("a final task I forgot") == "a-final-task-i-forgot"
-        assert normalize_task_name("Task #1!") == "task-1"
-
-    def test_special_characters_to_hyphens(self):
-        """Test that special characters are converted to hyphens."""
-        assert normalize_task_name("task#1!") == "task-1"
-        assert normalize_task_name("my@task$name") == "my-task-name"
-
-    def test_multiple_hyphens_collapsed(self):
-        """Test that multiple consecutive hyphens are collapsed."""
-        assert normalize_task_name("task---with---hyphens") == "task-with-hyphens"
-        assert normalize_task_name("task   with   spaces") == "task-with-spaces"
-
-    def test_leading_trailing_hyphens_stripped(self):
-        """Test that leading/trailing hyphens are removed."""
-        assert normalize_task_name("-task-") == "task"
-        assert normalize_task_name("---task---") == "task"
-
-    def test_empty_name_raises_error(self):
-        """Test that normalizing to empty string raises ValueError."""
-        with pytest.raises(ValueError, match="empty string"):
-            normalize_task_name("!!!")
-        with pytest.raises(ValueError, match="empty string"):
-            normalize_task_name("---")
-        with pytest.raises(ValueError, match="empty string"):
-            normalize_task_name("   ")
+# --- normalize_task_name ---
 
 
-class TestParseSections:
-    """Tests for section parsing."""
+def test_normalize_task_name_passes_through_already_normalized_name() -> None:
+    assert normalize_task_name("first-task") == "first-task"
 
-    def test_single_section(self):
-        """Test parsing a single section."""
-        content = """goal:
+
+def test_normalize_task_name_converts_spaces_to_hyphens() -> None:
+    assert normalize_task_name("even easier task") == "even-easier-task"
+
+
+def test_normalize_task_name_converts_long_name_with_spaces() -> None:
+    assert (
+        normalize_task_name("another task to demonstrate that spaces are ok in task names")
+        == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
+    )
+
+
+def test_normalize_task_name_lowercases_mixed_case() -> None:
+    assert normalize_task_name("a final task I forgot") == "a-final-task-i-forgot"
+    assert normalize_task_name("Task #1!") == "task-1"
+
+
+def test_normalize_task_name_converts_special_characters_to_hyphens() -> None:
+    assert normalize_task_name("task#1!") == "task-1"
+    assert normalize_task_name("my@task$name") == "my-task-name"
+
+
+def test_normalize_task_name_collapses_consecutive_hyphens() -> None:
+    assert normalize_task_name("task---with---hyphens") == "task-with-hyphens"
+    assert normalize_task_name("task   with   spaces") == "task-with-spaces"
+
+
+def test_normalize_task_name_strips_leading_and_trailing_hyphens() -> None:
+    assert normalize_task_name("-task-") == "task"
+    assert normalize_task_name("---task---") == "task"
+
+
+def test_normalize_task_name_raises_when_result_is_empty() -> None:
+    with pytest.raises(ValueError, match="empty string"):
+        normalize_task_name("!!!")
+    with pytest.raises(ValueError, match="empty string"):
+        normalize_task_name("---")
+    with pytest.raises(ValueError, match="empty string"):
+        normalize_task_name("   ")
+
+
+# --- parse_sections ---
+
+
+def test_parse_sections_parses_single_section() -> None:
+    content = """goal:
 demonstrate this format
 
 """
-        sections = parse_sections(content)
-        assert sections == {"goal": "demonstrate this format"}
+    assert parse_sections(content) == {"goal": "demonstrate this format"}
 
-    def test_multiple_sections(self):
-        """Test parsing multiple different sections."""
-        content = """goal:
+
+def test_parse_sections_parses_multiple_sections() -> None:
+    content = """goal:
 first section
 
 reminder:
 second section
 """
-        sections = parse_sections(content)
-        assert sections == {
-            "goal": "first section",
-            "reminder": "second section",
-        }
+    assert parse_sections(content) == {
+        "goal": "first section",
+        "reminder": "second section",
+    }
 
-    def test_multiple_instances_of_same_section(self):
-        """Test that multiple instances of same section are concatenated."""
-        content = """foo:
+
+def test_parse_sections_concatenates_repeated_section_headers() -> None:
+    content = """foo:
 first content
 
 bar:
@@ -101,99 +95,91 @@ middle section
 foo:
 second content
 """
-        sections = parse_sections(content)
-        assert sections == {
-            "foo": "first content\nsecond content",
-            "bar": "middle section",
-        }
+    assert parse_sections(content) == {
+        "foo": "first content\nsecond content",
+        "bar": "middle section",
+    }
 
-    def test_section_with_internal_content(self):
-        """Test section with multi-line content."""
-        content = """reminder:
+
+def test_parse_sections_preserves_multi_line_section_content() -> None:
+    content = """reminder:
 pay attention to all of the instructions!
     there might be details
 and it's important to get everything right
 
 """
-        sections = parse_sections(content)
-        expected = "pay attention to all of the instructions!\n    there might be details\nand it's important to get everything right"
-        assert sections["reminder"] == expected
+    expected = "pay attention to all of the instructions!\n    there might be details\nand it's important to get everything right"
+    assert parse_sections(content)["reminder"] == expected
 
-    def test_empty_content(self):
-        """Test parsing empty file."""
-        sections = parse_sections("")
-        assert sections == {}
 
-    def test_no_sections(self):
-        """Test parsing content with no sections."""
-        content = """just some text
+def test_parse_sections_returns_empty_for_empty_content() -> None:
+    assert parse_sections("") == {}
+
+
+def test_parse_sections_returns_empty_when_no_section_headers() -> None:
+    content = """just some text
 without any sections
 """
-        sections = parse_sections(content)
-        assert sections == {}
+    assert parse_sections(content) == {}
 
-    def test_section_at_end_of_file(self):
-        """Test section that ends at EOF without blank line."""
-        content = """task:
+
+def test_parse_sections_handles_section_ending_at_eof_without_blank_line() -> None:
+    content = """task:
 some task"""
-        sections = parse_sections(content)
-        assert sections == {"task": "some task"}
+    assert parse_sections(content) == {"task": "some task"}
 
 
-class TestParseTasks:
-    """Tests for task extraction from task section."""
+# --- parse_tasks ---
 
-    def test_single_task_with_content(self):
-        """Test parsing a single task with content."""
-        task_content = """first-task
-    do something easy"""
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 1
-        assert tasks[0].name == "first-task"
-        assert tasks[0].content == "do something easy"
 
-    def test_task_without_content(self):
-        """Test task with no content lines."""
-        task_content = "even-easier-task-with-no-description"
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 1
-        assert tasks[0].name == "even-easier-task-with-no-description"
-        assert tasks[0].content == ""
+def test_parse_tasks_parses_single_task_with_content() -> None:
+    tasks = parse_tasks("first-task\n    do something easy")
+    assert len(tasks) == 1
+    assert tasks[0].name == "first-task"
+    assert tasks[0].content == "do something easy"
 
-    def test_multiple_tasks(self):
-        """Test parsing multiple tasks."""
-        task_content = """first-task
+
+def test_parse_tasks_parses_task_without_content() -> None:
+    tasks = parse_tasks("even-easier-task-with-no-description")
+    assert len(tasks) == 1
+    assert tasks[0].name == "even-easier-task-with-no-description"
+    assert tasks[0].content == ""
+
+
+def test_parse_tasks_parses_multiple_tasks() -> None:
+    task_content = """first-task
     do something easy
 second-task
     do something else"""
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 2
-        assert tasks[0].name == "first-task"
-        assert tasks[0].content == "do something easy"
-        assert tasks[1].name == "second-task"
-        assert tasks[1].content == "do something else"
+    tasks = parse_tasks(task_content)
+    assert len(tasks) == 2
+    assert tasks[0].name == "first-task"
+    assert tasks[0].content == "do something easy"
+    assert tasks[1].name == "second-task"
+    assert tasks[1].content == "do something else"
 
-    def test_task_with_nested_indentation(self):
-        """Test task with various levels of indentation."""
-        task_content = """another task to demonstrate that spaces are ok in task names
+
+def test_parse_tasks_strips_only_first_four_spaces_of_indentation() -> None:
+    task_content = """another task to demonstrate that spaces are ok in task names
     and obviously
         there can be
             lots of indentation
     but remember to remove only the first 4 spaces"""
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 1
-        assert tasks[0].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
-        expected_content = "and obviously\n    there can be\n        lots of indentation\nbut remember to remove only the first 4 spaces"
-        assert tasks[0].content == expected_content
+    tasks = parse_tasks(task_content)
+    assert len(tasks) == 1
+    assert tasks[0].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
+    expected_content = (
+        "and obviously\n    there can be\n        lots of indentation\nbut remember to remove only the first 4 spaces"
+    )
+    assert tasks[0].content == expected_content
 
-    def test_empty_task_section(self):
-        """Test parsing empty task section."""
-        tasks = parse_tasks("")
-        assert tasks == []
 
-    def test_complete_example_from_spec(self):
-        """Test the complete example from the specification."""
-        task_content = """first-task
+def test_parse_tasks_returns_empty_for_empty_section() -> None:
+    assert parse_tasks("") == []
+
+
+def test_parse_tasks_parses_complete_example_from_spec() -> None:
+    task_content = """first-task
     do something easy
 even-easier-task-with-no-description
 another task to demonstrate that spaces are ok in task names
@@ -204,44 +190,45 @@ another task to demonstrate that spaces are ok in task names
 a-final-task-I-forgot
     with some details
     and text"""
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 4
+    tasks = parse_tasks(task_content)
+    assert len(tasks) == 4
 
-        assert tasks[0].name == "first-task"
-        assert tasks[0].content == "do something easy"
+    assert tasks[0].name == "first-task"
+    assert tasks[0].content == "do something easy"
 
-        assert tasks[1].name == "even-easier-task-with-no-description"
-        assert tasks[1].content == ""
+    assert tasks[1].name == "even-easier-task-with-no-description"
+    assert tasks[1].content == ""
 
-        assert tasks[2].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
-        expected = "and obviously\n    there can be\n        lots of indentation\nbut remember to remove only the first 4 spaces"
-        assert tasks[2].content == expected
+    assert tasks[2].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
+    expected = (
+        "and obviously\n    there can be\n        lots of indentation\nbut remember to remove only the first 4 spaces"
+    )
+    assert tasks[2].content == expected
 
-        assert tasks[3].name == "a-final-task-i-forgot"
-        assert tasks[3].content == "with some details\nand text"
+    assert tasks[3].name == "a-final-task-i-forgot"
+    assert tasks[3].content == "with some details\nand text"
 
-    def test_task_with_invalid_name_skipped(self):
-        """Test that tasks with invalid names are skipped."""
-        task_content = """valid-task
+
+def test_parse_tasks_skips_tasks_with_invalid_names() -> None:
+    task_content = """valid-task
     content here
 !!!
     this should be skipped
 another-valid-task
     more content"""
-        tasks = parse_tasks(task_content)
-        assert len(tasks) == 2
-        assert tasks[0].name == "valid-task"
-        assert tasks[1].name == "another-valid-task"
+    tasks = parse_tasks(task_content)
+    assert len(tasks) == 2
+    assert tasks[0].name == "valid-task"
+    assert tasks[1].name == "another-valid-task"
 
 
-class TestParseTaskFile:
-    """Tests for parsing complete task files."""
+# --- parse_task_file ---
 
-    def test_parse_complete_example(self, tmp_path: Path):
-        """Test parsing the complete example from spec."""
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """goal:
+
+def test_parse_task_file_parses_complete_example_from_spec(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """goal:
 demonstrate this format
 
 reminder:
@@ -267,479 +254,391 @@ a-final-task-I-forgot
     with some details
     and text
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        tasks = parse_task_file(task_file)
-        assert len(tasks) == 4
-        assert tasks[0].name == "first-task"
-        assert tasks[1].name == "even-easier-task-with-no-description"
-        assert tasks[2].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
-        assert tasks[3].name == "a-final-task-i-forgot"
-
-
-class TestTask:
-    """Tests for Task class."""
-
-    def test_to_dict(self):
-        """Test conversion to dictionary with sorted keys."""
-        task = Task(name="test-task", content="test content")
-        task_dict = task.to_dict()
-        assert task_dict == {"content": "test content", "name": "test-task"}
-        # Verify keys are in sorted order
-        assert list(task_dict.keys()) == ["content", "name"]
-
-    def test_equality(self):
-        """Test task equality."""
-        task1 = Task(name="task", content="content")
-        task2 = Task(name="task", content="content")
-        task3 = Task(name="task", content="different")
-        task4 = Task(name="different", content="content")
-
-        assert task1 == task2
-        assert task1 != task3
-        assert task1 != task4
-        assert task1 != "not a task"
+    tasks = parse_task_file(task_file)
+    assert len(tasks) == 4
+    assert tasks[0].name == "first-task"
+    assert tasks[1].name == "even-easier-task-with-no-description"
+    assert tasks[2].name == "another-task-to-demonstrate-that-spaces-are-ok-in-task-names"
+    assert tasks[3].name == "a-final-task-i-forgot"
 
 
-class TestJSONOperations:
-    """Tests for JSON file operations."""
-
-    def test_write_and_read_json(self, tmp_path: Path):
-        """Test writing and reading JSON files."""
-        json_file = tmp_path / "test.json"
-        data = {"content": "test content", "name": "test-task"}
-
-        write_json_file(json_file, data)
-        assert json_file.exists()
-
-        read_data = read_json_file(json_file)
-        assert read_data == data
-
-    def test_json_format(self, tmp_path: Path):
-        """Test that JSON is formatted correctly."""
-        json_file = tmp_path / "test.json"
-        data = {"content": "test", "name": "task"}
-
-        write_json_file(json_file, data)
-
-        content = json_file.read_text(encoding="utf-8")
-        # Should have 2-space indentation and sorted keys
-        expected = '{\n  "content": "test",\n  "name": "task"\n}\n'
-        assert content == expected
-
-    def test_read_nonexistent_file(self, tmp_path: Path):
-        """Test reading file that doesn't exist."""
-        json_file = tmp_path / "nonexistent.json"
-        result = read_json_file(json_file)
-        assert result is None
-
-    def test_read_malformed_json(self, tmp_path: Path):
-        """Test reading malformed JSON file."""
-        json_file = tmp_path / "malformed.json"
-        json_file.write_text("not valid json", encoding="utf-8")
-
-        result = read_json_file(json_file)
-        assert result is None
+# --- Task ---
 
 
-class TestIntegration:
-    """Integration tests for the coordinator script."""
+def test_task_to_dict_sorts_keys() -> None:
+    task = Task(name="test-task", content="test content")
+    task_dict = task.to_dict()
+    assert task_dict == {"content": "test content", "name": "test-task"}
+    assert list(task_dict.keys()) == ["content", "name"]
 
-    def test_initial_sync_creates_json_files(self, tmp_path: Path):
-        """Test that initial sync creates JSON files for tasks."""
-        # Create task file
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_task_equality_compares_name_and_content() -> None:
+    task1 = Task(name="task", content="content")
+    task2 = Task(name="task", content="content")
+    task3 = Task(name="task", content="different")
+    task4 = Task(name="different", content="content")
+
+    assert task1 == task2
+    assert task1 != task3
+    assert task1 != task4
+    assert task1 != "not a task"
+
+
+# --- JSON file operations ---
+
+
+def test_write_json_file_then_read_json_file_round_trips(tmp_path: Path) -> None:
+    json_file = tmp_path / "test.json"
+    data = {"content": "test content", "name": "test-task"}
+
+    write_json_file(json_file, data)
+    assert json_file.exists()
+
+    assert read_json_file(json_file) == data
+
+
+def test_write_json_file_uses_two_space_indent_and_sorted_keys(tmp_path: Path) -> None:
+    json_file = tmp_path / "test.json"
+    write_json_file(json_file, {"content": "test", "name": "task"})
+
+    content = json_file.read_text(encoding="utf-8")
+    expected = '{\n  "content": "test",\n  "name": "task"\n}\n'
+    assert content == expected
+
+
+def test_read_json_file_returns_none_for_nonexistent_file(tmp_path: Path) -> None:
+    assert read_json_file(tmp_path / "nonexistent.json") is None
+
+
+def test_read_json_file_returns_none_for_malformed_json(tmp_path: Path) -> None:
+    json_file = tmp_path / "malformed.json"
+    json_file.write_text("not valid json", encoding="utf-8")
+    assert read_json_file(json_file) is None
+
+
+# --- process_tasks / ProcessManager integration ---
+
+
+def test_process_tasks_initial_sync_creates_json_files_with_content(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content for task one
 task-two
     content for task two
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Create task directory
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
 
-        # Parse and process tasks manually (simulating what coordinator does)
-        tasks = parse_task_file(task_file)
-        for task in tasks:
-            json_path = task_dir / f"{task.name}.json"
-            write_json_file(json_path, task.to_dict())
+    assert task_names == {"task-one", "task-two"}
+    assert read_json_file(task_dir / "task-one.json") == {"content": "content for task one", "name": "task-one"}
+    assert read_json_file(task_dir / "task-two.json") == {"content": "content for task two", "name": "task-two"}
 
-        # Verify JSON files created
-        assert (task_dir / "task-one.json").exists()
-        assert (task_dir / "task-two.json").exists()
 
-        # Verify content
-        task_one_data = read_json_file(task_dir / "task-one.json")
-        assert task_one_data == {"content": "content for task one", "name": "task-one"}
+def test_process_tasks_rewrites_json_when_task_content_changes(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
+    process_manager = ProcessManager("echo {json_file}")
 
-    def test_update_detection(self, tmp_path: Path):
-        """Test that changes to tasks are detected."""
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_file.write_text("task:\nmy-task\n    original content\n", encoding="utf-8")
+    process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    json_path = task_dir / "my-task.json"
+    assert read_json_file(json_path) == {"content": "original content", "name": "my-task"}
 
-        # Create initial JSON file
-        json_path = task_dir / "test-task.json"
-        initial_data = {"content": "initial content", "name": "test-task"}
-        write_json_file(json_path, initial_data)
+    # Re-running with the same content must NOT rewrite the file (no-change branch).
+    mtime_before = json_path.stat().st_mtime_ns
+    process_tasks(task_file, task_dir, process_manager, previous_task_names={"my-task"})
+    assert json_path.stat().st_mtime_ns == mtime_before
 
-        # Verify no update needed for same content
-        existing = read_json_file(json_path)
-        assert existing == initial_data
+    # Changing the task body must rewrite the JSON with the new content.
+    task_file.write_text("task:\nmy-task\n    updated content\n", encoding="utf-8")
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names={"my-task"})
+    assert task_names == {"my-task"}
+    assert read_json_file(json_path) == {"content": "updated content", "name": "my-task"}
 
-        # Update with different content
-        updated_data = {"content": "updated content", "name": "test-task"}
-        write_json_file(json_path, updated_data)
 
-        # Verify update detected
-        existing = read_json_file(json_path)
-        assert existing == updated_data
-        assert existing != initial_data
+def test_spawn_handler_substitutes_json_path_into_handler_command(tmp_path: Path) -> None:
+    """ProcessManager.spawn_handler must format {json_file} with the absolute path and run it."""
+    output_file = tmp_path / "handler_output.txt"
+    json_path = tmp_path / "test.json"
+    json_path.write_text('{"content": "test", "name": "test"}', encoding="utf-8")
 
-    def test_handler_invocation(self, tmp_path: Path):
-        """Test that handler command can be invoked with format string."""
-        # Create output file for handler
-        output_file = tmp_path / "handler_output.txt"
+    process_manager = ProcessManager(f"echo {{json_file}} >> {output_file}")
+    process_manager.spawn_handler("some-task", json_path)
 
-        # Create test JSON file
-        json_file = tmp_path / "test.json"
-        json_file.write_text('{"content": "test", "name": "test"}', encoding="utf-8")
+    # spawn_handler runs the command asynchronously; wait on the tracked process so
+    # the assertion is deterministic rather than racing the handler.
+    handler = process_manager.active_handlers["some-task"]
+    handler.wait(timeout=10)
 
-        # Create handler command that writes to a file
-        handler_command = f'echo "{{json_file}}" >> {output_file}'
-        formatted_command = handler_command.format(json_file=str(json_file))
+    assert output_file.read_text().strip() == str(json_path.absolute())
 
-        # Invoke handler
-        subprocess.run(formatted_command, shell=True, check=True)
 
-        # Verify handler was invoked
-        assert output_file.exists()
-        content = output_file.read_text().strip()
-        assert str(json_file) in content
-
-    def test_task_deletion(self, tmp_path: Path):
-        """Test that removed tasks have their JSON files deleted."""
-        # Create initial task file with two tasks
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+def test_process_tasks_deletes_json_for_removed_task(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content one
 task-two
     content two
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"task-one", "task-two"}
+    assert (task_dir / "task-one.json").exists()
+    assert (task_dir / "task-two.json").exists()
 
-        # Initial sync - should create both tasks
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"task-one", "task-two"}
-        assert (task_dir / "task-one.json").exists()
-        assert (task_dir / "task-two.json").exists()
-
-        # Update file to remove task-two
-        task_file.write_text(
-            """task:
+    task_file.write_text(
+        """task:
 task-one
     content one
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        # Process with previous task names - should delete task-two
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == {"task-one"}
-        assert (task_dir / "task-one.json").exists()
-        assert not (task_dir / "task-two.json").exists()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == {"task-one"}
+    assert (task_dir / "task-one.json").exists()
+    assert not (task_dir / "task-two.json").exists()
 
-    def test_no_deletion_on_initial_sync(self, tmp_path: Path):
-        """Test that existing JSON files are not deleted during initial sync."""
-        # Create task file with one task
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_process_tasks_initial_sync_does_not_delete_orphan_json(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content one
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Create a pre-existing JSON file for a different task
-        orphan_json = task_dir / "old-task.json"
-        write_json_file(orphan_json, {"content": "old content", "name": "old-task"})
+    orphan_json = task_dir / "old-task.json"
+    write_json_file(orphan_json, {"content": "old content", "name": "old-task"})
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Initial sync with previous_task_names=None
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
 
-        # Should create task-one but NOT delete old-task
-        assert task_names == {"task-one"}
-        assert (task_dir / "task-one.json").exists()
-        assert orphan_json.exists()  # Should still exist
+    assert task_names == {"task-one"}
+    assert (task_dir / "task-one.json").exists()
+    assert orphan_json.exists()
 
-    def test_handler_terminated_on_deletion(self, tmp_path: Path):
-        """Test that handlers are terminated when tasks are deleted."""
-        # Create task file
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_process_tasks_terminates_handler_for_removed_task(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 long-running-task
     content
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Create a long-running handler command
-        handler_command = "sleep 100"
-        process_manager = ProcessManager(handler_command)
+    # Unique, long-lived duration so this spawned process can't collide with another
+    # test's handler (per the globally-unique-constant rule) and outlasts the test.
+    process_manager = ProcessManager("sleep 31607")
 
-        # Initial sync
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"long-running-task"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"long-running-task"}
 
-        # Spawn a handler for the task
-        json_path = task_dir / "long-running-task.json"
-        process_manager.spawn_handler("long-running-task", json_path)
+    json_path = task_dir / "long-running-task.json"
+    process_manager.spawn_handler("long-running-task", json_path)
 
-        # Verify handler is running
-        assert "long-running-task" in process_manager.active_handlers
-        handler_process = process_manager.active_handlers["long-running-task"]
-        assert handler_process.poll() is None  # Still running
+    assert "long-running-task" in process_manager.active_handlers
+    handler_process = process_manager.active_handlers["long-running-task"]
+    assert handler_process.poll() is None
 
-        # Update file to remove the task
-        task_file.write_text("", encoding="utf-8")
+    task_file.write_text("", encoding="utf-8")
 
-        # Process with deletion - should terminate handler
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == set()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == set()
 
-        # Handler should be terminated
-        assert "long-running-task" not in process_manager.active_handlers
+    assert "long-running-task" not in process_manager.active_handlers
 
-    def test_markdown_files_moved_on_deletion(self, tmp_path: Path):
-        """Test that markdown files are moved to md_done when tasks are deleted."""
-        # Create initial task file with two tasks
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_process_tasks_moves_markdown_files_for_deleted_task(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content one
 task-two
     content two
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Create md directory with markdown files for both tasks
-        md_dir = tmp_path / "md"
-        md_dir.mkdir()
+    md_dir = tmp_path / "md"
+    md_dir.mkdir()
 
-        # Create markdown files following the pattern <task_name>_*.md
-        md_file_one_a = md_dir / "task-one_notes.md"
-        md_file_one_b = md_dir / "task-one_details.md"
-        md_file_two = md_dir / "task-two_info.md"
+    md_file_one_a = md_dir / "task-one_notes.md"
+    md_file_one_b = md_dir / "task-one_details.md"
+    md_file_two = md_dir / "task-two_info.md"
 
-        md_file_one_a.write_text("Notes for task one", encoding="utf-8")
-        md_file_one_b.write_text("Details for task one", encoding="utf-8")
-        md_file_two.write_text("Info for task two", encoding="utf-8")
+    md_file_one_a.write_text("Notes for task one", encoding="utf-8")
+    md_file_one_b.write_text("Details for task one", encoding="utf-8")
+    md_file_two.write_text("Info for task two", encoding="utf-8")
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Initial sync - should create both tasks
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"task-one", "task-two"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"task-one", "task-two"}
 
-        # Update file to remove task-two
-        task_file.write_text(
-            """task:
+    task_file.write_text(
+        """task:
 task-one
     content one
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        # Process with deletion
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == {"task-one"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == {"task-one"}
 
-        # Verify task-two markdown file was moved to md_done
-        md_done_dir = tmp_path / "md_done"
-        assert md_done_dir.exists()
-        assert not md_file_two.exists()  # Should be moved
-        assert (md_done_dir / "task-two_info.md").exists()  # Should be in md_done
+    md_done_dir = tmp_path / "md_done"
+    assert md_done_dir.exists()
+    assert not md_file_two.exists()
+    assert (md_done_dir / "task-two_info.md").exists()
 
-        # Verify task-one markdown files are still in md (not moved)
-        assert md_file_one_a.exists()
-        assert md_file_one_b.exists()
+    assert md_file_one_a.exists()
+    assert md_file_one_b.exists()
 
-        # Verify content is preserved
-        moved_file = md_done_dir / "task-two_info.md"
-        assert moved_file.read_text(encoding="utf-8") == "Info for task two"
+    moved_file = md_done_dir / "task-two_info.md"
+    assert moved_file.read_text(encoding="utf-8") == "Info for task two"
 
-    def test_markdown_deletion_with_no_md_directory(self, tmp_path: Path):
-        """Test that task deletion works gracefully when md directory doesn't exist."""
-        # Create initial task file
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_process_tasks_deletion_works_without_md_directory(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content one
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Explicitly do NOT create md directory
+    # Explicitly do NOT create the md directory.
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Initial sync
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"task-one"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"task-one"}
 
-        # Update file to remove task-one
-        task_file.write_text("", encoding="utf-8")
+    task_file.write_text("", encoding="utf-8")
 
-        # Process with deletion - should not crash even without md directory
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == set()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == set()
 
-        # Verify JSON was deleted
-        assert not (task_dir / "task-one.json").exists()
+    assert not (task_dir / "task-one.json").exists()
 
-    def test_markdown_deletion_with_no_matching_files(self, tmp_path: Path):
-        """Test task deletion when no matching markdown files exist."""
-        # Create initial task file
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+
+def test_process_tasks_deletion_leaves_unrelated_markdown_untouched(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 task-one
     content one
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Create md directory but no markdown files for task-one
-        md_dir = tmp_path / "md"
-        md_dir.mkdir()
+    md_dir = tmp_path / "md"
+    md_dir.mkdir()
 
-        # Create a markdown file that doesn't match the pattern
-        other_file = md_dir / "other_file.md"
-        other_file.write_text("Some other content", encoding="utf-8")
+    other_file = md_dir / "other_file.md"
+    other_file.write_text("Some other content", encoding="utf-8")
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Initial sync
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"task-one"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"task-one"}
 
-        # Update file to remove task-one
-        task_file.write_text("", encoding="utf-8")
+    task_file.write_text("", encoding="utf-8")
 
-        # Process with deletion
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == set()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == set()
 
-        # Verify JSON was deleted
-        assert not (task_dir / "task-one.json").exists()
+    assert not (task_dir / "task-one.json").exists()
 
-        # Verify md_done was NOT created (no files to move)
-        md_done_dir = tmp_path / "md_done"
-        assert not md_done_dir.exists()
+    md_done_dir = tmp_path / "md_done"
+    assert not md_done_dir.exists()
+    assert other_file.exists()
 
-        # Verify the other file is still there
-        assert other_file.exists()
 
-    def test_multiple_markdown_files_moved(self, tmp_path: Path):
-        """Test that all matching markdown files are moved for a deleted task."""
-        # Create initial task file
-        task_file = tmp_path / "tasks.txt"
-        task_file.write_text(
-            """task:
+def test_process_tasks_moves_all_matching_markdown_files_for_deleted_task(tmp_path: Path) -> None:
+    task_file = tmp_path / "tasks.txt"
+    task_file.write_text(
+        """task:
 complex-task
     content
 """,
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
-        task_dir = tmp_path / "tasks"
-        task_dir.mkdir()
+    task_dir = tmp_path / "tasks"
+    task_dir.mkdir()
 
-        # Create md directory with multiple markdown files for the task
-        md_dir = tmp_path / "md"
-        md_dir.mkdir()
+    md_dir = tmp_path / "md"
+    md_dir.mkdir()
 
-        # Create several markdown files for the same task
-        md_files = [
-            md_dir / "complex-task_notes.md",
-            md_dir / "complex-task_details.md",
-            md_dir / "complex-task_summary.md",
-            md_dir / "complex-task_references.md",
-        ]
+    md_files = [
+        md_dir / "complex-task_notes.md",
+        md_dir / "complex-task_details.md",
+        md_dir / "complex-task_summary.md",
+        md_dir / "complex-task_references.md",
+    ]
 
-        for i, md_file in enumerate(md_files):
-            md_file.write_text(f"Content {i}", encoding="utf-8")
+    for i, md_file in enumerate(md_files):
+        md_file.write_text(f"Content {i}", encoding="utf-8")
 
-        # Create a dummy handler command
-        handler_command = "echo {json_file}"
-        process_manager = ProcessManager(handler_command)
+    process_manager = ProcessManager("echo {json_file}")
 
-        # Initial sync
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
-        assert task_names == {"complex-task"}
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=None)
+    assert task_names == {"complex-task"}
 
-        # Update file to remove the task
-        task_file.write_text("", encoding="utf-8")
+    task_file.write_text("", encoding="utf-8")
 
-        # Process with deletion
-        task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
-        assert task_names == set()
+    task_names = process_tasks(task_file, task_dir, process_manager, previous_task_names=task_names)
+    assert task_names == set()
 
-        # Verify all markdown files were moved
-        md_done_dir = tmp_path / "md_done"
-        assert md_done_dir.exists()
+    md_done_dir = tmp_path / "md_done"
+    assert md_done_dir.exists()
 
-        for md_file in md_files:
-            assert not md_file.exists()  # Should be moved from md
-            moved_file = md_done_dir / md_file.name
-            assert moved_file.exists()  # Should be in md_done
+    for md_file in md_files:
+        assert not md_file.exists()
+        assert (md_done_dir / md_file.name).exists()
 
-        # Verify content is preserved
-        for i, md_file in enumerate(md_files):
-            moved_file = md_done_dir / md_file.name
-            assert moved_file.read_text(encoding="utf-8") == f"Content {i}"
+    for i, md_file in enumerate(md_files):
+        assert (md_done_dir / md_file.name).read_text(encoding="utf-8") == f"Content {i}"

--- a/scripts/open_issue.py
+++ b/scripts/open_issue.py
@@ -10,13 +10,14 @@ for user review before submission.
 
 import argparse
 import webbrowser
+from collections.abc import Callable
 from collections.abc import Sequence
 from pathlib import Path
 
 from imbue.mngr.cli.issue_reporting import build_new_issue_url
 
 
-def main(argv: Sequence[str] | None = None) -> None:
+def main(argv: Sequence[str] | None = None, open_url: Callable[[str], object] = webbrowser.open) -> None:
     parser = argparse.ArgumentParser(description="Open a pre-populated GitHub issue in the browser")
     parser.add_argument("body_file", type=Path, help="Path to a markdown file containing the issue body")
     parser.add_argument("--title", required=True, help="Issue title string")
@@ -26,7 +27,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     body = args.body_file.read_text(encoding="utf-8")
     url = build_new_issue_url(args.title, body)
     print(f"Opening issue in browser: {args.title}")
-    webbrowser.open(url)
+    open_url(url)
 
 
 if __name__ == "__main__":

--- a/scripts/open_issue_test.py
+++ b/scripts/open_issue_test.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from urllib.parse import parse_qs
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -7,25 +9,26 @@ from scripts import open_issue
 
 def test_main_opens_url_with_title_and_body(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """main() builds a GitHub new-issue URL with the title and body file contents and opens it."""
+    """main() builds a GitHub new-issue URL routing the title and body file contents into the
+    correct query parameters, then hands it to the injected opener."""
+    body_text = "## Bug\n\nSomething broke."
     body_file = tmp_path / "body.md"
-    body_file.write_text("## Bug\n\nSomething broke.")
+    body_file.write_text(body_text)
 
     opened: list[str] = []
-    monkeypatch.setattr(open_issue.webbrowser, "open", opened.append)
-
-    open_issue.main(["--title", "Bug: spaces", str(body_file)])
+    open_issue.main(["--title", "Bug: spaces", str(body_file)], open_url=opened.append)
 
     assert len(opened) == 1
     url = opened[0]
-    assert url.startswith("https://github.com/imbue-ai/mngr/issues/new?")
-    # Encoded title and body both appear in the URL.
-    assert "Bug" in url
-    assert "spaces" in url
-    assert "Something" in url
+    split = urlsplit(url)
+    assert f"{split.scheme}://{split.netloc}{split.path}" == "https://github.com/imbue-ai/mngr/issues/new"
+    # The title and the body file's contents must land in their own query params (a
+    # title/body swap or a missing-encoding regression would fail these exact-match checks).
+    query = parse_qs(split.query)
+    assert query["title"] == ["Bug: spaces"]
+    assert query["body"] == [body_text]
 
     out = capsys.readouterr().out
     assert "Bug: spaces" in out

--- a/scripts/sync_common_ratchets_test.py
+++ b/scripts/sync_common_ratchets_test.py
@@ -1,6 +1,8 @@
 import textwrap
 
+from scripts.changelog_projects import pyproject_projects
 from scripts.sync_common_ratchets import EXCLUDED_RATCHET_PROJECTS
+from scripts.sync_common_ratchets import REPO_ROOT
 from scripts.sync_common_ratchets import RatchetTemplate
 from scripts.sync_common_ratchets import _discover_check_functions
 from scripts.sync_common_ratchets import _extract_tests
@@ -9,10 +11,17 @@ from scripts.sync_common_ratchets import _insert_test
 from test_meta_ratchets import _EXCLUDED_PROJECTS
 
 
-def test_find_test_ratchet_files_finds_all_projects() -> None:
-    """Ensure the script discovers test_ratchets.py in every project."""
+def test_find_test_ratchet_files_covers_every_pyproject_project() -> None:
+    """The discovered test_ratchets.py files must correspond exactly to the (non-excluded)
+    pyproject projects, cross-checked against the independent ``pyproject_projects`` discovery.
+
+    This catches a project being added without a ratchet file, or one being dropped, rather than
+    merely asserting a hand-guessed lower bound on the file count.
+    """
     files = _find_test_ratchet_files()
-    assert len(files) >= 20, f"Expected at least 20 files, found {len(files)}"
+    discovered_projects = {f.relative_to(REPO_ROOT).parts[1] for f in files}
+    expected_projects = set(pyproject_projects(REPO_ROOT)) - EXCLUDED_RATCHET_PROJECTS
+    assert discovered_projects == expected_projects
     for f in files:
         assert f.name == "test_ratchets.py"
         assert f.exists()
@@ -130,7 +139,10 @@ def test_discover_check_functions_finds_all() -> None:
     """Verify the script discovers all check functions from standard_ratchet_checks.py."""
     templates = _discover_check_functions()
     names = {t.name for t in templates}
-    assert len(templates) >= 40, f"Expected at least 40 check functions, found {len(templates)}"
+    # Every discovered check must yield a uniquely-named test_prevent_* template under a real
+    # section (_discover_check_functions raises rather than emitting "Unknown").
+    assert templates
+    assert len(names) == len(templates)
     assert "test_prevent_todos" in names
     assert "test_prevent_bare_except" in names
     assert "test_prevent_code_in_init_files" in names
@@ -140,9 +152,10 @@ def test_discover_check_functions_finds_all() -> None:
 
 
 def test_script_reports_all_in_sync() -> None:
-    """Verify the script's discovery and parsing works on the real repo."""
+    """Verify the script's discovery and parsing works on the real repo: every discovered
+    test_ratchets.py must yield at least one extracted test."""
     files = _find_test_ratchet_files()
-    assert len(files) >= 20
+    assert files
     for f in files:
         tests = _extract_tests(f.read_text())
         assert len(tests) > 0, f"{f}: no tests extracted"

--- a/scripts/version_sync_test.py
+++ b/scripts/version_sync_test.py
@@ -9,7 +9,11 @@ from scripts.utils import verify_pin_consistency
 
 
 def test_publish_graph_is_closed() -> None:
-    """No publishable package may have a runtime dependency on an unpublished workspace package."""
+    """No publishable package may have a runtime dependency on an unpublished workspace package.
+
+    validate_package_graph() raises if the publish graph is not closed, so reaching the end without
+    raising is the pass condition; there is nothing else to assert.
+    """
     validate_package_graph()
 
 


### PR DESCRIPTION
Acts on the `identify-bad-tests scripts` findings (report under `scripts/_tasks/bad-tests/`, gitignored).

## Changes
- **`scripts/josh/coordinator_test.py`** (the bulk): flattened the `Test*` classes into descriptively-named module-level `test_` functions (the style guide forbids grouping tests in classes), and replaced three tests that had stopped exercising production code:
  - `test_handler_invocation` only ran `echo` through the shell via `str.format` + `subprocess.run`, never touching `ProcessManager` -> now drives the real `ProcessManager.spawn_handler` and waits on the tracked process.
  - `test_update_detection` only round-tripped JSON (tautological, misnamed) -> now drives `process_tasks` through its real change/no-change branches.
  - `test_initial_sync_creates_json_files` reimplemented `process_tasks` in the test -> now calls `process_tasks` directly.
  - Gave the long-lived handler-termination test a unique `sleep` duration per the globally-unique-constant rule.
- **`scripts/open_issue.py` / `_test.py`**: `main` takes an injectable `open_url` callable instead of the test runtime-patching `webbrowser.open`; the test now asserts the title and body land in the correct URL query params (catches a title/body swap or missing encoding, which the old substring checks did not).
- **`scripts/sync_common_ratchets_test.py`**: cross-checks discovered `test_ratchets.py` files against the independent `pyproject_projects` discovery instead of asserting hand-guessed `>= N` floors.
- **`scripts/version_sync_test.py`**: documented the assert-by-raise contract.

## Testing
`just test-quick "scripts -m 'not acceptance and not release and not modal and not docker and not tmux'"` -> 176 passed, 0 failed. `uv run ty check` on the changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)