### PR TITLE
actually enforce changelog entries existing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,36 @@ on:
     branches: ['**']
 
 jobs:
+  # Authoritative changelog gate. Runs on the orchestrator (not in an offload
+  # sandbox) because it diffs the PR branch against its real base branch, and
+  # the sandbox has no base ref -- doing the diff there passes vacuously. Pure
+  # stdlib, so no `uv sync`; just enough git history to compute the diff.
+  check-changelog:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      # Shallow checkout, then deepen ONLY HEAD's ancestry (same rationale as
+      # the offload jobs below: a bare `--unshallow` pulls every branch). The
+      # merge-base with the base branch is an ancestor of HEAD, so deepening
+      # HEAD plus fetching the base tip is enough for a three-dot diff.
+      - uses: actions/checkout@v6
+
+      - name: Fetch base branch and deepen HEAD for the changelog diff
+        run: |
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --unshallow origin "$(git rev-parse HEAD)"
+          fi
+          git fetch --no-tags origin \
+            "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check changelog entries
+        run: python -m scripts.check_changelog_entries
+
   # Unit + integration tests via offload on Modal
   test-offload:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ['**']
 
 jobs:
-  # Authoritative changelog gate. Runs on the orchestrator (not in an offload
+  # Changelog gate. Runs on the orchestrator (not in an offload
   # sandbox) because it diffs the PR branch against its real base branch, and
   # the sandbox has no base ref -- doing the diff there passes vacuously. Pure
   # stdlib, so no `uv sync`; just enough git history to compute the diff.

--- a/dev/changelog/mngr-changelog-enforcement.md
+++ b/dev/changelog/mngr-changelog-enforcement.md
@@ -1,0 +1,5 @@
+Fixed the per-PR changelog enforcement check, which was passing vacuously in CI.
+
+The check previously ran as an acceptance test (`test_pr_has_changelog_entry`) inside the offload Modal sandbox, but the sandbox does a fresh `git init` (so `main == HEAD`) and never fetches `origin`, so its base-branch diff always came back empty and the check passed no matter what. Any PR could merge without changelog entries.
+
+The enforcement now lives in a dedicated CI gate, `scripts/check_changelog_entries.py` (run via the `check-changelog` GitHub Actions job and the `just check-changelog` recipe), which computes the changed-file set against the real base branch on the orchestrator where a base ref actually exists. It refuses to run with a loud non-zero exit if it cannot resolve a diff base distinct from HEAD, so it can never again pass vacuously. The old sandbox-bound acceptance test has been removed.

--- a/dev/changelog/mngr-changelog-enforcement.md
+++ b/dev/changelog/mngr-changelog-enforcement.md
@@ -1,5 +1,0 @@
-Fixed the per-PR changelog enforcement check, which was passing vacuously in CI.
-
-The check previously ran as an acceptance test (`test_pr_has_changelog_entry`) inside the offload Modal sandbox, but the sandbox does a fresh `git init` (so `main == HEAD`) and never fetches `origin`, so its base-branch diff always came back empty and the check passed no matter what. Any PR could merge without changelog entries.
-
-The enforcement now lives in a dedicated CI gate, `scripts/check_changelog_entries.py` (run via the `check-changelog` GitHub Actions job and the `just check-changelog` recipe), which computes the changed-file set against the real base branch on the orchestrator where a base ref actually exists. It refuses to run with a loud non-zero exit if it cannot resolve a diff base distinct from HEAD, so it can never again pass vacuously. The old sandbox-bound acceptance test has been removed.

--- a/justfile
+++ b/justfile
@@ -845,7 +845,7 @@ release *args:
 # check would pass vacuously. Pure stdlib, so no `uv sync` needed.
 # Check that this branch has a changelog entry per project it touches.
 check-changelog:
-    python -m scripts.check_changelog_entries
+    uv run python -m scripts.check_changelog_entries
 
 # (Re)deploy the nightly changelog-consolidation schedule from current source.
 changelog-deploy:

--- a/justfile
+++ b/justfile
@@ -838,14 +838,14 @@ release *args:
 # removes any existing schedule before recreating, so this is also how you
 # redeploy after editing scripts/changelog_consolidation_prompt.md or
 # scripts/changelog_deploy.sh.
