### PR TITLE
Fix file sharing

### DIFF
--- a/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
+++ b/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
@@ -11,8 +11,10 @@ because `/home/<name>` and `/tmp` are already lowercase.
 
 Added the ability to change the shared path in the file-sharing permission
 dialog before approving. The agent-requested path is now shown in an editable
-field; you can paste a different absolute path or pick one (file or directory)
-with a new Browse button that opens a native OS file dialog. Approving with an
+field; you can paste a different absolute path or pick one with new
+"Choose file…" / "Choose folder…" buttons that open a native OS file dialog
+(separate file and folder pickers because a single combined picker can't select
+both on Linux/Windows). Approving with an
 edited path retargets the grant to your chosen path -- the access mode the agent
 asked for (read-only vs. read & write) is preserved, and the edited path is
 re-validated for traversal before any grant is written. Approve stays disabled

--- a/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
+++ b/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
@@ -8,3 +8,13 @@ find resource provider`. The share is now registered under a lowercased key
 (while the filesystem provider keeps the real, correct-case path), so home-
 directory paths under macOS resolve correctly. Linux users were unaffected
 because `/home/<name>` and `/tmp` are already lowercase.
+
+Added the ability to change the shared path in the file-sharing permission
+dialog before approving. The agent-requested path is now shown in an editable
+field; you can paste a different absolute path or pick one (file or directory)
+with a new Browse button that opens a native OS file dialog. Approving with an
+edited path retargets the grant to your chosen path -- the access mode the agent
+asked for (read-only vs. read & write) is preserved, and the edited path is
+re-validated for traversal before any grant is written. Approve stays disabled
+while the path field is empty. The Browse button appears only in the desktop app
+(it uses a native picker); in a plain browser you can still paste a path.

--- a/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
+++ b/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
@@ -1,0 +1,10 @@
+Fixed a bug that broke WebDAV file sharing for macOS users. The `/api/v1/files`
+WebDAV server shares the user's home directory, but on macOS that path
+(`/Users/<name>`) contains uppercase characters. WsgiDAV matches request paths
+against a lowercased copy of each share key yet looks the matched share back up
+by that lowercased string, so any share key with uppercase characters resolved
+to no provider and every request under it returned `404 Not Found: Could not
+find resource provider`. The share is now registered under a lowercased key
+(while the filesystem provider keeps the real, correct-case path), so home-
+directory paths under macOS resolve correctly. Linux users were unaffected
+because `/home/<name>` and `/tmp` are already lowercase.

--- a/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
+++ b/apps/minds/changelog/hynek-fix-file-sharing-oddities.md
@@ -17,6 +17,13 @@ field; you can paste a different absolute path or pick one with new
 both on Linux/Windows). Approving with an
 edited path retargets the grant to your chosen path -- the access mode the agent
 asked for (read-only vs. read & write) is preserved, and the edited path is
-re-validated for traversal before any grant is written. Approve stays disabled
-while the path field is empty. The Browse button appears only in the desktop app
-(it uses a native picker); in a plain browser you can still paste a path.
+re-validated for traversal before any grant is written. The buttons appear only
+in the desktop app (they use a native picker); in a plain browser you can still
+paste a path.
+
+The edited path is also validated against the WebDAV mount roots (your home
+directory and the system temp directory) directly in Minds, so a path outside
+those is rejected immediately with a clear message instead of being forwarded to
+the gateway. The dialog gives instant feedback too: Approve stays disabled (and a
+hint appears) while the path field is empty or points outside a shared folder, as
+you type or pick.

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1995,6 +1995,36 @@ ipcMain.on('close-modal', (event) => {
   closeModal(getBundleFromEvent(event));
 });
 
+// Native file/directory picker for the file-sharing permission dialog.
+// The inbox modal calls this (via the preload bridge) so the user can
+// pick the path to share. We allow selecting either a file or a
+// directory (a shared directory grants access to everything beneath it).
+// Returns the chosen absolute path, or null when the user cancelled.
+ipcMain.handle('show-file-picker', async (event, options) => {
+  const bundle = getBundleFromEvent(event);
+  const opts = options || {};
+  const dialogOptions = {
+    // macOS can offer files and directories in one dialog. On Linux a
+    // dialog can't be both, so Electron shows a directory selector when
+    // both properties are set; a user who needs to share a single file
+    // there can paste its path into the field instead.
+    properties: ['openFile', 'openDirectory'],
+  };
+  if (typeof opts.defaultPath === 'string' && opts.defaultPath.length > 0) {
+    dialogOptions.defaultPath = opts.defaultPath;
+  }
+  // Anchor the dialog to the requesting window when we can resolve it so
+  // it behaves as a sheet/modal; fall back to an unparented dialog
+  // otherwise.
+  const result = bundle && bundle.window && !bundle.window.isDestroyed()
+    ? await dialog.showOpenDialog(bundle.window, dialogOptions)
+    : await dialog.showOpenDialog(dialogOptions);
+  if (result.canceled || !Array.isArray(result.filePaths) || result.filePaths.length === 0) {
+    return null;
+  }
+  return result.filePaths[0];
+});
+
 ipcMain.on('show-workspace-context-menu', (event, agentId, x, y) => {
   const bundle = getBundleFromEvent(event);
   if (!bundle || !agentId) return;

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1997,19 +1997,18 @@ ipcMain.on('close-modal', (event) => {
 
 // Native file/directory picker for the file-sharing permission dialog.
 // The inbox modal calls this (via the preload bridge) so the user can
-// pick the path to share. We allow selecting either a file or a
-// directory (a shared directory grants access to everything beneath it).
-// Returns the chosen absolute path, or null when the user cancelled.
+// pick the path to share. ``options.mode`` is 'file' or 'directory':
+// the dialog exposes separate "Choose file" / "Choose folder" buttons
+// rather than a single combined picker because a dialog can't be both a
+// file and a directory selector on Linux/Windows (Electron would fall
+// back to a directory selector, so picking a file there returns its
+// parent directory). Returns the chosen absolute path, or null when the
+// user cancelled.
 ipcMain.handle('show-file-picker', async (event, options) => {
   const bundle = getBundleFromEvent(event);
   const opts = options || {};
-  const dialogOptions = {
-    // macOS can offer files and directories in one dialog. On Linux a
-    // dialog can't be both, so Electron shows a directory selector when
-    // both properties are set; a user who needs to share a single file
-    // there can paste its path into the field instead.
-    properties: ['openFile', 'openDirectory'],
-  };
+  const property = opts.mode === 'directory' ? 'openDirectory' : 'openFile';
+  const dialogOptions = { properties: [property] };
   if (typeof opts.defaultPath === 'string' && opts.defaultPath.length > 0) {
     dialogOptions.defaultPath = opts.defaultPath;
   }

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -44,6 +44,13 @@ contextBridge.exposeInMainWorld('minds', {
   // Modal overlay close (used by the inbox shell and any one-off dialogs)
   closeModal: () => ipcRenderer.send('close-modal'),
 
+  // Native file/directory picker used by the file-sharing permission
+  // dialog so the user can pick the path to share instead of typing it.
+  // Resolves to the selected absolute path, or null if the user
+  // cancelled. ``options.defaultPath`` seeds the dialog's starting
+  // location.
+  showFilePicker: (options) => ipcRenderer.invoke('show-file-picker', options),
+
   // Multi-window workspace actions
   openWorkspaceInNewWindow: (agentId) =>
     ipcRenderer.send('open-workspace-in-new-window', agentId),

--- a/apps/minds/electron/preload.js
+++ b/apps/minds/electron/preload.js
@@ -46,9 +46,9 @@ contextBridge.exposeInMainWorld('minds', {
 
   // Native file/directory picker used by the file-sharing permission
   // dialog so the user can pick the path to share instead of typing it.
-  // Resolves to the selected absolute path, or null if the user
-  // cancelled. ``options.defaultPath`` seeds the dialog's starting
-  // location.
+  // ``options.mode`` is 'file' or 'directory'; ``options.defaultPath``
+  // seeds the dialog's starting location. Resolves to the selected
+  // absolute path, or null if the user cancelled.
   showFilePicker: (options) => ipcRenderer.invoke('show-file-picker', options),
 
   // Multi-window workspace actions

--- a/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client.py
@@ -484,7 +484,7 @@ class LatchkeyGatewayClient(MutableModel):
                 f"DELETE {url} returned {response.status_code}: {response.text.strip()}",
             )
 
-    def approve_permission_request(self, request_id: str) -> None:
+    def approve_permission_request(self, request_id: str, override_path: str | None = None) -> None:
         """Approve the named pending request via the gateway's bundled extension.
 
         Wraps ``POST /permission-requests/approve/<request_id>``. The
@@ -493,6 +493,14 @@ class LatchkeyGatewayClient(MutableModel):
         permissions.json, and removes the pending-request file. Failure
         leaves the request pending so the user can retry.
 
+        ``override_path`` is set only for *file-sharing* requests whose
+        shared path the user edited in the approval dialog before
+        approving. When provided, it is sent as a ``{"path": ...}`` JSON
+        body and the gateway recomputes the file-sharing effect for that
+        path (re-validating it for traversal) instead of using the
+        agent-supplied one. Leaving it ``None`` sends no body, so the
+        gateway applies the precomputed effect verbatim.
+
         Unlike :meth:`delete_permission_request`, ``404`` is *not*
         tolerated here -- approving a request that the gateway has
         forgotten about would silently drop the user's intent on the
@@ -500,9 +508,10 @@ class LatchkeyGatewayClient(MutableModel):
         """
         self.ensure_initialized()
         url = f"{self._require_base_url().rstrip('/')}/permission-requests/approve/{request_id}"
+        json_body = {"path": override_path} if override_path is not None else None
         try:
             with self._one_shot_client() as client:
-                response = client.post(url, headers=self._build_headers())
+                response = client.post(url, headers=self._build_headers(), json=json_body)
         except httpx.HTTPError as e:
             raise self._wrap_transport_error(e, f"POST {url} failed") from e
         if response.status_code >= 400:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/gateway_client_test.py
@@ -190,6 +190,36 @@ def test_approve_permission_request_posts_through_gateway() -> None:
     assert captured == {"method": "POST", "path": "/permission-requests/approve/evt-abc"}
 
 
+def test_approve_permission_request_sends_no_body_without_override() -> None:
+    """Without an override path the approve POST carries an empty body (gateway uses the precomputed effect)."""
+    captured: dict[str, object] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["content"] = request.content
+        return httpx.Response(200, json={"request_id": "evt-abc"})
+
+    client = _build_client(_handler)
+    client.approve_permission_request("evt-abc")
+    assert captured["content"] == b""
+
+
+def test_approve_permission_request_sends_override_path_body() -> None:
+    """An override path is sent as a ``{"path": ...}`` JSON body so the gateway recomputes the effect."""
+    captured: dict[str, object] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["content"] = request.content
+        captured["content_type"] = request.headers.get("content-type")
+        return httpx.Response(200, json={"request_id": "evt-abc"})
+
+    client = _build_client(_handler)
+    client.approve_permission_request("evt-abc", override_path="/Users/glenn/Documents/Shared")
+    sent_body = captured["content"]
+    assert isinstance(sent_body, bytes)
+    assert json.loads(sent_body) == {"path": "/Users/glenn/Documents/Shared"}
+    assert captured["content_type"] == "application/json"
+
+
 def test_approve_permission_request_raises_on_4xx() -> None:
     """Unlike ``delete``, ``approve`` does *not* swallow 404 / 4xx: a missing grant is a hard error."""
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -31,6 +31,7 @@ the gateway forgets the pending entry.
 
 import asyncio
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
 
@@ -55,6 +56,7 @@ from imbue.minds.desktop_client.request_events import RequestType
 from imbue.minds.desktop_client.request_events import append_response_event
 from imbue.minds.desktop_client.request_events import create_request_response_event
 from imbue.minds.desktop_client.request_handler import RequestEventHandler
+from imbue.minds.desktop_client.webdav import get_file_sharing_roots
 from imbue.mngr.primitives import AgentId
 
 # Label shown on the inbox list card (lower-case, short).
@@ -70,16 +72,33 @@ class InvalidSharePathError(Exception):
     """Raised when a user-edited share path is not an acceptable absolute path."""
 
 
-def _normalize_share_path(raw_path: str) -> str:
+def _is_path_within_roots(path: str, allowed_roots: Sequence[Path]) -> bool:
+    """Whether ``path`` is at or beneath one of ``allowed_roots``.
+
+    Case-insensitive and purely lexical, mirroring how the WebDAV server
+    matches its mount prefixes (WsgiDAV lowercases both the share keys
+    and the request path) so we never reject a path the server would
+    actually serve.
+    """
+    lower_path = path.lower()
+    for root in allowed_roots:
+        lower_root = str(root).rstrip("/").lower() or "/"
+        if lower_path == lower_root or lower_path.startswith(f"{lower_root}/"):
+            return True
+    return False
+
+
+def _normalize_share_path(raw_path: str, allowed_roots: Sequence[Path]) -> str:
     """Validate and normalize a user-edited absolute share path.
 
     Mirrors the gateway's ``validateAbsoluteFileSharingPath`` so the user
-    gets a clear, immediate error instead of a generic gateway 400. The
+    gets a clear, immediate error instead of a generic gateway 4xx. The
     gateway re-validates on approve regardless -- this is a friendlier
     first line of defence, not the security boundary.
 
-    Rejects empty, relative, and ``..``-containing paths. Returns the
-    stripped path on success.
+    Rejects empty, relative, and ``..``-containing paths, and paths that
+    fall outside ``allowed_roots`` (the WebDAV mount roots: home + temp).
+    Returns the stripped path on success.
     """
     path = raw_path.strip()
     if not path:
@@ -90,6 +109,9 @@ def _normalize_share_path(raw_path: str) -> str:
     # gateway's traversal check.
     if any(segment == ".." for segment in path.replace("\\", "/").split("/")):
         raise InvalidSharePathError(f"The path to share must not contain a '..' segment: {path}")
+    if not _is_path_within_roots(path, allowed_roots):
+        roots_str = ", ".join(str(root) for root in allowed_roots)
+        raise InvalidSharePathError(f"The path to share must be within a shared folder ({roots_str}): {path}")
     return path
 
 
@@ -162,6 +184,15 @@ class FileSharingGrantHandler(RequestEventHandler):
     mngr_message_sender: MngrMessageSender = Field(
         description="Sends ``mngr message`` nudges to the waiting agent on resolution.",
     )
+    share_roots: tuple[Path, ...] = Field(
+        default_factory=get_file_sharing_roots,
+        frozen=True,
+        description=(
+            "On-disk roots the WebDAV file server mounts (home + temp). A requested or "
+            "user-edited path outside these is rejected up front with a clear error rather "
+            "than being forwarded to the gateway. Defaults to the live WebDAV mount roots."
+        ),
+    )
 
     # -- RequestEventHandler interface ---------------------------------------
 
@@ -194,6 +225,7 @@ class FileSharingGrantHandler(RequestEventHandler):
             file_path=req_event.path,
             access=req_event.access,
             access_human_label=_access_human_label(req_event.access),
+            allowed_roots_json=json.dumps([str(root) for root in self.share_roots]),
             mngr_forward_origin=mngr_forward_origin,
         )
 
@@ -215,7 +247,11 @@ class FileSharingGrantHandler(RequestEventHandler):
         form = await request.form()
         raw_override = form.get(_FILE_PATH_FIELD)
         try:
-            effective_path = _normalize_share_path(str(raw_override)) if raw_override is not None else req_event.path
+            effective_path = (
+                _normalize_share_path(str(raw_override), self.share_roots)
+                if raw_override is not None
+                else req_event.path
+            )
         except InvalidSharePathError as e:
             return _json_error(str(e), status_code=400)
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -11,14 +11,20 @@ appending the response event, and notifying the waiting agent via
 A file-sharing permission request asks the user to grant the agent
 access to a single absolute file path on the desktop host, served
 through the ``minds-api-proxy`` Latchkey extension. Unlike its
-:mod:`.predefined` sibling, the dialog is a plain yes/no on a
-specific path -- there is no per-permission editing because the
-request itself is already fully-specified (one path, both read and
-write methods). Approval calls
-``POST /permission-requests/approve/<id>`` on the gateway's
-``permission-requests`` extension; the extension owns the actual
-write to the agent's ``latchkey_permissions.json`` using the
-``effect`` payload it precomputed when the request was created.
+:mod:`.predefined` sibling, there is no per-permission checkbox list:
+the request already names the single (path, access) pair. The dialog
+does, however, let the user *edit the shared path* before approving
+(the agent-requested path is pre-filled into an editable field, and a
+native file picker in the desktop app can fill it in). The access mode
+is fixed at request-creation time and is not user-editable.
+
+Approval calls ``POST /permission-requests/approve/<id>`` on the
+gateway's ``permission-requests`` extension; the extension owns the
+actual write to the agent's ``latchkey_permissions.json``. When the
+user left the path unchanged the extension uses the ``effect`` payload
+it precomputed at request-creation time; when the user edited the path
+we send it as a ``{"path": ...}`` body and the extension recomputes the
+file-sharing effect for that path (re-validating it for traversal).
 Denial reuses the legacy ``DELETE /permission-requests/<id>`` path so
 the gateway forgets the pending entry.
 """
@@ -53,6 +59,38 @@ from imbue.mngr.primitives import AgentId
 
 # Label shown on the inbox list card (lower-case, short).
 _KIND_LABEL: Final[str] = "file sharing"
+
+# Form field carrying the (possibly user-edited) absolute path to share.
+# The dialog pre-fills it with the agent-requested path; the user may
+# paste a different one or pick it from a native file dialog.
+_FILE_PATH_FIELD: Final[str] = "file_path"
+
+
+class InvalidSharePathError(Exception):
+    """Raised when a user-edited share path is not an acceptable absolute path."""
+
+
+def _normalize_share_path(raw_path: str) -> str:
+    """Validate and normalize a user-edited absolute share path.
+
+    Mirrors the gateway's ``validateAbsoluteFileSharingPath`` so the user
+    gets a clear, immediate error instead of a generic gateway 400. The
+    gateway re-validates on approve regardless -- this is a friendlier
+    first line of defence, not the security boundary.
+
+    Rejects empty, relative, and ``..``-containing paths. Returns the
+    stripped path on success.
+    """
+    path = raw_path.strip()
+    if not path:
+        raise InvalidSharePathError("The path to share must not be empty.")
+    if not path.startswith("/"):
+        raise InvalidSharePathError(f"The path to share must be absolute (start with '/'): {path}")
+    # Reject any ``..`` segment regardless of separator, matching the
+    # gateway's traversal check.
+    if any(segment == ".." for segment in path.replace("\\", "/").split("/")):
+        raise InvalidSharePathError(f"The path to share must not contain a '..' segment: {path}")
+    return path
 
 
 def _access_human_label(access: str) -> str:
@@ -168,10 +206,30 @@ class FileSharingGrantHandler(RequestEventHandler):
             return _json_error("Unsupported request type", status_code=500)
         request_event_id = str(req_event.event_id)
         parsed_agent_id = AgentId(req_event.agent_id)
+
+        # The dialog lets the user edit the shared path (paste or native
+        # file picker) before approving. Read the submitted value, falling
+        # back to the agent-requested path when the field is absent (e.g.
+        # an older client). Validate it up front for a friendly error; the
+        # gateway re-validates on approve.
+        form = await request.form()
+        raw_override = form.get(_FILE_PATH_FIELD)
+        try:
+            effective_path = _normalize_share_path(str(raw_override)) if raw_override is not None else req_event.path
+        except InvalidSharePathError as e:
+            return _json_error(str(e), status_code=400)
+
+        # Only send an override to the gateway when the user actually
+        # changed the path; otherwise the gateway applies the precomputed
+        # effect verbatim (and we avoid recomputation for the common case).
+        override_path = effective_path if effective_path != req_event.path else None
         try:
             await asyncio.get_running_loop().run_in_executor(
                 None,
-                lambda: self.gateway_client.approve_permission_request(request_event_id),
+                lambda: self.gateway_client.approve_permission_request(
+                    request_event_id,
+                    override_path=override_path,
+                ),
             )
         except LatchkeyGatewayClientError as e:
             logger.warning(
@@ -184,11 +242,11 @@ class FileSharingGrantHandler(RequestEventHandler):
                 status_code=502,
             )
 
-        message = _format_granted_message(req_event.path, req_event.access)
+        message = _format_granted_message(effective_path, req_event.access)
         response_event = self._write_response_and_notify(
             request_event_id=request_event_id,
             agent_id=parsed_agent_id,
-            file_path=req_event.path,
+            file_path=effective_path,
             status=RequestStatus.GRANTED,
             message=message,
         )

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
@@ -76,9 +76,16 @@ def _build_gateway_client(handler: _HttpxHandler) -> LatchkeyGatewayClient:
     )
 
 
+# Broad share roots so the existing tests' representative paths
+# (``/home/...``, ``/Users/...``, ``/tmp/...``) all validate as in-root.
+# Tests that exercise the out-of-root rejection inject a narrower set.
+_DEFAULT_TEST_SHARE_ROOTS: Final = (Path("/home"), Path("/Users"), Path("/tmp"))
+
+
 def _make_file_sharing_handler(
     tmp_path: Path,
     gateway_handler: _HttpxHandler,
+    share_roots: tuple[Path, ...] = _DEFAULT_TEST_SHARE_ROOTS,
 ) -> tuple[FileSharingGrantHandler, _RecordingMessageSender]:
     sender = _RecordingMessageSender(sent_messages=[])
     return (
@@ -86,6 +93,7 @@ def _make_file_sharing_handler(
             data_dir=tmp_path,
             gateway_client=_build_gateway_client(gateway_handler),
             mngr_message_sender=sender,
+            share_roots=share_roots,
         ),
         sender,
     )
@@ -404,6 +412,84 @@ def test_grant_rejects_traversal_in_edited_path(tmp_path: Path) -> None:
     assert response.status_code == 400
     assert ".." in response.json()["error"]
     assert gateway_called is False
+
+
+def test_grant_rejects_edited_path_outside_share_roots(tmp_path: Path) -> None:
+    """A path outside the WebDAV mount roots is rejected with a clean 400, not forwarded to the gateway."""
+    gateway_called = False
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal gateway_called
+        gateway_called = True
+        del request
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    in_root = str(tmp_path / "ok.txt")
+    handler, sender = _make_file_sharing_handler(tmp_path, _gateway_handler, share_roots=(tmp_path,))
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path=in_root,
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": "/etc/passwd"})
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert "shared folder" in error
+    # The error names the allowed root(s) so the user can self-correct.
+    assert str(tmp_path) in error
+    # We did not fall back to the gateway, and the request stays pending.
+    assert gateway_called is False
+    assert load_response_events(tmp_path) == []
+    assert sender.sent_messages == []
+
+
+def test_grant_accepts_edited_path_within_share_roots(tmp_path: Path) -> None:
+    """A path nested under an allowed root is accepted."""
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    handler, _sender = _make_file_sharing_handler(tmp_path, _gateway_handler, share_roots=(tmp_path,))
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path=str(tmp_path / "orig.txt"),
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    edited = str(tmp_path / "nested" / "file.txt")
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": edited})
+    assert response.status_code == 200
+    assert response.json()["outcome"] == "GRANTED"
+
+
+def test_render_request_detail_fragment_embeds_allowed_roots(tmp_path: Path) -> None:
+    """The dialog embeds the share roots so the inbox shell can validate client-side."""
+    handler, _sender = _make_file_sharing_handler(
+        tmp_path, lambda r: httpx.Response(200), share_roots=(Path("/home/glenn"), Path("/tmp"))
+    )
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path="/home/glenn/notes.txt",
+        access="READ",
+        rationale="r",
+    )
+    body = str(
+        handler.render_request_detail_fragment(
+            req_event=event,
+            backend_resolver=StaticBackendResolver(url_by_agent_and_service={}),
+            mngr_forward_origin="",
+        )
+    )
+    attrs = _parse_input_attrs(body, element_id="file-sharing-path-input")
+    assert json.loads(attrs["data-allowed-roots"]) == ["/home/glenn", "/tmp"]
 
 
 def test_grant_returns_502_when_gateway_rejects(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
@@ -178,12 +178,15 @@ def test_render_request_detail_fragment_has_editable_path_and_browse(tmp_path: P
         mngr_forward_origin="",
     )
     # The path is editable: an input named ``file_path`` pre-filled with
-    # the requested path, plus a Browse button keyed for the inbox shell.
+    # the requested path, plus separate file / folder pickers keyed for
+    # the inbox shell.
     assert 'name="file_path"' in body
     assert 'id="file-sharing-path-input"' in body
     assert 'value="/home/user/important.txt"' in body
-    assert 'id="file-sharing-browse-btn"' in body
-    assert "browseForSharePath" in body
+    assert 'id="file-sharing-browse-file-btn"' in body
+    assert 'id="file-sharing-browse-folder-btn"' in body
+    assert "browseForSharePath(&#39;file&#39;)" in body or "browseForSharePath('file')" in body
+    assert "browseForSharePath(&#39;directory&#39;)" in body or "browseForSharePath('directory')" in body
 
 
 def test_render_request_detail_fragment_marks_write_grants_distinctly(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing_test.py
@@ -1,6 +1,8 @@
 """Unit tests for :class:`FileSharingGrantHandler`."""
 
+import json
 from collections.abc import Callable
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Final
 
@@ -30,6 +32,30 @@ from imbue.minds.desktop_client.request_events import load_response_events
 from imbue.mngr.primitives import AgentId
 
 _HttpxHandler: Final = Callable[[httpx.Request], httpx.Response]
+
+
+def _parse_input_attrs(html: str, element_id: str) -> dict[str, str]:
+    """Return the attribute map of the ``<input>`` with the given id.
+
+    Used to assert that user-controlled values are safely encoded into
+    attributes (the HTML parser sees the real attribute boundaries, so a
+    successful breakout would surface as extra attributes rather than a
+    value substring).
+    """
+    found: dict[str, str] = {}
+
+    class _Finder(HTMLParser):
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag != "input":
+                return
+            attr_map = {name: (value or "") for name, value in attrs}
+            if attr_map.get("id") == element_id:
+                found.update(attr_map)
+
+    _Finder().feed(html)
+    if not found:
+        raise AssertionError(f"no <input> with id={element_id!r} found in HTML")
+    return found
 
 
 class _RecordingMessageSender(MngrMessageSender):
@@ -137,6 +163,29 @@ def test_render_request_detail_fragment_shows_path_and_rationale(tmp_path: Path)
     assert "<script>" not in body
 
 
+def test_render_request_detail_fragment_has_editable_path_and_browse(tmp_path: Path) -> None:
+    """The dialog renders the path as an editable input plus a Browse button."""
+    handler, _sender = _make_file_sharing_handler(tmp_path, lambda r: httpx.Response(200))
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path="/home/user/important.txt",
+        access="READ",
+        rationale="summarize the doc",
+    )
+    body = handler.render_request_detail_fragment(
+        req_event=event,
+        backend_resolver=StaticBackendResolver(url_by_agent_and_service={}),
+        mngr_forward_origin="",
+    )
+    # The path is editable: an input named ``file_path`` pre-filled with
+    # the requested path, plus a Browse button keyed for the inbox shell.
+    assert 'name="file_path"' in body
+    assert 'id="file-sharing-path-input"' in body
+    assert 'value="/home/user/important.txt"' in body
+    assert 'id="file-sharing-browse-btn"' in body
+    assert "browseForSharePath" in body
+
+
 def test_render_request_detail_fragment_marks_write_grants_distinctly(tmp_path: Path) -> None:
     """WRITE grants render the broader human-readable access label."""
     handler, _sender = _make_file_sharing_handler(tmp_path, lambda r: httpx.Response(200))
@@ -159,21 +208,33 @@ def test_render_request_detail_fragment_marks_write_grants_distinctly(tmp_path: 
 
 def test_render_request_detail_fragment_escapes_html_in_inputs(tmp_path: Path) -> None:
     handler, _sender = _make_file_sharing_handler(tmp_path, lambda r: httpx.Response(200))
+    # A path crafted to break out of the value="" attribute and inject an
+    # event handler if the renderer naively interpolated it.
+    malicious_path = '/tmp/" onfocus="alert(1)'
     event = create_latchkey_file_sharing_permission_request_event(
         agent_id=str(AgentId()),
-        path="/tmp/<script>alert(1)</script>.txt",
+        path=malicious_path,
         access="READ",
         rationale="<img src=x onerror=alert(2)>",
     )
-    body = handler.render_request_detail_fragment(
-        req_event=event,
-        backend_resolver=StaticBackendResolver(url_by_agent_and_service={}),
-        mngr_forward_origin="",
+    body = str(
+        handler.render_request_detail_fragment(
+            req_event=event,
+            backend_resolver=StaticBackendResolver(url_by_agent_and_service={}),
+            mngr_forward_origin="",
+        )
     )
-    # Raw HTML must not appear; entities must.
-    assert "<script>alert(1)" not in body
-    assert "&lt;script&gt;alert(1)" in body
+    # The rationale is rendered as element text, so raw HTML must be
+    # entity-escaped.
     assert "<img src=x" not in body
+
+    # The path is rendered into the value="" attribute of the editable
+    # input. Parse the input and verify the attribute carries the path
+    # verbatim with no injected handler -- i.e. the renderer safely quoted
+    # the value rather than letting the crafted ``"`` break out.
+    attrs = _parse_input_attrs(body, element_id="file-sharing-path-input")
+    assert attrs["value"] == malicious_path
+    assert "onfocus" not in attrs
 
 
 # -- apply_grant_request --
@@ -219,6 +280,127 @@ def test_grant_calls_gateway_approve_writes_response_notifies_agent(tmp_path: Pa
 
     # Agent was notified.
     assert sender.sent_messages == [(str(agent_id), body["message"])]
+
+
+def test_grant_with_edited_path_sends_override_and_uses_it(tmp_path: Path) -> None:
+    """Editing the path in the dialog sends an override body and reflects the new path everywhere."""
+    captured: dict[str, object] = {}
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["content"] = request.content
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    handler, sender = _make_file_sharing_handler(tmp_path, _gateway_handler)
+    agent_id = AgentId()
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(agent_id),
+        path="/home/user/requested.txt",
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    edited = "/Users/glenn/Documents/Shared"
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": edited})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["outcome"] == "GRANTED"
+    # The granted message names the edited path, not the requested one.
+    assert edited in body["message"]
+    assert "/home/user/requested.txt" not in body["message"]
+
+    # The gateway received the override path as a JSON body.
+    sent_body = captured["content"]
+    assert isinstance(sent_body, bytes)
+    assert json.loads(sent_body) == {"path": edited}
+
+    # The persisted response event records the edited path as its scope.
+    response_events = load_response_events(tmp_path)
+    assert len(response_events) == 1
+    assert response_events[0].scope == edited
+    # The agent notification names the edited path.
+    assert sender.sent_messages == [(str(agent_id), body["message"])]
+
+
+def test_grant_with_unchanged_path_sends_no_override_body(tmp_path: Path) -> None:
+    """Submitting the original path verbatim must not send an override (gateway uses the precomputed effect)."""
+    captured: dict[str, object] = {}
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        captured["content"] = request.content
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    handler, _sender = _make_file_sharing_handler(tmp_path, _gateway_handler)
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path="/home/user/data.txt",
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": "/home/user/data.txt"})
+    assert response.status_code == 200
+    assert response.json()["outcome"] == "GRANTED"
+    assert captured["content"] == b""
+
+
+def test_grant_rejects_relative_edited_path(tmp_path: Path) -> None:
+    """A relative edited path is rejected with a 400 before the gateway is called."""
+    gateway_called = False
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal gateway_called
+        gateway_called = True
+        del request
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    handler, sender = _make_file_sharing_handler(tmp_path, _gateway_handler)
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path="/home/user/data.txt",
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": "relative/path"})
+    assert response.status_code == 400
+    assert "absolute" in response.json()["error"].lower()
+    assert gateway_called is False
+    # The request stays pending: no response event, no agent notification.
+    assert load_response_events(tmp_path) == []
+    assert sender.sent_messages == []
+
+
+def test_grant_rejects_traversal_in_edited_path(tmp_path: Path) -> None:
+    """A ``..`` segment in the edited path is rejected with a 400 before the gateway is called."""
+    gateway_called = False
+
+    def _gateway_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal gateway_called
+        gateway_called = True
+        del request
+        return httpx.Response(200, json={"request_id": "evt-abc", "applied": {}})
+
+    handler, _sender = _make_file_sharing_handler(tmp_path, _gateway_handler)
+    event = create_latchkey_file_sharing_permission_request_event(
+        agent_id=str(AgentId()),
+        path="/home/user/data.txt",
+        access="READ",
+        rationale="need data",
+    )
+    inbox = RequestInbox().add_request(event)
+    client = _build_authenticated_client(tmp_path, handler, inbox)
+
+    response = client.post(f"/requests/{event.event_id}/grant", data={"file_path": "/home/user/../../etc/shadow"})
+    assert response.status_code == 400
+    assert ".." in response.json()["error"]
+    assert gateway_called is False
 
 
 def test_grant_returns_502_when_gateway_rejects(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/templates.py
@@ -75,6 +75,7 @@ def render_file_sharing_permission_dialog(
     file_path: str,
     access: str,
     access_human_label: str,
+    allowed_roots_json: str = "[]",
     mngr_forward_origin: str = "",
 ) -> str:
     """Render the file-sharing permission detail fragment.
@@ -89,6 +90,11 @@ def render_file_sharing_permission_dialog(
     human-readable rendering (``"read-only"`` / ``"read & write"``)
     used in the fragment body.
 
+    ``allowed_roots_json`` is a JSON array of the absolute WebDAV mount
+    roots (home + temp); the dialog embeds it so the inbox shell can give
+    instant client-side feedback (and disable Approve) when the edited
+    path falls outside them, mirroring the server-side check.
+
     ``mngr_forward_origin`` is the bare origin of the ``mngr forward`` plugin;
     the workspace link in the fragment points at ``{mngr_forward_origin}/goto/<agent>/``.
     """
@@ -101,6 +107,7 @@ def render_file_sharing_permission_dialog(
         file_path=file_path,
         access=access,
         access_human_label=access_human_label,
+        allowed_roots_json=allowed_roots_json,
         display_name=file_path,
         mngr_forward_origin=mngr_forward_origin,
     )

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
@@ -149,6 +149,30 @@
     // Approve becomes available as soon as any name="permissions" input
     // is checked. Re-run after every right-pane swap and on checkbox
     // change (via the delegated handler below).
+    // Parse the WebDAV mount roots the file-sharing dialog embeds on its
+    // path input (a JSON array of absolute paths). Returns [] when absent
+    // or malformed.
+    function sharePathRoots(input) {
+      try {
+        var parsed = JSON.parse(input.getAttribute("data-allowed-roots") || "[]");
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (e) {
+        return [];
+      }
+    }
+
+    // Whether ``value`` is at or beneath one of ``roots``. Case-insensitive
+    // and purely lexical, mirroring the server-side check (and WsgiDAV's
+    // share-prefix matching).
+    function isSharePathWithinRoots(value, roots) {
+      if (!value) return false;
+      var lower = value.toLowerCase();
+      return roots.some(function (root) {
+        var r = String(root).replace(/\/+$/, "").toLowerCase() || "/";
+        return lower === r || lower.indexOf(r + "/") === 0;
+      });
+    }
+
     function updateApproveState() {
       var form = document.getElementById("permissions-form");
       if (!form) return;
@@ -157,10 +181,20 @@
       var anyChecked = form.querySelector('input[name="permissions"]:checked') !== null;
       // The file-sharing dialog adds an editable path field. Its hidden
       // "permissions" checkbox is always checked, so gate Approve on the
-      // path being non-empty too -- otherwise the user could approve a
-      // blank path.
+      // path being both non-empty AND inside a shared root -- otherwise
+      // the user could approve a blank or unshareable path. A hint is
+      // shown next to the field for a non-empty out-of-root path so the
+      // feedback is instant (matching the server-side rejection) instead
+      // of only surfacing after submit.
       var pathInput = document.getElementById("file-sharing-path-input");
-      var pathOk = !pathInput || pathInput.value.trim().length > 0;
+      var pathOk = true;
+      if (pathInput) {
+        var value = pathInput.value.trim();
+        var withinRoots = isSharePathWithinRoots(value, sharePathRoots(pathInput));
+        pathOk = value.length > 0 && withinRoots;
+        var hint = document.getElementById("file-sharing-path-hint");
+        if (hint) hint.classList.toggle("hidden", !(value.length > 0 && !withinRoots));
+      }
       approveBtn.disabled = !(anyChecked && pathOk);
     }
     window.updateApproveState = updateApproveState;

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
@@ -155,9 +155,44 @@
       var approveBtn = document.getElementById("permissions-approve-btn");
       if (!approveBtn) return;
       var anyChecked = form.querySelector('input[name="permissions"]:checked') !== null;
-      approveBtn.disabled = !anyChecked;
+      // The file-sharing dialog adds an editable path field. Its hidden
+      // "permissions" checkbox is always checked, so gate Approve on the
+      // path being non-empty too -- otherwise the user could approve a
+      // blank path.
+      var pathInput = document.getElementById("file-sharing-path-input");
+      var pathOk = !pathInput || pathInput.value.trim().length > 0;
+      approveBtn.disabled = !(anyChecked && pathOk);
     }
     window.updateApproveState = updateApproveState;
+
+    // The file-sharing dialog ships its "Browse…" button hidden; reveal
+    // it only when the Electron native-picker bridge is available (in a
+    // plain browser the user pastes a path into the input instead).
+    // Idempotent: safe to call after every detail-pane render.
+    function wireSharePathControls() {
+      var browseBtn = document.getElementById("file-sharing-browse-btn");
+      if (browseBtn && window.minds && window.minds.showFilePicker) {
+        browseBtn.classList.remove("hidden");
+      }
+    }
+
+    // Open the OS file/directory picker and write the chosen absolute
+    // path back into the share-path input. Defaults the dialog to the
+    // path already in the field. A cancel (or any bridge error) leaves
+    // the field untouched.
+    window.browseForSharePath = async function () {
+      var input = document.getElementById("file-sharing-path-input");
+      if (!input || !(window.minds && window.minds.showFilePicker)) return;
+      try {
+        var selected = await window.minds.showFilePicker({ defaultPath: input.value.trim() });
+        if (typeof selected === "string" && selected.length > 0) {
+          input.value = selected;
+          updateApproveState();
+        }
+      } catch (e) {
+        /* user cancelled or the bridge errored -- keep the current path */
+      }
+    };
 
     function applyEmptyState() {
       var hasCards = !!inboxList.querySelector(".inbox-card");
@@ -236,6 +271,7 @@
       var html = await resp.text();
       inboxDetail.innerHTML = html;
       updateApproveState();
+      wireSharePathControls();
     }
 
     function setSelectedCard(id) {
@@ -457,6 +493,7 @@
     // detail, and pick the right empty/non-empty body class.
     applyEmptyState();
     updateApproveState();
+    wireSharePathControls();
   })();
 </script>
 {% endset %}

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Inbox.jinja
@@ -165,26 +165,31 @@
     }
     window.updateApproveState = updateApproveState;
 
-    // The file-sharing dialog ships its "Browse…" button hidden; reveal
-    // it only when the Electron native-picker bridge is available (in a
-    // plain browser the user pastes a path into the input instead).
-    // Idempotent: safe to call after every detail-pane render.
+    // The file-sharing dialog ships its "Choose file…" / "Choose folder…"
+    // buttons hidden; reveal them only when the Electron native-picker
+    // bridge is available (in a plain browser the user pastes a path into
+    // the input instead). Idempotent: safe to call after every
+    // detail-pane render.
     function wireSharePathControls() {
-      var browseBtn = document.getElementById("file-sharing-browse-btn");
-      if (browseBtn && window.minds && window.minds.showFilePicker) {
-        browseBtn.classList.remove("hidden");
-      }
+      if (!(window.minds && window.minds.showFilePicker)) return;
+      ["file-sharing-browse-file-btn", "file-sharing-browse-folder-btn"].forEach(function (id) {
+        var btn = document.getElementById(id);
+        if (btn) btn.classList.remove("hidden");
+      });
     }
 
-    // Open the OS file/directory picker and write the chosen absolute
-    // path back into the share-path input. Defaults the dialog to the
-    // path already in the field. A cancel (or any bridge error) leaves
-    // the field untouched.
-    window.browseForSharePath = async function () {
+    // Open the OS picker for the requested ``mode`` ('file' or
+    // 'directory') and write the chosen absolute path back into the
+    // share-path input. Defaults the dialog to the path already in the
+    // field. A cancel (or any bridge error) leaves the field untouched.
+    window.browseForSharePath = async function (mode) {
       var input = document.getElementById("file-sharing-path-input");
       if (!input || !(window.minds && window.minds.showFilePicker)) return;
       try {
-        var selected = await window.minds.showFilePicker({ defaultPath: input.value.trim() });
+        var selected = await window.minds.showFilePicker({
+          defaultPath: input.value.trim(),
+          mode: mode === "directory" ? "directory" : "file",
+        });
         if (typeof selected === "string" && selected.length > 0) {
           input.value = selected;
           updateApproveState();

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
@@ -51,17 +51,25 @@
                :value="file_path"
                extra="font-mono text-sm"
                oninput="window.updateApproveState && window.updateApproveState()" />
-    {# Browse opens the OS file picker and writes the chosen path back into
-       the field above. Placed below the input and left-aligned (rather
-       than to its right) so it does not stack in the same column as the
-       right-aligned Deny / Approve buttons. Hidden unless the Electron
-       native-picker bridge is present; in a plain browser the user pastes
-       a path into the field above. #}
-    <div class="mt-2">
-      <Button id="file-sharing-browse-btn"
+    {# Two single-purpose pickers (file vs. folder) rather than one
+       combined "Browse" button: a dialog can't be both a file and a
+       directory selector on Linux/Windows, so a combined picker there
+       falls back to a directory selector and picking a file returns its
+       parent directory. Each button opens the OS picker for its mode and
+       writes the chosen absolute path back into the field above. Placed
+       below the input and left-aligned (rather than to its right) so they
+       do not stack in the same column as the right-aligned Deny / Approve
+       buttons. Hidden unless the Electron native-picker bridge is present;
+       in a plain browser the user pastes a path into the field above. #}
+    <div class="mt-2 flex gap-2">
+      <Button id="file-sharing-browse-file-btn"
               variant="secondary"
               extra="hidden"
-              onclick="window.browseForSharePath && window.browseForSharePath()">Browse…</Button>
+              onclick="window.browseForSharePath && window.browseForSharePath('file')">Choose file…</Button>
+      <Button id="file-sharing-browse-folder-btn"
+              variant="secondary"
+              extra="hidden"
+              onclick="window.browseForSharePath && window.browseForSharePath('directory')">Choose folder…</Button>
     </div>
     {# Hidden checked input named ``permissions`` so the base dialog's
        updateApproveState treats this fragment as "has a selection":

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
@@ -17,14 +17,21 @@
     <p class="text-sm text-zinc-700 mb-3">
       {% if access == 'WRITE' %}
         Approving will grant {{ ws_name or agent_id }} and its sibling agents
-        <strong>read and write</strong> access (including delete) to the following file/directory:
+        <strong>read and write</strong> access (including delete) to the file/directory below.
       {% else %}
         Approving will grant {{ ws_name or agent_id }} and its sibling agents
-        <strong>read-only</strong> access to the following file:
+        <strong>read-only</strong> access to the file/directory below.
       {% endif %}
+      You can edit the path before approving -- paste a different one or pick it with Browse.
     </p>
-    <Card layout="row">
-      <code class="text-sm font-mono text-zinc-900 break-all flex-1 min-w-0">{{ file_path }}</code>
+    {# Editable share path. The input is pre-filled with the path the
+       agent requested; the user may change it (paste or native file
+       picker) before approving. The inbox shell's ``browseForSharePath``
+       opens the OS file dialog and writes the chosen path back here, and
+       its ``updateApproveState`` keeps Approve disabled while the field
+       is empty. #}
+    <div class="flex items-center justify-between gap-3 mb-1.5">
+      <FormLabel target="file-sharing-path-input">Path to share</FormLabel>
       {# Access mode badge -- emerald tint for read-only, amber for
          read+write so the broader grant stands out visually. #}
       {% if access == 'WRITE' %}
@@ -36,11 +43,26 @@
           {{ access_human_label }}
         </span>
       {% endif %}
-    </Card>
+    </div>
+    <div class="flex items-stretch gap-2">
+      <TextInput id="file-sharing-path-input"
+                 name="file_path"
+                 :value="file_path"
+                 extra="font-mono text-sm flex-1 min-w-0"
+                 oninput="window.updateApproveState && window.updateApproveState()" />
+      {# Hidden unless the Electron native-picker bridge is present (the
+         inbox shell reveals it on detail render). In a plain browser the
+         user can still paste a path into the input above. #}
+      <Button id="file-sharing-browse-btn"
+              variant="secondary"
+              extra="shrink-0 hidden"
+              onclick="window.browseForSharePath && window.browseForSharePath()">Browse…</Button>
+    </div>
     {# Hidden checked input named ``permissions`` so the base dialog's
-       updateApproveState enables the Approve button on first paint:
+       updateApproveState treats this fragment as "has a selection":
        there is no per-permission choice in this flow, the request itself
-       already names the single (path, access) pair. #}
+       already names the single (path, access) pair. Approve is gated
+       additionally on the path field being non-empty (see the shell). #}
     <input type="checkbox" name="permissions" value="file-sharing" checked hidden>
   </PermissionsForm>
 

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
@@ -1,4 +1,4 @@
-{#def agent_id, request_id, ws_name, rationale, file_path, access, access_human_label, display_name, mngr_forward_origin #}
+{#def agent_id, request_id, ws_name, rationale, file_path, access, access_human_label, display_name, allowed_roots_json="[]", mngr_forward_origin #}
 {#
   Latchkey file-sharing permission request fragment. Rendered inside the
   inbox modal's right pane. Provides a single hidden checked
@@ -46,11 +46,22 @@
         </span>
       {% endif %}
     </div>
+    {# ``data-allowed-roots`` carries the WebDAV mount roots so the inbox
+       shell can flag (and block Approve on) a path outside them as the
+       user types or picks one -- the same roots the server validates
+       against. #}
     <TextInput id="file-sharing-path-input"
                name="file_path"
                :value="file_path"
+               :data-allowed-roots="allowed_roots_json"
                extra="font-mono text-sm"
                oninput="window.updateApproveState && window.updateApproveState()" />
+    {# Shown by the inbox shell only when the field holds a non-empty path
+       that is outside the shared roots. #}
+    <p id="file-sharing-path-hint" class="hidden mt-1.5 text-xs text-amber-700">
+      This path isn't inside a folder Minds can share (your home folder or the system
+      temporary folder), so it can't be shared. Pick a path under one of those instead.
+    </p>
     {# Two single-purpose pickers (file vs. folder) rather than one
        combined "Browse" button: a dialog can't be both a file and a
        directory selector on Linux/Windows, so a combined picker there

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/LatchkeyFileSharingPermission.jinja
@@ -11,9 +11,9 @@
 
   <PermissionsForm :request_id="request_id">
     {# Single summary sentence (mirroring the predefined dialog's simple view)
-       naming the requesting workspace, the access level, and that the grant
-       is host-wide, followed by a white card showing the absolute file
-       path and an access badge. #}
+       naming the requesting workspace and the access level, followed by an
+       editable path field (with an access badge beside its label) and a
+       Browse button that opens the OS file picker. #}
     <p class="text-sm text-zinc-700 mb-3">
       {% if access == 'WRITE' %}
         Approving will grant {{ ws_name or agent_id }} and its sibling agents
@@ -30,10 +30,12 @@
        opens the OS file dialog and writes the chosen path back here, and
        its ``updateApproveState`` keeps Approve disabled while the field
        is empty. #}
-    <div class="flex items-center justify-between gap-3 mb-1.5">
-      <FormLabel target="file-sharing-path-input">Path to share</FormLabel>
-      {# Access mode badge -- emerald tint for read-only, amber for
-         read+write so the broader grant stands out visually. #}
+    {# Field label + access badge on one line, left-aligned, so the badge
+       reads as labelling the field rather than floating above the Browse
+       control on the right edge. Emerald tint for read-only, amber for
+       read+write so the broader grant stands out visually. #}
+    <div class="flex items-center gap-2 mb-1.5">
+      <FormLabel inline target="file-sharing-path-input">Path to share</FormLabel>
       {% if access == 'WRITE' %}
         <span class="shrink-0 text-xs font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-amber-50 text-amber-800 border border-amber-200">
           {{ access_human_label }}
@@ -44,18 +46,21 @@
         </span>
       {% endif %}
     </div>
-    <div class="flex items-stretch gap-2">
-      <TextInput id="file-sharing-path-input"
-                 name="file_path"
-                 :value="file_path"
-                 extra="font-mono text-sm flex-1 min-w-0"
-                 oninput="window.updateApproveState && window.updateApproveState()" />
-      {# Hidden unless the Electron native-picker bridge is present (the
-         inbox shell reveals it on detail render). In a plain browser the
-         user can still paste a path into the input above. #}
+    <TextInput id="file-sharing-path-input"
+               name="file_path"
+               :value="file_path"
+               extra="font-mono text-sm"
+               oninput="window.updateApproveState && window.updateApproveState()" />
+    {# Browse opens the OS file picker and writes the chosen path back into
+       the field above. Placed below the input and left-aligned (rather
+       than to its right) so it does not stack in the same column as the
+       right-aligned Deny / Approve buttons. Hidden unless the Electron
+       native-picker bridge is present; in a plain browser the user pastes
+       a path into the field above. #}
+    <div class="mt-2">
       <Button id="file-sharing-browse-btn"
               variant="secondary"
-              extra="shrink-0 hidden"
+              extra="hidden"
               onclick="window.browseForSharePath && window.browseForSharePath()">Browse…</Button>
     </div>
     {# Hidden checked input named ``permissions`` so the base dialog's

--- a/apps/minds/imbue/minds/desktop_client/webdav.py
+++ b/apps/minds/imbue/minds/desktop_client/webdav.py
@@ -103,7 +103,18 @@ def _build_wsgidav_config(share_roots: tuple[Path, ...]) -> dict[str, Any]:
     """Build the WsgiDAV config dict for ``share_roots``."""
     provider_mapping: dict[str, FilesystemProvider] = {}
     for root in share_roots:
-        provider_mapping[str(root)] = FilesystemProvider(str(root), readonly=False)
+        # WsgiDAV matches the request path against a *lowercased* copy of
+        # the share keys but then looks the matched share back up in
+        # ``provider_mapping`` using that lowercased string. A share key
+        # containing uppercase characters (e.g. a macOS home directory
+        # ``/Users/<name>``) therefore never resolves: the lookup misses,
+        # the provider comes back ``None``, and WsgiDAV answers 404. We
+        # register the share under a lowercased key so the lookup always
+        # hits; the ``FilesystemProvider`` keeps the real, correct-case
+        # path so files still resolve on case-sensitive filesystems. The
+        # share prefix length is identical regardless of case, so WsgiDAV's
+        # ``PATH_INFO`` stripping stays correct.
+        provider_mapping[str(root).lower()] = FilesystemProvider(str(root), readonly=False)
     return {
         "provider_mapping": provider_mapping,
         # Auth is enforced by the outer ASGI bearer-token gate; WsgiDAV

--- a/apps/minds/imbue/minds/desktop_client/webdav.py
+++ b/apps/minds/imbue/minds/desktop_client/webdav.py
@@ -139,6 +139,20 @@ def _build_wsgidav_config(share_roots: tuple[Path, ...]) -> dict[str, Any]:
     }
 
 
+def get_file_sharing_roots() -> tuple[Path, ...]:
+    """Return the on-disk roots the WebDAV file server mounts.
+
+    Currently the current user's home directory and the system temp
+    directory. This is the single source of truth for "which paths are
+    shareable": the WebDAV mount is built from it, and the file-sharing
+    permission handler validates a requested (or user-edited) path
+    against it so a path outside these roots is rejected with a clear
+    error before it ever reaches the gateway (which would otherwise be
+    the only thing to catch it, and only as a less-friendly 4xx).
+    """
+    return (Path.home(), Path(tempfile.gettempdir()))
+
+
 def create_webdav_app(expected_key_provider: ExpectedKeyProvider) -> ASGIApp:
     """Build the ASGI app to mount under ``/api/v1/files``.
 
@@ -146,9 +160,7 @@ def create_webdav_app(expected_key_provider: ExpectedKeyProvider) -> ASGIApp:
     WebDAV, gated by the central minds-api Bearer token resolved through
     ``expected_key_provider`` on each request.
     """
-    home_root = Path.home()
-    tmp_root = Path(tempfile.gettempdir())
-    share_roots = (home_root, tmp_root)
+    share_roots = get_file_sharing_roots()
     config = _build_wsgidav_config(share_roots)
     wsgi_app = WsgiDAVApp(config)
     # ``a2wsgi.WSGIMiddleware`` is structurally an ASGI app, but it is

--- a/apps/minds/imbue/minds/desktop_client/webdav_test.py
+++ b/apps/minds/imbue/minds/desktop_client/webdav_test.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from uuid import uuid4
 
 from starlette.testclient import TestClient
-
 from wsgidav.wsgidav_app import WsgiDAVApp
 
 from imbue.minds.config.data_types import WorkspacePaths

--- a/apps/minds/imbue/minds/desktop_client/webdav_test.py
+++ b/apps/minds/imbue/minds/desktop_client/webdav_test.py
@@ -7,11 +7,14 @@ from uuid import uuid4
 
 from starlette.testclient import TestClient
 
+from wsgidav.wsgidav_app import WsgiDAVApp
+
 from imbue.minds.config.data_types import WorkspacePaths
 from imbue.minds.desktop_client.api_key_store import generate_api_key
 from imbue.minds.desktop_client.app import create_desktop_client
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
+from imbue.minds.desktop_client.webdav import _build_wsgidav_config
 
 
 def _build_authenticated_client(tmp_path: Path) -> tuple[TestClient, str]:
@@ -163,6 +166,27 @@ def test_delete_removes_file_under_tmp(tmp_path: Path) -> None:
     )
     assert response.status_code in (200, 204)
     assert not target.exists()
+
+
+def test_share_root_with_uppercase_chars_resolves_to_provider(tmp_path: Path) -> None:
+    """A share root containing uppercase chars (e.g. macOS ``/Users/<name>``) resolves.
+
+    WsgiDAV lowercases share keys for matching but looks the matched share
+    back up by that lowercased string. Without the lowercased-key
+    workaround in ``_build_wsgidav_config`` a share like ``/Users/glenn``
+    resolves to ``provider=None``, and a PROPFIND under it 404s with
+    "Could not find resource provider". This reproduces that routing on
+    any OS, so it fails before the fix regardless of the host home path.
+    """
+    # ``FilesystemProvider`` requires the share root to exist, so we make a
+    # real directory whose path contains uppercase characters (mirroring a
+    # macOS ``/Users/<Name>`` home).
+    uppercase_root = tmp_path / "Users" / "Glenn"
+    uppercase_root.mkdir(parents=True)
+    config = _build_wsgidav_config((uppercase_root,))
+    app = WsgiDAVApp(config)
+    share, provider = app.resolve_provider(f"{uppercase_root}/Documents/Minds/notes.txt")
+    assert provider is not None, f"share {share!r} did not resolve to a provider"
 
 
 def test_paths_outside_share_roots_return_404(tmp_path: Path) -> None:

--- a/libs/mngr_latchkey/changelog/hynek-fix-file-sharing-oddities.md
+++ b/libs/mngr_latchkey/changelog/hynek-fix-file-sharing-oddities.md
@@ -9,3 +9,15 @@ request creation, the access mode fixed at creation time is preserved (a path
 override cannot escalate read-only to read-write), and only the `path` field is
 accepted in the body. An empty or `null` body preserves the previous behavior
 (apply the precomputed effect verbatim).
+
+File-sharing requests are now validated to be within one of the Minds WebDAV
+mount roots -- the user's home directory or the system temp directory -- at
+request-creation time (and at approve time for a user-edited path override).
+A grant for any path outside those roots is inert (the WebDAV server has no
+provider for it and answers 404), so rejecting it up front gives the agent a
+clear "must be within a shared root" error instead of an approve-then-404 dead
+end. The roots are derived from the gateway process's `homedir()` / `tmpdir()`,
+which match the `Path.home()` / `tempfile.gettempdir()` roots the Minds WebDAV
+server serves on the desktop host. The comparison is case-insensitive (mirroring
+the WebDAV share-prefix matching) and purely lexical (no symlink resolution or
+existence check).

--- a/libs/mngr_latchkey/changelog/hynek-fix-file-sharing-oddities.md
+++ b/libs/mngr_latchkey/changelog/hynek-fix-file-sharing-oddities.md
@@ -1,0 +1,11 @@
+The `permission-requests` gateway extension's approve endpoint
+(`POST /permission-requests/approve/<id>`) now accepts an optional JSON body
+carrying a single `path` field. When present, and only for `file-sharing`
+requests, the file-sharing effect is recomputed for that path instead of using
+the one precomputed at request-creation time -- this lets the Minds desktop
+client honor a user who edited the shared path in the approval dialog. The
+overridden path is re-validated with the same traversal-rejection rules used at
+request creation, the access mode fixed at creation time is preserved (a path
+override cannot escalate read-only to read-write), and only the `path` field is
+accepted in the body. An empty or `null` body preserves the previous behavior
+(apply the precomputed effect verbatim).

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
@@ -1194,7 +1194,77 @@ function mergeSchemas(existingSchemas, effectSchemas) {
   return base;
 }
 
-function handleApproveRequest(response, rawRequestId) {
+/**
+ * Parse the optional JSON body of a ``POST /permission-requests/approve/<id>``
+ * call. The desktop client sends a body only when the user edited the
+ * shared path in the approval dialog before approving; the body then
+ * carries a single ``path`` field with the (possibly new) absolute
+ * filesystem path the grant should target. An empty body (the common
+ * case -- the user approved the request as-is) yields ``null``.
+ *
+ * The override path is validated here with the same traversal-rejection
+ * rules that guard request *creation* (``validateAbsoluteFileSharingPath``),
+ * so a user-edited path is held to exactly the same security bar as an
+ * agent-supplied one. Any field other than ``path`` is rejected so the
+ * server stays the single source of truth on identity, target, and
+ * access mode.
+ */
+async function parseApproveOverrideBody(request) {
+  const raw = await readRequestBody(request);
+  if (raw.trim().length === 0) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new InvalidRequestBodyError(`approve body is not valid JSON: ${message}`);
+  }
+  // A literal JSON ``null`` body means "no override", same as an empty
+  // body -- some HTTP clients serialize an absent payload that way.
+  if (parsed === null) {
+    return null;
+  }
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new InvalidRequestBodyError('approve body must be a JSON object.');
+  }
+  ensureNoExtraneousFields('approve body ', ['path'], parsed);
+  if (parsed.path === undefined) {
+    return null;
+  }
+  validateAbsoluteFileSharingPath(parsed.path);
+  return { path: parsed.path };
+}
+
+/**
+ * Resolve the effect that approving ``requestRecord`` should splice in.
+ *
+ * With no override this is just the precomputed ``requestRecord.effect``.
+ * When the user edited the shared path in the dialog (``override`` is
+ * non-null), the effect is recomputed for the new path so the grant
+ * targets exactly what the user chose -- but only for ``file-sharing``
+ * requests, which are the only kind whose effect is path-derived. A
+ * path override on any other request type is a programming error in the
+ * caller and is rejected.
+ */
+function resolveEffectForApproval(requestRecord, override) {
+  if (override === null) {
+    return requestRecord.effect;
+  }
+  if (requestRecord.request_type !== REQUEST_TYPE_FILE_SHARING) {
+    throw new InvalidRequestBodyError(
+      `a 'path' override is only valid for '${REQUEST_TYPE_FILE_SHARING}' requests; `
+      + `request ${requestRecord.request_id} is '${requestRecord.request_type}'.`,
+    );
+  }
+  // The access mode is fixed at request-creation time and is not
+  // user-editable: the user may narrow/redirect *where* the grant
+  // applies, but not escalate read-only to read-write.
+  return computeFileSharingEffect(override.path, requestRecord.payload.access);
+}
+
+function handleApproveRequest(response, rawRequestId, override = null) {
   const requestId = validateRequestId(rawRequestId);
   const filePath = requestFilePath(requestId);
   const requestRecord = readRequestFile(filePath);
@@ -1202,7 +1272,7 @@ function handleApproveRequest(response, rawRequestId) {
     throw new RequestNotFoundError(requestId);
   }
   const target = requestRecord.target;
-  const effect = requestRecord.effect;
+  const effect = resolveEffectForApproval(requestRecord, override);
   const permissionsFile = readPermissionsFileOrEmpty(target);
 
   const updatedRules = effect.rules ? mergeRules(permissionsFile.rules, effect.rules) : permissionsFile.rules;
@@ -1253,7 +1323,8 @@ export default async function permissionRequestsExtension(request, response, con
       return true;
     }
     if (route.kind === 'approve' && method === 'POST') {
-      handleApproveRequest(response, route.requestIdFromPath);
+      const override = await parseApproveOverrideBody(request);
+      handleApproveRequest(response, route.requestIdFromPath, override);
       return true;
     }
     if (route.kind === 'item' && method === 'DELETE') {

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests.mjs
@@ -85,7 +85,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join, posix, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -310,15 +310,58 @@ function ensureNoExtraneousFields(parent, allowed, parsed) {
 }
 
 /**
+ * The on-disk roots the Minds WebDAV server mounts: the current user's
+ * home directory and the system temp directory. Computed from Node's
+ * ``homedir()`` / ``tmpdir()`` which -- on the desktop host, where the
+ * gateway and the Minds WebDAV server run as the same user in the same
+ * environment -- match the ``Path.home()`` / ``tempfile.gettempdir()``
+ * roots that ``webdav.py`` actually serves.
+ *
+ * Trailing slashes are stripped so the prefix test in
+ * ``isPathWithinFileSharingRoot`` is uniform. A falsy root (which
+ * ``homedir()`` / ``tmpdir()`` should never return on a real host) is
+ * dropped rather than collapsed to ``/`` (which would match every
+ * path).
+ */
+function fileSharingMountRoots() {
+  const roots = [];
+  for (const root of [homedir(), tmpdir()]) {
+    if (typeof root !== 'string' || root.length === 0) {
+      continue;
+    }
+    const trimmed = root.replace(/\/+$/, '');
+    roots.push(trimmed.length > 0 ? trimmed : '/');
+  }
+  return roots;
+}
+
+/**
+ * Whether ``filePath`` is at or beneath ``root``. The comparison is
+ * case-insensitive to mirror WsgiDAV's share-prefix matching (it
+ * lowercases both the share keys and the request path), and purely
+ * lexical -- we do not resolve symlinks or require the path to exist,
+ * matching how the WebDAV server mounts by string prefix.
+ */
+function isPathWithinFileSharingRoot(filePath, root) {
+  const lowerPath = filePath.toLowerCase();
+  const lowerRoot = root.toLowerCase();
+  return lowerPath === lowerRoot || lowerPath.startsWith(`${lowerRoot}/`);
+}
+
+/**
  * Validate an absolute filesystem path for the ``file-sharing`` payload.
  *
- * The path must start with ``/`` and must not contain any ``..``
- * segments (under either POSIX or Windows separators). We deliberately
- * do not resolve symlinks or check that the file exists here; that is
- * a job for the Minds API endpoint that ends up serving the file when
- * the request is approved. The goal is just to reject obvious traversal
- * patterns up front so a request like ``/etc/passwd/../shadow`` is
- * refused at creation time.
+ * The path must start with ``/``, must not contain any ``..`` segments
+ * (under either POSIX or Windows separators), and must lie within one
+ * of the WebDAV mount roots (the user's home directory or the system
+ * temp directory). We deliberately do not resolve symlinks or check
+ * that the file exists here; that is a job for the Minds API endpoint
+ * that ends up serving the file when the request is approved. The goals
+ * are to reject obvious traversal patterns (e.g. ``/etc/passwd/../shadow``)
+ * and to reject paths the WebDAV server could never serve (anything
+ * outside the two mounts), so the agent gets a clear error at request
+ * time -- or at approve time, when this also guards a user-edited path
+ * override -- rather than an approve-then-404 dead end.
  */
 function validateAbsoluteFileSharingPath(rawPath) {
   if (typeof rawPath !== 'string' || rawPath.length === 0) {
@@ -347,6 +390,14 @@ function validateAbsoluteFileSharingPath(rawPath) {
   const normalized = posix.normalize(rawPath);
   if (!normalized.startsWith('/') || normalized.includes('/../') || normalized.endsWith('/..')) {
     throw new InvalidRequestBodyError(`payload.'path' normalizes to a traversed path: ${rawPath} -> ${normalized}.`);
+  }
+  // Reject anything the Minds WebDAV server could never serve: it mounts
+  // only the home and temp roots, so a grant elsewhere is inert (404).
+  const roots = fileSharingMountRoots();
+  if (!roots.some((root) => isPathWithinFileSharingRoot(normalized, root))) {
+    throw new InvalidRequestBodyError(
+      `payload.'path' must be within a shared root (${roots.join(', ')}); got ${rawPath}.`,
+    );
   }
 }
 

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
@@ -698,6 +698,153 @@ def test_approve_404s_on_unknown_request_id(node_extension: tuple[str, Path, Pat
     assert "not found" in json.loads(body)["error"].lower()
 
 
+def test_approve_with_path_override_recomputes_file_sharing_effect(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """A user-edited path in the approve body retargets the file-sharing grant.
+
+    The agent requests one path; the user edits it before approving. The
+    grant that lands must target the user's path -- the per-file schema
+    name and pattern derive from the edited path, and the originally
+    requested path must not appear in the applied permissions.
+    """
+    base_url, _latchkey_directory, permissions_config_path = node_extension
+    requested_path = "/home/example/requested.txt"
+    edited_path = "/home/example/Documents/Shared"
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "needs a file",
+            "type": "file-sharing",
+            "payload": {"path": requested_path, "access": "READ"},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+
+    approve_status, approve_body = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": edited_path},
+    )
+    assert approve_status == 200, approve_body
+
+    applied = json.loads(permissions_config_path.read_text())
+    edited_name = _file_sharing_permission_name(edited_path, "READ")
+    requested_name = _file_sharing_permission_name(requested_path, "READ")
+    # The grant targets the edited path, not the originally requested one.
+    assert applied["rules"] == [{_FILE_SHARING_SCOPE_NAME: [edited_name]}]
+    assert edited_name in applied["schemas"]
+    assert requested_name not in applied["schemas"]
+    # The schema's URL pattern embeds the edited path under the WebDAV mount.
+    pattern = applied["schemas"][edited_name]["properties"]["path"]["pattern"]
+    assert edited_path in pattern
+    assert requested_path not in pattern
+
+
+def test_approve_with_path_override_preserves_requested_access_mode(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """Editing the path must not change the access mode fixed at request time."""
+    base_url, _latchkey_directory, permissions_config_path = node_extension
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "needs to write",
+            "type": "file-sharing",
+            "payload": {"path": "/home/example/orig", "access": "WRITE"},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    approve_status, _ = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": "/home/example/edited"},
+    )
+    assert approve_status == 200
+    applied = json.loads(permissions_config_path.read_text())
+    # The recomputed schema keeps the WRITE access mode (write verbs present).
+    write_name = _file_sharing_permission_name("/home/example/edited", "WRITE")
+    assert write_name in applied["schemas"]
+    methods = applied["schemas"][write_name]["properties"]["method"]["enum"]
+    assert "PUT" in methods and "DELETE" in methods
+
+
+def test_approve_rejects_path_override_for_predefined_request(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """A path override only makes sense for file-sharing; reject it elsewhere."""
+    base_url, _latchkey_directory, permissions_config_path = node_extension
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "x",
+            "type": "predefined",
+            "payload": {"scope": "slack-api", "permissions": ["slack-read-all"]},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    status, body = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": "/home/example/whatever"},
+    )
+    assert status == 400, body
+    assert "file-sharing" in json.loads(body)["error"]
+    # The grant was not applied (the request stays pending).
+    assert not permissions_config_path.exists()
+
+
+def test_approve_rejects_traversal_in_path_override(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """A ``..`` segment in the edited path is rejected just like at creation."""
+    base_url, *_ = node_extension
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "x",
+            "type": "file-sharing",
+            "payload": {"path": "/home/example/ok.txt", "access": "READ"},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    status, body = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": "/home/example/../../etc/shadow"},
+    )
+    assert status == 400, body
+    assert "traversal" in json.loads(body)["error"].lower()
+
+
+def test_approve_rejects_extraneous_field_in_override_body(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """Only ``path`` is allowed in the approve override body."""
+    base_url, *_ = node_extension
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "x",
+            "type": "file-sharing",
+            "payload": {"path": "/home/example/ok.txt", "access": "READ"},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    status, body = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": "/home/example/ok.txt", "access": "WRITE"},
+    )
+    assert status == 400, body
+    assert "access" in json.loads(body)["error"]
+
+
 def test_delete_removes_pending_request(node_extension: tuple[str, Path, Path]) -> None:
     base_url, latchkey_directory, _permissions_config_path = node_extension
     create_status, create_body = _post_json(

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/permission_requests_test.py
@@ -170,6 +170,14 @@ def node_extension(tmp_path: Path) -> Generator[tuple[str, Path, Path], None, No
             "LATCHKEY_DIRECTORY": str(latchkey_directory),
             "TEST_PERMISSIONS_CONFIG_PATH": str(permissions_config_path),
             "PATH": "/usr/bin:/bin",
+            # File-sharing path validation rejects paths outside the WebDAV
+            # mount roots, which the extension derives from the process's
+            # HOME / TMPDIR (Node's ``homedir()`` / ``tmpdir()``). Pin both
+            # to deterministic values so tests can use stable in-root paths
+            # (``/home/example/...`` and ``/tmp/...``) regardless of the
+            # runner's real HOME / TMPDIR.
+            "HOME": "/home/example",
+            "TMPDIR": "/tmp",
         },
         text=True,
     )
@@ -438,6 +446,41 @@ def test_post_rejects_traversal_in_file_sharing(node_extension: tuple[str, Path,
         assert status == 400, (traversal_path, body)
         message = json.loads(body)["error"].lower()
         assert "traversal" in message or "absolute" in message, (traversal_path, message)
+
+
+def test_post_rejects_path_outside_mount_roots(node_extension: tuple[str, Path, Path]) -> None:
+    """A path outside the home / temp WebDAV mounts is rejected at creation."""
+    base_url, *_ = node_extension
+    status, body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "wants a system file",
+            "type": "file-sharing",
+            "payload": {"path": "/etc/passwd", "access": "READ"},
+        },
+    )
+    assert status == 400, body
+    message = json.loads(body)["error"]
+    assert "shared root" in message
+    # The error names the roots so the agent can self-correct.
+    assert "/home/example" in message
+    assert "/tmp" in message
+
+
+def test_post_accepts_path_under_temp_root(node_extension: tuple[str, Path, Path]) -> None:
+    """A path under the system temp mount is accepted (the temp dir is a shared root)."""
+    base_url, *_ = node_extension
+    status, body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "share a scratch file",
+            "type": "file-sharing",
+            "payload": {"path": "/tmp/scratch/output.txt", "access": "WRITE"},
+        },
+    )
+    assert status == 201, body
 
 
 def test_post_rejects_extraneous_top_level_field(node_extension: tuple[str, Path, Path]) -> None:
@@ -819,6 +862,32 @@ def test_approve_rejects_traversal_in_path_override(
     )
     assert status == 400, body
     assert "traversal" in json.loads(body)["error"].lower()
+
+
+def test_approve_rejects_path_override_outside_mount_roots(
+    node_extension: tuple[str, Path, Path],
+) -> None:
+    """An edited path outside the WebDAV mounts is rejected on approve, same as at creation."""
+    base_url, _latchkey_directory, permissions_config_path = node_extension
+    create_status, create_body = _post_json(
+        f"{base_url}/permission-requests",
+        {
+            "agent_id": "agent-1",
+            "rationale": "x",
+            "type": "file-sharing",
+            "payload": {"path": "/home/example/ok.txt", "access": "READ"},
+        },
+    )
+    assert create_status == 201
+    request_id = json.loads(create_body)["request_id"]
+    status, body = _post_json(
+        f"{base_url}/permission-requests/approve/{request_id}",
+        {"path": "/etc/shadow"},
+    )
+    assert status == 400, body
+    assert "shared root" in json.loads(body)["error"]
+    # The grant was not applied (the request stays pending).
+    assert not permissions_config_path.exists()
 
 
 def test_approve_rejects_extraneous_field_in_override_body(


### PR DESCRIPTION
- Fix a bug that primarily manifested on macOS that caused file sharing to fail for Glenn in the first place.
    - (`wsgidav` converts mounts root points to lowercase)
- Allow people to easily override the requested path (something that Glenn attempted to do but couldn't).
- Let agents know when they're trying to request access to a file path that cannot be fulfilled (because it lies outside of the mounted root).

<img width="791" height="423" alt="browse_buttons" src="https://github.com/user-attachments/assets/6353dee3-207a-4f02-872f-a95a24c25ccb" />

