### PR TITLE
mngr_ttyd: make plugin tests verify real behavior

### DIFF
--- a/libs/mngr_ttyd/changelog/mngr-bad-tests-mngr-ttyd-local.md
+++ b/libs/mngr_ttyd/changelog/mngr-bad-tests-mngr-ttyd-local.md
@@ -1,0 +1,9 @@
+Strengthened the ttyd plugin test suite. Provisioning tests now run against a shared,
+interface-backed fake host (`FakeTtydHost` in a new `testing.py`) that actually executes
+commands and writes files, so they assert on real effects (the `commands/ttyd/` directory
+is created, `agent.sh` lands on disk and is executable) instead of on recorded command
+strings. The `ttyd_agent.sh` dispatch script is now verified by executing it against a fake
+`tmux` to confirm session routing (named target vs. ambient session), and the embedded ttyd
+and install shell programs are syntax-checked with `bash -n`. Redundant substring-grep
+assertions over the command constants were removed in favor of these behavior tests. No
+user-facing behavior change.

--- a/libs/mngr_ttyd/imbue/mngr_ttyd/plugin_test.py
+++ b/libs/mngr_ttyd/imbue/mngr_ttyd/plugin_test.py
@@ -1,51 +1,30 @@
 """Unit tests for the mngr_ttyd plugin."""
 
+import os
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from typing import cast
+from uuid import uuid4
+
+import pytest
 
 from imbue.mngr.interfaces.host import NamedCommand
 from imbue.mngr_ttyd.plugin import TTYD_COMMAND
 from imbue.mngr_ttyd.plugin import TTYD_INSTALL_COMMAND
-from imbue.mngr_ttyd.plugin import TTYD_SERVICE_NAME
 from imbue.mngr_ttyd.plugin import TTYD_VERSION
 from imbue.mngr_ttyd.plugin import TTYD_WINDOW_NAME
 from imbue.mngr_ttyd.plugin import on_after_provisioning
 from imbue.mngr_ttyd.plugin import override_command_options
+from imbue.mngr_ttyd.testing import FakeTtydHost
 
 
 class _DummyCommandClass:
     pass
 
 
-class _FakeTtydHost:
-    """Fake host for testing on_after_provisioning.
-
-    Tracks executed commands and written files. By default, all commands succeed.
-    Set ttyd_installed=False to simulate ttyd not being installed on the host.
-    """
-
-    def __init__(self, host_dir: Path, *, ttyd_installed: bool = True) -> None:
-        self.host_dir = host_dir
-        self._ttyd_installed = ttyd_installed
-        self.executed_cmds: list[str] = []
-        self.written_files: list[tuple[Path, bytes, str]] = []
-
-    def _execute_command(self, cmd: str, **kwargs: Any) -> SimpleNamespace:
-        self.executed_cmds.append(cmd)
-        if "command -v ttyd" in cmd and not self._ttyd_installed:
-            return SimpleNamespace(returncode=1, success=False, stdout="", stderr="")
-        return SimpleNamespace(returncode=0, success=True, stdout="", stderr="")
-
-    def execute_idempotent_command(self, cmd: str, **kwargs: Any) -> SimpleNamespace:
-        return self._execute_command(cmd, **kwargs)
-
-    def execute_stateful_command(self, cmd: str, **kwargs: Any) -> SimpleNamespace:
-        return self._execute_command(cmd, **kwargs)
-
-    def write_file(self, path: Path, content: bytes, mode: str = "0644") -> None:
-        self.written_files.append((path, content, mode))
+# -- override_command_options tests --
 
 
 def test_adds_ttyd_command_to_create() -> None:
@@ -105,8 +84,16 @@ def test_handles_missing_extra_window_param() -> None:
     assert TTYD_COMMAND in params["extra_window"][0]
 
 
+# -- TTYD_COMMAND / TTYD_INSTALL_COMMAND tests --
+
+
 def test_ttyd_command_is_parseable_as_named_command() -> None:
