### PR TITLE
minds: migrate state out of ~/.minds/ to platform-canonical roots

### DIFF
--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -249,6 +249,10 @@ jobs:
     timeout-minutes: 40
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # Opt every component (Electron app + e2e driver) into the override
+      # layout so the run is self-contained under one throwaway tree,
+      # independent of the runner's home-dir state from past runs.
+      MINDS_DATA_HOME: ${{ runner.temp }}/minds
     steps:
       - uses: actions/checkout@v6
       - name: verify ANTHROPIC_API_KEY injected
@@ -423,21 +427,24 @@ jobs:
           if [ -d /tmp/launch-to-msg-screenshots ]; then
             cp -R /tmp/launch-to-msg-screenshots artifacts/screenshots 2>/dev/null || true
           fi
-          # Diagnostic logs (also useful on success for tuning).
+          # Diagnostic logs (also useful on success for tuning). CI runs with
+          # MINDS_DATA_HOME set, so the production-tier roots are nested under it.
+          MINDS_BASE="${MINDS_DATA_HOME}/production"
+          APP_SUPPORT="${MINDS_BASE}/app_support"
           [ -d /tmp/launch-to-msg-logs ] && cp -R /tmp/launch-to-msg-logs artifacts/ || true
-          [ -d "$HOME/.minds/logs" ] && cp -R "$HOME/.minds/logs" artifacts/ || true
-          [ -d "$HOME/.minds/events" ] && cp -R "$HOME/.minds/events" artifacts/ || true
-          [ -d "$HOME/.minds/mngr" ] && cp -R "$HOME/.minds/mngr"/*/events artifacts/agent-events 2>/dev/null || true
+          [ -d "${MINDS_BASE}/logs" ] && cp -R "${MINDS_BASE}/logs" artifacts/ || true
+          [ -d "${APP_SUPPORT}/events" ] && cp -R "${APP_SUPPORT}/events" artifacts/ || true
+          [ -d "${APP_SUPPORT}/mngr" ] && cp -R "${APP_SUPPORT}/mngr"/*/events artifacts/agent-events 2>/dev/null || true
           log show --process Minds --last 5m 2>/dev/null > artifacts/macos-console.log || true
-          ls -la "$HOME/.minds" > artifacts/minds-dir-listing.txt 2>&1 || true
+          ls -la "${APP_SUPPORT}" > artifacts/minds-dir-listing.txt 2>&1 || true
           [ -f /tmp/minds-electron.log ] && cp /tmp/minds-electron.log artifacts/ || true
           [ -d /tmp/slack-mock ] && cp -R /tmp/slack-mock artifacts/ 2>/dev/null || true
           # Latchkey gateway state (encryption_key excluded by directory selection).
-          if [ -d "$HOME/.minds/latchkey" ]; then
+          if [ -d "${APP_SUPPORT}/latchkey" ]; then
             mkdir -p artifacts/latchkey
-            cp -R "$HOME/.minds/latchkey/mngr_latchkey" artifacts/latchkey/ 2>/dev/null || true
-            cp "$HOME/.minds/latchkey/latchkey_gateway.log" artifacts/latchkey/ 2>/dev/null || true
-            cp "$HOME/.minds/latchkey/latchkey_ensure_browser.log" artifacts/latchkey/ 2>/dev/null || true
+            cp -R "${APP_SUPPORT}/latchkey/mngr_latchkey" artifacts/latchkey/ 2>/dev/null || true
+            cp "${APP_SUPPORT}/latchkey/latchkey_gateway.log" artifacts/latchkey/ 2>/dev/null || true
+            cp "${APP_SUPPORT}/latchkey/latchkey_ensure_browser.log" artifacts/latchkey/ 2>/dev/null || true
           fi
       - uses: actions/upload-artifact@v7
         # Always upload: this branch's verify step relies on downloading

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -249,12 +249,15 @@ jobs:
     timeout-minutes: 40
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      # Opt every component (Electron app + e2e driver) into the override
-      # layout so the run is self-contained under one throwaway tree,
-      # independent of the runner's home-dir state from past runs.
-      MINDS_DATA_HOME: ${{ runner.temp }}/minds
     steps:
       - uses: actions/checkout@v6
+      - name: opt into the MINDS_DATA_HOME override layout
+        # Self-contained throwaway tree under the runner temp dir, so the run
+        # is independent of the runner's home-dir state from past runs. Set via
+        # $GITHUB_ENV (not job-level env) because the `runner` context is not
+        # available there; $RUNNER_TEMP is the same dir at runtime. Every
+        # subsequent step (reset, launch, e2e, artifacts) inherits it.
+        run: echo "MINDS_DATA_HOME=$RUNNER_TEMP/minds" >> "$GITHUB_ENV"
       - name: verify ANTHROPIC_API_KEY injected
         run: |
           if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then

--- a/.github/workflows/minds-runner-reset.yml
+++ b/.github/workflows/minds-runner-reset.yml
@@ -22,8 +22,9 @@ jobs:
         run: bash apps/minds/scripts/mac-runner-reset.sh "${{ inputs.app_zip_url }}"
       - name: verify clean state
         run: |
-          echo "--- ~/.minds ---"
-          ls -d "$HOME/.minds" 2>&1 || echo "  absent"
+          echo "--- Minds state roots ---"
+          ls -d "$HOME/Library/Application Support/Minds" "$HOME/Library/Caches/Minds" \
+            "$HOME/Library/Logs/Minds" "$HOME"/.minds "$HOME"/.minds-* 2>&1 || echo "  absent"
           echo "--- /Applications/minds.app ---"
           ls -d /Applications/minds.app 2>&1 || echo "  absent"
           echo "--- Minds processes ---"

--- a/apps/minds/README.md
+++ b/apps/minds/README.md
@@ -43,6 +43,47 @@ minds run
    - An **app watcher** service monitors `applications.toml` and writes server events to `events.jsonl` for discovery
    - A **cloudflared** service watches `runtime/secrets` for a tunnel token and runs the Cloudflare tunnel
 
