### PR TITLE
Revert Modal async-permission-propagation workaround

### DIFF
--- a/libs/mngr_modal/changelog/mngr-revert-modal-fix.md
+++ b/libs/mngr_modal/changelog/mngr-revert-modal-fix.md
@@ -1,0 +1,16 @@
+## Remove Modal async-permission-propagation workaround
+
+Modal has fixed the bug on their side where a just-created environment returned
+`modal.exception.PermissionDeniedError` for several seconds (async per-user
+permission propagation) before the creating user could operate on it.
+Read-after-write is now immediate, so the workaround is no longer needed.
+
+Removed from `mngr_modal`:
+
+- The `ModalProxyPermissionDeniedError` retries in
+  `_lookup_persistent_app_with_retry` and `_enter_ephemeral_app_context_with_retry`
+  (`imbue.mngr_modal.backend`); both decorators once again retry only on
+  `ModalProxyNotFoundError`.
+- The `_invoke_modal_sdk_delete_with_retry` test-cleanup helper in `conftest.py`;
+  `_classify_modal_sdk_delete` now invokes the SDK delete callable directly again.
+</content>

--- a/libs/mngr_modal/changelog/mngr-revert-modal-fix.md
+++ b/libs/mngr_modal/changelog/mngr-revert-modal-fix.md
@@ -13,4 +13,3 @@ Removed from `mngr_modal`:
   `ModalProxyNotFoundError`.
 - The `_invoke_modal_sdk_delete_with_retry` test-cleanup helper in `conftest.py`;
   `_classify_modal_sdk_delete` now invokes the SDK delete callable directly again.
-</content>

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -41,7 +41,6 @@ from imbue.modal_proxy.direct import DirectModalInterface
 from imbue.modal_proxy.errors import ModalProxyAuthError
 from imbue.modal_proxy.errors import ModalProxyError
 from imbue.modal_proxy.errors import ModalProxyNotFoundError
-from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.interface import AppInterface
 from imbue.modal_proxy.interface import ModalInterface
 from imbue.modal_proxy.interface import VolumeInterface