-# Authoritative changelog gate: fails if any project this branch touches is
-# missing its per-PR entry file. Computes the changed-file set against the real
-# base branch, so it must run on a real checkout (locally or the GitHub Actions
-# runner), NOT inside an offload sandbox -- the sandbox has no base ref and the
-# check would pass vacuously. Pure stdlib, so no `uv sync` needed.
+# Diffs against the real base branch, so it must run on a real checkout
+# (locally or the GitHub Actions runner), NOT inside an offload sandbox -- the
+# sandbox has no base ref and the check would pass vacuously. Bare `python`
+# (no `uv run`) because the gate is deliberately stdlib-only: no `uv sync`,
+# matching how the `check-changelog` CI job invokes it.
 # Check that this branch has a changelog entry per project it touches.
 check-changelog:
-    uv run python -m scripts.check_changelog_entries
+    python -m scripts.check_changelog_entries
 
 # (Re)deploy the nightly changelog-consolidation schedule from current source.
 changelog-deploy:

--- a/justfile
+++ b/justfile
@@ -838,6 +838,15 @@ release *args:
 # removes any existing schedule before recreating, so this is also how you
 # redeploy after editing scripts/changelog_consolidation_prompt.md or
 # scripts/changelog_deploy.sh.
+# Authoritative changelog gate: fails if any project this branch touches is
+# missing its per-PR entry file. Computes the changed-file set against the real
+# base branch, so it must run on a real checkout (locally or the GitHub Actions
+# runner), NOT inside an offload sandbox -- the sandbox has no base ref and the
+# check would pass vacuously. Pure stdlib, so no `uv sync` needed.
+# Check that this branch has a changelog entry per project it touches.
+check-changelog:
+    python -m scripts.check_changelog_entries
+
 # (Re)deploy the nightly changelog-consolidation schedule from current source.
 changelog-deploy:
     bash scripts/changelog_deploy.sh

--- a/justfile
+++ b/justfile
@@ -838,6 +838,10 @@ release *args:
 # removes any existing schedule before recreating, so this is also how you
 # redeploy after editing scripts/changelog_consolidation_prompt.md or
 # scripts/changelog_deploy.sh.
+# (Re)deploy the nightly changelog-consolidation schedule from current source.
+changelog-deploy:
+    bash scripts/changelog_deploy.sh
+
 # Diffs against the real base branch, so it must run on a real checkout
 # (locally or the GitHub Actions runner), NOT inside an offload sandbox -- the
 # sandbox has no base ref and the check would pass vacuously. Bare `python`
@@ -846,10 +850,6 @@ release *args:
 # Check that this branch has a changelog entry per project it touches.
 check-changelog:
     python -m scripts.check_changelog_entries
-
-# (Re)deploy the nightly changelog-consolidation schedule from current source.
-changelog-deploy:
-    bash scripts/changelog_deploy.sh
 
 # Opens a PR (which you can merge before re-running a blocked release) by
 # running the same agent the schedule runs nightly. Reads the provider +

