### PR TITLE
minds deployment_tests: harden suspicious edge-case handling

### DIFF
--- a/apps/minds/changelog/mngr-suspicious-edge-cases-minds-deployment-tests-local.md
+++ b/apps/minds/changelog/mngr-suspicious-edge-cases-minds-deployment-tests-local.md
@@ -1,0 +1,14 @@
+Hardened suspicious edge-case handling in the minds `deployment_tests` helper modules:
+
+- The stale-test-user sweep no longer treats a SuperTokens user with a missing `timeJoined` as
+  infinitely old (which could have authorized deleting a concurrent run's fresh user); unknown
+  age now biases toward skipping.
+- `neon_project_exists` no longer coerces a missing `projects` key to an empty list, so a
+  malformed Neon response surfaces loudly instead of silently reporting "project does not exist".
+- `supertokens_app_exists` no longer infers "app does not exist" from a generic `not found`
+  substring; only the specific SuperTokens error string and 401/404 status codes count as absence.
+- Removed dead `subject`/`created_at` fields and the unused `_parse_iso_timestamp` epoch-fallback
+  helper from the mail.tm client.
+- Documented the remaining intentional edge-case handling (SuperTokens response-shape tolerance,
+  empty mail.tm body fall-through, malformed-message skipping, and the `FctTemplateRef`
+  at-least-one-form invariant) with clarifying comments.

--- a/apps/minds/imbue/minds/deployment_tests/_mailtm.py
+++ b/apps/minds/imbue/minds/deployment_tests/_mailtm.py
@@ -148,6 +148,11 @@ class MailtmInbox(MutableModel):
             )
             response.raise_for_status()
             data = response.json()
+        # ``text``/``html`` may be absent or null on a message; coerce to empty so the
+        # concatenation below is well-typed. An empty body intentionally falls through to the
+        # caller (wait_for_*), whose regex then raises a MailtmFetchError reporting "no
+        # recognizable token/code" -- which is the correct outcome for a body we could not
+        # extract anything useful from.
         text = data.get("text") or ""
         html = data.get("html") or []
         if isinstance(html, list):

--- a/apps/minds/imbue/minds/deployment_tests/_mailtm.py
+++ b/apps/minds/imbue/minds/deployment_tests/_mailtm.py
@@ -128,12 +128,18 @@ class MailtmInbox(MutableModel):
             )
             response.raise_for_status()
             for raw in response.json().get("hydra:member", []):
+                # Skip entries with no id (malformed per mail.tm's schema) or already seen.
+                # Dropping an entry here is harmless: the outer loop keeps polling until the
+                # email arrives or the timeout fires, so a transient bad entry just delays a
+                # match rather than producing a wrong result.
                 message_id = raw.get("id")
                 if not message_id or message_id in self._seen_message_ids:
                     continue
                 to_addresses = tuple(addr.get("address", "") for addr in raw.get("to", []) if addr.get("address"))
                 if str(self.address) not in to_addresses:
                     continue
+                # A missing subject defaults to "" which can never contain the filter substring,
+                # so the message is correctly skipped rather than spuriously matched.
                 subject = raw.get("subject", "")
                 if subject_substring.lower() not in subject.lower():
                     continue

--- a/apps/minds/imbue/minds/deployment_tests/_mailtm.py
+++ b/apps/minds/imbue/minds/deployment_tests/_mailtm.py
@@ -12,12 +12,9 @@ This module is private (``_mailtm``) -- the public entrypoint is the
 
 import re
 import time
-from datetime import datetime
-from datetime import timezone
 from typing import Final
 
 import httpx
-from loguru import logger
 from pydantic import PrivateAttr
 from pydantic import SecretStr
 
@@ -44,8 +41,6 @@ class _MailtmMessage(FrozenModel):
 
     id: NonEmptyStr
     to_addresses: tuple[str, ...]
-    subject: str
-    created_at: datetime
 
 
 class MailtmInbox(MutableModel):
@@ -142,12 +137,7 @@ class MailtmInbox(MutableModel):
                 subject = raw.get("subject", "")
                 if subject_substring.lower() not in subject.lower():
                     continue
-                return _MailtmMessage(
-                    id=NonEmptyStr(message_id),
-                    to_addresses=to_addresses,
-                    subject=subject,
-                    created_at=_parse_iso_timestamp(raw.get("createdAt", "")),
-                )
+                return _MailtmMessage(id=NonEmptyStr(message_id), to_addresses=to_addresses)
         return None
 
     def _fetch_message_body(self, message_id: str) -> str:
@@ -177,14 +167,3 @@ def make_signup_address(account_address: MailtmAddress, suffix: str) -> SignupEm
         raise InvalidMailtmAddressError(f"mail.tm account address {account_address!r} is malformed: missing '@'.")
     local, _, domain = str(account_address).partition("@")
     return SignupEmailAddress(f"{local}+{suffix}@{domain}")
-
-
-def _parse_iso_timestamp(raw: str) -> datetime:
-    """Parse mail.tm's ISO timestamps; falls back to ``epoch`` on unparseable input."""
-    if not raw:
-        return datetime.fromtimestamp(0, tz=timezone.utc)
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
-        logger.warning("Unparseable mail.tm timestamp {!r}; falling back to epoch.", raw)
-        return datetime.fromtimestamp(0, tz=timezone.utc)

