### PR TITLE
add --window flag to mngr capture

### DIFF
--- a/libs/mngr/changelog/mngr-capture-any-window.md
+++ b/libs/mngr/changelog/mngr-capture-any-window.md
@@ -1,0 +1,1 @@
+Added a `--window` (`-w`) option to `mngr capture` for capturing a non-primary tmux window in the agent's session, by index (e.g. `--window 1`) or name. Without it, capture still reads the agent's primary window as before.

--- a/libs/mngr/docs/commands/secondary/capture.md
+++ b/libs/mngr/docs/commands/secondary/capture.md
@@ -6,7 +6,7 @@
 **Synopsis:**
 
 ```text
-mngr capture [AGENT] [--full] [--start/--no-start]
+mngr capture [AGENT] [--full] [--window WINDOW] [--start/--no-start]
 ```
 
 Capture and display an agent's tmux pane content.
@@ -17,6 +17,9 @@ to the agent's terminal.
 
 By default, captures only the visible pane content. Use --full to capture
 the entire scrollback buffer.
+
+By default, captures the agent's primary window. Use --window to capture a
+different tmux window in the agent's session, by index (e.g. 1) or name.
 
 If no agent is specified and running interactively, shows a selector.
 
@@ -37,6 +40,7 @@ mngr capture [OPTIONS] [AGENT]
 | ---- | ---- | ----------- | ------- |
 | `--start`, `--no-start` | boolean | Automatically start the host and agent if offline/stopped | `True` |
 | `--full`, `--no-full` | boolean | Capture the full scrollback buffer instead of just the visible pane | `False` |
+| `--window`, `-w` | text | tmux window (index or name) to capture, instead of the agent's primary window | None |
 
 ## Common
 
@@ -71,6 +75,12 @@ $ mngr capture my-agent
 
 ```bash
 $ mngr capture my-agent --full
+```
+
+**Capture a specific tmux window**
+
+```bash
+$ mngr capture my-agent --window 1
 ```
 
 **Capture without auto-starting**

--- a/libs/mngr/imbue/mngr/agents/base_agent.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent.py
@@ -369,9 +369,17 @@ class BaseAgent(AgentInterface[AgentConfigT]):
         """
         start_action()
 
-    def capture_pane_content(self, include_scrollback: bool = False) -> str | None:
-        """Capture the current tmux pane content for this agent."""
-        return self._capture_pane_content(self.tmux_target, include_scrollback=include_scrollback)
+    def capture_pane_content(self, include_scrollback: bool = False, window: int | str | None = None) -> str | None:
+        """Capture the current tmux pane content for this agent.
+
+        When window is None, captures the agent's primary window (window 0).
+        Otherwise, captures the given tmux window (by index or name) in the
+        agent's session.
+        """
+        target = (
+            self.tmux_target if window is None else TmuxWindowTarget(session_name=self.session_name, window=window)
+        )
+        return self._capture_pane_content(target, include_scrollback=include_scrollback)
 
     def _send_tmux_literal_keys(self, tmux_target: TmuxWindowTarget, message: str) -> None:
         """Send literal text to a tmux pane, choosing the best method by length.

--- a/libs/mngr/imbue/mngr/agents/base_agent_test.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent_test.py
@@ -16,6 +16,7 @@ from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import SendMessageError
 from imbue.mngr.errors import UserInputError
+from imbue.mngr.hosts.tmux import TmuxSessionTarget
 from imbue.mngr.hosts.tmux import TmuxWindowTarget
 from imbue.mngr.interfaces.data_types import CommandResult
 from imbue.mngr.primitives import ActivitySource
