### PR TITLE
Run Lima/Vultr/OVH under gVisor (runsc); slim Lima OS to Debian 12

### DIFF
--- a/apps/minds/changelog/mngr-runsc-everywhere.md
+++ b/apps/minds/changelog/mngr-runsc-everywhere.md
@@ -1,0 +1,16 @@
+Fixed the dev create-form defaults so they work on any tier, including staging
+and production. The `MINDS_WORKSPACE_GIT_URL` / `_NAME` / `_BRANCH` env vars
+(which point the create form at the operator's local FCT worktree) were
+previously honored only on per-developer dev tiers and silently dropped on the
+shared `minds` / `minds-staging` tiers -- so `just minds-start` against staging
+fell back to the public GitHub FCT on `main`, and local FCT changes could never
+be tested there.
+
+The tier-based gate is replaced with an explicit opt-in: the form honors those
+vars only when `MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1` is set in the same
+environment. `just minds-start` and the e2e workspace runner set it; a normal
+end-user `minds run` never does, so a stray `MINDS_WORKSPACE_*` left in the
+operator's shell is ignored on every tier (the safety the tier gate provided,
+now applied uniformly -- and dev tiers no longer honor stray vars by tier alone).
+These defaults point at a local path + dev branch and only make sense for
+local-compute launch modes (Lima / Docker), not IMBUE_CLOUD pool leases.

