### PR TITLE
Harden suspicious edge-case handling in apps/minds/scripts

### DIFF
--- a/apps/minds/changelog/mngr-suspicious-edge-cases-minds-scripts-local.md
+++ b/apps/minds/changelog/mngr-suspicious-edge-cases-minds-scripts-local.md
@@ -1,0 +1,6 @@
+Hardened suspicious edge-case handling in `apps/minds/scripts/` Python helpers:
+
+- `create_telegram_bot.py`: `_try_latchkey_auth_get` no longer swallows `KeyError` -- a `telegramUser` record from latchkey that is missing `dcId`/`authKeyHex` is now reported as malformed credentials instead of silently falling through to "no credentials found". The `subprocess.run`/`json.loads` try blocks were narrowed to single statements.
+- `create_telegram_bot.py`: `_fetch_telegram_web_api_credentials` drops the redundant `URLError` from its catch (it subclasses `OSError`) and documents that the caught `ValueError`s are the intended "extraction failed, use public defaults" signal.
+- `create_telegram_bot.py`: `create_bot` now raises `BotCreationError` when a successful BotFather response lacks a `t.me/<username>` link, instead of guessing the requested username and reporting it as confirmed.
+- `demo_desktop_client.py`: documented that the empty-listing fallback in `_render_directory_listing` (on `os.listdir` `OSError`) is a deliberate, demo-only degradation.

--- a/apps/minds/scripts/create_telegram_bot.py
+++ b/apps/minds/scripts/create_telegram_bot.py
@@ -100,7 +100,12 @@ def _fetch_telegram_web_api_credentials() -> tuple[int, str]:
 
         raise ValueError("Credential pattern not found in any bundle chunk")
 
-    except (urllib.error.URLError, OSError, ValueError) as exc:
+    except (OSError, ValueError) as exc:
+        # The three `raise ValueError(...)` above are deliberate "extraction failed"
+        # signals, and urlopen network failures arrive as OSError (urllib's URLError
+        # subclasses it, so listing it separately would be redundant). Either way we
+        # fall back to the public Telegram Web app credentials; the stderr warning is
+        # the loud-failure surface so a broken scrape is still noticed.
         sys.stderr.write(
             f"Warning: could not extract api credentials from Telegram Web bundle ({exc}), using known defaults\n"
         )

--- a/apps/minds/scripts/create_telegram_bot.py
+++ b/apps/minds/scripts/create_telegram_bot.py
@@ -299,9 +299,15 @@ def create_bot(bot_display_name: str, bot_username: str) -> tuple[str, str]:
 
             bot_token = token_match.group(1)
 
-            # Extract the actual username from the response
+            # Extract the actual username from the response. A successful BotFather
+            # creation always echoes the new bot as a t.me/<username> link, so its
+            # absence means the response format drifted -- fail loudly (like the other
+            # unexpected-response guards above) rather than reporting the requested
+            # username as if BotFather had confirmed it against this token.
             username_match = re.search(r"t\.me/(\w+)", response_text)
-            actual_username = username_match.group(1) if username_match else bot_username
+            if username_match is None:
+                raise BotCreationError(f"Could not extract bot username from BotFather response:\n{response_text}")
+            actual_username = username_match.group(1)
 
     finally:
         client.disconnect()

--- a/apps/minds/scripts/create_telegram_bot.py
+++ b/apps/minds/scripts/create_telegram_bot.py
@@ -144,19 +144,31 @@ def _try_latchkey_auth_get() -> str | None:
             text=True,
             timeout=10,
         )
-        if result.returncode != 0:
-            return None
-
-        creds = json.loads(result.stdout)
-        if creds.get("objectType") != "telegramUser":
-            return None
-
-        dc_id = creds["dcId"]
-        auth_key_hex = creds["authKeyHex"]
-        sys.stderr.write(f"Read credentials from latchkey (user={creds.get('firstName', '?')}, DC={dc_id})\n")
-        return _auth_key_to_string_session(dc_id, auth_key_hex)
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+    except subprocess.TimeoutExpired:
         return None
