### PR TITLE
fix bad merge

### DIFF
--- a/libs/mngr_usage/changelog/mngr-fix-main.md
+++ b/libs/mngr_usage/changelog/mngr-fix-main.md
@@ -1,0 +1,1 @@
+Fixed a type error introduced when an older branch merged into main: `mngr_usage`'s usage-preservation code referenced `VolumeFileType`, which had been renamed to `FileType` in `imbue.mngr.interfaces.data_types`. Updated the import and references to use `FileType`.

--- a/libs/mngr_usage/imbue/mngr_usage/preservation.py
+++ b/libs/mngr_usage/imbue/mngr_usage/preservation.py
@@ -38,8 +38,8 @@ from imbue.mngr.api.preservation import get_local_preserved_agent_dir
 from imbue.mngr.api.preservation import preserve_agent_data
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.interfaces.data_types import AgentDetails
+from imbue.mngr.interfaces.data_types import FileType
 from imbue.mngr.interfaces.data_types import HostDetails
-from imbue.mngr.interfaces.data_types import VolumeFileType
 from imbue.mngr.interfaces.host import HostFileReadInterface
 from imbue.mngr.interfaces.provider_instance import build_agent_details_from_offline_ref
 from imbue.mngr.primitives import AgentId
@@ -93,12 +93,12 @@ def _discover_usage_items(source: HostFileReadInterface, agent_state_dir: Path) 
     events_dir = agent_state_dir / EVENTS_DIR_NAME
     items: list[PreservedItem] = []
     for entry in source.list_directory(events_dir):
-        if entry.file_type != VolumeFileType.DIRECTORY:
+        if entry.file_type != FileType.DIRECTORY:
             continue
         source_name = Path(entry.path).name
         usage_rel = f"{EVENTS_DIR_NAME}/{source_name}/{USAGE_DIR_NAME}"
         if source.path_exists(agent_state_dir / usage_rel):
-            items.append(PreservedItem(rel_path=usage_rel, kind=VolumeFileType.DIRECTORY))
+            items.append(PreservedItem(rel_path=usage_rel, kind=FileType.DIRECTORY))
     return items
 
 
@@ -123,7 +123,7 @@ def preserve_agent_usage(
     items = _discover_usage_items(source, agent_state_dir)
     if not items:
         return
-    items.append(PreservedItem(rel_path=_DATA_JSON_FILENAME, kind=VolumeFileType.FILE))
+    items.append(PreservedItem(rel_path=_DATA_JSON_FILENAME, kind=FileType.FILE))
 
     dest_root = get_local_preserved_agent_dir(mngr_ctx, agent_name, agent_id)
     with log_span("Preserving usage data for agent {}", agent_name):


### PR DESCRIPTION
## Summary

The merge of the older `mngr/preserve-usage` branch (PR #1860) brought in `libs/mngr_usage/imbue/mngr_usage/preservation.py`, which still referenced `VolumeFileType` from `imbue.mngr.interfaces.data_types`. On main that enum had been renamed to `FileType` (the sibling `imbue.mngr.api.preservation` already used the new name), so the import and its three usages were dangling and produced a type error.

This updates the import and all three references to `FileType`.

## Testing

- `uv run ty check libs/mngr_usage/imbue/mngr_usage/preservation.py`: All checks passed
- `just test-quick libs/mngr_usage/imbue/mngr_usage/preservation_test.py`: 10 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)