### PR TITLE
no dialog when using enterprise authentication in antigravity

### DIFF
--- a/libs/mngr_antigravity/changelog/mngr-agy-enterprise.md
+++ b/libs/mngr_antigravity/changelog/mngr-agy-enterprise.md
@@ -1,0 +1,1 @@
+Fixed the antigravity onboarding seed so it also skips agy's first-run NUX for users authenticated through an enterprise account. The seed now marks `enterpriseOnboardingComplete` as `True` (previously `False`), which was leaving enterprise-authenticated users stuck in the enterprise onboarding flow on their first message.

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
@@ -234,10 +234,18 @@ def build_onboarding_seed() -> dict[str, Any]:
     (theme + ToS/telemetry) is gated by this file's presence/content, not by any
     ``settings.json`` key (verified empirically); without it agy intercepts the
     first message with the onboarding flow.
+
+    All three completion flags are marked ``True`` so the seed suppresses the NUX
+    regardless of how the user authenticated. agy runs a *separate* onboarding
+    flow for enterprise accounts gated on ``enterpriseOnboardingComplete``, so a
+    user logged in through an enterprise account is still intercepted unless that
+    flag is set too. Marking both account types complete is safe -- this file
+    only records that the first-run flow has been seen, and seeding the flag for
+    an account type the user does not have is inert.
     """
     return {
         "consumerOnboardingComplete": True,
-        "enterpriseOnboardingComplete": False,
+        "enterpriseOnboardingComplete": True,
         "onboardingComplete": True,
     }
 

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config.py
@@ -235,13 +235,10 @@ def build_onboarding_seed() -> dict[str, Any]:
     ``settings.json`` key (verified empirically); without it agy intercepts the
     first message with the onboarding flow.
 
-    All three completion flags are marked ``True`` so the seed suppresses the NUX
-    regardless of how the user authenticated. agy runs a *separate* onboarding
-    flow for enterprise accounts gated on ``enterpriseOnboardingComplete``, so a
-    user logged in through an enterprise account is still intercepted unless that
-    flag is set too. Marking both account types complete is safe -- this file
-    only records that the first-run flow has been seen, and seeding the flag for
-    an account type the user does not have is inert.
+    All three flags are ``True`` so the seed suppresses the NUX regardless of how
+    the user authenticated: agy gates a separate enterprise onboarding flow on
+    ``enterpriseOnboardingComplete``, so it must be set too. Marking an account
+    type the user does not have complete is inert.
     """
     return {
         "consumerOnboardingComplete": True,

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/antigravity_config_test.py
@@ -139,7 +139,7 @@ def test_build_onboarding_seed_emits_the_three_nux_keys() -> None:
     seed = build_onboarding_seed()
     assert seed == {
         "consumerOnboardingComplete": True,
-        "enterpriseOnboardingComplete": False,
+        "enterpriseOnboardingComplete": True,
         "onboardingComplete": True,
     }
 

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
@@ -774,11 +774,7 @@ def test_provision_per_agent_settings_ignores_user_base_when_sync_disabled(
 def test_provision_writes_onboarding_seed(
     antigravity_agent_auto_dismiss: AntigravityAgent, isolated_home: Path
 ) -> None:
-    """Provisioning writes the NUX seed to the path agy reads, so its first-run flow doesn't intercept the first message.
-
-    The seed's *contents* are owned by ``test_build_onboarding_seed_emits_the_three_nux_keys``;
-    here we only assert provisioning persists that seed at the expected path.
-    """
+    """Provisioning persists the NUX seed at the path agy reads (contents owned by the builder's own unit test)."""
     agent = antigravity_agent_auto_dismiss
     _provision(agent)
     onboarding_path = get_antigravity_onboarding_cache_path(agent._get_agy_home_dir())

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
@@ -24,6 +24,7 @@ from imbue.mngr.providers.local.instance import LocalProviderInstance
 from imbue.mngr_antigravity.antigravity_config import CAPTURE_CONVERSATION_ID_SCRIPT_NAME
 from imbue.mngr_antigravity.antigravity_config import CLEAR_ACTIVE_MARKER_WHEN_IDLE_SCRIPT_NAME
 from imbue.mngr_antigravity.antigravity_config import SET_ACTIVE_MARKER_SCRIPT_NAME
+from imbue.mngr_antigravity.antigravity_config import build_onboarding_seed
 from imbue.mngr_antigravity.antigravity_config import get_antigravity_hooks_config_path
 from imbue.mngr_antigravity.antigravity_config import get_antigravity_oauth_token_path
 from imbue.mngr_antigravity.antigravity_config import get_antigravity_onboarding_cache_path
@@ -773,17 +774,17 @@ def test_provision_per_agent_settings_ignores_user_base_when_sync_disabled(
 def test_provision_writes_onboarding_seed(
     antigravity_agent_auto_dismiss: AntigravityAgent, isolated_home: Path
 ) -> None:
-    """The NUX seed is written so agy's first-run flow doesn't intercept the first message."""
+    """Provisioning writes the NUX seed to the path agy reads, so its first-run flow doesn't intercept the first message.
+
+    The seed's *contents* are owned by ``test_build_onboarding_seed_emits_the_three_nux_keys``;
+    here we only assert provisioning persists that seed at the expected path.
+    """
     agent = antigravity_agent_auto_dismiss
     _provision(agent)
     onboarding_path = get_antigravity_onboarding_cache_path(agent._get_agy_home_dir())
     assert onboarding_path.exists()
     seed = json.loads(onboarding_path.read_text())
-    assert seed == {
-        "consumerOnboardingComplete": True,
-        "enterpriseOnboardingComplete": True,
-        "onboardingComplete": True,
-    }
+    assert seed == build_onboarding_seed()
 
 
 def test_provision_symlinks_oauth_token_into_per_agent_home(

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/plugin_test.py
@@ -781,7 +781,7 @@ def test_provision_writes_onboarding_seed(
     seed = json.loads(onboarding_path.read_text())
     assert seed == {
         "consumerOnboardingComplete": True,
-        "enterpriseOnboardingComplete": False,
+        "enterpriseOnboardingComplete": True,
         "onboardingComplete": True,
     }
 


### PR DESCRIPTION
## Summary

`build_onboarding_seed` hardcoded `enterpriseOnboardingComplete: False`. That seed exists solely to suppress agy's first-run NUX, but agy runs a *separate* onboarding flow for enterprise accounts gated on that flag. So consumer-authenticated users got the NUX skipped, while enterprise-authenticated users were still intercepted by the enterprise onboarding flow on their first message.

This marks all three completion flags `True` so the seed suppresses the NUX regardless of how the user authenticated. Seeding the flag for an account type the user doesn't have is inert — the file only records that the first-run flow has been seen.

## Changes

- `antigravity_config.py`: `enterpriseOnboardingComplete` now `True`; docstring explains why.
- Updated assertions in `antigravity_config_test.py` and `plugin_test.py`.
- Added changelog entry.

## Verification

Ran the affected unit tests: `antigravity_config_test.py` (22 passed) and `plugin_test.py::test_provision_writes_onboarding_seed` (1 passed).

Note: the fix rests on the reported behavior that agy's enterprise onboarding flow keys on `enterpriseOnboardingComplete`; not live-tested against an actual enterprise account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)