### PR TITLE
Harden suspicious edge cases in minds env provisioning

### DIFF
--- a/apps/minds/changelog/mngr-suspicious-edge-cases-minds-envs-local.md
+++ b/apps/minds/changelog/mngr-suspicious-edge-cases-minds-envs-local.md
@@ -1,0 +1,35 @@
+# Harden suspicious edge-case handling across `minds env` provisioning
+
+A cleanup pass over `apps/minds/imbue/minds/envs` replacing over-defensive
+error handling that could silently mask real failures (leaked cloud resources,
+masked data corruption) with handling that surfaces anomalies. User-visible
+effects are mostly "a previously-silent failure now raises a clear error" and
+better `minds env list` output:
+
+- `minds env destroy` now destroys mngr agents one at a time, so a genuine
+  destroy failure on one agent can no longer be masked by another agent
+  already being gone (which previously left the failed agent's cloud resources
+  stranded while reporting success).
+- Tier generation-id reads now surface a malformed/corrupt Vault generation
+  entry instead of silently minting a fresh id over it (which would have wiped
+  every developer's local state), and use the typed Vault "not found" signal
+  instead of matching error text.
+- Neon idempotency (already-exists / already-gone) now branches on the HTTP
+  status code carried on the error, not a substring of the response body; the
+  default branch is resolved via Neon's authoritative `default` flag rather
+  than guessing the first-listed branch; and a failed-rollback project delete
+  is now logged.
+- `modal environment create` idempotency now matches the specific "already
+  exists" phrase (the bare "exist" substring also matched "does not exist", so
+  a "workspace does not exist" failure was silently treated as success). Modal
+  `list --json` parsers now consistently raise on a non-list payload and warn
+  on shape-drift rows instead of silently degrading.
+- A Cloudflare tunnel identified as ours but with a missing id, an OVH VPS
+  whose IAM resource has an empty name, an unreadable-but-present mngr
+  `user_id` file, and a broken `$HOME` now raise instead of being silently
+  skipped (each previously leaked a resource or hid a broken environment).
+- `minds env list` now distinguishes a reserved tier whose committed
+  `client.toml` is present but unparseable (`in_repo_malformed`, shown as
+  "MALFORMED — fix the committed file") from an unprovisioned env.
+- `delete_vault_kv` now detects an already-absent entry by exit code (matching
+  `read_vault_kv`) rather than substring-matching the message.

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -1072,8 +1072,15 @@ def env_list(ctx: click.Context) -> None:
             return
         for s in summaries:
             marker = " (active)" if s.name == active else ""
-            connector = str(s.connector_url) if s.connector_url is not None else "(no client.toml)"
-            if s.client_config_path is None:
+            if s.connector_url is not None:
+                connector = str(s.connector_url)
+            elif s.client_config_source == "in_repo_malformed":
+                connector = "(malformed client.toml)"
+            else:
+                connector = "(no client.toml)"
+            if s.client_config_source == "in_repo_malformed":
+                client_loc = f"{s.client_config_path}  (in-repo, MALFORMED — fix the committed file)"
+            elif s.client_config_path is None:
                 client_loc = "(no client.toml — run `minds env deploy`)"
             elif s.client_config_source == "in_repo":
                 client_loc = f"{s.client_config_path}  (in-repo, committed)"

--- a/apps/minds/imbue/minds/envs/docker_cleanup.py
+++ b/apps/minds/imbue/minds/envs/docker_cleanup.py
@@ -47,11 +47,14 @@ class DockerCleanupError(MindError):
 
 
 def read_profile_user_id(mngr_host_dir: Path) -> str | None:
-    """Read the active mngr profile's ``user_id``, or None if it can't be resolved.
+    """Read the active mngr profile's ``user_id``, or None if there is no profile yet.
 
     The active profile dir is resolved via
     ``bootstrap.read_active_profile_dir`` and the user id lives at
-    ``<profile_dir>/user_id``.
+    ``<profile_dir>/user_id``. Returns None only for the legitimate
+    "no profile yet" states (no active profile dir, no user_id file, or an
+    empty file). A read failure on a user_id file that *does* exist raises
+    :class:`DockerCleanupError` rather than masquerading as "no profile".
     """
     profile_dir = read_active_profile_dir(mngr_host_dir)
     if profile_dir is None:
@@ -62,8 +65,13 @@ def read_profile_user_id(mngr_host_dir: Path) -> str | None:
     try:
         return user_id_path.read_text().strip() or None
     except OSError as e:
-        logger.warning("Could not read mngr profile user_id {}: {}", user_id_path, e)
-        return None
+        # The legitimate "no profile yet" cases already returned None above
+        # (no active profile dir / no user_id file). An OSError reading a file
+        # that *does* exist is an unexpected permission/IO failure, not an
+        # "absent" state: swallowing it to None would skip the state-container
+        # cleanup entirely, leaking the env's container forever -- the exact
+        # leak this module exists to prevent. Surface it instead.
+        raise DockerCleanupError(f"Could not read mngr profile user_id at {user_id_path}: {e}") from e
 
 
 def state_container_name(mngr_prefix: str, user_id: str) -> str:

--- a/apps/minds/imbue/minds/envs/generation.py
+++ b/apps/minds/imbue/minds/envs/generation.py
@@ -31,6 +31,7 @@ from typing import Final
 from uuid import uuid4
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.minds.envs.primitives import VaultReadError
 from imbue.minds.envs.primitives import VaultSecretNotFoundError
 from imbue.minds.envs.vault_reader import VAULT_BINARY
 from imbue.minds.envs.vault_reader import VaultPath
@@ -75,7 +76,19 @@ def read_generation_id(
         # transient / auth ``VaultReadError`` (other exit codes), which
         # must propagate so the operator notices Vault problems early.
         return None
-    return values.get(GENERATION_ID_KEY)
+    generation_id = values.get(GENERATION_ID_KEY)
+    if generation_id is None:
+        # The secret exists but lacks the generation key (a partial write /
+        # corruption). This is NOT the same as "no secret yet": returning
+        # None here would make ``ensure_generation_id`` mint + write a fresh
+        # id over the malformed entry, silently masking the corruption.
+        # Surface it so an operator fixes the Vault entry instead.
+        raise VaultReadError(
+            f"Vault entry {_generation_vault_path(tier_vault_prefix)!r} exists but has no "
+            f"{GENERATION_ID_KEY!r} key; the tier generation secret is malformed. Inspect / repair "
+            "it (or delete it so the next deploy re-mints one)."
+        )
+    return generation_id
 
 
 def ensure_generation_id(

--- a/apps/minds/imbue/minds/envs/generation.py
+++ b/apps/minds/imbue/minds/envs/generation.py
@@ -31,7 +31,7 @@ from typing import Final
 from uuid import uuid4
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
-from imbue.minds.envs.primitives import VaultReadError
+from imbue.minds.envs.primitives import VaultSecretNotFoundError
 from imbue.minds.envs.vault_reader import VAULT_BINARY
 from imbue.minds.envs.vault_reader import VaultPath
 from imbue.minds.envs.vault_reader import delete_vault_kv
@@ -68,13 +68,13 @@ def read_generation_id(
             parent_concurrency_group=parent_concurrency_group,
             vault_binary=vault_binary,
         )
-    except VaultReadError as exc:
-        # Treat "no entry" / "not found" as "no id yet"; surface anything
-        # else so the operator notices Vault problems early.
-        message = str(exc).lower()
-        if "not found" in message or "no value found" in message or "404" in message:
-            return None
-        raise
+    except VaultSecretNotFoundError:
+        # The path genuinely has no secret yet (Vault CLI exit code 2).
+        # ``read_vault_kv`` raises this dedicated subclass precisely so we
+        # can treat "absent" as "no id yet" WITHOUT also swallowing a
+        # transient / auth ``VaultReadError`` (other exit codes), which
+        # must propagate so the operator notices Vault problems early.
+        return None
     return values.get(GENERATION_ID_KEY)
 
 

--- a/apps/minds/imbue/minds/envs/generation_test.py
+++ b/apps/minds/imbue/minds/envs/generation_test.py
@@ -130,9 +130,12 @@ def test_read_generation_id_returns_none_when_key_absent_from_entry(
 
 
 def test_read_generation_id_propagates_unexpected_vault_error(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    # A non-2 exit is a transient / auth / connectivity failure (NOT
+    # "absent"). read_vault_kv raises a plain VaultReadError for it, which
+    # read_generation_id must let propagate rather than treat as "no id yet".
     fake = _make_fake_vault_binary(
         tmp_path,
-        get_exit_code=2,
+        get_exit_code=1,
         get_stderr="permission denied",
     )
     with pytest.raises(VaultReadError, match="permission denied"):

--- a/apps/minds/imbue/minds/envs/generation_test.py
+++ b/apps/minds/imbue/minds/envs/generation_test.py
@@ -114,19 +114,19 @@ def test_read_generation_id_returns_none_when_entry_missing(tmp_path: Path, _roo
     )
 
 
-def test_read_generation_id_returns_none_when_key_absent_from_entry(
+def test_read_generation_id_raises_when_key_absent_from_present_entry(
     tmp_path: Path, _root_cg: ConcurrencyGroup
 ) -> None:
-    # The entry exists but has no MINDS_TIER_GENERATION_ID key.
+    # The entry exists but has no MINDS_TIER_GENERATION_ID key (a partial
+    # write / corruption). This must surface, NOT be treated as "no id yet"
+    # (which would mint a fresh id over the malformed entry).
     fake = _make_fake_vault_binary(tmp_path, get_stdout=_kv_get_payload(generation_id=None))
-    assert (
+    with pytest.raises(VaultReadError, match="malformed"):
         read_generation_id(
             "secrets/minds/staging",
             parent_concurrency_group=_root_cg,
             vault_binary=str(fake),
         )
-        is None
-    )
 
 
 def test_read_generation_id_propagates_unexpected_vault_error(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:

--- a/apps/minds/imbue/minds/envs/mngr_agent_cleanup.py
+++ b/apps/minds/imbue/minds/envs/mngr_agent_cleanup.py
@@ -109,39 +109,61 @@ def real_destroy_mngr_agents(
     mngr_host_dir: Path,
     mngr_prefix: str,
     parent_concurrency_group: ConcurrencyGroup,
+    *,
+    mngr_binary: str = "mngr",
 ) -> None:
-    """Shell out to a single ``mngr destroy -f <ids...>`` with the env's MNGR_* vars set.
+    """Shell out to ``mngr destroy -f <id>`` once per agent, with the env's MNGR_* vars set.
 
     The CLI side wires this into the Providers bundle as the
-    ``destroy_mngr_agents`` callable. Subprocess runs under the
+    ``destroy_mngr_agents`` callable. Each subprocess runs under the
     parent ConcurrencyGroup so its lifetime is tracked alongside the
     rest of the destroy flow.
+
+    We destroy one id at a time rather than passing the whole list to a
+    single ``mngr destroy`` call. A single call returns one combined exit
+    status + output for the whole batch, so the "already gone" tolerance
+    below could only be applied to the batch as a whole: a batch where
+    agent A failed for a real reason but agent B was merely already-gone
+    would contain "not found" *somewhere* and be swallowed as success,
+    leaving A's cloud resources stranded. Destroying per-id scopes the
+    not-found check to the single id it came from, so a genuine failure
+    of one agent can never be masked by another agent being absent.
+    Destroying one agent still tears down its host-mates in the same
+    pass, so a host-mate processed later in the loop simply reports
+    "not found" -- which is correctly tolerated.
     """
     if not agent_ids:
         return
     subprocess_env = dict(os.environ)
     subprocess_env["MNGR_HOST_DIR"] = str(mngr_host_dir)
     subprocess_env["MNGR_PREFIX"] = mngr_prefix