--- a/scripts/check_changelog_entries.py
+++ b/scripts/check_changelog_entries.py
@@ -1,0 +1,217 @@
+"""Enforce that a PR adds one changelog entry per project it touches.
+
+This is the authoritative changelog gate. It runs on the *orchestrator* (a
+real local checkout, or the GitHub Actions runner) -- the only place a real
+base ref exists -- and never inside an offload sandbox. The offload sandbox
+does a fresh ``git init`` (so ``main == HEAD``) and never fetches ``origin``,
+so a base-branch diff computed there is structurally meaningless: it comes
+back empty and the check passes vacuously. See
+``scripts/check_changelog_entries_test.py`` for the regression coverage.
+
+The check has exactly one input: the set of files this PR changed relative to
+its base. That input is computed here, where the base ref is present, and the
+gate refuses to run (loud non-zero exit) rather than pass vacuously when it
+cannot establish a base distinct from HEAD.
+
+Run it from the repo root as a module so ``scripts`` is importable::
+
+    python -m scripts.check_changelog_entries
+
+Exit codes:
+    0  -- ok (entries present, or nothing to check: not a PR branch / exempt /
+          no project files changed)
+    1  -- one or more touched projects are missing their entry file
+    2  -- cannot establish a usable diff base (misconfiguration); never a
+          silent pass
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.changelog_projects import DEV_PROJECT
+from scripts.changelog_projects import all_known_projects
+from scripts.changelog_projects import project_entries_dir
+from scripts.changelog_projects import project_for_path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Branch prefixes exempt from the changelog requirement. The consolidation
+# agent's own PRs rewrite the consolidated changelogs and would otherwise be
+# caught requiring an entry for every project they touch.
+_EXEMPT_BRANCH_PREFIXES: tuple[str, ...] = ("mngr/changelog-consolidation",)
+
+
+def detect_branch(repo_root: Path) -> str | None:
+    """Return the PR branch name, or ``None`` if it can't be determined.
+
+    Mirrors ``imbue.imbue_common.test_profiles.detect_branch`` but is inlined
+    so this gate stays dependency-free (importable with stdlib only, no
+    ``uv sync`` needed in CI): GitHub Actions ``GITHUB_HEAD_REF`` (PR source
+    branch) first, then ``GITHUB_REF_NAME`` (push target), then local git.
+    """
+    for env_var in ("GITHUB_HEAD_REF", "GITHUB_REF_NAME"):
+        branch = os.environ.get(env_var, "")
+        if branch:
+            return branch
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
+def _rev_parse(ref: str, repo_root: Path) -> str | None:
+    """Return the commit SHA ``ref`` resolves to, or ``None`` if it doesn't."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sha = result.stdout.strip()
+    return sha if result.returncode == 0 and sha else None
+
+
+def resolve_diff_base(repo_root: Path) -> str:
+    """Return a git ref to diff the PR branch against.
+
+    Tries ``origin/$GITHUB_BASE_REF``, ``$GITHUB_BASE_REF``, ``origin/main``,
+    then ``main``, and returns the first that resolves to a commit *distinct
+    from HEAD*. A base equal to HEAD yields an empty diff and a vacuous pass
+    (the exact bug this gate exists to prevent), so such candidates are
+    rejected. Raises ``RuntimeError`` if none qualify -- the caller turns that
+    into a loud non-zero exit, never a pass.
+    """
+    head = _rev_parse("HEAD", repo_root)
+    candidates: list[str] = []
+    base_ref = os.environ.get("GITHUB_BASE_REF", "")
+    if base_ref:
+        candidates.extend([f"origin/{base_ref}", base_ref])
+    candidates.extend(["origin/main", "main"])
+
+    saw_head_collision = False
+    for ref in candidates:
+        sha = _rev_parse(ref, repo_root)
+        if sha is None:
+            continue
+        if sha == head:
+            saw_head_collision = True
+            continue
+        return ref
+
+    detail = (
+        " The only candidates that resolved point at HEAD itself, which would "
+        "produce an empty diff and silently pass. Fetch the real base branch "
+        "(e.g. `git fetch origin main`) before running this check."
+        if saw_head_collision
+        else " Fetch the base branch (e.g. `git fetch origin main`) and re-run."
+    )
+    raise RuntimeError("Cannot resolve a diff base distinct from HEAD: tried " + ", ".join(candidates) + "." + detail)
+
+
+def changed_files_against_base(base: str, repo_root: Path) -> list[str]:
+    """Return the repo-relative paths this branch changes vs. ``base``.
+
+    Uses ``git diff --name-only <base>...HEAD`` (three-dot / merge-base form).
+    Raises ``RuntimeError`` if ``git diff`` itself fails.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff failed against {base} (exit {result.returncode}): {result.stderr.strip()}")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def projects_requiring_entry(changed_files: list[str], repo_root: Path) -> set[str]:
+    """Return the set of projects this PR must produce a changelog entry for.
+
+    A project is "touched" iff the PR changes any file under it. Files that are
+    themselves changelog artifacts are intentionally *not* excluded -- adding
+    an entry file inherently satisfies the requirement, and a PR that only
+    edits a project's consolidated ``CHANGELOG.md`` still owes a per-PR entry
+    describing that edit.
+    """
+    known = set(all_known_projects(repo_root))
+    touched: set[str] = set()
+    for rel_path in changed_files:
+        project = project_for_path(rel_path, repo_root)
+        if project in known:
+            touched.add(project)
+    return touched
+
+
+def find_missing_entries(branch: str, touched: set[str], repo_root: Path) -> list[str]:
+    """Return the repo-relative entry paths that are missing for ``touched``."""
+    sanitized = branch.replace("/", "-")
+    missing: list[str] = []
+    for project in sorted(touched):
+        entry_path = project_entries_dir(project, repo_root) / f"{sanitized}.md"
+        if not entry_path.exists():
+            missing.append(str(entry_path.relative_to(repo_root)))
+    return missing
+
+
+def is_exempt_branch(branch: str) -> bool:
+    """Return whether ``branch`` is exempt from the changelog requirement."""
+    return any(branch.startswith(prefix) for prefix in _EXEMPT_BRANCH_PREFIXES)
+
+
+def main(repo_root: Path = _REPO_ROOT) -> int:
+    branch = detect_branch(repo_root)
+    if not branch or branch == "main":
+        print("changelog gate: not a PR branch (branch is empty or 'main'); nothing to check.")
+        return 0
+    if is_exempt_branch(branch):
+        print(f"changelog gate: branch '{branch}' is exempt from the changelog requirement.")
+        return 0
+
+    try:
+        diff_base = resolve_diff_base(repo_root)
+    except RuntimeError as exc:
+        print(f"changelog gate ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    changed_files = changed_files_against_base(diff_base, repo_root)
+    touched = projects_requiring_entry(changed_files, repo_root)
+    missing = find_missing_entries(branch, touched, repo_root)
+
+    if not missing:
+        print(
+            f"changelog gate: ok. Branch '{branch}' touches {sorted(touched)} "
+            f"(diff base '{diff_base}'); all required entries present."
+        )
+        return 0
+
+    print(
+        f"changelog gate FAILED: missing changelog entries for branch '{branch}' "
+        f"(diff base '{diff_base}', via git diff --name-only {diff_base}...HEAD). "
+        f"This PR touches project(s) {sorted(touched)}; each needs its own entry file.\n"
+        f"Create:\n" + "\n".join(f"  - {p}" for p in missing) + "\n"
+        f"Each file should briefly describe the user-visible changes in this PR that "
+        f"pertain to that project. The synthetic '{DEV_PROJECT}' project covers "
+        f"root-level files (scripts/, .github/, top-level docs, build tooling).\n"
+        f"\n"
+        f"If you believe this PR makes NO actual changes to one of the listed "
+        f"projects, do NOT add a placebo entry: a stale or misconfigured diff base "
+        f"('{diff_base}') can make unrelated files from main appear changed. The fix "
+        f"is to correct the diff base, not to add entries for projects you did not touch.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_changelog_entries.py
+++ b/scripts/check_changelog_entries.py
@@ -1,6 +1,6 @@
 """Enforce that a PR adds one changelog entry per project it touches.
 