-    """Verify that the injected command string can be parsed by NamedCommand.from_string."""
+    """The injected command string must round-trip through NamedCommand.from_string.
+
+    This is the real contract: ``override_command_options`` feeds the string into the
+    create flow, which parses it via ``NamedCommand.from_string``. If the window name or
+    quoting were malformed, the whole feature would break here.
+    """
     params: dict[str, Any] = {}
 
     override_command_options(
@@ -120,143 +107,190 @@ def test_ttyd_command_is_parseable_as_named_command() -> None:
     assert str(named_cmd.command) == TTYD_COMMAND
 
 
-def test_ttyd_command_uses_random_port() -> None:
-    """Verify that the ttyd command binds to a random port via -p 0."""
-    assert "ttyd -p 0" in TTYD_COMMAND
+def test_ttyd_command_is_valid_bash_syntax() -> None:
+    """The embedded ttyd shell program must be syntactically valid bash.
+
+    ``bash -n`` parses without executing, catching syntax errors (unbalanced quotes,
+    broken pipelines, etc.) that the substring assertions this replaced could never see.
+    """
+    result = subprocess.run(["bash", "-n", "-c", TTYD_COMMAND], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 
 
-def test_ttyd_command_enables_url_arg_dispatch() -> None:
-    """Verify that the ttyd command uses -a for URL-arg dispatch."""
-    assert "ttyd -p 0 -a" in TTYD_COMMAND
+def test_ttyd_install_command_is_valid_bash_and_pins_version() -> None:
+    """The install command must be valid bash and download the pinned ttyd version.
 
-
-def test_ttyd_command_writes_service_log() -> None:
-    """Verify that the ttyd command writes to services/events.jsonl for forwarding service discovery."""
-    assert "services/events.jsonl" in TTYD_COMMAND
-    assert TTYD_SERVICE_NAME in TTYD_COMMAND
-    assert "MNGR_AGENT_STATE_DIR" in TTYD_COMMAND
-    assert "service_registered" in TTYD_COMMAND
-    assert "timestamp" in TTYD_COMMAND
-    assert "event_id" in TTYD_COMMAND
-
-
-def test_ttyd_command_watches_stderr_for_port() -> None:
-    """Verify that the command parses the port from ttyd's output."""
-    assert "Listening on port:" in TTYD_COMMAND
-
-
-def test_ttyd_command_skips_log_when_no_state_dir() -> None:
-    """Verify that the command gracefully handles MNGR_AGENT_STATE_DIR being unset."""
-    assert 'if [ -n "$MNGR_AGENT_STATE_DIR" ]' in TTYD_COMMAND
-
-
-def test_ttyd_command_dispatches_to_ttyd_scripts() -> None:
-    """Verify that the dispatch script routes to commands/ttyd/<KEY>.sh."""
-    assert "commands/ttyd/$KEY.sh" in TTYD_COMMAND
-
-
-def test_ttyd_command_scans_ttyd_scripts_for_events() -> None:
-    """Verify that the port wrapper scans commands/ttyd/*.sh and writes events for each."""
-    assert 'commands/ttyd/"*.sh' in TTYD_COMMAND
-    assert "basename" in TTYD_COMMAND
-    assert "?arg=$_K" in TTYD_COMMAND
+    ``bash -n`` guards against syntax errors; the version/URL assertion checks that the
+    separate ``TTYD_VERSION`` constant is actually wired into the GitHub release URL (a
+    real cross-constant contract, not a restatement of a single literal).
+    """
+    result = subprocess.run(["bash", "-n", "-c", TTYD_INSTALL_COMMAND], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert f"github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}/" in TTYD_INSTALL_COMMAND
 
 
 # -- on_after_provisioning tests --
 
 
-def test_on_after_provisioning_writes_agent_script(tmp_path: Path) -> None:
-    """Verify that on_after_provisioning writes ttyd/agent.sh to the agent state dir."""
+def _fake_agent(agent_id: str) -> Any:
+    return cast(Any, SimpleNamespace(id=agent_id))
+
+
+def test_on_after_provisioning_writes_executable_agent_script(tmp_path: Path) -> None:
+    """on_after_provisioning writes the packaged ttyd/agent.sh to disk, executable."""
     host_dir = tmp_path / "host"
     host_dir.mkdir()
-    agent_id = "test-agent-123"
+    agent_id = f"agent-{uuid4().hex}"
 
-    host = _FakeTtydHost(host_dir)
+    host = FakeTtydHost(host_dir=host_dir)
 
-    on_after_provisioning(
-        agent=cast(Any, SimpleNamespace(id=agent_id)), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
-    )
+    on_after_provisioning(agent=_fake_agent(agent_id), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace()))
 
-    assert len(host.written_files) == 1
-    script_path, content, mode = host.written_files[0]
-    assert script_path == host_dir / "agents" / agent_id / "commands" / "ttyd" / "agent.sh"
-    assert mode == "0755"
-    assert b"#!/bin/bash" in content
-    assert b"tmux attach" in content
-
-
-def test_agent_script_honors_target_agent_name_arg(tmp_path: Path) -> None:
-    """Verify that the ttyd agent.sh routes to a named agent's tmux session when $1 is set.
-
-    The frontend passes the agent name as a second URL arg (?arg=agent&arg=<name>).
-    The dispatch script must attach to the session "${MNGR_PREFIX}<name>" so that
-    users can deep-link to a sub-agent's terminal rather than always landing on
-    the primary agent's session where ttyd itself runs.
-    """
-    host_dir = tmp_path / "host"
-    host_dir.mkdir()
-    host = _FakeTtydHost(host_dir)
-
-    on_after_provisioning(
-        agent=cast(Any, SimpleNamespace(id="a1")), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
-    )
-
-    _, content, _ = host.written_files[0]
-    script = content.decode()
-    # Honors $1 as target agent name.
-    assert '_TARGET_AGENT="${1:-}"' in script
-    # Uses MNGR_PREFIX when building the session name.
-    assert "MNGR_PREFIX" in script
-    # Falls back to the ambient session when $1 is empty.
-    assert "display-message -p '#{session_name}'" in script
+    script_path = host_dir / "agents" / agent_id / "commands" / "ttyd" / "agent.sh"
+    assert host.written_file_paths == [script_path]
+    assert script_path.is_file()
+    content = script_path.read_text()
+    assert content.startswith("#!/bin/bash")
+    assert "tmux attach" in content
+    # The script must be executable so ttyd can run it directly.
+    assert script_path.stat().st_mode & 0o111
 
 
 def test_on_after_provisioning_creates_ttyd_directory(tmp_path: Path) -> None:
-    """Verify that on_after_provisioning creates the commands/ttyd/ directory."""
+    """on_after_provisioning actually creates the commands/ttyd/ directory on the host."""
     host_dir = tmp_path / "host"
     host_dir.mkdir()
+    agent_id = f"agent-{uuid4().hex}"
 
-    host = _FakeTtydHost(host_dir)
+    host = FakeTtydHost(host_dir=host_dir)
 
-    on_after_provisioning(
-        agent=cast(Any, SimpleNamespace(id="a1")), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
-    )
+    on_after_provisioning(agent=_fake_agent(agent_id), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace()))
 
-    assert any("mkdir -p" in cmd and "commands/ttyd" in cmd for cmd in host.executed_cmds)
+    ttyd_dir = host_dir / "agents" / agent_id / "commands" / "ttyd"
+    assert ttyd_dir.is_dir()
 
 
 def test_on_after_provisioning_installs_ttyd_when_missing(tmp_path: Path) -> None:
-    """Verify that on_after_provisioning downloads ttyd binary when it is not already present."""
+    """When ttyd is absent, provisioning runs the GitHub download install command."""
     host_dir = tmp_path / "host"
     host_dir.mkdir()
 
-    host = _FakeTtydHost(host_dir, ttyd_installed=False)
+    host = FakeTtydHost(host_dir=host_dir, is_ttyd_installed=False)
 
     on_after_provisioning(
-        agent=cast(Any, SimpleNamespace(id="a1")), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
+        agent=_fake_agent(f"agent-{uuid4().hex}"), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
     )
 
-    assert any(cmd == TTYD_INSTALL_COMMAND for cmd in host.executed_cmds)
+    assert TTYD_INSTALL_COMMAND in host.executed_commands
 
 
 def test_on_after_provisioning_skips_install_when_ttyd_present(tmp_path: Path) -> None:
-    """Verify that on_after_provisioning skips ttyd install when it is already present."""
+    """When ttyd is already present, provisioning does not run the install command."""
     host_dir = tmp_path / "host"
     host_dir.mkdir()
 
-    host = _FakeTtydHost(host_dir, ttyd_installed=True)
+    host = FakeTtydHost(host_dir=host_dir, is_ttyd_installed=True)
 
     on_after_provisioning(
-        agent=cast(Any, SimpleNamespace(id="a1")), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
+        agent=_fake_agent(f"agent-{uuid4().hex}"), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace())
     )
 
-    assert not any(cmd == TTYD_INSTALL_COMMAND for cmd in host.executed_cmds)
+    assert TTYD_INSTALL_COMMAND not in host.executed_commands
 
 
-def test_ttyd_install_command_downloads_from_github() -> None:
-    """Verify that the install command downloads the correct ttyd version from GitHub releases."""
-    assert "github.com/tsl0922/ttyd/releases/download" in TTYD_INSTALL_COMMAND
-    assert TTYD_VERSION in TTYD_INSTALL_COMMAND
-    assert "/usr/local/bin/ttyd" in TTYD_INSTALL_COMMAND
-    assert "uname -m" in TTYD_INSTALL_COMMAND
-    assert "chmod +x" in TTYD_INSTALL_COMMAND
+# -- ttyd_agent.sh routing behavior tests --
+#
+# These run the real packaged dispatch script against a fake ``tmux`` placed on PATH,
+# so they verify the script's actual routing behavior (which tmux session it attaches
+# to) rather than grepping the script source for literals.
+
+
+_FAKE_TMUX = """#!/bin/bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_TMUX_LOG"
+if [ "$1" = "display-message" ]; then
+    printf '%s\\n' "$FAKE_AMBIENT_SESSION"
+fi
+exit 0
+"""
+
+
+def _provision_agent_script(host_dir: Path, agent_id: str) -> Path:
+    host = FakeTtydHost(host_dir=host_dir)
+    on_after_provisioning(agent=_fake_agent(agent_id), host=cast(Any, host), mngr_ctx=cast(Any, SimpleNamespace()))
+    return host_dir / "agents" / agent_id / "commands" / "ttyd" / "agent.sh"
+
+
+def _install_fake_tmux(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_tmux = bin_dir / "tmux"
+    fake_tmux.write_text(_FAKE_TMUX)
+    fake_tmux.chmod(0o755)
+    log_path = tmp_path / "tmux.log"
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("FAKE_TMUX_LOG", str(log_path))
+    return log_path
+
+
+def test_agent_script_attaches_to_named_session_when_target_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With a target agent name, the script attaches to "${MNGR_PREFIX}<name>" exactly.
+
+    The frontend deep-links to a sub-agent via ?arg=agent&arg=<name>; the script must
+    build the session name from MNGR_PREFIX and attach with tmux's ``=`` exact-match
+    prefix so it never lands on a prefix-collision sibling.
+    """
+    host_dir = tmp_path / "host"
+    host_dir.mkdir()
+    script_path = _provision_agent_script(host_dir, f"agent-{uuid4().hex}")
+    log_path = _install_fake_tmux(tmp_path, monkeypatch)
+    prefix = f"pfx-{uuid4().hex}-"
+    target = f"sub-{uuid4().hex}"
+    monkeypatch.setenv("MNGR_PREFIX", prefix)
+    monkeypatch.setenv("FAKE_AMBIENT_SESSION", "should-not-be-used")
+
+    result = subprocess.run(["bash", str(script_path), target], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    tmux_calls = log_path.read_text()
+    # Attaches to the named session, not the ambient one, using exact-match "=".
+    assert f"attach -t ={prefix}{target}:0" in tmux_calls
+    assert "display-message" not in tmux_calls
+
+
+def test_agent_script_attaches_to_ambient_session_when_no_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no target argument, the script attaches to the ambient tmux session.
+
+    It must query the current session via ``display-message`` and attach to it, so a
+    bare ?arg=agent link lands on the primary agent's own terminal.
+    """
+    host_dir = tmp_path / "host"
+    host_dir.mkdir()
+    script_path = _provision_agent_script(host_dir, f"agent-{uuid4().hex}")
+    log_path = _install_fake_tmux(tmp_path, monkeypatch)
+    ambient = f"ambient-{uuid4().hex}"
+    monkeypatch.setenv("FAKE_AMBIENT_SESSION", ambient)
+    monkeypatch.delenv("MNGR_PREFIX", raising=False)
+
+    result = subprocess.run(["bash", str(script_path)], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr
+    tmux_calls = log_path.read_text()
+    # Queried the ambient session, then attached to exactly that session name.
+    assert "display-message" in tmux_calls
+    assert f"attach -t ={ambient}:0" in tmux_calls
+
+
+def test_agent_script_is_valid_bash_syntax(tmp_path: Path) -> None:
+    """The packaged ttyd/agent.sh must be syntactically valid bash."""
+    host_dir = tmp_path / "host"
+    host_dir.mkdir()
+    script_path = _provision_agent_script(host_dir, f"agent-{uuid4().hex}")
+
+    result = subprocess.run(["bash", "-n", str(script_path)], capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stderr

--- a/libs/mngr_ttyd/imbue/mngr_ttyd/testing.py
+++ b/libs/mngr_ttyd/imbue/mngr_ttyd/testing.py
@@ -1,0 +1,59 @@
+"""Test utilities for mngr_ttyd: a thin subclass of the shared FakeHost."""
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from pydantic import Field
+
+from imbue.mngr.api.testing import FakeHost as BaseFakeHost
+from imbue.mngr.interfaces.data_types import CommandResult
+from imbue.mngr_ttyd.plugin import TTYD_INSTALL_COMMAND
+
+
+class FakeTtydHost(BaseFakeHost):
+    """OnlineHostInterface fake for mngr_ttyd provisioning tests.
+
+    Inherits the shared FakeHost, which executes commands on the local
+    filesystem and writes real files, so tests can assert on real effects
+    (directories that actually get created, scripts that actually land on disk
+    with the right permissions) rather than on recorded command strings.
+
+    Two operations are intercepted to keep tests deterministic and offline:
+    - the ``command -v ttyd`` presence probe, whose result is driven by
+      ``is_ttyd_installed`` (real execution would reflect whatever happens to
+      be installed on the CI machine),
+    - the ``TTYD_INSTALL_COMMAND`` GitHub download, which returns success
+      without running ``curl`` (real execution would hit the network).
+
+    Every command passed to ``execute_idempotent_command`` is recorded in
+    ``executed_commands`` so tests can assert which provisioning steps ran.
+    """
+
+    is_ttyd_installed: bool = Field(default=True, description="Result the ttyd presence probe should report")
+    executed_commands: list[str] = Field(
+        default_factory=list, description="Commands passed to execute_idempotent_command, in order"
+    )
+    written_file_paths: list[Path] = Field(default_factory=list, description="Paths written via write_file, in order")
+
+    def execute_idempotent_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        self.executed_commands.append(command)
+        if "command -v ttyd" in command:
+            return CommandResult(stdout="", stderr="", success=self.is_ttyd_installed)
+        if command == TTYD_INSTALL_COMMAND:
+            return CommandResult(stdout="", stderr="", success=True)
+        return super().execute_idempotent_command(
+            command, user=user, cwd=cwd, env=env, timeout_seconds=timeout_seconds
+        )
+
+    def write_file(self, path: Path, content: bytes, mode: str | None = None) -> None:
+        self.written_file_paths.append(path)
+        super().write_file(path, content, mode)
+        if mode is not None:
+            path.chmod(int(mode, 8))


### PR DESCRIPTION
## Summary

Ran `/identify-bad-tests libs/mngr_ttyd` and fixed the findings. The mngr_ttyd plugin tests previously verified literal substrings of command constants and recorded-but-never-executed commands, so they could pass on a broken command and were coupled to exact wording.

Changes:
- Add `imbue/mngr_ttyd/testing.py` with `FakeTtydHost`, a thin subclass of the shared `imbue.mngr.api.testing.FakeHost` (real interface, real local execution, real file writes). It intercepts only the non-deterministic `command -v ttyd` probe and the networked GitHub install command.
- Provisioning tests now assert real effects: the `commands/ttyd/` directory is actually created, and `agent.sh` actually lands on disk and is executable.
- Verify `ttyd_agent.sh` routing by executing it against a fake `tmux` on PATH: named-target deep-links attach to `=${MNGR_PREFIX}<name>:0`; a bare invocation attaches to the ambient session.
- `bash -n` syntax-check the embedded ttyd command and the install command (catches syntax errors no grep test could).
- Prune the redundant substring-grep tests over `TTYD_COMMAND` / the install command, keeping `test_ttyd_command_is_parseable_as_named_command` (a genuine external contract).

No user-facing behavior change; test-only.

Full project suite: 69 passed (tests + ratchets + coverage), `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)