@@ -348,6 +349,56 @@ def test_tmux_target_uses_exact_match_window_zero(
     assert target.session_name == test_agent.session_name
     assert target.window == 0
     assert target.as_shell_arg() == f"={test_agent.session_name}:0"
+
+
+@pytest.mark.tmux
+def test_capture_pane_content_targets_requested_window(
+    test_agent: BaseAgent,
+) -> None:
+    """capture_pane_content(window=...) should read the requested window, not window 0.
+
+    The agent runs in window 0, but sessions can hold extra windows (watchers,
+    ttyd, manually-opened terminals). Passing an explicit window must capture that
+    window's pane rather than the agent's primary one.
+    """
+    session_name = test_agent.session_name
+    window_zero_marker = "WINDOW_ZERO_MARKER"
+    window_one_marker = "WINDOW_ONE_MARKER"
+
+    test_agent.host.execute_idempotent_command(
+        f"tmux new-session -d -s '{session_name}' -x 200 -y 24 'echo {window_zero_marker}; sleep 493827'",
+        timeout_seconds=5.0,
+    )
+    try:
+        session_target = TmuxSessionTarget(session_name=session_name)
+        test_agent.host.execute_idempotent_command(
+            f"tmux new-window -t {session_target.as_shell_arg()} -d 'echo {window_one_marker}; sleep 493827'",
+            timeout_seconds=5.0,
+        )
+
+        def _default_capture_shows_window_zero() -> bool:
+            content = test_agent.capture_pane_content() or ""
+            return window_zero_marker in content
+
+        wait_for(
+            _default_capture_shows_window_zero,
+            error_message=f"Expected default capture to contain {window_zero_marker!r}",
+        )
+
+        def _window_one_capture_shows_window_one() -> bool:
+            content = test_agent.capture_pane_content(window=1) or ""
+            return window_one_marker in content
+
+        wait_for(
+            _window_one_capture_shows_window_one,
+            error_message=f"Expected window-1 capture to contain {window_one_marker!r}",
+        )
+
+        # Cross-check: window 1's content is distinct from the default (window 0) content.
+        assert window_zero_marker not in (test_agent.capture_pane_content(window=1) or "")
+        assert window_one_marker not in (test_agent.capture_pane_content() or "")
+    finally:
+        cleanup_tmux_session(session_name)
 
 
 @pytest.mark.tmux

--- a/libs/mngr/imbue/mngr/agents/base_headless_agent_test.py
+++ b/libs/mngr/imbue/mngr/agents/base_headless_agent_test.py
@@ -45,7 +45,7 @@ class _StoppedWithPaneContent(_AlwaysStopped):
 
     _pane_content: str | None = None
 
-    def capture_pane_content(self, include_scrollback: bool = False) -> str | None:
+    def capture_pane_content(self, include_scrollback: bool = False, window: int | str | None = None) -> str | None:
         return self._pane_content
 
 

--- a/libs/mngr/imbue/mngr/cli/capture.py
+++ b/libs/mngr/imbue/mngr/cli/capture.py
@@ -70,7 +70,14 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
     logger.debug("Capturing pane content for agent: {}", agent.name)
     content = agent.capture_pane_content(include_scrollback=opts.full, window=opts.window)
     if content is None:
-        logger.error("Failed to capture pane content for agent {}", agent.name)
+        if opts.window is None:
+            logger.error("Failed to capture pane content for agent {}", agent.name)
+        else:
+            logger.error(
+                "Failed to capture pane content for agent {} window {!r} (does it exist?)",
+                agent.name,
+                opts.window,
+            )
         ctx.exit(1)
         return
 

--- a/libs/mngr/imbue/mngr/cli/capture.py
+++ b/libs/mngr/imbue/mngr/cli/capture.py
@@ -22,6 +22,7 @@ class CaptureCliOptions(CommonCliOptions):
     agent: AgentAddress | None
     start: bool
     full: bool
+    window: str | None
 
 
 @click.command()
@@ -38,6 +39,12 @@ class CaptureCliOptions(CommonCliOptions):
     default=False,
     show_default=True,
     help="Capture the full scrollback buffer instead of just the visible pane",
+)
+@optgroup.option(
+    "--window",
+    "-w",
+    default=None,
+    help="tmux window (index or name) to capture, instead of the agent's primary window",
 )
 @add_common_options
 @click.pass_context
@@ -61,7 +68,7 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
     )
 
     logger.debug("Capturing pane content for agent: {}", agent.name)
-    content = agent.capture_pane_content(include_scrollback=opts.full)
+    content = agent.capture_pane_content(include_scrollback=opts.full, window=opts.window)
     if content is None:
         logger.error("Failed to capture pane content for agent {}", agent.name)
         ctx.exit(1)
