### PR TITLE
minds: reliably route stuck and stopped workspaces to the recovery page

### DIFF
--- a/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
+++ b/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
@@ -1,0 +1,7 @@
+Fixed: a stopped or unresponsive workspace could get stranded on the "Loading workspace" loader and never advance to the recovery page. The desktop shell decides to show the recovery page from a one-shot "system interface status" event; if the chrome window reloaded after a workspace went stuck, that status was lost and never replayed, so the auto-redirect never fired even though the backend had correctly detected the stuck workspace.
+
+Two changes close the gap:
+
+- The Electron shell now replays the latest non-healthy workspace status when a chrome/sidebar view (re)loads, so a reloaded window re-learns which workspaces are stuck and redirects to the recovery page.
+
+- The backend's chrome event stream now periodically re-asserts non-healthy workspace statuses (in addition to the existing connect-time snapshot and per-transition pushes), so a desynced window self-heals within a few seconds even if it missed the original event.

--- a/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
+++ b/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
@@ -4,6 +4,6 @@ Two changes close the gap:
 
 - The Electron shell now replays the latest non-healthy workspace status when a chrome/sidebar view (re)loads, so a reloaded window re-learns which workspaces are stuck and redirects to the recovery page.
 
-- The backend's chrome event stream now periodically re-asserts non-healthy workspace statuses (in addition to the existing connect-time snapshot and per-transition pushes), so a desynced window self-heals within a few seconds even if it missed the original event.
+- The backend's chrome event stream now periodically re-asserts non-healthy workspace statuses (in addition to the existing connect-time snapshot and per-transition pushes), so a desynced window self-heals within about 15 seconds even if it missed the original event.
 
 Also fixed: clicking into a mind whose container the landing page already shows as "Stopped" no longer waits through the multi-second stuck-detection window before a restart begins. The landing page now routes a known-stopped mind straight to the recovery page, which confirms the host is offline and cold-boots it immediately, instead of loading the workspace and waiting for repeated probe failures to first declare it stuck.

--- a/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
+++ b/apps/minds/changelog/gabriel-minds-recovery-status-replay.md
@@ -5,3 +5,5 @@ Two changes close the gap:
 - The Electron shell now replays the latest non-healthy workspace status when a chrome/sidebar view (re)loads, so a reloaded window re-learns which workspaces are stuck and redirects to the recovery page.
 
 - The backend's chrome event stream now periodically re-asserts non-healthy workspace statuses (in addition to the existing connect-time snapshot and per-transition pushes), so a desynced window self-heals within a few seconds even if it missed the original event.
+
+Also fixed: clicking into a mind whose container the landing page already shows as "Stopped" no longer waits through the multi-second stuck-detection window before a restart begins. The landing page now routes a known-stopped mind straight to the recovery page, which confirms the host is offline and cold-boots it immediately, instead of loading the workspace and waiting for repeated probe failures to first declare it stuck.

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -1434,10 +1434,20 @@ function handleChromeSSEEvent(evt) {
 
     updateAllOsTitles();
   } else if (evt.type === 'system_interface_status') {
-    // Remember each mind's latest health so the Stop handler can leave a
-    // window that is actively restarting alone (see confirm-stop-mind).
+    // Remember each mind's latest non-healthy health so (a) the Stop handler
+    // can leave a window that is actively restarting alone (see
+    // confirm-stop-mind) and (b) primeViewWithCachedChromeState can replay it
+    // to a freshly (re)loaded view. A ``healthy`` (or empty) status clears the
+    // entry: it mirrors the server snapshot (which omits healthy agents), keeps
+    // the map scoped to agents that still need attention, and matches chrome.js
+    // dropping the agent from its own map on ``healthy``.
     if (evt.agent_id) {
-      systemInterfaceStatusByAgent.set(String(evt.agent_id), evt.status ? String(evt.status) : '');
+      const status = evt.status ? String(evt.status) : '';
+      if (!status || status === 'healthy') {
+        systemInterfaceStatusByAgent.delete(String(evt.agent_id));
+      } else {
+        systemInterfaceStatusByAgent.set(String(evt.agent_id), status);
+      }
     }
   } else if (evt.type === 'auth_required') {
     // Clear every window's stored accent on the authenticated ->
@@ -1520,6 +1530,25 @@ function primeViewWithCachedChromeState(bundle, wc) {
     count: latestChromeState.requestCount,
     request_ids: latestChromeState.requestIds,
   });
