### PR TITLE
Harden suspicious edge-case handling in mngr/hosts

### DIFF
--- a/libs/mngr/changelog/mngr-suspicious-edge-cases-mngr-hosts-local.md
+++ b/libs/mngr/changelog/mngr-suspicious-edge-cases-mngr-hosts-local.md
@@ -1,0 +1,8 @@
+Hardened suspicious edge-case handling in `imbue/mngr/hosts/` (a cleanup pass). Internal robustness/clarity changes with no intended user-visible behavior change:
+
+- Offline host state derivation now documents that `stop_reason` carries a `HostState` name (including `DESTROYED`), and the stale `stop_reason` field docstring was corrected.
+- `Host.get_state`, `OuterHost._close_paramiko_client`, `OuterHost.write_file` (remote), and the remote `_get_file_mtime` now log the errors they catch instead of swallowing them silently.
+- `_get_agent_additional_commands` now raises a clear `CorruptedAgentDataError` on a malformed `additional_commands` entry instead of an opaque `KeyError`/`TypeError`.
+- `validate_and_create_discovered_agent` now skips records whose `id`/`name` are the wrong type (not just invalid strings) consistently, instead of crashing discovery.
+- Tightened a too-broad `except` in uptime parsing and removed a double-fallback when merging agent labels.
+- Added clarifying comments documenting why several edge-case handlers are intentional (cooperative-lock cleanup, SSH transport lookup, exception classification by message text, tmux lifecycle parsing, git base-branch default).

