### PR TITLE
fix error message referencing removed flag

### DIFF
--- a/libs/mngr/changelog/mngr-old-message.md
+++ b/libs/mngr/changelog/mngr-old-message.md
@@ -1,0 +1,1 @@
+Fix the "branch already checked out" error from `mngr create` to suggest the correct flag. It previously pointed users at `--in-place`, which no longer exists (it was consolidated into `--transfer`); it now suggests `--transfer=none`.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -1916,7 +1916,7 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
                     raise UserInputError(
                         f"{stderr.strip()}\n"
                         f"To create a new branch instead, use --branch BASE: or --branch BASE:new-name\n"
-                        f"To work directly in the existing worktree, use --in-place from that directory"
+                        f"To work directly in the existing worktree, use --transfer=none from that directory"
                     )
                 # `git worktree add` cannot resolve any commit reference in a
                 # repo with no commits and reports a cryptic error. Probe HEAD

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -1916,7 +1916,7 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
                     raise UserInputError(
                         f"{stderr.strip()}\n"
                         f"To create a new branch instead, use --branch BASE: or --branch BASE:new-name\n"
-                        f"To work directly in the existing worktree, use --transfer=none from that directory"
+                        f"To work directly in the existing worktree, cd into it and re-run with --transfer=none"
                     )
                 # `git worktree add` cannot resolve any commit reference in a
                 # repo with no commits and reports a cryptic error. Probe HEAD


### PR DESCRIPTION
## Summary
The "branch already checked out" error from `mngr create` suggested `--in-place`, a flag that no longer exists — it was consolidated into `--transfer` in `36436099d` (`--in-place` -> `--transfer=none`). That consolidation never updated this string literal, so users were pointed at a non-existent flag.

This corrects the suggestion to `--transfer=none` and rewords the line to tell users to `cd` into the existing worktree before re-running (since `--transfer=none` only applies when target == source path).

## Test
`test_worktree_already_checked_out_gives_helpful_error` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)