### PR TITLE
Indent rich-rendered help prose to man-page depth

### DIFF
--- a/libs/mngr/changelog/mngr-fix-man-page-indent.md
+++ b/libs/mngr/changelog/mngr-fix-man-page-indent.md
@@ -1,0 +1,1 @@
+Fixed the DESCRIPTION (and other prose) sections of `mngr <command> --help` to be indented to the man-page depth of seven spaces in an interactive terminal (the pager / rich path). Previously these sections rendered flush-left, unlike the piped/plain output and the surrounding sections.

--- a/libs/mngr/imbue/mngr/cli/help_formatter.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter.py
@@ -147,7 +147,9 @@ def get_terminal_width() -> int:
     return terminal_size.columns
 
 
-def render_markdown(markdown: str, *, use_ansi: bool, width: int, link_base: str | None = None, indent: int = 0) -> str:
+def render_markdown(
+    markdown: str, *, use_ansi: bool, width: int, link_base: str | None = None, indent: int = 0
+) -> str:
     """Render a markdown block for terminal display.
 
     When ``use_ansi`` is True, render via rich (tables, bold, code, links,

--- a/libs/mngr/imbue/mngr/cli/help_formatter.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter.py
@@ -147,7 +147,7 @@ def get_terminal_width() -> int:
     return terminal_size.columns
 
 
-def render_markdown(markdown: str, *, use_ansi: bool, width: int, link_base: str | None = None) -> str:
+def render_markdown(markdown: str, *, use_ansi: bool, width: int, link_base: str | None = None, indent: int = 0) -> str:
     """Render a markdown block for terminal display.
 
     When ``use_ansi`` is True, render via rich (tables, bold, code, links,
@@ -159,6 +159,10 @@ def render_markdown(markdown: str, *, use_ansi: bool, width: int, link_base: str
     anchor links are rewritten to absolute URLs resolved against it, so they are
     clickable terminal hyperlinks rather than dead relative targets. Plain
     (non-ANSI) output keeps the original relative links untouched.
+
+    When ``indent`` is greater than zero (and ``use_ansi`` is True), every
+    rendered line is left-padded by that many spaces, matching the man-page-style
+    indentation used for the prose sections of command help.
     """
     if not use_ansi:
         return markdown
@@ -166,7 +170,7 @@ def render_markdown(markdown: str, *, use_ansi: bool, width: int, link_base: str
     # it is only needed here, when rendering help for an interactive terminal.
     from imbue.mngr.cli.markdown_render import markdown_to_ansi
 
-    return markdown_to_ansi(markdown, width, link_base=link_base)
+    return markdown_to_ansi(markdown, width, link_base=link_base, indent=indent)
 
 
 @pure
@@ -311,7 +315,7 @@ def _write_git_style_help(
     # DESCRIPTION section
     output.write(f"{_format_section_title('Description')}\n")
     if use_ansi:
-        output.write(render_markdown(metadata.full_description.strip(), use_ansi=True, width=width))
+        output.write(render_markdown(metadata.full_description.strip(), use_ansi=True, width=width, indent=7))
         output.write("\n")
     else:
         for paragraph in metadata.full_description.strip().split("\n\n"):
@@ -327,7 +331,7 @@ def _write_git_style_help(
         for title, content in metadata.additional_sections:
             output.write(f"{_format_section_title(title)}\n")
             if use_ansi:
-                output.write(render_markdown(content.strip(), use_ansi=True, width=width))
+                output.write(render_markdown(content.strip(), use_ansi=True, width=width, indent=7))
                 output.write("\n")
             else:
                 for line in content.strip().split("\n"):

--- a/libs/mngr/imbue/mngr/cli/help_formatter_test.py
+++ b/libs/mngr/imbue/mngr/cli/help_formatter_test.py
@@ -912,6 +912,32 @@ def test_render_markdown_rewrites_links_when_ansi() -> None:
     assert "https://github.com/imbue-ai/mngr/blob/v1.2.3/libs/mngr_usage/README.md#y" in output
 
 
+def test_ansi_description_section_is_indented() -> None:
+    """The DESCRIPTION prose is indented to man-page depth in the ANSI (pager) path.
+
+    Regression test: the rich-rendered description used to render flush-left while
+    the surrounding section bodies stayed indented by seven spaces. It must match
+    the indentation the plain (piped) path produces.
+    """
+    metadata = CommandHelpMetadata(
+        key="test",
+        one_line_description="A test command",
+        synopsis="mngr test [options]",
+        description="A description paragraph that occupies the DESCRIPTION section.",
+    )
+
+    @click.command()
+    def test_cmd() -> None:
+        """A test command."""
+
+    ctx = click.Context(test_cmd, info_name="test")
+    output = format_git_style_help(ctx, test_cmd, metadata, use_ansi=True)
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", output)
+    description_line = next(line for line in plain.splitlines() if "description paragraph" in line)
+    assert description_line.startswith("       ")
+
+
 # =============================================================================
 # CLI documentation completeness
 # =============================================================================

--- a/libs/mngr/imbue/mngr/cli/markdown_render.py
+++ b/libs/mngr/imbue/mngr/cli/markdown_render.py
@@ -12,6 +12,7 @@ from urllib.parse import urljoin
 from markdown_it.token import Token
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.padding import Padding
 
 
 def _rewrite_link_hrefs(tokens: list[Token], base_url: str) -> None:
@@ -32,17 +33,22 @@ def _rewrite_link_hrefs(tokens: list[Token], base_url: str) -> None:
             _rewrite_link_hrefs(token.children, base_url)
 
 
-def markdown_to_ansi(markdown: str, width: int, link_base: str | None = None) -> str:
+def markdown_to_ansi(markdown: str, width: int, link_base: str | None = None, indent: int = 0) -> str:
     """Render a markdown string to an ANSI-formatted string at the given width.
 
     When ``link_base`` is given, relative and anchor links are rewritten to
     absolute URLs (resolved against it) before rendering, so the terminal
     hyperlinks rich emits are clickable rather than dead relative targets.
+
+    When ``indent`` is greater than zero, every rendered line is left-padded by
+    that many spaces. The content is wrapped to ``width`` minus the indent so the
+    padded text still fits, matching the man-page-style indentation used for the
+    DESCRIPTION and other prose sections of command help.
     """
     buffer = StringIO()
     console = Console(file=buffer, force_terminal=True, width=width, color_system="standard")
     rendered = Markdown(markdown)
     if link_base is not None:
         _rewrite_link_hrefs(rendered.parsed, link_base)
-    console.print(rendered)
+    console.print(Padding(rendered, (0, 0, 0, indent)) if indent else rendered)
     return buffer.getvalue()

--- a/libs/mngr/imbue/mngr/cli/markdown_render_test.py
+++ b/libs/mngr/imbue/mngr/cli/markdown_render_test.py
@@ -69,3 +69,25 @@ def test_no_link_base_leaves_links_alone() -> None:
     """Without a link_base, relative links are rendered as-is (no rewriting)."""
     hrefs = _emitted_link_hrefs(markdown_to_ansi("[Other](other.md)", 100))
     assert hrefs == {"other.md"}
+
+
+def _visible_lines(ansi: str) -> list[str]:
+    """Strip ANSI escape sequences, returning the visible text of each non-blank line."""
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", re.sub(r"\x1b\]8;[^\x1b]*\x1b\\", "", ansi))
+    return [line for line in plain.splitlines() if line.strip()]
+
+
+def test_indent_left_pads_every_line() -> None:
+    """A positive indent left-pads every rendered line by that many spaces."""
+    output = markdown_to_ansi("First paragraph.\n\nSecond paragraph.", 70, indent=7)
+    lines = _visible_lines(output)
+    assert lines, "expected rendered content"
+    assert all(line.startswith("       ") for line in lines)
+    assert "First paragraph." in output
+    assert "Second paragraph." in output
+
+
+def test_no_indent_does_not_pad() -> None:
+    """The default indent of zero leaves text flush against the left margin."""
+    output = markdown_to_ansi("Flush left.", 70)
+    assert _visible_lines(output)[0].startswith("Flush left.")


### PR DESCRIPTION
## Summary

The DESCRIPTION (and other prose) sections of `mngr <command> --help` rendered flush-left in an interactive terminal (the rich/pager path), while the piped/plain output and the surrounding sections stayed indented by seven spaces. This was introduced when help prose moved to rich rendering (commit 4f4f010f7): the rich path emitted markdown with no indentation.

## Fix

Thread an `indent` parameter through `render_markdown` / `markdown_to_ansi` (implemented via rich's `Padding`, which also wraps content to `width - indent`) and pass `indent=7` for the DESCRIPTION and additional sections. Topic pages (`mngr help <topic>`) stay full-width. The plain (non-ANSI) path is unchanged.

## Tests

- New unit tests in `markdown_render_test.py` for the indent behavior (and that the default leaves text flush-left).
- New `help_formatter_test.py` regression test asserting the ANSI DESCRIPTION section is indented seven spaces.
- All 114 tests in the affected CLI test files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)