### PR TITLE
flush transcript before switching to WAITING state

### DIFF
--- a/libs/mngr/changelog/mngr-catalyst-waiting.md
+++ b/libs/mngr/changelog/mngr-catalyst-waiting.md
@@ -1,0 +1,12 @@
+Added a shared shell library `mngr_common_transcript_lib.sh`, provisioned to every
+agent's `commands/` dir alongside `mngr_log.sh` and `mngr_transcript_lib.sh` (via
+`Host._ensure_shared_shell_libs`). It centralizes the common-transcript converter
+primitives shared across agent plugins:
+
+- the convert lock (a coarse mkdir-based mutex serializing the converter's
+read-modify-write so the background daemon and an on-demand `--single-pass` flush
+can't append duplicate events), and
+
+- the turn-end flush (one synchronous `--single-pass` of the raw streamer + common
+converter, in pipeline order), used by agent turn-end hooks so a WAITING-signal
+consumer can't outrun the converter.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -2269,7 +2269,11 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
             with log_span("Calling on_after_provisioning for agent {}", agent.name):
                 agent.on_after_provisioning(host=self, options=options, mngr_ctx=mngr_ctx)
 
-    _SHARED_SHELL_LIB_NAMES: ClassVar[tuple[str, ...]] = ("mngr_log.sh", "mngr_transcript_lib.sh")
+    _SHARED_SHELL_LIB_NAMES: ClassVar[tuple[str, ...]] = (
+        "mngr_log.sh",
+        "mngr_transcript_lib.sh",
+        "mngr_common_transcript_lib.sh",
+    )
 
     def _ensure_shared_shell_libs(self, agent: AgentInterface) -> None:
         """Write the shared shell libraries to host-level and agent-level commands dirs.
@@ -2285,6 +2289,11 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
           (field extraction, id-set construction, offset reconciliation,
           bounded sed-append, percent-encoded path keys) shared by per-agent
           streamers such as claude's ``stream_transcript.sh``.
+        - ``mngr_common_transcript_lib.sh`` provides the common-transcript
+          converter primitives (the convert lock and the turn-end flush) shared
+          by per-agent ``common_transcript.sh`` converters and the turn-end
+          hooks that flush them (claude's ``wait_for_stop_hook.sh``,
+          antigravity's ``statusline.sh``).
         """
         host_commands = self.host_dir / "commands"
         agent_commands = self._get_agent_state_dir(agent) / "commands"

--- a/libs/mngr/imbue/mngr/resources/mngr_common_transcript_lib.sh
+++ b/libs/mngr/imbue/mngr/resources/mngr_common_transcript_lib.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# mngr_common_transcript_lib.sh -- Shared primitives for common-transcript converters.
+#
+# Sourced by per-agent common_transcript.sh converters (claude, antigravity) and
+# by the turn-end hooks that flush them (claude's wait_for_stop_hook.sh,
+# antigravity's statusline.sh). Centralizes the parts of common-transcript
+# handling that are structurally identical regardless of the agent's native
+# session schema:
+#
+#   - mngr_common_transcript_acquire_lock
+#       Block until the per-agent convert lock is held, then return 0. Returns 1
+#       if it could not be taken within MNGR_CONVERT_LOCK_TIMEOUT seconds
+#       (default 30). The lock is a coarse mkdir-based mutex serializing the
+#       converter's read-modify-write so the background 5s daemon and an
+#       on-demand `--single-pass` flush never both append the same events into
+#       permanent duplicates (event-id dedup only skips IDs already present at
+#       read time). mkdir is atomic on POSIX filesystems, so it doubles as the
+#       mutex; a lock left by a crashed pass is broken once it is older than a
+#       minute. Same idiom as codex's codex_marker_lock.
+#
+#   - mngr_common_transcript_release_lock
+#       Drop the lock (idempotent).
+#
+#   - mngr_common_transcript_flush
+#       Run one synchronous `--single-pass` of the raw streamer then the
+#       common-transcript converter, in pipeline order, so a turn-end / WAITING
+#       signal can't outrun the converter. Best-effort: gated on each script
+#       existing (the common transcript is opt-in) and `|| true` so a flush
+#       failure can never strand the caller's turn-end signal. The converter's
+#       lock keeps this pass from racing the background daemon.
+#
+# Requires MNGR_AGENT_STATE_DIR. The lock is per-agent (exactly one converter
+# runs per agent), so a single lock dir under the state dir is sufficient.
+# Nothing runs at source time and the env is only read inside the functions, so
+# sourcing this lib can never fail -- even from a context that has not yet
+# validated MNGR_AGENT_STATE_DIR.
+
+_mngr_common_transcript_lock_dir() {
+    printf '%s/.common_transcript_convert.lock' "${MNGR_AGENT_STATE_DIR}"
+}
+
+mngr_common_transcript_acquire_lock() {
+    local lock_dir timeout waited
+    lock_dir="$(_mngr_common_transcript_lock_dir)"
+    timeout="${MNGR_CONVERT_LOCK_TIMEOUT:-30}"
+    waited=0
+    while ! mkdir "$lock_dir" 2>/dev/null; do
+        if [ -n "$(find "$lock_dir" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+            rmdir "$lock_dir" 2>/dev/null || true
+            continue
+        fi
+        if [ "$waited" -ge "$timeout" ]; then
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
+mngr_common_transcript_release_lock() {
+    rmdir "$(_mngr_common_transcript_lock_dir)" 2>/dev/null || true
+}
+
+mngr_common_transcript_flush() {
+    local cmds="${MNGR_AGENT_STATE_DIR}/commands"
+    if [ -x "$cmds/stream_transcript.sh" ]; then
+        bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    fi
+    if [ -x "$cmds/common_transcript.sh" ]; then
+        bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    fi
+}

--- a/libs/mngr_antigravity/changelog/mngr-catalyst-waiting.md
+++ b/libs/mngr_antigravity/changelog/mngr-catalyst-waiting.md
@@ -1,0 +1,12 @@
+Hardened the turn-end signal so consumers that read the common transcript on the WAITING
+transition (e.g. an orchestrator harvesting the agent's final message) can no longer
+outrun the converter. `statusline.sh` now, on the busy->idle edge, runs a synchronous
+`--single-pass` of the raw streamer and common-transcript converter, in pipeline order,
+before clearing the `active` marker -- so by the time the agent reports WAITING the common
+transcript already reflects the final assistant message. The flush is gated to the
+busy->idle edge so it costs at most one conversion pass per turn.
+
+The common-transcript converter now takes a coarse mkdir-based lock around its
+read-modify-write so the background 5s daemon and the on-demand flush can't both append
+the same events into duplicates. A lock left by a crashed pass is broken once it is older
+than a minute; the timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.

--- a/libs/mngr_antigravity/changelog/mngr-catalyst-waiting.md
+++ b/libs/mngr_antigravity/changelog/mngr-catalyst-waiting.md
@@ -1,12 +1,12 @@
 Hardened the turn-end signal so consumers that read the common transcript on the WAITING
 transition (e.g. an orchestrator harvesting the agent's final message) can no longer
-outrun the converter. `statusline.sh` now, on the busy->idle edge, runs a synchronous
-`--single-pass` of the raw streamer and common-transcript converter, in pipeline order,
-before clearing the `active` marker -- so by the time the agent reports WAITING the common
-transcript already reflects the final assistant message. The flush is gated to the
-busy->idle edge so it costs at most one conversion pass per turn.
+outrun the converter. `statusline.sh` now, on the busy->idle edge, flushes the transcript
+pipeline (a synchronous `--single-pass` of the raw streamer and common-transcript
+converter, in pipeline order) before clearing the `active` marker -- so by the time the
+agent reports WAITING the common transcript already reflects the final assistant message.
+The flush is gated to the busy->idle edge so it costs at most one conversion pass per turn.
 
-The common-transcript converter now takes a coarse mkdir-based lock around its
-read-modify-write so the background 5s daemon and the on-demand flush can't both append
-the same events into duplicates. A lock left by a crashed pass is broken once it is older
-than a minute; the timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.
+The flush and the converter's convert lock now come from the shared
+`mngr_common_transcript_lib.sh` (see the `mngr` changelog) rather than being duplicated
+per agent. The convert lock keeps the on-demand flush from racing the background 5s
+daemon into duplicate events; its timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
@@ -55,37 +55,11 @@ _MNGR_LOG_FILE="$AGENT_DATA_DIR/events/logs/common_transcript/events.jsonl"
 # shellcheck source=mngr_log.sh
 source "$MNGR_AGENT_STATE_DIR/commands/mngr_log.sh"
 
-# Serialize the read-modify-write conversion pass so the background daemon
-# (the 5s poll loop) and an on-demand `--single-pass` flush -- e.g. the one
-# statusline.sh fires on the busy->idle edge so the WAITING signal can't race
-# ahead of the converter -- never both append the same events. Without it,
-# two passes that read the dedup set before either writes would each append
-# the new events, leaving permanent duplicates (event-id dedup only skips
-# IDs already present at read time). mkdir is atomic on POSIX filesystems,
-# so it doubles as the mutex; a lock left by a crashed pass is broken once
-# it is older than a minute. Same idiom as codex's codex_marker_lock.
-_CONVERT_LOCK_DIR="$AGENT_DATA_DIR/.common_transcript_convert.lock"
-_CONVERT_LOCK_TIMEOUT="${MNGR_CONVERT_LOCK_TIMEOUT:-30}"
-
-_acquire_convert_lock() {
-    local waited=0
-    while ! mkdir "$_CONVERT_LOCK_DIR" 2>/dev/null; do
-        if [ -n "$(find "$_CONVERT_LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
-            rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
-            continue
-        fi
-        if [ "$waited" -ge "$_CONVERT_LOCK_TIMEOUT" ]; then
-            return 1
-        fi
-        sleep 1
-        waited=$((waited + 1))
-    done
-    return 0
-}
-
-_release_convert_lock() {
-    rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
-}
+# Shared common-transcript primitives: the convert lock that serializes this
+# converter's read-modify-write against any concurrent --single-pass flush (see
+# the library header for why duplicates would result without it).
+# shellcheck source=mngr_common_transcript_lib.sh
+source "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh"
 
 convert_new_events() {
     if [ ! -f "$INPUT_FILE" ]; then
@@ -93,8 +67,8 @@ convert_new_events() {
         return
     fi
 
-    if ! _acquire_convert_lock; then
-        log_warn "could not acquire convert lock after ${_CONVERT_LOCK_TIMEOUT}s; skipping pass"
+    if ! mngr_common_transcript_acquire_lock; then
+        log_warn "could not acquire convert lock; skipping pass"
         return
     fi
 
@@ -311,7 +285,7 @@ CONVERT_SCRIPT
 
     # The read-modify-write is done; drop the lock before the (lock-free)
     # logging below so a concurrent pass can proceed immediately.
-    _release_convert_lock
+    mngr_common_transcript_release_lock
 
     if [ -s "$convert_stderr" ]; then
         # Forward the heredoc Python's stderr to both the structured log

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript.sh
@@ -55,9 +55,46 @@ _MNGR_LOG_FILE="$AGENT_DATA_DIR/events/logs/common_transcript/events.jsonl"
 # shellcheck source=mngr_log.sh
 source "$MNGR_AGENT_STATE_DIR/commands/mngr_log.sh"
 
+# Serialize the read-modify-write conversion pass so the background daemon
+# (the 5s poll loop) and an on-demand `--single-pass` flush -- e.g. the one
+# statusline.sh fires on the busy->idle edge so the WAITING signal can't race
+# ahead of the converter -- never both append the same events. Without it,
+# two passes that read the dedup set before either writes would each append
+# the new events, leaving permanent duplicates (event-id dedup only skips
+# IDs already present at read time). mkdir is atomic on POSIX filesystems,
+# so it doubles as the mutex; a lock left by a crashed pass is broken once
+# it is older than a minute. Same idiom as codex's codex_marker_lock.
+_CONVERT_LOCK_DIR="$AGENT_DATA_DIR/.common_transcript_convert.lock"
+_CONVERT_LOCK_TIMEOUT="${MNGR_CONVERT_LOCK_TIMEOUT:-30}"
+
+_acquire_convert_lock() {
+    local waited=0
+    while ! mkdir "$_CONVERT_LOCK_DIR" 2>/dev/null; do
+        if [ -n "$(find "$_CONVERT_LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+            rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
+            continue
+        fi
+        if [ "$waited" -ge "$_CONVERT_LOCK_TIMEOUT" ]; then
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
+_release_convert_lock() {
+    rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
+}
+
 convert_new_events() {
     if [ ! -f "$INPUT_FILE" ]; then
         log_debug "Input file not found: $INPUT_FILE"
+        return
+    fi
+
+    if ! _acquire_convert_lock; then
+        log_warn "could not acquire convert lock after ${_CONVERT_LOCK_TIMEOUT}s; skipping pass"
         return
     fi
 
@@ -271,6 +308,10 @@ def convert():
 convert()
 CONVERT_SCRIPT
 )
+
+    # The read-modify-write is done; drop the lock before the (lock-free)
+    # logging below so a concurrent pass can proceed immediately.
+    _release_convert_lock
 
     if [ -s "$convert_stderr" ]; then
         # Forward the heredoc Python's stderr to both the structured log

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript_test.py
@@ -18,6 +18,7 @@ Each test sets up:
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import os
 import subprocess
@@ -27,6 +28,7 @@ from typing import Any
 
 import pytest
 
+from imbue.mngr import resources as mngr_resources
 from imbue.mngr.agents.common_transcript_records import validate_common_transcript_record
 
 _SCRIPT_PATH = Path(__file__).parent / "common_transcript.sh"
@@ -114,11 +116,16 @@ def _conversation_history(conv_id: str, step_index: int) -> str:
 
 @pytest.fixture
 def state_dir(tmp_path: Path, stub_mngr_log_sh: str) -> Path:
-    """Per-test fake $MNGR_AGENT_STATE_DIR with stub mngr_log.sh installed."""
+    """Per-test fake $MNGR_AGENT_STATE_DIR with stub mngr_log.sh + the real
+    shared common-transcript lib installed (the converter sources it for the
+    convert lock), mirroring Host._ensure_shared_shell_libs."""
     state = tmp_path / "agent"
     (state / "commands").mkdir(parents=True)
     (state / "logs" / "antigravity_transcript").mkdir(parents=True)
     (state / "commands" / "mngr_log.sh").write_text(stub_mngr_log_sh)
+    (state / "commands" / "mngr_common_transcript_lib.sh").write_text(
+        importlib.resources.files(mngr_resources).joinpath("mngr_common_transcript_lib.sh").read_text()
+    )
     return state
 
 

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/common_transcript_test.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
@@ -549,3 +550,71 @@ def test_emitted_common_records_conform_to_canonical_schema(state_dir: Path) -> 
     assert {r["type"] for r in records} == {"user_message", "assistant_message", "tool_result"}
     for record in records:
         assert validate_common_transcript_record(record) is None, record
+
+
+# -- Convert-lock serialization (shared by the 5s daemon and on-demand flush) --
+
+
+def _lock_dir(state_dir: Path) -> Path:
+    return state_dir / ".common_transcript_convert.lock"
+
+
+def test_held_convert_lock_skips_pass(state_dir: Path) -> None:
+    """A pass that cannot take the convert lock (held by a concurrent pass)
+    skips conversion rather than racing into duplicate output. Simulated by
+    pre-creating the (fresh) lock dir and giving the pass a short timeout."""
+    _write_raw_transcript(state_dir, [_user_input("conv-A", 0, "hello")])
+    _lock_dir(state_dir).mkdir(parents=True)
+
+    env = {**os.environ, "MNGR_AGENT_STATE_DIR": str(state_dir), "MNGR_CONVERT_LOCK_TIMEOUT": "1"}
+    result = subprocess.run(
+        ["bash", str(_SCRIPT_PATH), "--single-pass"], env=env, capture_output=True, text=True, check=True
+    )
+    assert "Traceback" not in result.stderr, result.stderr
+    assert _read_common_events(state_dir) == []
+
+    _lock_dir(state_dir).rmdir()
+    _run_converter(state_dir)
+    assert len(_read_common_events(state_dir)) == 1
+
+
+def test_stale_convert_lock_is_broken(state_dir: Path) -> None:
+    """A convert lock older than a minute is treated as stale and broken, so the
+    converter never wedges permanently."""
+    _write_raw_transcript(state_dir, [_user_input("conv-A", 0, "hello")])
+    lock = _lock_dir(state_dir)
+    lock.mkdir(parents=True)
+    stale = time.time() - 120
+    os.utime(lock, (stale, stale))
+
+    env = {**os.environ, "MNGR_AGENT_STATE_DIR": str(state_dir), "MNGR_CONVERT_LOCK_TIMEOUT": "1"}
+    result = subprocess.run(
+        ["bash", str(_SCRIPT_PATH), "--single-pass"], env=env, capture_output=True, text=True, check=True
+    )
+    assert "Traceback" not in result.stderr, result.stderr
+    assert len(_read_common_events(state_dir)) == 1
+
+
+def test_concurrent_passes_do_not_duplicate(state_dir: Path) -> None:
+    """Two passes racing over the same input must not both append the same
+    events: the lock serializes them so the second sees the first's output in
+    its dedup set. Without the lock this produces duplicate event_ids."""
+    _write_raw_transcript(state_dir, [_user_input(f"conv-{i}", i, f"msg {i}") for i in range(20)])
+
+    env = {**os.environ, "MNGR_AGENT_STATE_DIR": str(state_dir)}
+    procs = [
+        subprocess.Popen(
+            ["bash", str(_SCRIPT_PATH), "--single-pass"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        for _ in range(2)
+    ]
+    for proc in procs:
+        assert proc.wait(timeout=30) == 0
+
+    events = _read_common_events(state_dir)
+    event_ids = [e["event_id"] for e in events]
+    assert len(event_ids) == len(set(event_ids)), "convert lock failed to prevent duplicate events"
+    assert len(events) == 20

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
@@ -69,10 +69,36 @@ if [ -n "$conv_id" ]; then
     printf '%s' "$conv_id" > "$root_file"
 fi
 
+# Flush the transcript pipeline so the WAITING signal can't outrun it. The
+# raw streamer (1s poll) and common-transcript converter (5s poll) lag behind
+# agy's per-conversation JSONL; clearing the `active` marker below is the
+# turn-end signal `mngr wait --state WAITING` reads, and consumers that
+# harvest the final assistant message from the common transcript on that
+# signal (e.g. Catalyst's mngr_runner) would otherwise race the converter.
+# Forcing one synchronous pass of each, in pipeline order (raw first, then
+# common), guarantees the common transcript reflects the final message before
+# the marker is cleared. Best-effort: gated on the scripts existing (the
+# common transcript is opt-in) and `|| true` so a flush failure can never
+# strand the turn-end signal. The converter's mkdir lock keeps this pass from
+# racing the background daemon into duplicate events.
+flush_transcripts() {
+    local cmds="$MNGR_AGENT_STATE_DIR/commands"
+    [ -x "$cmds/stream_transcript.sh" ] && \
+        bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    [ -x "$cmds/common_transcript.sh" ] && \
+        bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
+}
+
 # Busy = any state that is not a known not-working state. Denylist so any
 # current/future busy state (working, ...) keeps the agent RUNNING.
 case "$agent_state" in
     idle | initializing | authenticating | "")
+        # Only flush on the busy->idle edge (marker still present from a prior
+        # busy sample), not on every idle/startup sample: that bounds the
+        # synchronous conversion to once per turn, right as the turn ends.
+        if [ -e "$marker_file" ]; then
+            flush_transcripts
+        fi
         rm -f "$marker_file"
         ;;
     *)

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
@@ -69,37 +69,29 @@ if [ -n "$conv_id" ]; then
     printf '%s' "$conv_id" > "$root_file"
 fi
 
-# Flush the transcript pipeline so the WAITING signal can't outrun it. The
-# raw streamer (1s poll) and common-transcript converter (5s poll) lag behind
-# agy's per-conversation JSONL; clearing the `active` marker below is the
-# turn-end signal `mngr wait --state WAITING` reads, and consumers that
-# harvest the final assistant message from the common transcript on that
-# signal (e.g. Catalyst's mngr_runner) would otherwise race the converter.
-# Forcing one synchronous pass of each, in pipeline order (raw first, then
-# common), guarantees the common transcript reflects the final message before
-# the marker is cleared. Best-effort: gated on the scripts existing (the
-# common transcript is opt-in) and `|| true` so a flush failure can never
-# strand the turn-end signal. The converter's mkdir lock keeps this pass from
-# racing the background daemon into duplicate events.
-flush_transcripts() {
-    local cmds="$MNGR_AGENT_STATE_DIR/commands"
-    if [ -x "$cmds/stream_transcript.sh" ]; then
-        bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    fi
-    if [ -x "$cmds/common_transcript.sh" ]; then
-        bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    fi
-}
+# Shared common-transcript helpers: mngr_common_transcript_flush forces a
+# synchronous pass of the raw streamer + common-transcript converter so the
+# WAITING signal can't outrun them (see below and the shared library header).
+# Sourced defensively (no set -e here): the lib is provisioned by
+# Host._ensure_shared_shell_libs, but a missing lib must never disrupt agy's
+# statusLine loop.
+if [ -r "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh" ]; then
+    # shellcheck source=../../../mngr/imbue/mngr/resources/mngr_common_transcript_lib.sh
+    source "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh"
+fi
 
 # Busy = any state that is not a known not-working state. Denylist so any
 # current/future busy state (working, ...) keeps the agent RUNNING.
 case "$agent_state" in
     idle | initializing | authenticating | "")
-        # Only flush on the busy->idle edge (marker still present from a prior
-        # busy sample), not on every idle/startup sample: that bounds the
-        # synchronous conversion to once per turn, right as the turn ends.
-        if [ -e "$marker_file" ]; then
-            flush_transcripts
+        # Flush the transcript pipeline so a consumer that harvests the final
+        # message from the common transcript on the WAITING transition (e.g.
+        # Catalyst's mngr_runner) can't outrun the converter. Only on the
+        # busy->idle edge (marker still present from a prior busy sample), not
+        # on every idle/startup sample: that bounds the synchronous conversion
+        # to once per turn, right as the turn ends.
+        if [ -e "$marker_file" ] && command -v mngr_common_transcript_flush >/dev/null 2>&1; then
+            mngr_common_transcript_flush
         fi
         rm -f "$marker_file"
         ;;

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline.sh
@@ -83,10 +83,12 @@ fi
 # racing the background daemon into duplicate events.
 flush_transcripts() {
     local cmds="$MNGR_AGENT_STATE_DIR/commands"
-    [ -x "$cmds/stream_transcript.sh" ] && \
+    if [ -x "$cmds/stream_transcript.sh" ]; then
         bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    [ -x "$cmds/common_transcript.sh" ] && \
+    fi
+    if [ -x "$cmds/common_transcript.sh" ]; then
         bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    fi
 }
 
 # Busy = any state that is not a known not-working state. Denylist so any

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline_test.py
@@ -188,3 +188,57 @@ def test_failing_user_statusline_does_not_break_side_effects(tmp_path: Path) -> 
     result = _run(tmp_path, _payload(agent_state="working"))
     assert _marker(tmp_path).exists()
     assert result.stdout == ""
+
+
+def _install_flush_stubs(state_dir: Path) -> Path:
+    """Install stub stream/common transcript scripts that record that they ran
+    (and whether the active marker was still present at that moment, to pin the
+    flush-before-clear ordering). Returns the sentinel path the stubs append to."""
+    commands = state_dir / "commands"
+    commands.mkdir(parents=True, exist_ok=True)
+    sentinel = state_dir / "flush_sentinel"
+    for name in ("stream_transcript.sh", "common_transcript.sh"):
+        script = commands / name
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            f'echo "{name}:marker=$([ -e "$MNGR_AGENT_STATE_DIR/active" ] && echo present || echo gone)" '
+            '>> "$MNGR_AGENT_STATE_DIR/flush_sentinel"\n'
+        )
+        script.chmod(0o755)
+    return sentinel
+
+
+def test_busy_to_idle_edge_flushes_before_clearing_marker(tmp_path: Path) -> None:
+    """On the busy->idle edge the transcript converters are flushed (single-pass)
+    BEFORE the active marker is cleared, so a WAITING-signal consumer that reads
+    the common transcript can't outrun the converter."""
+    sentinel = _install_flush_stubs(tmp_path)
+    # A prior busy sample left the marker present; this idle is the busy->idle edge.
+    _marker(tmp_path).touch()
+
+    _run(tmp_path, _payload(agent_state="idle"))
+
+    assert not _marker(tmp_path).exists()
+    # Both converters ran (marker still present at flush time -> flush precedes
+    # the clear), in pipeline order: raw streamer first, then common converter.
+    assert sentinel.read_text().splitlines() == [
+        "stream_transcript.sh:marker=present",
+        "common_transcript.sh:marker=present",
+    ]
+
+
+def test_idle_without_prior_busy_does_not_flush(tmp_path: Path) -> None:
+    """Idle/startup samples with no marker present (not a busy->idle edge) must
+    not pay for a synchronous flush."""
+    sentinel = _install_flush_stubs(tmp_path)
+    _run(tmp_path, _payload(agent_state="idle"))
+    assert not _marker(tmp_path).exists()
+    assert not sentinel.exists()
+
+
+def test_working_does_not_flush(tmp_path: Path) -> None:
+    """Entering a busy state sets the marker and never flushes."""
+    sentinel = _install_flush_stubs(tmp_path)
+    _run(tmp_path, _payload(agent_state="working"))
+    assert _marker(tmp_path).exists()
+    assert not sentinel.exists()

--- a/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline_test.py
+++ b/libs/mngr_antigravity/imbue/mngr_antigravity/resources/statusline_test.py
@@ -17,9 +17,12 @@ one is composed), and loud failure on a missing state dir. (`tmux wait-for` is
 
 from __future__ import annotations
 
+import importlib.resources
 import os
 import subprocess
 from pathlib import Path
+
+from imbue.mngr import resources as mngr_resources
 
 _SCRIPT_PATH = Path(__file__).parent / "statusline.sh"
 
@@ -191,11 +194,16 @@ def test_failing_user_statusline_does_not_break_side_effects(tmp_path: Path) -> 
 
 
 def _install_flush_stubs(state_dir: Path) -> Path:
-    """Install stub stream/common transcript scripts that record that they ran
-    (and whether the active marker was still present at that moment, to pin the
-    flush-before-clear ordering). Returns the sentinel path the stubs append to."""
+    """Install the real shared common-transcript lib (so statusline.sh's source
+    succeeds and mngr_common_transcript_flush is defined) plus stub stream/common
+    transcript scripts that record that they ran (and whether the active marker
+    was still present at that moment, to pin the flush-before-clear ordering).
+    Returns the sentinel path the stubs append to."""
     commands = state_dir / "commands"
     commands.mkdir(parents=True, exist_ok=True)
+    (commands / "mngr_common_transcript_lib.sh").write_text(
+        importlib.resources.files(mngr_resources).joinpath("mngr_common_transcript_lib.sh").read_text()
+    )
     sentinel = state_dir / "flush_sentinel"
     for name in ("stream_transcript.sh", "common_transcript.sh"):
         script = commands / name

--- a/libs/mngr_claude/changelog/mngr-catalyst-waiting.md
+++ b/libs/mngr_claude/changelog/mngr-catalyst-waiting.md
@@ -1,11 +1,11 @@
 Hardened the turn-end signal so consumers that read the common transcript on the WAITING
 transition (e.g. an orchestrator harvesting the agent's final message) can no longer
-outrun the converter. `wait_for_stop_hook.sh` now runs a synchronous `--single-pass` of
-the raw streamer and common-transcript converter, in pipeline order, before clearing the
-`active` marker -- so by the time the agent reports WAITING the common transcript already
-reflects the final assistant message.
+outrun the converter. `wait_for_stop_hook.sh` now flushes the transcript pipeline (a
+synchronous `--single-pass` of the raw streamer and common-transcript converter, in
+pipeline order) before clearing the `active` marker -- so by the time the agent reports
+WAITING the common transcript already reflects the final assistant message.
 
-The common-transcript converter now takes a coarse mkdir-based lock around its
-read-modify-write so the background 5s daemon and the on-demand flush can't both append
-the same events into duplicates. A lock left by a crashed pass is broken once it is older
-than a minute; the timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.
+The flush and the converter's convert lock now come from the shared
+`mngr_common_transcript_lib.sh` (see the `mngr` changelog) rather than being duplicated
+per agent. The convert lock keeps the on-demand flush from racing the background 5s
+daemon into duplicate events; its timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.

--- a/libs/mngr_claude/changelog/mngr-catalyst-waiting.md
+++ b/libs/mngr_claude/changelog/mngr-catalyst-waiting.md
@@ -1,0 +1,11 @@
+Hardened the turn-end signal so consumers that read the common transcript on the WAITING
+transition (e.g. an orchestrator harvesting the agent's final message) can no longer
+outrun the converter. `wait_for_stop_hook.sh` now runs a synchronous `--single-pass` of
+the raw streamer and common-transcript converter, in pipeline order, before clearing the
+`active` marker -- so by the time the agent reports WAITING the common transcript already
+reflects the final assistant message.
+
+The common-transcript converter now takes a coarse mkdir-based lock around its
+read-modify-write so the background 5s daemon and the on-demand flush can't both append
+the same events into duplicates. A lock left by a crashed pass is broken once it is older
+than a minute; the timeout is tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.

--- a/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript.sh
@@ -37,6 +37,38 @@ _MNGR_LOG_FILE="$AGENT_DATA_DIR/events/logs/common_transcript/events.jsonl"
 # shellcheck source=mngr_log.sh
 source "$MNGR_AGENT_STATE_DIR/commands/mngr_log.sh"
 
+# Serialize the read-modify-write conversion pass so the background daemon
+# (the 5s poll loop) and an on-demand `--single-pass` flush -- e.g. the one
+# wait_for_stop_hook.sh fires at turn end so the WAITING signal can't race
+# ahead of the converter -- never both append the same events. Without it,
+# two passes that read the dedup set before either writes would each append
+# the new events, leaving permanent duplicates (event-id dedup only skips
+# IDs already present at read time). mkdir is atomic on POSIX filesystems,
+# so it doubles as the mutex; a lock left by a crashed pass is broken once
+# it is older than a minute. Same idiom as codex's codex_marker_lock.
+_CONVERT_LOCK_DIR="$AGENT_DATA_DIR/.common_transcript_convert.lock"
+_CONVERT_LOCK_TIMEOUT="${MNGR_CONVERT_LOCK_TIMEOUT:-30}"
+
+_acquire_convert_lock() {
+    local waited=0
+    while ! mkdir "$_CONVERT_LOCK_DIR" 2>/dev/null; do
+        if [ -n "$(find "$_CONVERT_LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
+            rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
+            continue
+        fi
+        if [ "$waited" -ge "$_CONVERT_LOCK_TIMEOUT" ]; then
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 0
+}
+
+_release_convert_lock() {
+    rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
+}
+
 # Convert new Claude transcript events to the common format.
 #
 # Reads the full input file and the set of event_ids already in the output
@@ -45,6 +77,11 @@ source "$MNGR_AGENT_STATE_DIR/commands/mngr_log.sh"
 convert_new_events() {
     if [ ! -f "$INPUT_FILE" ]; then
         log_debug "Input file not found: $INPUT_FILE"
+        return
+    fi
+
+    if ! _acquire_convert_lock; then
+        log_warn "could not acquire convert lock after ${_CONVERT_LOCK_TIMEOUT}s; skipping pass"
         return
     fi
 
@@ -326,6 +363,10 @@ def convert():
 convert()
 CONVERT_SCRIPT
 )
+
+    # The read-modify-write is done; drop the lock before the (lock-free)
+    # logging below so a concurrent pass can proceed immediately.
+    _release_convert_lock
 
     if [ -s "$convert_stderr" ]; then
         log_warn "convert error: $(cat "$convert_stderr")"

--- a/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript.sh
@@ -37,37 +37,11 @@ _MNGR_LOG_FILE="$AGENT_DATA_DIR/events/logs/common_transcript/events.jsonl"
 # shellcheck source=mngr_log.sh
 source "$MNGR_AGENT_STATE_DIR/commands/mngr_log.sh"
 
-# Serialize the read-modify-write conversion pass so the background daemon
-# (the 5s poll loop) and an on-demand `--single-pass` flush -- e.g. the one
-# wait_for_stop_hook.sh fires at turn end so the WAITING signal can't race
-# ahead of the converter -- never both append the same events. Without it,
-# two passes that read the dedup set before either writes would each append
-# the new events, leaving permanent duplicates (event-id dedup only skips
-# IDs already present at read time). mkdir is atomic on POSIX filesystems,
-# so it doubles as the mutex; a lock left by a crashed pass is broken once
-# it is older than a minute. Same idiom as codex's codex_marker_lock.
-_CONVERT_LOCK_DIR="$AGENT_DATA_DIR/.common_transcript_convert.lock"
-_CONVERT_LOCK_TIMEOUT="${MNGR_CONVERT_LOCK_TIMEOUT:-30}"
-
-_acquire_convert_lock() {
-    local waited=0
-    while ! mkdir "$_CONVERT_LOCK_DIR" 2>/dev/null; do
-        if [ -n "$(find "$_CONVERT_LOCK_DIR" -maxdepth 0 -mmin +1 2>/dev/null)" ]; then
-            rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
-            continue
-        fi
-        if [ "$waited" -ge "$_CONVERT_LOCK_TIMEOUT" ]; then
-            return 1
-        fi
-        sleep 1
-        waited=$((waited + 1))
-    done
-    return 0
-}
-
-_release_convert_lock() {
-    rmdir "$_CONVERT_LOCK_DIR" 2>/dev/null || true
-}
+# Shared common-transcript primitives: the convert lock that serializes this
+# converter's read-modify-write against any concurrent --single-pass flush (see
+# the library header for why duplicates would result without it).
+# shellcheck source=mngr_common_transcript_lib.sh
+source "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh"
 
 # Convert new Claude transcript events to the common format.
 #
@@ -80,8 +54,8 @@ convert_new_events() {
         return
     fi
 
-    if ! _acquire_convert_lock; then
-        log_warn "could not acquire convert lock after ${_CONVERT_LOCK_TIMEOUT}s; skipping pass"
+    if ! mngr_common_transcript_acquire_lock; then
+        log_warn "could not acquire convert lock; skipping pass"
         return
     fi
 
@@ -366,7 +340,7 @@ CONVERT_SCRIPT
 
     # The read-modify-write is done; drop the lock before the (lock-free)
     # logging below so a concurrent pass can proceed immediately.
-    _release_convert_lock
+    mngr_common_transcript_release_lock
 
     if [ -s "$convert_stderr" ]; then
         log_warn "convert error: $(cat "$convert_stderr")"

--- a/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
@@ -11,6 +11,7 @@ so tests are fast and deterministic.
 
 from __future__ import annotations
 
+import importlib.resources
 import json
 import os
 import subprocess
@@ -19,6 +20,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from imbue.mngr import resources as mngr_resources
 from imbue.mngr.agents.common_transcript_records import validate_common_transcript_record
 
 # -- Helpers --
@@ -122,6 +124,14 @@ class ScriptRunner:
         log_path = self.agent_state_dir / "commands" / "mngr_log.sh"
         log_path.write_text(stub_mngr_log_sh)
         log_path.chmod(0o755)
+
+        # Write the real shared common-transcript lib: the converter sources it
+        # for the convert lock, mirroring Host._ensure_shared_shell_libs.
+        lib_path = self.agent_state_dir / "commands" / "mngr_common_transcript_lib.sh"
+        lib_path.write_text(
+            importlib.resources.files(mngr_resources).joinpath("mngr_common_transcript_lib.sh").read_text()
+        )
+        lib_path.chmod(0o755)
 
         # Standard paths
         self.script_path = Path(__file__).parent / "common_transcript.sh"

--- a/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/common_transcript_test.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -126,6 +127,8 @@ class ScriptRunner:
         self.script_path = Path(__file__).parent / "common_transcript.sh"
         self.input_file = self.agent_state_dir / "logs" / "claude_transcript" / "events.jsonl"
         self.output_file = self.agent_state_dir / "events" / "claude" / "common_transcript" / "events.jsonl"
+        # The mkdir-based mutex the converter takes around its read-modify-write.
+        self.lock_dir = self.agent_state_dir / ".common_transcript_convert.lock"
 
     def write_input(self, lines: list[str]) -> None:
         """Write lines to the input transcript file."""
@@ -148,11 +151,14 @@ class ScriptRunner:
                 events.append(json.loads(line))
         return events
 
-    def run_single_pass(self, timeout: float = 10.0) -> subprocess.CompletedProcess[str]:
+    def run_single_pass(
+        self, timeout: float = 10.0, extra_env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
         """Run the script with --single-pass."""
         env = {
             **os.environ,
             "MNGR_AGENT_STATE_DIR": str(self.agent_state_dir),
+            **(extra_env or {}),
         }
         return subprocess.run(
             ["bash", str(self.script_path), "--single-pass"],
@@ -812,3 +818,70 @@ def test_incremental_conversion(tmp_path: Path, stub_mngr_log_sh: str) -> None:
     assert len(events) == 2
     assert events[0]["content"] == "First"
     assert events[1]["content"] == "Second"
+
+
+def test_held_lock_skips_pass(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A pass that cannot take the convert lock (held by a concurrent pass)
+    skips its conversion rather than racing into duplicate output. Simulated by
+    pre-creating the (fresh) lock dir and giving the pass a short lock timeout."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    runner.write_input([_make_assistant_event(uuid4().hex, "2026-01-01T00:00:01Z", text="hi")])
+
+    # Hold the lock with a fresh mtime so the stale-break (>1min) does not fire.
+    runner.lock_dir.mkdir(parents=True)
+
+    result = runner.run_single_pass(extra_env={"MNGR_CONVERT_LOCK_TIMEOUT": "1"})
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    # Lock was held the whole time, so nothing was converted.
+    assert runner.get_output_events() == []
+
+    # Release the lock; the next pass converts normally.
+    runner.lock_dir.rmdir()
+    result = runner.run_single_pass()
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert len(runner.get_output_events()) == 1
+
+
+def test_stale_lock_is_broken(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """A convert lock older than a minute is treated as stale (left by a crashed
+    pass) and broken, so the converter never wedges permanently."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    runner.write_input([_make_assistant_event(uuid4().hex, "2026-01-01T00:00:01Z", text="hi")])
+
+    runner.lock_dir.mkdir(parents=True)
+    # Age the lock past the 1-minute stale threshold.
+    stale = time.time() - 120
+    os.utime(runner.lock_dir, (stale, stale))
+
+    result = runner.run_single_pass(extra_env={"MNGR_CONVERT_LOCK_TIMEOUT": "1"})
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    # The stale lock was broken, so conversion proceeded.
+    assert len(runner.get_output_events()) == 1
+
+
+def test_concurrent_passes_do_not_duplicate(tmp_path: Path, stub_mngr_log_sh: str) -> None:
+    """Two passes racing over the same input must not both append the same
+    events: the lock serializes them so the second sees the first's output in
+    its dedup set. Without the lock this produces duplicate event_ids."""
+    runner = ScriptRunner(tmp_path, stub_mngr_log_sh)
+    runner.write_input(
+        [_make_assistant_event(uuid4().hex, f"2026-01-01T00:00:{i:02d}Z", text=f"m{i}") for i in range(20)]
+    )
+
+    env = {**os.environ, "MNGR_AGENT_STATE_DIR": str(runner.agent_state_dir)}
+    procs = [
+        subprocess.Popen(
+            ["bash", str(runner.script_path), "--single-pass"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        for _ in range(2)
+    ]
+    for proc in procs:
+        assert proc.wait(timeout=30) == 0
+
+    events = runner.get_output_events()
+    event_ids = [e["event_id"] for e in events]
+    assert len(event_ids) == len(set(event_ids)), "convert lock failed to prevent duplicate events"
+    assert len(events) == 20

--- a/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
@@ -160,26 +160,23 @@ upload_autofix_issues() {
 # marker, which is the turn-end signal `mngr wait --state WAITING` reads --
 # and consumers that harvest the final assistant message from the common
 # transcript on that signal (e.g. Catalyst's mngr_runner) would otherwise
-# race the converter. Forcing one synchronous pass of each, in pipeline order
-# (raw first, then common), guarantees the common transcript reflects the
-# final message before the marker is cleared. Best-effort: gated on the
-# scripts existing (the common transcript is opt-in) and `|| true` so a flush
-# failure can never strand the turn-end signal. The converter's mkdir lock
-# keeps this pass from racing the background daemon into duplicate events.
-flush_transcripts() {
-    local cmds="$MNGR_AGENT_STATE_DIR/commands"
-    if [ -x "$cmds/stream_transcript.sh" ]; then
-        bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    fi
-    if [ -x "$cmds/common_transcript.sh" ]; then
-        bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    fi
-}
+# race the converter. mngr_common_transcript_flush forces one synchronous pass
+# of each converter, in pipeline order, so the common transcript reflects the
+# final message before the marker is cleared (see the shared library header).
+# Sourced and called defensively: the lib is provisioned by
+# Host._ensure_shared_shell_libs, but a missing lib or flush failure must never
+# strand the turn-end signal.
+if [ -n "${MNGR_AGENT_STATE_DIR:-}" ] && [ -r "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh" ]; then
+    # shellcheck source=../../../mngr/imbue/mngr/resources/mngr_common_transcript_lib.sh
+    source "$MNGR_AGENT_STATE_DIR/commands/mngr_common_transcript_lib.sh"
+fi
 
 # --- Post-completion actions (run after all other stop hooks finish) ---
 run_post_completion() {
     # Flush the transcript pipeline before mark_inactive clears the marker.
-    flush_transcripts
+    if command -v mngr_common_transcript_flush >/dev/null 2>&1; then
+        mngr_common_transcript_flush
+    fi
 
     # Only run post-completion if the orchestrator succeeded.
     # The code-guardian orchestrator writes .reviewer/outputs/orchestrator_success

--- a/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
@@ -154,8 +154,31 @@ upload_autofix_issues() {
     uv run modal volume put "${volume_name}" "$issues_file" "/${nested_path}/autofix.json" --force 2>/dev/null || true
 }
 
+# --- Flush the transcript pipeline so the WAITING signal can't outrun it ---
+# The raw streamer (1s poll) and common-transcript converter (5s poll) lag
+# behind Claude's session JSONL. mark_inactive (below) clears the `active`
+# marker, which is the turn-end signal `mngr wait --state WAITING` reads --
+# and consumers that harvest the final assistant message from the common
+# transcript on that signal (e.g. Catalyst's mngr_runner) would otherwise
+# race the converter. Forcing one synchronous pass of each, in pipeline order
+# (raw first, then common), guarantees the common transcript reflects the
+# final message before the marker is cleared. Best-effort: gated on the
+# scripts existing (the common transcript is opt-in) and `|| true` so a flush
+# failure can never strand the turn-end signal. The converter's mkdir lock
+# keeps this pass from racing the background daemon into duplicate events.
+flush_transcripts() {
+    local cmds="$MNGR_AGENT_STATE_DIR/commands"
+    [ -x "$cmds/stream_transcript.sh" ] && \
+        bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    [ -x "$cmds/common_transcript.sh" ] && \
+        bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
+}
+
 # --- Post-completion actions (run after all other stop hooks finish) ---
 run_post_completion() {
+    # Flush the transcript pipeline before mark_inactive clears the marker.
+    flush_transcripts
+
     # Only run post-completion if the orchestrator succeeded.
     # The code-guardian orchestrator writes .reviewer/outputs/orchestrator_success
     # on success with the commit hash.

--- a/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
+++ b/libs/mngr_claude/imbue/mngr_claude/resources/wait_for_stop_hook.sh
@@ -168,10 +168,12 @@ upload_autofix_issues() {
 # keeps this pass from racing the background daemon into duplicate events.
 flush_transcripts() {
     local cmds="$MNGR_AGENT_STATE_DIR/commands"
-    [ -x "$cmds/stream_transcript.sh" ] && \
+    if [ -x "$cmds/stream_transcript.sh" ]; then
         bash "$cmds/stream_transcript.sh" --single-pass >/dev/null 2>&1 || true
-    [ -x "$cmds/common_transcript.sh" ] && \
+    fi
+    if [ -x "$cmds/common_transcript.sh" ]; then
         bash "$cmds/common_transcript.sh" --single-pass >/dev/null 2>&1 || true
+    fi
 }
 
 # --- Post-completion actions (run after all other stop hooks finish) ---


### PR DESCRIPTION
kinda ugly but seems correct

---

## Problem

Investigating the comment in Catalyst's `mngr_runner.py`:

> A short unconditional wait so the common-transcript converter (which writes on a ~5s timer) catches up with whatever the turn-end signal raced ahead of

The runner harvests a step's final answer from the **common transcript**, but learns the turn is over from a **separate** signal (`mngr wait --state WAITING`, i.e. the `active` marker being cleared). Those travel down independent, unordered pipelines:

```
session JSONL → stream_transcript.sh (1s) → raw → common_transcript.sh (5s) → common transcript → mngr event   [the ANSWER]
Stop hook → clear `active` marker → mngr wait --state WAITING                                                   [DONE]
```

DONE can beat the ANSWER by up to ~6s + conversion time. The old band-aid was a fixed 10s `time.sleep` on every step: slow, and still timing-dependent (no positive confirmation).

## Fix (mngr-side, the real fix)

Make the WAITING signal **causally downstream** of the converter. The converters already shipped an unused `--single-pass` flag; this wires it in:

- **claude** (`wait_for_stop_hook.sh`): synchronous `--single-pass` of stream then common, in `run_post_completion`, before `mark_inactive` clears the marker.
- **antigravity** (`statusline.sh`): same, on the busy→idle edge, before clearing the marker (edge-gated so it costs at most one pass per turn).

Both are best-effort (gated on script existence, `|| true`) so a flush failure can never strand the turn-end signal.

A concurrency wrinkle this surfaces: the on-demand flush runs alongside the 5s daemon, and both append to the same file with read-then-append dedup → possible duplicate lines. So the converter now takes a coarse **mkdir-based lock** (the codebase's portable idiom, same as codex's `codex_marker_lock`) around its read-modify-write. Stale locks (>1min) self-heal; timeout tunable via `MNGR_CONVERT_LOCK_TIMEOUT`.

## Catalyst side (separate `ai-scientist` repo, branch `mngr/catalyst-waiting`)

With the signal now ordered after the converter, the fixed 10s sleep becomes a bounded early-exit poll: parses on the first iteration in the common case (~zero added latency), with the grace budget kept as a fallback for the premature-`end_turn` case and for an mngr build without the flush.

## Scope

claude + antigravity only (the agent types Catalyst uses). codex is left alone (its root/subagent marker recompute is more delicate and unused here).

## Tests

- converter lock: held-lock skip, stale-lock break, concurrent-passes-no-duplicates (both plugins)
- statusline: flush-before-clear ordering + pipeline order; no flush off-edge or when busy
- claude `wait_for_stop_hook.sh` has no unit harness (pre-existing; needs `/proc`); its flush mechanism is verified manually + via the shared converter tests
- catalyst runner tests updated for the new constant/loop

## Shared library (de-duplication)

The convert lock and turn-end flush were initially duplicated across claude's and antigravity's `common_transcript.sh` / turn-end hooks. They are now extracted into a shared shell library `libs/mngr/imbue/mngr/resources/mngr_common_transcript_lib.sh`, provisioned to every agent's `commands/` dir alongside `mngr_log.sh` and `mngr_transcript_lib.sh` (via `Host._ensure_shared_shell_libs`) -- the same shared-shell-lib pattern already used for the raw-streamer primitives. Converters source it for the lock; turn-end hooks source it defensively and call the shared flush. codex's converter is left untouched (no flusher today; the lib is there for it to adopt later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
