### PR TITLE
Harden suspicious edge-case handling in mngr_antigravity

### DIFF
--- a/libs/mngr_antigravity/changelog/mngr-suspicious-edge-cases-mngr-antigravity-local.md
+++ b/libs/mngr_antigravity/changelog/mngr-suspicious-edge-cases-mngr-antigravity-local.md
@@ -1,0 +1,5 @@
+Hardened suspicious edge-case handling in the antigravity plugin:
+
+- `merge_trusted_workspace` now raises `UserInputError` on a non-list `trustedWorkspaces` value instead of silently coercing it to a fresh single-entry array, so an unknown/hand-edited schema is surfaced rather than overwritten (consistent with the existing shape check used during provisioning).
+- Documented the previously-implicit defaults in the common-transcript converter: a missing tool-result `status` is intentionally treated as success, and non-string `PLANNER_RESPONSE` content degrades to empty text rather than crashing the converter.
+- Documented why the worktree-of-trusted-source check guards against the source path coinciding with the workspace-symlink path.

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
@@ -167,6 +167,15 @@ def merge_trusted_workspace(settings: Mapping[str, Any], workspace_path: str) ->
     the trust list); otherwise returns a fresh dict with the workspace
     appended.
 
+    Raises ``UserInputError`` if ``trustedWorkspaces`` is present but is not a
+    list. A non-list value means an unknown agy schema (or a hand edit), and
+    silently coercing it to a fresh single-entry array -- as this helper used
+    to do -- would destroy whatever was stored there. That is the same
+    refuse-to-overwrite stance ``read_antigravity_settings`` and
+    ``AntigravityAgent._check_existing_trustedworkspaces_shape`` take; keeping
+    it here too means the ``@pure`` helper can't silently lose data even if a
+    future caller forgets the upstream shape check.
+
     The array is preserved exactly as Antigravity writes it -- agy stores
     paths as strings with no further normalization, so the caller is
     responsible for passing the same canonical absolute path that ``agy``
@@ -175,10 +184,13 @@ def merge_trusted_workspace(settings: Mapping[str, Any], workspace_path: str) ->
     matching agy's own behavior.
     """
     existing_raw = settings.get(TRUSTED_WORKSPACES_KEY, [])
-    if isinstance(existing_raw, list):
-        existing: list[Any] = list(existing_raw)
-    else:
-        existing = []
+    if not isinstance(existing_raw, list):
+        raise UserInputError(
+            f"Antigravity settings have a non-list {TRUSTED_WORKSPACES_KEY} value "
+            f"({type(existing_raw).__name__}); refusing to overwrite it. Inspect the "
+            f"file by hand and either fix the value or remove the key, then re-run."
+        )
+    existing: list[Any] = list(existing_raw)
     if workspace_path in existing:
         return None
     merged: dict[str, Any] = dict(settings)

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
@@ -72,13 +72,13 @@ def test_merge_trusted_workspace_returns_none_when_already_trusted() -> None:
     assert merge_trusted_workspace(base, "/work/agent-1") is None
 
 
-def test_merge_trusted_workspace_promotes_non_list_value_to_fresh_array() -> None:
-    """If a future agy version stores a different shape under the key, we don't crash."""
+def test_merge_trusted_workspace_raises_on_non_list_value() -> None:
+    """A non-list value under the key means an unknown schema, so we refuse to overwrite it
+    rather than silently discarding whatever a future agy version stored there."""
     base = {"trustedWorkspaces": "unexpected"}
-    merged = merge_trusted_workspace(base, "/work/agent-1")
-
-    assert merged is not None
-    assert merged["trustedWorkspaces"] == ["/work/agent-1"]
+    with pytest.raises(UserInputError) as excinfo:
+        merge_trusted_workspace(base, "/work/agent-1")
+    assert "trustedWorkspaces" in str(excinfo.value)
 
 
 # =============================================================================

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
@@ -224,6 +224,10 @@ def convert():
                         "source": "antigravity/common_transcript",
                         "role": "assistant",
                         "model": None,
+                        # PLANNER_RESPONSE.content is always a string in agy
+                        # 1.0.0; the isinstance guard defends against a future
+                        # non-string shape by degrading to empty text rather
+                        # than crashing the whole converter on a single event.
                         "text": text if isinstance(text, str) else "",
                         "tool_calls": tool_calls,
                         "stop_reason": None,

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
@@ -242,6 +242,12 @@ def convert():
                 if event_id in existing_ids:
                     continue
                 output = _truncate(raw.get("content", ""), _MAX_OUTPUT_LENGTH)
+                # A CODE_ACTION always carries a `status` in agy 1.0.0 (observed
+                # value: DONE for a successful action); any other value means the
+                # action did not complete cleanly, so is_error is True. The
+                # "DONE" default only applies if the field is entirely absent --
+                # treat that unobserved shape as success rather than flagging an
+                # otherwise-normal result as a scary error in the transcript.
                 new_events.append((timestamp, {
                     "timestamp": timestamp,
                     "type": "tool_result",


### PR DESCRIPTION
Ran `/identify-suspicious-edge-cases` over `libs/mngr_antigravity` and acted on the findings. One real fix plus three clarifying comments (over-reports per the skill), each in its own commit.

## Findings

1. **`merge_trusted_workspace` silently coerced a non-list `trustedWorkspaces` to `[]`** (real fix). It discarded whatever was stored under the key and wrote a fresh single-entry array, contradicting the documented refuse-to-overwrite stance that `_check_existing_trustedworkspaces_shape` already enforces during provisioning. Now raises `UserInputError`; the test that asserted the coercion was updated to assert the raise.
2. **`is_error` status default** in `common_transcript.sh` — documented that a missing `status` field is intentionally treated as success.
3. **Redundant `source != workspace` guard** in `plugin.py` — documented the degenerate coincide case it covers.
4. **Non-string `PLANNER_RESPONSE.content` fallback** — documented it as forward-compat defense.

## Note for reviewer

Finding 1 changed *tested* behavior: the old `test_merge_trusted_workspace_promotes_non_list_value_to_fresh_array` deliberately asserted the silent coercion. I treated that as vestigial because the later-added shape check and its docstring document the team's current stance (surface the schema break rather than overwrite). If the "never crash, just coerce" philosophy is actually preferred for the `@pure` helper, revert the first commit.

## Tests

`just test-quick libs/mngr_antigravity` -> 137 passed, 0 failed. Ratchets: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)