### PR TITLE
mngr_forward: harden suspicious edge-case handling

### DIFF
--- a/libs/mngr/changelog/mngr-suspicious-edge-cases-mngr-forward-local.md
+++ b/libs/mngr/changelog/mngr-suspicious-edge-cases-mngr-forward-local.md
@@ -1,0 +1,1 @@
+`PluginConfig.merge_with` now returns `Self` instead of the base `PluginConfig`, so a plugin config subclass that inherits the base merge (rather than overriding it) keeps its own static type after merging. This is an internal typing improvement with no runtime behavior change.

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -505,11 +505,13 @@ class PluginConfig(FrozenModel):
         description="Whether this plugin is enabled",
     )
 
-    def merge_with(self, override: "PluginConfig") -> "PluginConfig":
+    def merge_with(self, override: "PluginConfig") -> Self:
         """Merge this config with an override config.
 
         Uses ``model_fields_set`` so plugin subclasses that add extra fields
-        get correct assign-by-default semantics on those fields too.
+        get correct assign-by-default semantics on those fields too. Returns
+        ``Self`` so a subclass that inherits this implementation (rather than
+        overriding it) keeps its own static type after merging.
         """
         explicitly_set = override.model_fields_set
         if not explicitly_set:

--- a/libs/mngr_forward/changelog/mngr-suspicious-edge-cases-mngr-forward-local.md
+++ b/libs/mngr_forward/changelog/mngr-suspicious-edge-cases-mngr-forward-local.md
@@ -1,0 +1,8 @@
+Hardened suspicious edge-case handling across the forward plugin:
+
+- Config merge: `[plugins.forward]` no longer silently re-enables a plugin that a lower config layer disabled. The plugin now inherits the base config-merge semantics (only fields an override layer explicitly set win) instead of a hand-written field-by-field merge.
+- A backend URL that cannot be parsed is now treated as loopback (refused) rather than dialed, closing a fail-open gap in the no-tunnel safety guard.
+- `mngr list` snapshot parsing now logs (instead of silently dropping) agent rows that are malformed or missing their id, so a bad upstream payload is visible rather than surfacing only as a confusing "no matching agents" error.
+- WebSocket close errors and other previously-silent swallows are now logged at trace level.
+
+No user-facing behavior changes beyond the above; the rest were internal robustness and clarity improvements (removed dead code, removed a thread-race sentinel, made an internal field non-optional).

--- a/libs/mngr_forward/imbue/mngr_forward/config.py
+++ b/libs/mngr_forward/imbue/mngr_forward/config.py
@@ -39,26 +39,11 @@ class ForwardPluginConfig(PluginConfig):
         description="Whether to open the login URL automatically (sets --open-browser by default).",
     )
 
-    def merge_with(self, override: "PluginConfig") -> "ForwardPluginConfig":
-        merged_enabled = override.enabled if override.enabled is not None else self.enabled
-        if not isinstance(override, ForwardPluginConfig):
-            return self.__class__(
-                enabled=merged_enabled,
-                port=self.port,
-                agent_include=self.agent_include,
-                agent_exclude=self.agent_exclude,
-                event_include=self.event_include,
-                event_exclude=self.event_exclude,
-                auto_open_browser=self.auto_open_browser,
-            )
-        return self.__class__(
-            enabled=merged_enabled,
-            port=override.port if override.port is not None else self.port,
-            agent_include=override.agent_include if override.agent_include is not None else self.agent_include,
-            agent_exclude=override.agent_exclude if override.agent_exclude is not None else self.agent_exclude,
-            event_include=override.event_include if override.event_include is not None else self.event_include,
-            event_exclude=override.event_exclude if override.event_exclude is not None else self.event_exclude,
-            auto_open_browser=(
-                override.auto_open_browser if override.auto_open_browser is not None else self.auto_open_browser
-            ),
-        )
+    # NOTE: merge_with is intentionally *not* overridden here. The base
+    # PluginConfig.merge_with uses override.model_fields_set, which already
+    # gives correct assign-by-default semantics for the forward-specific
+    # fields above (only fields the override layer explicitly set win). A
+    # hand-written field-by-field merge using ``value is not None`` would both
+    # be dead code on the non-optional fields and silently re-enable a plugin
+    # the lower layer disabled (an override that does not set ``enabled``
+    # defaults it to True). Inherit the base implementation instead.