-This is the authoritative changelog gate. It runs on the *orchestrator* (a
+This is the changelog gate. It runs on the *orchestrator* (a
 real local checkout, or the GitHub Actions runner) -- the only place a real
 base ref exists -- and never inside an offload sandbox. The offload sandbox
 does a fresh ``git init`` (so ``main == HEAD``) and never fetches ``origin``,

--- a/scripts/check_changelog_entries_test.py
+++ b/scripts/check_changelog_entries_test.py
@@ -1,0 +1,147 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_changelog_entries import changed_files_against_base
+from scripts.check_changelog_entries import find_missing_entries
+from scripts.check_changelog_entries import is_exempt_branch
+from scripts.check_changelog_entries import main
+from scripts.check_changelog_entries import projects_requiring_entry
+from scripts.check_changelog_entries import resolve_diff_base
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command in ``repo`` and return its stdout (stripped)."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a git repo with a single project skeleton and one commit on main.
+
+    Mirrors the real layout enough for the project-mapping helpers: a
+    ``libs/mngr`` project with a ``pyproject.toml`` and a ``changelog/``
+    directory, plus the synthetic ``dev`` bucket directories.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "libs" / "mngr" / "changelog").mkdir(parents=True)
+    (repo / "libs" / "mngr" / "pyproject.toml").write_text("")
+    (repo / "dev" / "changelog").mkdir(parents=True)
+    (repo / "README.md").write_text("base\n")
+
+    _git(repo, "-c", "init.defaultBranch=main", "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "base")
+    # Guarantee the branch is named 'main' regardless of the git default.
+    _git(repo, "branch", "-M", "main")
+    return repo
+
+
+@pytest.fixture(autouse=True)
+def _clear_github_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear GitHub Actions env so branch/base detection uses the temp repo's git."""
+    for var in ("GITHUB_HEAD_REF", "GITHUB_REF_NAME", "GITHUB_BASE_REF"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_resolve_diff_base_rejects_base_equal_to_head(tmp_path: Path) -> None:
+    """The core regression: a single-commit repo where main == HEAD (the offload
+    sandbox shape) must NOT yield a usable base -- it must raise, not pass."""
+    repo = _init_repo(tmp_path)
+    # Branch off without adding a commit: HEAD == main, exactly the sandbox case.
+    _git(repo, "checkout", "-b", "feature")
+
+    with pytest.raises(RuntimeError, match="distinct from HEAD"):
+        resolve_diff_base(repo)
+
+
+def test_resolve_diff_base_returns_main_when_distinct(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "change")
+
+    assert resolve_diff_base(repo) == "main"
+
+
+def test_changed_files_detects_project_change(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "change")
+
+    changed = changed_files_against_base("main", repo)
+    assert "libs/mngr/thing.py" in changed
+    assert projects_requiring_entry(changed, repo) == {"mngr"}
+
+
+def test_root_file_maps_to_dev(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "justfile").write_text("recipe:\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "root change")
+
+    changed = changed_files_against_base("main", repo)
+    assert projects_requiring_entry(changed, repo) == {"dev"}
+
+
+def test_find_missing_entries(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    # mngr has no entry for this branch; dev does.
+    (repo / "dev" / "changelog" / "feature-x.md").write_text("entry\n")
+    missing = find_missing_entries("feature/x", {"mngr", "dev"}, repo)
+    assert missing == ["libs/mngr/changelog/feature-x.md"]
+
+
+def test_main_fails_when_entry_missing(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "change")
+
+    assert main(repo) == 1
+
+
+def test_main_passes_when_entry_present(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
+    (repo / "libs" / "mngr" / "changelog" / "feature.md").write_text("did a thing\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "change with entry")
+
+    assert main(repo) == 0
+
+
+def test_main_errors_in_sandbox_shape(tmp_path: Path) -> None:
+    """End-to-end: the offload-sandbox shape (main == HEAD) returns exit 2, the
+    loud-failure code -- never a vacuous 0."""
+    repo = _init_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+
+    assert main(repo) == 2
+
+
+def test_main_skips_on_main_branch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    # Still on 'main'; nothing to enforce.
+    assert main(repo) == 0
+
+
+def test_is_exempt_branch() -> None:
+    assert is_exempt_branch("mngr/changelog-consolidation-2026-06-13")
+    assert not is_exempt_branch("mngr/some-feature")

--- a/scripts/check_changelog_entries_test.py
+++ b/scripts/check_changelog_entries_test.py
@@ -1,8 +1,9 @@
-import subprocess
 from pathlib import Path
 
 import pytest
 
+from imbue.mngr.utils.testing import init_git_repo
+from imbue.mngr.utils.testing import run_git_command
 from scripts.check_changelog_entries import changed_files_against_base
 from scripts.check_changelog_entries import find_missing_entries
 from scripts.check_changelog_entries import is_exempt_branch
@@ -11,39 +12,22 @@ from scripts.check_changelog_entries import projects_requiring_entry
 from scripts.check_changelog_entries import resolve_diff_base
 
 
-def _git(repo: Path, *args: str) -> str:
-    """Run a git command in ``repo`` and return its stdout (stripped)."""
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.strip()
-
-
 def _init_repo(tmp_path: Path) -> Path:
-    """Create a git repo with a single project skeleton and one commit on main.
+    """Create a git repo with a project skeleton committed on main.
 
-    Mirrors the real layout enough for the project-mapping helpers: a
+    Layout mirrors the real repo enough for the project-mapping helpers: a
     ``libs/mngr`` project with a ``pyproject.toml`` and a ``changelog/``
-    directory, plus the synthetic ``dev`` bucket directories.
+    directory, plus the synthetic ``dev`` bucket directories. Builds on the
+    shared ``init_git_repo`` helper (git config isolation, branch ``main``,
+    initial commit), then commits the skeleton on top.
     """
     repo = tmp_path / "repo"
-    repo.mkdir()
+    init_git_repo(repo, initial_commit=True)
     (repo / "libs" / "mngr" / "changelog").mkdir(parents=True)
     (repo / "libs" / "mngr" / "pyproject.toml").write_text("")
     (repo / "dev" / "changelog").mkdir(parents=True)
-    (repo / "README.md").write_text("base\n")
-
-    _git(repo, "-c", "init.defaultBranch=main", "init")
-    _git(repo, "config", "user.email", "test@example.com")
-    _git(repo, "config", "user.name", "Test")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "base")
-    # Guarantee the branch is named 'main' regardless of the git default.
-    _git(repo, "branch", "-M", "main")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "project skeleton")
     return repo
 
 
@@ -55,11 +39,11 @@ def _clear_github_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_resolve_diff_base_rejects_base_equal_to_head(tmp_path: Path) -> None:
-    """The core regression: a single-commit repo where main == HEAD (the offload
-    sandbox shape) must NOT yield a usable base -- it must raise, not pass."""
+    """The core regression: a repo where main == HEAD (the offload sandbox
+    shape) must NOT yield a usable base -- it must raise, not pass."""
     repo = _init_repo(tmp_path)
     # Branch off without adding a commit: HEAD == main, exactly the sandbox case.
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
 
     with pytest.raises(RuntimeError, match="distinct from HEAD"):
         resolve_diff_base(repo)
@@ -67,20 +51,20 @@ def test_resolve_diff_base_rejects_base_equal_to_head(tmp_path: Path) -> None:
 
 def test_resolve_diff_base_returns_main_when_distinct(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
     (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "change")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "change")
 
     assert resolve_diff_base(repo) == "main"
 
 
 def test_changed_files_detects_project_change(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
     (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "change")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "change")
 
     changed = changed_files_against_base("main", repo)
     assert "libs/mngr/thing.py" in changed
@@ -89,10 +73,10 @@ def test_changed_files_detects_project_change(tmp_path: Path) -> None:
 
 def test_root_file_maps_to_dev(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
     (repo / "justfile").write_text("recipe:\n")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "root change")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "root change")
 
     changed = changed_files_against_base("main", repo)
     assert projects_requiring_entry(changed, repo) == {"dev"}
@@ -108,21 +92,21 @@ def test_find_missing_entries(tmp_path: Path) -> None:
 
 def test_main_fails_when_entry_missing(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
     (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "change")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "change")
 
     assert main(repo) == 1
 
 
 def test_main_passes_when_entry_present(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
     (repo / "libs" / "mngr" / "thing.py").write_text("x = 1\n")
     (repo / "libs" / "mngr" / "changelog" / "feature.md").write_text("did a thing\n")
-    _git(repo, "add", "-A")
-    _git(repo, "commit", "-m", "change with entry")
+    run_git_command(repo, "add", "-A")
+    run_git_command(repo, "commit", "-m", "change with entry")
 
     assert main(repo) == 0
 
@@ -131,7 +115,7 @@ def test_main_errors_in_sandbox_shape(tmp_path: Path) -> None:
     """End-to-end: the offload-sandbox shape (main == HEAD) returns exit 2, the
     loud-failure code -- never a vacuous 0."""
     repo = _init_repo(tmp_path)
-    _git(repo, "checkout", "-b", "feature")
+    run_git_command(repo, "checkout", "-b", "feature")
 
     assert main(repo) == 2
 

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -1,6 +1,5 @@
 import ast
 import fnmatch
-import os
 import re
 import subprocess
 import sys
@@ -17,12 +16,9 @@ from imbue.imbue_common.ratchet_testing.core import _get_all_files_with_extensio
 from imbue.imbue_common.ratchet_testing.ratchets import check_no_import_lint_errors
 from imbue.imbue_common.ratchet_testing.ratchets import check_no_type_errors
 from imbue.imbue_common.ratchet_testing.ratchets import find_bash_scripts_without_strict_mode
-from imbue.imbue_common.test_profiles import detect_branch
-from scripts.changelog_projects import DEV_PROJECT
 from scripts.changelog_projects import all_known_projects
 from scripts.changelog_projects import project_dir as get_project_dir
 from scripts.changelog_projects import project_entries_dir
-from scripts.changelog_projects import project_for_path
 from scripts.changelog_projects import pyproject_projects
 
 _REPO_ROOT = Path(__file__).parent
@@ -567,132 +563,6 @@ def test_every_project_with_tests_has_coverage_config() -> None:
 
     assert len(errors) == 0, "Projects with tests are missing coverage configuration:\n" + "\n".join(
         f"  - {e}" for e in errors
-    )
-
-
-# --- Changelog entry enforcement ---
-
-# Branch prefixes that are exempt from the changelog requirement
-_CHANGELOG_EXEMPT_BRANCH_PREFIXES: tuple[str, ...] = ("mngr/changelog-consolidation",)
-
-
-def _resolve_diff_base() -> str:
-    """Return the git ref to diff the PR branch against.
-
-    Prefers ``origin/$GITHUB_BASE_REF`` in CI (the actual PR base), then
-    ``origin/main``, then plain ``main``. Returns the first ref that
-    ``git rev-parse`` resolves; otherwise raises ``RuntimeError``.
-    """
-    candidates: list[str] = []
-    base_ref = os.environ.get("GITHUB_BASE_REF", "")
-    if base_ref:
-        candidates.append(f"origin/{base_ref}")
-    candidates.extend(["origin/main", "main"])
-    for ref in candidates:
-        result = subprocess.run(
-            ["git", "rev-parse", "--verify", "--quiet", ref],
-            cwd=_REPO_ROOT,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            return ref
-    raise RuntimeError(
-        "Cannot resolve a diff base: none of "
-        + ", ".join(candidates)
-        + " are reachable. Fetch the base branch and re-run."
-    )
-
-
-def _changed_files_against_base(base: str) -> list[str]:
-    """Return the repo-relative paths the PR branch changes vs. ``base``.
-
-    Uses ``git diff --name-only <base>...HEAD`` (three-dot form, i.e. the
-    diff against the merge base) so renames/branches behave intuitively.
-    Raises ``RuntimeError`` if ``git diff`` itself fails.
-    """
-    result = subprocess.run(
-        ["git", "diff", "--name-only", f"{base}...HEAD"],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"git diff failed against {base} (exit {result.returncode}): {result.stderr.strip()}")
-    return [line for line in result.stdout.splitlines() if line.strip()]
-
-
-def _projects_requiring_entry(changed_files: list[str]) -> set[str]:
-    """Return the set of projects this PR must produce a changelog entry for.
-
-    A project is "touched" iff the PR changes any file under it.
-    ``project_for_path`` handles the ``libs/<name>`` / ``apps/<name>`` /
-    ``dev`` bucketing. Files that are themselves changelog artifacts (entry
-    files, ``CHANGELOG.md``, ``UNABRIDGED_CHANGELOG.md``) are intentionally
-    *not* excluded -- adding an entry file inherently satisfies the
-    requirement, and a PR that only edits a project's consolidated changelog
-    should still describe that edit in a per-PR entry.
-    """
-    known = set(all_known_projects(_REPO_ROOT))
-    touched: set[str] = set()
-    for rel_path in changed_files:
-        project = project_for_path(rel_path, _REPO_ROOT)
-        if project in known:
-            touched.add(project)
-    return touched
-
-
-# Marked as acceptance because this check should be done soon before merging,
-# not during iteration.
-@pytest.mark.acceptance
-def test_pr_has_changelog_entry() -> None:
-    """Ensure every PR branch has one changelog entry per project it touches.
-
-    For each project the PR changes a file in (``libs/<name>``,
-    ``apps/<name>``, or the synthetic ``dev`` bucket for root-level files),
-    require ``<project_dir>/changelog/<branch-name>.md`` to exist (with
-    slashes in the branch name replaced by dashes). The nightly consolidator
-    routes each project's entries into that project's ``UNABRIDGED_CHANGELOG.md``.
-    """
-    branch = detect_branch()
-
-    if not branch or branch == "main":
-        pytest.skip("Not a PR branch")
-
-    for prefix in _CHANGELOG_EXEMPT_BRANCH_PREFIXES:
-        if branch.startswith(prefix):
-            pytest.skip(f"Branch '{branch}' is exempt from changelog requirement")
-
-    diff_base = _resolve_diff_base()
-    changed_files = _changed_files_against_base(diff_base)
-    touched = _projects_requiring_entry(changed_files)
-
-    sanitized = branch.replace("/", "-")
-    missing: list[str] = []
-    for project in sorted(touched):
-        entry_path = project_entries_dir(project, _REPO_ROOT) / f"{sanitized}.md"
-        if not entry_path.exists():
-            missing.append(str(entry_path.relative_to(_REPO_ROOT)))
-
-    assert not missing, (
-        f"Missing changelog entries for branch '{branch}' "
-        f"(diff base: '{diff_base}', resolved via "
-        f"git diff --name-only {diff_base}...HEAD). This PR appears to touch "
-        f"the project(s) {sorted(touched)}; each needs its own entry file.\n"
-        f"Create:\n" + "\n".join(f"  - {p}" for p in missing) + "\n"
-        f"Each file should briefly describe the user-visible changes in this PR "
-        f"that pertain to that project. The synthetic '{DEV_PROJECT}' project "
-        f"covers root-level files (scripts/, .github/, top-level docs, build tooling).\n"
-        f"\n"
-        f"IMPORTANT: for any individual project listed above where you believe "
-        f"this PR makes NO actual changes to that project, do NOT add a placebo "
-        f"entry just to satisfy this check. A stale or misconfigured diff base "
-        f"('{diff_base}') can make unrelated files from main appear as if they "
-        f"changed on this branch, falsely implicating projects you didn't touch. "
-        f"In that case the right fix is to correct the diff base, not to add "
-        f"entries for projects you actually didn't change."
     )
 
 

--- a/test_meta_ratchets.py
+++ b/test_meta_ratchets.py
@@ -262,7 +262,7 @@ def test_prevent_bash_without_strict_mode() -> None:
     tracked paths from the build context, so they are absent on disk there.
     """
     violations = find_bash_scripts_without_strict_mode(_REPO_ROOT)
-    assert len(violations) <= snapshot(21), "Bash scripts missing 'set -euo pipefail':\n" + "\n".join(
+    assert len(violations) <= snapshot(17), "Bash scripts missing 'set -euo pipefail':\n" + "\n".join(
         f"  - {v}" for v in violations
     )
 


### PR DESCRIPTION
i'm impressed that the pure CLAUDE.md adherence was so good i didn't notice this until now!

doesn't run in local pytest; depends on the PR's base branch, and it seems more annoying than helpful to require that the PR exists and has a base branch set / in-progress work otherwise correctly configures a base branch

---

## Problem

The per-PR changelog requirement was **unenforced**. The check ran as `test_pr_has_changelog_entry` (an `@pytest.mark.acceptance` test) inside the offload Modal sandbox, but that sandbox:

- does a fresh `git init` in `post-source-setup.sh` (so `main == HEAD`), and
- never fetches `origin` (sandboxes have networking disabled), and
- never receives `GITHUB_BASE_REF` (the justfile only forwards `GITHUB_HEAD_REF`/`GITHUB_REF_NAME`).

So `_resolve_diff_base()` fell through to `main`, which resolved to the `sandbox-init` commit (== HEAD), making `git diff main...HEAD` empty. No projects were ever flagged, and the test passed vacuously no matter what. PR #2139 demonstrated this: it bumped `libs/mngr_codex` with no changelog entry and CI went green.

## Fix

The check has exactly one input — the set of files the PR changed vs. its base — and that input only exists where a real base ref is present (a local checkout or the GitHub Actions runner), never in the sandbox. So enforcement moves out of the sandbox entirely:

- **`scripts/check_changelog_entries.py`** — a dependency-free (stdlib + the existing pure-stdlib `scripts/changelog_projects.py`) gate that resolves the diff base, computes the changed files, maps them to projects, and checks each touched project has its `<project_dir>/changelog/<branch>.md` entry.
- It **fails loudly** (exit 2) rather than passing when it cannot resolve a base distinct from HEAD — a vacuous green is impossible by construction now.
- **`check-changelog` CI job** (`.github/workflows/ci.yml`) runs it on the orchestrator on `pull_request`, after fetching the base branch. No `uv sync` needed, so it's fast.
- **`just check-changelog`** runs the same gate locally.
- The old sandbox-bound acceptance test (and its now-unused helpers) is removed from `test_meta_ratchets.py`.

## Tests

`scripts/check_changelog_entries_test.py` covers the mapping, the missing-entry detection, and crucially the regression: a single-commit repo where `main == HEAD` (the sandbox shape) must error, never pass.

## End-to-end verification

The gate was exercised live against this PR, not just unit-tested:

- Temporarily removed this PR's changelog entry (`dev/changelog/mngr-changelog-enforcement.md`) and pushed (commit `bd9687a01`). The **`check-changelog` CI job failed** with exit 1 on the real GitHub Actions runner:
  > changelog gate FAILED: missing changelog entries for branch 'mngr/changelog-enforcement' (diff base 'origin/main', via git diff --name-only origin/main...HEAD). This PR touches project(s) ['dev']; each needs its own entry file.

  Note the diff base resolved to `origin/main` (a real base distinct from HEAD) — exactly the diff the old in-sandbox test could never compute.
- Restored the entry (revert commit `c69977cf0`); the gate returns to passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)