+  // Replay the latest non-healthy system-interface status for each agent so a
+  // freshly (re)loaded chrome/sidebar view re-learns which workspaces are
+  // stuck / restarting. Unlike the events above, per-agent health is NOT held
+  // in ``latestChromeState`` -- it lives in ``systemInterfaceStatusByAgent``,
+  // populated one-shot from the SSE's ``system_interface_status`` events.
+  // Without this replay, a renderer that reloads after an agent went STUCK
+  // never re-learns it: the backend only (re)emits ``system_interface_status``
+  // on a state transition or a brand-new SSE connection, and the main process
+  // holds a single long-lived SSE -- so the in-memory status here is the only
+  // surviving copy. Missing the replay leaves the stuck workspace's content
+  // view parked on the plugin's "Loading workspace" loader forever, because
+  // chrome.js's auto-redirect to the recovery page only fires when it holds a
+  // ``stuck`` status for the displayed agent. HEALTHY (and the empty
+  // placeholder) is skipped to mirror the server's connect-time snapshot,
+  // which omits healthy agents.
+  for (const [agentId, status] of systemInterfaceStatusByAgent) {
+    if (!status || status === 'healthy') continue;
+    wc.send('chrome-event', { type: 'system_interface_status', agent_id: agentId, status });
+  }
   // Re-send modal state to the chrome titlebar in case the modal opened
   // before chrome.js registered its onModalStateChanged listener (e.g. the
   // requests panel auto-opens at startup faster than chrome.js loads).

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -2173,15 +2173,23 @@ async def _handle_chrome_events(
             #
             # Clearing at the bottom of the loop instead would lose the
             # wakeup for any producer that fires between the drain and the
-            # bottom-of-loop clear, leaving the queued item idle for up to
-            # 30s -- a UX regression for health-state transitions like
-            # RESTARTING -> HEALTHY.
+            # bottom-of-loop clear, leaving the queued item idle until the
+            # next idle-wake timeout -- a UX regression for health-state
+            # transitions like RESTARTING -> HEALTHY.
             shutdown_event: threading.Event = request.app.state.shutdown_event
             connected = not await request.is_disconnected()
             while connected and not shutdown_event.is_set():
-                # Wait for a change signal or timeout (timeout for disconnect checks).
+                # Wait for a change signal or timeout. The timeout bounds both
+                # disconnect-detection latency and -- since the periodic status
+                # backstop below only runs on a loop wake -- the worst-case
+                # re-assert cadence on an otherwise-idle connection. Cap it at
+                # the re-assert interval so a steadily-stuck workspace really is
+                # re-asserted on that cadence rather than being stretched to a
+                # longer idle-wake period.
                 try:
-                    await asyncio.wait_for(change_event.wait(), timeout=30.0)
+                    await asyncio.wait_for(
+                        change_event.wait(), timeout=_SYSTEM_INTERFACE_STATUS_REASSERT_INTERVAL_SECONDS
+                    )
                 except TimeoutError:
                     pass
                 # Clear BEFORE draining so any producer firing between drain

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -2052,6 +2052,18 @@ def _handle_dev_styleguide() -> Response:
     return HTMLResponse(content=render_dev_styleguide_page())
 
 
+# How often the chrome-events stream re-asserts the current non-HEALTHY
+# system-interface statuses, on top of the one-shot connect-time snapshot and
+# the per-transition pushes. This is a self-healing backstop: a chrome renderer
+# that lost its in-memory health state (e.g. a reloaded webview whose one-shot
+# ``system_interface_status`` was never replayed) re-learns a still-stuck
+# workspace within this interval and can finally redirect to the recovery page,
+# even though the tracker emitted no fresh transition. Re-asserting ``stuck`` is
+# idempotent client-side (the recovery-redirect lock prevents re-navigation), so
+# the only cost is one tiny event per non-healthy agent per interval.
+_SYSTEM_INTERFACE_STATUS_REASSERT_INTERVAL_SECONDS: Final[float] = 15.0
+
+
 async def _handle_chrome_events(
     request: Request,
     auth_store: AuthStoreDep,
@@ -2138,6 +2150,9 @@ async def _handle_chrome_events(
                     yield "data: {}\n\n".format(
                         json.dumps(_system_interface_status_payload(tracker, str(aid), status))
                     )
+            # Anchor the periodic re-assert clock to the connect-time snapshot
+            # just sent, so the first backstop re-assert is a full interval out.
+            last_status_reassert = time.monotonic()
 
             # Wait for changes and push updates until client disconnects.
             #
@@ -2189,6 +2204,25 @@ async def _handle_chrome_events(
                 while not health_queue.empty():
                     aid_str, status = health_queue.get_nowait()
                     yield "data: {}\n\n".format(json.dumps(_system_interface_status_payload(tracker, aid_str, status)))
+
+                # Periodic backstop: re-assert the current non-HEALTHY statuses
+                # even when no transition fired this tick. The tracker only
+                # *transitions* on edges (HEALTHY <-> STUCK/RESTARTING/...), so a
+                # workspace that is steadily STUCK emits nothing after its one
+                # initial edge. A renderer that lost that one-shot event (e.g. a
+                # reloaded chrome webview) would otherwise never re-learn it and
+                # never redirect to the recovery page. Re-asserting is idempotent
+                # client-side (the recovery-redirect lock prevents re-navigation).
+                now = time.monotonic()
+                if (
+                    tracker is not None
+                    and now - last_status_reassert >= _SYSTEM_INTERFACE_STATUS_REASSERT_INTERVAL_SECONDS
+                ):
+                    last_status_reassert = now
+                    for aid, status in tracker.snapshot_all().items():
+                        yield "data: {}\n\n".format(
+                            json.dumps(_system_interface_status_payload(tracker, str(aid), status))
+                        )
 
                 # Each workspace entry carries its mind liveness (derived from
                 # discovery host state + any optimistic override), so a liveness

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Landing.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Landing.jinja
@@ -58,11 +58,22 @@
     window.landingRowClick = function (event, row) {
       var agentId = row.dataset.agentId;
       var status = healthStatusByAgent[agentId];
+      var ret = row.dataset.defaultHref || '';
       if (status === 'stuck' || status === 'restarting' || status === 'restart_failed') {
-        var ret = row.dataset.defaultHref || '';
         window.location = '/agents/' + encodeURIComponent(agentId) + '/recovery?return_to=' + encodeURIComponent(ret);
+      } else if (mindLivenessByAgent[agentId] === 'STOPPED') {
+        // The mind's container is stopped, so loading the workspace directly would
+        // strand the user on the loader for the full HEALTHY->STUCK probe-failure
+        // threshold before any restart is dispatched. We already know it's down, so
+        // route straight to the recovery page, which confirms host_offline via its
+        // probe and cold-boots the host immediately. ``intent=restart`` is required:
+        // the health tracker has never probed this stopped mind so it still reports
+        // HEALTHY, and without the intent the recovery handler would 302 us right
+        // back to the loader instead of dispatching the restart.
+        window.location = '/agents/' + encodeURIComponent(agentId)
+          + '/recovery?return_to=' + encodeURIComponent(ret) + '&intent=restart';
       } else {
-        window.location = row.dataset.defaultHref;
+        window.location = ret;
       }
     };
 

--- a/apps/minds/test/e2e/landing-stopped-mind-restart.spec.js
+++ b/apps/minds/test/e2e/landing-stopped-mind-restart.spec.js
@@ -1,0 +1,108 @@
+// Renderer-contract regression test for the landing page's stopped-mind
+// click-through fast path.
+//
+// Drives the REAL inline landing-page JS (the ``landingRowClick`` handler in
+// templates/pages/Landing.jinja) against the ACTUAL rendered page -- no
+// Electron app, no Docker, no live backend. The page HTML is produced by the
+// real ``render_landing_page`` (shelled through ``uv``) so the inline script we
+// exercise is byte-for-byte what ships; we only stub the network so the click's
+// navigation can be observed without a server behind it.
+//
+// The contract: clicking a mind whose container the landing page already knows
+// is STOPPED must route straight to the recovery page with ``intent=restart``
+// (which cold-boots the host immediately) instead of navigating to the normal
+// workspace loader, where it would otherwise sit for the full HEALTHY->STUCK
+// probe-failure threshold before any restart was dispatched. A RUNNING mind
+// must still navigate to its normal ``/goto/`` href.
+//
+// Like recovery-redirect.spec.js, this is a fast DOM-level contract test, not
+// one of the heavy app-launch specs; it is run via ``pnpm test:e2e`` locally.
+
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('@playwright/test');
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..', '..');
+const ORIGIN = 'http://localhost:8421';
+// Valid AgentId shape is ``agent-`` + 32 hex chars.
+const STOPPED_ID = 'agent-' + 'a'.repeat(32);
+const RUNNING_ID = 'agent-' + 'b'.repeat(32);
+
+const gotoHref = (agentId) => ORIGIN + '/goto/' + agentId + '/';
+const expectedRecoveryUrl = (agentId) =>
+  ORIGIN + '/agents/' + agentId + '/recovery?return_to=' +
+  encodeURIComponent(gotoHref(agentId)) + '&intent=restart';
+
+// Render the real landing page once, with one STOPPED and one RUNNING
+// shutdown-capable mind, using the production ``render_landing_page``. Shelling
+// to ``uv`` keeps the inline ``landingRowClick`` under test identical to what
+// ships rather than a hand-copied stub.
+const PY_RENDER = `
+import sys
+from imbue.minds.desktop_client.templates import render_landing_page
+from imbue.mngr.primitives import AgentId
+stopped = AgentId(${JSON.stringify(STOPPED_ID)})
+running = AgentId(${JSON.stringify(RUNNING_ID)})
+sys.stdout.write(render_landing_page(
+    accessible_agent_ids=(stopped, running),
+    mngr_forward_origin=${JSON.stringify(ORIGIN)},
+    shutdown_capable_agent_ids=(stopped, running),
+    mind_liveness_by_agent_id={str(stopped): "STOPPED", str(running): "RUNNING"},
+))
+`;
+
+let LANDING_HTML = '';
+
+test.beforeAll(() => {
+  LANDING_HTML = execFileSync(
+    'uv',
+    ['run', '--package', 'minds', 'python', '-c', PY_RENDER],
+    { cwd: REPO_ROOT, encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024 },
+  );
+});
+
+// Serve the rendered page for the document request and capture (then abort) any
+// subsequent document navigation -- which is exactly the ``window.location =``
+// that ``landingRowClick`` performs. Sub-resources (CSS, the landing SSE, etc.)
+// are aborted too; the inline handler under test needs none of them.
+async function loadLanding(page, captured) {
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const url = request.url();
+    if (url.endsWith('/landing')) {
+      await route.fulfill({ contentType: 'text/html', body: LANDING_HTML });
+    } else if (request.isNavigationRequest()) {
+      captured.push(url);
+      await route.abort('aborted');
+    } else {
+      await route.abort('aborted');
+    }
+  });
+  await page.goto(ORIGIN + '/landing', { waitUntil: 'domcontentloaded' });
+  // Sanity: the real inline script ran and exposed the handler under test.
+  await expect.poll(() => page.evaluate(() => typeof window.landingRowClick === 'function')).toBe(true);
+}
+
+// Click the row's name cell (bubbles to the Card's onclick) and return the URL
+// the handler navigated to.
+async function clickRowAndCaptureNav(page, agentId, captured) {
+  await page.click(`[data-agent-id="${agentId}"] .flex-1`);
+  await expect.poll(() => captured.length).toBeGreaterThan(0);
+  return captured[captured.length - 1];
+}
+
+test.describe('landing page stopped-mind click-through (landingRowClick contract)', () => {
+  test('a STOPPED mind routes to recovery with intent=restart (immediate cold-boot)', async ({ page }) => {
+    const captured = [];
+    await loadLanding(page, captured);
+    const nav = await clickRowAndCaptureNav(page, STOPPED_ID, captured);
+    expect(nav).toBe(expectedRecoveryUrl(STOPPED_ID));
+  });
+
+  test('a RUNNING mind navigates to its normal /goto/ loader', async ({ page }) => {
+    const captured = [];
+    await loadLanding(page, captured);
+    const nav = await clickRowAndCaptureNav(page, RUNNING_ID, captured);
+    expect(nav).toBe(gotoHref(RUNNING_ID));
+  });
+});

--- a/apps/minds/test/e2e/recovery-redirect.spec.js
+++ b/apps/minds/test/e2e/recovery-redirect.spec.js
@@ -1,0 +1,126 @@
+// Renderer-contract regression test for the workspace-recovery auto-redirect.
+//
+// Drives the REAL chrome.js (apps/.../desktop_client/static/chrome.js) in a
+// plain browser page -- no Electron app, no Docker, no backend -- feeding it
+// events through the exact ``window.minds`` bridge surface that Electron's
+// main.js drives. This locks in the contract the recovery fix depends on:
+//
+//   chrome.js redirects the content view to the recovery page IFF it is
+//   holding a ``stuck`` system-interface status for the currently-displayed
+//   workspace.
+//
+// The bug (stuck workspace stranded on the plugin's "Loading workspace"
+// loader, never reaching the recovery page) was that a reloaded chrome
+// renderer lost its one-shot ``system_interface_status`` and main.js's
+// ``primeViewWithCachedChromeState`` never replayed it. The fix makes the
+// prime replay non-healthy statuses; scenario 3 below mirrors exactly what the
+// fixed prime now sends. See main.js primeViewWithCachedChromeState and
+// app.py's periodic re-assert backstop.
+
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const CHROME_JS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'imbue',
+  'minds',
+  'desktop_client',
+  'static',
+  'chrome.js',
+);
+
+const AGENT_ID = 'agent-bb340d1c1d5a4c43b1396f277cfd6d81';
+
+// Minimal DOM + a faithful stub of the Electron preload bridge. chrome.js wires
+// these ids/callbacks at init; the test fires the captured callbacks exactly as
+// main.js's broadcastChromeEvent / current-workspace-changed IPC do. Captured
+// navigateContent calls land in window.__nav.
+const HARNESS_HTML = `<!DOCTYPE html><html><body data-mngr-forward-origin="http://localhost:8421">
+  <button id="sidebar-toggle"></button><button id="home-btn"></button>
+  <button id="back-btn"></button><button id="forward-btn"></button>
+  <button id="min-btn"></button><button id="max-btn"></button><button id="close-btn"></button>
+  <button id="user-btn"></button><button id="requests-toggle"></button>
+  <span id="page-title"></span><span id="requests-badge"></span>
+  <iframe id="content-frame"></iframe>
+  <div id="sidebar-panel"></div><div id="sidebar-workspaces"></div>
+  <script>
+    window.__nav = [];
+    window.__cb = {};
+    window.mindsAccent = { get: function (id, cb) { cb('#ffffff'); }, pickForeground: function () { return '0 0 0'; } };
+    window.minds = {
+      onChromeEvent: function (cb) { window.__cb.chromeEvent = cb; },
+      onCurrentWorkspaceChanged: function (cb) { window.__cb.currentWorkspace = cb; },
+      onContentTitleChange: function (cb) { window.__cb.contentTitle = cb; },
+      onContentURLChange: function (cb) { window.__cb.contentUrl = cb; },
+      onLastWorkspaceAgentIdChanged: function (cb) { window.__cb.lastWs = cb; },
+      onModalStateChanged: function (cb) { window.__cb.modal = cb; },
+      getLastWorkspaceAgentId: function () { return Promise.resolve(null); },
+      navigateContent: function (url) { window.__nav.push(url); },
+      toggleSidebar: function () {}, toggleInbox: function () {},
+      minimize: function () {}, maximize: function () {}, close: function () {},
+      contentGoBack: function () {}, contentGoForward: function () {},
+    };
+  </script>
+</body></html>`;
+
+const EXPECTED_RECOVERY_URL =
+  '/agents/' + AGENT_ID + '/recovery?return_to=' +
+  encodeURIComponent('http://localhost:8421/goto/' + AGENT_ID + '/');
+
+// Load the harness DOM + bridge stub, then inject the real chrome.js. Each call
+// is a fresh page, which is exactly what a reloaded chrome renderer looks like:
+// empty in-memory health state, listeners freshly registered.
+async function loadChrome(page) {
+  await page.setContent(HARNESS_HTML);
+  await page.addScriptTag({ path: CHROME_JS_PATH });
+  // Sanity: chrome.js ran to completion and registered the bridge callbacks.
+  await expect
+    .poll(() => page.evaluate(() => typeof window.__cb.chromeEvent === 'function' && typeof window.__cb.currentWorkspace === 'function'))
+    .toBe(true);
+}
+
+test.describe('workspace recovery auto-redirect (chrome.js contract)', () => {
+  test('redirects to the recovery page when a stuck status arrives for the displayed workspace', async ({ page }) => {
+    await loadChrome(page);
+    const nav = await page.evaluate((agentId) => {
+      window.__cb.currentWorkspace(agentId);
+      window.__cb.chromeEvent({ type: 'system_interface_status', agent_id: agentId, status: 'stuck' });
+      return window.__nav.slice();
+    }, AGENT_ID);
+    expect(nav).toEqual([EXPECTED_RECOVERY_URL]);
+  });
+
+  test('does NOT redirect when a reloaded renderer is only re-primed without the status (the bug)', async ({ page }) => {
+    await loadChrome(page);
+    const nav = await page.evaluate((agentId) => {
+      // Replay exactly what the PRE-FIX primeViewWithCachedChromeState sent on a
+      // chrome reload: workspaces, auth, requests -- but NOT the stuck status.
+      window.__cb.chromeEvent({ type: 'workspaces', workspaces: [{ id: agentId, name: 'queuetest', account: '' }] });
+      window.__cb.chromeEvent({ type: 'auth_status', signedIn: true });
+      window.__cb.chromeEvent({ type: 'requests', count: 0, request_ids: [] });
+      // The content view is parked on the stuck workspace's loader.
+      window.__cb.currentWorkspace(agentId);
+      // The tracker is still STUCK server-side, but its one-shot transition
+      // already fired before the reload -- so no fresh status event arrives.
+      return window.__nav.slice();
+    }, AGENT_ID);
+    expect(nav).toEqual([]);
+  });
+
+  test('redirects after a reload when the prime replays the stuck status (the fix)', async ({ page }) => {
+    await loadChrome(page);
+    const nav = await page.evaluate((agentId) => {
+      window.__cb.chromeEvent({ type: 'workspaces', workspaces: [{ id: agentId, name: 'queuetest', account: '' }] });
+      window.__cb.chromeEvent({ type: 'auth_status', signedIn: true });
+      window.__cb.chromeEvent({ type: 'requests', count: 0, request_ids: [] });
+      // THE FIX: the prime now replays the non-healthy status (mirrors
+      // primeViewWithCachedChromeState's system_interface_status replay loop).
+      window.__cb.chromeEvent({ type: 'system_interface_status', agent_id: agentId, status: 'stuck' });
+      window.__cb.currentWorkspace(agentId);
+      return window.__nav.slice();
+    }, AGENT_ID);
+    expect(nav).toEqual([EXPECTED_RECOVERY_URL]);
+  });
+});


### PR DESCRIPTION
## Problem

Opening a stopped or unresponsive Docker workspace could leave the app stuck on the plugin's "Loading workspace" loader, never advancing to the recovery page — even when the backend knew the workspace was unreachable. Two distinct gaps caused this:

1. **A stuck workspace's status could be lost after a chrome reload**, so the recovery auto-redirect never fired.
2. **Opening a workspace the landing page already knows is "Stopped"** still went through the normal loader and waited out the full HEALTHY→STUCK probe-failure window (~5s) before any restart was dispatched — and, combined with (1), could strand on the loader indefinitely.

## Root cause (1): lost one-shot status

The chrome shell auto-redirects to the recovery page when it holds a `stuck` `system_interface_status` for the currently-displayed workspace. That status reaches the renderer as a **one-shot** SSE event, but:

- `main.js` relayed it to the renderer yet did **not** include it in the replayable cache (`primeViewWithCachedChromeState` replayed workspaces/auth/requests/modal only); and
- the backend only (re)emitted `system_interface_status` on a state *transition* or a *brand-new* SSE connection.

So when the chrome renderer reloaded after a workspace went STUCK, its in-memory status was wiped and never restored: the tracker stayed STUCK (no new transition) and the single long-lived main-process SSE never re-pulled a snapshot. The renderer was permanently blind to the stuck state, so the redirect never fired.

This was traced against a live instance (tracker confirmed STUCK via the recovery endpoint; content view confirmed parked on the plugin loader; chrome shell observed reloading afterward) and reproduced/verified by driving the real `chrome.js` in a browser, then confirmed end-to-end with a live CDP A/B (fix ON → redirects in ~0.3s; fix OFF → stranded on the loader).

## Root cause (2): no fast path for a known-stopped mind

`landingRowClick` decided where a click went by looking only at the system-interface health (`stuck`/`restarting`/`restart_failed`). A freshly-stopped mind has no health status yet (the landing page even suppresses its health badge), so the click fell through to the normal `/goto/` loader and had to wait for the tracker to accumulate ~5s of continuous probe failures before a restart was dispatched — despite the landing page already knowing the container is "Stopped" (`mindLivenessByAgent`).

## Fix

- **Electron (`main.js`)**: `primeViewWithCachedChromeState` now replays the latest non-healthy `system_interface_status` for each agent to a freshly (re)loaded chrome/sidebar view, so a reloaded window re-learns stuck workspaces and redirects. The status map drops `healthy` entries so it stays scoped to agents that still need attention (mirroring `chrome.js`'s own semantics).
- **Backend (`app.py`)**: the `/_chrome/events` stream periodically re-asserts current non-healthy statuses (in addition to the connect-time snapshot and per-transition pushes), so a desynced renderer self-heals even if it missed the original event. Re-asserting `stuck` is idempotent client-side (the recovery-redirect lock prevents re-navigation). The re-assert runs on the events-loop wake, so the loop's idle wait is capped at the re-assert interval — making the self-heal cadence actually ~15s (matching the constant) rather than being stretched to the prior 30s idle floor.
- **Landing page (`Landing.jinja`)**: `landingRowClick` now routes a known-`STOPPED` mind straight to the recovery page with `intent=restart`, which confirms `host_offline` via its probe and cold-boots the host immediately. `intent=restart` is required because a never-probed stopped mind still reports HEALTHY to the tracker; without it the recovery handler would 302 the user right back to the loader.

## Testing

- `apps/minds/test/e2e/recovery-redirect.spec.js` (3 tests, all pass): drives the **real** `chrome.js` in a plain browser page (no Electron app, no Docker) and asserts the redirect happens iff a `stuck` status is held for the displayed workspace — baseline redirect; reloaded renderer re-primed *without* the status (reproduces the bug → no redirect); reloaded renderer with the status replayed (the fix → redirects).
- `apps/minds/test/e2e/landing-stopped-mind-restart.spec.js` (2 tests, all pass): renders the **real** landing page via `render_landing_page` and drives the real inline `landingRowClick` — a `STOPPED` mind routes to `/recovery?...&intent=restart`; a `RUNNING` mind navigates to its normal `/goto/` loader.
- The backend contract the fast path relies on (a HEALTHY-tracker mind + `intent=restart` renders/dispatches instead of 302-ing back) is already covered by `test_recovery_page_renders_for_healthy_agent_with_explicit_restart_intent` in the pytest suite (the CI gate).
- Note: the JS e2e specs are committed as fast, runnable regression artifacts but are **not** in the default CI gate (the JS e2e CI job targets `macos-launch.spec.js` only). The Python suite (including the recovery/`intent=restart` tests) runs in CI.
- `ruff check` clean on `app.py`; relevant minds unit/integration tests pass locally; full suite runs in CI.