--- a/libs/mngr_forward/imbue/mngr_forward/config_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/config_test.py
@@ -16,9 +16,8 @@ def test_merge_with_overrides_only_set_fields() -> None:
     override = ForwardPluginConfig(port=ForwardPort(9000))
     merged = base.merge_with(override)
     assert merged.port == ForwardPort(9000)
-    # agent_include in override is None; the base value should win.
-    # NOTE: pydantic resets None fields to defaults; the test demonstrates the behaviour.
-    assert merged.agent_include in (None, "has(agent.labels.workspace)")
+    # agent_include is not in the override's model_fields_set, so the base value wins.
+    assert merged.agent_include == "has(agent.labels.workspace)"
 
 
 def test_merge_with_explicit_disable() -> None:
@@ -26,3 +25,14 @@ def test_merge_with_explicit_disable() -> None:
     override = ForwardPluginConfig(enabled=False)
     merged = base.merge_with(override)
     assert merged.enabled is False
+
+
+def test_merge_with_does_not_re_enable_disabled_base() -> None:
+    # A base layer that disables the plugin must stay disabled when merged with
+    # an override that did not explicitly set ``enabled`` (regression: a
+    # hand-written ``value is not None`` merge would resurrect it to True).
+    base = ForwardPluginConfig(enabled=False)
+    override = ForwardPluginConfig(port=ForwardPort(9000))
+    merged = base.merge_with(override)
+    assert merged.enabled is False
+    assert merged.port == ForwardPort(9000)

--- a/libs/mngr_forward/imbue/mngr_forward/resolver.py
+++ b/libs/mngr_forward/imbue/mngr_forward/resolver.py
@@ -21,7 +21,6 @@ from typing import assert_never
 from pydantic import Field
 from pydantic import PrivateAttr
 
-from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.mngr.primitives import AgentId
 from imbue.mngr_forward.data_types import BackendUrl
@@ -173,4 +172,3 @@ class ForwardResolver(MutableModel):
                 return ProxyTarget(url=BackendUrl(url), ssh_info=ssh_info)
             case _ as unreachable:  # pragma: no cover
                 assert_never(unreachable)
-                raise SwitchError(f"Unknown forwarding strategy: {unreachable}")