@@ -76,7 +83,7 @@ def capture(ctx: click.Context, **kwargs: Any) -> None:
 CommandHelpMetadata(
     key="capture",
     one_line_description="Capture and display an agent's tmux pane content",
-    synopsis="mngr capture [AGENT] [--full] [--start/--no-start]",
+    synopsis="mngr capture [AGENT] [--full] [--window WINDOW] [--start/--no-start]",
     description="""Captures the current tmux pane content for the specified agent and
 prints it to stdout. Useful for debugging agent state without connecting
 to the agent's terminal.
@@ -84,10 +91,14 @@ to the agent's terminal.
 By default, captures only the visible pane content. Use --full to capture
 the entire scrollback buffer.
 
+By default, captures the agent's primary window. Use --window to capture a
+different tmux window in the agent's session, by index (e.g. 1) or name.
+
 If no agent is specified and running interactively, shows a selector.""",
     examples=(
         ("Capture visible pane content", "mngr capture my-agent"),
         ("Capture full scrollback buffer", "mngr capture my-agent --full"),
+        ("Capture a specific tmux window", "mngr capture my-agent --window 1"),
         ("Capture without auto-starting", "mngr capture my-agent --no-start"),
     ),
     see_also=(

--- a/libs/mngr/imbue/mngr/cli/capture_test.py
+++ b/libs/mngr/imbue/mngr/cli/capture_test.py
@@ -1,5 +1,7 @@
 """Unit tests for the capture CLI command."""
 
+import shlex
+import subprocess
 from pathlib import Path
 
 import pluggy
@@ -8,6 +10,7 @@ from click.testing import CliRunner
 
 from imbue.mngr.cli.capture import capture
 from imbue.mngr.cli.create import create
+from imbue.mngr.hosts.tmux import TmuxSessionTarget
 from imbue.mngr.hosts.tmux import TmuxWindowTarget
 from imbue.mngr.utils.polling import wait_for
 from imbue.mngr.utils.testing import capture_tmux_pane_contents
@@ -82,3 +85,73 @@ def test_capture_outputs_pane_content(
         )
         assert result.exit_code == 0
         assert "CAPTURE_TEST_MARKER" in result.output
+
+
+@pytest.mark.tmux
+def test_capture_specific_window(
+    cli_runner: CliRunner,
+    plugin_manager: pluggy.PluginManager,
+    temp_work_dir: Path,
+    mngr_test_prefix: str,
+) -> None:
+    """--window should capture a non-primary tmux window in the agent's session."""
+    agent_name = "test-capture-window"
+    session_name = f"{mngr_test_prefix}{agent_name}"
+    extra_window_name = "captureprobe"
+    extra_window_marker = "EXTRA_WINDOW_MARKER"
+
+    with tmux_session_cleanup(session_name):
+        create_result = cli_runner.invoke(
+            create,
+            [
+                "--name",
+                agent_name,
+                "--type",
+                "command",
+                "--source",
+                str(temp_work_dir),
+                "--transfer=none",
+                "--no-connect",
+                "--no-ensure-clean",
+                "--",
+                "echo CAPTURE_TEST_MARKER && sleep 493827",
+            ],
+            obj=plugin_manager,
+            catch_exceptions=False,
+        )
+        assert create_result.exit_code == 0, f"Create failed: {create_result.output}"
+
+        wait_for(
+            lambda: tmux_session_exists(session_name),
+            timeout=15.0,
+            error_message=f"Expected session {session_name} to exist",
+        )
+
+        # Open an extra named window running its own marker command. mngr already
+        # creates a "terminal" window alongside the agent, so target by name rather
+        # than assuming a particular index.
+        session_target = TmuxSessionTarget(session_name=session_name)
+        subprocess.run(
+            shlex.split(
+                f"tmux new-window -t {session_target.as_shell_arg()} -n {extra_window_name} "
+                f"-d 'echo {extra_window_marker}; sleep 493827'"
+            ),
+            check=True,
+        )
+
+        wait_for(
+            lambda: extra_window_marker
+            in capture_tmux_pane_contents(TmuxWindowTarget(session_name=session_name, window=extra_window_name)),
+            timeout=5.0,
+            error_message="Extra window output did not appear in tmux pane",
+        )
+
+        result = cli_runner.invoke(
+            capture,
+            [agent_name, "--window", extra_window_name],
+            obj=plugin_manager,
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert extra_window_marker in result.output
+        assert "CAPTURE_TEST_MARKER" not in result.output

--- a/libs/mngr/imbue/mngr/interfaces/agent.py
+++ b/libs/mngr/imbue/mngr/interfaces/agent.py
@@ -163,14 +163,17 @@ class AgentInterface(MutableModel, ABC, Generic[AgentConfigT]):
         ...
 
     @abstractmethod
-    def capture_pane_content(self, include_scrollback: bool = False) -> str | None:
+    def capture_pane_content(self, include_scrollback: bool = False, window: int | str | None = None) -> str | None:
         """Capture the current tmux pane content for this agent.
 
         When include_scrollback is True, captures the full scrollback buffer
         instead of just the visible pane.
 
+        When window is None, captures the agent's primary window. Otherwise,
+        captures the given tmux window (by index or name) in the agent's session.
+
         Returns the pane content as a string, or None if capture fails
-        (e.g., the session doesn't exist or the host is unreachable).
+        (e.g., the session/window doesn't exist or the host is unreachable).
         """
         ...
 


### PR DESCRIPTION
## Summary

Adds a `--window` / `-w` option to `mngr capture` so you can capture a non-primary tmux window in an agent's session, by index or name:

```
mngr capture my-agent --window 1
mngr capture my-agent --window terminal
```

Agents run in window 0, but sessions commonly hold additional windows (the `terminal` window mngr opens, watchers, ttyd, manually-opened panes). Without this, `capture` could only ever read window 0.

When `--window` is omitted, behavior is unchanged (captures the agent's primary window).

## Implementation

- Threaded an optional `window: int | str | None` parameter through `AgentInterface.capture_pane_content` and `BaseAgent.capture_pane_content`. When `None`, the agent's `tmux_target` (window 0) is used; otherwise a `TmuxWindowTarget` is built for the requested window in the agent's session.
- Added the `--window` / `-w` option to the `capture` CLI command, plus help metadata and an example.

## Testing

- `test_capture_pane_content_targets_requested_window` (base_agent, `@pytest.mark.tmux`): verifies window-targeted capture reads the requested window's pane, distinct from the default.
- `test_capture_specific_window` (capture CLI, `@pytest.mark.tmux`): end-to-end, captures a named extra window via `--window`.
- Manually verified against a live multi-window session (`--window` by both index and name returns distinct per-window content).
- Full mngr unit suite: 4302 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)