--- a/libs/mngr/imbue/mngr/hosts/common.py
+++ b/libs/mngr/imbue/mngr/hosts/common.py
@@ -339,11 +339,17 @@ def determine_lifecycle_state(
     case, states that would otherwise be REPLACED are reported as
     RUNNING_UNKNOWN_AGENT_TYPE instead.
     """
+    # An empty tmux_info means there is no tmux session for the agent -> STOPPED.
     if not tmux_info:
         return AgentLifecycleState.STOPPED
 
+    # A non-empty value that does not split into exactly 3 parts
+    # (pane_dead|pane_current_command|pane_pid) is unexpected -- it indicates a
+    # tmux output-format change or a bug, not a real lifecycle state. Log it so a
+    # regression is noticeable, then fall back to STOPPED.
     parts = tmux_info.split("|")
     if len(parts) != 3:
+        logger.debug("Unexpected tmux_info format (expected 3 |-separated parts): {!r}", tmux_info)
         return AgentLifecycleState.STOPPED
 
     pane_dead, current_command, pane_pid = parts

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2779,7 +2779,10 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         except FileNotFoundError as e:
             raise NoCommandDefinedError(f"No data.json file for agent {agent.name} ({agent.id})") from e
 
-        data = json.loads(content)
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise CorruptedAgentDataError(agent.id, data_path, e) from e
         try:
             return data["command"]
         except KeyError as e:
@@ -2793,7 +2796,10 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         except FileNotFoundError:
             return []
 
-        data = json.loads(content)
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise CorruptedAgentDataError(agent.id, data_path, e) from e
         raw_commands = data.get("additional_commands", [])
 
         # Handle both old format (list of strings) and new format (list of dicts).

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -49,6 +49,7 @@ from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import WorkDirExtraPathMode
 from imbue.mngr.errors import AgentNotFoundOnHostError
 from imbue.mngr.errors import AgentStartError
+from imbue.mngr.errors import CorruptedAgentDataError
 from imbue.mngr.errors import HostConnectionError
 from imbue.mngr.errors import HostDataSchemaError
 from imbue.mngr.errors import InvalidActivityTypeError
@@ -3132,7 +3133,9 @@ def _parse_uptime_output(stdout: str) -> float:
             return float(uptime_str)
         else:
             return 0.0
-    except (ValueError, OSError):
+    except ValueError:
+        # Only int()/float() parsing can fail here; both raise ValueError (no I/O,
+        # so no OSError). Unparseable output means "uptime unknown" -> 0.0.
         return 0.0
 
 

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2846,11 +2846,15 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
 
         try:
             result = self.execute_idempotent_command("echo ok")
+        except (OSError, HostConnectionError) as e:
+            # Ping failed: the host is (probably) unreachable. Fall through to the
+            # offline-derived state, but log why so a transient/unexpected failure
+            # is not silently indistinguishable from a genuinely down host.
+            logger.trace("Ping of host {} failed ({}); falling back to offline state derivation", self.id, e)
+        else:
             if result.success:
                 logger.trace("Determined host {} state=RUNNING (ping successful)", self.id)
                 return HostState.RUNNING
-        except (OSError, HostConnectionError):
-            pass
 
         # otherwise use the offline logic
         return super().get_state()

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -1205,6 +1205,10 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         if options.git and options.git.base_branch:
             base_branch_name = options.git.base_branch
         else:
+            # Default to the source repo's current branch. "main" is a deliberate
+            # convenience fallback for the rare case where the branch cannot be read
+            # (empty/failed rev-parse); callers whose source default branch differs
+            # (e.g. "master") should pass an explicit base_branch.
             base_branch_name = (
                 _git_command_stdout(source_host, "git rev-parse --abbrev-ref HEAD", source_path) or "main"
             )

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -692,8 +692,6 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         data_path = self.host_dir / "data.json"
         try:
             content = self.read_text_file(data_path)
-            data = json.loads(content)
-            return CertifiedHostData(**data)
         except FileNotFoundError:
             now = datetime.now(timezone.utc)
             # FIXME: this is suss--we should probably just explode if data.json is missing
@@ -706,6 +704,14 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
                 created_at=now,
                 updated_at=now,
             )
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            # A corrupt (non-JSON) data.json is a schema problem like an invalid one;
+            # map it to the same domain error instead of leaking a raw JSONDecodeError.
+            raise HostDataSchemaError(str(data_path), str(e)) from e
+        try:
+            return CertifiedHostData(**data)
         except ValidationError as e:
             raise HostDataSchemaError(str(data_path), str(e)) from e
 

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2779,15 +2779,21 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         data = json.loads(content)
         raw_commands = data.get("additional_commands", [])
 
-        # Handle both old format (list of strings) and new format (list of dicts)
+        # Handle both old format (list of strings) and new format (list of dicts).
+        # Anything else is corrupt data.json content, not a silently-tolerable shape:
+        # raise a clear error rather than letting an opaque KeyError/TypeError escape.
         result: list[NamedCommand] = []
         for cmd in raw_commands:
             if isinstance(cmd, str):
                 # Old format: plain string
                 result.append(NamedCommand(command=cmd, window_name=None))
-            else:
+            elif isinstance(cmd, dict) and "command" in cmd:
                 # New format: dict with command and window_name
                 result.append(NamedCommand(command=cmd["command"], window_name=cmd.get("window_name")))
+            else:
+                raise CorruptedAgentDataError(
+                    agent.id, data_path, ValueError(f"Malformed additional_commands entry: {cmd!r}")
+                )
         return result
 
     def get_agent_tmux_options(self, agent: AgentInterface) -> AgentTmuxOptions:

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -608,6 +608,9 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
             try:
                 yield
             except BaseException:
+                # BaseException (not Exception) is intentional: the lock must be released
+                # even on KeyboardInterrupt/SystemExit so the remote host can still
+                # idle-shutdown. The original exception is always re-raised below.
                 # On error, remove the lock file so the host can idle-shutdown normally,
                 # unless the user wants to retain it for debugging
                 is_retain_lock = os.environ.get("MNGR_DEBUG_RETAIN_LOCK_FOR_FAILED_HOSTS_DURING_CREATE") == "1"

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -188,6 +188,9 @@ _retry_on_transient_ssh_error = retry(
 def _get_ssh_transport(pyinfra_host: Any) -> Transport | None:
     """Extract the paramiko Transport from a pyinfra host, or None for non-SSH connectors."""
     try:
+        # Only the LocalConnector legitimately lacks `.connector.client`; that is the
+        # one expected AttributeError. (pyinfra_host is typed Any, so this duck-typed
+        # access is the available check.)
         client = pyinfra_host.connector.client
     except AttributeError:
         return None

--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -268,6 +268,9 @@ def derive_offline_host_state(
         # None means the host crashed (no controlled shutdown recorded).
         if stop_reason is None:
             return HostState.CRASHED
+        # stop_reason holds a HostState member name (PAUSED/STOPPED/DESTROYED -- see
+        # CertifiedHostData.stop_reason). HostState(...) validates it, raising ValueError
+        # on any string that is not a HostState member rather than silently inventing a state.
         return HostState(stop_reason)
 
     # Provider does not support shutdown (e.g. Modal). stop_reason may be
@@ -281,6 +284,7 @@ def derive_offline_host_state(
     # Has snapshots -- use stop_reason if set, otherwise CRASHED.
     if stop_reason is None:
         return HostState.CRASHED
+    # See note above: stop_reason is a HostState member name; HostState(...) validates it.
     return HostState(stop_reason)
 
 

--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -54,7 +54,9 @@ def validate_and_create_discovered_agent(
         return None
     try:
         agent_id = AgentId(agent_id_str)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
+        # TypeError covers a non-str id (e.g. an int/dict from corrupt JSON), which would
+        # otherwise escape this "tolerate malformed records" path and crash discovery.
         logger.opt(exception=e).warning(
             "Skipping malformed agent record for host {}: invalid 'id': {}", host_id, agent_data
         )
@@ -66,7 +68,8 @@ def validate_and_create_discovered_agent(
         return None
     try:
         agent_name = AgentName(agent_name_str)
-    except ValueError as e:
+    except (ValueError, TypeError) as e:
+        # TypeError covers a non-str name; see the 'id' handling above.
         logger.opt(exception=e).warning(
             "Skipping malformed agent record for host {}: invalid 'name': {}", host_id, agent_data
         )

--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -96,7 +96,10 @@ def apply_rename_to_agent_data(
     updated = dict(data)
     updated["name"] = str(new_name)
     if labels_to_merge:
-        current_labels = dict(updated.get("labels") or {})
+        # Default only the missing-key case to {}; a present-but-wrong-typed "labels"
+        # value should surface loudly at dict(...) rather than be silently discarded
+        # by an `or {}` that also swallows falsy values.
+        current_labels = dict(updated.get("labels", {}))
         updated["labels"] = {**current_labels, **dict(labels_to_merge)}
     return updated
 

--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -49,27 +49,30 @@ def validate_and_create_discovered_agent(
     Logs warnings for malformed records.
     """
     agent_id_str = agent_data.get("id")
-    if agent_id_str is None:
-        logger.warning("Skipping malformed agent record for host {}: missing 'id': {}", host_id, agent_data)
+    # isinstance(str) covers both a missing key (None) and a non-str value (e.g. an
+    # int/dict from corrupt JSON). A non-str would otherwise raise AttributeError
+    # inside AgentId(...) (the primitive calls value.strip()) and escape this
+    # "tolerate malformed records" path, crashing discovery.
+    if not isinstance(agent_id_str, str):
+        logger.warning("Skipping malformed agent record for host {}: missing or non-str 'id': {}", host_id, agent_data)
         return None
     try:
         agent_id = AgentId(agent_id_str)
-    except (ValueError, TypeError) as e:
-        # TypeError covers a non-str id (e.g. an int/dict from corrupt JSON), which would
-        # otherwise escape this "tolerate malformed records" path and crash discovery.
+    except ValueError as e:
         logger.opt(exception=e).warning(
             "Skipping malformed agent record for host {}: invalid 'id': {}", host_id, agent_data
         )
         return None
 
     agent_name_str = agent_data.get("name")
-    if agent_name_str is None:
-        logger.warning("Skipping malformed agent record for host {}: missing 'name': {}", host_id, agent_data)
+    if not isinstance(agent_name_str, str):
+        logger.warning(
+            "Skipping malformed agent record for host {}: missing or non-str 'name': {}", host_id, agent_data
+        )
         return None
     try:
         agent_name = AgentName(agent_name_str)
-    except (ValueError, TypeError) as e:
-        # TypeError covers a non-str name; see the 'id' handling above.
+    except ValueError as e:
         logger.opt(exception=e).warning(
             "Skipping malformed agent record for host {}: invalid 'name': {}", host_id, agent_data
         )

--- a/libs/mngr/imbue/mngr/hosts/offline_host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host_test.py
@@ -411,6 +411,28 @@ def test_validate_and_create_discovered_agent_returns_none_for_missing_name() ->
     assert ref is None
 
 
+@pytest.mark.allow_warnings(match=r"^Skipping malformed agent record for host")
+@pytest.mark.parametrize("bad_id", [123, {"nested": "dict"}, ["list"], 5.0])
+def test_validate_and_create_discovered_agent_returns_none_for_non_str_id(bad_id: object) -> None:
+    # A non-str id from corrupt JSON must be skipped (not crash with AttributeError
+    # raised inside AgentId(...), which would take down the whole discovery loop).
+    host_id = HostId.generate()
+    agent_data = {"id": bad_id, "name": "my-agent"}
+    ref = validate_and_create_discovered_agent(agent_data, host_id, ProviderInstanceName("p"))
+    assert ref is None
+
+
+@pytest.mark.allow_warnings(match=r"^Skipping malformed agent record for host")
+@pytest.mark.parametrize("bad_name", [123, {"nested": "dict"}, ["list"], 5.0])
+def test_validate_and_create_discovered_agent_returns_none_for_non_str_name(bad_name: object) -> None:
+    # A non-str name from corrupt JSON must be skipped, same as a non-str id.
+    host_id = HostId.generate()
+    agent_id = AgentId.generate()
+    agent_data = {"id": str(agent_id), "name": bad_name}
+    ref = validate_and_create_discovered_agent(agent_data, host_id, ProviderInstanceName("p"))
+    assert ref is None
+
+
 # =============================================================================
 # Tests for default discover_hosts_and_agents on the provider
 # =============================================================================

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -973,6 +973,14 @@ class OuterHost(OuterHostInterface):
             return None
 
         host_data = self.connector.host.data
+        # NOTE: the "root" default is correct for provider-created hosts (Docker/Modal),
+        # which log in as root and do not set ssh_user. It is potentially wrong for
+        # user-configured ssh:// outers: create_ssh_pyinfra_host_using_user_config()
+        # deliberately leaves ssh_user unset when the user is None so OpenSSH /
+        # ~/.ssh/config resolves it, and this default then forces user=root for those
+        # hosts, overriding the user's ssh_config User directive. Fixing that cleanly
+        # means letting the returned user be "unset" (mirroring the key_path=None
+        # treatment below), which changes this method's return contract.
         user = host_data.get("ssh_user", "root")
         hostname = self.connector.host.name
         port = host_data.get("ssh_port", 22)

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -192,7 +192,13 @@ def _sftp_walk(sftp: SFTPClient, dir_path: str, recursive: bool) -> list[VolumeF
 
 
 def _is_transient_ssh_error(exception: BaseException) -> bool:
-    """Check if the exception is a transient SSH connection error worth retrying."""
+    """Check if the exception is a transient SSH connection error worth retrying.
+
+    The "Socket is closed" classification (here and at the other ``str(e)`` checks
+    in this module) deliberately depends on paramiko's exception *message* text:
+    paramiko surfaces a closed transport as a bare ``OSError`` with no stable errno
+    or dedicated type to key off. Revisit these substrings on paramiko upgrades.
+    """
     if isinstance(exception, OSError) and "Socket is closed" in str(exception):
         return True
     if isinstance(exception, SSHException):

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -354,8 +354,9 @@ class OuterHost(OuterHostInterface):
         if client is not None:
             try:
                 client.close()
-            except (OSError, SSHException):
-                pass
+            except (OSError, SSHException) as e:
+                # Best-effort close; log so systematic close failures are visible.
+                logger.debug("Failed to close paramiko client for {}: {}", self.id, e)
 
     def disconnect(self) -> None:
         """Disconnect the pyinfra host if connected."""

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -917,8 +917,14 @@ class OuterHost(OuterHostInterface):
             try:
                 mtime = int(result.stdout.strip())
                 return datetime.fromtimestamp(mtime, tz=timezone.utc)
-            except ValueError:
-                pass
+            except ValueError as e:
+                # Unparseable stat output: should not happen, so log it rather than
+                # silently treating the file as absent.
+                logger.debug("Unparseable stat output for {} on host {}: {!r} ({})", path, self.id, result.stdout, e)
+        # NOTE: remote None conflates "file absent" with "stat failed" -- the 2>/dev/null
+        # in the command hides stderr, so we cannot distinguish them here. Callers must
+        # treat None as "mtime unknown", not strictly "file does not exist" (unlike the
+        # local branch above, which only maps FileNotFoundError to None).
         return None
 
     def get_file_mtime(self, path: Path) -> datetime | None:

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -860,7 +860,14 @@ class OuterHost(OuterHostInterface):
         else:
             try:
                 is_success = self._put_file(io.BytesIO(content), str(write_path))
-            except IOError:
+            except IOError as e:
+                # The retry below (mkdir -p + re-put) targets the common
+                # missing-parent-directory case. Other IOErrors (permission, disk
+                # full) will fail the retry too; log the original cause here so it
+                # is not lost behind the generic "Failed to write file" error.
+                logger.debug(
+                    "Initial put of {} on host {} failed ({}); will mkdir -p and retry", write_path, self.id, e
+                )
                 is_success = False
             if not is_success:
                 parent_dir = str(write_path.parent)

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -218,6 +218,9 @@ _retry_on_transient_ssh_error = retry(
 def _get_ssh_transport(pyinfra_host: Any) -> Transport | None:
     """Extract the paramiko Transport from a pyinfra host, or None for non-SSH connectors."""
     try:
+        # Only the LocalConnector legitimately lacks `.connector.client`; that is the
+        # one expected AttributeError. (pyinfra_host is typed Any, so this duck-typed
+        # access is the available check.)
         client = pyinfra_host.connector.client
     except AttributeError:
         return None

--- a/libs/mngr/imbue/mngr/interfaces/data_types.py
+++ b/libs/mngr/imbue/mngr/interfaces/data_types.py
@@ -344,7 +344,11 @@ class CertifiedHostData(FrozenModel):
     )
     stop_reason: str | None = Field(
         default=None,
-        description="Reason for last shutdown: 'PAUSED' (idle), 'STOPPED' (user requested or all agents exited), or None (crashed)",
+        description=(
+            "Reason for last shutdown, stored as a HostState member name: 'PAUSED' (idle), "
+            "'STOPPED' (user requested or all agents exited), 'DESTROYED' (host torn down), "
+            "or None (crashed -- no controlled shutdown recorded)"
+        ),
     )
     failure_reason: str | None = Field(
         default=None,


### PR DESCRIPTION
Cleanup pass over `libs/mngr/imbue/mngr/hosts/` driven by the identify-suspicious-edge-cases skill. Each finding is its own commit. No intended user-visible behavior change.

## Structural fixes (genuinely suspicious handlers)
- **`get_state`**: log the caught `(OSError, HostConnectionError)` ping failure instead of a bare `pass`, and narrow the `try`.
- **`_get_agent_additional_commands`**: raise `CorruptedAgentDataError` on a malformed `additional_commands` entry instead of an opaque `KeyError`/`TypeError`.
- **`validate_and_create_discovered_agent`**: catch `(ValueError, TypeError)` so a non-str id/name in a corrupt record is skipped consistently rather than crashing discovery.
- **`apply_rename_to_agent_data`**: drop the `or {}` double-fallback so a wrong-typed `labels` surfaces.
- **`_close_paramiko_client` / remote `write_file` / remote `_get_file_mtime`**: log the errors they catch instead of swallowing them.
- **`_parse_uptime_output`**: narrow `except (ValueError, OSError)` to `ValueError` (OSError is unreachable there).
- **`get_certified_data`**: map a corrupt (non-JSON) `data.json` to `HostDataSchemaError` instead of leaking a raw `JSONDecodeError`; split into single-statement trys.

## Documentation of correct-but-unexplained handlers (over-reports)
- `stop_reason` -> `HostState` coercion (plus corrected the stale `stop_reason` field docstring: providers also write `DESTROYED`).
- The `"root"` `ssh_user` default in `get_ssh_connection_info` (flagged as a possible real bug for user-configured `ssh://` outers; behavior left unchanged).
- The `"main"` base-branch fallback, `_get_ssh_transport`'s `AttributeError` catch, paramiko message-text classification, `determine_lifecycle_state` malformed-tmux handling, and `lock_cooperatively`'s `BaseException` catch.

## Open design question for review
`get_ssh_connection_info` forcing `ssh_user=root` overrides a user's `~/.ssh/config` `User` for user-configured `ssh://` outers. Fixing it cleanly changes the method's return contract, so it is documented rather than changed here.

## Testing
- `just test-quick` hosts unit tests: 266 passed
- `just test-quick` mngr ratchets: 55 passed
- `uv run ty check` on changed files: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)