### PR TITLE
Apply create-template setting/setting__extend entries to config (#1914)

### DIFF
--- a/blueprint/template-setting-not-applied/plan-template-setting-not-applied.md
+++ b/blueprint/template-setting-not-applied/plan-template-setting-not-applied.md
@@ -1,0 +1,78 @@
+# Plan: Fix create-template `setting`/`setting__extend` entries being silently dropped (issue #1914)
+
+## Overview
+
+- **Bug:** A create template can declare `setting__extend = ["providers.docker.docker_runtime=runsc"]`. The value flows into the create command's `--setting` param but never reaches the resolved `MngrConfig`, so it has no effect. Direct CLI `-S/--setting` works; only template-provided settings are lost.
+- **Root cause:** In `libs/mngr/imbue/mngr/cli/common_opts.py`, `setup_command_context` applies settings to the config exactly once (lines 209-217, `apply_settings_to_config(... initial_opts.setting ...)`), and does so *before* `apply_create_template` runs (line 234). The template appends its `setting__extend` entries into `updated_params["setting"]` *after* that single application point, so they land in `opts.setting` but are never merged into `mngr_ctx.config`. `get_provider_instance` reads provider config from `mngr_ctx.config`, which never saw them.
+- **Why latent so long:** The only prior template `setting__extend` provider use was `providers.docker.is_enabled=true`, which is a no-op regardless of this bug — `get_provider_instance` (`api/providers.py:57`) resolves an explicitly-named provider directly from `config.providers[name]` with no `is_enabled` gate (that gate lives only in `list_provider_names_to_load`, `:166`). `docker_runtime` is the first template-set provider field whose absence is observable.
+- **Fix approach (decided in Q&A):** Keep the existing line-209 CLI `-S` application so `apply_config_defaults`/`apply_create_template` still see CLI settings. Then, at the end of the pipeline (create only), re-run `apply_settings_to_config` on the **originally-loaded** config with the combined `template-then-CLI` setting list, replacing the config returned in `mngr_ctx`. This preserves "CLI `-S` wins over template" precedence and avoids double-applying `__extend` (because we re-apply against the original config, not the already-modified one).
+- **Guardrail:** Template-contributed `setting` keys that target `commands.*` or `create_templates.*` cannot take effect (those are consumed *before* the re-application point), so they raise `ConfigParseError` rather than failing silently. Validation is scoped to template-contributed entries only — direct CLI `-S commands.*` keeps working.
+- **Secondary fix:** `config get` and `config list --all` cannot surface provider-subclass fields (e.g. `docker_runtime`) because `MngrConfig.providers` is typed as the base `dict[..., ProviderInstanceConfig]` and `model_dump(mode="json")` serializes by declared type, dropping subclass-only fields. Add `serialize_as_any=True` at the two `config.py` call sites. This made the bug hard to diagnose (the natural probe reported "Key not found").
+
+## Expected behavior
+
+- A create template with `setting__extend = ["providers.docker.docker_runtime=runsc"]` results in the resolved `mngr_ctx.config.providers["docker"].docker_runtime == "runsc"`, and the launched container runs under `--runtime runsc` (matching `mngr create ... -S providers.docker.docker_runtime=runsc`).
+- Bare-assign template settings (`setting = ["..."]`) and `setting__extend` both reach the config, with the same parse/merge semantics as `--setting`.
+- Direct CLI `-S` still wins over a template-provided setting for the same key (e.g. template sets `docker_runtime=runsc`, CLI `-S providers.docker.docker_runtime=runc` → resolved value is `runc`).
+- Template settings are subject to the same settings-narrowing guard as `--setting`: a template `setting` assignment that would narrow a non-empty list/dict/set raises `ConfigParseError` unless `allow_settings_key_assignment_narrowing` is enabled.
+- A template `setting`/`setting__extend` targeting `commands.*` or `create_templates.*` raises `ConfigParseError` naming the template and key and pointing the user at the `[commands.*]`/`[create_templates.*]` config sections. (Direct CLI `-S` for these keys is unaffected.)
+- A template `setting` targeting `allow_settings_key_assignment_narrowing` hits the existing rejection in `apply_settings_to_config` (the flag can't be set this way), consistent with `--setting`.
+- `mngr config get providers.docker.docker_runtime` and `mngr config list --all` now show provider-subclass fields that are set, instead of "Key not found".
+- Non-`create` commands are unchanged: only the `create` path runs the re-application/validation.
+
+## Implementation plan
+
+### `libs/mngr/imbue/mngr/cli/common_opts.py`
+
+- **`setup_command_context`** (the core change):
+  - Before line 209, capture a reference to the originally-loaded config (the `mngr_ctx.config` value prior to the CLI `-S` merge) — call it `base_config`. The existing line-209 block continues to merge `initial_opts.setting` into `mngr_ctx.config` so `apply_config_defaults` (line 225) and `apply_create_template` (line 234) keep seeing CLI settings.
+  - After `restore_cli_list_values` (line 238) and only when `command_name == "create"`:
+    - Compute the combined setting list from the post-pipeline params: `combined_settings = updated_params.get("setting", ())`. Its ordering is `template_entries + cli_entries` (config base for `setting` is `()`, templates extend, then `restore_cli_list_values` appends the CLI tail).
+    - Isolate the template-contributed slice by trimming the known CLI tail: `cli_count = len(initial_opts.setting)`; `template_settings = combined_settings[: len(combined_settings) - cli_count]`. (Asserted-consistent: the trailing `cli_count` entries equal `initial_opts.setting`.)
+    - If `template_settings` is non-empty:
+      - Validate each template setting key via a new helper `_reject_ineffective_template_setting_keys(template_settings, template_names)`; raise `ConfigParseError` if any key path's first segment is `commands` or `create_templates`.
+      - Re-apply: `final_config = apply_settings_to_config(base_config, combined_settings, base_config.disabled_plugins)` and update `mngr_ctx` with `to_update(mngr_ctx.field_ref().config, final_config)`.
+  - Net effect: for create with template settings, the returned config is recomputed from the original config with `template-then-CLI` settings applied once; for create without template settings and for all other commands, behavior is identical to today.
+- **New helper `_reject_ineffective_template_setting_keys(template_settings, template_names)`**:
+  - Parse each `KEY=VALUE` (reuse the same split logic shape as `apply_settings_to_config`), take the dotted key path, and reject when the first segment is in a module-level constant `_TEMPLATE_INEFFECTIVE_SETTING_PREFIXES = frozenset({"commands", "create_templates"})`.
+  - Error message (per Q&A): names the offending template(s) and key, explains it cannot take effect via a template `setting` because those sections are resolved before template settings are applied, and suggests writing it directly under the `[commands.*]` / `[create_templates.*]` config section.
+- **`apply_create_template` docstring:** no behavior change, but its existing contract ("the same operator suffix recognised in TOML, `--setting`, and env vars") is now actually honored for `setting`; leave the docstring accurate (it already promises this).
+
+### `libs/mngr/imbue/mngr/cli/config.py`
+
+- **`_config_get_impl`** (line 447): change `mngr_ctx.config.model_dump(mode="json")` to `mngr_ctx.config.model_dump(mode="json", serialize_as_any=True)`.
+- **`_config_list_impl`** (line 253, the `--all` `full_view`): same `serialize_as_any=True` addition so the full dump includes provider-subclass fields.
+
+### Changelog
+
+- Add `libs/mngr/changelog/mngr-fix-settings-bug-ticket.md` describing: template `setting`/`setting__extend` now apply to the resolved config; new error for `commands.*`/`create_templates.*` template settings; `config get`/`list --all` now surface provider-subclass fields. (Single-project PR — only `libs/mngr` is touched.)
+
+## Implementation phases
+
+1. **Core re-application.** Capture `base_config`, add the create-only post-pipeline re-application of combined settings onto `base_config`, update `mngr_ctx.config`. Verify manually that a docker create-template `setting__extend` reaches `mngr_ctx.config` and the emitted `docker run` includes `--runtime`. System works for the happy path; validation/secondary fix not yet present.
+2. **Forbidden-key validation.** Add `_reject_ineffective_template_setting_keys` + the prefix constant + error message, wired before re-application. System now errors loudly instead of silently dropping `commands.*`/`create_templates.*` template settings.
+3. **`config get`/`list` traversal fix.** Add `serialize_as_any=True` at the two `config.py` call sites. The diagnostic probe now works.
+4. **Tests + changelog.** Add the unit tests below and the changelog entry. Run the full suite.
+
+## Testing strategy
+
+- **Unit (`libs/mngr/imbue/mngr/cli/common_opts_test.py`):**
+  - Template `setting__extend` lands in resolved config: drive `setup_command_context` for `create` via `CliRunner` (model on `test_setting_flag_overrides_config_via_setup_command_context` / `test_headless_flag_..._via_setup_command_context`) with a `create_templates.<name>` defining `setting__extend = ["providers.docker.docker_runtime=runsc"]`, and assert `mngr_ctx.config.providers["docker"].docker_runtime == "runsc"`.
+  - Bare-assign template `setting` (non-extend) also reaches config.
+  - CLI `-S` wins over a template setting for the same key (template `runsc`, CLI `-S ...=runc` → `runc`).
+  - Template `setting` narrowing assignment raises `ConfigParseError` without the opt-in (parallels `test_apply_settings_to_config_narrowing_raises_by_default`).
+  - Template `setting` targeting `commands.create.connect=false` raises `ConfigParseError`; the message names the template/key.
+  - Template `setting` targeting `create_templates.foo...` raises `ConfigParseError`.
+  - Direct CLI `-S commands.create.connect=false` still works (regression guard for the validation being template-scoped).
+  - Template `setting` targeting `allow_settings_key_assignment_narrowing` hits the existing rejection (parallels `test_apply_settings_to_config_rejects_setting_the_narrowing_flag`).
+- **Unit (`libs/mngr/imbue/mngr/cli/config_test.py`):**
+  - `config get providers.<name>.docker_runtime` returns the value for a config containing a `DockerProviderConfig` with `docker_runtime` set (previously "Key not found").
+  - `config list --all` includes the provider-subclass field.
+- **Edge cases to cover:** multiple `--template`s each contributing settings (stacked, later wins per `merge_with`); a create with both template settings and CLI `-S`; create with no template (re-application is a no-op / behavior unchanged); non-create command (`config`, etc.) unaffected.
+- **Full run:** `just test-offload` for the final check (acceptance tests run in CI). Iterate locally with `just test-quick "libs/mngr/imbue/mngr/cli/common_opts_test.py"` and the `config_test.py` path.
+
+## Open questions
+
+- **Slice-trim assumption:** isolating template settings by trimming `len(initial_opts.setting)` from the tail of `updated_params["setting"]` relies on the pipeline ordering (config base `()` + template + CLI). Should we instead have `apply_create_template` return the template-contributed setting entries explicitly for robustness, or is an internal consistency assertion on the CLI tail sufficient? (Current plan: keep the trim with an assertion.)
+- **`serialize_as_any` blast radius:** scoped to the two `config.py` call sites per Q&A. Confirm no other read path (e.g. structured `config get --format json` consumers) depends on the base-type-only projection.
+- **Acceptance coverage:** Q&A chose unit tests only for the core fix. Is a release/acceptance test that does a real `create --template` with docker and asserts `--runtime runsc` desired later, or is the unit-level assertion on resolved config sufficient?

--- a/dev/changelog/mngr-fix-settings-bug-ticket.md
+++ b/dev/changelog/mngr-fix-settings-bug-ticket.md
@@ -1,0 +1,1 @@
+Added an implementation-plan design doc under `blueprint/` for the create-template `setting`/`setting__extend` fix (see the `libs/mngr` entry for the user-visible behavior change).

--- a/libs/mngr/changelog/mngr-fix-settings-bug-ticket.md
+++ b/libs/mngr/changelog/mngr-fix-settings-bug-ticket.md
@@ -1,0 +1,5 @@
+Fixed create-template `setting`/`setting__extend` entries being silently dropped. A `--template` whose definition sets `setting__extend = ["providers.docker.docker_runtime=runsc"]` (or any other config key) now actually reaches the resolved config instead of being ignored. Direct CLI `-S` still wins over a template-provided setting for the same key.
+
+A template `setting` that targets `commands.*` or `create_templates.*` now raises a clear error (those sections are resolved before template settings are applied, so the value could never take effect) instead of being silently ignored.
+
+Fixed `mngr config get` and `mngr config list --all` so they surface provider-subclass fields (e.g. `docker_runtime` on a docker provider) instead of reporting "Key not found".

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -205,7 +205,16 @@ def setup_command_context(
         to_update(mngr_ctx.field_ref().is_full_discovery, initial_opts.safe),
     )
 
-    # Apply --setting overrides to config (right before CLI defaults are applied)
+    # Capture the originally-loaded config before any --setting is applied. The
+    # end-of-pipeline re-application (which folds in create-template-contributed
+    # settings) runs against this pristine base so it never double-applies an
+    # ``__extend`` operator.
+    base_config = mngr_ctx.config
+
+    # Apply --setting overrides to config (right before CLI defaults are applied).
+    # This uses the CLI -S flags only; config-default and create-template
+    # ``setting`` entries are folded in later via the end-of-pipeline pass so they
+    # can affect command-default resolution and template resolution first.
     if initial_opts.setting:
         updated_config = apply_settings_to_config(
             mngr_ctx.config,
@@ -236,6 +245,21 @@ def setup_command_context(
     # 4. Append CLI tuple/list values to the template result so CLI ends up at
     #    the tail of the merged list (config_base + template_result + CLI).
     updated_params = restore_cli_list_values(updated_params, cli_list_values)
+
+    # 5. Fold create-template (and config-default) ``setting`` entries into the
+    #    config. apply_create_template appends them to ``updated_params["setting"]``,
+    #    but the only --setting application above used the CLI flags, so without
+    #    this pass template-provided settings would never reach the resolved
+    #    config (e.g. providers.<name>.docker_runtime). Re-apply against the
+    #    pristine base config so CLI -S still wins and no ``__extend`` is doubled.
+    if command_name == "create":
+        mngr_ctx = _apply_template_contributed_settings(
+            mngr_ctx,
+            base_config=base_config,
+            combined_settings=updated_params.get("setting", ()),
+            cli_settings=initial_opts.setting,
+            template_names=updated_params.get("template", ()),
+        )
 
     # Block plugins that were disabled via command defaults or create templates
     # (e.g. disable_plugin from [commands.create] in settings.toml). load_config
@@ -463,6 +487,86 @@ def apply_settings_to_config(
         if violations:
             raise _build_setting_narrowing_error(violations)
     return config.merge_with(settings_config)
+
+
+# Top-level setting key segments whose effect is consumed earlier in
+# setup_command_context than the point where create-template ``setting`` entries
+# are folded into the config. A template (or command-default) ``setting``
+# targeting these can never take effect, so we reject it rather than dropping it
+# silently. Direct CLI ``-S`` for these keys is unaffected -- it is applied
+# before those phases run.
+_INEFFECTIVE_TEMPLATE_SETTING_PREFIXES: frozenset[str] = frozenset({"commands", "create_templates"})
+
+
+def _apply_template_contributed_settings(
+    mngr_ctx: MngrContext,
+    *,
+    base_config: MngrConfig,
+    combined_settings: Sequence[str],
+    cli_settings: Sequence[str],
+    template_names: Sequence[str],
+) -> MngrContext:
+    """Re-apply the post-template ``setting`` list to the config and return the updated context.
+
+    After the create pipeline runs, ``combined_settings`` is
+    ``config_default_settings + template_settings + cli_settings`` (the CLI flags
+    are appended last by ``restore_cli_list_values``). Only the CLI flags were
+    already merged into the config; the config-default and template-contributed
+    entries were not. Re-apply the whole list against the pristine ``base_config``
+    so those entries reach the resolved config, preserving "CLI wins" precedence
+    (CLI entries are last, and later same-key entries win) and avoiding
+    double-applying ``__extend`` operators.
+    """
+    combined = tuple(combined_settings)
+    cli = tuple(cli_settings)
+
+    # The CLI flags are the tail of the combined list; everything before them is
+    # contributed by config defaults or create templates and has not yet been
+    # applied to the config.
+    non_cli_count = len(combined) - len(cli)
+    if non_cli_count <= 0:
+        return mngr_ctx
+    assert combined[non_cli_count:] == cli, (
+        "Expected the CLI --setting flags to be the tail of the resolved setting list; "
+        f"got combined={combined!r}, cli={cli!r}"
+    )
+
+    non_cli_settings = combined[:non_cli_count]
+    _reject_ineffective_template_setting_keys(non_cli_settings, template_names)
+
+    final_config = apply_settings_to_config(base_config, combined, base_config.disabled_plugins)
+    return mngr_ctx.model_copy_update(
+        to_update(mngr_ctx.field_ref().config, final_config),
+    )
+
+
+def _reject_ineffective_template_setting_keys(settings: Sequence[str], template_names: Sequence[str]) -> None:
+    """Raise ``ConfigParseError`` if a non-CLI ``setting`` entry targets a key that cannot take effect.
+
+    ``commands.*`` (command defaults) and ``create_templates.*`` are resolved
+    earlier in setup_command_context than the point where create-template
+    ``setting`` entries are folded into the config, so such entries would be
+    silently ignored.
+    """
+    for setting_str in settings:
+        if "=" not in setting_str:
+            continue
+        key_path = setting_str.split("=", 1)[0].strip()
+        if not key_path:
+            continue
+        # Normalize hyphens to underscores so ``create-templates.*`` is caught
+        # the same way ``create_templates.*`` is (config key parsing treats them
+        # as equivalent).
+        first_segment = key_path.split(".", 1)[0].replace("-", "_")
+        if first_segment in _INEFFECTIVE_TEMPLATE_SETTING_PREFIXES:
+            template_hint = f" (from create template(s): {', '.join(template_names)})" if template_names else ""
+            raise ConfigParseError(
+                f"A create-template (or command-default) `setting` entry targets `{key_path}`{template_hint}, "
+                f"which cannot take effect: `commands.*` and `create_templates.*` are resolved before "
+                f"template settings are applied to the config, so the value would be silently ignored.\n"
+                f"Set this directly under the matching `[{first_segment}.*]` config section instead, or pass "
+                f"it as a direct CLI `-S {key_path}=...` (which is applied early enough to take effect)."
+            )
 
 
 def _build_setting_narrowing_error(violations: Sequence[str]) -> ConfigParseError:

--- a/libs/mngr/imbue/mngr/cli/common_opts_test.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts_test.py
@@ -34,6 +34,7 @@ from imbue.mngr.errors import UserInputError
 from imbue.mngr.plugins import hookspecs
 from imbue.mngr.primitives import LogLevel
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.primitives import ProviderInstanceName
 
 hookimpl = pluggy.HookimplMarker("mngr")
 
@@ -1336,6 +1337,213 @@ def test_setting_flag_sets_command_defaults_in_config(
     )
     assert result.exit_code == 0
     assert captured_config[0].commands["create"].defaults["connect"] is False
+
+
+# =============================================================================
+# Tests for create-template `setting`/`setting__extend` reaching the config
+# (regression for: template-provided settings were silently dropped).
+# =============================================================================
+
+
+def _make_create_command_capturing_config() -> tuple[click.Command, list[MngrConfig]]:
+    """Build a create-like click command and a sink that captures the resolved config.
+
+    The command carries a ``--template`` option (so create templates resolve) plus
+    the common options (so ``-S`` is parsed), and runs ``setup_command_context`` for
+    the ``create`` command.
+    """
+    captured_config: list[MngrConfig] = []
+
+    @click.command()
+    @click.option("--template", multiple=True, default=())
+    @add_common_options
+    @click.pass_context
+    def test_create(ctx: click.Context, **kwargs: Any) -> None:
+        mngr_ctx, _output_opts, _opts = setup_command_context(
+            ctx=ctx,
+            command_name="create",
+            command_class=CommonCliOptions,
+        )
+        captured_config.append(mngr_ctx.config)
+
+    return test_create, captured_config
+
+
+def test_create_template_setting_extend_lands_in_config(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create template's ``setting__extend`` should reach the resolved config."""
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[create_templates.tmpl]\nsetting__extend = ["prefix=tmpl-custom-"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=False)
+
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    assert captured_config[0].prefix == "tmpl-custom-"
+
+
+def test_create_template_setting_bare_assign_lands_in_config(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create template's bare ``setting`` (assign) should reach the resolved config."""
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[create_templates.tmpl]\nsetting = ["prefix=tmpl-bare-"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=False)
+
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    assert captured_config[0].prefix == "tmpl-bare-"
+
+
+def test_create_template_provider_subclass_setting_lands_in_config(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A create template setting targeting a provider-subclass field reaches the config.
+
+    This mirrors the original bug report (``providers.docker.docker_runtime`` set
+    via a template ``setting__extend`` was silently ignored), using the local
+    provider's subclass-only ``host_dir`` field so the test does not depend on the
+    docker backend being registered in the unit-test plugin manager. The provider
+    instance is named after its backend (``local``) because a ``setting`` delta
+    that omits ``backend`` resolves the backend from the instance name -- the same
+    convention the original docker repro relies on.
+    """
+    (tmp_path / "settings.toml").write_text(
+        "is_allowed_in_pytest = true\n\n"
+        '[providers.local]\nbackend = "local"\n\n'
+        '[create_templates.tmpl]\nsetting__extend = ["providers.local.host_dir=/tmp/mngr-template-probe"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=False)
+
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    # The stored instance is a LocalProviderConfig; dump it (its concrete type
+    # carries host_dir) to read the subclass-only field without a type error.
+    local_config = captured_config[0].providers[ProviderInstanceName("local")]
+    assert local_config.model_dump(mode="json")["host_dir"] == "/tmp/mngr-template-probe"
+
+
+def test_cli_setting_wins_over_create_template_setting(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct CLI ``-S`` for the same key beats the create template's setting."""
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[create_templates.tmpl]\nsetting__extend = ["prefix=from-template-"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(
+        cmd,
+        ["--template", "tmpl", "-S", "prefix=from-cli-"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    assert captured_config[0].prefix == "from-cli-"
+
+
+def test_create_template_setting_targeting_command_defaults_raises(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template ``setting`` for ``commands.*`` cannot take effect, so it must raise."""
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[create_templates.tmpl]\nsetting__extend = ["commands.create.connect=false"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, _captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=True)
+
+    assert result.exit_code != 0
+    assert "commands.create.connect" in result.output
+    assert "cannot take effect" in result.output
+
+
+def test_create_template_setting_targeting_create_templates_raises(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template ``setting`` for ``create_templates.*`` cannot take effect, so it must raise."""
+    (tmp_path / "settings.toml").write_text(
+        "is_allowed_in_pytest = true\n\n"
+        '[create_templates.tmpl]\nsetting__extend = ["create_templates.other.provider=docker"]\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, _captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=True)
+
+    assert result.exit_code != 0
+    assert "create_templates.other.provider" in result.output
+
+
+def test_cli_setting_for_command_defaults_still_works_on_create(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct CLI ``-S commands.*`` keeps working on create (the rejection is template-only)."""
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(
+        cmd,
+        ["-S", "commands.create.headless=true"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    assert captured_config[0].commands["create"].defaults["headless"] is True
+
+
+def test_create_template_setting_narrowing_raises(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template ``setting`` that narrows a non-empty list raises, like ``--setting``."""
+    (tmp_path / "settings.toml").write_text(
+        "is_allowed_in_pytest = true\n"
+        'enabled_backends = ["docker"]\n\n'
+        "[create_templates.tmpl]\nsetting__extend = ['enabled_backends=[]']\n"
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    cmd, _captured_config = _make_create_command_capturing_config()
+    result = cli_runner.invoke(cmd, ["--template", "tmpl"], obj=plugin_manager, catch_exceptions=True)
+
+    assert result.exit_code != 0
+    assert "narrowing" in result.output.lower()
 
 
 def test_disable_plugin_in_command_defaults_blocks_override_hook(

--- a/libs/mngr/imbue/mngr/cli/config.py
+++ b/libs/mngr/imbue/mngr/cli/config.py
@@ -250,7 +250,10 @@ def _config_list_impl(ctx: click.Context, **kwargs: Any) -> None:
         config_data = _load_config_file(config_path)
         _emit_config_list(config_data, output_opts, scope, config_path)
     else:
-        full_view = mngr_ctx.config.model_dump(mode="json")
+        # serialize_as_any preserves provider-subclass fields (e.g. docker_runtime
+        # on DockerProviderConfig); without it model_dump serializes providers by
+        # the declared base type and silently drops subclass-only keys.
+        full_view = mngr_ctx.config.model_dump(mode="json", serialize_as_any=True)
         if opts.all:
             config_data = full_view
         else:
@@ -444,7 +447,10 @@ def _config_get_impl(ctx: click.Context, key: str, **kwargs: Any) -> None:
         return
 
     # Merged mode: extends are already applied; bare key lookup is sufficient.
-    config_data = mngr_ctx.config.model_dump(mode="json")
+    # serialize_as_any preserves provider-subclass fields (e.g. docker_runtime on
+    # DockerProviderConfig); without it model_dump serializes providers by the
+    # declared base type and silently drops subclass-only keys.
+    config_data = mngr_ctx.config.model_dump(mode="json", serialize_as_any=True)
     try:
         value = _get_nested_value(config_data, key)
         _emit_config_value(key, value, output_opts)

--- a/libs/mngr/imbue/mngr/cli/config_test.py
+++ b/libs/mngr/imbue/mngr/cli/config_test.py
@@ -387,6 +387,58 @@ def test_config_get_existing_key(
     assert len(result.output.strip()) > 0
 
 
+def test_config_get_returns_provider_subclass_field(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`config get` should surface provider-subclass fields (e.g. local host_dir).
+
+    Regression: model_dump serialized providers by the declared base type and
+    dropped subclass-only keys, so this reported "Key not found". Uses the local
+    provider's ``host_dir`` (a subclass-only field) so the test does not depend
+    on the docker backend being registered in the unit-test plugin manager.
+    """
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[providers.mylocal]\nbackend = "local"\nhost_dir = "/tmp/mngr-subclass-probe"\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    result = cli_runner.invoke(
+        config,
+        ["get", "providers.mylocal.host_dir", "--format", "json"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    data = json.loads(result.output.strip())
+    assert data["value"] == "/tmp/mngr-subclass-probe"
+
+
+def test_config_list_all_includes_provider_subclass_field(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    plugin_manager: pluggy.PluginManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`config list --all` should include provider-subclass fields in the full view."""
+    (tmp_path / "settings.toml").write_text(
+        'is_allowed_in_pytest = true\n\n[providers.mylocal]\nbackend = "local"\nhost_dir = "/tmp/mngr-subclass-probe"\n'
+    )
+    monkeypatch.setenv("MNGR_PROJECT_CONFIG_DIR", str(tmp_path))
+
+    result = cli_runner.invoke(
+        config,
+        ["list", "--all", "--format", "json"],
+        obj=plugin_manager,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"output={result.output!r} exception={result.exception!r}"
+    data = json.loads(result.output.strip())
+    assert data["config"]["providers"]["mylocal"]["host_dir"] == "/tmp/mngr-subclass-probe"
+
+
 # =============================================================================
 # Tests for config output helper functions
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #1914. Create-template `setting`/`setting__extend` entries flowed into the create command's `--setting` param but were never merged into the resolved `MngrConfig`, so they had no effect (e.g. `providers.docker.docker_runtime` set by a template was silently ignored). Direct CLI `-S` worked; only template-provided settings were lost.

Root cause: `setup_command_context` applied `--setting` to the config exactly once, *before* `apply_create_template` ran, so the template-appended setting entries never reached the config.

## Changes

- `cli/common_opts.py`: fold the post-template `setting` list into the config at the end of the create pipeline. The combined list is re-applied against the pristine pre-`--setting` config, so CLI `-S` still wins over template settings (CLI entries are last in the list) and `__extend` operators are not doubled.
- Template (or command-default) `setting` entries targeting `commands.*` or `create_templates.*` now raise `ConfigParseError` -- those sections are resolved before template settings are applied, so the value could never take effect. Direct CLI `-S` for those keys is unaffected.
- Template `setting` entries go through the same settings-narrowing guard as `--setting`.
- `cli/config.py`: `config get` and `config list --all` now dump with `serialize_as_any=True`, so provider-subclass fields (e.g. `docker_runtime`) are visible instead of reporting "Key not found".

## Testing

- New unit tests in `common_opts_test.py`: template `setting__extend`/bare `setting` reach the config; provider-subclass field via template; CLI `-S` wins over template; `commands.*`/`create_templates.*` rejection; CLI `-S commands.*` still works on create; template-setting narrowing raises.
- New unit tests in `config_test.py`: `config get`/`config list --all` surface a provider-subclass field.
- `just test-quick` on both files: 160 passed. `ruff check`/`ruff format`/`ty check` clean on changed files.
- Manually verified the real CLI `mngr config get providers.local.host_dir` now returns the value.

Design doc: `blueprint/template-setting-not-applied/plan-template-setting-not-applied.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)