--- a/libs/mngr_forward/imbue/mngr_forward/resolver.py
+++ b/libs/mngr_forward/imbue/mngr_forward/resolver.py
@@ -15,6 +15,7 @@ agent is unknown, the requested service URL is not yet discovered, or the
 agent has no SSH info but the strategy requires one.
 """
 
+import io
 import threading
 from typing import assert_never
 
@@ -32,6 +33,19 @@ from imbue.mngr_forward.envelope import EnvelopeWriter
 from imbue.mngr_forward.ssh_tunnel import RemoteSSHInfo
 
 
+def _new_discarded_envelope_writer() -> EnvelopeWriter:
+    """Null-object writer for resolvers constructed without an explicit sink.
+
+    Production always injects the plugin's real stdout-backed ``EnvelopeWriter``
+    (see ``cli.py``); this default exists only so unit tests that don't assert
+    on emission can omit the argument. Emissions go to an in-memory buffer that
+    is never read, which keeps ``envelope_writer`` non-optional -- the type
+    checker proves it is always present, so the mutation paths need no
+    ``is not None`` guard -- without printing test noise to stdout.
+    """
+    return EnvelopeWriter(output=io.StringIO())
+
+
 class ForwardResolver(MutableModel):
     """Maps an agent ID to its current backend ``ProxyTarget``."""
 
@@ -39,15 +53,16 @@ class ForwardResolver(MutableModel):
         frozen=True,
         description="Either ForwardServiceStrategy or ForwardPortStrategy; chosen at CLI parse time",
     )
-    envelope_writer: EnvelopeWriter | None = Field(
-        default=None,
+    envelope_writer: EnvelopeWriter = Field(
+        default_factory=_new_discarded_envelope_writer,
         description=(
-            "Optional writer used to emit a ``resolver_snapshot`` envelope on every "
+            "Writer used to emit a ``resolver_snapshot`` envelope on every "
             "mutation of the per-agent services map -- ``update_services`` "
             "(set/replace) plus the destruction paths (``remove_known_agent`` and "
             "``update_known_agents`` when they drop an agent that had services). "
-            "The plugin wires this so a downstream consumer can mirror the per-agent "
-            "service map. None in tests / code paths that don't care about emission."
+            "The plugin (``cli.py``) injects its real stdout-backed writer so a "
+            "downstream consumer can mirror the per-agent service map; the default "
+            "is a no-op sink for tests that don't assert on emission."
         ),
     )
 
@@ -87,7 +102,7 @@ class ForwardResolver(MutableModel):
             self._initial_discovery_done = True
             if services_changed:
                 snapshot = self._snapshot_services_locked()
-        if snapshot is not None and self.envelope_writer is not None:
+        if snapshot is not None:
             self.envelope_writer.emit_resolver_snapshot(snapshot)
 
     def add_known_agent(self, agent_id: AgentId) -> None:
@@ -114,7 +129,7 @@ class ForwardResolver(MutableModel):
             self._ssh_by_agent.pop(aid_str, None)
             if services_changed:
                 snapshot = self._snapshot_services_locked()
-        if snapshot is not None and self.envelope_writer is not None:
+        if snapshot is not None:
             self.envelope_writer.emit_resolver_snapshot(snapshot)
 
     def update_services(self, agent_id: AgentId, services: dict[str, str]) -> None:
@@ -128,8 +143,7 @@ class ForwardResolver(MutableModel):
         with self._lock:
             self._services_by_agent[str(agent_id)] = dict(services)
             snapshot = self._snapshot_services_locked()
-        if self.envelope_writer is not None:
-            self.envelope_writer.emit_resolver_snapshot(snapshot)
+        self.envelope_writer.emit_resolver_snapshot(snapshot)
 
     def update_ssh_info(self, agent_id: AgentId, ssh_info: RemoteSSHInfo) -> None:
         """Set or replace the SSH info for a single agent."""

--- a/libs/mngr_forward/imbue/mngr_forward/resolver.py
+++ b/libs/mngr_forward/imbue/mngr_forward/resolver.py
@@ -41,7 +41,10 @@ def _new_discarded_envelope_writer() -> EnvelopeWriter:
     on emission can omit the argument. Emissions go to an in-memory buffer that
     is never read, which keeps ``envelope_writer`` non-optional -- the type
     checker proves it is always present, so the mutation paths need no
-    ``is not None`` guard -- without printing test noise to stdout.
+    ``is not None`` guard -- without printing test noise to stdout. (A bare
+    ``io.TextIOBase`` discard sink is not assignable to ``IO[str]`` under the
+    type checker, and the buffer only ever fills in tests, where resolvers are
+    short-lived, so ``StringIO`` is the pragmatic choice.)
     """
     return EnvelopeWriter(output=io.StringIO())
 

--- a/libs/mngr_forward/imbue/mngr_forward/resolver_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/resolver_test.py
@@ -101,9 +101,11 @@ def test_update_services_emits_resolver_snapshot_envelope() -> None:
     )
 
 