+    if result.returncode != 0:
+        return None
+
+    try:
+        creds = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if creds.get("objectType") != "telegramUser":
+        return None
+
+    # A telegramUser record missing these keys is malformed latchkey output, not an
+    # absent credential source. Surface it as our own error instead of swallowing a
+    # KeyError and silently falling through to the next source (which would mislead
+    # the user into thinking they have no stored credentials at all).
+    if "dcId" not in creds or "authKeyHex" not in creds:
+        raise TelegramCredentialError(
+            "latchkey returned a telegramUser record missing 'dcId'/'authKeyHex'; the "
+            "stored credentials are malformed. Re-run 'latchkey auth browser telegram'."
+        )
+    dc_id = creds["dcId"]
+    auth_key_hex = creds["authKeyHex"]
+    sys.stderr.write(f"Read credentials from latchkey (user={creds.get('firstName', '?')}, DC={dc_id})\n")
+    return _auth_key_to_string_session(dc_id, auth_key_hex)
 
 
 def _get_string_session() -> str:

--- a/apps/minds/scripts/demo_desktop_client.py
+++ b/apps/minds/scripts/demo_desktop_client.py
@@ -42,6 +42,10 @@ def _render_directory_listing(dir_path: str, url_path: str) -> HTMLResponse:
     try:
         items = sorted(os.listdir(dir_path))
     except OSError:
+        # os.listdir can still fail on a path the caller already confirmed is a
+        # directory (e.g. permission denied, or a race that removed it). This is a
+        # debugging demo, so degrade to an empty listing rather than crashing the
+        # request handler -- correctness of the listing is not load-bearing here.
         items = []
 
     # Use absolute links -- the desktop client rewrites them transparently


### PR DESCRIPTION
Acts on the `identify-suspicious-edge-cases` findings for `apps/minds/scripts`. Each finding is its own commit.

The JS build tooling (`build.js`, `download-binaries.js`) and bash scripts (`propagate_changes`, etc.) already handle their edge cases well (re-throw with context, `else` branches that `throw`, retry only transient errors). All fixes are in the two standalone Python scripts.

## Changes

1. **`create_telegram_bot.py` — stop swallowing `KeyError` on malformed latchkey creds.** `_try_latchkey_auth_get` wrapped six statements in one `try` and caught `KeyError`, so a `telegramUser` record missing `dcId`/`authKeyHex` was silently treated as "no credentials here" and the resolver fell through to "no credentials found". Narrowed the `try`s to single statements and now raise `TelegramCredentialError` on the malformed record.

2. **`create_telegram_bot.py` — tighten the api-cred scrape catch and document the fallback.** Dropped the redundant `URLError` (subclasses `OSError`) from `_fetch_telegram_web_api_credentials`, and documented that the caught `ValueError`s are the intended "extraction failed → public defaults" control-flow signal (the stderr warning is the loud surface). Fallback kept — it's a defensible strategy.

3. **`create_telegram_bot.py` — raise instead of guessing the bot username.** On a successful BotFather response, `create_bot` fell back to the *requested* `bot_username` when no `t.me/<username>` link was found, reporting it as confirmed. Now raises `BotCreationError`, consistent with the other unexpected-response guards.

4. **`demo_desktop_client.py` — document the deliberate empty-listing degradation.** `_render_directory_listing` catches `OSError` from `os.listdir` and renders an empty listing; added a comment explaining this is intentional, demo-only behavior.

## Testing

These scripts are standalone (not part of the shipped `imbue` package, not imported by package code or any test), so there are no automated tests covering them. Verified: `py_compile`, ruff pre-commit hook, and clean import + CLI wiring (`create_telegram_bot.py --help` renders; `demo_desktop_client.py` imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)