### PR TITLE
Harden suspicious edge-case handling in imbue_common

### DIFF
--- a/libs/imbue_common/changelog/mngr-suspicious-edge-cases-imbue-common-local.md
+++ b/libs/imbue_common/changelog/mngr-suspicious-edge-cases-imbue-common-local.md
@@ -1,5 +1,9 @@
 Hardened suspicious edge-case handling in `imbue_common`:
 
+- Ratchet AST scanning no longer *silently* skips files that fail to parse: it now
+  logs a warning naming the file and the `SyntaxError` (the skip itself is kept so
+  a file using newer-than-runtime syntax can't crash a scan, but it is no longer
+  invisible).
 - JSONL log formatting now distinguishes a missing exception type/value from a
   falsy one (uses `is not None` instead of truthiness), so a custom exception
   whose `__bool__` is falsy no longer drops its `value` from the structured log.

--- a/libs/imbue_common/changelog/mngr-suspicious-edge-cases-imbue-common-local.md
+++ b/libs/imbue_common/changelog/mngr-suspicious-edge-cases-imbue-common-local.md
@@ -1,0 +1,11 @@
+Hardened suspicious edge-case handling in `imbue_common`:
+
+- JSONL log formatting now distinguishes a missing exception type/value from a
+  falsy one (uses `is not None` instead of truthiness), so a custom exception
+  whose `__bool__` is falsy no longer drops its `value` from the structured log.
+- `rotation_lock` now catches the precise `BlockingIOError` (lock contended)
+  rather than a broad `OSError` when probing a non-blocking `flock`, matching the
+  shared pytest lock implementation.
+- Added clarifying comments documenting why several intentionally-defensive
+  fallbacks are safe (git-blame header parsing, log-sink size stat) and removed a
+  redundant `hasattr` guard in the if/elif-chain ratchet helper.

--- a/libs/imbue_common/imbue/imbue_common/logging.py
+++ b/libs/imbue_common/imbue/imbue_common/logging.py
@@ -259,7 +259,11 @@ def rotation_lock(directory: Path) -> Iterator[None]:
         acquire_start = time.monotonic()
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except OSError:
+        except BlockingIOError:
+            # The lock is currently held by another process (EWOULDBLOCK/EAGAIN,
+            # which Python surfaces as BlockingIOError). Fall back to a blocking
+            # acquire. Other OSErrors (bad fd, EINTR) are genuine faults and must
+            # propagate rather than be silently treated as contention.
             logger.warning("Waiting for rotation lock at {}", lock_path)
             fcntl.flock(fd, fcntl.LOCK_EX)
             acquire_elapsed = time.monotonic() - acquire_start