-def test_update_services_without_envelope_writer_is_silent() -> None:
-    # No envelope writer => no emission, no failure. Tested for the path used by
-    # existing resolver-only tests and any code path that doesn't need the snapshot.
+def test_update_services_with_default_writer_does_not_emit_to_stdout() -> None:
+    # Constructed without an explicit writer, the resolver uses the no-op
+    # default sink: mutations succeed without raising and nothing reaches the
+    # real envelope stream. This is the path used by resolver-only tests and
+    # any code that doesn't need the snapshot.
     resolver = ForwardResolver(strategy=ForwardServiceStrategy(service_name="system_interface"))
     resolver.add_known_agent(TEST_AGENT_ID_1)
     resolver.update_services(TEST_AGENT_ID_1, {"system_interface": "http://127.0.0.1:9100"})

--- a/libs/mngr_forward/imbue/mngr_forward/resolver_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/resolver_test.py
@@ -101,7 +101,7 @@ def test_update_services_emits_resolver_snapshot_envelope() -> None:
     )
 
 
-def test_update_services_with_default_writer_does_not_emit_to_stdout() -> None:
+def test_update_services_with_default_writer_does_not_emit_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
     # Constructed without an explicit writer, the resolver uses the no-op
     # default sink: mutations succeed without raising and nothing reaches the
     # real envelope stream. This is the path used by resolver-only tests and
@@ -109,6 +109,11 @@ def test_update_services_with_default_writer_does_not_emit_to_stdout() -> None:
     resolver = ForwardResolver(strategy=ForwardServiceStrategy(service_name="system_interface"))
     resolver.add_known_agent(TEST_AGENT_ID_1)
     resolver.update_services(TEST_AGENT_ID_1, {"system_interface": "http://127.0.0.1:9100"})
+    # The default sink discards to an in-memory buffer, so nothing should reach
+    # the process's real stdout (regression guard: were the default ever wired
+    # back to sys.stdout, a resolver_snapshot envelope would leak here).
+    captured = capsys.readouterr()
+    assert captured.out == ""
 
 
 def _resolver_snapshot_payloads(buf: io.StringIO) -> list[dict[str, dict[str, str]]]:

--- a/libs/mngr_forward/imbue/mngr_forward/server.py
+++ b/libs/mngr_forward/imbue/mngr_forward/server.py
@@ -87,7 +87,10 @@ def _is_loopback_url(url: str) -> bool:
     try:
         parsed = urlsplit(url)
     except ValueError:
-        return False
+        # This is a safety guard, so fail closed on an unparseable URL: treat
+        # it as loopback so the no-tunnel callers refuse to dial it, rather
+        # than fail open and proxy to a URL we could not even parse.
+        return True
     raw_host = parsed.hostname
     if raw_host is None:
         return False

