### PR TITLE
Coerce static SSH host entries during config loading

### DIFF
--- a/libs/mngr/changelog/danver-investigate-ssh.md
+++ b/libs/mngr/changelog/danver-investigate-ssh.md
@@ -1,0 +1,15 @@
+Fixed a crash that made statically-configured SSH hosts unusable, and added documentation for the SSH provider.
+
+- Static `[providers.<pool>.hosts.<host>]` tables defined in `settings.toml` previously crashed every
+  host-enumerating command (`mngr list`, `mngr connect`, `mngr create <agent>@<host>.<pool>`, ...) with
+  `AttributeError: 'dict' object has no attribute 'key_file'`. Provider configs are built with
+  `model_construct` (to keep unset top-level fields `None` for config-layer merging), which does not
+  coerce nested values, so each host entry stayed a raw dict instead of an `SSHHostConfig` and blew up
+  as soon as the backend touched it. The config loader now coerces nested pydantic-model fields (the
+  only one today being the SSH provider's `hosts` map) after `model_construct`, so static SSH hosts load
+  and resolve correctly. A malformed host entry now produces a clear `providers.<pool>.hosts` config
+  error instead of a late crash.
+- Added an [SSH provider documentation page](../docs/core_plugins/providers/ssh.md) covering host
+  configuration (`address`/`port`/`user`/`key_file`/`known_hosts_file`), the dynamic-hosts file, the
+  `NAME@HOST.PROVIDER` form for running an agent on a configured host, and the provider's limitations
+  (no host creation/snapshots/tags). Registered the `ssh` backend in the provider concepts doc.

--- a/libs/mngr/docs/concepts/providers.md
+++ b/libs/mngr/docs/concepts/providers.md
@@ -21,6 +21,15 @@ profile = "development"
 backend = "docker"
 host = "ssh://user@server"
 
+# A pool of pre-existing machines reached over SSH (see the ssh provider page).
+[providers.my-ssh-pool]
+backend = "ssh"
+
+[providers.my-ssh-pool.hosts.myvm]
+address = "192.168.1.100"
+user = "root"
+key_file = "~/.ssh/id_ed25519"
+
 [providers.team-mngr]
 backend = "mngr"
 url = "https://mngr.internal.company.com"
@@ -37,6 +46,10 @@ Runs agents directly on your machine with no isolation. Always available--no con
 Runs agents in Docker containers. Available as long as `docker` is installed.
 
 Provides container isolation while keeping everything local or on a remote Docker daemon. Uses SSH for host operations after initial container setup.
+
+### ssh
+
+Runs agents on pre-existing hosts you reach over SSH (e.g. a VM you already own). Unlike `local` and `docker`, it has no usable default instance: you must configure a pool of hosts (it does not create, destroy, or snapshot hosts). Target a configured host with the `NAME@HOST.PROVIDER` address form. See the [ssh provider page](../core_plugins/providers/ssh.md) for the full configuration and host schema.
 
 ## Responsibilities
 

--- a/libs/mngr/docs/core_plugins/providers/ssh.md
+++ b/libs/mngr/docs/core_plugins/providers/ssh.md
@@ -1,0 +1,89 @@
+# SSH Provider
+
+The SSH provider runs agents on **pre-existing hosts** that you reach over SSH (for example, a VM or bare-metal box you already own). Unlike cloud providers, it does **not** create, destroy, stop, start, or snapshot hosts -- the machines must already exist and be reachable. mngr connects to them via pyinfra's SSH connector and manages agents on top.
+
+Hosts are **statically configured** in your mngr settings (or registered dynamically; see [Dynamic hosts](#dynamic-hosts) below). The SSH provider does not support creating hosts, so you target an existing configured host by name rather than asking for a new one.
+
+## Configuration
+
+Define an SSH provider instance and one table per host under it:
+
+```toml
+[providers.my-ssh-pool]
+backend = "ssh"
+# host_dir = "/tmp/mngr"   # optional: where mngr keeps its state on the remote hosts
+
+[providers.my-ssh-pool.hosts.myvm]
+address = "192.168.1.100"          # hostname or IP (required)
+port = 22                          # optional, default 22
+user = "root"                      # optional, default "root"
+key_file = "~/.ssh/id_ed25519"     # optional: path to the SSH private key (~ is expanded)
+# known_hosts_file = "~/.ssh/known_hosts"  # optional: enables strict host-key checking
+```
+
+You can list as many hosts as you like under one pool:
+
+```toml
+[providers.my-ssh-pool.hosts.web1]
+address = "10.0.0.11"
+
+[providers.my-ssh-pool.hosts.web2]
+address = "10.0.0.12"
+user = "ubuntu"
+key_file = "~/.ssh/deploy_key"
+```
+
+### Host fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `address` | yes | -- | SSH hostname or IP address |
+| `port` | no | `22` | SSH port |
+| `user` | no | `root` | SSH username |
+| `key_file` | no | none | Path to the SSH private key (`~` is expanded). If omitted, your ssh-agent / default keys are used. |
+| `known_hosts_file` | no | none | Path to a `known_hosts` file. When set, strict host-key checking is enabled for that host. |
+
+## Usage
+
+Because the SSH provider cannot create hosts, target an **existing** configured host using the `NAME@HOST.PROVIDER` address form (`HOST` is the host name from your config, `PROVIDER` is the pool name):
+
+```bash
+# Run a claude agent named "my-agent" on the configured host "myvm" in "my-ssh-pool"
+mngr create my-agent@myvm.my-ssh-pool claude
+```
+
+List what the provider can see:
+
+```bash
+mngr list --provider my-ssh-pool
+```
+
+Do **not** use the `NAME@.PROVIDER` form (or `--new-host`) with the SSH provider -- that asks mngr to create a new host, which this provider does not support and will reject.
+
+## Dynamic hosts
+
+In addition to the static `hosts` tables above, an SSH pool reads hosts from a TOML file so other tooling can register hosts at runtime. By default this is:
+
+```
+<profile_dir>/providers/<instance-name>/dynamic_hosts.toml
+```
+
+Override the path with `dynamic_hosts_file` on the provider:
+
+```toml
+[providers.my-ssh-pool]
+backend = "ssh"
+dynamic_hosts_file = "~/.mngr/my-ssh-pool-hosts.toml"
+```
+
+The file uses the same per-host schema as the static `hosts` tables (one `[<host-name>]` table per host). If a host name appears in both the static config and the dynamic file, the static config wins. Malformed entries in the dynamic file are skipped with a warning rather than aborting discovery.
+
+## Limitations
+
+The SSH provider connects to machines it does not own, so several provider features are intentionally unsupported and will raise if invoked:
+
+- **No host lifecycle**: cannot create, destroy, stop, or start hosts (they are pre-existing).
+- **No snapshots**: there is no cloud infrastructure to snapshot.
+- **No volumes**.
+- **No tags**: hosts are statically configured, so tags are neither stored nor mutable.
+- **No outer host**: `mngr exec --outer` has nothing to target (the configured machine *is* the host).

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -591,6 +591,14 @@ def _coerce_nested_model_fields(
     None-for-unset merge semantics for unset fields are both unaffected. Nested
     entries are atomic (validated as a unit), which is why coercing them does not
     interfere with the layer merge. Returns a new dict; the input is not mutated.
+
+    Unlike ``_check_unknown_fields``, this does not take ``strict``/``silent``: a
+    malformed nested value is always fatal. Downgrading to warn-and-skip is not an
+    option here, because the only way to "skip" coercion is to leave the raw dict
+    in place -- which reintroduces the exact late ``AttributeError`` this function
+    exists to prevent. A clear ``ConfigParseError`` at parse time is strictly
+    better, and this path was already a hard crash before coercion existed, so
+    always raising is not a forward-compat regression.
     """
     result = dict(raw_config)
     for field_name, value in raw_config.items():

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from typing import Any
 from typing import Final
 from typing import Sequence
+from typing import get_args
 from uuid import uuid4
 
 import pluggy
 from loguru import logger
 from pydantic import BaseModel
+from pydantic import TypeAdapter
+from pydantic import ValidationError
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
@@ -559,6 +562,48 @@ def _check_unknown_fields(
             del raw_config[key]
 
 
+def _annotation_references_model(annotation: Any) -> bool:
+    """Whether a field annotation is a pydantic model or contains one as a type
+    argument (e.g. ``SSHHostConfig``, ``dict[str, SSHHostConfig]``,
+    ``list[SSHHostConfig]``, ``SSHHostConfig | None``).
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return True
+    return any(_annotation_references_model(arg) for arg in get_args(annotation))
+
+
+def _coerce_nested_model_fields(
+    raw_config: dict[str, Any],
+    config_class: type[BaseModel],
+    context: str,
+) -> dict[str, Any]:
+    """Validate fields whose declared type involves a nested pydantic model.
+
+    Provider configs are built with ``model_construct`` (see ``_parse_providers``)
+    so that unset top-level fields stay ``None`` for config-layer merging. But
+    ``model_construct`` does not coerce values, so a nested-model field such as
+    ``SSHProviderConfig.hosts`` (``dict[str, SSHHostConfig]``) would keep its raw
+    TOML dicts and blow up the moment the backend accessed an attribute on them
+    (``AttributeError: 'dict' object has no attribute 'key_file'``).
+
+    Only fields actually present in ``raw_config`` are touched, and only those
+    whose annotation references a pydantic model, so scalar fields and the
+    None-for-unset merge semantics for unset fields are both unaffected. Nested
+    entries are atomic (validated as a unit), which is why coercing them does not
+    interfere with the layer merge. Returns a new dict; the input is not mutated.
+    """
+    result = dict(raw_config)
+    for field_name, value in raw_config.items():
+        field_info = config_class.model_fields.get(field_name)
+        if field_info is None or not _annotation_references_model(field_info.annotation):
+            continue
+        try:
+            result[field_name] = TypeAdapter(field_info.annotation).validate_python(value)
+        except ValidationError as e:
+            raise ConfigParseError(f"Invalid value for '{context}.{field_name}': {e}") from e
+    return result
+
+
 def _parse_providers(
     raw_providers: dict[str, dict[str, Any]],
     disabled_plugins: frozenset[str],
@@ -614,6 +659,7 @@ def _parse_providers(
                 logger.warning(msg)
             continue
         _check_unknown_fields(raw_config, config_class, f"providers.{name}", strict=strict, silent=silent)
+        raw_config = _coerce_nested_model_fields(raw_config, config_class, f"providers.{name}")
         providers[ProviderInstanceName(name)] = config_class.model_construct(**raw_config)
 
     return providers

--- a/libs/mngr/imbue/mngr/providers/ssh/backend_test.py
+++ b/libs/mngr/imbue/mngr/providers/ssh/backend_test.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.loader import parse_config
+from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.ssh.backend import SSHProviderBackend
@@ -158,3 +160,41 @@ def test_ssh_host_config_defaults() -> None:
     assert config.port == 22
     assert config.user == "root"
     assert config.key_file is None
+
+
+def test_static_hosts_from_settings_dict_are_coerced(temp_mngr_ctx: MngrContext) -> None:
+    """Static ``[providers.*.hosts.*]`` tables loaded through the config parser
+    must become ``SSHHostConfig`` objects, not raw dicts.
+
+    Regression test: provider configs are built with ``model_construct`` (to keep
+    unset top-level fields ``None`` for config-layer merging), which skips coercion
+    of nested model fields. Without coercion, ``hosts`` entries stayed raw dicts and
+    every host-enumerating command (``mngr list``, ``mngr connect``, ...) crashed
+    with ``AttributeError: 'dict' object has no attribute 'key_file'`` while
+    building the provider instance. This exercises the real parse path
+    (``parse_config``), unlike the other tests here which hand in already-built
+    ``SSHHostConfig`` objects.
+    """
+    raw_settings = {
+        "providers": {
+            "my-ssh": {
+                "backend": "ssh",
+                "hosts": {
+                    "server1": {"address": "192.168.1.1", "key_file": "~/.ssh/id_rsa"},
+                },
+            },
+        },
+    }
+    config = parse_config(raw_settings, disabled_plugins=frozenset())
+    provider_config = config.providers[ProviderInstanceName("my-ssh")]
+    assert isinstance(provider_config, SSHProviderConfig)
+    assert isinstance(provider_config.hosts["server1"], SSHHostConfig)
+
+    # End-to-end: building the instance and resolving the host must not raise.
+    instance = SSHProviderBackend.build_provider_instance(
+        name=ProviderInstanceName("my-ssh"),
+        config=provider_config,
+        mngr_ctx=temp_mngr_ctx,
+    )
+    host = instance.get_host(HostName("server1"))
+    assert host.id is not None


### PR DESCRIPTION
## Problem

A customer reported that statically-configured SSH hosts didn't work: after adding an SSH provider and a host to `settings.toml`, `mngr` "wasn't able to resolve the host." Investigation showed every host-enumerating command (`mngr list`, `mngr connect`, `mngr create <agent>@<host>.<pool>`, `mngr exec`, ...) crashed while building the SSH provider instance with:

```
AttributeError: 'dict' object has no attribute 'key_file'
```

## Root cause

`_parse_providers` builds provider configs with `model_construct` (which skips validation/coercion, so unset top-level fields stay `None` for config-layer merging). `SSHProviderConfig.hosts` (`dict[str, SSHHostConfig]`) is the **only** nested-model provider-config field, so its entries were left as raw TOML dicts. `FrozenModel` does not set `revalidate_instances`, so `MngrConfig.model_validate` never re-coerced them either. The backend then did `host_config.key_file` on a `dict` and crashed. The *dynamic*-hosts path (`SSHHostConfig.model_validate`) was unaffected — only the static `settings.toml` path was broken, and no test exercised it.

## Fix

`_parse_providers` now coerces nested pydantic-model provider-config fields after `model_construct`, via a small generic helper (matching the existing `_normalize_tuple_fields_for_construct` precedent). Only fields present in the raw config whose annotation references a model are touched, so scalar fields and the None-for-unset merge semantics are unaffected. A malformed host entry now surfaces a clear `providers.<pool>.hosts` config error instead of a late `AttributeError`.

## Tests

- Added `test_static_hosts_from_settings_dict_are_coerced` — drives the real parse path (`parse_config` → `build_provider_instance` → `get_host`), reproducing the crash and asserting host entries become `SSHHostConfig`. (Existing SSH tests hand in already-built `SSHHostConfig` objects, which is why they missed this.)
- Verified end-to-end via the real `load_config` + `get_all_provider_instances` (the call that crashed): the pool builds, the host discovers and resolves, and `key_file` expands correctly.
- Local: full `providers/ssh` dir (47), full `config` dir (414), and `utils/test_ratchets.py` (56) all pass.

## Docs

- New `libs/mngr/docs/core_plugins/providers/ssh.md` (host schema, dynamic hosts, the `NAME@HOST.PROVIDER` usage form, limitations).
- Registered `ssh` in `libs/mngr/docs/concepts/providers.md` with a working config example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
