### PR TITLE
research: gitignored folder for conference paper datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ apps/minds_workspace_server/package-lock.json
 
 # tmr (task-runner) orchestration scratch report
 **/tmr-report/
+
+# Research data (downloaded datasets, not checked in)
+/research/

--- a/dev/changelog/mngr-reasoning-researcher.md
+++ b/dev/changelog/mngr-reasoning-researcher.md
@@ -1,0 +1,1 @@
+Added a gitignored `research/` folder (excluded via `.gitignore`) for downloaded paper datasets used by reasoning-researcher work. The folder holds scripts that pull NeurIPS/ICLR/ICML papers (titles, abstracts, reviewer scores, accept tiers) from the OpenReview API and enrich them with Semantic Scholar citation counts; the data itself is not checked in.


### PR DESCRIPTION
## Summary

Sets up data sources for filtering through all papers from the two most recent editions of NeurIPS, ICLR, and ICML (24,242 papers total).

The actual datasets and the scripts that produce them live in a new **gitignored** `research/` folder, so the only tracked change here is adding `/research/` to `.gitignore` (plus a changelog entry).

## What was collected (locally, not committed)

- **OpenReview API2** -> titles, abstracts, keywords, authors, accept tier (oral/spotlight/poster), per-reviewer scores (rating/confidence/soundness/...), and meta-reviews.
- **Semantic Scholar** -> citation counts (chosen over OpenAlex, which badly undercounts recent ML papers).

Coverage: reviewer scores for all editions except ICML 2024 (reviews not public there); citations at ~95% for the established editions. NeurIPS 2025 / ICLR 2026 citations are pending (Semantic Scholar has not tagged those venues yet; backfillable with a free API key, see `research/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)