### PR TITLE
launch-to-msg: marker + slack reflect what was actually tested

### DIFF
--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -1099,6 +1099,11 @@ jobs:
           APP_ZIP_URL: ${{ needs.build.outputs.app_zip_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER: ${{ github.event_name }}
+          # Who/what initiated this run + which ref it ran on. For a
+          # workflow_dispatch this is the user; for schedule it's the
+          # github-actions[bot] (we hide that one for readability).
+          ACTOR:    ${{ github.actor }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [[ -z "$WEBHOOK" ]]; then
@@ -1197,12 +1202,22 @@ jobs:
           links_inner+=" | <https://github.com/imbue-ai/mngr/commit/${MNGR_SHA}|mngr commit>"
           links_inner+=" | <https://github.com/imbue-ai/forever-claude-template/commit/${FCT_SHA}|fct commit>"
           links_line="[${links_inner}]"
+          # Compose the "trigger=..." string. For the twice-daily cron
+          # show just `schedule on <ref>`; for a manual dispatch show
+          # who pressed the button and from which branch -- that's the
+          # signal you need to tell "running on main as a regular CI"
+          # apart from "weishi forced one to test branch X".
+          if [[ "$TRIGGER" == "schedule" ]]; then
+            trigger_str="schedule on ${REF_NAME}"
+          else
+            trigger_str="${TRIGGER} by @${ACTOR} on ${REF_NAME}"
+          fi
           # Assemble the final message. Line 1 is always present. Line 2
           # (SHAs) is always present. Line 3 (metrics) is omitted when we
           # have no values. Line 4 (links) is always present, though
           # `binary` falls out when build didn't produce one.
           line1=$(printf '%s *launch-to-msg* — %s in %s%s, _trigger=_ `%s`' \
-            "$emoji" "$verdict_word" "$duration" "$detail" "$TRIGGER")
+            "$emoji" "$verdict_word" "$duration" "$detail" "$trigger_str")
           line2="[_mngr_ \`${MNGR_SHORT}\` | _FCT_ \`${FCT_SHORT}\`]"
           if [[ -n "$metrics_line" ]]; then
             text=$(printf '%s\n%s\n%s\n%s' "$line1" "$line2" "$metrics_line" "$links_line")

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -415,6 +415,16 @@ jobs:
       launch_to_ready: ${{ steps.timings.outputs.launch_to_ready }}
       w1_create:       ${{ steps.timings.outputs.w1_create }}
       w2_create:       ${{ steps.timings.outputs.w2_create }}
+      # FCT SHA re-resolved right before the e2e launches the .app
+      # (see the existing `fct_sha` step in this job's steps list).
+      # check_should_run's `fct_sha` was resolved at workflow-start
+      # time -- which can drift if FCT main moves during the build's
+      # 20-25 min run. This output reflects the SHA that the .app's
+      # `git clone` is about to use (assuming MINDS_WORKSPACE_BRANCH
+      # is set to a moving ref like `main`). update_marker keys the
+      # marker on this value; notify_slack reports it. Both are then
+      # truthful about what was actually tested.
+      tested_fct_sha:  ${{ steps.fct_sha.outputs.sha }}
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
@@ -1009,13 +1019,17 @@ jobs:
     steps:
       - name: write marker file
         env:
-          PAIR_KEY: ${{ needs.check_should_run.outputs.pair_key }}
+          # Prefer the SHA the e2e actually exercised (re-resolved at e2e
+          # start time, output by launch_to_msg) over the one
+          # check_should_run computed at workflow-start time. They match
+          # in steady state but can drift when FCT main moves during the
+          # 20-25 min ToDesktop build, in which case the e2e's clone uses
+          # the newer SHA while check_should_run's value is stale.
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.check_should_run.outputs.fct_sha }}
+          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
         run: |
           set -euo pipefail
           {
-            echo "pair_key: $PAIR_KEY"
             echo "mngr: $MNGR_SHA"
             echo "fct:  $FCT_SHA"
             echo "saved_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -1025,14 +1039,17 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/launch-to-msg-marker.txt
-          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.check_should_run.outputs.fct_sha }}
+          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
       - name: emit summary