--- a/libs/imbue_common/imbue/imbue_common/logging.py
+++ b/libs/imbue_common/imbue/imbue_common/logging.py
@@ -336,6 +336,11 @@ def make_jsonl_file_sink(
             try:
                 state["size"] = Path(bound_path).stat().st_size
             except OSError:
+                # A logging sink must never raise into the host program. stat
+                # cannot realistically fail right after a successful append-mode
+                # open, but if it does the worst case of defaulting to 0 is a
+                # delayed rotation (the file may grow past max_size before the
+                # next check trips), never lost or corrupted log content.
                 state["size"] = 0
         return state["file"]
 

--- a/libs/imbue_common/imbue/imbue_common/logging.py
+++ b/libs/imbue_common/imbue/imbue_common/logging.py
@@ -218,8 +218,8 @@ def _build_flat_log_dict(
     exc = record["exception"]
     if exc is not None:
         event["exception"] = {
-            "type": exc.type.__name__ if exc.type else None,
-            "value": str(exc.value) if exc.value else None,
+            "type": exc.type.__name__ if exc.type is not None else None,
+            "value": str(exc.value) if exc.value is not None else None,
             "traceback": bool(exc.traceback),
         }
     else:

--- a/libs/imbue_common/imbue/imbue_common/logging.py
+++ b/libs/imbue_common/imbue/imbue_common/logging.py
@@ -352,6 +352,10 @@ def make_jsonl_file_sink(
                 try:
                     actual_size = path.stat().st_size
                 except OSError:
+                    # The file is gone -- another process renamed it away as part of
+                    # its own rotation. Treating size as 0 (< bound_max_size) routes
+                    # us into the "already rotated, reopen our handle" branch below,
+                    # which is exactly the correct response.
                     actual_size = 0
                 if actual_size < bound_max_size:
                     # Already rotated by another process -- reopen our handle

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py
@@ -261,6 +261,12 @@ def _get_file_blame_dates(file_path: Path) -> dict[int, datetime]:
                 try:
                     current_line_number = int(parts[2])
                 except ValueError:
+                    # A non-header line can satisfy the length/prefix heuristic above
+                    # (e.g. a long `summary ...` line) and have a non-numeric third
+                    # token. Nulling current_line_number here is safe because
+                    # --line-porcelain always emits `committer-time` *before* those
+                    # metadata lines within a block, so the timestamp for this block
+                    # has already been recorded against the real (header) line number.
                     current_line_number = None
         elif line.startswith("committer-time ") and current_line_number is not None:
             timestamp_str = line.split(" ", 1)[1]

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/core.py
@@ -10,6 +10,7 @@ from typing import Final
 from typing import Self
 from typing import TypeVar
 
+from loguru import logger
 from pydantic import Field
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema
@@ -183,11 +184,19 @@ def _read_file_contents(file_path: Path) -> str:
 
 @lru_cache(maxsize=None)
 def _parse_file_ast(file_path: Path) -> ast.Module | None:
-    """Parse and cache the AST for a Python file. Returns None if parsing fails."""
+    """Parse and cache the AST for a Python file. Returns None if parsing fails.
+
+    A file that fails to parse is skipped by all AST-based ratchet checks. We do
+    not raise, because a scanned-but-not-executed file may legitimately use syntax
+    newer than the interpreter running the tests. We do log a warning so the skip
+    is never silent (a real ratchet violation in an unparseable file would
+    otherwise go unnoticed). The lru_cache keeps the warning to once per file.
+    """
     contents = _read_file_contents(file_path)
     try:
         return ast.parse(contents, filename=str(file_path))
-    except SyntaxError:
+    except SyntaxError as e:
+        logger.warning("Skipping unparseable file in ratchet AST scan: {} ({})", file_path, e)
         return None
 
 

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/core_test.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/core_test.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import subprocess
 from pathlib import Path
@@ -12,8 +13,10 @@ from imbue.imbue_common.ratchet_testing.core import RatchetMatchChunk
 from imbue.imbue_common.ratchet_testing.core import RegexPattern
 from imbue.imbue_common.ratchet_testing.core import _get_all_files_with_extension
 from imbue.imbue_common.ratchet_testing.core import _get_non_ignored_files_with_extension
+from imbue.imbue_common.ratchet_testing.core import _parse_file_ast
 from imbue.imbue_common.ratchet_testing.core import _read_file_contents
 from imbue.imbue_common.ratchet_testing.core import format_ratchet_failure_message
+from imbue.imbue_common.ratchet_testing.core import get_ast_nodes_of_type
 from imbue.imbue_common.ratchet_testing.core import get_ratchet_failures
 
 
@@ -245,6 +248,26 @@ def test_read_file_contents_caches_results(tmp_path: Path) -> None:
 
     assert content1 == "original content"
     assert content1 is content2
+
+
+def test_parse_file_ast_returns_none_for_unparseable_file(tmp_path: Path) -> None:
+    """An unparseable file degrades to None (and empty AST node lookups) rather than raising,
+    so a single broken file cannot crash a ratchet scan."""
+    bad_file = tmp_path / "broken.py"
+    bad_file.write_text("def foo(:\n    pass\n")
+
+    assert _parse_file_ast(bad_file) is None
+    # AST-based ratchet lookups degrade to an empty list instead of raising.
+    assert get_ast_nodes_of_type(bad_file, ast.FunctionDef) == []
+
+
+def test_parse_file_ast_parses_valid_file(tmp_path: Path) -> None:
+    good_file = tmp_path / "good.py"
+    good_file.write_text("def foo():\n    pass\n")
+
+    tree = _parse_file_ast(good_file)
+    assert tree is not None
+    assert [n.name for n in get_ast_nodes_of_type(good_file, ast.FunctionDef)] == ["foo"]
 
 
 def test_get_ratchet_failures_finds_matches_in_git_repo(git_repo: Path) -> None:

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/ratchets.py
@@ -99,7 +99,9 @@ def _get_if_chain_end_line(if_node: ast.If) -> int:
         else:
             break
 
-    if hasattr(current, "end_lineno") and current.end_lineno is not None:
+    # Every parsed ast.stmt carries end_lineno; the typeshed stub still types it
+    # Optional, so the is-not-None check (not a hasattr probe) is what matters.
+    if current.end_lineno is not None:
         return current.end_lineno
 
     return current.lineno


### PR DESCRIPTION
## Summary

Hardens suspicious edge-case handling in `libs/imbue_common`, found via the `identify-suspicious-edge-cases` review. Findings and their dispositions are recorded in `libs/imbue_common/_tasks/suspicious-edge-cases/` (gitignored). Each finding is its own commit.

Code-behavior fixes:
- **`_parse_file_ast` no longer silently skips unparseable files.** It caught `SyntaxError` and returned `None`, so every AST-based ratchet silently skipped any file that failed to parse (potentially masking a real violation). It now logs a warning naming the file; the skip is kept so a scanned-but-not-executed file using newer-than-runtime syntax can't crash a scan.
- **JSONL exception envelope uses `is not None`, not truthiness.** A custom exception whose `__bool__` is falsy would otherwise drop its `value` from the structured log.
- **`rotation_lock` catches `BlockingIOError`, not broad `OSError`,** when probing a non-blocking `flock` (matching `conftest_hooks._acquire_global_test_lock`). Unrelated faults now propagate instead of being treated as lock contention.

Clarity-only (over-reports that turned out correct):
- Comment documenting why the git-blame `ValueError` -> `None` fallback is safe (porcelain field ordering).
- Comment documenting why the log-sink `stat` -> `0` fallback is safe (a sink must not raise; worst case is delayed rotation).
- Removed a redundant `hasattr(..., "end_lineno")` guard in the if/elif-chain ratchet helper.

## Testing

- `just test-quick libs/imbue_common` -> 221 passed (includes 2 new unit tests for `_parse_file_ast`).
- `just test-quick libs/imbue_common/imbue/imbue_common/test_ratchets.py` -> 55 passed (ratchet counts unchanged).
- `uv run ty check` on edited files -> all checks passed.

Base branch: `mngr/review-more-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
