### PR TITLE
minds: carve bundled-app runtime fixes out of #1317

### DIFF
--- a/apps/minds/.gitignore
+++ b/apps/minds/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 resources/
 dist/
+electron/build-info.json
 .visual-diff/

--- a/apps/minds/changelog/mngr-build-electron.md
+++ b/apps/minds/changelog/mngr-build-electron.md
@@ -1,0 +1,21 @@
+Bundled-app runtime fixes for the standalone minds.app, carved out of #1317 so they can land independently of that PR's mngr_forward / e2e / spec work.
+
+Electron runtime (`electron/`):
+- `main.js`: the macOS About panel now shows the git SHA the build was cut from (appended to ToDesktop's buildId), so a shipped binary maps back to a commit. DevTools auto-open is gated behind `MINDS_OPEN_DEVTOOLS=1` (the built-in cmd+opt+I shortcut crashes under BaseWindow + WebContentsViews).
+- `backend.js`: spawn `uv run --active` with `VIRTUAL_ENV` pointed at the per-user venv (`~/.minds/.venv`) instead of `<project>/.venv`, which lives inside the signed, read-only `.app` bundle and fails with "Operation not permitted" on macOS. Pass `MINDS_RESTIC_BINARY`, append `/opt/homebrew/bin` and `/usr/local/bin` to PATH (LaunchServices-started apps inherit a minimal PATH), and run the backend with `-v` so INFO-level lifecycle logs land in `minds.log`.
+- `env-setup.js`: `uv sync --active` plus an explicit `--reinstall-package` for every workspace package, so an upgrade actually re-extracts our freshly-built wheels (their PEP 440 version is unchanged across releases, so uv otherwise treats them as already-installed and the user keeps running stale code).
+- `paths.js`: add `getResticPath()`.
+- `pyproject/pyproject.toml`: list every bundled workspace package as a direct dependency with matching `[tool.uv.sources]` overrides (uv ignores source overrides for transitive-only packages and silently pulls stale PyPI versions).
+
+Build pipeline (`scripts/`):
+- `download-binaries.js`: download a per-platform `restic` binary (pinned, checksum-verified) into `resources/restic/`.
+- `ensure-binaries.js` (new): `prestart` hook that downloads only the missing bundled binaries for dev `pnpm start`.
+- `build.js`: download restic, build each workspace package to a wheel and rewrite the runtime pyproject + lockfile against those wheels, bake the git SHA into `build-info.json`, and bundle latchkey via `pnpm deploy --prod` (lockfile-pinned).
+- `build_test.py`: `test_workspace_package_lists_are_consistent` drift guard asserting the four copies of the workspace-package list agree; wheels-are-pure-Python / exclude-test-files acceptance checks; node-missing skip for the todesktop entitlement tests.
+
+Packaging:
+- `package.json`, `pnpm-workspace.yaml` (cross-platform `supportedArchitectures`), `pnpm-lock.yaml`, `todesktop.js` (sign the bundled restic), `.gitignore` (`electron/build-info.json`).
+
+Runtime restic discovery:
+- `desktop_client/restic_cli.py`: resolve restic from `MINDS_RESTIC_BINARY` (the bundled binary) before falling back to a PATH lookup.
+- `conftest.py`: point `MINDS_RESTIC_BINARY` at the bundled binary when present so tests don't need a system-wide restic install.

--- a/apps/minds/conftest.py
+++ b/apps/minds/conftest.py
@@ -18,6 +18,9 @@ backend guard AND the CI cleanup script (cleanup_old_modal_test_environments.py)
 both recognize.
 """
 
+import os
+from pathlib import Path
+
 import pytest
 
 from imbue.imbue_common.conftest_hooks import register_conftest_hooks
@@ -25,6 +28,21 @@ from imbue.imbue_common.conftest_hooks import register_marker
 from imbue.mngr.utils.logging import suppress_warnings
 from imbue.mngr.utils.plugin_testing import register_plugin_test_fixtures
 from imbue.mngr.utils.testing import generate_test_environment_name
+
+# Point ``MINDS_RESTIC_BINARY`` at the bundled ``resources/restic/restic``
+# binary so restic_cli tests don't require a system-wide restic install.
+# Mirrors what Electron's backend.js does at runtime: a Minds end user --
+# or a dev running tests -- should never have to ``brew install restic``.
+# Run unconditionally before any test module is imported; restic_cli.py
+# reads the env var lazily, so a late-setting fixture would also work,
+# but doing it here is one line and matches how the runtime flows.
+#
+# If ``resources/restic/restic`` doesn't exist (``pnpm build`` hasn't run),
+# leave the env var unset -- ensure_restic_available() then raises a
+# message that points at the right fix.
+_BUNDLED_RESTIC = Path(__file__).parent / "resources" / "restic" / "restic"
+if _BUNDLED_RESTIC.exists() and "MINDS_RESTIC_BINARY" not in os.environ:
+    os.environ["MINDS_RESTIC_BINARY"] = str(_BUNDLED_RESTIC)
 
 suppress_warnings()
 register_marker(

--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -204,8 +204,17 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
 
         uvBin = uvPath;
         args = [
+          // -v lifts INFO-level logs (lifecycle: "mngr observe started",
+          // "observe exited unexpectedly", etc.) into minds.log so user bug
+          // reports contain enough context to debug "Discovering agents..."
+          // hangs. Single v keeps noise manageable; -vv (DEBUG) is dev-only.
           'run', '--project', pyprojectDir,
-          'minds', '--format', 'jsonl',
+          // --active makes uv use VIRTUAL_ENV (~/.minds/.venv) instead of
+          // <project>/.venv, which is inside the signed .app bundle and
+          // read-only on macOS. Without this, `uv run` tries to create
+          // .venv inside the bundle and fails with "Operation not permitted".
+          '--active',
+          'minds', '-v', '--format', 'jsonl',
           '--log-file', path.join(logDir, 'minds-events.jsonl'),
           'run',
           '--host', '127.0.0.1',
@@ -214,9 +223,22 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
           ...configFileArgs,
         ];
         cwd = pyprojectDir;
+        // LaunchServices-started apps on macOS inherit a minimal PATH
+        // without /opt/homebrew/bin or /usr/local/bin. Append both so
+        // user-installed tools (`docker` from Docker Desktop, etc.) are
+        // reachable. Bundled uv/git/lima are prepended via their own
+        // absolute paths above. On Linux these dirs are also conventional
+        // (`/usr/local/bin` is std) and the append is harmless either way.
+        const systemPath = process.env.PATH || '';
+        const homebrewPaths = ['/opt/homebrew/bin', '/usr/local/bin'].filter(
+          (p) => !systemPath.split(':').includes(p)
+        ).join(':');
+        const augmentedSystemPath = homebrewPaths
+          ? `${systemPath}:${homebrewPaths}`
+          : systemPath;
         env = {
           ...process.env,
-          PATH: `${uvBinDir}:${gitBinDir}:${limaBinDir}:${process.env.PATH}`,
+          PATH: `${uvBinDir}:${gitBinDir}:${limaBinDir}:${augmentedSystemPath}`,
           UV_CACHE_DIR: uvCacheDir,
           UV_PYTHON_INSTALL_DIR: uvPythonDir,
           MINDS_ELECTRON: '1',
@@ -225,11 +247,14 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
           MNGR_PREFIX: mngrPrefix,
           MINDS_LATCHKEY_BINARY: paths.getLatchkeyPath(),
           MINDS_LATCHKEY_DIRECTORY: paths.getLatchkeyDirectory(),
+          MINDS_RESTIC_BINARY: paths.getResticPath(),
           // Tell the packaged latchkey shim which Electron binary to use as Node.
           MINDS_ELECTRON_EXEC_PATH: process.execPath,
+          // Set VIRTUAL_ENV to the per-user venv so `uv run --active` uses
+          // it. Without this, uv falls back to <project>/.venv which is
+          // inside the signed .app bundle (read-only on macOS).
+          VIRTUAL_ENV: paths.getVenvDir(),
         };
-        // Remove VIRTUAL_ENV to avoid uv warnings about path mismatches
-        delete env.VIRTUAL_ENV;
       }
 
       const child = spawn(uvBin, args, {

--- a/apps/minds/electron/env-setup.js
+++ b/apps/minds/electron/env-setup.js
@@ -30,10 +30,43 @@ function runEnvSetup(onProgress) {
 
     onProgress('Setting up environment...');
 
+    // Workspace packages that we ship as freshly-built wheels with each
+    // release. Their PEP 440 version (e.g. minds-0.1.0) stays the same
+    // across releases, so without an explicit reinstall hint uv considers
+    // them already-installed and skips updating them on upgrade -- the
+    // user keeps running the OLD code in ~/.minds/.venv even after the
+    // signed .app bundle has been replaced. Forcing --reinstall-package
+    // for each one makes `uv sync` re-extract our wheels every launch,
+    // while PyPI deps stay cached. This list is mirrored in
+    // scripts/build.js, electron/pyproject/pyproject.toml, and
+    // scripts/build_test.py; the drift guard
+    // test_workspace_package_lists_are_consistent in build_test.py fails
+    // if any of them disagree, so update all four together.
+    const WORKSPACE_PACKAGES = [
+      'minds',
+      'imbue-mngr',
+      'imbue-mngr-claude',
+      'imbue-mngr-forward',
+      'imbue-mngr-imbue-cloud',
+      'imbue-mngr-latchkey',
+      'imbue-mngr-lima',
+      'imbue-mngr-modal',
+      'imbue-mngr-ovh',
+      'imbue-mngr-vps-docker',
+      'imbue-common',
+      'concurrency-group',
+      'resource-guards',
+      'modal-proxy',
+    ];
+
     const args = [
       'sync',
       '--project', pyprojectDir,
+      // --active makes uv honor VIRTUAL_ENV instead of `<project-dir>/.venv`
+      // (which is inside the signed .app bundle and read-only on macOS).
+      '--active',
       '--python-preference', 'only-managed',
+      ...WORKSPACE_PACKAGES.flatMap((p) => ['--reinstall-package', p]),
     ];
 
     const env = {

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1,4 +1,4 @@
-const { BaseWindow, WebContentsView, Menu, Notification, ipcMain, net, shell, app, session, screen, dialog, clipboard } = require('electron');
+const { BaseWindow, WebContentsView, Menu, Notification, clipboard, dialog, ipcMain, net, shell, app, session, screen } = require('electron');
 const todesktop = require('@todesktop/runtime');
 const path = require('path');
 const fs = require('fs');
@@ -18,6 +18,25 @@ if (app.isPackaged) {
   });
 } else {
   console.log('[update] Skipping ToDesktop init (dev build -- not packaged)');
+}
+
+// Surface the git SHA the build was cut from in the standard macOS About
+// panel, appended to ToDesktop's buildId so you can map a shipped binary
+// back to a commit. Gated on app.isPackaged because dev runs do not
+// regenerate build-info.json and would otherwise show a stale SHA.
+if (app.isPackaged) {
+  try {
+    const { gitSha } = JSON.parse(fs.readFileSync(path.join(__dirname, 'build-info.json'), 'utf8'));
+    const pkg = require('../package.json');
+    const shortSha = gitSha.slice(0, 8);
+    app.setAboutPanelOptions({
+      applicationName: pkg.productName,
+      applicationVersion: pkg.version,
+      version: pkg.tdBuildId ? `${pkg.tdBuildId} · ${shortSha}` : shortSha,
+    });
+  } catch (err) {
+    console.warn(`[about-panel] Could not load build-info.json: ${err.message}`);
+  }
 }
 
 // Redirect Electron's userData directory to ~/.<MINDS_ROOT_NAME>/ so that dev
@@ -309,7 +328,10 @@ function createBundleWebContentsViews(win) {
   win.contentView.addChildView(chromeView);
   win.contentView.addChildView(contentView);
 
-  // Auto-open DevTools for dev-time inspection.
+  // Auto-open DevTools when MINDS_OPEN_DEVTOOLS=1 is set. The built-in
+  // cmd+opt+I shortcut hits an Electron menu handler that assumes a
+  // BrowserWindow (we use BaseWindow + WebContentsViews) and crashes;
+  // this env var is the escape hatch for dev-time inspection.
   if (process.env.MINDS_OPEN_DEVTOOLS === '1') {
     contentView.webContents.once('did-finish-load', () => {
       contentView.webContents.openDevTools({ mode: 'detach' });

--- a/apps/minds/electron/paths.js
+++ b/apps/minds/electron/paths.js
@@ -44,6 +44,22 @@ function getLimaBinDir() {
 }
 
 /**
+ * Path to the bundled restic binary used by the desktop client to
+ * provision and query per-workspace backup repositories.
+ *
+ * Both dev and packaged mode resolve to ``resources/restic/restic``:
+ * build.js downloads restic per target platform into that location via
+ * scripts/download-binaries.js. In dev, ``pnpm start`` runs the
+ * ``prestart`` hook (``node scripts/download-binaries.js``) so the
+ * binary is present before Electron boots, mirroring the bundled-app
+ * UX -- a Minds end user (or dev) should never have to install restic
+ * separately.
+ */
+function getResticPath() {
+  return path.join(getResourcesDir(), 'restic', 'restic');
+}
+
+/**
  * Path to the Latchkey CLI shipped as an npm dependency of this app.
  *
  * Dev mode: pnpm installs the package into ``apps/minds/node_modules`` and
@@ -214,6 +230,7 @@ module.exports = {
   getLimaBinDir,
   getLatchkeyPath,
   getLatchkeyDirectory,
+  getResticPath,
   getMindsRootName,
   getDataDir,
   getMngrHostDir,

--- a/apps/minds/electron/pyproject/pyproject.toml
+++ b/apps/minds/electron/pyproject/pyproject.toml
@@ -2,21 +2,51 @@
 name = "minds-desktop"
 version = "0.1.0"
 requires-python = "==3.12.13"
+# All workspace packages must be listed as direct dependencies so uv honors
+# the tool-uv-sources path overrides. uv ignores source overrides for
+# transitive-only packages and falls back to PyPI, which silently installs
+# stale published versions instead of our freshly built wheels.
+# This list (both [project] dependencies and [tool.uv.sources]) is mirrored
+# in scripts/build.js, electron/env-setup.js, and scripts/build_test.py; the
+# drift guard test_workspace_package_lists_are_consistent in build_test.py
+# fails if any of them disagree, so update all four together.
 dependencies = [
     "minds>=0.1.0",
+    "imbue-mngr>=0.2.0",
     "imbue-mngr-claude>=0.2.0",
+    "imbue-mngr-forward>=0.1.0",
+    "imbue-mngr-imbue-cloud>=0.1.0",
+    "imbue-mngr-latchkey>=0.1.0",
+    "imbue-mngr-lima>=0.1.0",
     "imbue-mngr-modal>=0.2.0",
+    "imbue-mngr-ovh>=0.1.0",
+    "imbue-mngr-vps-docker>=0.1.0",
+    "imbue-common>=0.1.0",
+    "concurrency-group>=0.1.0",
+    "resource-guards>=0.1.0",
+    "modal-proxy>=0.1.0",
 ]
 
-# Supply-chain hardening: refuse to resolve any distribution published less
-# than 14 days ago, so a freshly-compromised release cannot be pulled into an
-# end-user install during first-launch `uv sync`. Applies to all dependencies,
-# including transitive ones. Only affects resolution (e.g. re-locking), not
-# installation from an already-pinned lockfile.
+# Supply-chain hardening: rolling 14-day cooldown. Refuses any wheel /
+# source-dist resolved with an upload-time newer than `now - 14d`. Mirrors
+# the pnpm-workspace.yaml minimumReleaseAge gate so a freshly-compromised
+# release can't be pulled in before being noticed and yanked. Only bites
+# during resolution (`uv lock`); a frozen install replays the lockfile.
 [tool.uv]
 exclude-newer = "14 days"
 
 [tool.uv.sources]
 minds = { path = "../../../../apps/minds", editable = true }
+imbue-mngr = { path = "../../../../libs/mngr", editable = true }
 imbue-mngr-claude = { path = "../../../../libs/mngr_claude", editable = true }
+imbue-mngr-forward = { path = "../../../../libs/mngr_forward", editable = true }
+imbue-mngr-imbue-cloud = { path = "../../../../libs/mngr_imbue_cloud", editable = true }
+imbue-mngr-latchkey = { path = "../../../../libs/mngr_latchkey", editable = true }
+imbue-mngr-lima = { path = "../../../../libs/mngr_lima", editable = true }
 imbue-mngr-modal = { path = "../../../../libs/mngr_modal", editable = true }
+imbue-mngr-ovh = { path = "../../../../libs/mngr_ovh", editable = true }
+imbue-mngr-vps-docker = { path = "../../../../libs/mngr_vps_docker", editable = true }
+imbue-common = { path = "../../../../libs/imbue_common", editable = true }
+concurrency-group = { path = "../../../../libs/concurrency_group", editable = true }
+resource-guards = { path = "../../../../libs/resource_guards", editable = true }
+modal-proxy = { path = "../../../../libs/modal_proxy", editable = true }

--- a/apps/minds/imbue/minds/desktop_client/restic_cli.py
+++ b/apps/minds/imbue/minds/desktop_client/restic_cli.py
@@ -36,7 +36,23 @@ from imbue.minds.errors import BackupProvisioningError
 
 _T = TypeVar("_T")
 
-_RESTIC_BINARY: Final[str] = "restic"
+
+def _get_restic_binary() -> str:
+    """Resolve the restic CLI path.
+
+    Prefers ``MINDS_RESTIC_BINARY`` -- the bundled binary that ships in
+    ``resources/restic/restic``. Electron's backend.js sets it in both
+    dev and packaged mode (via ``paths.getResticPath()``); tests get it
+    from the session conftest. End users -- and devs running tests --
+    never need a system-wide restic install. Falls back to ``"restic"``
+    (PATH lookup) only as a last resort.
+
+    Resolved at every call site rather than at import time so a fixture
+    can set the env var before the first restic operation runs.
+    """
+    return os.environ.get("MINDS_RESTIC_BINARY") or "restic"
+
+
 # restic treats locks older than 30 minutes as stale and ignores them.
 _LOCK_STALE_SECONDS: Final[float] = 30 * 60.0
 _DEFAULT_TIMEOUT_SECONDS: Final[float] = 60.0
@@ -65,11 +81,19 @@ class ResticTransientAuthError(BackupProvisioningError):
 
 
 def ensure_restic_available() -> None:
-    """Raise ``ResticNotInstalledError`` if ``restic`` is not on PATH."""
-    if shutil.which(_RESTIC_BINARY) is None:
+    """Raise ``ResticNotInstalledError`` if ``restic`` cannot be located.
+
+    The bundled binary at ``resources/restic/restic`` is the expected
+    source; a missing binary means the dev tree hasn't run ``pnpm
+    build`` (which downloads restic) and ``pnpm start``'s ``prestart``
+    hook hasn't run either.
+    """
+    binary = _get_restic_binary()
+    if shutil.which(binary) is None:
         raise ResticNotInstalledError(
-            "restic is not installed on this machine; install it to enable backups "
-            "(https://restic.readthedocs.io/en/stable/020_installation.html)"
+            f"restic binary not found at {binary!r}. The minds build is supposed "
+            "to bundle it; run `pnpm build` in apps/minds/ to download "
+            "resources/restic/restic, or set MINDS_RESTIC_BINARY explicitly."
         )
 
 
@@ -87,7 +111,7 @@ def _run_restic(
     cg = parent_cg.make_concurrency_group(name="restic") if parent_cg is not None else ConcurrencyGroup(name="restic")
     with cg:
         return cg.run_process_to_completion(
-            command=[_RESTIC_BINARY, *args],
+            command=[_get_restic_binary(), *args],
             env=env,
             timeout=float(timeout_seconds),
             is_checked_after=False,

--- a/apps/minds/imbue/minds/test_ratchets.py
+++ b/apps/minds/imbue/minds/test_ratchets.py
@@ -134,7 +134,7 @@ def test_prevent_namedtuple() -> None:
 
 
 def test_prevent_yaml_usage() -> None:
-    rc.check_yaml_usage(_DIR, snapshot(0))
+    rc.check_yaml_usage(_DIR, snapshot(8))
 
 
 def test_prevent_functools_partial() -> None:

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,26 +1,30 @@
 {
   "name": "minds",
   "productName": "Minds",
-  "version": "0.1.0",
+  "version": "0.2.36",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",
   "author": "Imbue <dev@imbue.com>",
   "main": "electron/main.js",
   "scripts": {
+    "prestart": "node scripts/ensure-binaries.js",
     "start": "electron .",
     "build": "node scripts/build.js",
     "dist": "pnpm build && pnpm exec todesktop build",
     "todesktop:beforeInstall": "./scripts/download-binaries.js",
     "fetch-tailwind": "bash scripts/fetch_tailwind.sh",
-    "postinstall": "bash scripts/fetch_tailwind.sh"
+    "postinstall": "bash scripts/fetch_tailwind.sh",
+    "test:e2e": "playwright test --config=test/e2e/playwright.config.js"
   },
   "dependencies": {
     "@todesktop/runtime": "^1.6.0",
     "latchkey": "^2.15.1"
   },
   "devDependencies": {
+    "@todesktop/cli": "^1.8.0",
     "electron": "40.10.1",
-    "@todesktop/cli": "^1.8.0"
+    "@playwright/test": "1.60.0",
+    "playwright": "1.60.0"
   },
   "engines": {
     "node": "24.15.0",

--- a/apps/minds/pnpm-lock.yaml
+++ b/apps/minds/pnpm-lock.yaml
@@ -15,12 +15,18 @@ importers:
         specifier: ^2.15.1
         version: 2.15.1
     devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@todesktop/cli':
         specifier: ^1.8.0
         version: 1.23.2
       electron:
         specifier: 40.10.1
         version: 40.10.1
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
 
 packages:
 
@@ -595,6 +601,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -3197,6 +3208,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/apps/minds/pnpm-workspace.yaml
+++ b/apps/minds/pnpm-workspace.yaml
@@ -6,9 +6,21 @@ onlyBuiltDependencies:
 # freshly-compromised release therefore cannot be pulled in until it has had
 # time to be noticed and yanked. Only bites during resolution (e.g. `pnpm
 # install` without --frozen-lockfile, `pnpm add`, `pnpm update`); frozen
-# installs replay the existing lockfile unaffected. Available since pnpm
-# 10.16.0 (this app pins 10.33.4).
+# installs replay the existing lockfile unaffected.
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude:
   - latchkey
   - "@imbue-ai/detent"
+
+# ToDesktop builds every platform target from one host, but pnpm (like
+# npm) only installs optional deps matching the build host's
+# OS/arch/libc. Without these knobs, scripts/build.js's `pnpm deploy`
+# would omit the cross-platform native prebuilds (@napi-rs/keyring-*,
+# playwright fsevents, ...) and the shipped resources/latchkey/ would
+# crash on user platforms different from the builder's. Every variant
+# is already resolved in pnpm-lock.yaml, so this only changes WHICH
+# resolved entries get materialized, not which versions are picked.
+supportedArchitectures:
+  os: [current, darwin, linux, win32]
+  cpu: [current, x64, arm64]
+  libc: [current, glibc, musl]

--- a/apps/minds/scripts/build.js
+++ b/apps/minds/scripts/build.js
@@ -10,12 +10,96 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync, execFileSync } = require('child_process');
-const { downloadGit, downloadUv, download } = require('./download-binaries.js');
+const { downloadGit, downloadUv, downloadRestic, download } = require('./download-binaries.js');
 
 const ROOT = path.resolve(__dirname, '..');
 const RESOURCES_DIR = path.join(ROOT, 'resources');
 
-const LIMA_VERSION = '2.1.1';
+// Pinned at 2.0.3 to avoid the gvisor-tap-vsock TCP forwarder regression
+// introduced in lima 2.1.0. Lima 2.1.x's usernet forwarder (the path used
+// when the guest's systemd < 256, which includes Ubuntu 24.04, our FCT
+// base) wedges fresh ssh connections post-VM-READY: TCP-accepted on the
+// host then CLOSE_WAIT, no data flow to the in-VM sshd, no
+// git-receive-pack ever spawns -- mngr create hangs forever at
+// "Transferring git repository...". Root cause is the inetaf/tcpproxy
+// "half-close dance" leaking goroutines in io.Copy; lima a2b52885
+// (gvisor-tap-vsock 0.8.7 -> 0.8.8) is the regression boundary.
+// Tracked upstream as lima-vm/lima#4558 + #5042, no fix in flight yet.
+const LIMA_VERSION = '2.0.3';
+
+const MONOREPO_ROOT = path.resolve(ROOT, '../..');
+
+/**
+ * Workspace packages bundled into the standalone app. Each entry maps the
+ * package name (as it appears in `dependencies` / `[tool.uv.sources]`) to its
+ * path inside the monorepo.
+ *
+ * The packaged app only needs the transitive runtime closure of what minds
+ * imports; other workspace members (e.g. mngr_vps_docker, mngr_kanpan) are
+ * not included.
+ *
+ * This list is mirrored in electron/env-setup.js, electron/pyproject/
+ * pyproject.toml, and scripts/build_test.py. The drift guard
+ * `test_workspace_package_lists_are_consistent` in build_test.py fails if any
+ * of them disagree, so update all four together.
+ */
+const WORKSPACE_PACKAGES = {
+  'minds':                  'apps/minds',
+  'imbue-mngr':             'libs/mngr',
+  'imbue-mngr-claude':      'libs/mngr_claude',
+  'imbue-mngr-forward':     'libs/mngr_forward',
+  'imbue-mngr-imbue-cloud': 'libs/mngr_imbue_cloud',
+  'imbue-mngr-latchkey':    'libs/mngr_latchkey',
+  'imbue-mngr-lima':        'libs/mngr_lima',
+  'imbue-mngr-modal':       'libs/mngr_modal',
+  'imbue-mngr-ovh':         'libs/mngr_ovh',
+  'imbue-mngr-vps-docker':  'libs/mngr_vps_docker',
+  'imbue-common':           'libs/imbue_common',
+  'concurrency-group':      'libs/concurrency_group',
+  'resource-guards':        'libs/resource_guards',
+  'modal-proxy':            'libs/modal_proxy',
+};
+
+/**
+ * Build each workspace package as a wheel into `resources/wheels/`.
+ *
+ * Relies on each package's `pyproject.toml` (and hatchling's
+ * `[tool.hatch.build.targets.wheel]` config) to determine what goes into the
+ * wheel. In particular, the `exclude = [...]` line in each package's config
+ * is what keeps tests out of the wheel.
+ *
+ * Returns a map of package name → wheel filename, used downstream when
+ * rewriting `pyproject.toml` to reference the wheels.
+ */
+function buildWorkspaceWheels() {
+  const wheelsDir = path.join(RESOURCES_DIR, 'wheels');
+  fs.mkdirSync(wheelsDir, { recursive: true });
+
+  const wheelByPackage = {};
+  for (const name of Object.keys(WORKSPACE_PACKAGES)) {
+    execSync(`uv build --package ${JSON.stringify(name)} --wheel --out-dir ${JSON.stringify(wheelsDir)}`, {
+      cwd: MONOREPO_ROOT, stdio: 'inherit',
+    });
+    // Wheel filenames follow PEP 427: `{name}-{version}-{py}-{abi}-{platform}.whl`
+    // where `name` has hyphens normalized to underscores. Since we build
+    // serially and clean RESOURCES_DIR at the top of main(), exactly one
+    // wheel per package should exist with the expected prefix.
+    const normalized = name.replace(/-/g, '_');
+    const matches = fs.readdirSync(wheelsDir).filter(
+      (f) => f.endsWith('.whl') && f.startsWith(normalized + '-'),
+    );
+    if (matches.length !== 1) {
+      throw new Error(
+        `Expected exactly one wheel for ${name} (prefix "${normalized}-") in ${wheelsDir}, ` +
+        `found ${matches.length}: ${JSON.stringify(matches)}`,
+      );
+    }
+    wheelByPackage[name] = matches[0];
+    console.log(`Built wheel for ${name}: ${matches[0]}`);
+  }
+  return wheelByPackage;
+}
+
 
 function getPlatformArch() {
   const platform = process.platform;
@@ -98,50 +182,48 @@ function dereferenceSymlinksInPlace(root) {
 }
 
 /**
- * Resolve the on-disk package.json for a dependency as seen from a given
- * starting directory. Handles pnpm's layout (where transitive deps aren't
- * hoisted to the root node_modules) by threading the right search path.
- */
-function resolveInstalledPackage(name, fromDir) {
-  const packageJsonPath = require.resolve(`${name}/package.json`, {
-    paths: [fromDir],
-  });
-  return { packageJsonPath, pkg: readJson(packageJsonPath) };
-}
-
-/**
  * Bundle the latchkey npm CLI (plus all its runtime dependencies) into
  * ``resources/latchkey/``.
  *
  * Context:
  *   apps/minds is managed by pnpm, which installs each package into its own
  *   ``node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>/`` directory and
- *   wires up sibling symlinks for deps. Naively copying just the latchkey
- *   package directory leaves Node unable to resolve ``commander``, ``zod``,
- *   etc., because those live as siblings in the pnpm virtual store rather
- *   than as nested directories inside the package.
+ *   wires up sibling symlinks for deps. The store cannot be shipped inside
+ *   asar: copied symlinks break on relocate/sign and the packager can't
+ *   traverse the store.
  *
- *   To get a self-contained, portable bundle we do a fresh, flat
- *   ``npm install`` into a scratch staging directory and copy the resulting
- *   hoisted ``node_modules/`` tree wholesale into ``resources/latchkey/``.
+ *   ``pnpm deploy`` is the purpose-built tool for producing a
+ *   self-contained, copyable package directory. With ``inject-workspace-
+ *   packages=true`` (modern, non-legacy mode) it uses the workspace
+ *   lockfile to pin every transitive, so the bundled
+ *   ``playwright`` / ``playwright-core`` match exactly what
+ *   ``pnpm-lock.yaml`` resolved. We deploy the ``minds`` workspace
+ *   package itself with ``--prod`` to exclude minds' devDeps (the e2e
+ *   playwright + electron) and copy the resulting ``node_modules`` into
+ *   ``resources/latchkey/``.
  *
- * Platform-fanout (native prebuilds):
- *   Some deps use ``optionalDependencies`` to ship one platform-specific
- *   prebuilt native addon per target. Specifically:
- *     - ``@napi-rs/keyring`` fans out to ``@napi-rs/keyring-<os>-<arch>[-libc]``.
- *     - ``playwright`` has an optional ``fsevents`` for macOS.
- *   npm's default installer skips any optional dep whose ``os``/``cpu``
- *   doesn't match the build host, which breaks cross-platform packaging
- *   (todesktop builds multiple targets from one host). We sidestep that by
- *   listing every such fanout dep explicitly as a top-level dependency in
- *   the staging ``package.json`` (with ``--force`` so npm doesn't refuse
- *   them). The fanout set is read from each parent package's own
- *   ``optionalDependencies``, so it tracks upstream version bumps without
- *   manual intervention.
+ *   The ``--config`` flags steer the deploy:
+ *     - ``node-linker=hoisted`` produces a flat top-level layout (real
+ *       directories, not symlinks into a virtual store) so asar can
+ *       traverse it. Only ``node_modules/.bin/*`` retain internal
+ *       symlinks; dereferenceSymlinksInPlace() materializes those.
+ *     - ``ignore-scripts=true`` prevents playwright's postinstall from
+ *       downloading ~500MB of browser binaries into the bundle --
+ *       latchkey fetches Chromium lazily at runtime via ``ensure-browser``.
+ *     - ``inject-workspace-packages=true`` is the gate pnpm 10 requires
+ *       to use the modern (lockfile-respecting) deploy implementation.
+ *       It's a no-op for our case because minds has no workspace deps.
  *
- *   ``--ignore-scripts`` prevents playwright's postinstall from downloading
- *   ~500MB of browser binaries into the staging tree -- latchkey only uses
- *   playwright lazily, and any needed browsers are fetched at runtime.
+ *   Cross-platform native prebuilds (``@napi-rs/keyring-*``, playwright
+ *   ``fsevents``) come in via the workspace-level ``supportedArchitectures``
+ *   block in ``pnpm-workspace.yaml`` -- pnpm materializes every prebuild
+ *   variant listed there, regardless of the build host's OS/arch/libc.
+ *
+ *   ``@todesktop/runtime`` and its own transitives (electron-updater,
+ *   builder-util-runtime, ...) ride along because they're also prod deps
+ *   of minds. They sit next to latchkey in ``resources/latchkey/``
+ *   without colliding; the small extra weight is acceptable in exchange
+ *   for not having to compute a latchkey-only transitive closure.
  *
  * Runtime:
  *   A small shell shim at ``resources/latchkey/bin/latchkey`` invokes the
@@ -154,82 +236,38 @@ function bundleLatchkey() {
   const destNodeModules = path.join(destDir, 'node_modules');
   const destBinDir = path.join(destDir, 'bin');
 
-  // Discover versions and fanout sets from the already-pnpm-installed deps
-  // under apps/minds/node_modules/. This keeps the bundled versions in lock
-  // step with what dev mode and pnpm-lock.yaml pin. keyring and playwright
-  // are transitive deps of latchkey, so under pnpm they aren't hoisted to
-  // apps/minds/node_modules -- we resolve them starting from latchkey's own
-  // install directory.
-  const latchkey = resolveInstalledPackage('latchkey', ROOT);
-  const latchkeyDir = path.dirname(latchkey.packageJsonPath);
-  const keyring = resolveInstalledPackage('@napi-rs/keyring', latchkeyDir);
-  const playwright = resolveInstalledPackage('playwright', latchkeyDir);
-
-  const cliRelative =
-    typeof latchkey.pkg.bin === 'string'
-      ? latchkey.pkg.bin
-      : latchkey.pkg.bin && latchkey.pkg.bin.latchkey;
-  if (!cliRelative) {
-    throw new Error(`latchkey@${latchkey.pkg.version} is missing a "bin" entry`);
-  }
-
-  // Union of every platform-specific optional prebuild we want to guarantee
-  // is in the bundle, regardless of the build host's OS/arch/libc.
-  const fanoutDeps = {
-    ...(keyring.pkg.optionalDependencies || {}),
-    ...(playwright.pkg.optionalDependencies || {}),
-  };
-
   const stagingParent = fs.mkdtempSync(path.join(os.tmpdir(), 'minds-latchkey-'));
   try {
     const stagingDir = path.join(stagingParent, 'staging');
-    fs.mkdirSync(stagingDir, { recursive: true });
 
-    const stagingPackage = {
-      name: 'minds-latchkey-bundle',
-      version: '0.0.0',
-      private: true,
-      dependencies: {
-        latchkey: latchkey.pkg.version,
-        ...fanoutDeps,
-      },
-    };
-    fs.writeFileSync(
-      path.join(stagingDir, 'package.json'),
-      JSON.stringify(stagingPackage, null, 2) + '\n'
-    );
-
-    console.log(
-      `Installing latchkey@${latchkey.pkg.version} into staging with ` +
-      `${Object.keys(fanoutDeps).length} platform-fanout deps...`
-    );
+    console.log('Running pnpm deploy to stage latchkey + minds prod deps...');
     execFileSync(
-      'npm',
+      'pnpm',
       [
-        'install',
-        '--omit=dev',
-        '--ignore-scripts',
-        '--force',
-        '--no-audit',
-        '--no-fund',
-        '--no-package-lock',
+        '--filter', 'minds',
+        'deploy',
+        '--prod',
+        '--config.node-linker=hoisted',
+        '--config.ignore-scripts=true',
+        '--config.inject-workspace-packages=true',
+        stagingDir,
       ],
-      { cwd: stagingDir, stdio: 'inherit' }
+      { cwd: ROOT, stdio: 'inherit' }
     );
 
     const stagingNodeModules = path.join(stagingDir, 'node_modules');
     if (!fs.existsSync(path.join(stagingNodeModules, 'latchkey', 'package.json'))) {
       throw new Error(
-        `npm install did not produce latchkey under ${stagingNodeModules}`
+        `pnpm deploy did not produce latchkey under ${stagingNodeModules}`
       );
     }
 
     // Copy the flat, self-contained node_modules tree into resources/.
-    // dereference: true handles most symlinks, but nested symlinks (notably
-    // node_modules/.bin/*) end up pointing back at the source tree rather
-    // than being materialized as real files. dereferenceSymlinksInPlace()
-    // below walks the copied tree and fixes that up, so the bundle is fully
-    // self-contained and safe to package/sign/relocate.
+    // Top-level package directories are real (hoisted linker); only
+    // node_modules/.bin/* are symlinks (internal, relative to siblings).
+    // dereferenceSymlinksInPlace() materializes those as real files so
+    // macOS code-signing doesn't ENOENT on dangling targets after the
+    // scratch dir is removed.
     fs.mkdirSync(destDir, { recursive: true });
     fs.cpSync(stagingNodeModules, destNodeModules, {
       recursive: true,
@@ -238,6 +276,15 @@ function bundleLatchkey() {
     dereferenceSymlinksInPlace(destNodeModules);
   } finally {
     fs.rmSync(stagingParent, { recursive: true, force: true });
+  }
+
+  const latchkeyPkg = readJson(path.join(destNodeModules, 'latchkey', 'package.json'));
+  const cliRelative =
+    typeof latchkeyPkg.bin === 'string'
+      ? latchkeyPkg.bin
+      : latchkeyPkg.bin && latchkeyPkg.bin.latchkey;
+  if (!cliRelative) {
+    throw new Error(`latchkey@${latchkeyPkg.version} is missing a "bin" entry`);
   }
 
   // Emit the shim. It resolves the CLI relative to its own location so the
@@ -287,7 +334,7 @@ function bundleLatchkey() {
   execFileSync(process.execPath, [bundledCli, '--version'], { stdio: 'inherit' });
 
   console.log(
-    `latchkey@${latchkey.pkg.version} bundled at ${destNodeModules} ` +
+    `latchkey@${latchkeyPkg.version} bundled at ${destNodeModules} ` +
     `(shim: ${shimPath})`
   );
 }
@@ -338,31 +385,22 @@ async function downloadLima({ platform, arch }) {
   }
 }
 
-function copyPyproject() {
-  const srcDir = path.join(ROOT, 'electron', 'pyproject');
-  const destDir = path.join(RESOURCES_DIR, 'pyproject');
-  fs.mkdirSync(destDir, { recursive: true });
-
-  // Copy pyproject.toml, stripping any [tool.uv.sources] section that
-  // contains local editable paths (only valid in the monorepo layout)
-  const pyprojectSrc = path.join(srcDir, 'pyproject.toml');
-  if (fs.existsSync(pyprojectSrc)) {
-    let content = fs.readFileSync(pyprojectSrc, 'utf-8');
-    content = content.replace(/\[tool\.uv\.sources\][^\[]*/, '').trimEnd() + '\n';
-    fs.writeFileSync(path.join(destDir, 'pyproject.toml'), content);
-    console.log(`Copied pyproject.toml to ${destDir} (stripped local sources)`);
-  } else {
-    console.warn(`Warning: ${pyprojectSrc} not found`);
+/**
+ * Write the current git SHA into electron/build-info.json so the runtime
+ * can surface it in the About panel. Falls back to "unknown" if the
+ * working tree has no .git (e.g. building from a tarball).
+ */
+function bakeBuildInfo() {
+  let gitSha;
+  try {
+    gitSha = execSync('git rev-parse HEAD', { cwd: MONOREPO_ROOT }).toString().trim();
+  } catch (err) {
+    console.warn(`Could not resolve git SHA (${err.message}); falling back to "unknown".`);
+    gitSha = 'unknown';
   }
-
-  // Copy lockfile as-is
-  const lockSrc = path.join(srcDir, 'uv.lock');
-  if (fs.existsSync(lockSrc)) {
-    fs.copyFileSync(lockSrc, path.join(destDir, 'uv.lock'));
-    console.log(`Copied uv.lock to ${destDir}`);
-  } else {
-    console.warn(`Warning: ${lockSrc} not found`);
-  }
+  const buildInfoPath = path.join(ROOT, 'electron', 'build-info.json');
+  fs.writeFileSync(buildInfoPath, JSON.stringify({ gitSha }) + '\n');
+  console.log(`Bundled gitSha=${gitSha} -> ${buildInfoPath}`);
 }
 
 /**
@@ -466,6 +504,68 @@ function bundleClientConfig() {
   fs.writeFileSync(bundledRootNameFile, rootNameBundle + '\n');
   console.log(`Bundled ${resolvedConfig} -> ${bundledClient}`);
   console.log(`Bundled MINDS_ROOT_NAME=${rootNameBundle} -> ${bundledRootNameFile}`);
+
+  // The source-tree _bundled/ above ends up inside app.asar, which the
+  // Python backend subprocess cannot read. paths.js getBundledConfigDir()
+  // resolves the packaged-mode bundle under the pyproject resources dir
+  // (extraResources copies resources/ -> Resources/), so stage a second
+  // copy there on the real filesystem where `minds run --config-file`
+  // can reach it.
+  const packagedBundledDir = path.join(
+    RESOURCES_DIR,
+    'pyproject',
+    'imbue',
+    'minds',
+    'config',
+    'envs',
+    '_bundled'
+  );
+  fs.mkdirSync(packagedBundledDir, { recursive: true });
+  fs.copyFileSync(resolvedConfig, path.join(packagedBundledDir, 'client.toml'));
+  fs.writeFileSync(path.join(packagedBundledDir, 'root_name'), rootNameBundle + '\n');
+  console.log(`Staged bundled config for packaged runtime at ${packagedBundledDir}`);
+}
+
+/**
+ * Write `resources/pyproject/pyproject.toml` and regenerate `uv.lock`.
+ *
+ * Starts from `electron/pyproject/pyproject.toml` (the dev-time pyproject),
+ * replaces `[tool.uv.sources]` with entries pointing at the bundled wheels,
+ * and then runs `uv lock` in-place so the lockfile matches the rewritten
+ * pyproject. This re-resolves PyPI deps from scratch, which is fine -- they're
+ * the same deps, just locked against the new workspace source definitions.
+ */
+function stageRuntimePyproject(wheelByPackage) {
+  const srcDir = path.join(ROOT, 'electron', 'pyproject');
+  const destDir = path.join(RESOURCES_DIR, 'pyproject');
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const pyprojectSrc = path.join(srcDir, 'pyproject.toml');
+  let content = fs.readFileSync(pyprojectSrc, 'utf-8');
+
+  const sourceLines = ['[tool.uv.sources]'];
+  for (const [name, whlFile] of Object.entries(wheelByPackage)) {
+    sourceLines.push(`${name} = { path = "../wheels/${whlFile}" }`);
+  }
+  const newSources = sourceLines.join('\n') + '\n';
+
+  // Anchor at start-of-line so the literal "[tool.uv.sources]" substring
+  // inside the file-level docstring (a comment that names the section) is
+  // not mistaken for the section header itself.
+  const sectionRe = /^\[tool\.uv\.sources\][^\[]*/m;
+  if (sectionRe.test(content)) {
+    content = content.replace(sectionRe, newSources);
+  } else {
+    content = content.trimEnd() + '\n\n' + newSources;
+  }
+  fs.writeFileSync(path.join(destDir, 'pyproject.toml'), content);
+  console.log(`Staged pyproject.toml at ${destDir}`);
+
+  // Regenerate the lockfile against the rewritten pyproject. This is simpler
+  // and more robust than string-surgery on the dev-time uv.lock: uv emits the
+  // exact right shape for wheel-path sources itself.
+  execSync('uv lock', { cwd: destDir, stdio: 'inherit' });
+  console.log(`Regenerated uv.lock at ${destDir}`);
 }
 
 async function main() {
@@ -485,11 +585,14 @@ async function main() {
     downloadUv(RESOURCES_DIR, { platform, arch }),
     downloadLima({ platform, arch }),
     downloadGit(RESOURCES_DIR, { platform }),
+    downloadRestic(RESOURCES_DIR, { platform, arch }),
   ]);
 
   bundleLatchkey();
-  copyPyproject();
+  const wheelByPackage = buildWorkspaceWheels();
+  stageRuntimePyproject(wheelByPackage);
   bundleClientConfig();
+  bakeBuildInfo();
 
   console.log('\nBuild complete!');
   console.log(`Resources directory: ${RESOURCES_DIR}`);

--- a/apps/minds/scripts/build_test.py
+++ b/apps/minds/scripts/build_test.py
@@ -1,15 +1,204 @@
-"""Tests for the bundling contract that ``apps/minds/scripts/build.js`` relies on."""
+"""Tests for the bundling contract that ``apps/minds/scripts/build.js`` relies on.
+
+The build script calls ``uv build --package <name> --wheel`` for each workspace
+package it ships. Two properties are load-bearing:
+
+- Every bundled wheel must be pure Python (``py3-none-any``), because the
+  build is single-platform and the wheel is shipped to all platforms as-is.
+- Every bundled wheel must exclude test files, because the packaged app has
+  no use for them and shipping them bloats the bundle / exposes test-only
+  imports to the runtime.
+
+``test_workspace_wheel_is_pure_python`` and
+``test_workspace_wheel_excludes_test_files`` run ``uv build`` for each
+workspace package listed in ``WORKSPACE_PACKAGES`` and assert both
+properties. Because they exercise the real build toolchain and build every
+wheel, they are marked ``@pytest.mark.acceptance``.
+
+``test_workspace_package_lists_are_consistent`` is a fast, pure file-parsing
+drift guard (no toolchain, no network) and stays an unmarked integration
+test so it runs on every branch.
+"""
 
 import json
 import plistlib
+import re
 import shutil
 import subprocess
+import zipfile
 from pathlib import Path
 from typing import Final
 
+import pytest
+
+# The full set of workspace packages bundled into the standalone app. This
+# same set is hand-maintained in three other places:
+#   - apps/minds/scripts/build.js          (WORKSPACE_PACKAGES object)
+#   - apps/minds/electron/env-setup.js     (WORKSPACE_PACKAGES array)
+#   - apps/minds/electron/pyproject/pyproject.toml ([project.dependencies]
+#                                           and [tool.uv.sources])
+# test_workspace_package_lists_are_consistent below is the drift guard that
+# keeps all four in sync -- two production regressions (0.2.13, 0.2.25) came
+# from exactly this list drifting, so the guard is load-bearing.
+WORKSPACE_PACKAGES = [
+    "minds",
+    "imbue-mngr",
+    "imbue-mngr-claude",
+    "imbue-mngr-forward",
+    "imbue-mngr-imbue-cloud",
+    "imbue-mngr-latchkey",
+    "imbue-mngr-lima",
+    "imbue-mngr-modal",
+    "imbue-mngr-ovh",
+    "imbue-mngr-vps-docker",
+    "imbue-common",
+    "concurrency-group",
+    "resource-guards",
+    "modal-proxy",
+]
+
 APP_ROOT = Path(__file__).resolve().parents[1]
+MONOREPO_ROOT = Path(__file__).resolve().parents[3]
+TEST_PATTERN = re.compile(r"(^|/)(test_[^/]*\.py|[^/]+_test\.py|conftest\.py)$")
+
+
+@pytest.fixture(scope="module")
+def built_wheels(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    """Build every workspace package wheel once, share across tests in the module."""
+    out_dir = tmp_path_factory.mktemp("wheels")
+    wheels: dict[str, Path] = {}
+    for name in WORKSPACE_PACKAGES:
+        before = set(out_dir.iterdir())
+        subprocess.run(
+            ["uv", "build", "--package", name, "--wheel", "--out-dir", str(out_dir)],
+            cwd=MONOREPO_ROOT,
+            check=True,
+            capture_output=True,
+        )
+        produced = [p for p in out_dir.iterdir() if p not in before and p.suffix == ".whl"]
+        assert len(produced) == 1, f"Expected exactly one wheel for {name}, got {produced}"
+        wheels[name] = produced[0]
+    return wheels
+
+
+@pytest.mark.acceptance
+@pytest.mark.parametrize("package_name", WORKSPACE_PACKAGES)
+def test_workspace_wheel_is_pure_python(built_wheels: dict[str, Path], package_name: str) -> None:
+    """Every workspace wheel must be tagged py3-none-any.
+
+    If this ever fails, a workspace package has picked up a C extension or a
+    Python-version-specific dependency. The wheel-bundling strategy assumes
+    pure Python so one build ships to all platforms. Adding native code
+    requires per-platform wheel builds (see build.js).
+    """
+    whl = built_wheels[package_name]
+    # Wheel filename convention: {distribution}-{version}-{python tag}-{abi tag}-{platform tag}.whl
+    parts = whl.stem.split("-")
+    assert parts[-3:] == ["py3", "none", "any"], (
+        f"{whl.name} is not pure Python. Expected tags py3-none-any, got {parts[-3:]}. "
+        "Workspace packages must be pure Python for the current bundling strategy."
+    )
+
+
+@pytest.mark.acceptance
+@pytest.mark.parametrize("package_name", WORKSPACE_PACKAGES)
+def test_workspace_wheel_excludes_test_files(built_wheels: dict[str, Path], package_name: str) -> None:
+    """Wheels must not contain test files.
+
+    If this fails, the package's ``pyproject.toml`` is missing or has wrong
+    `exclude` rules under `[tool.hatch.build.targets.wheel]`. See e.g.
+    ``libs/imbue_common/pyproject.toml`` for the expected pattern.
+    """
+    with zipfile.ZipFile(built_wheels[package_name]) as zf:
+        leaks = [n for n in zf.namelist() if TEST_PATTERN.search(n)]
+    assert leaks == [], (
+        f"{built_wheels[package_name].name} contains test files that should be excluded: {leaks}. "
+        'Add `exclude = ["*_test.py", "test_*.py", "**/conftest.py"]` to '
+        "[tool.hatch.build.targets.wheel] in the package's pyproject.toml."
+    )
+
+
+def _parse_build_js_packages() -> set[str]:
+    """Extract the WORKSPACE_PACKAGES object keys from scripts/build.js.
+
+    The object literal looks like ``const WORKSPACE_PACKAGES = { 'name': 'path', ... };``
+    -- we slice out that block and pull every quoted key.
+    """
+    text = (APP_ROOT / "scripts" / "build.js").read_text()
+    match = re.search(r"const WORKSPACE_PACKAGES\s*=\s*\{(.*?)\};", text, re.DOTALL)
+    assert match is not None, "Could not locate WORKSPACE_PACKAGES object in build.js"
+    return set(re.findall(r"""['"]([^'"]+)['"]\s*:""", match.group(1)))
+
+
+def _parse_env_setup_js_packages() -> set[str]:
+    """Extract the WORKSPACE_PACKAGES array entries from electron/env-setup.js.
+
+    The array literal looks like ``const WORKSPACE_PACKAGES = [ 'name', ... ];``.
+    """
+    text = (APP_ROOT / "electron" / "env-setup.js").read_text()
+    match = re.search(r"const WORKSPACE_PACKAGES\s*=\s*\[(.*?)\];", text, re.DOTALL)
+    assert match is not None, "Could not locate WORKSPACE_PACKAGES array in env-setup.js"
+    return set(re.findall(r"""['"]([^'"]+)['"]""", match.group(1)))
+
+
+def _parse_pyproject_packages() -> tuple[set[str], set[str]]:
+    """Extract package names from electron/pyproject/pyproject.toml.
+
+    Returns ``(dependency_names, source_names)`` -- the names listed under
+    ``[project] dependencies`` (with version specifiers stripped) and the
+    keys under ``[tool.uv.sources]``. Both must mirror WORKSPACE_PACKAGES.
+    """
+    text = (APP_ROOT / "electron" / "pyproject" / "pyproject.toml").read_text()
+
+    deps_match = re.search(r"^dependencies\s*=\s*\[(.*?)\]", text, re.DOTALL | re.MULTILINE)
+    assert deps_match is not None, "Could not locate [project] dependencies in pyproject.toml"
+    # Strip PEP 508 version specifiers (>=, ==, etc.) to get the bare name.
+    dependency_names = {re.split(r"[><=!~ ]", entry)[0] for entry in re.findall(r'"([^"]+)"', deps_match.group(1))}
+
+    sources_match = re.search(r"^\[tool\.uv\.sources\]\n(.*?)(?=^\[|\Z)", text, re.DOTALL | re.MULTILINE)
+    assert sources_match is not None, "Could not locate [tool.uv.sources] in pyproject.toml"
+    source_names = set(re.findall(r"^([A-Za-z0-9_.-]+)\s*=", sources_match.group(1), re.MULTILINE))
+
+    return dependency_names, source_names
+
+
+def test_workspace_package_lists_are_consistent() -> None:
+    """Bidirectional drift guard across every place the bundled-package list lives.
+
+    The set of workspace packages shipped in the standalone app is hand-maintained
+    in four files: this test, scripts/build.js, electron/env-setup.js, and
+    electron/pyproject/pyproject.toml (both [project] dependencies and
+    [tool.uv.sources]). They MUST all agree -- two production regressions
+    (0.2.13, 0.2.25) were caused by this list drifting. Any package added to or
+    removed from one file but not the others fails here, naming the offender.
+    """
+    expected = set(WORKSPACE_PACKAGES)
+    dependency_names, source_names = _parse_pyproject_packages()
+    actual_by_source = {
+        "scripts/build.js": _parse_build_js_packages(),
+        "electron/env-setup.js": _parse_env_setup_js_packages(),
+        "electron/pyproject/pyproject.toml [project.dependencies]": dependency_names,
+        "electron/pyproject/pyproject.toml [tool.uv.sources]": source_names,
+    }
+    mismatches = {
+        source: sorted(found.symmetric_difference(expected))
+        for source, found in actual_by_source.items()
+        if found != expected
+    }
+    assert not mismatches, (
+        "Bundled workspace-package lists have drifted out of sync. "
+        f"build_test.py WORKSPACE_PACKAGES = {sorted(expected)}. "
+        f"Differences (symmetric difference vs the test's list) by file: {mismatches}. "
+        "Update every file so the package sets match exactly."
+    )
+
 
 _NODE_BINARY: Final[str | None] = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    _NODE_BINARY is None,
+    reason="evaluating apps/minds/todesktop.js requires a node binary on PATH",
+)
 
 
 def _load_todesktop_config() -> dict:
@@ -53,3 +242,66 @@ def test_bundled_limactl_is_signed_with_virtualization_entitlement() -> None:
         "todesktop.js mac.additionalBinariesToSign must include the bundled "
         f"limactl so it is signed with mac.entitlements; got {additional}."
     )
+
+
+def test_bundle_latchkey_uses_pnpm_deploy_against_lockfile() -> None:
+    """Guard: bundleLatchkey() must use ``pnpm deploy --prod`` so the shipped
+    latchkey tree is pinned by ``pnpm-lock.yaml``, not a fresh registry resolve.
+
+    The previous implementation did ``npm install --no-package-lock`` into a
+    scratch dir, which re-resolved every latchkey transitive from version
+    ranges at build time. That floated the shipped ``playwright`` /
+    ``playwright-core`` independently of dev/CI and already caused user-facing
+    breakage (playwright-core 1.60 internals shipped against latchkey code
+    expecting the pre-1.60 layout). If a future change reintroduces an
+    install path that bypasses the lockfile, this guard fails.
+    """
+    text = (APP_ROOT / "scripts" / "build.js").read_text()
+    match = re.search(r"function bundleLatchkey\(\) \{(.*?)\n\}\n", text, re.DOTALL)
+    assert match is not None, "Could not locate bundleLatchkey() in build.js"
+    body = match.group(1)
+
+    assert "'pnpm'" in body and "'deploy'" in body and "'--prod'" in body, (
+        "bundleLatchkey() must invoke `pnpm deploy --prod` so the shipped "
+        "latchkey tree is lockfile-pinned. See "
+        "/tmp/minds-build-js-pnpm-deploy-handoff.md for context."
+    )
+    forbidden = [
+        ("npm install", "'install'"),
+        ("--no-package-lock flag", "--no-package-lock"),
+    ]
+    for label, needle in forbidden:
+        assert needle not in body, (
+            f"bundleLatchkey() contains {label} ({needle!r}). That bypasses "
+            "pnpm-lock.yaml and floats the shipped playwright independently "
+            "of what dev/CI tested. Use `pnpm deploy --prod` instead."
+        )
+
+
+def test_pnpm_workspace_pins_cross_platform_architectures() -> None:
+    """Guard: pnpm-workspace.yaml must list every target platform under
+    ``supportedArchitectures`` so cross-platform native prebuilds
+    (@napi-rs/keyring-*, playwright fsevents, ...) materialize in the
+    ``pnpm deploy`` output regardless of the build host's OS/arch/libc.
+
+    ToDesktop runs ``pnpm build`` once per release on a single host, so the
+    bundle must contain prebuilds for every target. Without this block,
+    pnpm (like npm) only installs prebuilds matching the build host and the
+    shipped resources/latchkey/ would crash on user platforms different
+    from the builder's. Every variant is already resolved in
+    ``pnpm-lock.yaml``, so this only changes which resolved entries get
+    materialized.
+    """
+    text = (APP_ROOT / "pnpm-workspace.yaml").read_text()
+    assert "supportedArchitectures:" in text, (
+        "pnpm-workspace.yaml must declare supportedArchitectures so "
+        "scripts/build.js's `pnpm deploy` materializes cross-platform "
+        "native prebuilds."
+    )
+    for platform_name in ("darwin", "linux", "win32"):
+        assert platform_name in text, (
+            f"pnpm-workspace.yaml supportedArchitectures.os must include "
+            f"'{platform_name}' (the ToDesktop build targets it)."
+        )
+    for cpu in ("x64", "arm64"):
+        assert cpu in text, f"pnpm-workspace.yaml supportedArchitectures.cpu must include '{cpu}'."

--- a/apps/minds/scripts/download-binaries.js
+++ b/apps/minds/scripts/download-binaries.js
@@ -24,6 +24,7 @@ const { execSync } = require('child_process');
 const UV_VERSION = '0.11.15';
 const GIT_FOR_WINDOWS_VERSION = '2.49.0';
 const GIT_FOR_WINDOWS_TAG = `v${GIT_FOR_WINDOWS_VERSION}.windows.1`;
+const RESTIC_VERSION = '0.18.1';
 
 /**
  * SHA256 hashes for each downloaded archive, pinned by filename.
@@ -31,10 +32,12 @@ const GIT_FOR_WINDOWS_TAG = `v${GIT_FOR_WINDOWS_VERSION}.windows.1`;
  * Sources:
  * - uv: https://github.com/astral-sh/uv/releases/download/<version>/<file>.sha256
  * - MinGit: https://github.com/git-for-windows/git/releases/tag/<tag> release notes
+ * - restic: https://github.com/restic/restic/releases/download/v<version>/SHA256SUMS
  *
- * Update this map whenever UV_VERSION or GIT_FOR_WINDOWS_VERSION changes.
- * If a download hash doesn't match an entry here, the script aborts before
- * extracting or executing any downloaded bytes.
+ * Update this map whenever UV_VERSION, GIT_FOR_WINDOWS_VERSION, or
+ * RESTIC_VERSION changes. If a download hash doesn't match an entry
+ * here, the script aborts before extracting or executing any
+ * downloaded bytes.
  */
 const EXPECTED_SHA256 = {
   'uv-aarch64-apple-darwin.tar.gz':     '7e5b336108f8576eda1939920ca0a805b4a9a3c3d3eb2f6140e38b7092fbe4f3',
@@ -42,6 +45,10 @@ const EXPECTED_SHA256 = {
   'uv-x86_64-unknown-linux-gnu.tar.gz': 'b03e572f010bea94a4a52d42671ba72981e12894f71576181a1d26ff68546da7',
   'uv-x86_64-pc-windows-msvc.zip':      '04b98d414a9000e25e5e0e7c9f53749e66b790cdaffc582829e6f58c544ee11c',
   'MinGit-2.49.0-64-bit.zip':           '971cdee7c0feaa1e41369c46da88d1000a24e79a6f50191c820100338fb7eca5',
+  'restic_0.18.1_darwin_arm64.bz2':     '193fccc8bb4567b498923bc70261e104ff22be88016f0f108b035dad372ab711',
+  'restic_0.18.1_darwin_amd64.bz2':     'eb8543ed92ff1ddb67762daebf09f7bea4b0c37d21edb6a910bee3d4f514015f',
+  'restic_0.18.1_linux_amd64.bz2':      '680838f19d67151adba227e1570cdd8af12c19cf1735783ed1ba928bc41f363d',
+  'restic_0.18.1_windows_amd64.zip':    '0c1a713440578cb400d2e76208feb24f1b339426b075a21f73b6b2132692515d',
 };
 
 const MAX_REDIRECTS = 5;
@@ -66,6 +73,19 @@ function getUvDownloadUrl({ platform, arch }) {
     ? `uv-${arch}-apple-darwin`
     : `uv-${arch}-unknown-linux-gnu`;
   return `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${target}.tar.gz`;
+}
+
+function getResticDownloadUrl({ platform, arch }) {
+  // restic ships per-platform archives at
+  // restic_<ver>_<os>_<arch>.{bz2,zip}; Go-style arch names: amd64/arm64.
+  const goArch = arch === 'x86_64' ? 'amd64' : arch === 'aarch64' ? 'arm64' : null;
+  if (goArch === null) {
+    throw new Error(`Unsupported restic arch: ${arch}`);
+  }
+  if (platform === 'win32') {
+    return `https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_windows_${goArch}.zip`;
+  }
+  return `https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_${platform}_${goArch}.bz2`;
 }
 
 /**
@@ -182,6 +202,52 @@ async function downloadUv(resourcesDir, { platform, arch }) {
     fs.chmodSync(uvBinary, 0o755);
   }
   console.log(`[download-binaries] uv installed at ${uvBinary}`);
+}
+
+async function downloadRestic(resourcesDir, { platform, arch }) {
+  const resticDir = path.join(resourcesDir, 'restic');
+  if (fs.existsSync(resticDir)) fs.rmSync(resticDir, { recursive: true });
+  fs.mkdirSync(resticDir, { recursive: true });
+
+  const url = getResticDownloadUrl({ platform, arch });
+  const filename = path.basename(new URL(url).pathname);
+  console.log(`[download-binaries] Downloading restic from ${url}...`);
+
+  const archive = await download(url);
+  verifyChecksum(archive, filename);
+
+  const resticName = platform === 'win32' ? 'restic.exe' : 'restic';
+  const resticPath = path.join(resticDir, resticName);
+
+  if (platform === 'win32') {
+    const zipPath = path.join(resticDir, 'restic.zip');
+    fs.writeFileSync(zipPath, archive);
+    execSync(`powershell -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${resticDir}'"`, { stdio: 'inherit' });
+    fs.unlinkSync(zipPath);
+    // The archive ships the binary as restic_<ver>_windows_<arch>.exe;
+    // rename to restic.exe for a stable runtime path.
+    const stem = path.basename(filename, '.zip');
+    const extractedExe = path.join(resticDir, `${stem}.exe`);
+    if (fs.existsSync(extractedExe) && extractedExe !== resticPath) {
+      fs.renameSync(extractedExe, resticPath);
+    }
+    // Runtime resolves restic as 'restic' (no .exe); duplicate so both names work.
+    fs.copyFileSync(resticPath, path.join(resticDir, 'restic'));
+  } else {
+    // restic ships its bz2 as the bare binary (no tar wrapper). bunzip2 is
+    // available on macOS (BSD) and Linux by default; we stage the archive
+    // to a temp .bz2 and decompress in place.
+    const bzPath = path.join(resticDir, 'restic.bz2');
+    fs.writeFileSync(bzPath, archive);
+    execSync(`bunzip2 -f "${bzPath}"`, { stdio: 'inherit' });
+    // bunzip2 strips the .bz2 suffix, leaving resticDir/restic.
+    if (!fs.existsSync(resticPath)) {
+      throw new Error(`restic binary not found at ${resticPath} after bunzip2`);
+    }
+    fs.chmodSync(resticPath, 0o755);
+  }
+
+  console.log(`[download-binaries] restic installed at ${resticPath}`);
 }
 
 /**
@@ -313,7 +379,9 @@ async function downloadGit(resourcesDir, { platform }) {
  *
  * pnpm and Node are NOT provisioned here -- ToDesktop's `pnpmVersion`
  * and `nodeVersion` fields in `todesktop.js` cover that. This hook only
- * handles binaries ToDesktop has no first-class knob for: `uv` and `git`.
+ * handles binaries ToDesktop has no first-class knob for: `uv`, `git`,
+ * and `restic` (used by the desktop client to manage per-workspace
+ * backups).
  */
 async function downloadBinaries(resourcesDir) {
   const { platform, arch } = getPlatformArch();
@@ -322,6 +390,7 @@ async function downloadBinaries(resourcesDir) {
   await Promise.all([
     downloadUv(resourcesDir, { platform, arch }),
     downloadGit(resourcesDir, { platform }),
+    downloadRestic(resourcesDir, { platform, arch }),
   ]);
 
   console.log('[download-binaries] Done.');
@@ -339,6 +408,7 @@ async function beforeInstall({ appDir }) {
 
 beforeInstall.downloadGit = downloadGit;
 beforeInstall.downloadUv = downloadUv;
+beforeInstall.downloadRestic = downloadRestic;
 beforeInstall.download = download;
 module.exports = beforeInstall;
 

--- a/apps/minds/scripts/ensure-binaries.js
+++ b/apps/minds/scripts/ensure-binaries.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Lazy wrapper around scripts/download-binaries.js for `pnpm start`.
+ *
+ * download-binaries.js always re-downloads (the build path wants a
+ * clean slate). For dev mode we only want to download what's missing,
+ * so re-launching minds with `pnpm start` doesn't pay ~30MB of network
+ * every time. Check each expected output path; only invoke the full
+ * downloader when at least one is absent.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const RESOURCES = path.join(ROOT, 'resources');
+
+// Each entry is a path that must exist (post-download) for the bundle to
+// be considered complete. Mirror this with whatever bin/ paths the build
+// produces -- keep in sync with build.js + download-binaries.js outputs.
+const REQUIRED = [
+  path.join(RESOURCES, 'restic', 'restic'),
+  path.join(RESOURCES, 'uv', 'uv'),
+  path.join(RESOURCES, 'git', 'bin', 'git'),
+  path.join(RESOURCES, 'lima', 'bin', 'limactl'),
+];
+
+const missing = REQUIRED.filter((p) => !fs.existsSync(p));
+if (missing.length === 0) {
+  console.log('[ensure-binaries] All bundled binaries present; skipping download.');
+  process.exit(0);
+}
+
+console.log(
+  '[ensure-binaries] Missing bundled binaries:\n  ' +
+    missing.join('\n  ') +
+    '\n[ensure-binaries] Running scripts/download-binaries.js...'
+);
+execFileSync(process.execPath, [path.join(__dirname, 'download-binaries.js')], { stdio: 'inherit' });

--- a/apps/minds/todesktop.js
+++ b/apps/minds/todesktop.js
@@ -11,6 +11,9 @@ module.exports = {
   extraResources: [{ from: 'resources/', to: '.' }],
   mac: {
     entitlements: 'entitlements.mac.plist',
-    additionalBinariesToSign: ['resources/lima/bin/limactl'],
+    additionalBinariesToSign: [
+      'resources/lima/bin/limactl',
+      'resources/restic/restic',
+    ],
   },
 };


### PR DESCRIPTION
Carves the **bundled-app runtime fixes + build pipeline** out of #1317 (`wz/minds_onboard`) into a focused PR branched off `main`, so the bundle work can be reviewed and land independently of #1317's mngr_forward / e2e / spec changes.

The diff vs `main` is a strict subset of `wz/minds_onboard` vs `main`: every file below is the verbatim `wz/minds_onboard` version (the one exception is the minds yaml ratchet count, explained below).

## In scope — and why each is a "bundled-app runtime fix"

**Electron runtime (`apps/minds/electron/`)**
- `backend.js` — `uv run --active` + `VIRTUAL_ENV=~/.minds/.venv` (the in-bundle `<project>/.venv` is read-only on macOS → "Operation not permitted"); `MINDS_RESTIC_BINARY`; PATH augmented with `/opt/homebrew/bin` + `/usr/local/bin` (LaunchServices apps inherit a minimal PATH); `-v` so INFO logs reach `minds.log`.
- `env-setup.js` — `uv sync --active` + `--reinstall-package` per workspace package, so upgrades re-extract freshly-built wheels instead of keeping stale code in the per-user venv.
- `main.js` — About-panel git SHA; `MINDS_OPEN_DEVTOOLS=1` escape hatch.
- `paths.js` — `getResticPath()`.
- `pyproject/pyproject.toml` — workspace packages as direct deps + `[tool.uv.sources]` overrides.

**Build pipeline (`apps/minds/scripts/`)**
- `build.js` — restic download, per-package wheel build + runtime pyproject/lockfile rewrite, `build-info.json` SHA, latchkey via `pnpm deploy --prod`.
- `download-binaries.js` — per-platform restic downloader (pinned + checksum-verified).
- `ensure-binaries.js` (new) — `prestart` hook downloading only missing dev binaries.
- `build_test.py` — `test_workspace_package_lists_are_consistent` drift guard + wheel purity/test-exclusion acceptance checks.

**Packaging**
- `package.json`, `pnpm-workspace.yaml` (`supportedArchitectures`), `pnpm-lock.yaml`, `todesktop.js` (sign bundled restic), `.gitignore` (`electron/build-info.json`).

**Runtime restic discovery (bundle wiring)**
- `desktop_client/restic_cli.py` — resolve restic from `MINDS_RESTIC_BINARY` (the matched pair for backend.js setting it).
- `conftest.py` — point `MINDS_RESTIC_BINARY` at the bundled binary in tests.

**Ratchet**
- `imbue/minds/test_ratchets.py` — yaml count `0 → 8`, accounting for the `pnpm-lock.yaml` / `pnpm-workspace.yaml` filename references in the carried `build_test.py` assertion strings. Recomputed against this branch's tree (not wz's, which also counts the feature files left out of this carve-out). No other ratchet counts change.

## Explicitly NOT in scope (stays in #1317)
mngr_forward subdomain self-heal, the `mngr_lima` 1800s timeout, `launch_to_msg_e2e.py` + `minds-launch-to-msg.yml`, the `minds-macos-launch.yml` smoke suite + `test/e2e/*`, `specs/minds-platform-canonical-dirs`, and the unrelated `desktop_client` feature work (agent_creator, first_launch_prefetch, laptop_agent_types_seed, destroying, templates, cli/run.py).

## Verification
- `test_workspace_package_lists_are_consistent` + full minds ratchets pass locally (57 passed).
- `pnpm install --frozen-lockfile` (node 24.15.0, pnpm 10.33.4) succeeds → `test-docker-electron` install step consistent.
- All carried JS files pass `node --check`.
- The 4 local restic integration-test failures are pre-existing and environmental (the test file runs restic integration tests unconditionally and fails-not-skips without a system restic, which CI images provide); restic_cli.py's change is behavior-preserving when `MINDS_RESTIC_BINARY` is unset.

After this lands, `wz/minds_onboard` should be rebased onto main; #1317 keeps the out-of-scope changes.

Relates to #1317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)