+        env:
+          MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
+          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
         run: |
           {
             echo "## Marker updated"
-            echo "- cache key: \`launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.check_should_run.outputs.fct_sha }}\`"
-            echo "- mngr: \`${{ needs.check_should_run.outputs.mngr_sha }}\`"
-            echo "- FCT:  \`${{ needs.check_should_run.outputs.fct_sha }}\`"
+            echo "- cache key: \`launch-to-msg-green-mngr-${MNGR_SHA}-fct-${FCT_SHA}\`"
+            echo "- mngr: \`${MNGR_SHA}\`"
+            echo "- FCT:  \`${FCT_SHA}\`"
             echo ""
             echo "**To inspect the latest green pair manually:**"
             echo ""
@@ -1061,7 +1078,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOULD_RUN: ${{ needs.check_should_run.outputs.should_run }}
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.check_should_run.outputs.fct_sha }}
+          # Prefer launch_to_msg's re-resolved FCT SHA (truthful to what
+          # was tested) over check_should_run's start-time value when
+          # available. Skip path / failed-before-e2e leaves the start-time
+          # value, which is the right fallback in those cases.
+          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
           BUILD_RESULT:         ${{ needs.build.result }}
           LAUNCH_TO_MSG_RESULT: ${{ needs.launch_to_msg.result }}
           MACOS_LAUNCH_RESULT:  ${{ needs.macos_launch.result }}

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -415,16 +415,6 @@ jobs:
       launch_to_ready: ${{ steps.timings.outputs.launch_to_ready }}
       w1_create:       ${{ steps.timings.outputs.w1_create }}
       w2_create:       ${{ steps.timings.outputs.w2_create }}
-      # FCT SHA re-resolved right before the e2e launches the .app
-      # (see the existing `fct_sha` step in this job's steps list).
-      # check_should_run's `fct_sha` was resolved at workflow-start
-      # time -- which can drift if FCT main moves during the build's
-      # 20-25 min run. This output reflects the SHA that the .app's
-      # `git clone` is about to use (assuming MINDS_WORKSPACE_BRANCH
-      # is set to a moving ref like `main`). update_marker keys the
-      # marker on this value; notify_slack reports it. Both are then
-      # truthful about what was actually tested.
-      tested_fct_sha:  ${{ steps.fct_sha.outputs.sha }}
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
@@ -659,21 +649,22 @@ jobs:
           # session for depth rather than spinning a separate workflow per
           # scenario.
           WORKSPACE_COUNT:    "2"
-          # Pin the FCT ref the binary creates against to the `template_ref`
-          # dispatch input. Without this, minds falls back to
-          # `FALLBACK_BRANCH = "v0.2.35"` (templates.py) regardless of what the
-          # workflow_dispatch input says, so a `template_ref=main` run silently
-          # exercises v0.2.35 instead.
+          # Pin the FCT ref the binary creates against to the SHA
+          # `check_should_run` resolved at workflow-start time. Passing
+          # the resolved 40-char SHA (not the raw input ref like `main`)
+          # FREEZES the value: the agent inside lima clones exactly the
+          # SHA that the cache marker + slack message are about to
+          # claim was tested. Without freezing, FCT main can move during
+          # the 20-25 min ToDesktop build and the agent ends up cloning
+          # a different commit than the marker records.
           # MINDS_WORKSPACE_BRANCH is gated by MINDS_USE_LOCAL_WORKSPACE_DEFAULTS=1
-          # in templates._operator_workspace_default (an end-user `minds run` ignores
-          # a stray MINDS_WORKSPACE_* in the shell unless explicitly opted in).
-          # We pass the branch / tag name (not the resolved SHA) because the
-          # binary's `git clone --branch <ref>` only accepts branch names and
-          # tags. The resolved SHA is still recorded in the GHA step summary
-          # for audit. Moving refs (e.g. `main`) thus float between runs --
-          # the trade-off is "must clone-able" vs "must be byte-identical".
+          # in templates._operator_workspace_default (an end-user `minds run`
+          # ignores a stray MINDS_WORKSPACE_* in the shell unless explicitly
+          # opted in). Passing a SHA was unblocked by PR #2100: clone_git_repo
+          # + checkout_branch now go through git init + fetch + checkout
+          # rather than `git clone --branch <ref>`, which had rejected SHAs.
           MINDS_USE_LOCAL_WORKSPACE_DEFAULTS: "1"
-          MINDS_WORKSPACE_BRANCH: ${{ inputs.template_ref || 'main' }}
+          MINDS_WORKSPACE_BRANCH: ${{ needs.check_should_run.outputs.fct_sha }}
         run: |
           # pipefail is REQUIRED: without it, the pipeline below exits
           # with tee's status (always 0), so an e2e failure (exit 1) is
@@ -1019,13 +1010,13 @@ jobs:
     steps:
       - name: write marker file
         env:
-          # update_marker only runs when launch_to_msg succeeded (see this
-          # job's `if:`), so launch_to_msg's `fct_sha` step ran and
-          # tested_fct_sha is guaranteed populated -- the SHA we record
-          # here is the one the e2e actually exercised, not the start-
-          # time guess.
+          # The (mngr, FCT) pair we just verified green. Both SHAs are
+          # frozen at workflow-start time by `check_should_run`; the e2e
+          # exercises EXACTLY these SHAs (the SHA is passed to the .app
+          # via MINDS_WORKSPACE_BRANCH, which `clone_git_repo` accepts
+          # since PR #2100). No drift.
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha }}
+          FCT_SHA:  ${{ needs.check_should_run.outputs.fct_sha }}
         run: |
           set -euo pipefail
           {
@@ -1038,11 +1029,11 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/launch-to-msg-marker.txt
-          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.launch_to_msg.outputs.tested_fct_sha }}
+          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.check_should_run.outputs.fct_sha }}
       - name: emit summary
         env:
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha }}
+          FCT_SHA:  ${{ needs.check_should_run.outputs.fct_sha }}
         run: |
           {
             echo "## Marker updated"
@@ -1077,11 +1068,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOULD_RUN: ${{ needs.check_should_run.outputs.should_run }}
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          # Prefer launch_to_msg's re-resolved FCT SHA (truthful to what
-          # was tested) over check_should_run's start-time value when
-          # available. Skip path / failed-before-e2e leaves the start-time
-          # value, which is the right fallback in those cases.
-          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
+          # FCT SHA frozen at workflow-start by `check_should_run` and
+          # passed verbatim to the .app via MINDS_WORKSPACE_BRANCH. No
+          # drift between what we report and what the e2e cloned.
+          FCT_SHA:  ${{ needs.check_should_run.outputs.fct_sha }}
           BUILD_RESULT:         ${{ needs.build.result }}
           LAUNCH_TO_MSG_RESULT: ${{ needs.launch_to_msg.result }}
           MACOS_LAUNCH_RESULT:  ${{ needs.macos_launch.result }}

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -1019,14 +1019,13 @@ jobs:
     steps:
       - name: write marker file
         env:
-          # Prefer the SHA the e2e actually exercised (re-resolved at e2e
-          # start time, output by launch_to_msg) over the one
-          # check_should_run computed at workflow-start time. They match
-          # in steady state but can drift when FCT main moves during the
-          # 20-25 min ToDesktop build, in which case the e2e's clone uses
-          # the newer SHA while check_should_run's value is stale.
+          # update_marker only runs when launch_to_msg succeeded (see this
+          # job's `if:`), so launch_to_msg's `fct_sha` step ran and
+          # tested_fct_sha is guaranteed populated -- the SHA we record
+          # here is the one the e2e actually exercised, not the start-
+          # time guess.
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
+          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha }}
         run: |
           set -euo pipefail
           {
@@ -1039,11 +1038,11 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/launch-to-msg-marker.txt
-          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
+          key: launch-to-msg-green-mngr-${{ needs.check_should_run.outputs.mngr_sha }}-fct-${{ needs.launch_to_msg.outputs.tested_fct_sha }}
       - name: emit summary
         env:
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}
-          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha || needs.check_should_run.outputs.fct_sha }}
+          FCT_SHA:  ${{ needs.launch_to_msg.outputs.tested_fct_sha }}
         run: |
           {
             echo "## Marker updated"

--- a/apps/minds/changelog/wz-launch-to-msg-truthful-fct-sha.md
+++ b/apps/minds/changelog/wz-launch-to-msg-truthful-fct-sha.md
@@ -1,0 +1,6 @@
+launch-to-msg slack message now reports the FCT SHA the e2e actually
+exercised (re-resolved right before the .app launches) instead of the
+SHA `check_should_run` computed at workflow-start time. Also: trigger
+line now surfaces who initiated the run and on which ref --
+`schedule on main` for the twice-daily cron vs.
+`workflow_dispatch by @<actor> on <branch>` for a manual dispatch.


### PR DESCRIPTION
## Summary

`check_should_run` resolves the FCT ref (e.g. `main`, `v0.3.0`) at workflow-start time, but the build job then runs for 20-25 min before the e2e's `git clone` actually happens inside lima. If FCT main moves during that window, the slack notification and cache-marker both reference a SHA that wasn't really tested.

## Fix

Re-use the existing `fct_sha` step in `launch_to_msg` that re-resolves the FCT ref right before the e2e launches the .app. Expose it as a job output `tested_fct_sha` and have `update_marker` + `notify_slack` prefer that value over `check_should_run.outputs.fct_sha`. Fallback to the start-time value when launch_to_msg didn't run (skip path) or failed before resolve.

## Properties

- Marker cache-key now records the SHA the e2e actually exercised.
- Slack message reflects that same SHA. No more 'we tested A but the message claims B' mismatch.
- Skip path (cache hit on the start-time pair) is unchanged.
- check_should_run's lookup logic still uses start-time SHA (correct semantic for 'should we even queue the Mac runner').

## Residual

There is still a small (~30s) window between this re-resolve step and the agent's actual `git clone` inside lima. A perfectly truthful slack message would require shelling into the agent's container post-clone to read `/code/forever-claude-template`'s HEAD. That is a deeper change to the e2e Python script (probably ~20 lines + an output-plumbing step). Leaving as a follow-up if the ~30s window matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)