### PR TITLE
Improve the wording of selected system messages.

### DIFF
--- a/apps/minds/changelog/hynek-improve-system-message-wording.md
+++ b/apps/minds/changelog/hynek-improve-system-message-wording.md
@@ -1,0 +1,1 @@
+Remove potentially confusing parts of the messages sent to agents after approving or denying permission requests

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -152,17 +152,11 @@ def _access_human_label(access: str) -> str:
 
 
 def _format_granted_message(file_path: str, access: str) -> str:
-    return (
-        f"Your {_access_human_label(access)} file-sharing permission request for "
-        f"'{file_path}' was granted."
-    )
+    return f"Your {_access_human_label(access)} file-sharing permission request for '{file_path}' was granted."
 
 
 def _format_denied_message(file_path: str, access: str) -> str:
-    return (
-        f"Your {_access_human_label(access)} file-sharing permission request for "
-        f"'{file_path}' was denied."
-    )
+    return f"Your {_access_human_label(access)} file-sharing permission request for '{file_path}' was denied."
 
 
 def _json_error(message: str, status_code: int) -> Response:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/file_sharing.py
@@ -154,14 +154,14 @@ def _access_human_label(access: str) -> str:
 def _format_granted_message(file_path: str, access: str) -> str:
     return (
         f"Your {_access_human_label(access)} file-sharing permission request for "
-        f"'{file_path}' was granted. Please retry the call that was blocked."
+        f"'{file_path}' was granted."
     )
 
 
 def _format_denied_message(file_path: str, access: str) -> str:
     return (
         f"Your {_access_human_label(access)} file-sharing permission request for "
-        f"'{file_path}' was denied. Do not retry the blocked call."
+        f"'{file_path}' was denied."
     )
 
 

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined.py
@@ -106,12 +106,12 @@ def _format_granted_message(service_display_name: str, granted: Sequence[str]) -
     permissions = ", ".join(granted)
     return (
         f"Your permission request for {service_display_name} was granted with the following "
-        f"permissions: {permissions}. Please retry the call that was blocked."
+        f"permissions: {permissions}."
     )
 
 
 def _format_denied_message(service_display_name: str) -> str:
-    return f"Your permission request for {service_display_name} was denied. Do not retry the blocked call."
+    return f"Your permission request for {service_display_name} was denied."
 
 
 def _format_auth_failed_message(service_display_name: str, detail: str) -> str:


### PR DESCRIPTION
The messages sent to agents after approving or denying permission requests were needlessly referring to "blocked calls". In some situations, that was confusing to the agent (since there were situations when a permission request could have been sent without a call being blocked first).

The retry / don't retry follow-up should be clear to the agents from context (and I tested and validated this with opus-4-8 based agents).