### PR TITLE
set imbue-mngr-codex version to 0.1.0

### DIFF
--- a/libs/mngr_codex/pyproject.toml
+++ b/libs/mngr_codex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbue-mngr-codex"
-version = "0.1.3"
+version = "0.1.0"
 description = "Codex agent type plugin for mngr"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1906,7 +1906,7 @@ requires-dist = [
 
 [[package]]
 name = "imbue-mngr-codex"
-version = "0.1.3"
+version = "0.1.0"
 source = { editable = "libs/mngr_codex" }
 dependencies = [
     { name = "imbue-mngr" },


### PR DESCRIPTION
it hasn't been released yet, so it's a bit silly to start at 0.1.3

---

Bump the `imbue-mngr-codex` package version from `0.1.3` to `0.1.0` and sync `uv.lock`.

Note: no changelog entry is included, so the changelog CI check is expected to fail (intentional, per the desire to cut the release immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)