-    command = ["mngr", "destroy", "-f", *agent_ids]
-    cg = parent_concurrency_group.make_concurrency_group(name="mngr-destroy-batch")
-    with cg:
-        result = cg.run_process_to_completion(
-            command=command,
-            timeout=_MNGR_DESTROY_TIMEOUT_SECONDS,
-            is_checked_after=False,
-            env=subprocess_env,
+
+    failures: list[str] = []
+    for agent_id in agent_ids:
+        cg = parent_concurrency_group.make_concurrency_group(name=f"mngr-destroy-{agent_id}")
+        with cg:
+            result = cg.run_process_to_completion(
+                command=[mngr_binary, "destroy", "-f", agent_id],
+                timeout=_MNGR_DESTROY_TIMEOUT_SECONDS,
+                is_checked_after=False,
+                env=subprocess_env,
+            )
+        if result.returncode == 0:
+            continue
+        # mngr's "no such agent" wording: "Agent <id> not found". Because
+        # this output is scoped to exactly one id, an already-gone agent
+        # (destroyed manually, or torn down as a host-mate of an earlier
+        # id in this loop) is safe to treat as a no-op.
+        message = (result.stderr + result.stdout).lower()
+        if "not found" in message or "does not exist" in message:
+            logger.debug("mngr agent {} already gone; treating as destroyed", agent_id)
+            continue
+        stderr = result.stderr.strip() or result.stdout.strip()
+        failures.append(f"{agent_id} (exit {result.returncode}): {stderr}")
+
+    if failures:
+        raise MngrAgentCleanupError(
+            "`mngr destroy` failed for {} agent(s): {}. ".format(len(failures), "; ".join(failures))
+            + "The env root has NOT been removed; re-run `minds env destroy` once the underlying "
+            "issue is fixed."
         )
-    if result.returncode == 0:
-        return
-    # mngr's "no such agent" wording: "Agent <id> not found". Treat a
-    # batch that only tripped on already-gone agents as a no-op (someone
-    # destroyed them manually).
-    message = (result.stderr + result.stdout).lower()
-    if "not found" in message or "does not exist" in message:
-        return
-    stderr = result.stderr.strip() or result.stdout.strip()
-    raise MngrAgentCleanupError(
-        f"`mngr destroy {' '.join(agent_ids)}` failed (exit {result.returncode}): {stderr}. "
-        "The env root has NOT been removed; re-run `minds env destroy` once the underlying "
-        "issue is fixed."
-    )

--- a/apps/minds/imbue/minds/envs/mngr_agent_cleanup_test.py
+++ b/apps/minds/imbue/minds/envs/mngr_agent_cleanup_test.py
@@ -1,0 +1,65 @@
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.minds.envs.mngr_agent_cleanup import MngrAgentCleanupError
+from imbue.minds.envs.mngr_agent_cleanup import real_destroy_mngr_agents
+
+
+@pytest.fixture
+def _root_cg() -> Iterator[ConcurrencyGroup]:
+    cg = ConcurrencyGroup(name="mngr-agent-cleanup-test-root")
+    with cg:
+        yield cg
+
+
+def _make_fake_mngr_binary(tmp_path: Path) -> Path:
+    """A fake ``mngr`` whose per-id exit code/output depends on the id arg.
+
+    Invoked as ``mngr destroy -f <id>`` (so the id is ``$3``). It models
+    three agents: one already gone (mngr's "not found" wording, non-zero
+    exit), one that fails for a genuine reason, and any other id succeeds.
+    """
+    script = tmp_path / "mngr"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        'agent_id="$3"\n'
+        'case "$agent_id" in\n'
+        '  gone-agent) echo "Agent gone-agent not found" >&2; exit 1 ;;\n'
+        '  broken-agent) echo "docker error: container is stuck" >&2; exit 1 ;;\n'
+        "  *) exit 0 ;;\n"
+        "esac\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def test_destroy_all_succeed_is_noop(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    fake = _make_fake_mngr_binary(tmp_path)
+    real_destroy_mngr_agents(["agent-a", "agent-b"], tmp_path, "minds-dev-", _root_cg, mngr_binary=str(fake))
+
+
+def test_destroy_tolerates_already_gone_agent(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    # An agent that mngr reports as already gone is a no-op (manually
+    # destroyed, or torn down as a host-mate of an earlier id).
+    fake = _make_fake_mngr_binary(tmp_path)
+    real_destroy_mngr_agents(["gone-agent"], tmp_path, "minds-dev-", _root_cg, mngr_binary=str(fake))
+
+
+def test_real_failure_not_masked_by_a_gone_agent(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    # The regression this guards: a batch containing one already-gone agent
+    # AND one genuinely-failing agent must NOT be swallowed as success just
+    # because "not found" appears somewhere in the combined output.
+    fake = _make_fake_mngr_binary(tmp_path)
+    with pytest.raises(MngrAgentCleanupError) as exc_info:
+        real_destroy_mngr_agents(
+            ["gone-agent", "broken-agent"], tmp_path, "minds-dev-", _root_cg, mngr_binary=str(fake)
+        )
+    message = str(exc_info.value)
+    assert "broken-agent" in message
+    assert "container is stuck" in message
+    # The env root must be reported as NOT removed so the operator re-runs.
+    assert "NOT been removed" in message

--- a/apps/minds/imbue/minds/envs/paths.py
+++ b/apps/minds/imbue/minds/envs/paths.py
@@ -32,6 +32,7 @@ from imbue.minds.bootstrap import resolve_minds_root_name
 from imbue.minds.bootstrap import root_name_for_env_name
 from imbue.minds.envs.primitives import DevEnvName
 from imbue.minds.envs.primitives import InvalidDevEnvNameError
+from imbue.minds.errors import MindError
 
 _CLIENT_FILENAME = "client.toml"
 _SECRETS_FILENAME = "secrets.toml"
@@ -80,7 +81,14 @@ def list_env_root_dirs() -> tuple[Path, ...]:
     """
     home = Path.home()
     if not home.is_dir():
-        return ()
+        # A missing / non-directory $HOME is a broken operator environment,
+        # not a legitimate "zero envs" state. Returning () here would make
+        # `minds env list` show nothing and could mislead an operator into
+        # thinking their envs are gone (and re-provisioning). Surface it.
+        raise MindError(
+            f"Home directory {home} is not a directory; cannot enumerate minds envs. "
+            "Check that $HOME points at a valid directory."
+        )
     matches: list[Path] = []
     for child in home.iterdir():
         if not child.is_dir():

--- a/apps/minds/imbue/minds/envs/paths_test.py
+++ b/apps/minds/imbue/minds/envs/paths_test.py
@@ -1,0 +1,33 @@
+"""Unit tests for the per-env data-root path helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from imbue.minds.envs.paths import list_env_root_dirs
+from imbue.minds.errors import MindError
+
+
+def test_list_env_root_dirs_lists_minds_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # production root + two dev roots, plus a decoy that must be ignored.
+    (tmp_path / ".minds").mkdir()
+    (tmp_path / ".minds-dev-josh").mkdir()
+    (tmp_path / ".minds-staging").mkdir()
+    (tmp_path / ".minds-backup-2024-01-01").mkdir()  # illegal env name -> excluded
+    (tmp_path / ".unrelated").mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    roots = list_env_root_dirs()
+    names = [p.name for p in roots]
+    # production (".minds") sorts first; the backup/unrelated dirs are excluded.
+    assert names == [".minds", ".minds-dev-josh", ".minds-staging"]
+
+
+def test_list_env_root_dirs_raises_when_home_is_not_a_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A broken $HOME is not a legitimate "zero envs" state -- surface it
+    # rather than silently returning ().
+    monkeypatch.setenv("HOME", str(tmp_path / "does-not-exist"))
+    with pytest.raises(MindError, match="not a directory"):
+        list_env_root_dirs()

--- a/apps/minds/imbue/minds/envs/paths_test.py
+++ b/apps/minds/imbue/minds/envs/paths_test.py
@@ -13,7 +13,8 @@ def test_list_env_root_dirs_lists_minds_roots(monkeypatch: pytest.MonkeyPatch, t
     (tmp_path / ".minds").mkdir()
     (tmp_path / ".minds-dev-josh").mkdir()
     (tmp_path / ".minds-staging").mkdir()
-    (tmp_path / ".minds-backup-2024-01-01").mkdir()  # illegal env name -> excluded
+    # ".minds-backup-2024-01-01" is an illegal env name -> excluded; ".unrelated" isn't a minds root.
+    (tmp_path / ".minds-backup-2024-01-01").mkdir()
     (tmp_path / ".unrelated").mkdir()
     monkeypatch.setenv("HOME", str(tmp_path))
 

--- a/apps/minds/imbue/minds/envs/per_env_deploy.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy.py
@@ -800,13 +800,26 @@ def _find_modal_app_id(*, app_name: str, modal_env: str, parent_cg: ConcurrencyG
         rows = json.loads(result.stdout)
     except (ValueError, json.JSONDecodeError) as exc:
         raise ModalDeployError(f"`modal app list --json` returned non-JSON: {exc}") from exc
+    return _select_app_id_from_rows(rows, app_name=app_name)
+
+
+def _select_app_id_from_rows(rows: object, *, app_name: str) -> str | None:
+    """Find the running app id for ``app_name`` in ``modal app list --json`` rows.
+
+    Raises :class:`ModalDeployError` on a non-list payload (genuinely
+    unexpected given ``returncode == 0``; consistent with the other Modal-
+    list parsers). Modal's column names have shifted across versions, so the
+    common shapes for both name and id are checked; stopped apps are skipped
+    so we don't try to stop containers for an already-terminated app. A row
+    that matches our app but carries no recognized id key is a shape shift
+    that would otherwise look like "app not found" -- it warns rather than
+    silently returning None. Pure function so the parsing is unit-testable.
+    """
     if not isinstance(rows, list):
-        return None
-    # Modal's column names have shifted across versions; check the common shapes
-    # for both name and id. Skip stopped apps so we don't try to stop containers
-    # for an already-terminated app.
+        raise ModalDeployError(f"`modal app list --json` returned a non-list payload: {rows!r}")
     for row in rows:
         if not isinstance(row, dict):
+            logger.warning("`modal app list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
         name_value = row.get("Name") or row.get("name") or row.get("App")
         state_value = (row.get("State") or row.get("state") or "").lower()
@@ -816,6 +829,12 @@ def _find_modal_app_id(*, app_name: str, modal_env: str, parent_cg: ConcurrencyG
             id_value = row.get(id_key)
             if isinstance(id_value, str) and id_value:
                 return id_value
+        logger.warning(
+            "`modal app list --json` row matched app {!r} but carried no recognized id key "
+            "(Modal output shape may have shifted): {!r}",
+            app_name,
+            row,
+        )
     return None
 
 
@@ -839,17 +858,37 @@ def _list_modal_app_container_ids(*, app_id: str, modal_env: str, parent_cg: Con
         rows = json.loads(result.stdout)
     except (ValueError, json.JSONDecodeError) as exc:
         raise ModalDeployError(f"`modal container list --json` returned non-JSON: {exc}") from exc
+    return _extract_container_ids_from_rows(rows)
+
+
+def _extract_container_ids_from_rows(rows: object) -> tuple[str, ...]:
+    """Pull the container ids out of ``modal container list --json`` rows.
+
+    Raises :class:`ModalDeployError` on a non-list payload (genuinely
+    unexpected given ``returncode == 0``; consistent with the other Modal-
+    list parsers), so a silently-empty container list never masks a shape
+    shift that would leave containers running. Warns about -- and skips --
+    non-dict rows and rows with no recognized id key. Pure function so the
+    parsing is unit-testable.
+    """
     if not isinstance(rows, list):
-        return ()
+        raise ModalDeployError(f"`modal container list --json` returned a non-list payload: {rows!r}")
     ids: list[str] = []
     for row in rows:
         if not isinstance(row, dict):
+            logger.warning("`modal container list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
         for id_key in ("Container ID", "container_id", "ID", "id"):
             value = row.get(id_key)
             if isinstance(value, str) and value:
                 ids.append(value)
                 break
+        else:
+            logger.warning(
+                "`modal container list --json` row carried no recognized id key "
+                "(Modal output shape may have shifted); skipping it: {!r}",
+                row,
+            )
     return tuple(ids)
 
 

--- a/apps/minds/imbue/minds/envs/per_env_deploy.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy.py
@@ -274,13 +274,16 @@ def push_per_env_modal_secret(
         raise ModalDeployError(f"`modal secret create {secret_name}` failed (exit {result.returncode}): {stderr}")
 
 
-def ensure_modal_env(name: DevEnvName, *, parent_cg: ConcurrencyGroup) -> None:
+def ensure_modal_env(name: DevEnvName, *, parent_cg: ConcurrencyGroup, modal_binary: str = "modal") -> None:
     """Create the Modal env if it doesn't already exist; otherwise no-op.
 
-    Modal's "already exists" failure has shifted wording across
-    versions; both known variants contain the substring ``exist``.
+    Matches the specific "already exists" phrase (as
+    :func:`providers.modal_env.create_modal_env` does). The bare substring
+    ``exist`` would also match "does not exist" / "nonexistent", silently
+    treating e.g. a "workspace does not exist" failure as success and
+    proceeding to deploy against an env that was never created.
     """
-    command = ["modal", "environment", "create", str(name)]
+    command = [modal_binary, "environment", "create", str(name)]
     cg = parent_cg.make_concurrency_group(name=f"modal-env-create-{name}")
     with cg:
         result = cg.run_process_to_completion(
@@ -292,7 +295,7 @@ def ensure_modal_env(name: DevEnvName, *, parent_cg: ConcurrencyGroup) -> None:
     if result.returncode == 0:
         return
     message = (result.stderr + result.stdout).lower()
-    if "exist" in message:
+    if "already exists" in message:
         return
     stderr = result.stderr.strip() or result.stdout.strip()
     raise ModalDeployError(f"`modal environment create {name}` failed (exit {result.returncode}): {stderr}")

--- a/apps/minds/imbue/minds/envs/per_env_deploy.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy.py
@@ -29,7 +29,6 @@ import os
 import re
 from pathlib import Path
 from typing import Final
-from typing import cast
 
 from loguru import logger
 from pydantic import AnyUrl
@@ -804,6 +803,23 @@ def _find_modal_app_id(*, app_name: str, modal_env: str, parent_cg: ConcurrencyG
     return _select_app_id_from_rows(rows, app_name=app_name)
 
 
+def first_str_value(row: object, keys: tuple[str, ...]) -> str | None:
+    """Return the first non-empty string value at any of ``keys`` in dict ``row``.
+
+    Tolerates Modal's shifting column names (callers pass every known alias)
+    and untyped JSON: ``row`` is whatever ``json.loads`` produced, so anything
+    that isn't a dict -- or a dict with no matching string value -- yields
+    ``None``. Iterating ``items()`` (rather than ``row.get(key)``) keeps the
+    type checker happy on a dict narrowed from ``object``.
+    """
+    if not isinstance(row, dict):
+        return None
+    for key, value in row.items():
+        if key in keys and isinstance(value, str) and value:
+            return value
+    return None
+
+
 def _select_app_id_from_rows(rows: object, *, app_name: str) -> str | None:
     """Find the running app id for ``app_name`` in ``modal app list --json`` rows.
 
@@ -822,16 +838,13 @@ def _select_app_id_from_rows(rows: object, *, app_name: str) -> str | None:
         if not isinstance(row, dict):
             logger.warning("`modal app list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
-        row_map = cast("dict[str, object]", row)
-        name_value = row_map.get("Name") or row_map.get("name") or row_map.get("App")
-        state_raw = row_map.get("State") or row_map.get("state")
-        state_value = state_raw.lower() if isinstance(state_raw, str) else ""
+        name_value = first_str_value(row, ("Name", "name", "App"))
+        state_value = (first_str_value(row, ("State", "state")) or "").lower()
         if name_value != app_name or "stop" in state_value:
             continue
-        for id_key in ("App ID", "app_id", "AppID", "ID", "id"):
-            id_value = row_map.get(id_key)
-            if isinstance(id_value, str) and id_value:
-                return id_value
+        app_id_value = first_str_value(row, ("App ID", "app_id", "AppID", "ID", "id"))
+        if app_id_value is not None:
+            return app_id_value
         logger.warning(
             "`modal app list --json` row matched app {!r} but carried no recognized id key "
             "(Modal output shape may have shifted): {!r}",
@@ -881,12 +894,9 @@ def _extract_container_ids_from_rows(rows: object) -> tuple[str, ...]:
         if not isinstance(row, dict):
             logger.warning("`modal container list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
-        row_map = cast("dict[str, object]", row)
-        for id_key in ("Container ID", "container_id", "ID", "id"):
-            value = row_map.get(id_key)
-            if isinstance(value, str) and value:
-                ids.append(value)
-                break
+        container_id = first_str_value(row, ("Container ID", "container_id", "ID", "id"))
+        if container_id is not None:
+            ids.append(container_id)
         else:
             logger.warning(
                 "`modal container list --json` row carried no recognized id key "

--- a/apps/minds/imbue/minds/envs/per_env_deploy.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy.py
@@ -29,6 +29,7 @@ import os
 import re
 from pathlib import Path
 from typing import Final
+from typing import cast
 
 from loguru import logger
 from pydantic import AnyUrl
@@ -821,12 +822,14 @@ def _select_app_id_from_rows(rows: object, *, app_name: str) -> str | None:
         if not isinstance(row, dict):
             logger.warning("`modal app list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
-        name_value = row.get("Name") or row.get("name") or row.get("App")
-        state_value = (row.get("State") or row.get("state") or "").lower()
+        row_map = cast("dict[str, object]", row)
+        name_value = row_map.get("Name") or row_map.get("name") or row_map.get("App")
+        state_raw = row_map.get("State") or row_map.get("state")
+        state_value = state_raw.lower() if isinstance(state_raw, str) else ""
         if name_value != app_name or "stop" in state_value:
             continue
         for id_key in ("App ID", "app_id", "AppID", "ID", "id"):
-            id_value = row.get(id_key)
+            id_value = row_map.get(id_key)
             if isinstance(id_value, str) and id_value:
                 return id_value
         logger.warning(
@@ -878,8 +881,9 @@ def _extract_container_ids_from_rows(rows: object) -> tuple[str, ...]:
         if not isinstance(row, dict):
             logger.warning("`modal container list --json` returned a non-dict row; skipping it: {!r}", row)
             continue
+        row_map = cast("dict[str, object]", row)
         for id_key in ("Container ID", "container_id", "ID", "id"):
-            value = row.get(id_key)
+            value = row_map.get(id_key)
             if isinstance(value, str) and value:
                 ids.append(value)
                 break

--- a/apps/minds/imbue/minds/envs/per_env_deploy.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy.py
@@ -486,20 +486,27 @@ def deploy_remote_service_connector(
         )
 
 
-def _parse_deploy_url_from_stdout(stdout: str) -> AnyUrl | None:
+def _parse_deploy_url_from_stdout(stdout: str, *, app_name: str, modal_env: str) -> AnyUrl:
     """Extract the deployed function URL from ``modal deploy`` stdout.
 
     Modal wraps long URLs across lines in TTY-style output; collapsing
     whitespace before matching catches both wrapped and inline forms.
     Returns the last ``.modal.run`` URL seen (the deployed function);
     earlier matches may be Modal dashboard URLs that aren't useful here.
-    Returns ``None`` if no URL is present (the caller decides whether
-    that's fatal).
+
+    Raises :class:`ModalDeployError` if no URL is present. A successful
+    ``modal deploy`` that emits no ``.modal.run`` URL is always fatal --
+    the sole caller cannot proceed without the deployed URL -- so the
+    failure is raised here rather than handed back as an optional the
+    caller is forced to re-check.
     """
     collapsed = re.sub(r"\s+", "", stdout)
     matches = _MODAL_DEPLOY_URL_PATTERN.findall(collapsed)
     if not matches:
-        return None
+        raise ModalDeployError(
+            f"`modal deploy --name {app_name} --env {modal_env}` succeeded but no .modal.run URL "
+            f"appeared in its stdout. Captured tail: {stdout[-500:]}"
+        )
     return AnyUrl(matches[-1])
 
 
@@ -559,13 +566,7 @@ def _deploy_modal_app(
         raise ModalDeployError(
             f"`modal deploy --name {app_name} --env {modal_env}` failed (exit {result.returncode}): {stderr}"
         )
-    url = _parse_deploy_url_from_stdout(result.stdout)
-    if url is None:
-        raise ModalDeployError(
-            f"`modal deploy --name {app_name} --env {modal_env}` succeeded but no .modal.run URL "
-            f"appeared in its stdout. Captured tail: {result.stdout[-500:]}"
-        )
-    return url
+    return _parse_deploy_url_from_stdout(result.stdout, app_name=app_name, modal_env=modal_env)
 
 
 def _modal_subprocess_env() -> dict[str, str]:

--- a/apps/minds/imbue/minds/envs/per_env_deploy_test.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy_test.py
@@ -8,12 +8,55 @@ pool-host queries, the latter for the LiteLLM proxy's Prisma-managed
 backing store). Both DSNs come from the same per-env Neon project.
 """
 
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
 from pydantic import SecretStr
 
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.minds.envs.per_env_deploy import ModalDeployError
 from imbue.minds.envs.per_env_deploy import compute_per_env_overrides
+from imbue.minds.envs.per_env_deploy import ensure_modal_env
 from imbue.minds.envs.primitives import DevEnvName
 from imbue.minds.envs.providers.neon_db import NeonProjectRecord
 from imbue.minds.envs.providers.supertokens_app import SuperTokensAppRecord
+
+
+@pytest.fixture
+def _root_cg() -> Iterator[ConcurrencyGroup]:
+    cg = ConcurrencyGroup(name="per-env-deploy-test-root")
+    with cg:
+        yield cg
+
+
+def _make_fake_modal_binary(tmp_path: Path, *, exit_code: int, stderr: str = "") -> Path:
+    stderr_path = tmp_path / "_fake_modal_stderr.txt"
+    stderr_path.write_text(stderr)
+    script = tmp_path / "modal"
+    script.write_text(f"#!/usr/bin/env bash\ncat {stderr_path} >&2\nexit {exit_code}\n")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def test_ensure_modal_env_succeeds_on_zero_exit(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    fake = _make_fake_modal_binary(tmp_path, exit_code=0)
+    ensure_modal_env(DevEnvName("dev-josh"), parent_cg=_root_cg, modal_binary=str(fake))
+
+
+def test_ensure_modal_env_tolerates_already_exists(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    fake = _make_fake_modal_binary(tmp_path, exit_code=1, stderr="Environment 'dev-josh' already exists")
+    ensure_modal_env(DevEnvName("dev-josh"), parent_cg=_root_cg, modal_binary=str(fake))
+
+
+def test_ensure_modal_env_raises_on_does_not_exist(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:
+    # The regression: a "does not exist" failure must NOT be swallowed by a
+    # bare "exist" substring match (which would proceed to deploy against an
+    # env that was never created).
+    fake = _make_fake_modal_binary(tmp_path, exit_code=1, stderr="Workspace 'minds-dev' does not exist")
+    with pytest.raises(ModalDeployError, match="does not exist"):
+        ensure_modal_env(DevEnvName("dev-josh"), parent_cg=_root_cg, modal_binary=str(fake))
 
 
 def _fake_neon_record() -> NeonProjectRecord:

--- a/apps/minds/imbue/minds/envs/per_env_deploy_test.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy_test.py
@@ -85,10 +85,11 @@ def test_select_app_id_from_rows_raises_on_non_list_payload() -> None:
 
 
 def test_extract_container_ids_collects_ids_across_key_variants() -> None:
+    # The third row has no recognized id key -> warned + skipped, not fatal.
     rows = [
         {"Container ID": "ta-1"},
         {"container_id": "ta-2"},
-        {"unrecognized": "skip-me"},  # warned + skipped, not fatal
+        {"unrecognized": "skip-me"},
     ]
     assert _extract_container_ids_from_rows(rows) == ("ta-1", "ta-2")
 

--- a/apps/minds/imbue/minds/envs/per_env_deploy_test.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy_test.py
@@ -17,6 +17,7 @@ from pydantic import SecretStr
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.envs.per_env_deploy import ModalDeployError
+from imbue.minds.envs.per_env_deploy import _parse_deploy_url_from_stdout
 from imbue.minds.envs.per_env_deploy import compute_per_env_overrides
 from imbue.minds.envs.per_env_deploy import ensure_modal_env
 from imbue.minds.envs.primitives import DevEnvName
@@ -38,6 +39,26 @@ def _make_fake_modal_binary(tmp_path: Path, *, exit_code: int, stderr: str = "")
     script.write_text(f"#!/usr/bin/env bash\ncat {stderr_path} >&2\nexit {exit_code}\n")
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return script
+
+
+def test_parse_deploy_url_returns_last_modal_run_url() -> None:
+    # The deployed function URL is the last .modal.run URL (earlier ones may
+    # be dashboard links); wrapped/inline whitespace is collapsed first.
+    stdout = (
+        "View Deployment: https://modal.com/apps/minds-dev/dev-josh\n"
+        "https://minds-dev-dev-josh--rsc-dev-a\npi.modal.run\n"
+    )
+    url = _parse_deploy_url_from_stdout(stdout, app_name="rsc-dev", modal_env="dev-josh")
+    assert str(url).rstrip("/") == "https://minds-dev-dev-josh--rsc-dev-api.modal.run"
+
+
+def test_parse_deploy_url_raises_when_no_url_present() -> None:
+    # A modal deploy with no .modal.run URL is always fatal; the parser
+    # raises rather than returning an optional the caller must re-check.
+    with pytest.raises(ModalDeployError, match="no .modal.run URL"):
+        _parse_deploy_url_from_stdout(
+            "Deployment complete, nothing useful here", app_name="rsc-dev", modal_env="dev-josh"
+        )
 
 
 def test_ensure_modal_env_succeeds_on_zero_exit(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:

--- a/apps/minds/imbue/minds/envs/per_env_deploy_test.py
+++ b/apps/minds/imbue/minds/envs/per_env_deploy_test.py
@@ -17,7 +17,9 @@ from pydantic import SecretStr
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.envs.per_env_deploy import ModalDeployError
+from imbue.minds.envs.per_env_deploy import _extract_container_ids_from_rows
 from imbue.minds.envs.per_env_deploy import _parse_deploy_url_from_stdout
+from imbue.minds.envs.per_env_deploy import _select_app_id_from_rows
 from imbue.minds.envs.per_env_deploy import compute_per_env_overrides
 from imbue.minds.envs.per_env_deploy import ensure_modal_env
 from imbue.minds.envs.primitives import DevEnvName
@@ -59,6 +61,41 @@ def test_parse_deploy_url_raises_when_no_url_present() -> None:
         _parse_deploy_url_from_stdout(
             "Deployment complete, nothing useful here", app_name="rsc-dev", modal_env="dev-josh"
         )
+
+
+def test_select_app_id_from_rows_finds_running_app() -> None:
+    # Column-name variants are tolerated; stopped apps + non-matching names
+    # are skipped; the running match's id is returned.
+    rows = [
+        {"Name": "rsc-dev", "State": "stopped", "App ID": "ap-old"},
+        {"name": "other-app", "state": "deployed", "app_id": "ap-other"},
+        {"Name": "rsc-dev", "State": "deployed", "App ID": "ap-live"},
+    ]
+    assert _select_app_id_from_rows(rows, app_name="rsc-dev") == "ap-live"
+
+
+def test_select_app_id_from_rows_returns_none_when_absent() -> None:
+    assert _select_app_id_from_rows([{"Name": "other", "State": "deployed", "ID": "x"}], app_name="rsc-dev") is None
+
+
+def test_select_app_id_from_rows_raises_on_non_list_payload() -> None:
+    # returncode == 0 with non-list JSON is unexpected -> raise, not return None.
+    with pytest.raises(ModalDeployError, match="non-list payload"):
+        _select_app_id_from_rows({"unexpected": "object"}, app_name="rsc-dev")
+
+
+def test_extract_container_ids_collects_ids_across_key_variants() -> None:
+    rows = [
+        {"Container ID": "ta-1"},
+        {"container_id": "ta-2"},
+        {"unrecognized": "skip-me"},  # warned + skipped, not fatal
+    ]
+    assert _extract_container_ids_from_rows(rows) == ("ta-1", "ta-2")
+
+
+def test_extract_container_ids_raises_on_non_list_payload() -> None:
+    with pytest.raises(ModalDeployError, match="non-list payload"):
+        _extract_container_ids_from_rows("not a list")
 
 
 def test_ensure_modal_env_succeeds_on_zero_exit(tmp_path: Path, _root_cg: ConcurrencyGroup) -> None:

--- a/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels.py
+++ b/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels.py
@@ -90,8 +90,17 @@ def list_tunnels_for_env(
                 continue
             if metadata.get("env") == expected_env:
                 tunnel_id = tunnel.get("id")
-                if isinstance(tunnel_id, str):
-                    matches.append(tunnel_id)
+                if not isinstance(tunnel_id, str) or not tunnel_id:
+                    # The earlier `continue`s filter out tunnels that aren't
+                    # ours. This one IS ours (metadata.env matched) but has no
+                    # usable id -- an anomaly, not an expected skip. Silently
+                    # dropping it would leak the tunnel (the caller would never
+                    # delete it). Surface it instead.
+                    raise CloudflareTunnelProviderError(
+                        f"Cloudflare tunnel matched env {expected_env!r} but has a missing / "
+                        f"non-string `id`: {tunnel.get('id')!r}"
+                    )
+                matches.append(tunnel_id)
         result_info = payload.get("result_info")
         total_pages = result_info.get("total_pages", 1) if isinstance(result_info, dict) else 1
         has_more_pages = page < total_pages

--- a/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels_test.py
+++ b/apps/minds/imbue/minds/envs/providers/cloudflare_tunnels_test.py
@@ -94,6 +94,22 @@ def test_list_tunnels_for_env_returns_empty_when_no_match() -> None:
     )
 
 
+def test_list_tunnels_for_env_raises_on_matched_tunnel_with_bad_id() -> None:
+    # A tunnel positively identified as ours (metadata.env matches) but with a
+    # missing / non-string id is an anomaly, not an expected skip: silently
+    # dropping it would leak the tunnel. It must surface.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok_list_response([{"id": None, "metadata": {"env": "dev-josh"}}])
+
+    with pytest.raises(CloudflareTunnelProviderError, match="non-string `id`"):
+        list_tunnels_for_env(
+            DevEnvName("dev-josh"),
+            account_id="acct",
+            api_token=SecretStr("t"),
+            transport=httpx.MockTransport(handler),
+        )
+
+
 def test_list_tunnels_for_env_raises_on_http_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, text="server boom")

--- a/apps/minds/imbue/minds/envs/providers/neon_db.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db.py
@@ -491,11 +491,17 @@ def create_neon_project(
         if not project_was_pre_existing:
             try:
                 _neon_request("DELETE", f"/projects/{project_id}", api_token=api_token)
-            except NeonProviderError:
-                # Swallow cleanup errors; the original failure is what
-                # the caller needs to see. A leaked project will be
-                # picked up by the next deploy via the by-name lookup.
-                pass
+            except NeonProviderError as cleanup_exc:
+                # Swallow cleanup errors; the original failure is what the
+                # caller needs to see. But log it -- a project we could not
+                # delete is leaked until the next deploy's by-name lookup
+                # surfaces it, which an operator should be able to see.
+                logger.warning(
+                    "Failed to delete Neon project {} during rollback; it may be leaked "
+                    "(the next deploy's by-name lookup will surface it): {}",
+                    project_id,
+                    cleanup_exc,
+                )
         raise
 
     return NeonProjectRecord(

--- a/apps/minds/imbue/minds/envs/providers/neon_db.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db.py
@@ -76,7 +76,21 @@ LITELLM_COST_DB_NAME: Final[str] = "litellm_cost"
 
 
 class NeonProviderError(MindError):
-    """Raised when the Neon API rejects a request."""
+    """Raised when the Neon API rejects a request.
+
+    ``status_code`` carries the HTTP status of the rejecting response when
+    the error came from a ``>= 400`` reply (``None`` for transport errors,
+    non-JSON bodies, or shape mismatches). Callers branch on it for
+    idempotency (e.g. ``== 409`` "already exists", ``== 404`` "absent")
+    instead of substring-matching the message -- the message embeds up to
+    500 chars of response body, so a different error's body could contain
+    "409"/"404" and silently flip a genuine failure into a treated-as-
+    success no-op.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class NeonBranchSummary(FrozenModel):
@@ -184,7 +198,10 @@ def _neon_request(
             "operation likely never finished."
         )
     if response.status_code >= 400:
-        raise NeonProviderError(f"Neon API returned {response.status_code} for {method} {path}: {response.text[:500]}")
+        raise NeonProviderError(
+            f"Neon API returned {response.status_code} for {method} {path}: {response.text[:500]}",
+            status_code=response.status_code,
+        )
     try:
         return response.json()
     except ValueError as exc:
@@ -347,7 +364,8 @@ def _ensure_database(
             json_body={"database": {"name": database_name, "owner_name": "neondb_owner"}},
         )
     except NeonProviderError as exc:
-        if "409" not in str(exc):
+        # 409 == database already exists on this branch -> idempotent success.
+        if exc.status_code != 409:
             raise
 
 
@@ -515,7 +533,8 @@ def delete_neon_project(
     try:
         _neon_request("DELETE", f"/projects/{existing.id}", api_token=api_token)
     except NeonProviderError as exc:
-        if "404" in str(exc):
+        # 404 == project already gone -> idempotent success.
+        if exc.status_code == 404:
             return
         raise
 
@@ -590,8 +609,10 @@ def restore_branch_from_snapshot(
             },
         )
     except NeonProviderError as exc:
-        message = str(exc)
-        if "409" in message and "already exists" in message:
+        # 409 + "already exists" == the preserve branch was already created by
+        # a prior run -> the restore already happened. The body-text check
+        # stays as a secondary guard so an *unrelated* 409 still surfaces.
+        if exc.status_code == 409 and "already exists" in str(exc).lower():
             logger.info(
                 "Skipped Neon restore of branch {!r}: preserve branch {!r} already exists "
                 "(restore was already applied by a prior run).",
@@ -615,7 +636,8 @@ def delete_neon_branch(project_id: str, branch_id: str, *, api_token: SecretStr)
     try:
         _neon_request("DELETE", f"/projects/{project_id}/branches/{branch_id}", api_token=api_token)
     except NeonProviderError as exc:
-        if "404" in str(exc):
+        # 404 == branch already gone -> idempotent success.
+        if exc.status_code == 404:
             return
         raise
 

--- a/apps/minds/imbue/minds/envs/providers/neon_db.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db.py
@@ -100,6 +100,10 @@ class NeonBranchSummary(FrozenModel):
 
     id: str
     name: str
+    # Neon flags exactly one branch per project as the default. This is the
+    # authoritative "which branch is the root" signal -- far more reliable
+    # than matching on the name "main" (which can be renamed).
+    default: bool = False
 
 
 class NeonProjectRecord(FrozenModel):
@@ -336,10 +340,32 @@ def _resolve_default_branch(project_id: str, *, api_token: SecretStr) -> NeonBra
         branches = _BRANCH_LIST_ADAPTER.validate_python(branches_raw)
     except ValidationError as exc:
         raise NeonProviderError(f"Neon /projects/{project_id}/branches returned an unexpected shape: {exc}") from exc
+    return _select_default_branch(branches, project_id=project_id)
+
+
+def _select_default_branch(branches: list[NeonBranchSummary], *, project_id: str) -> NeonBranchSummary:
+    """Pick the default branch from a project's branch list.
+
+    Prefers Neon's authoritative ``default`` flag. Falls back to the
+    conventional name "main" only if (unexpectedly) no branch is flagged,
+    since minds always creates its projects with a default "main" branch.
+    Refuses to guess when neither signal is present: returning an arbitrary
+    branch (the previous ``branches[0]`` behaviour) could silently restore /
+    migrate against a snapshot child branch rather than the true default.
+
+    Pure function -- lives next to its only caller so the selection logic
+    can be unit-tested without standing up a Neon stub.
+    """
+    for branch in branches:
+        if branch.default:
+            return branch
     for branch in branches:
         if branch.name == "main":
             return branch
-    return branches[0]
+    raise NeonProviderError(
+        f"Neon project {project_id} has no branch flagged `default` and none named 'main'; "
+        f"cannot determine the default branch (branches: {[b.name for b in branches]})."
+    )
 
 
 def _ensure_database(

--- a/apps/minds/imbue/minds/envs/providers/neon_db_test.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db_test.py
@@ -18,6 +18,17 @@ def _make_summary(*, id: str, created_at: str = "2026-01-01T00:00:00Z") -> NeonP
     return NeonProjectSummary(id=id, name="minds-dev-josh", created_at=created_at)
 
 
+def test_neon_provider_error_carries_status_code() -> None:
+    # Callers branch on .status_code (not message substrings) for idempotency.
+    err = NeonProviderError("Neon API returned 409 ...", status_code=409)
+    assert err.status_code == 409
+
+
+def test_neon_provider_error_status_code_defaults_to_none() -> None:
+    # Transport errors / shape mismatches have no HTTP status.
+    assert NeonProviderError("transport blew up").status_code is None
+
+
 def test_select_one_or_raise_returns_none_when_no_projects_match() -> None:
     assert _select_one_or_raise_multi_match([], "minds-dev-josh", org_id="org-x") is None
 

--- a/apps/minds/imbue/minds/envs/providers/neon_db_test.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db_test.py
@@ -8,9 +8,11 @@ turns a list of matching Neon projects into "adopt", "create", or
 
 import pytest
 
+from imbue.minds.envs.providers.neon_db import NeonBranchSummary
 from imbue.minds.envs.providers.neon_db import NeonProjectSummary
 from imbue.minds.envs.providers.neon_db import NeonProviderError
 from imbue.minds.envs.providers.neon_db import _format_multi_match_message
+from imbue.minds.envs.providers.neon_db import _select_default_branch
 from imbue.minds.envs.providers.neon_db import _select_one_or_raise_multi_match
 
 
@@ -27,6 +29,34 @@ def test_neon_provider_error_carries_status_code() -> None:
 def test_neon_provider_error_status_code_defaults_to_none() -> None:
     # Transport errors / shape mismatches have no HTTP status.
     assert NeonProviderError("transport blew up").status_code is None
+
+
+def test_select_default_branch_prefers_the_default_flag() -> None:
+    # The default-flagged branch wins even when another branch is named "main".
+    branches = [
+        NeonBranchSummary(id="b-main", name="main", default=False),
+        NeonBranchSummary(id="b-real", name="renamed-root", default=True),
+    ]
+    assert _select_default_branch(branches, project_id="p1").id == "b-real"
+
+
+def test_select_default_branch_falls_back_to_name_main() -> None:
+    # No branch is flagged default (unexpected) -> fall back to name "main".
+    branches = [
+        NeonBranchSummary(id="b-child", name="snapshot-xyz", default=False),
+        NeonBranchSummary(id="b-main", name="main", default=False),
+    ]
+    assert _select_default_branch(branches, project_id="p1").id == "b-main"
+
+
+def test_select_default_branch_raises_when_no_default_or_main() -> None:
+    # Neither signal present -> refuse to guess (don't return an arbitrary branch).
+    branches = [
+        NeonBranchSummary(id="b-1", name="snapshot-a", default=False),
+        NeonBranchSummary(id="b-2", name="snapshot-b", default=False),
+    ]
+    with pytest.raises(NeonProviderError, match="cannot determine the default branch"):
+        _select_default_branch(branches, project_id="p1")
 
 
 def test_select_one_or_raise_returns_none_when_no_projects_match() -> None:

--- a/apps/minds/imbue/minds/envs/providers/ovh_tags.py
+++ b/apps/minds/imbue/minds/envs/providers/ovh_tags.py
@@ -18,7 +18,6 @@ handles discovery + destruction.
 from typing import Final
 
 import ovh
-from loguru import logger
 from ovh.exceptions import InvalidConfiguration
 from pydantic import Field
 from pydantic import SecretStr
@@ -131,8 +130,14 @@ def delete_instances(
     client = _build_client(credentials)
     for resource in instances:
         if not resource.name:
-            logger.warning("Skipping OVH IAM resource with empty name: urn={}", resource.urn)
-            continue
+            # The name is the VPS id we terminate by. An IAM resource matched
+            # for termination with an empty name is a data anomaly, not an
+            # expected skip: skipping it leaves the VPS running (and billing).
+            # We cannot build a VpsInstanceId from it, so surface it.
+            raise OvhProviderError(
+                f"OVH IAM resource matched for termination has an empty name (urn={resource.urn}); "
+                "cannot terminate the VPS. Inspect it in the OVH dashboard and re-run `minds env destroy`."
+            )
         try:
             client.destroy_instance(VpsInstanceId(resource.name))
         except VpsApiError as exc:

--- a/apps/minds/imbue/minds/envs/provisioning.py
+++ b/apps/minds/imbue/minds/envs/provisioning.py
@@ -498,7 +498,8 @@ class DevEnvSummary(FrozenModel):
         default=None,
         description=(
             "Where the client.toml lives: 'env_root' for dev envs, 'in_repo' for "
-            "reserved tiers (staging / production). None when there's no client.toml."
+            "reserved tiers (staging / production), 'in_repo_malformed' when that "
+            "committed file is present but fails to parse. None when there's no client.toml."
         ),
     )
     connector_url: AnyUrl | None = Field(
@@ -1462,7 +1463,11 @@ def list_dev_envs() -> tuple[DevEnvSummary, ...]:
     (``client_config_source``), and the ``connector_url`` parsed out
     of it. Rows that have no client.toml anywhere (an unprovisioned
     dev env) leave ``connector_url`` / ``client_config_path`` /
-    ``client_config_source`` as ``None``.
+    ``client_config_source`` as ``None``. A reserved tier whose committed
+    in-repo client.toml is present but unparseable gets
+    ``client_config_source="in_repo_malformed"`` (with ``connector_url``
+    None) so the breakage is visible rather than indistinguishable from an
+    unprovisioned env.
     """
     summaries: list[DevEnvSummary] = []
     for env_root in list_env_root_dirs():
@@ -1481,12 +1486,14 @@ def list_dev_envs() -> tuple[DevEnvSummary, ...]:
                 client_config_source = "in_repo"
                 try:
                     connector_url = load_client_config(repo_path).connector_url
-                except EnvConfigError:
-                    # Malformed in-repo file: leave connector_url None
-                    # rather than blowing up the whole list. The CLI
-                    # surfaces "no client.toml" which prompts the
-                    # operator to fix the committed file.
-                    pass
+                except EnvConfigError as exc:
+                    # The committed in-repo file is present but does not parse.
+                    # Don't blow up the whole list, but DON'T leave it looking
+                    # like a healthy "in_repo" row with a mysteriously-missing
+                    # connector either: mark the source distinctly so the CLI
+                    # shows the file is broken, and warn so it's visible in logs.
+                    client_config_source = "in_repo_malformed"
+                    logger.warning("Malformed committed client.toml for tier {!r} at {}: {}", env_name, repo_path, exc)
         else:
             dev_env_name = DevEnvName(env_name)
             if client_config_exists(dev_env_name):

--- a/apps/minds/imbue/minds/envs/provisioning.py
+++ b/apps/minds/imbue/minds/envs/provisioning.py
@@ -89,6 +89,7 @@ from imbue.minds.envs.providers.neon_db import NeonProjectRecord
 from imbue.minds.envs.providers.ovh_tags import OvhCredentials
 from imbue.minds.envs.providers.supertokens_app import SuperTokensAppRecord
 from imbue.minds.envs.providers.supertokens_app import app_id_from_connection_uri
+from imbue.minds.envs.recover import NeonRecoverInfo
 from imbue.minds.envs.recover import RecoverTarget
 from imbue.minds.envs.recover import delete_recover_target
 from imbue.minds.envs.recover import find_monorepo_root
@@ -725,9 +726,11 @@ def _deploy_env_locked(
         modal_env=modal_env,
         modal_workspace=modal_workspace,
         vault_path_prefix=tier_vault_prefix,
-        neon_project_id=neon_project_id_for_snapshot,
-        neon_branch_id=neon_branch_id_for_snapshot,
-        neon_snapshot_branch_id=neon_snapshot_branch_id,
+        neon_restore=NeonRecoverInfo(
+            project_id=neon_project_id_for_snapshot,
+            branch_id=neon_branch_id_for_snapshot,
+            snapshot_branch_id=neon_snapshot_branch_id,
+        ),
         app_versions_to_restore=app_versions_to_restore,
     )
     try:

--- a/apps/minds/imbue/minds/envs/recover.py
+++ b/apps/minds/imbue/minds/envs/recover.py
@@ -46,6 +46,7 @@ from typing import Self
 from loguru import logger
 from pydantic import Field
 from pydantic import SecretStr
+from pydantic import ValidationError
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
@@ -161,10 +162,51 @@ class RecoverTarget(FrozenModel):
             data = json.loads(raw)
         except (ValueError, json.JSONDecodeError) as exc:
             raise MindError(f"Recover-target file is not valid JSON: {exc}") from exc
-        return cls.model_validate(data)
+        if isinstance(data, dict):
+            data = _migrate_legacy_neon_fields(data)
+        try:
+            return cls.model_validate(data)
+        except ValidationError as exc:
+            # The JSON parsed but doesn't match the model (e.g. a future /
+            # foreign shape). Distinguish this from a genuine JSON-syntax
+            # error so the operator isn't told "not valid JSON" about a file
+            # that is valid JSON.
+            raise MindError(f"Recover-target file has an unexpected shape: {exc}") from exc
 
     def to_json_bytes(self) -> bytes:
         return json.dumps(self.model_dump(mode="json"), indent=2, sort_keys=True).encode("utf-8")
+
+
+# Maps the pre-NeonRecoverInfo flat field names to their place inside the
+# collapsed ``neon_restore`` sub-object. Used only by the back-compat reader.
+_LEGACY_NEON_FIELD_MAP: Final[dict[str, str]] = {
+    "neon_project_id": "project_id",
+    "neon_branch_id": "branch_id",
+    "neon_snapshot_branch_id": "snapshot_branch_id",
+}
+
+
+def _migrate_legacy_neon_fields(data: dict[str, object]) -> dict[str, object]:
+    """Lift a pre-``NeonRecoverInfo`` recover-target's flat Neon ids into ``neon_restore``.
+
+    Recover-target files written before the three flat ``neon_*`` fields were
+    collapsed into the ``neon_restore`` sub-object carry the old top-level
+    keys. Since :class:`RecoverTarget` is ``extra="forbid"``, such a file would
+    otherwise fail validation when read back by a newer ``minds env recover``
+    -- exactly the mid-recovery wall this subsystem exists to avoid. Fold the
+    legacy keys into a ``neon_restore`` object (all three present + non-empty)
+    or ``None`` (a legacy no-Neon deploy). A file already in the new shape
+    (``neon_restore`` present, or no legacy keys at all) is returned untouched.
+    """
+    if "neon_restore" in data or not any(key in data for key in _LEGACY_NEON_FIELD_MAP):
+        return data
+    migrated = {key: value for key, value in data.items() if key not in _LEGACY_NEON_FIELD_MAP}
+    legacy_values = {new: data.get(old) for old, new in _LEGACY_NEON_FIELD_MAP.items()}
+    if all(isinstance(value, str) and value for value in legacy_values.values()):
+        migrated["neon_restore"] = legacy_values
+    else:
+        migrated["neon_restore"] = None
+    return migrated
 
 
 def find_monorepo_root(*, cwd: Path | None = None) -> Path:

--- a/apps/minds/imbue/minds/envs/recover.py
+++ b/apps/minds/imbue/minds/envs/recover.py
@@ -92,6 +92,37 @@ class RecoverFailedError(MindError):
     """
 
 
+class NeonRecoverInfo(FrozenModel):
+    """All-or-nothing Neon instant-restore inputs captured at deploy start.
+
+    Modeled as one sub-object (rather than three independent optionals on
+    :class:`RecoverTarget`) so a partially-populated capture is
+    unrepresentable: ``recover_env`` either has a complete Neon restore
+    target or none at all. Present on ``RecoverTarget.neon_restore`` when the
+    deploy captured a Neon snapshot; absent (``None``) for a deploy with no
+    Neon-restore configuration.
+    """
+
+    project_id: str = Field(
+        description=(
+            "Neon project id the snapshot branch was created in. For dev (creates_resources=true) "
+            "it's the just-provisioned per-env project; for shared tiers (creates_resources=false) "
+            "it's the operator-managed project id from "
+            "``secrets/minds/<tier>/neon-admin.NEON_PROJECT_ID``."
+        ),
+    )
+    branch_id: str = Field(
+        description="Default branch id on the Neon project (parent of the snapshot branch).",
+    )
+    snapshot_branch_id: str = Field(
+        description=(
+            "Branch id of the snapshot branch created at deploy start (off the default branch, "
+            "named ``pre-deploy-<deploy_id>``). Recover restores the default branch from this "
+            "snapshot via Neon's ``POST .../branches/{main}/restore`` with ``source_branch_id``."
+        ),
+    )
+
+
 class RecoverTarget(FrozenModel):
     """Captured "where to get back to" state, written atomically at deploy start.
 
@@ -108,27 +139,13 @@ class RecoverTarget(FrozenModel):
     modal_env: str = Field(description="The Modal env the deploy targeted.")
     modal_workspace: str
     vault_path_prefix: str
-    neon_project_id: str | None = Field(
+    neon_restore: NeonRecoverInfo | None = Field(
         default=None,
         description=(
-            "Neon project id the snapshot branch was created in. For dev (creates_resources=true) "
-            "it's the just-provisioned per-env project; for shared tiers (creates_resources=false) "
-            "it's the operator-managed project id from "
-            "``secrets/minds/<tier>/neon-admin.NEON_PROJECT_ID``."
-        ),
-    )
-    neon_branch_id: str | None = Field(
-        default=None,
-        description="Default branch id on the Neon project (parent of the snapshot branch).",
-    )
-    neon_snapshot_branch_id: str | None = Field(
-        default=None,
-        description=(
-            "Branch id of the snapshot branch created at deploy start (off the default branch, "
-            "named ``pre-deploy-<deploy_id>``). Recover restores the default branch from this "
-            "snapshot via Neon's ``POST .../branches/{main}/restore`` with ``source_branch_id``. "
-            "``None`` if the deploy is for a tier without Neon-restore configuration (missing "
-            "``NEON_PROJECT_ID`` in Vault for a shared tier)."
+            "Neon instant-restore inputs (project / default-branch / snapshot-branch ids), or "
+            "``None`` for a deploy with no Neon-restore configuration. All-or-nothing: a partial "
+            "capture is unrepresentable, so recover never has to reconcile three independent "
+            "optionals."
         ),
     )
     app_versions_to_restore: dict[str, str | None] = Field(
@@ -292,13 +309,12 @@ def recover_env(
     Reversal order (matches the deploy order in reverse):
 
     1. ``modal app rollback`` each app to its captured pre-deploy version.
-    2. Neon: restore ``target.neon_branch_id`` (the project's default
-       branch) from ``target.neon_snapshot_branch_id`` (the pre-deploy
-       child branch the deploy created), capturing the pre-restore
-       state under ``pre-rollback-<deploy_id>`` so the operator can
-       inspect the broken state via the Neon console if needed. Only
-       runs when all three of ``neon_snapshot_branch_id``,
-       ``neon_project_id``, and ``neon_branch_id`` are populated.
+    2. Neon: restore the project's default branch from the pre-deploy
+       child branch the deploy created, capturing the pre-restore state
+       under ``pre-rollback-<deploy_id>`` so the operator can inspect the
+       broken state via the Neon console if needed. Only runs when
+       ``target.neon_restore`` is present (the deploy captured a Neon
+       snapshot).
     3. ``modal secret delete <svc>-<tier>-<deploy_id>`` for every
        service in ``deploy_config.secrets.services``.
     4. Delete the recover-target file.
@@ -361,14 +377,14 @@ def _recover_env_locked(
             errors.append(f"modal app rollback {app_name} {version}: {exc}")
 
     # Step 2: Neon instant restore from the captured snapshot branch.
-    if target.neon_snapshot_branch_id and target.neon_project_id and target.neon_branch_id:
+    if target.neon_restore is not None:
         try:
             with info_span(
                 "Restoring Neon branch {!r} from snapshot branch {!r}",
-                target.neon_branch_id,
-                target.neon_snapshot_branch_id,
+                target.neon_restore.branch_id,
+                target.neon_restore.snapshot_branch_id,
             ):
-                _restore_neon(target=target, credentials=credentials)
+                _restore_neon(neon=target.neon_restore, deploy_id=target.deploy_id, credentials=credentials)
         except NeonProviderError as exc:
             logger.warning("Recover: Neon restore failed: {}", exc)
             errors.append(f"neon restore_branch_from_snapshot: {exc}")
@@ -403,21 +419,20 @@ def _recover_env_locked(
     )
 
 
-def _restore_neon(*, target: RecoverTarget, credentials) -> None:
+def _restore_neon(*, neon: NeonRecoverInfo, deploy_id: DeployId, credentials) -> None:
     """Adapter that calls ``restore_branch_from_snapshot`` with credential lookup.
 
+    Takes the (guaranteed-complete) :class:`NeonRecoverInfo` directly, so
+    the three ids are present by type -- no None-narrowing asserts needed.
     The ``preserve_under_name`` argument captures the broken pre-restore
     state under ``pre-rollback-<deploy_id>`` so the operator can inspect
     it later via the Neon console.
     """
-    assert target.neon_project_id is not None
-    assert target.neon_branch_id is not None
-    assert target.neon_snapshot_branch_id is not None
     restore_branch_from_snapshot(
-        target.neon_project_id,
-        target.neon_branch_id,
-        target.neon_snapshot_branch_id,
-        preserve_under_name=f"pre-rollback-{target.deploy_id}",
+        neon.project_id,
+        neon.branch_id,
+        neon.snapshot_branch_id,
+        preserve_under_name=f"pre-rollback-{deploy_id}",
         api_token=credentials.neon_api_token,
     )
 
@@ -443,6 +458,7 @@ def make_neon_snapshot_branch_name(deploy_id: DeployId) -> str:
 
 
 __all__ = [
+    "NeonRecoverInfo",
     "NotInMonorepoError",
     "RecoverFailedError",
     "RecoverTarget",

--- a/apps/minds/imbue/minds/envs/recover_test.py
+++ b/apps/minds/imbue/minds/envs/recover_test.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from imbue.minds.envs.recover import NeonRecoverInfo
 from imbue.minds.envs.recover import NotInMonorepoError
 from imbue.minds.envs.recover import RecoverTarget
 from imbue.minds.envs.recover import RecoverTargetAlreadyExistsError
@@ -29,9 +30,11 @@ def _sample_target(env_name: str = _ENV_NAME) -> RecoverTarget:
         modal_env=env_name,
         modal_workspace="minds-dev",
         vault_path_prefix="secrets/minds/dev",
-        neon_project_id="proj-fake-123",
-        neon_branch_id="br-main-1",
-        neon_snapshot_branch_id="br-snap-pre-deploy",
+        neon_restore=NeonRecoverInfo(
+            project_id="proj-fake-123",
+            branch_id="br-main-1",
+            snapshot_branch_id="br-snap-pre-deploy",
+        ),
         app_versions_to_restore={"rsc-dev": "v17", "llm-dev": None},
     )
 
@@ -121,3 +124,22 @@ def test_app_versions_to_restore_may_carry_none(tmp_path: Path) -> None:
     parsed = read_recover_target(repo_root=tmp_path, env_name=_ENV_NAME)
     assert parsed.app_versions_to_restore["llm-dev"] is None
     assert parsed.app_versions_to_restore["rsc-dev"] == "v17"
+
+
+def test_neon_restore_round_trips_as_nested_object(tmp_path: Path) -> None:
+    # The three Neon ids are one all-or-nothing sub-object; a partial capture
+    # is unrepresentable. Confirm the nested object survives the JSON round-trip.
+    target = _sample_target()
+    parsed = RecoverTarget.from_json_bytes(target.to_json_bytes())
+    assert parsed.neon_restore is not None
+    assert parsed.neon_restore.project_id == "proj-fake-123"
+    assert parsed.neon_restore.branch_id == "br-main-1"
+    assert parsed.neon_restore.snapshot_branch_id == "br-snap-pre-deploy"
+
+
+def test_neon_restore_may_be_absent(tmp_path: Path) -> None:
+    # A deploy with no Neon-restore configuration carries neon_restore=None;
+    # recover skips the Neon step for it.
+    target = _sample_target().model_copy(update={"neon_restore": None})
+    parsed = RecoverTarget.from_json_bytes(target.to_json_bytes())
+    assert parsed.neon_restore is None

--- a/apps/minds/imbue/minds/envs/recover_test.py
+++ b/apps/minds/imbue/minds/envs/recover_test.py
@@ -138,8 +138,17 @@ def test_neon_restore_round_trips_as_nested_object(tmp_path: Path) -> None:
 
 
 def test_neon_restore_may_be_absent(tmp_path: Path) -> None:
-    # A deploy with no Neon-restore configuration carries neon_restore=None;
-    # recover skips the Neon step for it.
-    target = _sample_target().model_copy(update={"neon_restore": None})
+    # A deploy with no Neon-restore configuration carries neon_restore=None
+    # (the field defaults to None); recover skips the Neon step for it.
+    target = RecoverTarget(
+        deploy_id=DeployId("20260517T143022Z"),
+        env_name=_ENV_NAME,
+        tier="dev",
+        modal_env=_ENV_NAME,
+        modal_workspace="minds-dev",
+        vault_path_prefix="secrets/minds/dev",
+        app_versions_to_restore={"rsc-dev": "v17"},
+    )
+    assert target.neon_restore is None
     parsed = RecoverTarget.from_json_bytes(target.to_json_bytes())
     assert parsed.neon_restore is None

--- a/apps/minds/imbue/minds/envs/recover_test.py
+++ b/apps/minds/imbue/minds/envs/recover_test.py
@@ -1,5 +1,6 @@
 """Unit tests for the recover-target file IO + reversal logic."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,7 @@ from imbue.minds.envs.recover import recover_target_exists
 from imbue.minds.envs.recover import recover_target_path
 from imbue.minds.envs.recover import write_recover_target_atomic
 from imbue.minds.envs.secret_lifecycle import DeployId
+from imbue.minds.errors import MindError
 
 _ENV_NAME = "dev-josh-1"
 
@@ -135,6 +137,59 @@ def test_neon_restore_round_trips_as_nested_object(tmp_path: Path) -> None:
     assert parsed.neon_restore.project_id == "proj-fake-123"
     assert parsed.neon_restore.branch_id == "br-main-1"
     assert parsed.neon_restore.snapshot_branch_id == "br-snap-pre-deploy"
+
+
+def test_from_json_bytes_migrates_legacy_flat_neon_fields() -> None:
+    # A recover-target file written before the NeonRecoverInfo collapse carries
+    # flat neon_project_id / neon_branch_id / neon_snapshot_branch_id keys. The
+    # reader must lift them into neon_restore rather than reject the file
+    # (RecoverTarget is extra="forbid"), so an in-flight pre-upgrade recovery
+    # still works.
+    legacy_json = json.dumps(
+        {
+            "deploy_id": "20260517T143022Z",
+            "env_name": _ENV_NAME,
+            "tier": "dev",
+            "modal_env": _ENV_NAME,
+            "modal_workspace": "minds-dev",
+            "vault_path_prefix": "secrets/minds/dev",
+            "neon_project_id": "proj-legacy",
+            "neon_branch_id": "br-legacy",
+            "neon_snapshot_branch_id": "br-snap-legacy",
+            "app_versions_to_restore": {"rsc-dev": "v9"},
+        }
+    ).encode("utf-8")
+    parsed = RecoverTarget.from_json_bytes(legacy_json)
+    assert parsed.neon_restore is not None
+    assert parsed.neon_restore.project_id == "proj-legacy"
+    assert parsed.neon_restore.branch_id == "br-legacy"
+    assert parsed.neon_restore.snapshot_branch_id == "br-snap-legacy"
+
+
+def test_from_json_bytes_migrates_legacy_no_neon_to_none() -> None:
+    # A legacy file whose flat neon ids were all null maps to neon_restore=None.
+    legacy_json = json.dumps(
+        {
+            "deploy_id": "20260517T143022Z",
+            "env_name": _ENV_NAME,
+            "tier": "dev",
+            "modal_env": _ENV_NAME,
+            "modal_workspace": "minds-dev",
+            "vault_path_prefix": "secrets/minds/dev",
+            "neon_project_id": None,
+            "neon_branch_id": None,
+            "neon_snapshot_branch_id": None,
+            "app_versions_to_restore": {"rsc-dev": "v9"},
+        }
+    ).encode("utf-8")
+    parsed = RecoverTarget.from_json_bytes(legacy_json)
+    assert parsed.neon_restore is None
+
+
+def test_from_json_bytes_reports_shape_mismatch_distinctly() -> None:
+    # Valid JSON but the wrong shape must NOT be reported as "not valid JSON".
+    with pytest.raises(MindError, match="unexpected shape"):
+        RecoverTarget.from_json_bytes(b'{"totally": "wrong"}')
 
 
 def test_neon_restore_may_be_absent(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/envs/secret_lifecycle.py
+++ b/apps/minds/imbue/minds/envs/secret_lifecycle.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Final
 from typing import Self
+from typing import cast
 
 from loguru import logger
 from pydantic import GetCoreSchemaHandler
@@ -184,16 +185,22 @@ def _extract_secret_names_from_rows(rows: object) -> tuple[str, ...]:
         raise ModalDeployError(f"`modal secret list --json` returned a non-list payload: {rows!r}")
     names: list[str] = []
     for row in rows:
-        if isinstance(row, dict) and isinstance(row.get("Name"), str):
-            names.append(row["Name"])
-        elif isinstance(row, dict) and isinstance(row.get("name"), str):
-            names.append(row["name"])
-        else:
+        name: str | None = None
+        if isinstance(row, dict):
+            row_map = cast("dict[str, object]", row)
+            candidate = row_map.get("Name")
+            if not isinstance(candidate, str):
+                candidate = row_map.get("name")
+            if isinstance(candidate, str):
+                name = candidate
+        if name is None:
             logger.warning(
                 "`modal secret list --json` row had no usable Name/name field; skipping it in GC "
                 "(Modal output shape may have shifted): {!r}",
                 row,
             )
+            continue
+        names.append(name)
     return tuple(names)
 
 

--- a/apps/minds/imbue/minds/envs/secret_lifecycle.py
+++ b/apps/minds/imbue/minds/envs/secret_lifecycle.py
@@ -23,7 +23,6 @@ from datetime import datetime
 from datetime import timezone
 from typing import Final
 from typing import Self
-from typing import cast
 
 from loguru import logger
 from pydantic import GetCoreSchemaHandler
@@ -33,6 +32,7 @@ from pydantic_core import core_schema
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.primitives import NonEmptyStr
 from imbue.minds.envs.per_env_deploy import ModalDeployError
+from imbue.minds.envs.per_env_deploy import first_str_value
 from imbue.minds.errors import MindError
 
 # ``YYYYMMDDTHHMMSSZ`` -- compact ISO 8601 (RFC 3339 without separators),
@@ -185,14 +185,7 @@ def _extract_secret_names_from_rows(rows: object) -> tuple[str, ...]:
         raise ModalDeployError(f"`modal secret list --json` returned a non-list payload: {rows!r}")
     names: list[str] = []
     for row in rows:
-        name: str | None = None
-        if isinstance(row, dict):
-            row_map = cast("dict[str, object]", row)
-            candidate = row_map.get("Name")
-            if not isinstance(candidate, str):
-                candidate = row_map.get("name")
-            if isinstance(candidate, str):
-                name = candidate
+        name = first_str_value(row, ("Name", "name"))
         if name is None:
             logger.warning(
                 "`modal secret list --json` row had no usable Name/name field; skipping it in GC "

--- a/apps/minds/imbue/minds/envs/secret_lifecycle.py
+++ b/apps/minds/imbue/minds/envs/secret_lifecycle.py
@@ -167,6 +167,19 @@ def list_modal_secrets(*, modal_env: str, parent_cg: ConcurrencyGroup) -> tuple[
         rows = json.loads(result.stdout)
     except (ValueError, json.JSONDecodeError) as exc:
         raise ModalDeployError(f"`modal secret list --json` returned non-JSON: {exc}") from exc
+    return _extract_secret_names_from_rows(rows)
+
+
+def _extract_secret_names_from_rows(rows: object) -> tuple[str, ...]:
+    """Pull the secret names out of ``modal secret list --json`` rows.
+
+    Raises :class:`ModalDeployError` on a non-list payload (genuinely
+    unexpected given ``returncode == 0``). Skips -- and warns about -- rows
+    with no usable ``Name`` / ``name`` field, since Modal's output shape has
+    shifted across versions; warning makes such a shift detectable rather
+    than silently dropping still-live secrets from the GC. Pure function so
+    the parsing is unit-testable without a fake CLI.
+    """
     if not isinstance(rows, list):
         raise ModalDeployError(f"`modal secret list --json` returned a non-list payload: {rows!r}")
     names: list[str] = []
@@ -176,11 +189,11 @@ def list_modal_secrets(*, modal_env: str, parent_cg: ConcurrencyGroup) -> tuple[
         elif isinstance(row, dict) and isinstance(row.get("name"), str):
             names.append(row["name"])
         else:
-            # Modal CLI's output shape has shifted across versions; skip
-            # rows that don't carry a usable Name / name field instead of
-            # raising (we lose visibility into them in the GC, but the
-            # operator can still inspect the env via the Modal dashboard).
-            continue
+            logger.warning(
+                "`modal secret list --json` row had no usable Name/name field; skipping it in GC "
+                "(Modal output shape may have shifted): {!r}",
+                row,
+            )
     return tuple(names)
 
 

--- a/apps/minds/imbue/minds/envs/secret_lifecycle_test.py
+++ b/apps/minds/imbue/minds/envs/secret_lifecycle_test.py
@@ -10,10 +10,28 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.envs.per_env_deploy import ModalDeployError
 from imbue.minds.envs.secret_lifecycle import DeployId
 from imbue.minds.envs.secret_lifecycle import InvalidDeployIdError
+from imbue.minds.envs.secret_lifecycle import _extract_secret_names_from_rows
 from imbue.minds.envs.secret_lifecycle import gc_old_per_tier_secrets
 from imbue.minds.envs.secret_lifecycle import make_deploy_id
 from imbue.minds.envs.secret_lifecycle import parse_timestamped_secret_name
 from imbue.minds.envs.secret_lifecycle import timestamped_secret_name
+
+
+def test_extract_secret_names_handles_both_key_casings() -> None:
+    rows = [{"Name": "a-dev-20260101T000000Z"}, {"name": "b-dev-20260101T000000Z"}]
+    assert _extract_secret_names_from_rows(rows) == ("a-dev-20260101T000000Z", "b-dev-20260101T000000Z")
+
+
+def test_extract_secret_names_skips_drift_rows() -> None:
+    # Rows with no usable Name/name field are skipped (warned), not fatal --
+    # so a partial shape shift doesn't abort the whole GC pass.
+    rows = [{"Name": "good-dev-20260101T000000Z"}, {"unexpected": "shape"}, "not-a-dict"]
+    assert _extract_secret_names_from_rows(rows) == ("good-dev-20260101T000000Z",)
+
+
+def test_extract_secret_names_raises_on_non_list_payload() -> None:
+    with pytest.raises(ModalDeployError, match="non-list payload"):
+        _extract_secret_names_from_rows({"unexpected": "object"})
 
 
 def test_deploy_id_round_trip() -> None:

--- a/apps/minds/imbue/minds/envs/vault_reader.py
+++ b/apps/minds/imbue/minds/envs/vault_reader.py
@@ -263,8 +263,13 @@ def delete_vault_kv(
         raise VaultReadError(f"Failed to invoke {vault_binary}: {exc}") from exc
     if result.returncode == 0:
         return
-    message = (result.stderr + result.stdout).lower()
-    if "not found" in message or "no value found" in message or "404" in message:
+    if result.returncode == _VAULT_NOT_FOUND_EXIT_CODE:
+        # The entry is already absent. `vault kv metadata delete` returns the
+        # same "no value at this path" exit code as `kv get`, so re-running
+        # destroy after a partial failure is safe. Branch on the exit code
+        # (mirroring read_vault_kv) rather than substring-matching the output,
+        # which could mask an unrelated failure whose text happens to contain
+        # "not found" / "404".
         return
     stderr = result.stderr.strip() or result.stdout.strip()
     raise VaultReadError(f"`{vault_binary} kv metadata delete {relative}` failed (exit {result.returncode}): {stderr}")

--- a/apps/minds/imbue/minds/envs/vault_reader_test.py
+++ b/apps/minds/imbue/minds/envs/vault_reader_test.py
@@ -7,6 +7,7 @@ import pytest
 from imbue.minds.envs.primitives import VaultReadError
 from imbue.minds.envs.primitives import VaultSecretNotFoundError
 from imbue.minds.envs.vault_reader import VaultPath
+from imbue.minds.envs.vault_reader import delete_vault_kv
 from imbue.minds.envs.vault_reader import read_vault_kv
 
 
@@ -98,3 +99,22 @@ def test_read_vault_kv_malformed_data_shape(tmp_path: Path) -> None:
     fake = _make_fake_vault_binary(tmp_path, stdout='{"data": "not a dict"}')
     with pytest.raises(VaultReadError, match="no data.data dict"):
         read_vault_kv(VaultPath("secrets/minds/dev/cloudflare"), vault_binary=str(fake))
+
+
+def test_delete_vault_kv_idempotent_on_absent_entry(tmp_path: Path) -> None:
+    # `vault kv metadata delete` returns the same "no value here" exit code
+    # as `kv get` for an absent path -> treated as success so re-running
+    # destroy after a partial failure is safe.
+    fake = _make_fake_vault_binary(tmp_path, stdout="", exit_code=2, stderr="No value found at secrets/...")
+    delete_vault_kv(VaultPath("secrets/minds/dev/generation"), vault_binary=str(fake))
+
+
+def test_delete_vault_kv_propagates_real_failure_even_if_text_says_not_found(tmp_path: Path) -> None:
+    # A non-2 exit is a genuine failure (auth/connectivity/permission). It
+    # must surface even if its message happens to contain "not found" -- the
+    # exact masking the old substring match allowed.
+    fake = _make_fake_vault_binary(
+        tmp_path, stdout="", exit_code=1, stderr="permission denied: secret path not found in policy"
+    )
+    with pytest.raises(VaultReadError, match="failed"):
+        delete_vault_kv(VaultPath("secrets/minds/dev/generation"), vault_binary=str(fake))


### PR DESCRIPTION
## Suspicious edge-case hardening pass over `apps/minds/imbue/minds/envs`

An `/identify-suspicious-edge-cases` cleanup pass over the `minds env`
provisioning subsystem, then fixing each finding. The full report is at
`apps/minds/_tasks/suspicious-edge-cases/2026-06-04-08-48-35.md` (gitignored).
Each of the 16 findings is its own commit; the theme is replacing
over-defensive handling that silently masked real failures (leaked cloud
resources, masked data corruption, broken operator environments) with handling
that surfaces the anomaly.

### Findings fixed (one commit each)
1. **mngr agent destroy** — destroy agents per-id so a real failure on one
   agent isn't masked by another already being gone (which left cloud
   resources stranded).
2. **generation read** — catch the typed `VaultSecretNotFoundError` instead of
   substring-matching Vault error text.
13. **generation read** — raise on a present-but-keyless generation entry
   instead of minting a fresh id over the corruption.
4. **Neon idempotency** — branch on a structured `status_code` on
   `NeonProviderError`, not substrings of the response body (4 callers).
6. **Neon rollback** — log the swallowed project-cleanup error.
15. **Neon default branch** — resolve via the `default` flag, not `branches[0]`.
8. **`delete_vault_kv`** — detect absence by exit code (matching
   `read_vault_kv`), not substring.
5. **`ensure_modal_env`** — match the specific `"already exists"` phrase, not
   the bare `"exist"` (which also matched `"does not exist"`).
14. **Modal list parsers** — consistently raise on a non-list payload and warn
   on shape-drift rows; extracted pure, unit-tested helpers.
16. **`_parse_deploy_url_from_stdout`** — raise instead of returning an
   always-fatal `None`.
11. **`read_profile_user_id`** — surface an OSError on a present `user_id`
   file (was skipping cleanup -> leaked state container).
9. **Cloudflare tunnels** — raise on an our-tunnel with a missing/non-string
   id (was silently leaked).
12. **OVH** — raise on an IAM resource with an empty name (was silently left
   running + billing).
10. **`list_env_root_dirs`** — raise on a broken `$HOME` instead of returning
   "zero envs".
3. **`list_dev_envs`** — surface a malformed committed `client.toml`
   (`in_repo_malformed`) instead of hiding it as a healthy row.
7. **`RecoverTarget`** — collapse three optional Neon ids into one
   all-or-nothing `NeonRecoverInfo | None` (removes the partial-population
   ambiguity and three type-narrowing asserts). Changes the ephemeral
   recover-target JSON shape (no migration; the file is per-deploy + gitignored).

Two follow-up commits keep `ty` + the cast/model_copy/trailing-comment
ratchets green.

### Testing
- `just test-quick` across the touched modules: all green (176 in the
  combined envs + cli run).
- `uv run ty check` on `apps/minds/imbue/minds/envs` + `cli/env.py`: clean.
- `apps/minds/imbue/minds/test_ratchets.py`: 55 passed.
- Full suite via CI (`just test-offload`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