@@ -133,11 +132,7 @@ def _lookup_persistent_app_with_env_retry(
 
 
 @retry(
-    # Retry on PermissionDeniedError as well: after `modal environment create`
-    # returns success, Modal's per-user permission entry is propagated
-    # asynchronously and operations on the new env raise PermissionDeniedError
-    # for ~3-7 seconds before catching up.
-    retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
+    retry=retry_if_exception_type(ModalProxyNotFoundError),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,
@@ -180,11 +175,7 @@ def _enter_ephemeral_app_context_with_env_retry(
 
 
 @retry(
-    # Retry on PermissionDeniedError as well: after `modal environment create`
-    # returns success, Modal's per-user permission entry is propagated
-    # asynchronously and operations on the new env raise PermissionDeniedError
-    # for ~3-7 seconds before catching up.
-    retry=retry_if_exception_type((ModalProxyNotFoundError, ModalProxyPermissionDeniedError)),
+    retry=retry_if_exception_type(ModalProxyNotFoundError),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,

--- a/libs/mngr_modal/imbue/mngr_modal/conftest.py
+++ b/libs/mngr_modal/imbue/mngr_modal/conftest.py
@@ -16,10 +16,6 @@ import pytest
 import toml
 from loguru import logger
 from modal.environments import delete_environment
-from tenacity import retry
-from tenacity import retry_if_exception_type
-from tenacity import stop_after_attempt
-from tenacity import wait_exponential
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.data_types import MngrConfig
@@ -213,23 +209,6 @@ def _apply_cleanup_outcome(
             assert_never(unreachable)
 
 
-@retry(
-    retry=retry_if_exception_type(modal.exception.PermissionDeniedError),
-    stop=stop_after_attempt(5),
-    wait=wait_exponential(multiplier=1, min=1, max=5),
-    reraise=True,
-)
-def _invoke_modal_sdk_delete_with_retry(delete_fn: Callable[[], object]) -> None:
-    """Invoke a Modal SDK delete callable, retrying on transient PermissionDeniedError.
-
-    Modal's per-user permission entry for a just-created resource propagates
-    asynchronously, so deletes immediately after creation can spuriously fail
-    with PermissionDeniedError for ~3-7 seconds before the permission system
-    catches up. Retry with exponential backoff to ride through that window.
-    """
-    delete_fn()
-
-
 def _classify_modal_sdk_delete(delete_fn: Callable[[], object], resource_description: str) -> ModalCleanupOutcome:
     """Run an SDK delete callable and classify the outcome as a `ModalCleanupOutcome`.
 
@@ -244,7 +223,7 @@ def _classify_modal_sdk_delete(delete_fn: Callable[[], object], resource_descrip
     returning `None`; the return value is intentionally discarded here.
     """
     try:
-        _invoke_modal_sdk_delete_with_retry(delete_fn)
+        delete_fn()
         return ModalCleanupOutcome.DELETED
     except modal.exception.NotFoundError:
         logger.debug("Modal {} already gone", resource_description)

--- a/libs/modal_proxy/changelog/mngr-revert-modal-fix.md
+++ b/libs/modal_proxy/changelog/mngr-revert-modal-fix.md
@@ -11,4 +11,3 @@ Removed from `modal_proxy`:
 - The `_translate_modal_error` branch that mapped
   `modal.exception.PermissionDeniedError` to it (`imbue.modal_proxy.direct`);
   permission-denied errors once again fall through to the base `ModalProxyError`.
-</content>

--- a/libs/modal_proxy/changelog/mngr-revert-modal-fix.md
+++ b/libs/modal_proxy/changelog/mngr-revert-modal-fix.md
@@ -1,0 +1,14 @@
+## Remove Modal async-permission-propagation workaround
+
+Modal has fixed the bug on their side where a just-created environment returned
+`modal.exception.PermissionDeniedError` for several seconds (async per-user
+permission propagation) before the creating user could operate on it.
+Read-after-write is now immediate, so the workaround is no longer needed.
+
+Removed from `modal_proxy`:
+
+- The `ModalProxyPermissionDeniedError` error class (`imbue.modal_proxy.errors`).
+- The `_translate_modal_error` branch that mapped
+  `modal.exception.PermissionDeniedError` to it (`imbue.modal_proxy.direct`);
+  permission-denied errors once again fall through to the base `ModalProxyError`.
+</content>

--- a/libs/modal_proxy/imbue/modal_proxy/direct.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct.py
@@ -45,7 +45,6 @@ from imbue.modal_proxy.errors import ModalProxyError
 from imbue.modal_proxy.errors import ModalProxyInternalError
 from imbue.modal_proxy.errors import ModalProxyInvalidError
 from imbue.modal_proxy.errors import ModalProxyNotFoundError
-from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyRemoteError
 from imbue.modal_proxy.errors import ModalProxyTypeError
@@ -79,8 +78,6 @@ def _translate_modal_error(e: modal.exception.Error) -> ModalProxyError:
     """Convert a modal exception to the corresponding ModalProxy exception."""
     if isinstance(e, modal.exception.AuthError):
         return ModalProxyAuthError(str(e))
-    if isinstance(e, modal.exception.PermissionDeniedError):
-        return ModalProxyPermissionDeniedError(str(e))
     if isinstance(e, modal.exception.NotFoundError):
         return ModalProxyNotFoundError(str(e))
     if isinstance(e, modal.exception.InvalidError):

--- a/libs/modal_proxy/imbue/modal_proxy/direct_test.py
+++ b/libs/modal_proxy/imbue/modal_proxy/direct_test.py
@@ -29,7 +29,6 @@ from imbue.modal_proxy.direct import _unwrap_secret
 from imbue.modal_proxy.direct import _unwrap_volume
 from imbue.modal_proxy.errors import ModalProxyAppLockedError
 from imbue.modal_proxy.errors import ModalProxyError
-from imbue.modal_proxy.errors import ModalProxyPermissionDeniedError
 from imbue.modal_proxy.errors import ModalProxyRateLimitError
 from imbue.modal_proxy.errors import ModalProxyTypeError
 from imbue.modal_proxy.errors import is_app_locked_error
@@ -189,13 +188,6 @@ def test_translate_resource_exhausted_to_rate_limit_error() -> None:
     result = _translate_modal_error(modal_err)
     assert isinstance(result, ModalProxyRateLimitError)
     assert "rate limit" in str(result)
-
-
-def test_translate_permission_denied_to_permission_denied_error() -> None:
-    modal_err = modal.exception.PermissionDeniedError("user lacks access to environment 'mngr_test-abc'")
-    result = _translate_modal_error(modal_err)
-    assert isinstance(result, ModalProxyPermissionDeniedError)
-    assert "lacks access" in str(result)
 
 
 # --- Volume retry predicate tests ---

--- a/libs/modal_proxy/imbue/modal_proxy/errors.py
+++ b/libs/modal_proxy/imbue/modal_proxy/errors.py
@@ -50,17 +50,6 @@ class ModalProxyNotFoundError(ModalProxyError):
     """Raised when a Modal resource is not found."""
 
 
-class ModalProxyPermissionDeniedError(ModalProxyError):
-    """Raised when Modal denies access to a resource.
-
-    Modal's per-user permission entries are propagated asynchronously, so a
-    just-created environment (or a just-deleted volume) will report this
-    error for several seconds before the permission system catches up.
-    Callers that are in the middle of a creation/teardown flow should retry
-    this error with backoff.
-    """
-
-
 class ModalProxyInvalidError(ModalProxyError):
     """Raised when an invalid argument is passed to Modal."""
 


### PR DESCRIPTION
## Summary

Reverts the workaround added in `99dc38446` (and its follow-on test/doc commits) that captured `modal.exception.PermissionDeniedError` raised during Modal's async per-user permission propagation window.

Modal recently migrated their permissions system such that a just-created environment returned `PermissionDeniedError` for ~3-7 seconds (per-user permission entry granted asynchronously) before the creating user could operate on it. Modal has since fixed this on their side -- read-after-write is now immediate -- so the workaround is no longer needed.

## Changes

`modal_proxy`:
- Remove `ModalProxyPermissionDeniedError` (`imbue.modal_proxy.errors`).
- Remove the `_translate_modal_error` branch mapping `modal.exception.PermissionDeniedError` to it (`imbue.modal_proxy.direct`); permission-denied errors once again fall through to the base `ModalProxyError`.
- Drop the now-obsolete `test_translate_permission_denied_to_permission_denied_error` unit test.

`mngr_modal`:
- Both `_lookup_persistent_app_with_retry` and `_enter_ephemeral_app_context_with_retry` tenacity decorators retry only on `ModalProxyNotFoundError` again.
- Remove the `_invoke_modal_sdk_delete_with_retry` test-cleanup helper in `conftest.py`; `_classify_modal_sdk_delete` invokes the SDK delete callable directly again.

## Testing

- `direct_test.py`: 27 passed
- `mngr_modal` unit/integration (non-modal): 391 passed
- `test_meta_ratchets.py::test_no_type_errors`: passed
- ratchets for both projects: 112 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)