+## Where Minds stores its data
+
+Minds follows each OS's documented conventions instead of a single dotfolder.
+State is split across four roots, each with the tier (`production` / `staging` /
+`dev-<name>`) as its first subdirectory:
+
+| Category | macOS | Linux (XDG) |
+|----------|-------|-------------|
+| App support (secrets, sessions, mngr, ssh, telegram, latchkey, backups) | `~/Library/Application Support/Minds/<tier>/` | `~/.local/share/minds/<tier>/` |
+| Cache (regenerable, e.g. the FCT clone) | `~/Library/Caches/Minds/<tier>/` | `~/.cache/minds/<tier>/` |
+| Logs | `~/Library/Logs/Minds/<tier>/` | `~/.local/state/minds/<tier>/logs/` |
+| Config (`client.toml`, `config.toml`) | `~/Library/Application Support/Minds/<tier>/config/` | `~/.config/minds/<tier>/` |
+
+Set `MINDS_DATA_HOME` to override everything: all four roots become
+`$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}/`. This is what the
+test/CI runner uses for a self-contained, throwaway tree.
+
+An older install under `~/.minds/` (or `~/.minds-<tier>/`) is migrated to these
+locations automatically on first launch of a new build; the legacy directory is
+left in place with a `MIGRATED.txt` pointer and is safe to delete.
+
+## Uninstalling Minds
+
+Drag `Minds.app` to the Trash, then delete the four data roots for each tier you
+used (see the table above). For production on macOS that is:
+
+```bash
+rm -rf "$HOME/Library/Application Support/Minds/production" \
+       "$HOME/Library/Caches/Minds/production" \
+       "$HOME/Library/Logs/Minds/production"
+```
+
+Or let the CLI do it for one env (after confirmation):
+
+```bash
+uv run minds env teardown production   # or staging / dev-<name>
+```
+
+`minds env teardown` deletes only local data roots; it does not touch any cloud
+resources (use `minds env destroy` for a deployed env's cloud teardown).
+
 ## Learn more
 
 - [Architecture and design](./docs/design.md)

--- a/apps/minds/changelog/wz-minds-platform-dirs.md
+++ b/apps/minds/changelog/wz-minds-platform-dirs.md
@@ -1,0 +1,28 @@
+Minds now stores its state under platform-canonical directories instead of a
+single `~/.minds/` (or `~/.minds-<tier>/`) dotfolder.
+
+State is split across four roots, each with the tier (`production` / `staging` /
+`dev-<name>`) as its first subdirectory:
+
+- macOS: `~/Library/Application Support/Minds/<tier>/` (secrets, sessions, mngr,
+  ssh, telegram, latchkey, backups), `~/Library/Caches/Minds/<tier>/`
+  (regenerable caches), `~/Library/Logs/Minds/<tier>/` (logs), and
+  `<app-support>/config/` (config).
+- Linux: the XDG data / cache / state / config dirs
+  (`~/.local/share/minds/<tier>/`, `~/.cache/minds/<tier>/`,
+  `~/.local/state/minds/<tier>/logs/`, `~/.config/minds/<tier>/`), honoring
+  `XDG_*_HOME`.
+- `MINDS_DATA_HOME` overrides everything to
+  `$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}/`.
+
+A legacy `~/.minds*` install is migrated onto the new roots automatically on the
+first launch of a new build. The migration is idempotent, crash-safe, and
+non-destructive: it moves known subdirs to their new roots, rewrites the
+absolute paths embedded in `mngr/profiles/*/data.json` (e.g. docker SSH keys),
+records a `migration.lock`, and leaves the old directory in place with a
+`MIGRATED.txt` pointer plus backwards-compat symlinks at the old `mngr/` and
+`ssh/` paths so already-running Lima VMs keep working.
+
+New: `minds env teardown [<env>]` deletes an env's local data roots after
+confirmation (a clean uninstall path; does not touch cloud resources). The
+README gains "Where Minds stores its data" and "Uninstalling Minds" sections.

--- a/apps/minds/docs/desktop-app.md
+++ b/apps/minds/docs/desktop-app.md
@@ -86,27 +86,38 @@ All three are placed in the `resources/` directory (outside the asar archive) an
 
 ## Data directory
 
-Every minds env owns one data root. Production lives at `~/.minds/`;
-every other env lives at `~/.minds-<env-name>/`. The contents are the
-same shape:
+Each env's state is split across four platform-canonical roots keyed by tier
+(`production` / `staging` / `dev-<name>`), instead of one dotfolder. On macOS
+those are `~/Library/Application Support/Minds/<tier>/` (app support),
+`~/Library/Caches/Minds/<tier>/` (cache), `~/Library/Logs/Minds/<tier>/` (logs),
+and `<app-support>/config/` (config); on Linux the XDG data/cache/state/config
+dirs. `MINDS_DATA_HOME` overrides everything to
+`$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}/`. See the
+[README data-locations table](../README.md#where-minds-stores-its-data).
 
 ```
-~/.minds-<env-name>/
+<app_support>/            # ~/Library/Application Support/Minds/<tier>/ (macOS)
   .venv/                  # uv-managed Python virtual environment
   .uv-cache/              # uv package cache
   .uv-python/             # uv-managed Python installations
-  logs/
-    minds.log             # Combined stdout/stderr log from the backend
-    minds-events.jsonl    # Structured JSONL event log
-  auth/                   # Cookie signing key, one-time codes
-  config.toml             # Optional minds user preferences (default account, etc.)
-  client.toml             # Per-env public config (URLs only; dev envs only -- staging/production source from in-repo)
+  auth/                   # Cookie signing key, one-time codes, sessions
+  config/
+    config.toml           # Optional minds user preferences (default account, etc.)
+    client.toml           # Per-env public config (URLs only; dev envs only -- staging/production source from in-repo)
   secrets.toml            # Per-env chmod-0600 secrets (Neon DSN, SuperTokens API key; dev envs only)
   window-state.json       # Per-window content URLs, restored on next launch
   mngr/                   # mngr host directory (MNGR_HOST_DIR)
     agents/               # per-agent state managed by mngr
   <agent-id>/             # Per-agent workspace directories
+<cache>/                  # ~/Library/Caches/Minds/<tier>/ (macOS)
+  template-cache/         # FCT bare clone reused across agent creates
+<logs>/                   # ~/Library/Logs/Minds/<tier>/ (macOS)
+  minds.log               # Combined stdout/stderr log from the backend
+  minds-events.jsonl      # Structured JSONL event log
 ```
+
+A legacy `~/.minds/` (or `~/.minds-<tier>/`) install is migrated onto these
+roots automatically on first launch of a new build.
 
 `MINDS_ROOT_NAME` selects which data root the backend uses. Activation
 (`minds env activate <name>`) sets it to `minds-<env-name>` (or just

--- a/apps/minds/docs/environments.md
+++ b/apps/minds/docs/environments.md
@@ -18,14 +18,26 @@ pool-management SSH keypair. There is zero cross-tier reach.
 
 ## Per-env data root
 
-Every minds env owns one data root:
+Each env's state lives under platform-canonical roots keyed by tier rather than
+a single dotfolder. The app-support root (secrets, mngr, ssh, telegram,
+latchkey, dev-env `client.toml`/`secrets.toml`) per tier is:
 
-| Env name              | Data root                | `MINDS_ROOT_NAME`    |
-|-----------------------|--------------------------|----------------------|
-| `production`          | `~/.minds/`              | `minds`              |
-| `staging`             | `~/.minds-staging/`      | `minds-staging`      |
-| `dev-<your-user>`     | `~/.minds-dev-<your-user>/` | `minds-dev-<your-user>` |
-| `dev-josh-1` (any dev) | `~/.minds-dev-josh-1/`  | `minds-dev-josh-1`   |
+| Env name              | App-support root (macOS)                          | `MINDS_ROOT_NAME`    |
+|-----------------------|---------------------------------------------------|----------------------|
+| `production`          | `~/Library/Application Support/Minds/production/`  | `minds`              |
+| `staging`             | `~/Library/Application Support/Minds/staging/`     | `minds-staging`      |
+| `dev-<your-user>`     | `~/Library/Application Support/Minds/dev-<your-user>/` | `minds-dev-<your-user>` |
+| `dev-josh-1` (any dev) | `~/Library/Application Support/Minds/dev-josh-1/` | `minds-dev-josh-1`   |
+
+On Linux the app-support root is `~/.local/share/minds/<tier>/`; caches, logs,
+and config live under their own roots (see the
+[README data-locations table](../README.md#where-minds-stores-its-data)).
+`MINDS_DATA_HOME` overrides everything to
+`$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}/`.
+
+> Note: older `~/.minds/` and `~/.minds-<tier>/` paths mentioned elsewhere in
+> this doc are the *legacy* location. A new build migrates that tree onto the
+> roots above on first launch.
 
 By convention dev env names lead with the tier (`dev-`) so the
 `MINDS_ROOT_NAME` always reads tier-first: `minds-dev-<your-user>`,

--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -209,7 +209,7 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
           // reports contain enough context to debug "Discovering agents..."
           // hangs. Single v keeps noise manageable; -vv (DEBUG) is dev-only.
           'run', '--project', pyprojectDir,
-          // --active makes uv use VIRTUAL_ENV (~/.minds/.venv) instead of
+          // --active makes uv use VIRTUAL_ENV (the per-user app-support .venv) instead of
           // <project>/.venv, which is inside the signed .app bundle and
           // read-only on macOS. Without this, `uv run` tries to create
           // .venv inside the bundle and fails with "Operation not permitted".

--- a/apps/minds/electron/paths.js
+++ b/apps/minds/electron/paths.js
@@ -88,7 +88,7 @@ function getLatchkeyPath() {
  * once for all their agents, instead of once per agent.
  */
 function getLatchkeyDirectory() {
-  return path.join(getDataDir(), 'latchkey');
+  return path.join(getAppSupportDir(), 'latchkey');
 }
 
 /**
@@ -179,32 +179,109 @@ function getMindsRootName() {
   return 'minds';
 }
 
+/**
+ * Tier subdirectory name for the active root name. Mirror of the Python
+ * `minds_tier_for`: `minds` -> `production`, `minds-<env>` -> `<env>`.
+ */
+function getTier() {
+  const rootName = getMindsRootName();
+  if (rootName === 'minds') {
+    return 'production';
+  }
+  return rootName.slice('minds-'.length);
+}
+
+function xdgBase(envVar, fallback) {
+  const value = process.env[envVar];
+  if (value && path.isAbsolute(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * Resolve the four platform-canonical roots, mirroring the Python
+ * `imbue.minds.bootstrap._minds_roots_for`:
+ *   1. MINDS_DATA_HOME override -> $MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}
+ *   2. darwin -> Apple Application Support / Caches / Logs
+ *   3. otherwise (Linux) -> the XDG data / cache / state / config dirs
+ */
+function getMindsRoots() {
+  const tier = getTier();
+  const home = os.homedir();
+  const override = process.env.MINDS_DATA_HOME;
+  if (override) {
+    const base = path.join(override, tier);
+    return {
+      appSupport: path.join(base, 'app_support'),
+      cache: path.join(base, 'cache'),
+      logs: path.join(base, 'logs'),
+      config: path.join(base, 'config'),
+    };
+  }
+  if (process.platform === 'darwin') {
+    const appSupport = path.join(home, 'Library', 'Application Support', 'Minds', tier);
+    return {
+      appSupport,
+      cache: path.join(home, 'Library', 'Caches', 'Minds', tier),
+      logs: path.join(home, 'Library', 'Logs', 'Minds', tier),
+      config: path.join(appSupport, 'config'),
+    };
+  }
+  const dataHome = xdgBase('XDG_DATA_HOME', path.join(home, '.local', 'share'));
+  const cacheHome = xdgBase('XDG_CACHE_HOME', path.join(home, '.cache'));
+  const stateHome = xdgBase('XDG_STATE_HOME', path.join(home, '.local', 'state'));
+  const configHome = xdgBase('XDG_CONFIG_HOME', path.join(home, '.config'));
+  return {
+    appSupport: path.join(dataHome, 'minds', tier),
+    cache: path.join(cacheHome, 'minds', tier),
+    logs: path.join(stateHome, 'minds', tier, 'logs'),
+    config: path.join(configHome, 'minds', tier),
+  };
+}
+
+function getAppSupportDir() {
+  return getMindsRoots().appSupport;
+}
+
+function getCacheDir() {
+  return getMindsRoots().cache;
+}
+
+function getConfigDir() {
+  return getMindsRoots().config;
+}
+
+// Electron userData + window-state.json live under the app-support root.
 function getDataDir() {
-  return path.join(os.homedir(), '.' + getMindsRootName());
+  return getAppSupportDir();
 }
 
 function getMngrHostDir() {
-  return path.join(getDataDir(), 'mngr');
+  return path.join(getAppSupportDir(), 'mngr');
 }
 
 function getMngrPrefix() {
   return getMindsRootName() + '-';
 }
 
+// The uv cache, managed python, and .venv are kept under the app-support
+// root (not the cache root) so an OS cache purge can't delete the running
+// app's interpreter out from under it.
 function getUvCacheDir() {
-  return path.join(getDataDir(), '.uv-cache');
+  return path.join(getAppSupportDir(), '.uv-cache');
 }
 
 function getUvPythonDir() {
-  return path.join(getDataDir(), '.uv-python');
+  return path.join(getAppSupportDir(), '.uv-python');
 }
 
 function getLogDir() {
-  return path.join(getDataDir(), 'logs');
+  return getMindsRoots().logs;
 }
 
 function getVenvDir() {
-  return path.join(getDataDir(), '.venv');
+  return path.join(getAppSupportDir(), '.venv');
 }
 
 function getPyprojectDir() {
@@ -232,6 +309,11 @@ module.exports = {
   getLatchkeyDirectory,
   getResticPath,
   getMindsRootName,
+  getTier,
+  getMindsRoots,
+  getAppSupportDir,
+  getCacheDir,
+  getConfigDir,
   getDataDir,
   getMngrHostDir,
   getMngrPrefix,

--- a/apps/minds/imbue/minds/bootstrap.py
+++ b/apps/minds/imbue/minds/bootstrap.py
@@ -14,6 +14,8 @@ import re
 import shutil
 import sys
 import tomllib
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from typing import Final
 
@@ -363,6 +365,162 @@ def _ensure_mngr_settings(root_name: str) -> None:
     _cleanup_legacy_dynamic_hosts(root_name)
 
 
+_MIGRATION_LOCK_FILENAME: Final[str] = "migration.lock"
+_MIGRATED_README_FILENAME: Final[str] = "MIGRATED.txt"
+# Per-subdir map from a legacy ``~/.<root_name>/`` entry to its new root +
+# relative destination. ``"app_support" | "cache" | "logs" | "config"``
+# selects which canonical root the entry moves under. Entries absent from
+# the legacy tree are skipped; Electron-managed junk (``.venv``,
+# ``.uv-cache``, Chromium ``Cache``/``Code Cache``, etc.) is deliberately
+# omitted so it is regenerated in place rather than copied.
+_LEGACY_LAYOUT_MAP: Final[tuple[tuple[str, str, str], ...]] = (
+    ("auth", "app_support", "auth"),
+    ("mngr", "app_support", "mngr"),
+    ("ssh", "app_support", "ssh"),
+    ("telegram", "app_support", "telegram"),
+    ("latchkey", "app_support", "latchkey"),
+    ("backups", "app_support", "backups"),
+    ("backup_envs", "app_support", "backup_envs"),
+    ("backup_password", "app_support", "backup_password"),
+    ("destroying", "app_support", "destroying"),
+    ("user_context", "app_support", "user_context"),
+    ("events", "app_support", "events"),
+    ("workspace_associations.json", "app_support", "workspace_associations.json"),
+    ("sessions.json", "app_support", "sessions.json"),
+    ("last_good_agent_topology.json", "app_support", "last_good_agent_topology.json"),
+    ("secrets.toml", "app_support", "secrets.toml"),
+    ("template-cache", "cache", "template-cache"),
+    ("config.toml", "config", "config.toml"),
+    ("client.toml", "config", "client.toml"),
+    ("minds_root.toml", "config", "minds_root.toml"),
+)
+
+
+def _move_into_place(src: Path, dest: Path) -> None:
+    """Move ``src`` to ``dest`` via a sibling ``._migrating`` staging name.
+
+    Crash-safe: the final ``dest`` only ever appears via an atomic rename of
+    a fully-staged copy, so a kill mid-move never leaves a half-written
+    ``dest``. ``shutil.move`` handles both same-filesystem renames (fast) and
+    cross-filesystem copies (the rare Linux ``$HOME`` != ``~/.local/share``
+    mount case).
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    staging = dest.parent / f"{dest.name}._migrating"
+    if staging.exists():
+        if staging.is_dir():
+            shutil.rmtree(staging)
+        else:
+            staging.unlink()
+    shutil.move(str(src), str(staging))
+    os.replace(staging, dest)
+
+
+def migrate_legacy_minds_layout(root_name: str) -> bool:
+    """Move a legacy ``~/.<root_name>/`` tree onto the platform-canonical roots.
+
+    Idempotent: a no-op once ``migration.lock`` exists under the app-support
+    root, or when there is no legacy directory to migrate. Each known subdir
+    is moved to its destination root (see :data:`_LEGACY_LAYOUT_MAP`); the
+    legacy ``logs/`` contents fold into the canonical logs root. An entry
+    whose destination already exists is left untouched (never overwritten).
+    On success a lock file records the migration and a ``MIGRATED.txt`` is
+    left in the legacy directory pointing at the new roots; the legacy
+    directory itself is not deleted.
+
+    Returns ``True`` when a migration ran, ``False`` when it was skipped.
+    """
+    legacy = minds_data_dir_for(root_name)
+    app_support, cache, logs, config = _minds_roots_for(root_name)
+    roots = {"app_support": app_support, "cache": cache, "logs": logs, "config": config}
+    lock_path = app_support / _MIGRATION_LOCK_FILENAME
+    if lock_path.exists():
+        return False
+    if not legacy.is_dir():
+        return False
+    # A migration can be partially complete if a prior run crashed before
+    # writing the lock; resume by moving only the entries not yet at dest.
+    for src_rel, root_key, dest_rel in _LEGACY_LAYOUT_MAP:
+        src = legacy / src_rel
+        if not src.exists():
+            continue
+        dest = roots[root_key] / dest_rel
+        if dest.exists():
+            continue
+        _move_into_place(src, dest)
+        logger.info("Migrated minds state {} -> {}", src, dest)
+    legacy_logs = legacy / "logs"
+    if legacy_logs.is_dir():
+        logs.mkdir(parents=True, exist_ok=True)
+        for entry in legacy_logs.iterdir():
+            dest = logs / entry.name
+            if dest.exists():
+                continue
+            _move_into_place(entry, dest)
+            logger.info("Migrated minds log {} -> {}", entry, dest)
+    _rewrite_mngr_data_json_paths(legacy, app_support)
+    app_support.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps(
+            {
+                "migrated_at": datetime.now(timezone.utc).isoformat(),
+                "from": str(legacy),
+                "roots": {key: str(path) for key, path in roots.items()},
+            },
+            indent=2,
+        )
+    )
+    (legacy / _MIGRATED_README_FILENAME).write_text(
+        "This directory's minds state has moved to platform-canonical locations:\n"
+        + "".join(f"  {key}: {path}\n" for key, path in roots.items())
+        + "\nThis legacy directory is no longer read. It is safe to delete once you\n"
+        "have confirmed the new build works.\n"
+    )
+    logger.info("Completed legacy minds layout migration for {} (lock: {})", root_name, lock_path)
+    return True
+
+
+def _rewrite_mngr_data_json_paths(legacy: Path, app_support: Path) -> None:
+    """Rewrite absolute legacy paths embedded in migrated mngr ``data.json`` files.
+
+    mngr's per-host records under ``mngr/profiles/<id>/data.json`` embed
+    absolute paths (e.g. ``~/.minds/mngr/profiles/<id>/keys/docker_ssh_key``)
+    that point into the now-vacated legacy tree. After the move, rewrite the
+    legacy prefix to the app-support prefix so each record points at the
+    relocated key material. Best-effort per file: a malformed JSON file is
+    logged and skipped rather than aborting the whole migration.
+    """
+    profiles_dir = app_support / "mngr" / "profiles"
+    if not profiles_dir.is_dir():
+        return
+    old_prefix = str(legacy)
+    new_prefix = str(app_support)
+    for data_json in profiles_dir.glob("*/data.json"):
+        try:
+            raw = data_json.read_text()
+        except OSError as e:
+            logger.warning("Could not read mngr record {} during migration: {}", data_json, e)
+            continue
+        if old_prefix not in raw:
+            continue
+        # Validate it parses before and after so we never write back garbage.
+        try:
+            json.loads(raw)
+        except json.JSONDecodeError as e:
+            logger.warning("Skipping path rewrite of malformed mngr record {}: {}", data_json, e)
+            continue
+        rewritten = raw.replace(old_prefix, new_prefix)
+        try:
+            json.loads(rewritten)
+        except json.JSONDecodeError as e:
+            logger.warning("Path rewrite produced invalid JSON for {}; leaving as-is: {}", data_json, e)
+            continue
+        tmp_path = data_json.with_suffix(".json._migrating")
+        tmp_path.write_text(rewritten)
+        tmp_path.rename(data_json)
+        logger.info("Rewrote legacy paths in mngr record {}", data_json)
+
+
 def _cleanup_legacy_dynamic_hosts(root_name: str) -> None:
     """Remove the stale ``ssh/dynamic_hosts.toml`` file + ``ssh/keys/leased_host/`` dir.
 
@@ -440,6 +598,15 @@ def apply_bootstrap() -> None:
         # has not activated any env yet".
         return
     root_name = resolve_minds_root_name()
+    # Migrate any legacy ~/.<root_name>/ tree onto the platform-canonical
+    # roots BEFORE exporting MNGR_HOST_DIR or touching mngr settings, so mngr
+    # reads the relocated state rather than a fresh empty host_dir. Best-effort:
+    # a migration failure must not block startup -- the user falls back to a
+    # fresh install rather than a hard crash.
+    try:
+        migrate_legacy_minds_layout(root_name)
+    except OSError as e:
+        logger.warning("Legacy minds layout migration failed for {}: {}", root_name, e)
     os.environ["MNGR_HOST_DIR"] = str(mngr_host_dir_for(root_name))
     os.environ["MNGR_PREFIX"] = mngr_prefix_for(root_name)
     _ensure_mngr_settings(root_name)

--- a/apps/minds/imbue/minds/bootstrap.py
+++ b/apps/minds/imbue/minds/bootstrap.py
@@ -476,8 +476,38 @@ def migrate_legacy_minds_layout(root_name: str) -> bool:
         + "\nThis legacy directory is no longer read. It is safe to delete once you\n"
         "have confirmed the new build works.\n"
     )
+    _create_legacy_compat_symlinks(legacy, app_support)
     logger.info("Completed legacy minds layout migration for {} (lock: {})", root_name, lock_path)
     return True
+
+
+# Subdirs that an already-running Lima VM may bind-mount from the old path
+# (the mngr profile + its docker SSH keys). Symlinking them back keeps those
+# VMs working until they are naturally destroyed + recreated; remove the
+# shim after one minor-version cycle.
+_LEGACY_COMPAT_SYMLINK_SUBDIRS: Final[tuple[str, ...]] = ("mngr", "ssh")
+
+
+def _create_legacy_compat_symlinks(legacy: Path, app_support: Path) -> None:
+    """Leave symlinks at the moved-away legacy mngr/ssh paths -> their new homes.
+
+    Risk 3: a Lima instance yaml created before the move bind-mounts host paths
+    under ``~/.<root_name>/mngr`` (SSH keys it surfaces inside the VM). After
+    the move those paths are vacant; a compat symlink makes them resolve to the
+    relocated material so existing VMs keep booting. Best-effort: a symlink
+    failure (e.g. a platform without symlink support) is logged, not fatal.
+    """
+    for subdir in _LEGACY_COMPAT_SYMLINK_SUBDIRS:
+        target = app_support / subdir
+        link = legacy / subdir
+        if not target.exists() or link.exists() or link.is_symlink():
+            continue
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except OSError as e:
+            logger.warning("Could not create legacy compat symlink {} -> {}: {}", link, target, e)
+        else:
+            logger.info("Left legacy compat symlink {} -> {}", link, target)
 
 
 def _rewrite_mngr_data_json_paths(legacy: Path, app_support: Path) -> None:

--- a/apps/minds/imbue/minds/bootstrap.py
+++ b/apps/minds/imbue/minds/bootstrap.py
@@ -176,23 +176,27 @@ def _xdg_base(env_var: str, default: Path) -> Path:
     return default
 
 
-def _minds_roots_for(root_name: str) -> tuple[Path, Path, Path, Path]:
+def _minds_roots_for(root_name: str, platform_name: str | None = None) -> tuple[Path, Path, Path, Path]:
     """Resolve the four platform-canonical roots ``(app_support, cache, logs, config)``.
 
     Resolution order:
       1. ``MINDS_DATA_HOME`` override -> ``$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}``.
-      2. ``sys.platform == "darwin"`` -> Apple's Application Support / Caches / Logs.
+      2. ``platform_name == "darwin"`` -> Apple's Application Support / Caches / Logs.
       3. Otherwise (Linux) -> the XDG data / cache / state / config dirs.
 
-    Windows is unsupported (matches CLAUDE.md).
+    ``platform_name`` defaults to :data:`sys.platform`; it is a parameter so
+    tests can exercise both OS branches on either host. Windows is
+    unsupported (matches CLAUDE.md).
     """
+    if platform_name is None:
+        platform_name = sys.platform
     tier = minds_tier_for(root_name)
     override = os.environ.get(MINDS_DATA_HOME_ENV_VAR)
     if override:
         base = Path(override).expanduser() / tier
         return base / "app_support", base / "cache", base / "logs", base / "config"
     home = Path.home()
-    if sys.platform == "darwin":
+    if platform_name == "darwin":
         app_support = home / "Library" / "Application Support" / _MINDS_BUNDLE_NAME / tier
         cache = home / "Library" / "Caches" / _MINDS_BUNDLE_NAME / tier
         logs = home / "Library" / "Logs" / _MINDS_BUNDLE_NAME / tier

--- a/apps/minds/imbue/minds/bootstrap.py
+++ b/apps/minds/imbue/minds/bootstrap.py
@@ -218,6 +218,26 @@ def minds_app_support_dir_for(root_name: str) -> Path:
     return _minds_roots_for(root_name)[0]
 
 
+def minds_tiers_parent_dir(platform_name: str | None = None) -> Path:
+    """Return the directory under which every tier's app-support root lives.
+
+    The common parent for enumerating tiers (``minds env list``):
+    ``$MINDS_DATA_HOME`` under the override, ``~/Library/Application
+    Support/Minds`` on macOS, ``$XDG_DATA_HOME/minds`` on Linux. For each
+    child ``<tier>`` here, the tier's app-support root is
+    ``minds_app_support_dir_for(root_name_for_env_name(<tier>))``.
+    """
+    if platform_name is None:
+        platform_name = sys.platform
+    override = os.environ.get(MINDS_DATA_HOME_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+    home = Path.home()
+    if platform_name == "darwin":
+        return home / "Library" / "Application Support" / _MINDS_BUNDLE_NAME
+    return _xdg_base("XDG_DATA_HOME", home / ".local" / "share") / _MINDS_XDG_DIR_NAME
+
+
 def minds_cache_dir_for(root_name: str) -> Path:
     """Return the cache root (template-cache/; regenerable, OS may purge)."""
     return _minds_roots_for(root_name)[1]
@@ -234,8 +254,8 @@ def minds_config_dir_for(root_name: str) -> Path:
 
 
 def mngr_host_dir_for(root_name: str) -> Path:
-    """Return the mngr host directory for a given root name (e.g. ~/.minds/mngr)."""
-    return minds_data_dir_for(root_name) / "mngr"
+    """Return the mngr host directory for a given root name (under the app-support root)."""
+    return minds_app_support_dir_for(root_name) / "mngr"
 
 
 def mngr_prefix_for(root_name: str) -> str:
@@ -353,10 +373,10 @@ def _cleanup_legacy_dynamic_hosts(root_name: str) -> None:
     at long-destroyed VPS IPs, and any code path that reads it would
     block on TCP timeouts. Best-effort: log + continue on any FS error.
     """
-    data_dir = minds_data_dir_for(root_name)
+    ssh_dir = minds_app_support_dir_for(root_name) / "ssh"
     legacy_paths = (
-        data_dir / "ssh" / "dynamic_hosts.toml",
-        data_dir / "ssh" / "keys" / "leased_host",
+        ssh_dir / "dynamic_hosts.toml",
+        ssh_dir / "keys" / "leased_host",
     )
     for path in legacy_paths:
         if not path.exists():

--- a/apps/minds/imbue/minds/bootstrap.py
+++ b/apps/minds/imbue/minds/bootstrap.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import tomllib
 from pathlib import Path
 from typing import Final
@@ -21,6 +22,15 @@ from loguru import logger
 
 MINDS_ROOT_NAME_ENV_VAR: Final[str] = "MINDS_ROOT_NAME"
 DEFAULT_MINDS_ROOT_NAME: Final[str] = "minds"
+# Single opaque override for the whole platform-canonical layout: when set,
+# all four roots become ``$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}``.
+# Used by tests and the CI runner to get one self-contained throwaway tree
+# independent of the host's home-dir state.
+MINDS_DATA_HOME_ENV_VAR: Final[str] = "MINDS_DATA_HOME"
+# Bundle name matching the ToDesktop bundle; the first path component under
+# each macOS Library root and the directory name under each XDG root.
+_MINDS_BUNDLE_NAME: Final[str] = "Minds"
+_MINDS_XDG_DIR_NAME: Final[str] = "minds"
 # Names that are not legal env-name suffixes. Today this is just the prefix
 # string itself, because ``minds-`` with an empty suffix would round-trip
 # to the production path (``~/.minds-/`` is nonsensical) and we'd rather
@@ -124,8 +134,99 @@ def root_name_for_env_name(env_name: str) -> str:
 
 
 def minds_data_dir_for(root_name: str) -> Path:
-    """Return the minds data directory for a given root name (e.g. ~/.minds)."""
+    """Return the *legacy* minds data directory for a given root name (e.g. ~/.minds).
+
+    Deprecated: this is the pre-platform-canonical single dotfolder under
+    ``$HOME``. New code resolves per-category roots via
+    :func:`minds_app_support_dir_for` / :func:`minds_cache_dir_for` /
+    :func:`minds_logs_dir_for` / :func:`minds_config_dir_for` (or the
+    :class:`imbue.minds.config.data_types.MindsPaths` model built from
+    them). Kept as the canonical answer to "where did state live before
+    the move?" -- the startup migration reads from here.
+    """
     return Path.home() / ".{}".format(root_name)
+
+
+def minds_tier_for(root_name: str) -> str:
+    """Return the platform-canonical tier subdirectory name for a root name.
+
+    ``minds`` -> ``production``; ``minds-<env>`` -> ``<env>`` (so
+    ``minds-staging`` -> ``staging``, ``minds-dev-josh-3`` ->
+    ``dev-josh-3``, ``minds-dev-staging`` -> ``dev-staging``). This is the
+    first subdirectory under each canonical root, lifting the tier
+    discriminator out of the ``$HOME`` dotfolder name. Delegates to
+    :func:`env_name_from_root_name` so the prefix-stripping rule lives in
+    one place and cross-tier names never collapse (``minds-dev-staging``
+    stays distinct from ``minds-staging``).
+    """
+    return env_name_from_root_name(root_name)
+
+
+def _xdg_base(env_var: str, default: Path) -> Path:
+    """Return the XDG base dir from ``env_var``, honoring it only when absolute.
+
+    Per the XDG Base Directory spec, a relative value must be ignored and
+    the default used instead.
+    """
+    value = os.environ.get(env_var)
+    if value:
+        candidate = Path(value)
+        if candidate.is_absolute():
+            return candidate
+    return default
+
+
+def _minds_roots_for(root_name: str) -> tuple[Path, Path, Path, Path]:
+    """Resolve the four platform-canonical roots ``(app_support, cache, logs, config)``.
+
+    Resolution order:
+      1. ``MINDS_DATA_HOME`` override -> ``$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}``.
+      2. ``sys.platform == "darwin"`` -> Apple's Application Support / Caches / Logs.
+      3. Otherwise (Linux) -> the XDG data / cache / state / config dirs.
+
+    Windows is unsupported (matches CLAUDE.md).
+    """
+    tier = minds_tier_for(root_name)
+    override = os.environ.get(MINDS_DATA_HOME_ENV_VAR)
+    if override:
+        base = Path(override).expanduser() / tier
+        return base / "app_support", base / "cache", base / "logs", base / "config"
+    home = Path.home()
+    if sys.platform == "darwin":
+        app_support = home / "Library" / "Application Support" / _MINDS_BUNDLE_NAME / tier
+        cache = home / "Library" / "Caches" / _MINDS_BUNDLE_NAME / tier
+        logs = home / "Library" / "Logs" / _MINDS_BUNDLE_NAME / tier
+        config = app_support / "config"
+        return app_support, cache, logs, config
+    data_home = _xdg_base("XDG_DATA_HOME", home / ".local" / "share")
+    cache_home = _xdg_base("XDG_CACHE_HOME", home / ".cache")
+    state_home = _xdg_base("XDG_STATE_HOME", home / ".local" / "state")
+    config_home = _xdg_base("XDG_CONFIG_HOME", home / ".config")
+    app_support = data_home / _MINDS_XDG_DIR_NAME / tier
+    cache = cache_home / _MINDS_XDG_DIR_NAME / tier
+    logs = state_home / _MINDS_XDG_DIR_NAME / tier / "logs"
+    config = config_home / _MINDS_XDG_DIR_NAME / tier
+    return app_support, cache, logs, config
+
+
+def minds_app_support_dir_for(root_name: str) -> Path:
+    """Return the app-support root (secrets, sessions, mngr/, ssh/, telegram/, latchkey/, backups/)."""
+    return _minds_roots_for(root_name)[0]
+
+
+def minds_cache_dir_for(root_name: str) -> Path:
+    """Return the cache root (template-cache/; regenerable, OS may purge)."""
+    return _minds_roots_for(root_name)[1]
+
+
+def minds_logs_dir_for(root_name: str) -> Path:
+    """Return the logs root (minds.log, minds-events.jsonl)."""
+    return _minds_roots_for(root_name)[2]
+
+
+def minds_config_dir_for(root_name: str) -> Path:
+    """Return the config root (client.toml, config.toml, minds_root.toml)."""
+    return _minds_roots_for(root_name)[3]
 
 
 def mngr_host_dir_for(root_name: str) -> Path:

--- a/apps/minds/imbue/minds/bootstrap_test.py
+++ b/apps/minds/imbue/minds/bootstrap_test.py
@@ -10,16 +10,19 @@ from imbue.minds.bootstrap import DEFAULT_MINDS_ROOT_NAME
 from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.bootstrap import MINDS_ROOT_NAME_PATTERN
 from imbue.minds.bootstrap import _ensure_mngr_settings
+from imbue.minds.bootstrap import _minds_roots_for
 from imbue.minds.bootstrap import apply_bootstrap
 from imbue.minds.bootstrap import env_name_from_root_name
 from imbue.minds.bootstrap import is_minds_root_name_set_to_active_env
 from imbue.minds.bootstrap import minds_data_dir_for
+from imbue.minds.bootstrap import minds_tier_for
 from imbue.minds.bootstrap import mngr_host_dir_for
 from imbue.minds.bootstrap import mngr_prefix_for
 from imbue.minds.bootstrap import resolve_minds_root_name
 from imbue.minds.bootstrap import root_name_for_env_name
 from imbue.minds.bootstrap import set_imbue_cloud_provider_for_account
 from imbue.minds.bootstrap import set_provider_is_enabled
+from imbue.minds.config.data_types import MindsPaths
 from imbue.minds.testing import stub_mngr_host_dir
 
 
@@ -447,3 +450,136 @@ def test_set_imbue_cloud_provider_for_account_repairs_missing_default_block_on_r
     parsed = tomllib.loads(settings_path.read_text())
     assert parsed["providers"]["imbue_cloud"] == {"backend": "imbue_cloud", "is_enabled": False}
     assert parsed["plugins"]["recursive"]["enabled"] is False
+
+
+# -- Platform-canonical layout resolver (MindsPaths) --
+
+
+def _clear_layout_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove the override + XDG vars so layout tests see a clean baseline."""
+    for var in (
+        "MINDS_DATA_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_STATE_HOME",
+        "XDG_CONFIG_HOME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_minds_tier_for_maps_root_name_to_tier() -> None:
+    assert minds_tier_for("minds") == "production"
+    assert minds_tier_for("minds-staging") == "staging"
+    assert minds_tier_for("minds-dev-josh-3") == "dev-josh-3"
+    assert minds_tier_for("minds-ci-abc") == "ci-abc"
+
+
+def test_minds_tier_for_does_not_collapse_dev_staging() -> None:
+    """Risk #5: ``minds-dev-staging`` must stay distinct from ``minds-staging``."""
+    assert minds_tier_for("minds-dev-staging") == "dev-staging"
+    assert minds_tier_for("minds-staging") == "staging"
+    assert minds_tier_for("minds-dev-staging") != minds_tier_for("minds-staging")
+
+
+def test_minds_data_home_override_layout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
+    app_support, cache, logs, config = _minds_roots_for("minds-staging")
+    assert app_support == tmp_path / "staging" / "app_support"
+    assert cache == tmp_path / "staging" / "cache"
+    assert logs == tmp_path / "staging" / "logs"
+    assert config == tmp_path / "staging" / "config"
+
+
+def test_minds_data_home_override_wins_over_platform(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
+    # darwin requested, but the override must still win.
+    app_support, _cache, _logs, _config = _minds_roots_for("minds", platform_name="darwin")
+    assert app_support == tmp_path / "production" / "app_support"
+
+
+def test_darwin_layout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app_support, cache, logs, config = _minds_roots_for("minds", platform_name="darwin")
+    assert app_support == tmp_path / "Library" / "Application Support" / "Minds" / "production"
+    assert cache == tmp_path / "Library" / "Caches" / "Minds" / "production"
+    assert logs == tmp_path / "Library" / "Logs" / "Minds" / "production"
+    assert config == app_support / "config"
+
+
+def test_darwin_layout_dev_tier(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app_support, _cache, _logs, _config = _minds_roots_for("minds-dev-josh-3", platform_name="darwin")
+    assert app_support == tmp_path / "Library" / "Application Support" / "Minds" / "dev-josh-3"
+
+
+def test_linux_xdg_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    app_support, cache, logs, config = _minds_roots_for("minds", platform_name="linux")
+    assert app_support == tmp_path / ".local" / "share" / "minds" / "production"
+    assert cache == tmp_path / ".cache" / "minds" / "production"
+    assert logs == tmp_path / ".local" / "state" / "minds" / "production" / "logs"
+    assert config == tmp_path / ".config" / "minds" / "production"
+
+
+def test_linux_honors_xdg_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+    app_support, cache, logs, config = _minds_roots_for("minds-staging", platform_name="linux")
+    assert app_support == tmp_path / "xdg-data" / "minds" / "staging"
+    assert cache == tmp_path / "xdg-cache" / "minds" / "staging"
+    assert logs == tmp_path / "xdg-state" / "minds" / "staging" / "logs"
+    assert config == tmp_path / "xdg-config" / "minds" / "staging"
+
+
+def test_linux_ignores_relative_xdg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The XDG spec mandates ignoring relative base dirs and using the default."""
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_DATA_HOME", "relative/not/absolute")
+    app_support, _cache, _logs, _config = _minds_roots_for("minds", platform_name="linux")
+    assert app_support == tmp_path / ".local" / "share" / "minds" / "production"
+
+
+def test_dev_staging_distinct_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Risk #5 end-to-end: the two tiers resolve to different roots."""
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
+    dev_staging, *_ = _minds_roots_for("minds-dev-staging")
+    staging, *_ = _minds_roots_for("minds-staging")
+    assert dev_staging != staging
+    assert dev_staging == tmp_path / "dev-staging" / "app_support"
+    assert staging == tmp_path / "staging" / "app_support"
+
+
+def test_minds_paths_for_root_name_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
+    paths = MindsPaths.for_root_name("minds-dev-josh-3")
+    assert paths.tier == "dev-josh-3"
+    assert paths.app_support == tmp_path / "dev-josh-3" / "app_support"
+    assert paths.cache == tmp_path / "dev-josh-3" / "cache"
+    assert paths.logs == tmp_path / "dev-josh-3" / "logs"
+    assert paths.config == tmp_path / "dev-josh-3" / "config"
+    assert paths.legacy_data_dir == Path.home() / ".minds-dev-josh-3"
+    assert paths.auth_dir == paths.app_support / "auth"
+    assert paths.mngr_host_dir == paths.app_support / "mngr"
+
+
+def test_minds_paths_flat_shorthand(tmp_path: Path) -> None:
+    """``data_dir=`` lays all four roots flat under one directory (test convenience)."""
+    paths = MindsPaths(data_dir=tmp_path)
+    assert paths.app_support == tmp_path
+    assert paths.cache == tmp_path
+    assert paths.logs == tmp_path
+    assert paths.config == tmp_path
+    assert paths.legacy_data_dir == tmp_path
+    assert paths.auth_dir == tmp_path / "auth"

--- a/apps/minds/imbue/minds/bootstrap_test.py
+++ b/apps/minds/imbue/minds/bootstrap_test.py
@@ -145,8 +145,10 @@ def test_minds_data_dir_for() -> None:
     assert minds_data_dir_for("minds") == Path.home() / ".minds"
 
 
-def test_mngr_host_dir_for() -> None:
-    assert mngr_host_dir_for("minds-dev-josh-3") == Path.home() / ".minds-dev-josh-3" / "mngr"
+def test_mngr_host_dir_for(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
+    assert mngr_host_dir_for("minds-dev-josh-3") == tmp_path / "dev-josh-3" / "app_support" / "mngr"
 
 
 def test_mngr_prefix_for() -> None:
@@ -154,16 +156,18 @@ def test_mngr_prefix_for() -> None:
     assert mngr_prefix_for("minds") == "minds-"
 
 
-def test_apply_bootstrap_sets_env_vars_when_root_name_set(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bootstrap_sets_env_vars_when_root_name_set(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _clear_env(monkeypatch)
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
     monkeypatch.setenv(MINDS_ROOT_NAME_ENV_VAR, "minds-dev-testname")
     apply_bootstrap()
 
-    assert os.environ["MNGR_HOST_DIR"] == str(Path.home() / ".minds-dev-testname" / "mngr")
+    assert os.environ["MNGR_HOST_DIR"] == str(tmp_path / "dev-testname" / "app_support" / "mngr")
     assert os.environ["MNGR_PREFIX"] == "minds-dev-testname-"
 
 
-def test_apply_bootstrap_overrides_inherited_mngr_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bootstrap_overrides_inherited_mngr_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Explicit MINDS_ROOT_NAME wins over an inherited MNGR_HOST_DIR/MNGR_PREFIX.
 
     Without this, a minds process spawned from a parent that already set
@@ -172,12 +176,14 @@ def test_apply_bootstrap_overrides_inherited_mngr_vars(monkeypatch: pytest.Monke
     minds bootstrap writes to.
     """
     _clear_env(monkeypatch)
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
     monkeypatch.setenv(MINDS_ROOT_NAME_ENV_VAR, "minds-dev-josh-3")
     monkeypatch.setenv("MNGR_HOST_DIR", "/custom/host/dir")
     monkeypatch.setenv("MNGR_PREFIX", "custom-")
     apply_bootstrap()
 
-    assert os.environ["MNGR_HOST_DIR"] == str(Path.home() / ".minds-dev-josh-3" / "mngr")
+    assert os.environ["MNGR_HOST_DIR"] == str(tmp_path / "dev-josh-3" / "app_support" / "mngr")
     assert os.environ["MNGR_PREFIX"] == "minds-dev-josh-3-"
 
 
@@ -206,7 +212,7 @@ def test_apply_bootstrap_unset_does_not_write_mngr_vars(monkeypatch: pytest.Monk
     assert "MNGR_PREFIX" not in os.environ
 
 
-def test_apply_bootstrap_invalid_value_still_writes_default(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_bootstrap_invalid_value_still_writes_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """A stale `MINDS_ROOT_NAME=devminds` shell still gets consistent MNGR_* vars.
 
     The bootstrap resolves to the production default and exports the
@@ -214,10 +220,12 @@ def test_apply_bootstrap_invalid_value_still_writes_default(monkeypatch: pytest.
     host_dir to point at instead of half-honoring the bad value.
     """
     _clear_env(monkeypatch)
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
     monkeypatch.setenv(MINDS_ROOT_NAME_ENV_VAR, "devminds")
     monkeypatch.setenv("MNGR_HOST_DIR", "/custom/host/dir")
     apply_bootstrap()
-    assert os.environ["MNGR_HOST_DIR"] == str(Path.home() / ".minds" / "mngr")
+    assert os.environ["MNGR_HOST_DIR"] == str(tmp_path / "production" / "app_support" / "mngr")
     assert os.environ["MNGR_PREFIX"] == "minds-"
 
 
@@ -475,7 +483,7 @@ def test_minds_tier_for_maps_root_name_to_tier() -> None:
 
 
 def test_minds_tier_for_does_not_collapse_dev_staging() -> None:
-    """Risk #5: ``minds-dev-staging`` must stay distinct from ``minds-staging``."""
+    """Cross-tier collision: minds-dev-staging must stay distinct from minds-staging."""
     assert minds_tier_for("minds-dev-staging") == "dev-staging"
     assert minds_tier_for("minds-staging") == "staging"
     assert minds_tier_for("minds-dev-staging") != minds_tier_for("minds-staging")
@@ -550,7 +558,7 @@ def test_linux_ignores_relative_xdg(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
 
 def test_dev_staging_distinct_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Risk #5 end-to-end: the two tiers resolve to different roots."""
+    """Cross-tier collision, end-to-end: the two tiers resolve to different roots."""
     _clear_layout_env(monkeypatch)
     monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path))
     dev_staging, *_ = _minds_roots_for("minds-dev-staging")

--- a/apps/minds/imbue/minds/bootstrap_test.py
+++ b/apps/minds/imbue/minds/bootstrap_test.py
@@ -686,3 +686,24 @@ def test_migration_rewrites_mngr_data_json_paths(monkeypatch: pytest.MonkeyPatch
     assert parsed["ssh_key_path"] == str(expected_key)
     assert str(legacy) not in new_data_json.read_text()
     assert (expected_key).read_text() == "PRIVATE KEY"
+
+
+def test_migration_leaves_legacy_compat_symlinks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Risk 3: moved-away mngr/ssh keep resolving at the legacy path via symlink."""
+    home, data = _legacy_migration_env(monkeypatch, tmp_path)
+    legacy = home / ".minds"
+    (legacy / "mngr" / "profiles" / "p1" / "keys").mkdir(parents=True)
+    (legacy / "mngr" / "profiles" / "p1" / "keys" / "docker_ssh_key").write_text("KEY")
+    (legacy / "ssh").mkdir()
+    (legacy / "ssh" / "config").write_text("Host x")
+
+    assert migrate_legacy_minds_layout("minds") is True
+
+    app_support = data / "production" / "app_support"
+    legacy_mngr = legacy / "mngr"
+    legacy_ssh = legacy / "ssh"
+    assert legacy_mngr.is_symlink()
+    assert legacy_ssh.is_symlink()
+    # The old absolute path still reaches the relocated key material.
+    assert (legacy / "mngr" / "profiles" / "p1" / "keys" / "docker_ssh_key").read_text() == "KEY"
+    assert legacy_mngr.resolve() == (app_support / "mngr").resolve()

--- a/apps/minds/imbue/minds/bootstrap_test.py
+++ b/apps/minds/imbue/minds/bootstrap_test.py
@@ -586,7 +586,7 @@ def test_minds_paths_for_root_name_override(monkeypatch: pytest.MonkeyPatch, tmp
 
 def test_minds_paths_flat_shorthand(tmp_path: Path) -> None:
     """``data_dir=`` lays all four roots flat under one directory (test convenience)."""
-    paths = MindsPaths(data_dir=tmp_path)
+    paths = MindsPaths.flat(tmp_path)
     assert paths.app_support == tmp_path
     assert paths.cache == tmp_path
     assert paths.logs == tmp_path

--- a/apps/minds/imbue/minds/bootstrap_test.py
+++ b/apps/minds/imbue/minds/bootstrap_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import tomllib
@@ -14,6 +15,7 @@ from imbue.minds.bootstrap import _minds_roots_for
 from imbue.minds.bootstrap import apply_bootstrap
 from imbue.minds.bootstrap import env_name_from_root_name
 from imbue.minds.bootstrap import is_minds_root_name_set_to_active_env
+from imbue.minds.bootstrap import migrate_legacy_minds_layout
 from imbue.minds.bootstrap import minds_data_dir_for
 from imbue.minds.bootstrap import minds_tier_for
 from imbue.minds.bootstrap import mngr_host_dir_for
@@ -591,3 +593,96 @@ def test_minds_paths_flat_shorthand(tmp_path: Path) -> None:
     assert paths.config == tmp_path
     assert paths.legacy_data_dir == tmp_path
     assert paths.auth_dir == tmp_path / "auth"
+
+
+# -- Legacy -> platform-canonical migration --
+
+
+def _legacy_migration_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    """Point HOME (legacy roots) and MINDS_DATA_HOME (new roots) at tmp subdirs."""
+    home = tmp_path / "home"
+    home.mkdir()
+    data = tmp_path / "data"
+    monkeypatch.setenv("HOME", str(home))
+    _clear_layout_env(monkeypatch)
+    monkeypatch.setenv("MINDS_DATA_HOME", str(data))
+    return home, data
+
+
+def test_migration_noop_when_no_legacy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _legacy_migration_env(monkeypatch, tmp_path)
+    assert migrate_legacy_minds_layout("minds") is False
+
+
+def test_migration_moves_state_to_canonical_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home, data = _legacy_migration_env(monkeypatch, tmp_path)
+    legacy = home / ".minds"
+    (legacy / "auth" / "sessions").mkdir(parents=True)
+    (legacy / "auth" / "sessions" / "acct.json").write_text("{}")
+    (legacy / "template-cache" / "forever-claude-template").mkdir(parents=True)
+    (legacy / "template-cache" / "forever-claude-template" / "x").write_text("clone")
+    (legacy / "logs").mkdir()
+    (legacy / "logs" / "minds.log").write_text("log line")
+    (legacy / "config.toml").write_text("default_account_id = 'a'\n")
+
+    assert migrate_legacy_minds_layout("minds") is True
+
+    base = data / "production"
+    assert (base / "app_support" / "auth" / "sessions" / "acct.json").read_text() == "{}"
+    assert (base / "cache" / "template-cache" / "forever-claude-template" / "x").read_text() == "clone"
+    assert (base / "logs" / "minds.log").read_text() == "log line"
+    assert (base / "config" / "config.toml").read_text() == "default_account_id = 'a'\n"
+    assert (base / "app_support" / "migration.lock").is_file()
+    assert (legacy / "MIGRATED.txt").is_file()
+    # Moved-away entries no longer live in the legacy tree.
+    assert not (legacy / "auth").exists()
+    assert not (legacy / "config.toml").exists()
+
+
+def test_migration_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home, data = _legacy_migration_env(monkeypatch, tmp_path)
+    legacy = home / ".minds"
+    (legacy / "auth").mkdir(parents=True)
+    (legacy / "auth" / "code.json").write_text("1")
+    assert migrate_legacy_minds_layout("minds") is True
+    # A second run is a no-op (lock present) and does not move newly-created
+    # legacy files.
+    (legacy / "auth").mkdir(exist_ok=True)
+    (legacy / "auth" / "late.json").write_text("2")
+    assert migrate_legacy_minds_layout("minds") is False
+    assert not (data / "production" / "app_support" / "auth" / "late.json").exists()
+
+
+def test_migration_does_not_overwrite_existing_dest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home, data = _legacy_migration_env(monkeypatch, tmp_path)
+    legacy = home / ".minds"
+    (legacy / "auth").mkdir(parents=True)
+    (legacy / "auth" / "code.json").write_text("legacy")
+    dest_auth = data / "production" / "app_support" / "auth"
+    dest_auth.mkdir(parents=True)
+    (dest_auth / "code.json").write_text("already-there")
+    assert migrate_legacy_minds_layout("minds") is True
+    # The pre-existing destination wins; the legacy copy is left in place.
+    assert (dest_auth / "code.json").read_text() == "already-there"
+    assert (legacy / "auth" / "code.json").read_text() == "legacy"
+
+
+def test_migration_rewrites_mngr_data_json_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Risk 1: absolute paths inside mngr/profiles/*/data.json are rewritten."""
+    home, data = _legacy_migration_env(monkeypatch, tmp_path)
+    legacy = home / ".minds"
+    profile = legacy / "mngr" / "profiles" / "p1"
+    (profile / "keys").mkdir(parents=True)
+    (profile / "keys" / "docker_ssh_key").write_text("PRIVATE KEY")
+    legacy_key = legacy / "mngr" / "profiles" / "p1" / "keys" / "docker_ssh_key"
+    (profile / "data.json").write_text(json.dumps({"ssh_key_path": str(legacy_key), "name": "agent-1"}))
+
+    assert migrate_legacy_minds_layout("minds") is True
+
+    app_support = data / "production" / "app_support"
+    new_data_json = app_support / "mngr" / "profiles" / "p1" / "data.json"
+    parsed = json.loads(new_data_json.read_text())
+    expected_key = app_support / "mngr" / "profiles" / "p1" / "keys" / "docker_ssh_key"
+    assert parsed["ssh_key_path"] == str(expected_key)
+    assert str(legacy) not in new_data_json.read_text()
+    assert (expected_key).read_text() == "PRIVATE KEY"

--- a/apps/minds/imbue/minds/cli/env.py
+++ b/apps/minds/imbue/minds/cli/env.py
@@ -47,6 +47,7 @@ from imbue.minds.cli._activated_env import require_activated_env_name
 from imbue.minds.cli._activated_env import require_deploy_mode_activation
 from imbue.minds.cli._activated_env import tier_for_env_name as _tier_for_env_name
 from imbue.minds.cli._activated_env import validate_modal_profile_exists_in_modal_toml
+from imbue.minds.config.data_types import MindsPaths
 from imbue.minds.config.loader import EnvConfigError
 from imbue.minds.config.loader import load_client_config
 from imbue.minds.config.loader import load_deploy_config
@@ -1098,6 +1099,46 @@ def env_list(ctx: click.Context) -> None:
             write_stdout_line(json.dumps(entry, default=str))
     else:
         write_stdout_line(json.dumps(payload, indent=2, default=str))
+
+
+@env.command("teardown")
+@click.argument("name", type=str, required=False)
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+@click.pass_context
+def env_teardown(ctx: click.Context, name: str | None, yes: bool) -> None:
+    """Delete every local data root for an env (uninstall its on-disk state).
+
+    Removes the app-support / cache / logs / config roots for the chosen env,
+    plus the legacy ``~/.<root_name>/`` dotfolder if one survived a migration.
+    Does NOT touch cloud resources -- use ``minds env destroy`` for that.
+    Defaults to the active env, or ``production`` when nothing is activated.
+    """
+    _refuse_if_any_recover_target_exists()
+    output_format: OutputFormat = (ctx.obj or {}).get("output_format", OutputFormat.HUMAN)
+    env_name = name or active_env_name_or_none() or "production"
+    paths = MindsPaths.for_root_name(root_name_for_env_name(env_name))
+    # dict.fromkeys dedups while preserving order (config nests under
+    # app_support on macOS, so the two can coincide).
+    candidates = (paths.app_support, paths.cache, paths.logs, paths.config, paths.legacy_data_dir)
+    existing = [p for p in dict.fromkeys(candidates) if p.exists() or p.is_symlink()]
+    if not existing:
+        logger.info("No on-disk state found for env {!r}.", env_name)
+        _emit_json({"name": env_name, "status": "absent", "deleted": []}, output_format=output_format)
+        return
+    if not yes and output_format is OutputFormat.HUMAN:
+        logger.info("About to permanently delete the following for env {!r}:", env_name)
+        for path in existing:
+            logger.info("  {}", path)
+        click.confirm("Proceed?", abort=True)
+    deleted: list[str] = []
+    for path in existing:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+        deleted.append(str(path))
+    logger.info("Tore down {} root(s) for env {!r}.", len(deleted), env_name)
+    _emit_json({"name": env_name, "status": "torn_down", "deleted": deleted}, output_format=output_format)
 
 
 @env.command("deploy")

--- a/apps/minds/imbue/minds/cli/env_test.py
+++ b/apps/minds/imbue/minds/cli/env_test.py
@@ -256,3 +256,31 @@ def test_deactivate_unsets_modal_profile(_isolated_env: Path) -> None:
     assert "unset MNGR_HOST_DIR" in result.output
     assert "unset MNGR_PREFIX" in result.output
     assert "unset MINDS_CLIENT_CONFIG_PATH" in result.output
+
+
+# -- teardown: local uninstall of an env's data roots --
+
+
+def test_env_teardown_removes_all_roots(_isolated_env: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from imbue.minds.config.data_types import MindsPaths
+
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path / "data"))
+    paths = MindsPaths.for_root_name("minds-staging")
+    for root in (paths.app_support, paths.cache, paths.logs, paths.config):
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "marker").write_text("x")
+
+    result = CliRunner().invoke(env, ["teardown", "staging", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not paths.app_support.exists()
+    assert not paths.cache.exists()
+    assert not paths.logs.exists()
+    assert not paths.config.exists()
+
+
+def test_env_teardown_is_noop_when_absent(
+    _isolated_env: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("MINDS_DATA_HOME", str(tmp_path / "data"))
+    result = CliRunner().invoke(env, ["teardown", "dev-nope", "--yes"])
+    assert result.exit_code == 0, result.output

--- a/apps/minds/imbue/minds/cli/run.py
+++ b/apps/minds/imbue/minds/cli/run.py
@@ -35,13 +35,12 @@ from pydantic import Field
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
-from imbue.minds.bootstrap import minds_data_dir_for
 from imbue.minds.bootstrap import reconcile_imbue_cloud_providers_from_sessions
 from imbue.minds.bootstrap import resolve_minds_root_name
 from imbue.minds.config.data_types import DEFAULT_DESKTOP_CLIENT_HOST
 from imbue.minds.config.data_types import DEFAULT_DESKTOP_CLIENT_PORT
 from imbue.minds.config.data_types import MNGR_BINARY
-from imbue.minds.config.data_types import WorkspacePaths
+from imbue.minds.config.data_types import MindsPaths
 from imbue.minds.config.loader import load_client_config
 from imbue.minds.desktop_client.agent_creator import AgentCreator
 from imbue.minds.desktop_client.api_key_store import generate_api_key
@@ -161,8 +160,8 @@ def run(
             "`dev-<your-user>`, `staging`, or `production`), then re-run."
         )
     root_name = resolve_minds_root_name()
-    data_directory = minds_data_dir_for(root_name)
-    minds_config = MindsConfig(data_dir=data_directory)
+    paths = MindsPaths.for_root_name(root_name)
+    minds_config = MindsConfig(data_dir=paths.config)
     client_config_path = config_file
     client_env_config = load_client_config(client_config_path)
     connector_url_str = str(client_env_config.connector_url).rstrip("/")
@@ -171,7 +170,10 @@ def run(
     logger.info("Starting `minds run`...")
     logger.info("  Bare-origin: http://{}:{}", host, port)
     logger.info("  MINDS_ROOT_NAME: {}", root_name)
-    logger.info("  Data directory: {}", data_directory)
+    logger.info("  App support: {}", paths.app_support)
+    logger.info("  Cache: {}", paths.cache)
+    logger.info("  Logs: {}", paths.logs)
+    logger.info("  Config: {}", paths.config)
     logger.info("  Config file: {}", client_config_path)
     logger.info("  connector_url: {}", client_env_config.connector_url)
     logger.info("  litellm_proxy_url: {}", client_env_config.litellm_proxy_url)
@@ -180,14 +182,13 @@ def run(
     # so the reconcile happens here once we've loaded the client config.
     reconcile_imbue_cloud_providers_from_sessions(connector_url_str, root_name=root_name)
 
-    paths = WorkspacePaths(data_dir=data_directory)
     auth_store = FileAuthStore(data_directory=paths.auth_dir)
     is_electron = os.getenv("MINDS_ELECTRON") == "1"
     notification_dispatcher = NotificationDispatcher(is_electron=is_electron)
     backend_resolver = MngrCliBackendResolver(
-        last_good_agents_path=paths.data_dir / "last_good_agent_topology.json",
+        last_good_agents_path=paths.app_support / "last_good_agent_topology.json",
     )
-    latchkey = _build_latchkey(data_directory=data_directory)
+    latchkey = _build_latchkey(app_support=paths.app_support)
     latchkey.initialize()
 
     # Mint a fresh central minds API key for this process. The same
@@ -249,14 +250,14 @@ def run(
 
     mngr_message_sender = MngrMessageSender()
     latchkey_permission_handler = LatchkeyPermissionGrantHandler(
-        data_dir=data_directory,
+        data_dir=paths.app_support,
         latchkey=latchkey,
         services_catalog=ServicesCatalog(gateway_client=gateway_client),
         mngr_message_sender=mngr_message_sender,
         gateway_client=gateway_client,
     )
     file_sharing_handler = FileSharingGrantHandler(
-        data_dir=data_directory,
+        data_dir=paths.app_support,
         gateway_client=gateway_client,
         mngr_message_sender=mngr_message_sender,
     )
@@ -265,8 +266,8 @@ def run(
         connector_url=client_env_config.connector_url,
     )
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
-    session_store = MultiAccountSessionStore(data_dir=data_directory, cli=imbue_cloud_cli)
-    response_events = load_response_events(data_directory)
+    session_store = MultiAccountSessionStore(data_dir=paths.app_support, cli=imbue_cloud_cli)
+    response_events = load_response_events(paths.app_support)
     request_inbox = RequestInbox()
     for resp in response_events:
         request_inbox = request_inbox.add_response(resp)
@@ -362,7 +363,7 @@ def run(
     # the lazy fallback at create-agent time keeps working.
     from imbue.minds.desktop_client.first_launch_prefetch import start_first_launch_prefetch
 
-    start_first_launch_prefetch(paths.data_dir, root_concurrency_group)
+    start_first_launch_prefetch(paths.cache, root_concurrency_group)
 
     # Emit the started event so Electron can pre-set the cookie before the
     # first navigation. ``minds run`` itself does not open the browser at
@@ -576,7 +577,7 @@ class _StreamedPermissionRequestHandler(FrozenModel):
         self.backend_resolver.notify_change()
 
 
-def _build_latchkey(data_directory: Path) -> Latchkey:
+def _build_latchkey(app_support: Path) -> Latchkey:
     # The latchkey-binary path is supplied by the Electron shell (which
     # bundles its own copy of latchkey under the app resources) via
     # ``MINDS_LATCHKEY_BINARY``. We fall back to ``"latchkey"`` on PATH
@@ -594,7 +595,7 @@ def _build_latchkey(data_directory: Path) -> Latchkey:
     if directory_override:
         latchkey_directory = Path(directory_override).expanduser()
     else:
-        latchkey_directory = data_directory / "latchkey"
+        latchkey_directory = app_support / "latchkey"
     # The per-env encryption key is loaded lazily on every subprocess
     # spawn inside ``Latchkey`` itself (via ``_load_encryption_key``)
     # so the secret only lives in parent-process memory for the

--- a/apps/minds/imbue/minds/config/data_types.py
+++ b/apps/minds/imbue/minds/config/data_types.py
@@ -46,24 +46,82 @@ def _resolve_mngr_binary() -> str:
 MNGR_BINARY: Final[str] = _resolve_mngr_binary()
 
 
-class WorkspacePaths(FrozenModel):
-    """Resolved filesystem paths for minds data storage."""
+class MindsPaths(FrozenModel):
+    """Resolved per-category, platform-canonical filesystem roots for minds state.
 
-    data_dir: Path = Field(description="Root directory for minds data (e.g. ~/.minds)")
+    Replaces the single ``~/.minds-<tier>/`` dotfolder with four roots, each
+    following the host OS's documented conventions (Apple Application
+    Support / Caches / Logs on macOS; the XDG data / cache / state / config
+    dirs on Linux). Built via :meth:`for_root_name`, which delegates the
+    actual resolution to the (mngr-free) functions in
+    :mod:`imbue.minds.bootstrap`.
+
+    For tests, the legacy single-root shape is still accepted:
+    ``MindsPaths(data_dir=tmp_path)`` lays all four roots flat under one
+    directory, matching the ``MINDS_DATA_HOME`` override layout.
+    """
+
+    tier: str = Field(default="production", description="Tier subdirectory name (production, staging, dev-<name>).")
+    app_support: Path = Field(description="Secrets, sessions, mngr/, ssh/, telegram/, latchkey/, backups/.")
+    cache: Path = Field(description="Regenerable caches (template-cache/); the OS may purge these.")
+    logs: Path = Field(description="Log files (minds.log, minds-events.jsonl).")
+    config: Path = Field(description="User-editable config (client.toml, config.toml, minds_root.toml).")
+    legacy_data_dir: Path = Field(description="Pre-move ~/.<root_name>/ location; read-only after migration.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _expand_legacy_data_dir(cls, data: object) -> object:
+        """Accept ``data_dir=<base>`` as a flat all-in-one-root shorthand.
+
+        Lets tests construct a self-contained throwaway tree the same way
+        the ``MINDS_DATA_HOME`` override lays one out (all four roots under
+        one directory), without enumerating every root.
+        """
+        if isinstance(data, dict) and "data_dir" in data:
+            base = Path(data.pop("data_dir"))
+            data.setdefault("app_support", base)
+            data.setdefault("cache", base)
+            data.setdefault("logs", base)
+            data.setdefault("config", base)
+            data.setdefault("legacy_data_dir", base)
+        return data
+
+    @classmethod
+    def for_root_name(cls, root_name: str) -> "MindsPaths":
+        """Resolve the platform-canonical roots for ``root_name`` (e.g. ``minds``)."""
+        from imbue.minds.bootstrap import minds_app_support_dir_for
+        from imbue.minds.bootstrap import minds_cache_dir_for
+        from imbue.minds.bootstrap import minds_config_dir_for
+        from imbue.minds.bootstrap import minds_data_dir_for
+        from imbue.minds.bootstrap import minds_logs_dir_for
+        from imbue.minds.bootstrap import minds_tier_for
+
+        return cls(
+            tier=minds_tier_for(root_name),
+            app_support=minds_app_support_dir_for(root_name),
+            cache=minds_cache_dir_for(root_name),
+            logs=minds_logs_dir_for(root_name),
+            config=minds_config_dir_for(root_name),
+            legacy_data_dir=minds_data_dir_for(root_name),
+        )
 
     @property
     def auth_dir(self) -> Path:
-        """Directory for authentication data (signing key, one-time codes)."""
-        return self.data_dir / "auth"
+        """Directory for authentication data (signing key, one-time codes, sessions)."""
+        return self.app_support / "auth"
 
     @property
     def mngr_host_dir(self) -> Path:
-        """Directory where mngr stores agent state for this minds install (e.g. ~/.minds/mngr)."""
-        return self.data_dir / "mngr"
+        """Directory where mngr stores agent state for this minds install (under app_support)."""
+        return self.app_support / "mngr"
 
     def workspace_dir(self, agent_id: AgentId) -> Path:
-        """Directory for a specific workspace's repo (e.g. ~/.minds/<agent-id>/)."""
-        return self.data_dir / str(agent_id)
+        """Directory for a specific workspace's repo (under app_support)."""
+        return self.app_support / str(agent_id)
+
+
+# Deprecated alias kept for one release cycle; ``MindsPaths`` is the canonical name.
+WorkspacePaths = MindsPaths
 
 
 class ClientEnvConfig(FrozenModel):

--- a/apps/minds/imbue/minds/config/data_types.py
+++ b/apps/minds/imbue/minds/config/data_types.py
@@ -13,6 +13,12 @@ from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.primitives import NonEmptyStr
 from imbue.imbue_common.primitives import NonNegativeInt
+from imbue.minds.bootstrap import minds_app_support_dir_for
+from imbue.minds.bootstrap import minds_cache_dir_for
+from imbue.minds.bootstrap import minds_config_dir_for
+from imbue.minds.bootstrap import minds_data_dir_for
+from imbue.minds.bootstrap import minds_logs_dir_for
+from imbue.minds.bootstrap import minds_tier_for
 from imbue.minds.errors import MalformedMngrOutputError
 from imbue.minds.primitives import ServiceName
 from imbue.mngr.primitives import AgentId
@@ -89,13 +95,6 @@ class MindsPaths(FrozenModel):
     @classmethod
     def for_root_name(cls, root_name: str) -> "MindsPaths":
         """Resolve the platform-canonical roots for ``root_name`` (e.g. ``minds``)."""
-        from imbue.minds.bootstrap import minds_app_support_dir_for
-        from imbue.minds.bootstrap import minds_cache_dir_for
-        from imbue.minds.bootstrap import minds_config_dir_for
-        from imbue.minds.bootstrap import minds_data_dir_for
-        from imbue.minds.bootstrap import minds_logs_dir_for
-        from imbue.minds.bootstrap import minds_tier_for
-
         return cls(
             tier=minds_tier_for(root_name),
             app_support=minds_app_support_dir_for(root_name),

--- a/apps/minds/imbue/minds/config/data_types.py
+++ b/apps/minds/imbue/minds/config/data_types.py
@@ -62,9 +62,7 @@ class MindsPaths(FrozenModel):
     actual resolution to the (mngr-free) functions in
     :mod:`imbue.minds.bootstrap`.
 
-    For tests, the legacy single-root shape is still accepted:
-    ``MindsPaths(data_dir=tmp_path)`` lays all four roots flat under one
-    directory, matching the ``MINDS_DATA_HOME`` override layout.
+    For tests, :meth:`flat` lays all four roots under one directory.
     """
 
     tier: str = Field(default="production", description="Tier subdirectory name (production, staging, dev-<name>).")
@@ -74,23 +72,10 @@ class MindsPaths(FrozenModel):
     config: Path = Field(description="User-editable config (client.toml, config.toml, minds_root.toml).")
     legacy_data_dir: Path = Field(description="Pre-move ~/.<root_name>/ location; read-only after migration.")
 
-    @model_validator(mode="before")
     @classmethod
-    def _expand_legacy_data_dir(cls, data: object) -> object:
-        """Accept ``data_dir=<base>`` as a flat all-in-one-root shorthand.
-
-        Lets tests construct a self-contained throwaway tree the same way
-        the ``MINDS_DATA_HOME`` override lays one out (all four roots under
-        one directory), without enumerating every root.
-        """
-        if isinstance(data, dict) and "data_dir" in data:
-            base = Path(data.pop("data_dir"))
-            data.setdefault("app_support", base)
-            data.setdefault("cache", base)
-            data.setdefault("logs", base)
-            data.setdefault("config", base)
-            data.setdefault("legacy_data_dir", base)
-        return data
+    def flat(cls, base: Path, *, tier: str = "production") -> "MindsPaths":
+        """Lay all four roots flat under ``base`` (a self-contained test tree)."""
+        return cls(tier=tier, app_support=base, cache=base, logs=base, config=base, legacy_data_dir=base)
 
     @classmethod
     def for_root_name(cls, root_name: str) -> "MindsPaths":

--- a/apps/minds/imbue/minds/config/data_types_test.py
+++ b/apps/minds/imbue/minds/config/data_types_test.py
@@ -11,7 +11,7 @@ from imbue.mngr.primitives import AgentId
 
 def test_workspace_paths_workspace_dir_uses_agent_id(tmp_path: Path) -> None:
     """Verify workspace_dir incorporates the agent_id into the path."""
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId()
 
     result = paths.workspace_dir(agent_id)
@@ -20,12 +20,12 @@ def test_workspace_paths_workspace_dir_uses_agent_id(tmp_path: Path) -> None:
 
 
 def test_workspace_paths_auth_dir_is_under_data_dir(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     assert paths.auth_dir == tmp_path / "auth"
 
 
 def test_workspace_paths_mngr_host_dir_is_under_data_dir(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     assert paths.mngr_host_dir == tmp_path / "mngr"
 
 

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -1322,7 +1322,7 @@ class AgentCreator(MutableModel):
                     # under ``data_dir/template-cache/forever-claude-template``,
                     # pass it as ``--reference-if-able`` so we reuse those
                     # objects and the network fetch shrinks to the delta.
-                    ref_repo = self.paths.data_dir / "template-cache" / "forever-claude-template"
+                    ref_repo = self.paths.cache / "template-cache" / "forever-claude-template"
                     clone_git_repo(
                         GitUrl(repo_source),
                         clone_target,

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -421,7 +421,7 @@ def _make_test_creator(
     probe_timeout_seconds: float = 0.5,
     system_interface_health_tracker: SystemInterfaceHealthTracker | None = None,
 ) -> AgentCreator:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     cg = ConcurrencyGroup(name="agent-creator-test")
     cg.__enter__()
     return AgentCreator(
@@ -710,7 +710,7 @@ def _make_creator_with_cli(tmp_path: Path, cli: _RecordingImbueCloudCli) -> Agen
     cg = ConcurrencyGroup(name="agent-creator-test")
     cg.__enter__()
     return AgentCreator(
-        paths=WorkspacePaths(data_dir=tmp_path),
+        paths=WorkspacePaths.flat(tmp_path),
         root_concurrency_group=cg,
         notification_dispatcher=NotificationDispatcher.create(is_electron=False, tkinter_module=None, is_macos=False),
         imbue_cloud_cli=cli,

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -95,7 +95,7 @@ def _handle_telegram_status(
         is_active = telegram_orchestrator.agent_has_telegram(parsed_id)
         if is_active:
             paths: WorkspacePaths = request.app.state.api_v1_paths
-            credentials = load_agent_bot_credentials(paths.data_dir, parsed_id)
+            credentials = load_agent_bot_credentials(paths.app_support, parsed_id)
             result: dict[str, object] = {
                 "agent_id": str(parsed_id),
                 "status": str(TelegramSetupStatus.DONE),

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1297,7 +1297,7 @@ def _resolve_destroying_for_landing(
     paths: WorkspacePaths | None,
     all_agent_ids: tuple[AgentId, ...],
 ) -> dict[str, str]:
-    """Walk ``<paths.data_dir>/destroying/``, delete DONE records, return marker map.
+    """Walk ``<paths.app_support>/destroying/``, delete DONE records, return marker map.
 
     Returns ``{agent_id_str: "running" | "failed"}`` for any in-flight or
     failed destroy whose agent_id is currently known to the resolver. DONE

--- a/apps/minds/imbue/minds/desktop_client/app_backup_request_test.py
+++ b/apps/minds/imbue/minds/desktop_client/app_backup_request_test.py
@@ -11,7 +11,7 @@ from imbue.minds.primitives import BackupProvider
 
 
 def _paths(tmp_path: Path) -> WorkspacePaths:
-    return WorkspacePaths(data_dir=tmp_path)
+    return WorkspacePaths.flat(tmp_path)
 
 
 def _build(

--- a/apps/minds/imbue/minds/desktop_client/backup_env_store.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_env_store.py
@@ -25,7 +25,7 @@ _BACKUP_ENV_DIRNAME = "backup_envs"
 
 def backup_env_dir(paths: WorkspacePaths) -> Path:
     """Return the directory holding the canonical per-workspace restic env files."""
-    return paths.data_dir / _BACKUP_ENV_DIRNAME
+    return paths.app_support / _BACKUP_ENV_DIRNAME
 
 
 def canonical_env_path(paths: WorkspacePaths, agent_id: AgentId) -> Path:

--- a/apps/minds/imbue/minds/desktop_client/backup_env_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_env_store_test.py
@@ -13,7 +13,7 @@ from imbue.mngr.primitives import AgentId
 
 
 def _paths(tmp_path: Path) -> WorkspacePaths:
-    return WorkspacePaths(data_dir=tmp_path)
+    return WorkspacePaths.flat(tmp_path)
 
 
 def test_read_returns_none_when_absent(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/backup_export_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_export_test.py
@@ -36,13 +36,13 @@ def test_export_zip_path_for_host_is_keyed_and_in_tmp() -> None:
 
 
 def test_export_raises_without_canonical_env(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     with pytest.raises(BackupExportError):
         export_latest_snapshot_zip(paths=paths, agent_id=_fresh_agent_id(), host_id="host-" + uuid4().hex)
 
 
 def test_export_raises_when_repository_missing(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = _fresh_agent_id()
     # Canonical env present but with no RESTIC_REPOSITORY line.
     write_canonical_env(paths, agent_id, "RESTIC_PASSWORD=secret\n")
@@ -55,7 +55,7 @@ def test_export_raises_when_repository_missing(tmp_path: Path) -> None:
 
 @pytest.mark.timeout(60)
 def test_export_latest_snapshot_zip_produces_zip(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path / "minds-data")
+    paths = WorkspacePaths.flat(tmp_path / "minds-data")
     agent_id = _fresh_agent_id()
     host_id = "host-" + uuid4().hex
     repo = str(tmp_path / "repo")

--- a/apps/minds/imbue/minds/desktop_client/backup_password_store.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_password_store.py
@@ -24,7 +24,7 @@ _BACKUP_PASSWORD_FILENAME = "backup_password"
 
 def backup_password_file_path(paths: WorkspacePaths) -> Path:
     """Return the path of the shared master-password file for this minds env."""
-    return paths.data_dir / _BACKUP_PASSWORD_FILENAME
+    return paths.app_support / _BACKUP_PASSWORD_FILENAME
 
 
 def has_saved_backup_password(paths: WorkspacePaths) -> bool:

--- a/apps/minds/imbue/minds/desktop_client/backup_password_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_password_store_test.py
@@ -11,7 +11,7 @@ from imbue.minds.desktop_client.backup_password_store import save_backup_passwor
 
 
 def _paths(tmp_path: Path) -> WorkspacePaths:
-    return WorkspacePaths(data_dir=tmp_path)
+    return WorkspacePaths.flat(tmp_path)
 
 
 def test_read_returns_none_when_absent(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/backup_status_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backup_status_test.py
@@ -24,7 +24,7 @@ from imbue.mngr.primitives import AgentId
 
 
 def _paths(tmp_path: Path) -> WorkspacePaths:
-    return WorkspacePaths(data_dir=tmp_path)
+    return WorkspacePaths.flat(tmp_path)
 
 
 def _now() -> datetime:

--- a/apps/minds/imbue/minds/desktop_client/destroying.py
+++ b/apps/minds/imbue/minds/desktop_client/destroying.py
@@ -11,7 +11,7 @@ exit -- so it is structurally the wrong tool here. Same justification as
 ``apps/minds/imbue/minds/desktop_client/latchkey/_spawn.py``.
 
 Status is fully derived from disk + the live resolver; there is no
-state.json. For each in-flight destroy ``<paths.data_dir>/destroying/<agent_id>/``
+state.json. For each in-flight destroy ``<paths.app_support>/destroying/<agent_id>/``
 contains exactly two files: ``pid`` (single-line text) and
 ``output.log`` (combined stdout+stderr from the bash wrapper).
 :py:class:`DestroyingStatus` is computed from ``pid`` liveness +
@@ -69,7 +69,7 @@ class DestroyingRecord(FrozenModel):
     """Snapshot of a detached destroy's state.
 
     All fields are derived from disk inspection of
-    ``<paths.data_dir>/destroying/<agent_id>/`` plus the caller's
+    ``<paths.app_support>/destroying/<agent_id>/`` plus the caller's
     ``agent_in_resolver`` answer; there is no on-disk state.json.
     """
 
@@ -85,7 +85,7 @@ class DestroyingRecord(FrozenModel):
 
 
 def _destroying_dir(paths: WorkspacePaths, agent_id: AgentId) -> Path:
-    return paths.data_dir / _DESTROYING_DIR_NAME / str(agent_id)
+    return paths.app_support / _DESTROYING_DIR_NAME / str(agent_id)
 
 
 def _pid_file(paths: WorkspacePaths, agent_id: AgentId) -> Path:
@@ -344,14 +344,14 @@ def list_destroying(
     paths: WorkspacePaths,
     agent_ids_in_resolver: frozenset[AgentId],
 ) -> dict[AgentId, DestroyingRecord]:
-    """Walk ``<paths.data_dir>/destroying/`` and return a record per agent_id.
+    """Walk ``<paths.app_support>/destroying/`` and return a record per agent_id.
 
     Used by the landing-page renderer. ``agent_ids_in_resolver`` is the
     snapshot of ``MngrCliBackendResolver.list_known_workspace_ids()`` at
     render time so the same set is shared across every record's status
     derivation.
     """
-    root = paths.data_dir / _DESTROYING_DIR_NAME
+    root = paths.app_support / _DESTROYING_DIR_NAME
     if not root.is_dir():
         return {}
     records: dict[AgentId, DestroyingRecord] = {}
@@ -370,7 +370,7 @@ def list_destroying(
 
 
 def delete_destroying(agent_id: AgentId, paths: WorkspacePaths) -> bool:
-    """Remove ``<paths.data_dir>/destroying/<agent_id>/``. Idempotent.
+    """Remove ``<paths.app_support>/destroying/<agent_id>/``. Idempotent.
 
     Returns ``True`` if the directory was present and removed,
     ``False`` if there was nothing to remove. Best-effort: errors during

--- a/apps/minds/imbue/minds/desktop_client/destroying_test.py
+++ b/apps/minds/imbue/minds/desktop_client/destroying_test.py
@@ -97,7 +97,7 @@ def test_build_destroy_command_without_host_id_falls_back_to_single() -> None:
 
 
 def test_start_destroy_writes_pid_file_and_log(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=0, stdout="destroyed agent\n")
     record = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(fake), mngr_binary="mngr")
@@ -110,7 +110,7 @@ def test_start_destroy_writes_pid_file_and_log(tmp_path: Path) -> None:
 
 
 def test_read_destroying_status_running_when_pid_alive(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     # Sleep long enough for the next read but not so long that the test gets slow.
     sleeper = tmp_path / "bin" / "mngr"
@@ -133,7 +133,7 @@ def test_read_destroying_status_running_when_pid_alive(tmp_path: Path) -> None:
 
 
 def test_read_destroying_status_done_when_pid_dead_and_agent_gone(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=0)
     record = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(fake), mngr_binary="mngr")
@@ -145,7 +145,7 @@ def test_read_destroying_status_done_when_pid_dead_and_agent_gone(tmp_path: Path
 
 
 def test_read_destroying_status_failed_when_pid_dead_but_agent_still_present(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=1, stderr="boom\n")
     record = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(fake), mngr_binary="mngr")
@@ -156,12 +156,12 @@ def test_read_destroying_status_failed_when_pid_dead_but_agent_still_present(tmp
 
 
 def test_read_destroying_returns_none_when_no_directory(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     assert read_destroying(AgentId.generate(), paths, agent_in_resolver=False) is None
 
 
 def test_start_destroy_is_idempotent_while_running(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     sleeper = tmp_path / "bin" / "mngr"
     sleeper.parent.mkdir(exist_ok=True)
@@ -181,7 +181,7 @@ def test_start_destroy_is_idempotent_while_running(tmp_path: Path) -> None:
 
 
 def test_list_destroying_walks_dir_and_picks_up_each_agent(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_a = AgentId.generate()
     agent_b = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=0)
@@ -198,7 +198,7 @@ def test_list_destroying_walks_dir_and_picks_up_each_agent(tmp_path: Path) -> No
 
 
 def test_delete_destroying_is_idempotent(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=0)
     record = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(fake), mngr_binary="mngr")
@@ -209,7 +209,7 @@ def test_delete_destroying_is_idempotent(tmp_path: Path) -> None:
 
 
 def test_read_log_chunk_returns_tail_from_offset(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     fake = _make_fake_mngr(tmp_path, exit_code=0, stdout="hello world\n")
     record = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(fake), mngr_binary="mngr")
@@ -224,14 +224,14 @@ def test_read_log_chunk_returns_tail_from_offset(tmp_path: Path) -> None:
 
 
 def test_read_log_chunk_raises_filenotfound_when_no_record(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     with pytest.raises(FileNotFoundError):
         read_log_chunk(AgentId.generate(), paths, offset=0)
 
 
 def test_idempotent_after_failure_overwrites_log(tmp_path: Path) -> None:
     """A Retry overwrites the previous run's log so the user sees the new attempt fresh."""
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_id = AgentId.generate()
     failing = _make_fake_mngr(tmp_path, exit_code=1, stderr="first run boom\n")
     first = start_destroy(agent_id, paths, host_id=None, env=_path_with_fake_mngr(failing), mngr_binary="mngr")

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
@@ -73,7 +73,7 @@ def _build_authenticated_client(
     auth_dir = tmp_path / "auth"
     auth_store = FileAuthStore(data_directory=auth_dir)
     backend_resolver: BackendResolverInterface = StaticBackendResolver(url_by_agent_and_service={})
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     app = create_desktop_client(
         auth_store=auth_store,
         backend_resolver=backend_resolver,

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined_test.py
@@ -714,7 +714,7 @@ def _build_authenticated_client(
     auth_dir = tmp_path / "auth"
     auth_store = FileAuthStore(data_directory=auth_dir)
     backend_resolver: BackendResolverInterface = StaticBackendResolver(url_by_agent_and_service={})
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     app = create_desktop_client(
         auth_store=auth_store,
         backend_resolver=backend_resolver,

--- a/apps/minds/imbue/minds/desktop_client/minds_config.py
+++ b/apps/minds/imbue/minds/desktop_client/minds_config.py
@@ -26,7 +26,7 @@ _CONFIG_FILENAME: Final[str] = "config.toml"
 class MindsConfig(MutableModel):
     """Thread-safe configuration manager for ``~/.minds/config.toml``."""
 
-    data_dir: Path = Field(frozen=True, description="Root data directory (e.g. ~/.minds)")
+    data_dir: Path = Field(frozen=True, description="Config root directory where config.toml lives.")
     _lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     @property

--- a/apps/minds/imbue/minds/desktop_client/onboarding.py
+++ b/apps/minds/imbue/minds/desktop_client/onboarding.py
@@ -309,7 +309,7 @@ class OnboardingApplier(MutableModel):
         """Resolve the user's name and write the per-creation user-context JSON file."""
         user_name = resolve_local_user_name()
         document = build_user_context_document(user_name)
-        context_dir = self.paths.data_dir / USER_CONTEXT_DIR_NAME
+        context_dir = self.paths.app_support / USER_CONTEXT_DIR_NAME
         context_dir.mkdir(parents=True, exist_ok=True)
         context_path = context_dir / f"{creation_id}.json"
         context_path.write_text(json.dumps(document, indent=2))

--- a/apps/minds/imbue/minds/desktop_client/onboarding_test.py
+++ b/apps/minds/imbue/minds/desktop_client/onboarding_test.py
@@ -92,7 +92,7 @@ def _make_applier(
     root_concurrency_group: ConcurrencyGroup,
     notification_dispatcher: NotificationDispatcher,
 ) -> OnboardingApplier:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_creator = AgentCreator(
         paths=paths,
         root_concurrency_group=root_concurrency_group,
@@ -166,7 +166,7 @@ def test_q2_and_q3_are_applied_concurrently(
     root_concurrency_group: ConcurrencyGroup,
     notification_dispatcher: NotificationDispatcher,
 ) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     agent_creator = AgentCreator(
         paths=paths,
         root_concurrency_group=root_concurrency_group,

--- a/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
+++ b/apps/minds/imbue/minds/desktop_client/permission_routes_test.py
@@ -243,7 +243,7 @@ def _build_authenticated_client(
         )
     else:
         backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
 
     app = create_desktop_client(
         auth_store=auth_store,
@@ -835,7 +835,7 @@ def _build_authenticated_client_with_handlers(
         )
     else:
         backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     app = create_desktop_client(
         auth_store=auth_store,
         backend_resolver=backend_resolver,

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -503,7 +503,7 @@ def _create_test_server_with_agent_creator(
     root_cg = ConcurrencyGroup(name="test-root")
     root_cg.__enter__()
     agent_creator = AgentCreator(
-        paths=WorkspacePaths(data_dir=tmp_path / "minds"),
+        paths=WorkspacePaths.flat(tmp_path / "minds"),
         root_concurrency_group=root_cg,
         notification_dispatcher=NotificationDispatcher.create(is_electron=False, tkinter_module=None, is_macos=False),
         system_interface_health_tracker=SystemInterfaceHealthTracker(),
@@ -1324,7 +1324,7 @@ def test_destroying_agent_ids_returns_ids_with_live_destroy(tmp_path: Path) -> N
     failed destroy id whose marker dir exists on disk.
     """
     agent_id = AgentId()
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     destroying_dir = tmp_path / "destroying" / str(agent_id)
     destroying_dir.mkdir(parents=True)
     # The current process pid is alive, so the helper sees the destroy as
@@ -1419,7 +1419,7 @@ def _create_test_client_with_stores(
         session_store=session_store,
         minds_config=minds_config,
         request_inbox=request_inbox,
-        paths=WorkspacePaths(data_dir=tmp_path),
+        paths=WorkspacePaths.flat(tmp_path),
     )
     client = TestClient(app, base_url="http://localhost")
     return client, auth_store
@@ -1509,7 +1509,7 @@ def test_requests_panel_card_routes_via_minds_bridge(tmp_path: Path) -> None:
         session_store=session_store,
         minds_config=minds_config,
         request_inbox=request_inbox,
-        paths=WorkspacePaths(data_dir=tmp_path),
+        paths=WorkspacePaths.flat(tmp_path),
     )
     client = TestClient(app, base_url="http://localhost")
     _authenticate_client(client, auth_store)

--- a/apps/minds/imbue/minds/desktop_client/webdav_test.py
+++ b/apps/minds/imbue/minds/desktop_client/webdav_test.py
@@ -16,7 +16,7 @@ from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
 
 def _build_authenticated_client(tmp_path: Path) -> tuple[TestClient, str]:
     """Build a TestClient + the central minds API key it expects."""
-    paths = WorkspacePaths(data_dir=tmp_path / "minds")
+    paths = WorkspacePaths.flat(tmp_path / "minds")
     auth_store = FileAuthStore(data_directory=paths.auth_dir)
     api_key = generate_api_key()
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})

--- a/apps/minds/imbue/minds/envs/paths.py
+++ b/apps/minds/imbue/minds/envs/paths.py
@@ -27,7 +27,8 @@ from pathlib import Path
 from imbue.minds.bootstrap import MINDS_ROOT_NAME_ENV_VAR
 from imbue.minds.bootstrap import env_name_from_root_name
 from imbue.minds.bootstrap import is_minds_root_name_set_to_active_env
-from imbue.minds.bootstrap import minds_data_dir_for
+from imbue.minds.bootstrap import minds_app_support_dir_for
+from imbue.minds.bootstrap import minds_tiers_parent_dir
 from imbue.minds.bootstrap import resolve_minds_root_name
 from imbue.minds.bootstrap import root_name_for_env_name
 from imbue.minds.envs.primitives import DevEnvName
@@ -39,12 +40,14 @@ _MINDS_PREFIX = "minds"
 
 
 def env_root_dir(name: DevEnvName) -> Path:
-    """Return ``~/.minds-<name>/`` (or ``~/.minds/`` for ``production``).
+    """Return the env's app-support root (e.g. the ``<tier>/`` app-support dir).
 
-    Computed via :func:`root_name_for_env_name` so the special-cased
-    ``production`` -> ``~/.minds/`` mapping stays in one place.
+    The per-env on-disk root for mngr profile / auth / agents / the dev-env
+    ``client.toml`` + ``secrets.toml``. Computed via
+    :func:`root_name_for_env_name` so the ``production`` mapping stays in
+    one place.
     """
-    return minds_data_dir_for(root_name_for_env_name(str(name)))
+    return minds_app_support_dir_for(root_name_for_env_name(str(name)))
 
 
 def client_config_file(name: DevEnvName) -> Path:
@@ -70,14 +73,38 @@ def secrets_file(name: DevEnvName) -> Path:
 
 
 def list_env_root_dirs() -> tuple[Path, ...]:
-    """Glob the user's home for every ``~/.minds*/`` directory.
+    """Return every env's app-support root on disk, plus un-migrated legacy roots.
 
-    Returns each existing root in sorted order, with ``~/.minds/``
-    (production) first if it exists. Used by ``minds env list`` to
-    enumerate every env on disk -- including ones the user manually
-    ``mkdir``'d. Callers that need to filter by "has a real
-    ``client.toml``" do so themselves.
+    Enumerates the tier subdirectories under the platform-canonical tiers
+    parent (``minds_tiers_parent_dir``) and maps each to its app-support
+    root, then appends any surviving legacy ``~/.minds*/`` dotfolders that
+    a one-shot migration has not yet moved. Sorted with the production
+    root first. Used by ``minds env list``; callers that need to filter by
+    "has a real ``client.toml``" do so themselves.
     """
+    matches: list[Path] = []
+    seen: set[Path] = set()
+    parent = minds_tiers_parent_dir()
+    if parent.is_dir():
+        for child in parent.iterdir():
+            if not child.is_dir():
+                continue
+            tier = child.name
+            if tier != "production" and not _is_legal_env_name(tier):
+                continue
+            root = minds_app_support_dir_for(root_name_for_env_name(tier))
+            if root not in seen:
+                seen.add(root)
+                matches.append(root)
+    for legacy in _list_legacy_env_root_dirs():
+        if legacy not in seen:
+            seen.add(legacy)
+            matches.append(legacy)
+    return tuple(sorted(matches, key=_env_root_sort_key))
+
+
+def _list_legacy_env_root_dirs() -> tuple[Path, ...]:
+    """Glob the user's home for every legacy ``~/.minds*/`` directory."""
     home = Path.home()
     if not home.is_dir():
         return ()
@@ -99,16 +126,13 @@ def list_env_root_dirs() -> tuple[Path, ...]:
         if not _is_legal_env_name(env_name):
             continue
         matches.append(child)
-    return tuple(sorted(matches, key=_env_root_sort_key))
+    return tuple(matches)
 
 
 def _env_root_sort_key(path: Path) -> tuple[int, str]:
-    # ``~/.minds`` (production) sorts first, then everything else
-    # alphabetically by env name. The numeric prefix keeps production
-    # at the head of the list even when its dirname (``.minds``) would
-    # otherwise sort between hypothetical ``.mindd*`` / ``.minde*``
-    # neighbors.
-    if path.name == f".{_MINDS_PREFIX}":
+    # The production root sorts first, then everything else alphabetically
+    # by directory name.
+    if path.name in ("production", f".{_MINDS_PREFIX}"):
         return (0, "")
     return (1, path.name)
 
@@ -143,10 +167,11 @@ def active_env_name_or_none() -> str | None:
 
 
 def resolved_env_root_dir() -> Path:
-    """Return the ``minds_data_dir_for`` of the resolved root name.
+    """Return the app-support root of the resolved root name.
 
     Used by callers that just want "where does my mngr profile / auth /
     agents live" without caring whether the user has activated a real
-    env. Falls back to ``~/.minds/`` when nothing is activated.
+    env. Falls back to the production app-support root when nothing is
+    activated.
     """
-    return minds_data_dir_for(resolve_minds_root_name())
+    return minds_app_support_dir_for(resolve_minds_root_name())

--- a/apps/minds/imbue/minds/envs/provisioning.py
+++ b/apps/minds/imbue/minds/envs/provisioning.py
@@ -1506,17 +1506,25 @@ def list_dev_envs() -> tuple[DevEnvSummary, ...]:
 
 
 def _env_name_from_root_path(env_root: Path) -> str:
-    """Convert ``~/.minds/`` or ``~/.minds-<name>/`` back to an env name.
+    """Convert an env's app-support root (or a legacy dotfolder) back to an env name.
 
-    The mirror of :func:`imbue.minds.envs.paths.env_root_dir`. Inlined
-    here (instead of in ``paths.py``) so the regex stays close to its
-    only caller, the ``list_dev_envs`` glob walker.
+    The mirror of :func:`imbue.minds.envs.paths.env_root_dir`. Handles both
+    the platform-canonical roots (whose directory name is the tier, which
+    equals the env name) and the un-migrated legacy ``~/.minds`` /
+    ``~/.minds-<name>`` dotfolders. The ``MINDS_DATA_HOME`` override nests
+    the tier one level up (``<tier>/app_support``), so unwrap that first.
     """
     dirname = env_root.name
     if dirname == ".minds":
         return "production"
-    assert dirname.startswith(".minds-"), f"Unexpected env root path: {env_root}"
-    return dirname[len(".minds-") :]
+    if dirname.startswith(".minds-"):
+        return dirname[len(".minds-") :]
+    if dirname == "app_support":
+        # Override layout: ``$MINDS_DATA_HOME/<tier>/app_support``.
+        return env_root.parent.name
+    # Canonical macOS / Linux layout: the directory name is the tier,
+    # which is the env name (``production`` / ``staging`` / ``dev-<name>``).
+    return dirname
 
 
 # Re-export the per_env_deploy helpers so the CLI can build a Providers

--- a/apps/minds/imbue/minds/envs/provisioning_test.py
+++ b/apps/minds/imbue/minds/envs/provisioning_test.py
@@ -23,6 +23,9 @@ from imbue.minds.envs.local_store import env_root_exists
 from imbue.minds.envs.local_store import read_client_config_file
 from imbue.minds.envs.local_store import read_secrets_file
 from imbue.minds.envs.mngr_agent_cleanup import MngrAgentCleanupError
+from imbue.minds.envs.paths import client_config_file
+from imbue.minds.envs.paths import env_root_dir
+from imbue.minds.envs.paths import secrets_file
 from imbue.minds.envs.per_env_deploy import ModalDeployError
 from imbue.minds.envs.primitives import DevEnvName
 from imbue.minds.envs.providers.modal_env import ModalEnvProviderError
@@ -410,10 +413,10 @@ def test_deploy_dev_env_writes_split_files(_isolated_home: Path, _root_cg: Concu
     assert "SUPERTOKENS_API_KEY" in secrets.secrets
 
     # Sanity: the result struct carries paths to both files.
-    assert result.client_config_path is not None and result.client_config_path.endswith(
-        "/.minds-dev-alice/client.toml"
+    assert result.client_config_path is not None and result.client_config_path == str(
+        client_config_file(DevEnvName("dev-alice"))
     )
-    assert result.secrets_path is not None and result.secrets_path.endswith("/.minds-dev-alice/secrets.toml")
+    assert result.secrets_path is not None and result.secrets_path == str(secrets_file(DevEnvName("dev-alice")))
 
 
 def test_deploy_dev_env_is_idempotent_on_re_run(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
@@ -600,7 +603,7 @@ def test_destroy_env_dev_destroys_mngr_agents_before_cloud_teardown(
         parent_concurrency_group=_root_cg,
     )
     # Seed two fake agent dirs under the env's mngr profile.
-    agents_dir = _isolated_home / ".minds-dev-kim" / "mngr" / "agents"
+    agents_dir = env_root_dir(DevEnvName("dev-kim")) / "mngr" / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
     (agents_dir / "agent-1111").mkdir()
     (agents_dir / "agent-2222").mkdir()
@@ -635,7 +638,7 @@ def test_destroy_env_dev_keep_agents_skips_mngr_destroy(_isolated_home: Path, _r
         providers=providers,
         parent_concurrency_group=_root_cg,
     )
-    agents_dir = _isolated_home / ".minds-dev-liz" / "mngr" / "agents"
+    agents_dir = env_root_dir(DevEnvName("dev-liz")) / "mngr" / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
     (agents_dir / "agent-1111").mkdir()
     call_log["calls"].clear()
@@ -824,7 +827,7 @@ def test_deploy_env_shared_tier_writes_nothing_to_disk(_isolated_home: Path, _ro
     assert result.client_config_path is None
     assert result.secrets_path is None
     # ~/.minds/, ~/.minds-staging/ are not created by shared-tier deploy.
-    assert not (_isolated_home / ".minds-staging").exists()
+    assert not (env_root_dir(DevEnvName("staging"))).exists()
     assert not (_isolated_home / ".minds").exists()
 
 
@@ -985,7 +988,7 @@ def test_destroy_env_tier_stops_apps_deletes_secrets_and_removes_env_root(
     # operator workflow (you only destroy what you deployed).
     call_log = _make_call_log()
     providers = _build_fake_providers(call_log)
-    _isolated_home.joinpath(".minds-staging").mkdir(exist_ok=True)
+    env_root_dir(DevEnvName("staging")).mkdir(parents=True, exist_ok=True)
     deploy_env(
         DevEnvName("staging"),
         tier="staging",
@@ -1024,13 +1027,13 @@ def test_destroy_env_tier_stops_apps_deletes_secrets_and_removes_env_root(
     first_delete_idx = min(call_log["calls"].index(d) for d in deletes)
     assert call_log["calls"].index(stops[-1]) < first_delete_idx
     # Env root gone -- subsequent activation has to re-create it.
-    assert not (_isolated_home / ".minds-staging").exists()
+    assert not (env_root_dir(DevEnvName("staging"))).exists()
 
 
 def test_destroy_env_tier_destroys_mngr_agents_first(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
     """Tier destroy must `mngr destroy` any agents under the env root before cloud teardown."""
     # Seed an env root + a couple of fake agent dirs under it.
-    staging_root = _isolated_home / ".minds-staging"
+    staging_root = env_root_dir(DevEnvName("staging"))
     agents_dir = staging_root / "mngr" / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "agent-9999").mkdir()
@@ -1083,8 +1086,8 @@ def test_destroy_env_tier_proceeds_when_env_root_missing(_isolated_home: Path, _
 
 def test_destroy_env_tier_leaves_env_root_when_step_fails(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
     """If any cleanup step fails, the env root must stay so re-runs can recover."""
-    staging_root = _isolated_home / ".minds-staging"
-    staging_root.mkdir()
+    staging_root = env_root_dir(DevEnvName("staging"))
+    staging_root.mkdir(parents=True)
 
     failing_providers = _build_fake_providers(_make_call_log(), fail_step="stop_modal_app")
     with pytest.raises(ModalDeployError, match="modal app stop boom"):
@@ -1103,8 +1106,8 @@ def test_destroy_env_tier_wipes_supertokens_app_with_parsed_app_id(
     _isolated_home: Path, _root_cg: ConcurrencyGroup
 ) -> None:
     """SuperTokens wipe must extract the app_id from the Vault connection URI."""
-    staging_root = _isolated_home / ".minds-staging"
-    staging_root.mkdir()
+    staging_root = env_root_dir(DevEnvName("staging"))
+    staging_root.mkdir(parents=True)
     call_log = _make_call_log()
     providers = _build_fake_providers(
         call_log,
@@ -1131,8 +1134,8 @@ def test_destroy_env_tier_wipes_supertokens_app_with_parsed_app_id(
 
 def test_destroy_env_tier_wipes_neon_with_dsn_from_vault(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
     """Neon wipe must use the DATABASE_URL from the tier Vault entry."""
-    staging_root = _isolated_home / ".minds-staging"
-    staging_root.mkdir()
+    staging_root = env_root_dir(DevEnvName("staging"))
+    staging_root.mkdir(parents=True)
     call_log = _make_call_log()
     providers = _build_fake_providers(
         call_log,
@@ -1161,8 +1164,8 @@ def test_destroy_env_tier_refuses_when_supertokens_vault_entry_incomplete(
     _isolated_home: Path, _root_cg: ConcurrencyGroup
 ) -> None:
     """A misconfigured / missing Vault entry must fail loud, not skip the wipe."""
-    staging_root = _isolated_home / ".minds-staging"
-    staging_root.mkdir()
+    staging_root = env_root_dir(DevEnvName("staging"))
+    staging_root.mkdir(parents=True)
     providers = _build_fake_providers(
         _make_call_log(),
         vault_responses={
@@ -1186,7 +1189,7 @@ def test_destroy_env_tier_refuses_when_supertokens_vault_entry_incomplete(
 
 def test_destroy_env_tier_full_step_order(_isolated_home: Path, _root_cg: ConcurrencyGroup) -> None:
     """End-to-end tier destroy: same step ordering as dev destroy (only resource-management ops differ + the generation-id removal is tier-only)."""
-    staging_root = _isolated_home / ".minds-staging"
+    staging_root = env_root_dir(DevEnvName("staging"))
     agents_dir = staging_root / "mngr" / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "agent-aaaa").mkdir()

--- a/apps/minds/imbue/minds/telegram/setup.py
+++ b/apps/minds/imbue/minds/telegram/setup.py
@@ -120,8 +120,8 @@ class TelegramSetupOrchestrator(MutableModel):
         aid = str(agent_id)
 
         # Check if already has credentials
-        if has_agent_bot_credentials(self.paths.data_dir, agent_id):
-            existing = load_agent_bot_credentials(self.paths.data_dir, agent_id)
+        if has_agent_bot_credentials(self.paths.app_support, agent_id):
+            existing = load_agent_bot_credentials(self.paths.app_support, agent_id)
             with self._lock:
                 self._statuses[aid] = TelegramSetupStatus.DONE
                 if existing is not None:
@@ -163,7 +163,7 @@ class TelegramSetupOrchestrator(MutableModel):
 
     def agent_has_telegram(self, agent_id: AgentId) -> bool:
         """Check whether the given agent has Telegram bot credentials."""
-        return has_agent_bot_credentials(self.paths.data_dir, agent_id)
+        return has_agent_bot_credentials(self.paths.app_support, agent_id)
 
     def wait_for_all(self, timeout: float = 10.0) -> None:
         """Wait for all background setup threads to finish."""
@@ -182,7 +182,7 @@ class TelegramSetupOrchestrator(MutableModel):
         try:
             with log_span("Setting up Telegram for agent {}", agent_id):
                 # Step 1: get or extract user credentials
-                user_credentials = load_telegram_user_credentials(self.paths.data_dir)
+                user_credentials = load_telegram_user_credentials(self.paths.app_support)
 
                 if user_credentials is None:
                     with self._lock:
@@ -190,7 +190,7 @@ class TelegramSetupOrchestrator(MutableModel):
 
                     logger.info("No stored Telegram credentials, opening browser for login...")
                     user_credentials = extract_telegram_credentials_from_browser()
-                    save_telegram_user_credentials(self.paths.data_dir, user_credentials)
+                    save_telegram_user_credentials(self.paths.app_support, user_credentials)
                 else:
                     logger.debug(
                         "Using stored Telegram credentials for {} (DC={})",
@@ -221,7 +221,7 @@ class TelegramSetupOrchestrator(MutableModel):
                 )
 
                 # Step 4: persist bot credentials
-                save_agent_bot_credentials(self.paths.data_dir, agent_id, bot_credentials)
+                save_agent_bot_credentials(self.paths.app_support, agent_id, bot_credentials)
 
                 with self._lock:
                     self._statuses[aid] = TelegramSetupStatus.DONE

--- a/apps/minds/imbue/minds/telegram/setup_test.py
+++ b/apps/minds/imbue/minds/telegram/setup_test.py
@@ -42,7 +42,7 @@ def test_generate_bot_display_name() -> None:
 
 
 def test_orchestrator_start_setup_returns_done_when_already_configured(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
     agent_id = AgentId()
 
@@ -65,7 +65,7 @@ def test_orchestrator_start_setup_returns_done_when_already_configured(tmp_path:
 
 
 def test_orchestrator_agent_has_telegram_returns_false_when_no_credentials(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
     agent_id = AgentId()
 
@@ -73,7 +73,7 @@ def test_orchestrator_agent_has_telegram_returns_false_when_no_credentials(tmp_p
 
 
 def test_orchestrator_agent_has_telegram_returns_true_when_credentials_exist(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
     agent_id = AgentId()
 
@@ -90,14 +90,14 @@ def test_orchestrator_agent_has_telegram_returns_true_when_credentials_exist(tmp
 
 
 def test_orchestrator_get_setup_info_returns_none_for_unknown_agent(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
 
     assert orchestrator.get_setup_info(AgentId()) is None
 
 
 def test_orchestrator_start_setup_skips_when_setup_already_in_progress(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
     agent_id = AgentId()
     aid = str(agent_id)
@@ -120,7 +120,7 @@ def test_orchestrator_start_setup_skips_when_setup_already_in_progress(tmp_path:
 
 
 def test_orchestrator_wait_for_all_returns_immediately_when_no_threads(tmp_path: Path) -> None:
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     orchestrator = TelegramSetupOrchestrator(paths=paths)
 
     orchestrator.wait_for_all(timeout=0.1)

--- a/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
+++ b/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
@@ -69,7 +69,7 @@ def test_telegram_status_returns_done_when_bot_credentials_exist(tmp_path: Path)
 
     # Pre-populate bot credentials
     save_agent_bot_credentials(
-        data_dir=orchestrator.paths.data_dir,
+        data_dir=orchestrator.paths.app_support,
         agent_id=agent_id,
         credentials=TelegramBotCredentials(
             bot_token=SecretStr("fake-token"),
@@ -103,7 +103,7 @@ def test_telegram_setup_returns_done_immediately_when_already_configured(tmp_pat
 
     # Pre-populate bot credentials
     save_agent_bot_credentials(
-        data_dir=orchestrator.paths.data_dir,
+        data_dir=orchestrator.paths.app_support,
         agent_id=agent_id,
         credentials=TelegramBotCredentials(
             bot_token=SecretStr("existing-token"),
@@ -169,7 +169,7 @@ def test_workspace_settings_shows_telegram_active_when_bot_exists(tmp_path: Path
 
     # Pre-populate bot credentials for one agent
     save_agent_bot_credentials(
-        data_dir=orchestrator.paths.data_dir,
+        data_dir=orchestrator.paths.app_support,
         agent_id=agent_id_1,
         credentials=TelegramBotCredentials(
             bot_token=SecretStr("active-token"),

--- a/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
+++ b/apps/minds/imbue/minds/telegram/test_telegram_endpoints.py
@@ -33,7 +33,7 @@ def _create_test_server_with_telegram(
         service_logs={str(agent_id): server_log},
     )
 
-    paths = WorkspacePaths(data_dir=tmp_path / "minds_data")
+    paths = WorkspacePaths.flat(tmp_path / "minds_data")
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
 
     app = create_desktop_client(
@@ -141,7 +141,7 @@ def _create_test_server_with_two_agents(
         },
     )
 
-    paths = WorkspacePaths(data_dir=tmp_path / "minds_data")
+    paths = WorkspacePaths.flat(tmp_path / "minds_data")
     telegram_orchestrator = TelegramSetupOrchestrator(paths=paths)
 
     app = create_desktop_client(

--- a/apps/minds/scripts/build.js
+++ b/apps/minds/scripts/build.js
@@ -420,10 +420,11 @@ function bakeBuildInfo() {
  *
  *   - MINDS_ROOT_NAME_BUNDLE: the MINDS_ROOT_NAME the runtime should
  *     export before launching `minds run`. Production builds use
- *     "minds" (so on-disk state lands in ~/.minds/); a staging build
- *     uses "minds-staging" (so state lands in ~/.minds-staging/ and
- *     never collides with an installed prod build). Must match the
- *     minds(-<env-name>)? shape enforced by the runtime bootstrap.
+ *     "minds" (so on-disk state lands under the production-tier roots);
+ *     a staging build uses "minds-staging" (so state lands under the
+ *     staging-tier roots and never collides with an installed prod
+ *     build). Must match the minds(-<env-name>)? shape enforced by the
+ *     runtime bootstrap.
  *
  * When both are unset, leaves _bundled/ empty -- this is the
  * `uv run minds run` / dev-mode case where the user is expected to

--- a/apps/minds/scripts/launch_to_msg_e2e.py
+++ b/apps/minds/scripts/launch_to_msg_e2e.py
@@ -78,6 +78,8 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from imbue.minds.config.data_types import MindsPaths
+
 
 class E2EFailure(Exception):
     """Raised for end-to-end drive failures specific to this script's domain.
@@ -94,13 +96,15 @@ class E2EFailure(Exception):
 # --- knobs (override via env) ---
 
 MINDS_APP_PATH = Path(os.environ.get("MINDS_APP_PATH", "/Applications/Minds.app/Contents/MacOS/Minds"))
-MINDS_HOME = Path(os.environ.get("HOME", "/Users/macrunner")) / ".minds"
-EVENTS_LOG = MINDS_HOME / "logs" / "minds-events.jsonl"
-ONE_TIME_CODES = MINDS_HOME / "auth" / "one_time_codes.json"
+# Resolve the platform-canonical roots the same way the app does -- honoring
+# MINDS_DATA_HOME, which CI sets so the whole run is self-contained.
+MINDS_PATHS = MindsPaths.for_root_name(os.environ.get("MINDS_ROOT_NAME", "minds"))
+EVENTS_LOG = MINDS_PATHS.logs / "minds-events.jsonl"
+ONE_TIME_CODES = MINDS_PATHS.app_support / "auth" / "one_time_codes.json"
 SCREENSHOT_DIR = Path(os.environ.get("LAUNCH_TO_MSG_SHOTS_DIR", "/tmp/launch-to-msg-screenshots"))
 SLACK_MOCK_STATE = Path("/tmp/slack-mock")
 SLACK_MOCK_PORT = 8443  # plain HTTP; socat terminates TLS on :443
-LATCHKEY_DIR = MINDS_HOME / "latchkey"
+LATCHKEY_DIR = MINDS_PATHS.app_support / "latchkey"
 
 HOST_NAME = os.environ.get("HOST_NAME") or f"e2e{time.strftime('%H%M%S')}"
 HOST_NAME_2 = os.environ.get("HOST_NAME_2") or f"{HOST_NAME}-b"
@@ -1236,7 +1240,7 @@ async def amain() -> int:
             # tile check above (which scrapes the same discovery layer the
             # destroy handler does).
             logger.info("=== mngr CLI list: cross-check W1 present, W2 removed ===")
-            bundled_mngr = MINDS_HOME / ".venv" / "bin" / "mngr"
+            bundled_mngr = MINDS_PATHS.app_support / ".venv" / "bin" / "mngr"
             if bundled_mngr.exists():
                 # mngr's lima provider shells out to ``limactl list --json``
                 # without going through the bundled-binary env vars (those
@@ -1249,7 +1253,7 @@ async def amain() -> int:
                 bundled_lima_bin = minds_resources / "lima" / "bin"
                 mngr_env = {
                     **os.environ,
-                    "MNGR_HOST_DIR": str(MINDS_HOME / "mngr"),
+                    "MNGR_HOST_DIR": str(MINDS_PATHS.mngr_host_dir),
                     "PATH": f"{bundled_lima_bin}:{os.environ.get('PATH', '')}",
                 }
                 # ``--on-error continue`` puts each provider's discovery error

--- a/apps/minds/scripts/mac-runner-reset.sh
+++ b/apps/minds/scripts/mac-runner-reset.sh
@@ -88,20 +88,36 @@ log "wiping leftover /tmp diagnostic artifacts from prior runs"
 # scripts that no longer exist.
 rm -f /tmp/minds-electron.log 2>/dev/null || true
 
-log "removing ~/.minds and /Applications/minds.app"
 # `rm -rf` can race against a not-yet-fully-dead Minds backend process that
-# is still writing to ~/.minds/Cache or ~/.minds/Code Cache. Retry a few
-# times with a short backoff before giving up.
-for attempt in 1 2 3 4 5; do
-  if rm -rf "$HOME/.minds" 2>/dev/null; then
-    break
-  fi
-  log "  rm ~/.minds attempt $attempt failed (likely still being written); waiting 2s"
-  sleep 2
-  if [[ $attempt -eq 5 ]]; then
-    log "  forcing one more pass with verbose errors"
-    rm -rf "$HOME/.minds" || true
-  fi
+# is still writing to a Chromium Cache / Code Cache dir. Retry a few times
+# with a short backoff before giving up.
+wipe_dir() {
+  local target="$1"
+  [[ -e "$target" ]] || return 0
+  for attempt in 1 2 3 4 5; do
+    if rm -rf "$target" 2>/dev/null; then
+      return 0
+    fi
+    log "  rm $target attempt $attempt failed (likely still being written); waiting 2s"
+    sleep 2
+  done
+  log "  forcing one more pass with verbose errors"
+  rm -rf "$target" || true
+}
+
+log "removing Minds state roots and /Applications/minds.app"
+# The override layout (CI sets MINDS_DATA_HOME) puts every root under one
+# tree; clear it wholesale.
+if [[ -n "${MINDS_DATA_HOME:-}" ]]; then
+  wipe_dir "$MINDS_DATA_HOME"
+fi
+# Platform-canonical macOS roots (used when MINDS_DATA_HOME is unset).
+wipe_dir "$HOME/Library/Application Support/Minds"
+wipe_dir "$HOME/Library/Caches/Minds"
+wipe_dir "$HOME/Library/Logs/Minds"
+# Legacy single-dotfolder roots from before the platform-dirs migration.
+for legacy in "$HOME"/.minds "$HOME"/.minds-*; do
+  wipe_dir "$legacy"
 done
 sudo rm -rf /Applications/minds.app
 

--- a/apps/minds/test_sse_redirect.py
+++ b/apps/minds/test_sse_redirect.py
@@ -52,7 +52,7 @@ def test_sse_redirect_on_done(tmp_path: Path) -> None:
     port = _find_free_port()
     code = OneTimeCode("test-sse-code-abc123")
 
-    paths = WorkspacePaths(data_dir=tmp_path)
+    paths = WorkspacePaths.flat(tmp_path)
     auth_store = FileAuthStore(data_directory=paths.auth_dir)
     auth_store.add_one_time_code(code=code)
     resolver = MngrCliBackendResolver()

--- a/dev/changelog/wz-minds-platform-dirs.md
+++ b/dev/changelog/wz-minds-platform-dirs.md
@@ -1,0 +1,5 @@
+The `minds-launch-to-msg` e2e workflow now sets `MINDS_DATA_HOME=$RUNNER_TEMP/minds`
+so the whole run is self-contained under one throwaway tree, independent of the
+self-hosted runner's home-dir state from past runs. Diagnostic-artifact
+collection reads from the new platform-canonical roots, and the runner-reset
+diagnostics list them.


### PR DESCRIPTION
Implements `specs/minds-platform-canonical-dirs/spec.md`.

Moves minds runtime state out of the single `~/.minds/` (and `~/.minds-<tier>/`)
dotfolder onto per-platform, per-category roots, with automatic migration on
first launch.

## Layout
Four roots, each with the tier (`production`/`staging`/`dev-<name>`) as its first
subdirectory:
- **macOS**: `~/Library/Application Support/Minds/<tier>/` (app support),
  `~/Library/Caches/Minds/<tier>/` (cache), `~/Library/Logs/Minds/<tier>/` (logs),
  `<app-support>/config/` (config).
- **Linux**: XDG data/cache/state/config dirs (honoring `XDG_*_HOME`).
- **`MINDS_DATA_HOME`** overrides all of it to
  `$MINDS_DATA_HOME/<tier>/{app_support,cache,logs,config}/`.

## Commit shape (Phase 1 → 4)
1. `bootstrap`: `MindsPaths` resolver + three-platform layout (no callsite changes)
2. `bootstrap_test`: resolution matrix (platform × tier × override; risk 5)
3. `minds`: route call sites through `MindsPaths`
4. (folded into 1) `minds_data_dir_for` kept as the legacy/`legacy_data_dir` alias
5. `minds`: one-shot startup migration **including** the `data.json` path rewrite
   (risk 1) — the two suggested Phase-2 commits are merged because moving the key
   material without rewriting the records pointing at it would be a broken
   intermediate
6. `externals`: Electron `paths.js`, `launch_to_msg_e2e.py`, `mac-runner-reset.sh`,
   and the CI workflow (`MINDS_DATA_HOME=$RUNNER_TEMP/minds`, risk 4)
7. `minds`: backwards-compat symlinks at the legacy `mngr/`+`ssh/` paths (risk 3)
8. `minds`: `minds env teardown` (clean local uninstall)
9. `docs`: README uninstall + data-location sections, changelog entries

## Risks handled explicitly
- **#1 data.json absolute paths**: migration rewrites the legacy prefix to the
  app-support prefix in `mngr/profiles/*/data.json`, validated as JSON.
- **#3 Lima bind mounts**: per-subdir compat symlinks (`mngr/`, `ssh/`) left at
  the old path so existing VMs keep booting (symlink-shim approach, not VM
  destroy).
- **#5 cross-tier collision**: `minds-dev-staging` → `dev-staging`, distinct from
  `minds-staging` → `staging` (test-covered).

## Verification
- `just test-quick apps/minds/imbue/minds/bootstrap_test.py` green (54 passed).
- `uv run ty check` clean.
- Manual real-FS run: `MINDS_DATA_HOME` round-trip lands files under the override
  tree (not `~/.minds`); darwin canonical layout resolves under `~/Library/...`;
  migration of a fake legacy `~/.minds` moves files, rewrites `data.json`, writes
  `migration.lock` + `MIGRATED.txt` + compat symlinks, and re-running is a no-op.
- CI `minds-launch-to-msg.yml` (canonical end-to-end) fired against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)