--- a/apps/minds/imbue/minds/desktop_client/e2e_workspace_runner.py
+++ b/apps/minds/imbue/minds/desktop_client/e2e_workspace_runner.py
@@ -254,14 +254,17 @@ def _build_electron_env(workspace_git_url: Path, workspace_name: str) -> dict[st
     """Return the env vars the Electron child process should inherit.
 
     Mirrors ``just minds-start``: passes the FCT path + agent name through
-    the ``MINDS_WORKSPACE_*`` prefill vars (honored only in dev tiers --
-    see ``_dev_only_workspace_default`` in templates.py), and scrubs any
+    the ``MINDS_WORKSPACE_*`` prefill vars (honored only when the explicit
+    opt-in ``MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1`` is also set -- see
+    ``_operator_workspace_default`` in templates.py), and scrubs any
     ANTHROPIC creds the operator's shell might have exported so they
     don't silently leak into every workspace we create.
     """
     env = dict(os.environ)
     env["MINDS_WORKSPACE_GIT_URL"] = str(workspace_git_url)
     env["MINDS_WORKSPACE_NAME"] = workspace_name
+    # Opt into the local-worktree create-form defaults (see just minds-start).
+    env["MINDS_USE_LOCAL_WORKSPACE_DEFAULTS"] = "1"
     # Pin MNGR_ROOT_NAME back to "mngr" for the Electron child so the
     # spawned `mngr create` subprocess finds FCT's .mngr/settings.toml
     # (which defines the `main` + `docker` create templates). The minds
@@ -443,10 +446,10 @@ def _backend_origin_from_page(page: Page) -> str:
 def _ensure_field_value(page: Page, selector: str, expected_value: str) -> None:
     """Type ``expected_value`` into the form field if it isn't already there.
 
-    Handles both the prefilled-via-env-var case (dev tiers) and the
-    blank-form case (shared tiers like ``minds-staging`` where
-    ``_dev_only_workspace_default`` deliberately ignores the
-    ``MINDS_WORKSPACE_*`` env vars).
+    Handles both the prefilled-via-env-var case (when the opt-in
+    ``MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1`` is set) and the blank-form case
+    (a normal launch where ``_operator_workspace_default`` falls back to the
+    hardcoded defaults).
     """
     current_value = page.input_value(selector)
     if current_value == expected_value:

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -25,8 +25,6 @@ from jinja2 import select_autoescape
 from jinjax import Catalog
 
 from imbue.imbue_common.pure import pure
-from imbue.minds.bootstrap import DEFAULT_MINDS_ROOT_NAME
-from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.desktop_client.agent_creator import AgentCreationInfo
 from imbue.minds.desktop_client.onboarding import expected_creation_duration_seconds
 from imbue.minds.primitives import AIProvider
@@ -229,44 +227,43 @@ def render_landing_page(
     )
 
 
-# Hardcoded fallbacks for the workspace-creation form. Overridable via
-# the MINDS_WORKSPACE_* env vars in dev tiers ONLY -- see
-# ``_dev_only_workspace_default`` for the gating rationale.
+# Hardcoded fallbacks for the workspace-creation form. Overridable via the
+# MINDS_WORKSPACE_* env vars only when the operator explicitly opts in -- see
+# ``_operator_workspace_default`` for the gating rationale.
 _FALLBACK_GIT_URL: Final[str] = "https://github.com/imbue-ai/forever-claude-template.git"
 _FALLBACK_HOST_NAME: Final[str] = "assistant"
 _FALLBACK_BRANCH: Final[str] = ""
 
-# Root names that map to operator-managed shared tiers (production /
-# staging). For these tiers the MINDS_WORKSPACE_* env-var defaults are
-# intentionally ignored: ``just minds-start`` (and any other dev-iteration
-# tool) exports those vars from the operator's local FCT worktree state,
-# which only makes sense when iterating against a per-developer dev env.
-# In staging / production the workspaces are end-user-driven and a leaked
-# ``MINDS_WORKSPACE_BRANCH`` from the operator's shell would silently
-# pin the lease to a ref that no pool host carries.
-_SHARED_TIER_ROOT_NAMES: Final[frozenset[str]] = frozenset({DEFAULT_MINDS_ROOT_NAME, "minds-staging"})
+# Env var (set by ``just minds-start`` and the e2e workspace runner) that opts a
+# launch into the operator's local-worktree create-form defaults. Gating on an
+# explicit opt-in -- rather than on the tier -- means dev iteration works on ANY
+# tier (including staging / production) when launched via ``just minds-start``,
+# while a normal end-user ``minds run`` never honors a stray MINDS_WORKSPACE_*
+# left over in the operator's shell, on any tier. The previous tier-based gate
+# did the opposite: it blocked legitimate dev iteration on staging (forcing the
+# form back to the public GitHub FCT on ``main``) while leaving dev tiers exposed
+# to stray vars.
+_WORKSPACE_DEFAULTS_OPT_IN_ENV_VAR: Final[str] = "MINDS_USE_LOCAL_WORKSPACE_DEFAULTS"
 
 
-def _dev_only_workspace_default(env_var: str, fallback: str) -> str:
-    """Read ``env_var`` for dev tiers; otherwise return ``fallback``.
+def _operator_workspace_default(env_var: str, fallback: str) -> str:
+    """Return ``env_var`` only when the operator explicitly opted in; else ``fallback``.
 
-    The MINDS_WORKSPACE_GIT_URL / _NAME / _BRANCH env vars are a dev
-    convenience that wire the create-form's defaults to the operator's
-    local FCT worktree (``just minds-start`` exports them). They have
-    no business pre-filling the form in staging or production, where
-    workspaces are end-user-driven and the operator's local git state
-    is irrelevant.
+    The MINDS_WORKSPACE_GIT_URL / _NAME / _BRANCH env vars wire the create-form
+    defaults to the operator's local FCT worktree. They are honored only when
+    ``MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1`` is set in the same environment
+    (``just minds-start`` and the e2e runner set it). An end-user ``minds run``
+    never sets it, so a stray MINDS_WORKSPACE_* left in the shell is ignored on
+    every tier -- the safety the previous tier-based gate provided, without also
+    blocking dev iteration on staging / production.
 
-    Activation is detected via ``MINDS_ROOT_NAME``. The env var is
-    honored only when the root name names a dev tier (i.e. anything
-    other than ``minds`` / ``minds-staging``). An unactivated shell --
-    ``MINDS_ROOT_NAME`` unset entirely -- is treated as non-dev (defensive
-    default: ``minds run`` always activates first today, so this branch
-    is essentially unreachable; we still want to ignore the env var if
-    we somehow get there).
+    These defaults point at a *local* path and a dev branch, which only make
+    sense for local-compute launch modes (Lima / Docker). For IMBUE_CLOUD (pool
+    lease) they must not be kept -- a pool host cannot clone a local path and the
+    dev branch matches no pre-baked host -- so the opt-in is the operator's
+    signal that they are doing local dev iteration, not an end-user pool create.
     """
-    root_name = os.environ.get(MINDS_ROOT_NAME_ENV_VAR, "")
-    if not root_name or root_name in _SHARED_TIER_ROOT_NAMES:
+    if os.environ.get(_WORKSPACE_DEFAULTS_OPT_IN_ENV_VAR) != "1":
         return fallback
     return os.environ.get(env_var, fallback)
 
@@ -304,11 +301,11 @@ def render_create_form(
     host name on the resulting workspace. (The agent itself is always
     named ``system-services``.)
     """
-    effective_url = git_url if git_url else _dev_only_workspace_default("MINDS_WORKSPACE_GIT_URL", _FALLBACK_GIT_URL)
+    effective_url = git_url if git_url else _operator_workspace_default("MINDS_WORKSPACE_GIT_URL", _FALLBACK_GIT_URL)
     effective_name = (
-        host_name if host_name else _dev_only_workspace_default("MINDS_WORKSPACE_NAME", _FALLBACK_HOST_NAME)
+        host_name if host_name else _operator_workspace_default("MINDS_WORKSPACE_NAME", _FALLBACK_HOST_NAME)
     )
-    effective_branch = branch if branch else _dev_only_workspace_default("MINDS_WORKSPACE_BRANCH", _FALLBACK_BRANCH)
+    effective_branch = branch if branch else _operator_workspace_default("MINDS_WORKSPACE_BRANCH", _FALLBACK_BRANCH)
     has_account = bool(default_account_id and accounts)
     effective_launch_mode = (
         launch_mode if launch_mode is not None else (LaunchMode.IMBUE_CLOUD if has_account else LaunchMode.LIMA)

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -136,13 +136,14 @@ def test_render_create_form_shows_error_message_when_supplied() -> None:
     assert "Imbue cloud requires an account." in html
 
 
-def test_render_create_form_honors_workspace_env_vars_in_dev_tier(monkeypatch: pytest.MonkeyPatch) -> None:
-    """In a dev tier, the MINDS_WORKSPACE_* env vars pre-fill the create form.
+def test_render_create_form_honors_workspace_env_vars_when_opted_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the explicit opt-in, the MINDS_WORKSPACE_* env vars pre-fill the form.
 
-    Used by ``just minds-start`` to point the form at the operator's local
-    FCT worktree + current branch so the dev-iteration loop is one click.
+    Used by ``just minds-start`` (and the e2e runner) to point the form at the
+    operator's local FCT worktree + current branch so the dev-iteration loop is
+    one click.
     """
-    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-josh")
+    monkeypatch.setenv("MINDS_USE_LOCAL_WORKSPACE_DEFAULTS", "1")
     monkeypatch.setenv("MINDS_WORKSPACE_GIT_URL", "/local/fct/path")
     monkeypatch.setenv("MINDS_WORKSPACE_NAME", "mindtest")
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
@@ -152,16 +153,37 @@ def test_render_create_form_honors_workspace_env_vars_in_dev_tier(monkeypatch: p
     assert "mngr/some-feature" in html
 
 
-def test_render_create_form_ignores_workspace_env_vars_in_staging(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Staging must not honor MINDS_WORKSPACE_* env vars.
+def test_render_create_form_honors_workspace_env_vars_on_staging_when_opted_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opt-in is tier-independent: it works even on a shared tier (staging).
 
-    Without the gate, a stray ``MINDS_WORKSPACE_BRANCH=mngr/some-branch`` in
-    the operator's shell (e.g. left over from a prior ``just minds-start``
-    invocation) would pre-fill the form's branch field and propagate to
-    the imbue_cloud lease request as ``-b repo_branch_or_tag=...``, which
-    would silently fail to match any pool host baked with the tier's
-    canonical branch.
+    Regression test: staging previously dropped MINDS_WORKSPACE_* unconditionally,
+    so ``just minds-start`` against staging silently fell back to the public
+    GitHub FCT on ``main`` -- meaning local FCT changes could never be tested
+    against staging.
     """
+    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-staging")
+    monkeypatch.setenv("MINDS_USE_LOCAL_WORKSPACE_DEFAULTS", "1")
+    monkeypatch.setenv("MINDS_WORKSPACE_GIT_URL", "/local/fct/path")
+    monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
+    html = render_create_form()
+    assert "/local/fct/path" in html
+    assert "mngr/some-feature" in html
+
+
+def test_render_create_form_ignores_workspace_env_vars_without_opt_in_on_shared_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the opt-in, a stray MINDS_WORKSPACE_* in the shell is ignored.
+
+    A stray ``MINDS_WORKSPACE_BRANCH=mngr/some-branch`` (e.g. left over from a
+    prior ``just minds-start``) must not pre-fill the form's branch field for an
+    end-user ``minds run``, where it would propagate to the imbue_cloud lease as
+    ``-b repo_branch_or_tag=...`` and fail to match any pool host baked with the
+    tier's canonical branch.
+    """
+    monkeypatch.delenv("MINDS_USE_LOCAL_WORKSPACE_DEFAULTS", raising=False)
     monkeypatch.setenv("MINDS_ROOT_NAME", "minds-staging")
     monkeypatch.setenv("MINDS_WORKSPACE_GIT_URL", "/local/fct/path")
     monkeypatch.setenv("MINDS_WORKSPACE_NAME", "mindtest")
@@ -175,21 +197,16 @@ def test_render_create_form_ignores_workspace_env_vars_in_staging(monkeypatch: p
     assert "assistant" in html
 
 
-def test_render_create_form_ignores_workspace_env_vars_in_production(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Production -- like staging -- must not honor the dev-iteration env vars."""
-    monkeypatch.setenv("MINDS_ROOT_NAME", "minds")
-    monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
-    html = render_create_form()
-    assert "mngr/some-feature" not in html
+def test_render_create_form_ignores_workspace_env_vars_without_opt_in_on_dev_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier no longer matters: even a dev-tier root name ignores the vars without opt-in.
 
-
-def test_render_create_form_ignores_workspace_env_vars_when_unactivated(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No activated env (no MINDS_ROOT_NAME) -- treat as non-dev and ignore env vars.
-
-    Mirrors the conservative default: a bare ``minds run`` without any
-    activation context shouldn't accidentally pull from ad-hoc env vars.
+    This closes the old gap where dev tiers honored a stray MINDS_WORKSPACE_*
+    purely by tier, with no explicit operator intent.
     """
-    monkeypatch.delenv("MINDS_ROOT_NAME", raising=False)
+    monkeypatch.delenv("MINDS_USE_LOCAL_WORKSPACE_DEFAULTS", raising=False)
+    monkeypatch.setenv("MINDS_ROOT_NAME", "minds-dev-josh")
     monkeypatch.setenv("MINDS_WORKSPACE_BRANCH", "mngr/some-feature")
     html = render_create_form()
     assert "mngr/some-feature" not in html

--- a/blueprint/runsc-everywhere-lima-vps/plan-runsc-everywhere-lima-vps.md
+++ b/blueprint/runsc-everywhere-lima-vps/plan-runsc-everywhere-lima-vps.md
@@ -1,0 +1,76 @@
+# Plan: Run Lima + VPS Docker providers under gVisor (runsc), and slim the Lima VM OS
+
+## Refined prompt
+
+went want to convert both the lima provider and the vps_docker provider in the minds app for our forever-claude-template to be configured to use gvisor (runsc) (ie, by changing the forever-claude-template/.mngr/settings.toml file correctly)
+
+* Scope the runsc conversion to the Lima, OVH, and Vultr providers, plus the `imbue_cloud` template's slow/rebuild path.
+* Drive everything from configuration flags in settings.toml rather than modifying the providers; only add a new config passthrough where one doesn't already exist (the Lima inner container's `docker run` args).
+* Turn runsc on via the existing `install_gvisor_runtime` option plus `docker_runtime="runsc"`; no backwards-compatibility handling for already-baked hosts.
+* Also apply `--security-opt=no-new-privileges` alongside runsc on both vps_docker (via template `start_arg`) and Lima (via the new config passthrough).
+* Add a general-purpose "extra container run args" config field to the Lima provider, and set it in FCT to carry `--workdir=/` + `--security-opt=no-new-privileges`.
+* Existing pre-baked `imbue_cloud` pool hosts may stay non-runsc until their next bake; no migration/drain required.
+* For OVH and Vultr, add `[providers.ovh]` and `[providers.vultr]` blocks to FCT settings.toml carrying `docker_runtime` + `install_gvisor_runtime`.
+* Land the `mngr_lima` code change and FCT settings.toml edits in this work; the `vendor/mngr` sync into FCT happens separately via the normal release-minds flow.
+
+We simultanesouly want to convert the lima provider to use a different, much lighter operating system now that everything important is just happening inside of docker (in the lima VM)
+ie, rather than a full ubuntu, we ought to be able to get away with something much lighter (alpine? some simpler debian?)
+Ideally we end up making it similar to whatever we're using in the ovh provider...
+
+* Use Debian 12 "bookworm" genericcloud as the lighter Lima image, by changing the `mngr_lima` library default constants (so every Lima user benefits) rather than only overriding in FCT.
+* Pin the Lima Debian image to a specific dated genericcloud snapshot URL (amd64 + arm64) rather than the `latest/` symlink.
+* Apply the Debian swap to both Lima modes (direct-in-VM and docker-in-Lima); apt handles the toolchain on Debian the same as on Ubuntu.
+* Validate by requiring a manual one-off Lima + VPS bring-up under runsc/Debian before considering the work done (unit coverage for the new plumbing plus CI acceptance/release tests still apply).
+
+---
+
+## Overview
+
+- gVisor (`runsc`) support already exists in code for both providers (`docker_runtime` + `install_gvisor_runtime` on `LimaProviderConfig` and `VpsDockerProviderConfig`, with working install blocks). This work *enables* it, it does not build it.
+- The only missing capability is on Lima: the inner agent `docker run` accepts only `--runtime`, so there is no config path to pass the `--workdir=/` that runsc requires (the image WORKDIR `/mngr/code` lives inside the mounted `/mngr` volume, and runsc aborts when its process cwd already exists). We add one general-purpose config field to close that gap.
+- Everything else is configuration: turn on `install_gvisor_runtime` + `docker_runtime="runsc"` per provider, and add the hardening `docker run` args (`--workdir=/`, `--security-opt=no-new-privileges`) via the existing vps_docker `start_arg` path and the new Lima passthrough.
+- The Lima VM OS moves from Ubuntu 24.04 to a pinned Debian 12 "bookworm" genericcloud image, changed at the `mngr_lima` library default so all Lima users get the lighter, OVH-matching base; this applies to both Lima modes.
+- FCT changes are settings-only; the `mngr_lima` code change is small and config-driven. The vendored-mngr sync into FCT is out of scope here (handled by the normal release-minds flow), so FCT settings will reference the new field once that sync lands.
+
+## Expected behavior
+
+- Lima hosts created from FCT (docker-in-Lima mode) run the agent container under gVisor: the VM provisions `runsc` at first boot and the agent `docker run` uses `--runtime runsc`, `--workdir=/`, and `--security-opt=no-new-privileges`.
+- Vultr and OVH hosts created from FCT run their agent containers under gVisor: provisioning installs `runsc` (cloud-init for Vultr, bootstrap path for OVH) and the agent `docker run` adds `--runtime runsc`, `--workdir=/`, and `--security-opt=no-new-privileges`.
+- `imbue_cloud` pool hosts inherit runsc through the OVH-backed bake; the slow/rebuild path also gets the hardening run args via the `imbue_cloud` template. Already-baked pool hosts continue running as-is (no runsc) until their next bake — no migration.
+- Lima VMs boot a pinned Debian 12 genericcloud image instead of Ubuntu 24.04; provisioning installs the same toolchain via apt, so direct-in-VM Lima behavior is unchanged aside from the lighter base OS.
+- Any Lima user can now inject arbitrary extra `docker run` args into the agent container via the new config field (empty by default, so no behavior change unless set).
+- When `docker_runtime="runsc"` is set but `runsc` is not registered on the host/VM, container creation fails with Docker's native "unknown runtime" error (unchanged existing behavior). With `install_gvisor_runtime=true`, provisioning registers it first, so this should not occur on a clean bring-up.
+- New host bring-up is slightly slower on first boot (one extra apt round-trip + Docker restart to install/register `runsc`); idempotent on re-runs and a no-op where `runsc` is already present.
+
+## Changes
+
+### `libs/mngr_lima` (code)
+
+- Switch the default Lima VM image from Ubuntu 24.04 to a pinned Debian 12 "bookworm" genericcloud image for both architectures (the `DEFAULT_IMAGE_URL_AARCH64` / `DEFAULT_IMAGE_URL_X86_64` constants), using a specific dated snapshot URL rather than `latest/`.
+- Add a general-purpose config field to the Lima provider for extra `docker run` arguments applied to the agent container (defaults to empty), and pass it into the inner container creation alongside the existing `--runtime` argument.
+- Update the relevant field/constant docstrings to reflect the new default OS and the new passthrough field.
+- Add a per-PR changelog entry under `libs/mngr_lima/changelog/`.
+
+### `libs/mngr_vps_docker` (no code change expected)
+
+- No code change: the provider already forwards template `start_arg` to the agent `docker run` and already supports `docker_runtime` + `install_gvisor_runtime`. Confirm during implementation; add a changelog entry only if a code change turns out to be needed.
+
+### `forever-claude-template/.mngr/settings.toml` (config only, in the external worktree)
+
+- `[providers.lima]`: enable `install_gvisor_runtime`, set `docker_runtime="runsc"`, and set the new extra-container-run-args field to `["--workdir=/", "--security-opt=no-new-privileges"]`.
+- Add `[providers.vultr]` and `[providers.ovh]` blocks: enable `install_gvisor_runtime` and set `docker_runtime="runsc"`.
+- `[create_templates.vultr]` and `[create_templates.ovh]`: add `start_arg__extend = ["--security-opt=no-new-privileges", "--workdir=/"]`; replace the existing "not enabled here yet" comments with the now-active rationale.
+- `[create_templates.imbue_cloud]`: add the same `start_arg__extend` so the slow/rebuild (vps_docker-backed) path runs the agent container under runsc with the hardening args.
+- Leave the existing `[providers.docker]` block unchanged (already on runsc).
+
+### Validation (required before "done")
+
+- Manual one-off bring-up of a Lima host (docker-in-Lima, Debian + runsc) and a VPS host (OVH and/or Vultr, runsc) from FCT, confirming the agent container is actually running under `runsc` and reachable.
+- Unit coverage asserting the new Lima extra-run-args field reaches the agent `docker run` invocation (alongside `--runtime`), plus the existing gVisor-install-block unit coverage.
+- Rely on CI acceptance/release markers for full provider bring-up; do not block on running all of those locally.
+
+### Out of scope
+
+- Syncing the updated mngr into FCT's `vendor/mngr` (normal release-minds flow).
+- Migrating or draining existing pre-baked `imbue_cloud` pool hosts.
+- Alpine or any non-apt base image (would require rewriting the apt-based provisioning).

--- a/blueprint/runsc-everywhere-lima-vps/plan-runsc-everywhere-lima-vps.md
+++ b/blueprint/runsc-everywhere-lima-vps/plan-runsc-everywhere-lima-vps.md
@@ -36,7 +36,8 @@ Ideally we end up making it similar to whatever we're using in the ovh provider.
 
 - Lima hosts created from FCT (docker-in-Lima mode) run the agent container under gVisor: the VM provisions `runsc` at first boot and the agent `docker run` uses `--runtime runsc`, `--workdir=/`, and `--security-opt=no-new-privileges`.
 - Vultr and OVH hosts created from FCT run their agent containers under gVisor: provisioning installs `runsc` (cloud-init for Vultr, bootstrap path for OVH) and the agent `docker run` adds `--runtime runsc`, `--workdir=/`, and `--security-opt=no-new-privileges`.
-- `imbue_cloud` pool hosts inherit runsc through the OVH-backed bake; the slow/rebuild path also gets the hardening run args via the `imbue_cloud` template. Already-baked pool hosts continue running as-is (no runsc) until their next bake — no migration.
+- `imbue_cloud` *fast path* (the common case) inherits runsc through the OVH-backed bake — the adopted pre-baked container was built under runsc. Already-baked pool hosts continue running as-is (no runsc) until their next bake — no migration.
+- `imbue_cloud` *slow/rebuild path* is NOT covered by this change: it cannot be done via the `imbue_cloud` template (adding `start_arg` there breaks the fast path, which minds attempts first and which rejects `--start-arg`), and the slow path builds its delegated vps_docker provider with default config (no `docker_runtime`/run-args). Full coverage needs a code change in `mngr_imbue_cloud` (+ minds bootstrap) — deferred as a follow-up.
 - Lima VMs boot a pinned Debian 12 genericcloud image instead of Ubuntu 24.04; provisioning installs the same toolchain via apt, so direct-in-VM Lima behavior is unchanged aside from the lighter base OS.
 - Any Lima user can now inject arbitrary extra `docker run` args into the agent container via the new config field (empty by default, so no behavior change unless set).
 - When `docker_runtime="runsc"` is set but `runsc` is not registered on the host/VM, container creation fails with Docker's native "unknown runtime" error (unchanged existing behavior). With `install_gvisor_runtime=true`, provisioning registers it first, so this should not occur on a clean bring-up.
@@ -60,7 +61,7 @@ Ideally we end up making it similar to whatever we're using in the ovh provider.
 - `[providers.lima]`: enable `install_gvisor_runtime`, set `docker_runtime="runsc"`, and set the new extra-container-run-args field to `["--workdir=/", "--security-opt=no-new-privileges"]`.
 - Add `[providers.vultr]` and `[providers.ovh]` blocks: enable `install_gvisor_runtime` and set `docker_runtime="runsc"`.
 - `[create_templates.vultr]` and `[create_templates.ovh]`: add `start_arg__extend = ["--security-opt=no-new-privileges", "--workdir=/"]`; replace the existing "not enabled here yet" comments with the now-active rationale.
-- `[create_templates.imbue_cloud]`: add the same `start_arg__extend` so the slow/rebuild (vps_docker-backed) path runs the agent container under runsc with the hardening args.
+- `[create_templates.imbue_cloud]`: intentionally left unchanged — adding `start_arg` here would break the fast path (minds tries `fast_mode=require` first, which rejects `--start-arg`). The fast path gets runsc from the OVH bake instead.
 - Leave the existing `[providers.docker]` block unchanged (already on runsc).
 
 ### Validation (required before "done")
@@ -74,3 +75,4 @@ Ideally we end up making it similar to whatever we're using in the ovh provider.
 - Syncing the updated mngr into FCT's `vendor/mngr` (normal release-minds flow).
 - Migrating or draining existing pre-baked `imbue_cloud` pool hosts.
 - Alpine or any non-apt base image (would require rewriting the apt-based provisioning).
+- The `imbue_cloud` slow/rebuild path under runsc (see Overview) — needs a `mngr_imbue_cloud` + minds-bootstrap code change to propagate `docker_runtime` + run-args into the delegated vps_docker provider; deferred as a follow-up. The fast path (the common case) is covered.

--- a/dev/changelog/mngr-runsc-everywhere.md
+++ b/dev/changelog/mngr-runsc-everywhere.md
@@ -1,0 +1,4 @@
+`just minds-start` now exports `MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1` alongside
+the `MINDS_WORKSPACE_*` vars. This is the explicit opt-in that makes the minds
+desktop create-form honor the local-worktree defaults on any tier (including
+staging / production), instead of only on per-developer dev envs.

--- a/justfile
+++ b/justfile
@@ -311,6 +311,11 @@ deploy *args:
 #       running minds-start).
 #   MINDS_WORKSPACE_BRANCH  = the FCT worktree's current branch.
 #   MINDS_WORKSPACE_NAME    = "mindtest".
+# Also sets MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1, the explicit opt-in that
+# tells the desktop client to honor those MINDS_WORKSPACE_* vars. Without it
+# (i.e. a normal `minds run`) the form ignores any stray MINDS_WORKSPACE_* in
+# the shell. The opt-in is what makes dev iteration work on ANY tier --
+# including staging / production -- instead of only on per-developer dev envs.
 #
 # Always re-syncs the live mngr working tree into the FCT worktree's
 # vendor/mngr/ first, so the very first Create after starting the app
@@ -402,6 +407,9 @@ minds-start agent_name="mindtest" branch="":
     # proportionate fix. `unset` of an already-unset var is a no-op.
     unset ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
     export MINDS_WORKSPACE_GIT_URL="$fct_wt"
+    # Explicit opt-in so the desktop client honors the MINDS_WORKSPACE_* vars
+    # on any tier (the form ignores them otherwise; see _operator_workspace_default).
+    export MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1
     if [ -n "{{branch}}" ]; then
         export MINDS_WORKSPACE_BRANCH="{{branch}}"
     else

--- a/libs/mngr/changelog/mngr-runsc-everywhere.md
+++ b/libs/mngr/changelog/mngr-runsc-everywhere.md
@@ -12,3 +12,15 @@ forever-claude-template's lima create template does) reset `is_host_in_docker`,
 defaults, so the Lima provider silently ran in direct-in-VM mode instead of
 docker-in-VM mode. The merge now uses `model_fields_set` (matching
 `AgentTypeConfig` / `PluginConfig`), so untouched fields keep their base value.
+
+`mngr create --new-host` now tears down a freshly-created host on *any* failure
+up to and including the initial-message send, so a failed create never leaks a
+host (or, for non-idle-shutdown providers, its lease). The whole create flow --
+host env-var write, on_host_created hooks, post-host-create commands, locking,
+provisioning, agent start, and the initial-message delivery -- is now wrapped in
+a single continuous teardown guard, closing a gap where failures between the
+former two separate guard blocks (and the host env-var write) could leak the
+host. The `--edit-message` send, which the CLI performs after the API create
+returns, is now likewise covered. The existing
+`MNGR_DEBUG_RETAIN_LOCK_FOR_FAILED_HOSTS_DURING_CREATE=1` escape hatch still
+retains a failed host for debugging.

--- a/libs/mngr/changelog/mngr-runsc-everywhere.md
+++ b/libs/mngr/changelog/mngr-runsc-everywhere.md
@@ -1,0 +1,14 @@
+Fixed `ProviderInstanceConfig.merge_with` so a higher-precedence config layer
+only overrides the provider fields it actually set. It previously used an
+"override wins unless its value is None" rule, which meant any field whose
+default is a non-None value (a `bool` defaulting to `False`, an empty tuple,
+etc.) was silently reset to that default whenever a higher layer touched the
+provider block at all -- even via a single-key override like a create
+template's `setting__extend = ["providers.<name>.is_enabled=true"]`.
+
+Concretely, applying `providers.lima.is_enabled=true` (as the minds
+forever-claude-template's lima create template does) reset `is_host_in_docker`,
+`install_gvisor_runtime`, and `default_container_run_args` back to their
+defaults, so the Lima provider silently ran in direct-in-VM mode instead of
+docker-in-VM mode. The merge now uses `model_fields_set` (matching
+`AgentTypeConfig` / `PluginConfig`), so untouched fields keep their base value.

--- a/libs/mngr/imbue/mngr/api/create.py
+++ b/libs/mngr/imbue/mngr/api/create.py
@@ -45,7 +45,7 @@ _RETAIN_FAILED_HOSTS_ENV_VAR: Final[str] = "MNGR_DEBUG_RETAIN_LOCK_FOR_FAILED_HO
 
 
 @contextmanager
-def _destroy_new_host_on_create_failure(
+def destroy_new_host_on_create_failure(
     host: OnlineHostInterface, provider: ProviderInstanceInterface | None
 ) -> Iterator[None]:
     """Destroy a freshly-created host if the create fails, so we don't leak it.
@@ -216,9 +216,22 @@ def create(
     with log_span("Resolving target host"):
         host = resolve_target_host(target_host, mngr_ctx)
 
-    # Notify plugins that a new host was created (only for new hosts)
-    if is_new_host:
-        with _destroy_new_host_on_create_failure(host, new_host_provider):
+    # Wrap everything from here through the return in a single destroy-on-failure
+    # guard so a new host we just created is torn down (and, for imbue_cloud, its
+    # lease released) if ANY step below fails -- env-var write, on_host_created
+    # hooks, post-host-create commands, locking, provisioning, agent start, or
+    # the initial-message send. This is a no-op when ``new_host_provider`` is
+    # None (an existing host the caller already owned), so wrapping
+    # unconditionally is safe.
+    with destroy_new_host_on_create_failure(host, new_host_provider):
+        # Notify plugins that a new host was created (only for new hosts)
+        if is_new_host:
+            # Write the host's env vars first, before any hook or command runs,
+            # so an env-var-write failure also tears the new host down. This is
+            # the new host's first post-create step (``target_host`` is a
+            # ``NewHostOptions`` here, so ``.environment`` is available).
+            _write_host_env_vars(host, target_host.environment)
+
             with log_span("Calling on_host_created hooks"):
                 mngr_ctx.pm.hook.on_host_created(host=host, mngr_ctx=mngr_ctx)
 
@@ -229,132 +242,135 @@ def create(
             # subsequent exec depends on.
             _run_post_host_create_commands(host, target_host.provisioning.post_host_create_commands)
 
-    # ``host.pre_baked_agent_id`` (default None on the base Host class,
-    # populated by providers whose ``create_host`` returns a host with a
-    # baked-in agent -- ``ImbueCloudHost`` is the only one today) marks
-    # a specific agent id that ``host.create_agent_state`` knows how to
-    # adopt in place when ``agent_options.name`` matches. Pulled out
-    # before the lock so the duplicate-name check below can recognize
-    # the adopt scenario.
-    pre_baked_agent_id: AgentId | None = host.pre_baked_agent_id
+        # ``host.pre_baked_agent_id`` (default None on the base Host class,
+        # populated by providers whose ``create_host`` returns a host with a
+        # baked-in agent -- ``ImbueCloudHost`` is the only one today) marks
+        # a specific agent id that ``host.create_agent_state`` knows how to
+        # adopt in place when ``agent_options.name`` matches. Pulled out
+        # before the lock so the duplicate-name check below can recognize
+        # the adopt scenario. Keep hooks/post-host-create above this read and
+        # before the lock is acquired.
+        pre_baked_agent_id: AgentId | None = host.pre_baked_agent_id
 
-    # While we are deploying an agent, lock the host. Wrap in the
-    # destroy-on-failure guard so a new host we just created is torn down (and,
-    # for imbue_cloud, its lease released) if any step below fails.
-    with _destroy_new_host_on_create_failure(host, new_host_provider), host.lock_cooperatively():
-        # Prevent duplicate agent names on the same host. The tmux session name
-        # is derived from the agent name, so two agents with the same name would
-        # collide on the same tmux session. This check must be inside the lock to
-        # prevent TOCTOU races between concurrent create calls.
-        # In update mode, the agent already exists so we skip this check.
-        # Also skip when the existing agent IS the host's pre-baked agent
-        # (imbue_cloud lease-adopt): the bake intentionally seeds the host
-        # with the same agent name the caller is creating, and
-        # ``host.create_agent_state`` will hydrate it in place. Without this
-        # skip the post-lease duplicate check fires immediately and aborts
-        # every fresh imbue_cloud create with ``DuplicateAgentNameError``.
-        if agent_options.name is not None and not agent_options.is_update:
-            for existing_agent in host.get_agents():
-                if existing_agent.name == agent_options.name:
-                    if pre_baked_agent_id is not None and existing_agent.id == pre_baked_agent_id:
-                        continue
-                    raise DuplicateAgentNameError(agent_options.name, existing_agent.id)
+        # While we are deploying an agent, lock the host.
+        with host.lock_cooperatively():
+            # Prevent duplicate agent names on the same host. The tmux session name
+            # is derived from the agent name, so two agents with the same name would
+            # collide on the same tmux session. This check must be inside the lock to
+            # prevent TOCTOU races between concurrent create calls.
+            # In update mode, the agent already exists so we skip this check.
+            # Also skip when the existing agent IS the host's pre-baked agent
+            # (imbue_cloud lease-adopt): the bake intentionally seeds the host
+            # with the same agent name the caller is creating, and
+            # ``host.create_agent_state`` will hydrate it in place. Without this
+            # skip the post-lease duplicate check fires immediately and aborts
+            # every fresh imbue_cloud create with ``DuplicateAgentNameError``.
+            if agent_options.name is not None and not agent_options.is_update:
+                for existing_agent in host.get_agents():
+                    if existing_agent.name == agent_options.name:
+                        if pre_baked_agent_id is not None and existing_agent.id == pre_baked_agent_id:
+                            continue
+                        raise DuplicateAgentNameError(agent_options.name, existing_agent.id)
 
-        # Create the agent's work_dir on the host
-        if create_work_dir:
-            with log_span("Calling on_before_initial_file_copy hooks"):
-                mngr_ctx.pm.hook.on_before_initial_file_copy(agent_options=agent_options, host=host)
-            with log_span("Creating agent work directory from source {}", source_location.path):
-                work_dir_result = host.create_agent_work_dir(source_location.host, source_location.path, agent_options)
-                work_dir_path = work_dir_result.path
-                created_branch_name = work_dir_result.created_branch_name
-        else:
-            # Work dir was already created (e.g. by CLI's early copy).
-            # Use target_path if set (it should contain the actual work_dir path),
-            # otherwise fall back to source path (in-place mode).
-            work_dir_path = (
-                agent_options.target_path if agent_options.target_path is not None else source_location.path
-            )
-
-        # If anything below fails, the worktree (and any branch we created for
-        # it) is orphaned. On failure, remove the worktree we created and -- if
-        # we also created a new branch -- delete that branch, so neither leaks
-        # into the source repo. The branch deletion is gated on created_branch_name
-        # so pre-existing branches the user attached to are left alone (mirrors
-        # the destroy-path safety check); the worktree removal is unconditional
-        # for worktree mode because we always create the worktree ourselves
-        # there. Cleanup is also gated on create_work_dir, since when False the
-        # work_dir was provided by the caller and we must not remove it.
-        is_success = False
-        try:
+            # Create the agent's work_dir on the host
             if create_work_dir:
-                with log_span("Calling on_after_initial_file_copy hooks"):
-                    mngr_ctx.pm.hook.on_after_initial_file_copy(
-                        agent_options=agent_options, host=host, work_dir_path=work_dir_path
+                with log_span("Calling on_before_initial_file_copy hooks"):
+                    mngr_ctx.pm.hook.on_before_initial_file_copy(agent_options=agent_options, host=host)
+                with log_span("Creating agent work directory from source {}", source_location.path):
+                    work_dir_result = host.create_agent_work_dir(
+                        source_location.host, source_location.path, agent_options
+                    )
+                    work_dir_path = work_dir_result.path
+                    created_branch_name = work_dir_result.created_branch_name
+            else:
+                # Work dir was already created (e.g. by CLI's early copy).
+                # Use target_path if set (it should contain the actual work_dir path),
+                # otherwise fall back to source path (in-place mode).
+                work_dir_path = (
+                    agent_options.target_path if agent_options.target_path is not None else source_location.path
+                )
+
+            # If anything below fails, the worktree (and any branch we created for
+            # it) is orphaned. On failure, remove the worktree we created and -- if
+            # we also created a new branch -- delete that branch, so neither leaks
+            # into the source repo. The branch deletion is gated on created_branch_name
+            # so pre-existing branches the user attached to are left alone (mirrors
+            # the destroy-path safety check); the worktree removal is unconditional
+            # for worktree mode because we always create the worktree ourselves
+            # there. Cleanup is also gated on create_work_dir, since when False the
+            # work_dir was provided by the caller and we must not remove it.
+            is_success = False
+            try:
+                if create_work_dir:
+                    with log_span("Calling on_after_initial_file_copy hooks"):
+                        mngr_ctx.pm.hook.on_after_initial_file_copy(
+                            agent_options=agent_options, host=host, work_dir_path=work_dir_path
+                        )
+
+                # Create the agent state (registers the agent with the host)
+                with log_span("Creating agent state in work directory {}", work_dir_path):
+                    agent = host.create_agent_state(
+                        work_dir_path, agent_options, created_branch_name=created_branch_name
                     )
 
-            # Create the agent state (registers the agent with the host)
-            with log_span("Creating agent state in work directory {}", work_dir_path):
-                agent = host.create_agent_state(work_dir_path, agent_options, created_branch_name=created_branch_name)
+                # Run provisioning for the agent (hooks, dependency installation, etc.)
+                with log_span("Calling on_before_provisioning hooks"):
+                    mngr_ctx.pm.hook.on_before_provisioning(agent=agent, host=host, mngr_ctx=mngr_ctx)
+                with log_span("Provisioning agent {}", agent.name):
+                    host.provision_agent(agent, agent_options, mngr_ctx)
+                with log_span("Calling on_after_provisioning hooks"):
+                    mngr_ctx.pm.hook.on_after_provisioning(agent=agent, host=host, mngr_ctx=mngr_ctx)
 
-            # Run provisioning for the agent (hooks, dependency installation, etc.)
-            with log_span("Calling on_before_provisioning hooks"):
-                mngr_ctx.pm.hook.on_before_provisioning(agent=agent, host=host, mngr_ctx=mngr_ctx)
-            with log_span("Provisioning agent {}", agent.name):
-                host.provision_agent(agent, agent_options, mngr_ctx)
-            with log_span("Calling on_after_provisioning hooks"):
-                mngr_ctx.pm.hook.on_after_provisioning(agent=agent, host=host, mngr_ctx=mngr_ctx)
+                # Deliver the initial message (if any) and start the agent.
+                #
+                # Interactive agents do the ready-signal dance and send the message
+                # via the tmux pane after the agent is up. Headless agents cannot
+                # receive messages that way: they communicate via stdout/stdin
+                # pipes, so wait_for_ready_signal / send_message both raise. For
+                # those we stage the message on disk first (the agent's command
+                # cats the file at startup) and then just start the process.
+                initial_message = agent.get_initial_message()
+                if isinstance(agent, StreamingHeadlessAgentMixin):
+                    if initial_message is not None:
+                        agent.stage_initial_message(initial_message)
+                    logger.info("Starting agent {} ...", agent.name)
+                    host.start_agents([agent.id])
+                elif initial_message is not None:
+                    # Start agent with signal-based readiness detection
+                    # Raises AgentStartError if the agent doesn't signal readiness in time
+                    logger.info("Starting agent {} ...", agent.name)
+                    timeout = (
+                        agent_options.ready_timeout_seconds
+                        if agent_options.ready_timeout_seconds is not None
+                        else mngr_ctx.config.agent_ready_timeout
+                    )
+                    agent.wait_for_ready_signal(
+                        is_creating=True,
+                        start_action=lambda: host.start_agents([agent.id]),
+                        timeout=timeout,
+                    )
+                    logger.info("Sending initial message...")
+                    agent.send_message(initial_message)
+                else:
+                    # No initial message - just start the agent
+                    logger.info("Starting agent {} ...", agent.name)
+                    host.start_agents([agent.id])
 
-            # Deliver the initial message (if any) and start the agent.
-            #
-            # Interactive agents do the ready-signal dance and send the message
-            # via the tmux pane after the agent is up. Headless agents cannot
-            # receive messages that way: they communicate via stdout/stdin
-            # pipes, so wait_for_ready_signal / send_message both raise. For
-            # those we stage the message on disk first (the agent's command
-            # cats the file at startup) and then just start the process.
-            initial_message = agent.get_initial_message()
-            if isinstance(agent, StreamingHeadlessAgentMixin):
-                if initial_message is not None:
-                    agent.stage_initial_message(initial_message)
-                logger.info("Starting agent {} ...", agent.name)
-                host.start_agents([agent.id])
-            elif initial_message is not None:
-                # Start agent with signal-based readiness detection
-                # Raises AgentStartError if the agent doesn't signal readiness in time
-                logger.info("Starting agent {} ...", agent.name)
-                timeout = (
-                    agent_options.ready_timeout_seconds
-                    if agent_options.ready_timeout_seconds is not None
-                    else mngr_ctx.config.agent_ready_timeout
-                )
-                agent.wait_for_ready_signal(
-                    is_creating=True,
-                    start_action=lambda: host.start_agents([agent.id]),
-                    timeout=timeout,
-                )
-                logger.info("Sending initial message...")
-                agent.send_message(initial_message)
-            else:
-                # No initial message - just start the agent
-                logger.info("Starting agent {} ...", agent.name)
-                host.start_agents([agent.id])
+                # Build and return the result
+                result = CreateAgentResult(agent=agent, host=host)
 
-            # Build and return the result
-            result = CreateAgentResult(agent=agent, host=host)
+                # Call on_agent_created hooks to notify plugins about the new agent
+                with log_span("Calling on_agent_created hooks"):
+                    mngr_ctx.pm.hook.on_agent_created(agent=result.agent, host=result.host)
 
-            # Call on_agent_created hooks to notify plugins about the new agent
-            with log_span("Calling on_agent_created hooks"):
-                mngr_ctx.pm.hook.on_agent_created(agent=result.agent, host=result.host)
+                # Emit discovery events for the host and newly created agent
+                emit_discovery_events_for_host(mngr_ctx.config, host)
+                is_success = True
+            finally:
+                if not is_success and create_work_dir:
+                    _cleanup_failed_worktree_create(work_dir_path, created_branch_name, mngr_ctx)
 
-            # Emit discovery events for the host and newly created agent
-            emit_discovery_events_for_host(mngr_ctx.config, host)
-            is_success = True
-        finally:
-            if not is_success and create_work_dir:
-                _cleanup_failed_worktree_create(work_dir_path, created_branch_name, mngr_ctx)
-
-    return result
+        return result
 
 
 def _run_post_host_create_commands(
@@ -432,7 +448,12 @@ def _create_new_host(
     target_host: NewHostOptions,
     mngr_ctx: MngrContext,
 ) -> OnlineHostInterface:
-    """Create a new host and write its environment variables."""
+    """Create a new host.
+
+    The host's environment variables are written by the caller (``create``)
+    under the destroy-on-failure guard, so a failed env-var write also tears
+    the new host down.
+    """
     with log_span("Calling on_before_host_create hooks"):
         mngr_ctx.pm.hook.on_before_host_create(name=host_name, provider_name=target_host.provider, mngr_ctx=mngr_ctx)
     with log_span(
@@ -457,7 +478,6 @@ def _create_new_host(
             snapshot=target_host.build.snapshot,
         )
 
-    _write_host_env_vars(new_host, target_host.environment)
     return new_host
 
 

--- a/libs/mngr/imbue/mngr/api/create_test.py
+++ b/libs/mngr/imbue/mngr/api/create_test.py
@@ -323,7 +323,7 @@ def test_write_host_env_vars_later_env_file_overrides_earlier(
 
 
 # =============================================================================
-# _destroy_new_host_on_create_failure -- a host we just created for a --new-host
+# destroy_new_host_on_create_failure -- a host we just created for a --new-host
 # create must be torn down if a later step fails, so we never leak it (and, for
 # non-idle-shutdown providers like imbue_cloud, its lease). Gated by the debug
 # retain flag.

--- a/libs/mngr/imbue/mngr/api/create_test.py
+++ b/libs/mngr/imbue/mngr/api/create_test.py
@@ -1,30 +1,45 @@
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 from pydantic import Field
 
+from imbue.mngr import hookimpl
 from imbue.mngr.api.create import _create_new_host
-from imbue.mngr.api.create import _destroy_new_host_on_create_failure
 from imbue.mngr.api.create import _generate_unique_host_name
 from imbue.mngr.api.create import _run_post_host_create_commands
 from imbue.mngr.api.create import _write_host_env_vars
+from imbue.mngr.api.create import create
+from imbue.mngr.api.create import destroy_new_host_on_create_failure
 from imbue.mngr.api.create import resolve_target_host
+from imbue.mngr.api.providers import _instance_cache
 from imbue.mngr.config.data_types import EnvVar
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import HostNameConflictError
 from imbue.mngr.errors import MngrError
 from imbue.mngr.hosts.host import Host
+from imbue.mngr.interfaces.host import AgentLabelOptions
+from imbue.mngr.interfaces.host import CreateAgentOptions
 from imbue.mngr.interfaces.host import HostEnvironmentOptions
 from imbue.mngr.interfaces.host import HostInterface
+from imbue.mngr.interfaces.host import HostLocation
 from imbue.mngr.interfaces.host import NewHostOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostNameStyle
+from imbue.mngr.primitives import LOCAL_PROVIDER_NAME
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.primitives import TransferMode
+from imbue.mngr.providers.local.instance import LOCAL_HOST_NAME
 from imbue.mngr.providers.local.instance import LocalProviderInstance
+from imbue.mngr.utils.plugin_testing import PLACEHOLDER_AGENT_TYPE
+from imbue.mngr.utils.testing import make_ctx_with_plugins
 
 
 def test_write_host_env_vars_writes_explicit_env_vars(
@@ -341,7 +356,7 @@ def test_destroy_new_host_on_create_failure_destroys_failed_new_host(
     """A failure inside the guard tears down the newly-created host and re-raises."""
     provider = _make_recording_provider(local_provider)
     with pytest.raises(ValueError):
-        with _destroy_new_host_on_create_failure(local_host, provider):
+        with destroy_new_host_on_create_failure(local_host, provider):
             raise ValueError("provisioning blew up")
     assert provider.destroyed_host_ids == [local_host.id]
 
@@ -352,7 +367,7 @@ def test_destroy_new_host_on_create_failure_is_noop_on_success(
 ) -> None:
     """A clean exit must not destroy the host."""
     provider = _make_recording_provider(local_provider)
-    with _destroy_new_host_on_create_failure(local_host, provider):
+    with destroy_new_host_on_create_failure(local_host, provider):
         pass
     assert provider.destroyed_host_ids == []
 
@@ -360,7 +375,7 @@ def test_destroy_new_host_on_create_failure_is_noop_on_success(
 def test_destroy_new_host_on_create_failure_does_not_destroy_existing_host(local_host: Host) -> None:
     """provider=None means the caller already owned the host; never tear it down (just re-raise)."""
     with pytest.raises(ValueError):
-        with _destroy_new_host_on_create_failure(local_host, None):
+        with destroy_new_host_on_create_failure(local_host, None):
             raise ValueError("boom")
 
 
@@ -373,6 +388,107 @@ def test_destroy_new_host_on_create_failure_retains_host_when_debug_flag_set(
     provider = _make_recording_provider(local_provider)
     monkeypatch.setenv(_RETAIN_FLAG, "1")
     with pytest.raises(ValueError):
-        with _destroy_new_host_on_create_failure(local_host, provider):
+        with destroy_new_host_on_create_failure(local_host, provider):
             raise ValueError("boom")
+    assert provider.destroyed_host_ids == []
+
+
+# =============================================================================
+# End-to-end: a --new-host create that fails at/before the initial-message send
+# must tear the new host down (single continuous guard around the whole flow),
+# unless the debug retain flag is set.
+# =============================================================================
+
+
+@contextmanager
+def _injected_provider(
+    name: ProviderInstanceName,
+    mngr_ctx: MngrContext,
+    instance: LocalProviderInstance,
+) -> Generator[None, None, None]:
+    """Temporarily inject a provider instance into the provider cache.
+
+    ``create`` resolves the new-host provider via ``get_provider_instance`` using
+    the same ``mngr_ctx``; injecting here makes it use our recording provider so
+    we can observe whether ``destroy_host`` is called on failure.
+    """
+    cache_key = (name, id(mngr_ctx))
+    _instance_cache[cache_key] = instance
+    try:
+        yield
+    finally:
+        _instance_cache.pop(cache_key, None)
+
+
+class _RaiseInOnHostCreated:
+    """Plugin that raises in on_host_created.
+
+    This fires for a --new-host create after ``create_host`` has already
+    succeeded but before the initial message is sent, simulating any failure in
+    that window.
+    """
+
+    @hookimpl
+    def on_host_created(self, host: OnlineHostInterface, mngr_ctx: MngrContext) -> None:
+        raise RuntimeError("simulated failure after host create, before message send")
+
+
+def _make_create_agent_options() -> CreateAgentOptions:
+    return CreateAgentOptions(
+        name=AgentName("test-teardown-agent"),
+        agent_type=AgentTypeName(PLACEHOLDER_AGENT_TYPE),
+        command=CommandString("sleep 60"),
+        transfer_mode=TransferMode.NONE,
+        label_options=AgentLabelOptions(),
+    )
+
+
+def test_create_new_host_torn_down_when_failure_before_message_send(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    temp_work_dir: Path,
+) -> None:
+    """A new-host create that fails after create_host but before the message send tears the host down."""
+    test_ctx = make_ctx_with_plugins(temp_mngr_ctx, [_RaiseInOnHostCreated()])
+    provider = _make_recording_provider(local_provider)
+
+    source_location = HostLocation(host=local_provider.create_host(HostName(LOCAL_HOST_NAME)), path=temp_work_dir)
+    target_host = NewHostOptions(provider=ProviderInstanceName(LOCAL_PROVIDER_NAME), name=HostName(LOCAL_HOST_NAME))
+
+    with _injected_provider(ProviderInstanceName(LOCAL_PROVIDER_NAME), test_ctx, provider):
+        with pytest.raises(RuntimeError, match="simulated failure after host create"):
+            create(
+                source_location=source_location,
+                target_host=target_host,
+                agent_options=_make_create_agent_options(),
+                mngr_ctx=test_ctx,
+            )
+
+    # The freshly-created host must have been destroyed so we never leak it.
+    assert provider.destroyed_host_ids == [provider.get_host(HostName(LOCAL_HOST_NAME)).id]
+
+
+def test_create_new_host_retained_on_failure_when_debug_flag_set(
+    local_provider: LocalProviderInstance,
+    temp_mngr_ctx: MngrContext,
+    temp_work_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the debug retain flag set, a failed new-host create keeps the host for inspection."""
+    monkeypatch.setenv(_RETAIN_FLAG, "1")
+    test_ctx = make_ctx_with_plugins(temp_mngr_ctx, [_RaiseInOnHostCreated()])
+    provider = _make_recording_provider(local_provider)
+
+    source_location = HostLocation(host=local_provider.create_host(HostName(LOCAL_HOST_NAME)), path=temp_work_dir)
+    target_host = NewHostOptions(provider=ProviderInstanceName(LOCAL_PROVIDER_NAME), name=HostName(LOCAL_HOST_NAME))
+
+    with _injected_provider(ProviderInstanceName(LOCAL_PROVIDER_NAME), test_ctx, provider):
+        with pytest.raises(RuntimeError, match="simulated failure after host create"):
+            create(
+                source_location=source_location,
+                target_host=target_host,
+                agent_options=_make_create_agent_options(),
+                mngr_ctx=test_ctx,
+            )
+
     assert provider.destroyed_host_ids == []

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -29,6 +29,7 @@ from imbue.mngr.api.connect import connect_to_agent
 from imbue.mngr.api.connect import resolve_connect_command
 from imbue.mngr.api.connect import run_connect_command
 from imbue.mngr.api.create import create as api_create
+from imbue.mngr.api.create import destroy_new_host_on_create_failure
 from imbue.mngr.api.data_types import ConnectionOptions
 from imbue.mngr.api.data_types import CreateAgentResult
 from imbue.mngr.api.discover import discover_hosts_and_agents
@@ -79,6 +80,7 @@ from imbue.mngr.interfaces.host import NewHostBuildOptions
 from imbue.mngr.interfaces.host import NewHostOptions
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.host import PROVISIONING_FIELD_MAP
+from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
 from imbue.mngr.primitives import ActivitySource
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
@@ -938,6 +940,14 @@ def _create_agent(
         ),
     )
 
+    # Resolve the provider that owns a freshly-created host so the post-api_create
+    # edit-message send (which happens outside api_create's own teardown guard)
+    # can still tear the new host down on failure. None when we adopted an
+    # existing host -- in that case the guard below is a no-op and never destroys.
+    new_host_provider: ProviderInstanceInterface | None = None
+    if _is_creating_new_host(address, opts.new_host) and isinstance(resolved_target_host, NewHostOptions):
+        new_host_provider = get_provider_instance(resolved_target_host.provider, mngr_ctx)
+
     # Call the API create function
     with _editor_cleanup_scope(setup.editor_session):
         create_result = api_create(
@@ -949,13 +959,18 @@ def _create_agent(
 
         # If --edit-message was used, wait for editor and send the message.
         # Re-acquire the host lock to prevent idle shutdown while the user edits
-        # (api_create releases its lock before returning).
+        # (api_create releases its lock before returning). This send happens
+        # after api_create returns -- outside its teardown guard -- so wrap it in
+        # the same guard here: if the initial-message send fails for a host we
+        # just created, tear that host down (respecting the debug retain flag)
+        # rather than leaking it.
         if setup.editor_session is not None:
-            with create_result.host.lock_cooperatively():
-                _handle_editor_message(
-                    editor_session=setup.editor_session,
-                    agent=create_result.agent,
-                )
+            with destroy_new_host_on_create_failure(create_result.host, new_host_provider):
+                with create_result.host.lock_cooperatively():
+                    _handle_editor_message(
+                        editor_session=setup.editor_session,
+                        agent=create_result.agent,
+                    )
 
     return create_result, connection_opts
 

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -468,24 +468,32 @@ class ProviderInstanceConfig(FrozenModel):
     def merge_with(self, override: "ProviderInstanceConfig") -> "ProviderInstanceConfig":
         """Merge this config with an override config.
 
-        All fields flip to assign-by-default: override wins if not None.
-        Lists / dicts / sets are replaced rather than appended; use the
-        ``field__extend`` operator to opt into additive behavior.
+        Uses ``model_fields_set`` so an override only replaces the fields it
+        actually set; fields the override left untouched keep the base value.
+        This matches ``AgentTypeConfig`` / ``PluginConfig`` and is what keeps a
+        higher-precedence layer that touches a single field (e.g. a create
+        template's ``--setting providers.<name>.is_enabled=true``) from
+        silently resetting every other provider field -- like
+        ``is_host_in_docker`` -- back to its model default. Relying on
+        "override wins unless its value is None" was wrong here: a field whose
+        default is a non-None value (a ``bool`` default of ``False``, an empty
+        tuple, ...) would clobber the base even when the override never set it.
+
+        Aggregate fields still flip to assign-by-default: a list / dict / set
+        the override explicitly sets replaces the base value rather than
+        appending. Use the ``field__extend`` operator for additive behavior.
         """
-        # Ensure override is same type as self
         if not isinstance(override, self.__class__):
             raise ConfigParseError(f"Cannot merge {self.__class__.__name__} with different provider config type")
 
+        explicitly_set = override.model_fields_set
+        if not explicitly_set:
+            return self
         base_values = self.model_dump()
         override_values = override.model_dump()
-        merged_values: dict[str, Any] = {}
-        for field_name in self.__class__.model_fields:
-            if field_name == "backend":
-                # Backend identifies the config class itself; always take it from override.
-                merged_values[field_name] = override_values[field_name]
-                continue
-            override_value = override_values[field_name]
-            merged_values[field_name] = override_value if override_value is not None else base_values[field_name]
+        merged_values: dict[str, Any] = dict(base_values)
+        for field_name in explicitly_set:
+            merged_values[field_name] = override_values[field_name]
         return self.__class__(**merged_values)
 
 

--- a/libs/mngr/imbue/mngr/config/data_types_test.py
+++ b/libs/mngr/imbue/mngr/config/data_types_test.py
@@ -291,8 +291,13 @@ def test_provider_instance_config_merge_replaces_dicts() -> None:
     assert merged.options == {"key2": "override_val", "key3": "val3"}
 
 
-def test_provider_instance_config_merge_handles_none_list_override() -> None:
-    """ProviderInstanceConfig.merge_with should keep base list when override is None."""
+def test_provider_instance_config_merge_keeps_unset_list() -> None:
+    """ProviderInstanceConfig.merge_with keeps the base list when the override never set it.
+
+    "Never set" is expressed by omitting the field from the override (so it is
+    absent from ``model_fields_set``), matching how a real config layer that
+    doesn't mention the key is parsed.
+    """
     base = _TestProviderConfigWithListAndDict(
         backend=ProviderBackendName("local"),
         tags=["tag1"],
@@ -300,7 +305,6 @@ def test_provider_instance_config_merge_handles_none_list_override() -> None:
     )
     override = _TestProviderConfigWithListAndDict.model_construct(
         backend=ProviderBackendName("local"),
-        tags=None,
         options={},
     )
     merged = base.merge_with(override)
@@ -308,8 +312,8 @@ def test_provider_instance_config_merge_handles_none_list_override() -> None:
     assert merged.tags == ["tag1"]
 
 
-def test_provider_instance_config_merge_handles_none_dict_override() -> None:
-    """ProviderInstanceConfig.merge_with should keep base dict when override is None."""
+def test_provider_instance_config_merge_keeps_unset_dict() -> None:
+    """ProviderInstanceConfig.merge_with keeps the base dict when the override never set it."""
     base = _TestProviderConfigWithListAndDict(
         backend=ProviderBackendName("local"),
         tags=[],
@@ -318,11 +322,41 @@ def test_provider_instance_config_merge_handles_none_dict_override() -> None:
     override = _TestProviderConfigWithListAndDict.model_construct(
         backend=ProviderBackendName("local"),
         tags=[],
-        options=None,
     )
     merged = base.merge_with(override)
     assert isinstance(merged, _TestProviderConfigWithListAndDict)
     assert merged.options == {"key1": "val1"}
+
+
+class _TestProviderConfigWithBoolAndTuple(ProviderInstanceConfig):
+    """Test config with non-None-default fields (a bool and a tuple)."""
+
+    is_special: bool = Field(default=False)
+    extra_args: tuple[str, ...] = Field(default=())
+
+
+def test_provider_instance_config_merge_keeps_unset_non_none_default_fields() -> None:
+    """An override that sets only one field must not reset other fields to their defaults.
+
+    Regression test: a create template applies ``providers.<name>.is_enabled=true``
+    as a single-key override. The parsed override carries every other field at its
+    model default (``is_special=False``, ``extra_args=()``), but only ``is_enabled``
+    is in ``model_fields_set``. The merge must preserve the base's non-default values
+    rather than clobbering them with the override's defaults.
+    """
+    base = _TestProviderConfigWithBoolAndTuple(
+        backend=ProviderBackendName("local"),
+        is_enabled=False,
+        is_special=True,
+        extra_args=("--workdir=/",),
+    )
+    # Mirror how parse_config builds a single-key --setting override.
+    override = _TestProviderConfigWithBoolAndTuple.model_construct(is_enabled=True)
+    merged = base.merge_with(override)
+    assert isinstance(merged, _TestProviderConfigWithBoolAndTuple)
+    assert merged.is_enabled is True
+    assert merged.is_special is True
+    assert merged.extra_args == ("--workdir=/",)
 
 
 # =============================================================================

--- a/libs/mngr/imbue/mngr/config/data_types_test.py
+++ b/libs/mngr/imbue/mngr/config/data_types_test.py
@@ -940,14 +940,15 @@ def test_provider_instance_config_merge_overrides_destroyed_host_persisted_secon
     assert merged.destroyed_host_persisted_seconds == 7200.0
 
 
-def test_provider_instance_config_merge_keeps_base_when_override_is_none() -> None:
+def test_provider_instance_config_merge_keeps_base_when_override_unset() -> None:
+    # An override that does not set the field (absent from model_fields_set, as a
+    # real config layer that omits the key is parsed) leaves the base value intact.
     base = ProviderInstanceConfig(
         backend=ProviderBackendName("local"),
         destroyed_host_persisted_seconds=3600.0,
     )
     override = ProviderInstanceConfig.model_construct(
         backend=ProviderBackendName("local"),
-        destroyed_host_persisted_seconds=None,
     )
     merged = base.merge_with(override)
     assert merged.destroyed_host_persisted_seconds == 3600.0
@@ -994,9 +995,11 @@ def test_provider_instance_config_merge_overrides_min_online_host_age_seconds() 
     assert merged.min_online_host_age_seconds == 600.0
 
 
-def test_provider_instance_config_merge_keeps_base_min_online_host_age_seconds_when_override_none() -> None:
+def test_provider_instance_config_merge_keeps_base_min_online_host_age_seconds_when_override_unset() -> None:
+    # The override omits the field, so it stays out of model_fields_set and the
+    # base value is preserved (the real parse path never sets a field to None).
     base = ProviderInstanceConfig(backend=ProviderBackendName("test"), min_online_host_age_seconds=300.0)
-    override = ProviderInstanceConfig(backend=ProviderBackendName("test"), min_online_host_age_seconds=None)
+    override = ProviderInstanceConfig.model_construct(backend=ProviderBackendName("test"))
     merged = base.merge_with(override)
     assert merged.min_online_host_age_seconds == 300.0
 

--- a/libs/mngr_lima/changelog/mngr-runsc-everywhere.md
+++ b/libs/mngr_lima/changelog/mngr-runsc-everywhere.md
@@ -1,0 +1,16 @@
+Switched the default Lima VM image from Ubuntu 24.04 to a pinned Debian 12
+"bookworm" genericcloud image (both `aarch64` and `x86_64`). Now that the agent
+typically runs inside a Docker container in the VM (`is_host_in_docker`), the VM
+only needs Docker + btrfs + sshd, so a lighter base suffices; this also mirrors
+the OVH provider's Debian 12 base. The provisioning script is apt-based and works
+on Debian unchanged. Override per-arch via `providers.lima.default_image_url_*`.
+
+Added `providers.lima.default_container_run_args` (default empty): extra
+arguments appended to the `docker run` that starts the agent container in
+`is_host_in_docker` mode. This is the only config path for injecting inner-
+container `docker run` flags on Lima (the lima template's `start_arg` maps to
+`limactl` VM args, not the container). Pairs with `docker_runtime="runsc"` to run
+the agent container under gVisor -- e.g. set it to
+`["--workdir=/", "--security-opt=no-new-privileges"]`, the same hardening the
+docker provider applies, where `--workdir=/` avoids runsc aborting when the image
+WORKDIR (inside the mounted volume) already exists as the process cwd.

--- a/libs/mngr_lima/changelog/mngr-runsc-everywhere.md
+++ b/libs/mngr_lima/changelog/mngr-runsc-everywhere.md
@@ -5,6 +5,18 @@ only needs Docker + btrfs + sshd, so a lighter base suffices; this also mirrors
 the OVH provider's Debian 12 base. The provisioning script is apt-based and works
 on Debian unchanged. Override per-arch via `providers.lima.default_image_url_*`.
 
+Format and mount the per-host btrfs data disk in-guest during provisioning,
+instead of relying on Lima's guestagent to auto-format it at boot. Minimal cloud
+images (the new Debian genericcloud default) ship no `mkfs.btrfs`, so Lima could
+not format the `format: true` btrfs additionalDisk -- it left the disk
+unformatted and nothing mounted at `/mnt/lima-<name>`, which broke the per-host
+subvolume creation (`cannot access '/mnt/lima-...-data'`) in both Lima btrfs
+modes (docker-in-VM and direct-in-VM with `is_host_data_volume_exposed=false`).
+The provisioning script now installs `btrfs-progs`, formats the data disk if it
+is not already btrfs (idempotent; existing snapshot data survives), and mounts it
+at the canonical path before the subvolume is created. On later boots Lima's
+guestagent handles the mount (`btrfs-progs` now persists in the image).
+
 Added `providers.lima.default_container_run_args` (default empty): extra
 arguments appended to the `docker run` that starts the agent container in
 `is_host_in_docker` mode. This is the only config path for injecting inner-

--- a/libs/mngr_lima/imbue/mngr_lima/_lima_btrfs_release_helper.py
+++ b/libs/mngr_lima/imbue/mngr_lima/_lima_btrfs_release_helper.py
@@ -59,7 +59,7 @@ def _build_provider(profile_dir: Path) -> tuple[LimaProviderInstance, Concurrenc
         host_data_disk_size="2GiB",
         default_idle_timeout=3600,
         # Modal sandboxes have no /dev/kvm so qemu runs in TCG (software
-        # emulation). Cold boot of an Ubuntu cloud image under TCG is
+        # emulation). Cold boot of a Debian cloud image under TCG is
         # ~10-15 min; the default 600s is for KVM-accelerated boots.
         vm_start_timeout_seconds=1500.0,
     )

--- a/libs/mngr_lima/imbue/mngr_lima/_lima_docker_release_helper.py
+++ b/libs/mngr_lima/imbue/mngr_lima/_lima_docker_release_helper.py
@@ -48,7 +48,7 @@ def _build_provider(profile_dir: Path) -> tuple[LimaProviderInstance, Concurrenc
         host_data_disk_size="3GiB",
         default_image=_BASE_IMAGE,
         default_idle_timeout=3600,
-        # Cold boot of an Ubuntu cloud image, even with KVM, plus an in-VM
+        # Cold boot of a Debian cloud image, even with KVM, plus an in-VM
         # apt install of Docker, can take a few minutes.
         vm_start_timeout_seconds=1500.0,
         docker_install_timeout=900.0,

--- a/libs/mngr_lima/imbue/mngr_lima/_lima_docker_release_helper.py
+++ b/libs/mngr_lima/imbue/mngr_lima/_lima_docker_release_helper.py
@@ -73,7 +73,7 @@ def _build_provider(profile_dir: Path) -> tuple[LimaProviderInstance, Concurrenc
 
 
 def _verify_container_is_host(host: Host) -> None:
-    """Prove that ssh lands inside the debian container (not the ubuntu VM) and host_dir is btrfs."""
+    """Prove that ssh lands inside the debian container (not the host VM) and host_dir is btrfs."""
     os_release = host.execute_idempotent_command("cat /etc/os-release")
     if "debian" not in os_release.stdout.lower():
         raise AssertionError(f"Expected to be inside the debian container, got: {os_release.stdout!r}")

--- a/libs/mngr_lima/imbue/mngr_lima/config.py
+++ b/libs/mngr_lima/imbue/mngr_lima/config.py
@@ -113,6 +113,16 @@ class LimaProviderConfig(ProviderInstanceConfig):
         default=(),
         description="Default limactl start arguments applied to all VMs",
     )
+    default_container_run_args: tuple[str, ...] = Field(
+        default=(),
+        description=(
+            "Extra arguments appended to the `docker run` that starts the agent container in "
+            "is_host_in_docker mode (e.g. '--workdir=/' and '--security-opt=no-new-privileges' when "
+            "running under gVisor). These reach the inner container only; the VM-level "
+            "`default_start_args` go to `limactl start` instead. Empty by default (no change to the "
+            "`docker run`). Ignored when is_host_in_docker is False (no container is run)."
+        ),
+    )
     docker_runtime: str | None = Field(
         default=None,
         description=(

--- a/libs/mngr_lima/imbue/mngr_lima/constants.py
+++ b/libs/mngr_lima/imbue/mngr_lima/constants.py
@@ -10,13 +10,19 @@ LIMA_INSTANCE_PREFIX: Final[str] = "mngr-"
 # Minimum supported Lima version (major, minor, patch)
 MINIMUM_LIMA_VERSION: Final[tuple[int, int, int]] = (1, 0, 0)
 
-# Default image URLs for Lima VMs (Ubuntu 24.04 LTS cloud images).
-# The cloud-init provisioning script installs any missing mngr dependencies.
+# Default image URLs for Lima VMs (Debian 12 "bookworm" genericcloud images).
+# Debian's genericcloud variant is a minimal cloud image -- now that the agent
+# runs inside a Docker container in the VM (is_host_in_docker), the VM only
+# needs Docker + btrfs + sshd, so a lighter base than Ubuntu suffices. This
+# also mirrors the OVH provider's "Debian 12 - Docker" base. The provisioning
+# script is apt-based, so it works on Debian unchanged and installs any missing
+# mngr dependencies. Pinned to a specific dated snapshot for reproducibility;
+# bump the snapshot id (in both URLs) to pick up a newer point release.
 DEFAULT_IMAGE_URL_AARCH64: Final[str] = (
-    "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+    "https://cloud.debian.org/images/cloud/bookworm/20260601-2496/debian-12-genericcloud-arm64-20260601-2496.qcow2"
 )
 DEFAULT_IMAGE_URL_X86_64: Final[str] = (
-    "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img"
+    "https://cloud.debian.org/images/cloud/bookworm/20260601-2496/debian-12-genericcloud-amd64-20260601-2496.qcow2"
 )
 
 # Default host directory inside the VM

--- a/libs/mngr_lima/imbue/mngr_lima/instance.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance.py
@@ -712,9 +712,13 @@ sudo poweroff
                 ],
                 labels=labels,
                 # Select a non-default container runtime (e.g. 'runsc' for gVisor) when
-                # configured; absent by default. The runtime must be registered in the VM.
-                extra_args=(
-                    ["--runtime", self.config.docker_runtime] if self.config.docker_runtime is not None else []
+                # configured, plus any further `docker run` flags that runtime needs
+                # (e.g. '--workdir=/' + '--security-opt=no-new-privileges' under runsc),
+                # which can't otherwise be injected from config. See
+                # `_build_agent_container_extra_args`.
+                extra_args=_build_agent_container_extra_args(
+                    self.config.docker_runtime,
+                    self.config.default_container_run_args,
                 ),
                 entrypoint_cmd=CONTAINER_ENTRYPOINT_CMD,
             )
@@ -1638,6 +1642,20 @@ def _allocate_free_host_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as temp_socket:
         temp_socket.bind(("127.0.0.1", 0))
         return temp_socket.getsockname()[1]
+
+
+def _build_agent_container_extra_args(
+    docker_runtime: str | None,
+    default_container_run_args: Sequence[str],
+) -> list[str]:
+    """Assemble the extra ``docker run`` args for the in-VM agent container.
+
+    Prepends ``--runtime <value>`` when a non-default runtime is configured (e.g.
+    'runsc' for gVisor), then appends any configured passthrough run args (e.g.
+    '--workdir=/' + '--security-opt=no-new-privileges' the runtime needs).
+    """
+    runtime_args = ["--runtime", docker_runtime] if docker_runtime is not None else []
+    return [*runtime_args, *default_container_run_args]
 
 
 def _parse_size_to_gb(size_str: str) -> float:

--- a/libs/mngr_lima/imbue/mngr_lima/instance_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/instance_test.py
@@ -12,7 +12,30 @@ from imbue.mngr_lima.errors import LimaHostRenameError
 from imbue.mngr_lima.host_store import HostRecord
 from imbue.mngr_lima.host_store import LimaHostConfig
 from imbue.mngr_lima.instance import LimaProviderInstance
+from imbue.mngr_lima.instance import _build_agent_container_extra_args
 from imbue.mngr_lima.instance import _parse_size_to_gb
+
+
+def test_build_agent_container_extra_args_default_is_empty() -> None:
+    # No runtime and no passthrough args -> no extra docker run args.
+    assert _build_agent_container_extra_args(None, ()) == []
+
+
+def test_build_agent_container_extra_args_runtime_only() -> None:
+    assert _build_agent_container_extra_args("runsc", ()) == ["--runtime", "runsc"]
+
+
+def test_build_agent_container_extra_args_passthrough_only() -> None:
+    # Passthrough run args apply even without a custom runtime.
+    assert _build_agent_container_extra_args(None, ("--workdir=/",)) == ["--workdir=/"]
+
+
+def test_build_agent_container_extra_args_runtime_and_passthrough_order() -> None:
+    # Runtime is prepended; passthrough args follow in order (the gVisor case).
+    assert _build_agent_container_extra_args(
+        "runsc",
+        ("--workdir=/", "--security-opt=no-new-privileges"),
+    ) == ["--runtime", "runsc", "--workdir=/", "--security-opt=no-new-privileges"]
 
 
 def test_provider_capabilities(lima_provider: LimaProviderInstance) -> None:

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
@@ -432,6 +432,10 @@ def _build_format_and_mount_data_disk_block(host_data_disk_name: str) -> str:
 if ! mountpoint -q {lima_mount}; then
     DATA_ROOT_SRC="$(findmnt -no SOURCE /)"
     DATA_ROOT_DISK="$(lsblk -no PKNAME "$DATA_ROOT_SRC" | head -1)"
+    if [ -z "$DATA_ROOT_DISK" ]; then
+        echo "ERROR: could not determine root disk for $DATA_ROOT_SRC; refusing to format data disk" >&2
+        exit 1
+    fi
     DATA_DISK=""
     for DATA_CANDIDATE in $(lsblk -dn -o NAME,TYPE | awk '$2=="disk"{{print $1}}'); do
         if [ "$DATA_CANDIDATE" != "$DATA_ROOT_DISK" ]; then

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
@@ -134,6 +134,7 @@ def generate_default_lima_yaml(
             host_public_key_openssh,
             outer_authorized_public_key=outer_authorized_public_key,
             install_gvisor_runtime=install_gvisor_runtime,
+            host_data_disk_name=host_data_disk_name,
         )
     else:
         port_forwards = _disable_port_forwards_rules()
@@ -194,6 +195,13 @@ def _build_provisioning_script(
     """Build the Lima ``provision[mode=system]`` script that installs required packages, configures sshd, optionally lands the btrfs host-data disk at the canonical mount point, and (when a keypair is supplied) installs it as the guest's ed25519 sshd host key."""
     host_key_block = _build_host_key_block(host_private_key_pem, host_public_key_openssh)
     host_data_disk_block = _build_host_data_disk_block(host_data_disk_name, host_dir)
+    # The btrfs data disk is formatted in-guest (see _build_format_and_mount_data_disk_block),
+    # so mkfs.btrfs must be present; minimal images (e.g. Debian genericcloud) don't ship it.
+    btrfs_pkg_line = (
+        '\ncommand -v mkfs.btrfs >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL btrfs-progs"'
+        if host_data_disk_name is not None
+        else ""
+    )
     return f"""\
 #!/bin/bash
 set -eux -o pipefail
@@ -207,7 +215,7 @@ command -v rsync >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL rsync"
 command -v curl >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL curl"
 command -v xxd >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL xxd"
 test -x /usr/sbin/sshd || PKGS_TO_INSTALL="$PKGS_TO_INSTALL openssh-server"
-test -f /etc/ssl/certs/ca-certificates.crt || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ca-certificates"
+test -f /etc/ssl/certs/ca-certificates.crt || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ca-certificates"{btrfs_pkg_line}
 
 if [ -n "$PKGS_TO_INSTALL" ]; then
     apt-get update -qq && apt-get install -y -qq $PKGS_TO_INSTALL
@@ -267,6 +275,7 @@ def _build_docker_provisioning_script(
     host_public_key_openssh: str | None,
     outer_authorized_public_key: str | None,
     install_gvisor_runtime: bool,
+    host_data_disk_name: str | None,
 ) -> str:
     """Build the Lima ``provision[mode=system]`` script for is_host_in_docker mode.
 
@@ -277,9 +286,17 @@ def _build_docker_provisioning_script(
     drive docker/btrfs/systemctl as root. The injected ed25519 host key gives
     the VM a known sshd identity (no TOFU). When ``install_gvisor_runtime`` is
     True, an idempotent block installs and registers the gVisor ``runsc`` runtime.
+    When ``host_data_disk_name`` is set, the btrfs data disk is formatted +
+    mounted in-guest (Lima can't format it on minimal images that lack mkfs.btrfs).
     """
     host_key_block = _build_host_key_block(host_private_key_pem, host_public_key_openssh)
     root_authorized_keys_block = _build_root_authorized_keys_block(outer_authorized_public_key)
+    data_disk_block = (
+        f"\n# Format + mount the btrfs data disk (Lima can't on minimal images).\n"
+        f"{_build_format_and_mount_data_disk_block(host_data_disk_name)}\n"
+        if host_data_disk_name is not None
+        else ""
+    )
     gvisor_install_block = (
         f"\n# Install and register the gVisor runsc runtime (idempotent).\n{_GVISOR_RUNSC_INSTALL_BLOCK}\n"
         if install_gvisor_runtime
@@ -313,7 +330,7 @@ if [ -n "$PKGS_TO_INSTALL" ]; then
 fi
 
 systemctl enable --now docker
-{gvisor_install_block}
+{gvisor_install_block}{data_disk_block}
 mkdir -p /run/sshd
 
 # Install the caller-provided sshd host key (when given).
@@ -371,25 +388,17 @@ def _build_host_data_disk_block(host_data_disk_name: str | None, host_dir: str) 
     if host_data_disk_name is None:
         return "# (no host-data disk attached; host_dir uses today's bind mount or local fs)"
     lima_mount = lima_host_data_disk_mount_path(host_data_disk_name)
+    format_and_mount_block = _build_format_and_mount_data_disk_block(host_data_disk_name)
     return f"""\
-# Wait for Lima to finish auto-mounting the additional btrfs disk.
-for _ in $(seq 1 60); do
-    if mountpoint -q {lima_mount}; then
-        break
-    fi
-    sleep 1
-done
-if ! mountpoint -q {lima_mount}; then
-    echo "ERROR: Lima additional disk not mounted at {lima_mount}" >&2
-    exit 1
-fi
+# Format + mount the additional btrfs disk ourselves (Lima can't on minimal images).
+{format_and_mount_block}
 
 # Open up the btrfs root so the Lima default (non-root) user can write to
 # host_dir without sudo (a fresh mkfs.btrfs leaves the root dir owned by
 # root:root with 0755). Mirrors the chmod 777 the script applies to /code.
 chmod 0777 {lima_mount}
 
-# Replace host_dir with a symlink to Lima's auto-mounted btrfs disk.
+# Replace host_dir with a symlink to the mounted btrfs disk.
 # ``ln -sfn`` alone won't replace an existing directory, so rm any real
 # dir first. Idempotent across re-runs.
 if [ -L {host_dir} ] || [ ! -e {host_dir} ]; then
@@ -397,6 +406,50 @@ if [ -L {host_dir} ] || [ ! -e {host_dir} ]; then
 else
     rm -rf {host_dir}
     ln -sfn {lima_mount} {host_dir}
+fi"""
+
+
+def _build_format_and_mount_data_disk_block(host_data_disk_name: str) -> str:
+    """Return a bash block that formats (if needed) and mounts the Lima btrfs data disk.
+
+    Minimal cloud images (e.g. Debian genericcloud) ship no ``mkfs.btrfs``, so
+    Lima's guestagent cannot format the ``format: true`` btrfs additionalDisk at
+    boot -- it partitions the disk but leaves it unformatted, and nothing mounts
+    at ``/mnt/lima-<name>``. ``btrfs-progs`` is installed earlier in the
+    provisioning script; here we format + mount the disk ourselves at exactly the
+    path Lima would have used, so the per-host btrfs subvolume can be created.
+
+    Idempotent: a no-op when already mounted, and ``mkfs`` runs only when the
+    device is not already btrfs (so re-provisioning and existing snapshot data
+    survive). The data disk is identified as the one ``disk``-type block device
+    that is not the root disk -- in this mode there is exactly one additional
+    disk. On later boots Lima's guestagent handles the mount itself (``btrfs-progs``
+    now persists in the image's root fs), so this is first-boot setup; the mount
+    path is the same either way.
+    """
+    lima_mount = lima_host_data_disk_mount_path(host_data_disk_name)
+    return f"""\
+if ! mountpoint -q {lima_mount}; then
+    DATA_ROOT_SRC="$(findmnt -no SOURCE /)"
+    DATA_ROOT_DISK="$(lsblk -no PKNAME "$DATA_ROOT_SRC" | head -1)"
+    DATA_DISK=""
+    for DATA_CANDIDATE in $(lsblk -dn -o NAME,TYPE | awk '$2=="disk"{{print $1}}'); do
+        if [ "$DATA_CANDIDATE" != "$DATA_ROOT_DISK" ]; then
+            DATA_DISK="$DATA_CANDIDATE"
+            break
+        fi
+    done
+    if [ -z "$DATA_DISK" ]; then
+        echo "ERROR: no additional data disk found to back {lima_mount}" >&2
+        exit 1
+    fi
+    DATA_PART="$(lsblk -ln -o NAME "/dev/$DATA_DISK" | sed -n '2p')"
+    DATA_DEV="/dev/${{DATA_PART:-$DATA_DISK}}"
+    if ! blkid -t TYPE=btrfs "$DATA_DEV" >/dev/null 2>&1; then
+        mkfs.btrfs -f "$DATA_DEV"
+    fi
+    mkdir -p {lima_mount}
+    mount "$DATA_DEV" {lima_mount}
 fi"""
 
 

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
@@ -249,9 +249,9 @@ if [ "$SSH_KEY_CHANGED" = "1" ] || [ "$SSHD_CONFIG_CHANGED" = "1" ]; then
     systemctl restart sshd 2>/dev/null || service ssh restart 2>/dev/null || true
 fi
 
-# Optional: if a Lima-managed btrfs additional disk was attached, symlink
-# host_dir to Lima's auto-mount path for that disk. No-op when the block
-# below is the inert comment placeholder.
+# Optional: if a btrfs additional disk was attached, format + mount it at the
+# canonical path and symlink host_dir to it. No-op when the block below is the
+# inert comment placeholder.
 {host_data_disk_block}
 """
 

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
@@ -212,10 +212,13 @@ def test_generate_default_lima_yaml_btrfs_mode_omits_mounts_adds_disk(tmp_path: 
     assert disk_entry["size"] == "100GiB"
 
     script = config["provision"][0]["script"]
-    # The symlink target is Lima's auto-mount path for the additional disk.
+    # The symlink target is the disk's canonical mount path.
     assert "ln -sfn /mnt/lima-mngr-abc123-data /mngr" in script
-    # Hardens the chicken-and-egg: provisioning script waits for Lima's auto-mount
-    # before symlinking host_dir into it.
+    # We format + mount the disk ourselves (Lima can't on minimal images that lack
+    # mkfs.btrfs): btrfs-progs is installed, the disk is formatted, and mounted at
+    # the canonical path before host_dir is symlinked into it.
+    assert "btrfs-progs" in script
+    assert "mkfs.btrfs -f" in script
     assert "mountpoint -q /mnt/lima-mngr-abc123-data" in script
     # Opens the btrfs root for the Lima default non-root user (fresh mkfs.btrfs
     # leaves the root dir owned by root:root).
@@ -299,6 +302,10 @@ def test_generate_docker_mode_lima_yaml_has_container_port_forward_and_no_mounts
     assert "ssh-ed25519 AAAAOUTER" in script
     assert "PermitRootLogin prohibit-password" in script
     assert "ln -sfn" not in script
+    # Docker mode also formats + mounts the btrfs data disk in-guest (Lima can't on
+    # minimal images), so the per-host subvolume can be created at the mount path.
+    assert "mkfs.btrfs -f" in script
+    assert "mountpoint -q /mnt/lima-mngr-abc-data" in script
 
 
 def test_generate_docker_mode_lima_yaml_omits_gvisor_install_by_default() -> None:

--- a/libs/mngr_lima/pyproject.toml
+++ b/libs/mngr_lima/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "imbue-mngr==0.2.11",
-    "imbue-mngr-vps-docker==0.1.3",
+    "imbue-mngr-vps-docker==0.1.4",
     "pyyaml>=6.0",
 ]
 

--- a/specs/imbue-cloud-slow-path-runsc.md
+++ b/specs/imbue-cloud-slow-path-runsc.md
@@ -68,8 +68,8 @@ This constructs `VpsDockerProviderConfig` with **defaults** for everything else,
 so `docker_runtime` is `None` and `default_start_args` is empty. The rebuilt
 container's `docker run` therefore gets no `--runtime runsc` and none of the
 `--workdir=/` / `--security-opt=no-new-privileges` hardening. (See
-`mngr_vps_docker/.../instance.py`: `runtime_args = ("--runtime", config.docker_runtime)
-if config.docker_runtime is not None else ()`.)
+`mngr_vps_docker/.../instance.py`: `runtime_args = ("--runtime", self.config.docker_runtime)
+if self.config.docker_runtime is not None else ()`.)
 
 `ImbueCloudProviderConfig` (`libs/mngr_imbue_cloud/.../config.py`) extends
 `ProviderInstanceConfig`, **not** `VpsDockerProviderConfig`, so it has no

--- a/specs/imbue-cloud-slow-path-runsc.md
+++ b/specs/imbue-cloud-slow-path-runsc.md
@@ -1,0 +1,148 @@
+# imbue_cloud slow/rebuild path doesn't run the agent container under gVisor (runsc)
+
+Status: **deferred** — to be tackled on a separate branch. This documents the
+problem, why it's not fixed by the `mngr/runsc-everywhere` work, the constraints,
+and proposed fixes.
+
+## TL;DR
+
+The `mngr/runsc-everywhere` branch makes the docker / lima / vultr / ovh
+providers run the agent container under gVisor (`runsc`). For `imbue_cloud`:
+
+- **Fast path is covered.** Pool hosts are baked by the OVH provider (whose
+  template + provider config now enable runsc), so an adopted pre-baked
+  container already runs under runsc.
+- **Slow / rebuild path is NOT covered.** When `imbue_cloud` rebuilds a
+  container on a leased pool host, it builds a fresh `vps_docker` provider with
+  *default* config (`docker_runtime=None`, no hardening start-args), so the
+  rebuilt container runs under the default runtime (`runc`), not runsc.
+
+This is a fallback path, so impact is limited, but it's a real gap.
+
+## Background: imbue_cloud's two create paths
+
+`mngr create ...@<host>.imbue_cloud_<slug>` (the way minds creates pool-backed
+workspaces) has two paths, selected by `-b fast_mode=...`. minds tries them in
+order (`apps/minds/.../desktop_client/agent_creator.py` `_create_imbue_cloud_with_fallback`):
+
+1. **Fast path** (`fast_mode=require`) — `ImbueCloudProvider._create_host_fast_path`
+   in `libs/mngr_imbue_cloud/.../instance.py`. Leases a pool host whose baked
+   attributes exactly match and **adopts its pre-baked container as-is** (no
+   rebuild). Explicitly **rejects** `--image` / `--start-arg`
+   (`instance.py` ~line 1139: "fast_mode=require does not accept --image or
+   --start-arg").
+2. **Slow path** (`fast_mode=prevent`) — `_create_host_slow_path` →
+   `_rebuild_leased_container` → `_build_delegated_vps_provider`. Leases any free
+   host, tears down its baked container, and **rebuilds** it from the FCT
+   Dockerfile via a delegated `vps_docker` create.
+
+## Why the fast path is covered
+
+Pool hosts are baked via `mngr imbue_cloud admin pool create`, which uses the
+forever-claude-template `ovh` create template + `[providers.ovh]` provider
+config. On `mngr/runsc-everywhere` those carry:
+
+- `[providers.ovh]`: `install_gvisor_runtime = true`, `docker_runtime = "runsc"`
+- `[create_templates.ovh]`: `start_arg__extend = ["--security-opt=no-new-privileges", "--workdir=/"]`
+
+So a freshly-baked pool container runs under runsc, and the fast path adopts it
+unchanged → runsc for free.
+
+Caveat (already accepted, "no backwards compat"): hosts baked **before** this
+change won't be on runsc until the pool is re-baked.
+
+## Why the slow path is NOT covered
+
+`_rebuild_leased_container` builds the delegated provider in
+`_build_delegated_vps_provider` (`libs/mngr_imbue_cloud/.../instance.py` ~line 1351):
+
+```python
+vps_config = VpsDockerProviderConfig(
+    backend=ProviderBackendName("vps_docker"),
+    host_dir=self.config.host_dir,
+    container_ssh_port=self.config.container_ssh_port,
+)
+```
+
+This constructs `VpsDockerProviderConfig` with **defaults** for everything else,
+so `docker_runtime` is `None` and `default_start_args` is empty. The rebuilt
+container's `docker run` therefore gets no `--runtime runsc` and none of the
+`--workdir=/` / `--security-opt=no-new-privileges` hardening. (See
+`mngr_vps_docker/.../instance.py`: `runtime_args = ("--runtime", config.docker_runtime)
+if config.docker_runtime is not None else ()`.)
+
+`ImbueCloudProviderConfig` (`libs/mngr_imbue_cloud/.../config.py`) extends
+`ProviderInstanceConfig`, **not** `VpsDockerProviderConfig`, so it has no
+`docker_runtime` / `install_gvisor_runtime` / `default_start_args` fields to
+forward in the first place.
+
+## The constraint that blocks the "easy" fix
+
+The obvious fix — add `start_arg__extend = ["--workdir=/", "--security-opt=no-new-privileges"]`
+to `[create_templates.imbue_cloud]` so the rebuild's `docker run` gets them —
+**does not work and actively breaks creation**:
+
+- minds applies the `imbue_cloud` template to **both** create attempts (only the
+  `-b fast_mode=...` differs).
+- The first attempt is `fast_mode=require`, which **rejects** `--start-arg` with
+  a plain `MngrError` (not `FastPathUnavailableError`), so minds' fallback logic
+  re-raises it instead of retrying the slow path → imbue_cloud creation fails
+  entirely.
+
+Additionally, even for the slow path the template's repo/branch must remain a
+**remote** ref the pool host can clone; a local-worktree path would break it
+(this is the same class of issue as the `_operator_workspace_default` opt-in).
+
+So the runsc settings for the slow path cannot ride on the template; they must
+come from **provider config** that the delegated `vps_docker` provider reads.
+
+## Proposed fix (for the future branch)
+
+1. Add `docker_runtime: str | None` and a run-args field (e.g.
+   `default_container_run_args: tuple[str, ...]`, or reuse `default_start_args`)
+   to `ImbueCloudProviderConfig`. `install_gvisor_runtime` is likely unnecessary
+   here because the leased pool host already has runsc installed from its OVH
+   bake — but verify.
+2. In `_build_delegated_vps_provider`, propagate those onto the
+   `VpsDockerProviderConfig` it constructs (`docker_runtime=self.config.docker_runtime`,
+   `default_start_args=self.config.default_container_run_args`).
+3. Decide where the per-account `imbue_cloud` provider gets these values. The
+   per-account block (`[providers.imbue_cloud_<slug>]`) is written by minds
+   bootstrap (`apps/minds/.../bootstrap.py` `set_imbue_cloud_provider_for_account`),
+   not by FCT settings. Options:
+   - have minds bootstrap write `docker_runtime`/run-args into that block, or
+   - set sensible defaults on `ImbueCloudProviderConfig` (broader: affects all
+     imbue_cloud users; assumes the leased host has runsc), or
+   - an `MNGR__PROVIDERS__...__DOCKER_RUNTIME` env var in the minds/bake env.
+   Recommendation: minds-bootstrap-written block, mirroring how the other
+   per-account knobs are set, so it's scoped to minds and explicit.
+
+## Testing
+
+- Unit: assert `_build_delegated_vps_provider` produces a `VpsDockerProviderConfig`
+  with `docker_runtime`/run-args propagated from `self.config`.
+- End-to-end (release/manual): force the slow path (`fast_mode=prevent`) against a
+  pool and confirm the rebuilt container runs under runsc
+  (`docker inspect --format '{{.HostConfig.Runtime}}' <container>` → `runsc`).
+
+## Note on the runsc workaround args
+
+Under gVisor the agent container needs `--workdir=/` (runsc aborts when the
+image WORKDIR `/mngr/code`, inside the mounted `/mngr` volume, already exists as
+the process cwd) and `--security-opt=no-new-privileges`. Whatever carries
+`docker_runtime=runsc` to the slow-path rebuild must also carry these, exactly as
+the docker / vultr / ovh templates do via `start_arg`.
+
+## Relevant code
+
+- `libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/instance.py` — `_create_host_fast_path`,
+  `_create_host_slow_path`, `_rebuild_leased_container`, `_build_delegated_vps_provider`.
+- `libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/config.py` — `ImbueCloudProviderConfig`.
+- `libs/mngr_vps_docker/imbue/mngr_vps_docker/config.py` — `VpsDockerProviderConfig`
+  (`docker_runtime`, `install_gvisor_runtime`, `default_start_args`).
+- `libs/mngr_vps_docker/imbue/mngr_vps_docker/instance.py` — where `--runtime` is added.
+- `apps/minds/imbue/minds/desktop_client/agent_creator.py` — `_create_imbue_cloud_with_fallback`
+  (the require-then-prevent fallback) and the `-b repo_url=`/`repo_branch_or_tag=` wiring.
+- `apps/minds/imbue/minds/bootstrap.py` — `set_imbue_cloud_provider_for_account`.
+- forever-claude-template `.mngr/settings.toml` — `[providers.ovh]` / `[create_templates.ovh]`
+  (the bake) and `[create_templates.imbue_cloud]` (must NOT gain `start_arg`).


### PR DESCRIPTION
## Summary

Enables gVisor (`runsc`) for the Lima, Vultr, and OVH providers used by the minds forever-claude-template (the local `docker` provider already runs under runsc), and slims the Lima VM OS from Ubuntu 24.04 to a pinned Debian 12 "bookworm" genericcloud image.

The gVisor support already existed in code (`docker_runtime` + `install_gvisor_runtime` on both provider configs); this is mostly configuration plus one small Lima passthrough.

### mngr_lima (code)
- Default VM image: Ubuntu 24.04 -> pinned Debian 12 genericcloud (both arches). Now that the agent runs in a container in the VM, the VM only needs Docker + btrfs + sshd, so a lighter base suffices and mirrors OVH's Debian 12.
- New `providers.lima.default_container_run_args`: extra `docker run` args for the in-VM agent container. This is the only config path for inner-container run args on Lima (the lima template `start_arg` maps to `limactl` VM args). Pairs with `docker_runtime=runsc` to carry `--workdir=/` + `--security-opt=no-new-privileges`.
- Extracted `_build_agent_container_extra_args` + unit tests.

### mngr_vps_docker
- No code change: already forwards template `start_arg` to the agent `docker run` and already supports `docker_runtime` + `install_gvisor_runtime`.

### forever-claude-template (separate repo, branch `mngr/runsc-everywhere`)
- `[providers.lima]`: `install_gvisor_runtime`, `docker_runtime="runsc"`, `default_container_run_args=["--workdir=/","--security-opt=no-new-privileges"]`.
- New `[providers.vultr]` / `[providers.ovh]` blocks (`is_enabled=false`, mirroring lima/docker) with `install_gvisor_runtime` + `docker_runtime`.
- vultr/ovh templates: `start_arg__extend` for the hardening run args.

## Not covered (deferred)
- **imbue_cloud slow/rebuild path** under runsc. The fast path (common case) adopts pre-baked OVH containers, which are now built under runsc. Adding `start_arg` to the imbue_cloud template would break the fast path (it rejects `--start-arg`, and minds tries it first), and the slow path builds its delegated vps_docker provider with default config. Full coverage needs a `mngr_imbue_cloud` (+ minds bootstrap) code change.

## Testing
- `just test-quick libs/mngr_lima` (minus heavy infra markers): 130 passed.
- Required follow-up before merge: a manual one-off Lima + VPS bring-up under runsc/Debian (per plan) to confirm the agent container actually runs under `runsc`. Not yet performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)