--- a/libs/mngr_forward/imbue/mngr_forward/server.py
+++ b/libs/mngr_forward/imbue/mngr_forward/server.py
@@ -618,8 +618,8 @@ async def _handle_workspace_forward_websocket(
         logger.debug("SSH tunnel setup failed for WS {}: {}", agent_id, e)
         try:
             await websocket.close(code=1011, reason="SSH tunnel failed")
-        except RuntimeError:
-            pass
+        except RuntimeError as close_error:
+            logger.trace("WebSocket already closed while sending close frame: {}", close_error)
         return
 
     if tunnel_socket_path is None and _is_loopback_url(backend_url) and not allow_host_loopback:
@@ -631,8 +631,8 @@ async def _handle_workspace_forward_websocket(
         )
         try:
             await websocket.close(code=1013, reason=_WS_CLOSE_REASON_LOOPBACK_REFUSED)
-        except RuntimeError:
-            pass
+        except RuntimeError as close_error:
+            logger.trace("WebSocket already closed while sending close frame: {}", close_error)
         return
 
     ws_backend = backend_url.replace("http://", "ws://").replace("https://", "wss://").rstrip("/")
@@ -666,8 +666,8 @@ async def _handle_workspace_forward_websocket(
         logger.debug("Backend WS connection failed for {}: {}", agent_id, connection_error)
         try:
             await websocket.close(code=1011, reason="Backend connection failed")
-        except RuntimeError:
-            pass
+        except RuntimeError as close_error:
+            logger.trace("WebSocket already closed while sending close frame: {}", close_error)
 
 
 # -- Bare-origin handlers --------------------------------------------------

--- a/libs/mngr_forward/imbue/mngr_forward/server_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/server_test.py
@@ -359,6 +359,9 @@ def test_is_loopback_url() -> None:
     assert not _is_loopback_url("http://stub-backend:8000")
     assert not _is_loopback_url("http://10.0.0.5:8000")
     assert not _is_loopback_url("http://example.com")
+    # A URL that urlsplit cannot parse fails closed (treated as loopback so
+    # the no-tunnel callers refuse to dial it).
+    assert _is_loopback_url("http://[::1")
 
 
 @pytest.mark.parametrize(

--- a/libs/mngr_forward/imbue/mngr_forward/snapshot.py
+++ b/libs/mngr_forward/imbue/mngr_forward/snapshot.py
@@ -80,9 +80,11 @@ def _parse_snapshot(json_output: str) -> ForwardListSnapshot:
     agents: list[ForwardAgentSnapshot] = []
     for raw in raw_agents:
         if not isinstance(raw, dict):
+            logger.warning("Skipping non-dict agent row in `mngr list` output: {!r}", raw)
             continue
         agent_id_str = raw.get("id")
         if agent_id_str is None:
+            logger.warning("Skipping agent row with no id in `mngr list` output: {!r}", raw)
             continue
         try:
             agent_id = AgentId(agent_id_str)

--- a/libs/mngr_forward/imbue/mngr_forward/snapshot.py
+++ b/libs/mngr_forward/imbue/mngr_forward/snapshot.py
@@ -111,15 +111,18 @@ def _parse_snapshot(json_output: str) -> ForwardListSnapshot:
     return ForwardListSnapshot(agents=tuple(agents))
 
 
-def _parse_str_field(raw: dict[str, Any] | Any, key: str) -> str:
+def _parse_str_field(raw: dict[str, Any], key: str) -> str:
     """Pull ``key`` out of ``raw`` as a string, defaulting to empty.
 
-    Tolerates missing keys, non-dict containers, and non-string values so a
-    partial ``mngr list --format json`` payload (e.g. an older mngr version
-    that doesn't carry one of these fields) doesn't break snapshot parsing.
+    Tolerates missing keys and non-string values so a partial
+    ``mngr list --format json`` payload (e.g. an older mngr version that
+    doesn't carry one of these fields) doesn't break snapshot parsing. An
+    empty string therefore means "field absent from this mngr version's
+    output", which matters because these values feed client-side CEL
+    ``--agent-include``/``--agent-exclude`` filtering: a silently-empty
+    ``host_id``/``provider_name`` can change which agents match a filter.
+    Callers guarantee ``raw`` is a dict, so no container type-check here.
     """
-    if not isinstance(raw, dict):
-        return ""
     value = raw.get(key)
     return str(value) if value is not None else ""
 

--- a/libs/mngr_forward/imbue/mngr_forward/stream_manager.py
+++ b/libs/mngr_forward/imbue/mngr_forward/stream_manager.py
@@ -540,6 +540,12 @@ class ForwardStreamManager(MutableModel):
             # envelope; the plugin doesn't consume them itself.
             return
 
+        # Every services-source event carries an explicit "type" by contract:
+        # the registering side always writes "service_registered" or
+        # "service_deregistered" (see mngr_ttyd's emitter and the hello-world
+        # example), and minds' backend_resolver defaults the same way. The
+        # default-to-registered is therefore only a belt-and-suspenders guard
+        # for a field that is, in practice, always present.
         event_type = raw.get("type", "service_registered")
         service = raw.get("service")
         if not isinstance(service, str) or not service:

--- a/libs/mngr_forward/imbue/mngr_forward/stream_manager.py
+++ b/libs/mngr_forward/imbue/mngr_forward/stream_manager.py
@@ -400,16 +400,25 @@ class ForwardStreamManager(MutableModel):
         host_id_str = str(event.host_id)
         with self._lock:
             self._ssh_by_host_id[host_id_str] = ssh_info
-            agents_on_host = [AgentId(aid) for aid, hid in self._agent_host_map.items() if hid == host_id_str]
+            # Capture the provider name alongside the agent id under this single
+            # lock acquisition. _agent_host_map and _discovered_agents always
+            # carry identical key sets (written and removed together), so the
+            # indexing is safe here and avoids a second, racy lookup that a
+            # concurrent _destroy_agent could otherwise turn into a miss.
+            agents_on_host = [
+                (AgentId(aid), str(self._discovered_agents[aid].provider_name))
+                for aid, hid in self._agent_host_map.items()
+                if hid == host_id_str
+            ]
 
-        for agent_id in agents_on_host:
+        for agent_id, provider_name in agents_on_host:
             self.resolver.update_ssh_info(agent_id, ssh_info)
             for callback in self._on_agent_discovered_callbacks:
                 self._safely_call(
                     callback,
                     agent_id,
                     ssh_info,
-                    self._provider_name_for_agent(agent_id),
+                    provider_name,
                     name="on_agent_discovered (ssh-info-late)",
                 )
 
@@ -461,13 +470,6 @@ class ForwardStreamManager(MutableModel):
             if host_id is None:
                 return None
             return self._ssh_by_host_id.get(host_id)
-
-    def _provider_name_for_agent(self, agent_id: AgentId) -> str:
-        with self._lock:
-            agent = self._discovered_agents.get(str(agent_id))
-        if agent is None:
-            return "unknown"
-        return str(agent.provider_name)
 
     # -- per-agent events streams -----------------------------------------
 


### PR DESCRIPTION
Acts on the findings from an `/identify-suspicious-edge-cases` scan of `libs/mngr_forward`. One commit per finding.

## Findings addressed

1. **Config merge re-enable bug** (`config.py`): deleted the hand-written `ForwardPluginConfig.merge_with` override. It reimplemented the base merge with `value is not None` guards that were dead on non-optional fields and, worse, silently re-enabled a plugin a lower config layer had disabled. Now inherits the base `model_fields_set` merge. Added a regression test.
2. **Silent WS close swallows** (`server.py`): three `except RuntimeError: pass` blocks now log at trace, matching the file's convention.
3. **Silently dropped agent rows** (`snapshot.py`): malformed / id-less rows from `mngr list` are now logged instead of dropped silently.
4. **Dead `raise` after `assert_never`** (`resolver.py`): removed the unreachable raise and its unused import.
5. **Fail-open security guard** (`server.py`): `_is_loopback_url` now fails closed (treats an unparseable URL as loopback, so the no-tunnel callers refuse it).
6. **Typeless services-event default** (`stream_manager.py`): documented that every emitter writes an explicit `type` by contract.
7. **`"unknown"` provider sentinel** (`stream_manager.py`): captured the provider name under the same lock as the agent id, eliminating a destroy-TOCTOU lookup and the sentinel.
8. **Optional-for-tests field** (`resolver.py`): made `envelope_writer` non-optional via a null-object default, dropping three `is not None` guards.
9. **`AutoAddPolicy` SSH fallback**: left as-is per maintainer decision (documented trade-off; agents are short-lived hosts on trusted networks).
10. **Redundant dict-guard** (`snapshot.py`): dropped a dead inner `isinstance` and documented the empty-string default's effect on CEL filtering.

Plus a follow-on in `libs/mngr`: `PluginConfig.merge_with` now returns `Self` (matching the four sibling base configs in the same file), so subclasses that inherit the base merge keep their static type — required for finding #1's deletion to type-check.

## Testing
- `just test-quick libs/mngr_forward -m 'not tmux and not modal and not docker and not docker_sdk and not acceptance and not release'`: 230 passed, 0 failed.
- `uv run ty check`: passes (only a pre-existing unrelated `celtypes` warning).
- Full offload suite runs in CI.

Note: the same buggy config-merge pattern (finding #1) is copied in `mngr_latchkey` and `mngr_notifications`, which were outside this scan's scope and are left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)