--- a/apps/minds/imbue/minds/deployment_tests/data_types.py
+++ b/apps/minds/imbue/minds/deployment_tests/data_types.py
@@ -73,6 +73,10 @@ class FctTemplateRef(FrozenModel):
         """
         if self.worktree_path is not None:
             return str(self.worktree_path)
+        # All three fields are individually optional because this type models two distinct
+        # modes (local worktree vs pushed-branch ref), but the orchestrator always populates
+        # at least one mode -- an invariant the type system cannot express. Assert it here so
+        # an unpopulated ref crashes loudly rather than falling back to a bogus "None#None" arg.
         assert self.test_branch is not None and self.test_remote is not None, (
             "FctTemplateRef has neither a local worktree path nor a pushed branch ref; "
             "the orchestrator should always populate at least one."

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -191,8 +191,13 @@ def sweep_stale_users(
                 user_info = raw_user.get("user", raw_user)
                 emails: list[str] = user_info.get("emails", [])
                 user_id = user_info.get("id") or user_info.get("recipeUserId")
-                time_joined = user_info.get("timeJoined", 0)
-                if not user_id or not emails or time_joined > cutoff_ms:
+                # A missing timeJoined means we cannot establish the user's age, so we must
+                # NOT delete it: the age cutoff exists precisely to avoid deleting a concurrent
+                # run's freshly-created user. Bias an unknown age toward "too new to delete"
+                # (skip) rather than the old ``get(..., 0)`` which treated it as epoch-old and
+                # would have authorized deletion.
+                time_joined = user_info.get("timeJoined")
+                if not user_id or not emails or time_joined is None or time_joined > cutoff_ms:
                     continue
                 if not any(email_pattern.match(email) for email in emails):
                     continue

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -269,7 +269,12 @@ def neon_project_exists(*, name: DevEnvName, org_id: str, api_token: SecretStr) 
         resp = client.get(url, headers=headers)
         resp.raise_for_status()
     payload = resp.json()
-    raw_projects = payload.get("projects", [])
+    # Index ``projects`` directly rather than defaulting to ``[]``: a 200 from Neon's
+    # list-projects endpoint always carries the key (possibly an empty list). Coercing a
+    # missing key to ``[]`` would make this return False, which would silently let the
+    # post-destroy ``not neon_project_exists(...)`` assertion pass even if a project leaked.
+    # A surprising response shape should crash here, not be read as "no projects".
+    raw_projects = payload["projects"]
     matches = [p for p in raw_projects if p.get("name") == project_name]
     return len(matches) > 0
 

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -294,7 +294,11 @@ def supertokens_app_exists(*, name: DevEnvName, core_base_url: str, api_key: Sec
     if resp.status_code == 200:
         return True
     body = resp.text.lower()
-    if resp.status_code in (401, 404) or "app does not exist" in body or "not found" in body:
+    # Only treat 401/404 or the specific SuperTokens "app does not exist" error as absence.
+    # A generic "not found" substring is too broad -- an unrelated 404 (a misrouted proxy
+    # response, an error mentioning some other missing resource) would be misread as "app
+    # absent" and could mask a real state in the deploy/destroy round-trip assertions.
+    if resp.status_code in (401, 404) or "app does not exist" in body:
         return False
     raise MindError(
         f"SuperTokens probe for app {str(name)!r} returned an unexpected response: "

--- a/apps/minds/imbue/minds/deployment_tests/helpers.py
+++ b/apps/minds/imbue/minds/deployment_tests/helpers.py
@@ -188,6 +188,12 @@ def sweep_stale_users(
             resp.raise_for_status()
             data = resp.json()
             for raw_user in data.get("users", []):
+                # SuperTokens' list-users response shape varies across CDI versions: newer cores
+                # wrap each entry as ``{"recipeId": ..., "user": {...}}`` while older ones return
+                # the user dict bare. Accept either. Likewise the user id is ``id`` on the
+                # emailpassword user object but ``recipeUserId`` on some account-linking shapes.
+                # This sweep is best-effort cleanup, so tolerating both shapes is preferable to
+                # crashing the session-autouse fixture on a version we did not anticipate.
                 user_info = raw_user.get("user", raw_user)
                 emails: list[str] = user_info.get("emails", [])
                 user_id = user_info.get("id") or user_info.get("recipeUserId")


### PR DESCRIPTION
Cleanup pass over the minds \`deployment_tests\` helper modules (\`apps/minds/imbue/minds/deployment_tests\`), per the identify-suspicious-edge-cases skill. Each finding is its own commit.

## Fixes (behavior changes)
- **timeJoined default direction** (\`sweep_stale_users\`): a missing \`timeJoined\` was defaulted to \`0\` (epoch-old), which made the user eligible for deletion -- the opposite of the age cutoff's purpose (never delete a concurrent run's fresh user). Unknown age now skips the user.
- **\`neon_project_exists\`**: indexes \`payload["projects"]\` directly instead of \`.get("projects", [])\`, so a malformed Neon 200 crashes loudly rather than silently reading as "no projects" and letting the post-destroy leak assertion pass.
- **\`supertokens_app_exists\`**: dropped the over-broad \`"not found"\` substring; only 401/404 or the specific \`"app does not exist"\` error now count as absence.
- **dead code**: removed unused \`subject\`/\`created_at\` fields and the \`_parse_iso_timestamp\` epoch-fallback helper from the mail.tm client.

## Documentation (correct handlers, now explained)
- SuperTokens list-users response-shape tolerance in the sweep.
- Empty mail.tm body fall-through in \`_fetch_message_body\`.
- Malformed-message skip / subject default in \`_poll_for_new_message\`.
- \`FctTemplateRef\` at-least-one-form invariant behind the runtime assert.

## Verification
The deployment tests themselves are release-marked and require the live orchestrator (Vault + deployed SuperTokens/Neon/mail.tm), so they cannot run locally. Verified via: clean imports, \`ty check\` (passed), minds ratchets (55 passed), and orchestrator conftest collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)