### PR TITLE
gitignore *.local.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,8 +238,9 @@
 # Local working / scratch markdown (not committed)
 **/*.local.md
 
-# so the user can make their own notification script
-**/scripts/notify_user.local.sh
+# Local working / scratch shell scripts (not committed)
+# (covers user notification scripts like scripts/notify_user.local.sh, too)
+**/*.local.sh
 
 # Test output files (slow tests, coverage summaries)
 **/.test_output/

--- a/dev/changelog/mngr-review-more-tests.md
+++ b/dev/changelog/mngr-review-more-tests.md
@@ -1,0 +1,1 @@
+Ignore local scratch shell scripts: added a general `**/*.local.sh` rule to `.gitignore` (mirroring the existing `**/*.local.md`), so any `*.local.sh` helper script stays untracked. This subsumes the previous single-file `**/scripts/notify_user.local.sh` entry, which was removed.

--- a/dev/changelog/mngr-review-more-tests.md
+++ b/dev/changelog/mngr-review-more-tests.md
@@ -1,1 +1,0 @@
-Ignore local scratch shell scripts: added a general `**/*.local.sh` rule to `.gitignore` (mirroring the existing `**/*.local.md`), so any `*.local.sh` helper script stays untracked. This subsumes the previous single-file `**/scripts/notify_user.local.sh` entry, which was removed.


### PR DESCRIPTION
Add a general **/*.local.sh ignore rule (parallel to **/*.local.md) so local helper/demo shell scripts stay untracked; remove the now-redundant single-file **/scripts/notify_user.local.sh entry it subsumes.