### PR TITLE
pi subagent extensions: lifecycle verification + npm-sync comment

### DIFF
--- a/libs/mngr_pi_coding/changelog/mngr-pi-subagents.md
+++ b/libs/mngr_pi_coding/changelog/mngr-pi-subagents.md
@@ -1,0 +1,6 @@
+Documented (in a code comment) why the per-agent config sync deliberately omits
+pi's `npm` dir: pi auto-installs the `packages` listed in the synced
+`settings.json` into each agent's `$PI_CODING_AGENT_DIR/npm` on startup, so
+npm-package extensions (e.g. `npm:pi-subagents`) are available under mngr without
+copying `node_modules`, at the cost of a ~1s per-agent install that needs network
+on first launch. No behavior change.

--- a/libs/mngr_pi_coding/imbue/mngr_pi_coding/plugin.py
+++ b/libs/mngr_pi_coding/imbue/mngr_pi_coding/plugin.py
@@ -40,6 +40,17 @@ _PI_AGENT_SUBDIR: str = "agent"
 # definitions (``*.md``) that subagent extensions (pi's in-tree example, or
 # community packages like ``pi-subagents``) read from the config dir; without it
 # a synced subagent extension would load but find no agents to delegate to.
+#
+# Note: the ``npm`` dir (where ``pi install`` materialises npm-package extensions
+# under ``npm/node_modules``) is deliberately NOT synced. pi re-resolves the
+# ``packages`` list in the synced ``settings.json`` on every startup and
+# auto-installs any missing ones into the per-agent ``$PI_CODING_AGENT_DIR/npm``,
+# so npm-package extensions (e.g. ``npm:pi-subagents``) become available without
+# copying ``node_modules`` around, and each agent keeps an isolated install. The
+# only cost is a per-agent ``npm install`` (~1s) on first launch, which needs
+# network and so would not work on a fully-offline host; if that latency or the
+# offline case ever matters, copy ``npm`` into the per-agent dir here (copy, not
+# symlink -- a shared ``node_modules`` would race across concurrent startups).
 _SYNCED_RESOURCE_DIRS: tuple[str, ...] = ("skills", "prompts", "extensions", "themes", "agents")
 
 # The pi agent-type name, used for the per-agent transcript directories


### PR DESCRIPTION
Investigates the pi "subagents" community extensions under mngr and documents one incidental behavior.

## Code change
Comment-only: documents at `_SYNCED_RESOURCE_DIRS` (in `mngr_pi_coding/plugin.py`) why the per-agent config sync deliberately omits pi's `npm` dir — pi auto-installs the `packages` from the synced `settings.json` into each agent's `$PI_CODING_AGENT_DIR/npm` on startup, so npm-package extensions work under mngr without copying `node_modules` (cost: a ~1s per-agent install on first launch). No behavior change.

## Investigation (findings kept local in a gitignored `*.local.md`, not in this PR)
Verified, against real mngr `pi-coding` agents driving each extension on a real subagent task, how the RUNNING/WAITING lifecycle state behaves with subagents:

- `pi-subagents` (nicobailon), `@tintinweb/pi-subagents`, `@gotgenes/pi-subagents`: all install and load under mngr. Lifecycle is **correct for foreground (blocking) subagents** but **wrong for background/async subagents** — once the main agent dispatches a background subagent and ends its turn, mngr reports `WAITING` while the subagent is still running. Confirmed via the `active` marker, literal `mngr list` STATE, and the live subagent process tree.
- `oh-my-pi` (can1357): **incompatible** with how mngr drives pi — it is a standalone `omp` binary, not a `pi` extension, so it cannot be loaded via `pi -e`.

Root cause: the `active` marker is driven solely by the root session's `agent_start`/`agent_end` and has no accounting of outstanding background children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)