### PR TITLE
mngr usage recipes tweaks

### DIFF
--- a/libs/mngr_usage/changelog/mngr-usage-demo-tweak.md
+++ b/libs/mngr_usage/changelog/mngr-usage-demo-tweak.md
@@ -1,0 +1,1 @@
+Cron recipes: the "dispatch tasks from a queue directory" recipe now creates each agent on its own fresh branch off `main` (`mngr create --from ":$PROJECT_DIR" --branch main:`), so concurrent tasks never share a working branch. Also documented the random-selection variant (swap `sort` for `sort -R`).

--- a/libs/mngr_usage/docs/cron_recipes.md
+++ b/libs/mngr_usage/docs/cron_recipes.md
@@ -192,9 +192,7 @@ alive="$(mngr list --include 'labels.queue == "live" && state == "RUNNING"' --id
 # Only launch if there's spare capacity going unused.
 "$(dirname "$0")/spare-capacity.sh" || exit 0
 
-# Grab the oldest queued task, if any. (For no particular order, swap `sort` for
-# `sort -R` to shuffle and claim a random task instead -- portable across macOS
-# and Linux.)
+# Grab the oldest queued task, if any. (For a random order, use `sort -R`.)
 task_file="$(find "$TODO_DIR" -maxdepth 1 -name '*.md' -type f | sort | head -n1)"
 [[ -n "$task_file" ]] || exit 0
 

--- a/libs/mngr_usage/docs/cron_recipes.md
+++ b/libs/mngr_usage/docs/cron_recipes.md
@@ -192,7 +192,9 @@ alive="$(mngr list --include 'labels.queue == "live" && state == "RUNNING"' --id
 # Only launch if there's spare capacity going unused.
 "$(dirname "$0")/spare-capacity.sh" || exit 0
 
-# Grab the oldest queued task, if any.
+# Grab the oldest queued task, if any. (For no particular order, swap `sort` for
+# `sort -R` to shuffle and claim a random task instead -- portable across macOS
+# and Linux.)
 task_file="$(find "$TODO_DIR" -maxdepth 1 -name '*.md' -type f | sort | head -n1)"
 [[ -n "$task_file" ]] || exit 0
 
@@ -207,10 +209,12 @@ mv "$task_file" "$claimed" || exit 0
 name="$(basename "$claimed" .md | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
 [[ -n "$name" ]] || name="task-$(date +%s)"
 
-# Create the agent in the project repo we cd'd into, tag it into the live pool,
-# and hand it the task file as its first message. --no-connect keeps it
-# non-interactive (cron has no TTY to attach a tmux session to).
-mngr create "$name" claude --label queue=live \
+# Create the agent, tag it into the live pool, and hand it the task file as its
+# first message. --no-connect keeps it non-interactive (cron has no TTY to attach
+# a tmux session to). --from ":$PROJECT_DIR" sources from the project repo, and
+# --branch main: gives each agent its own fresh branch off main (empty NEW ->
+# mngr/<name>) so concurrent tasks never share a working branch.
+mngr create "$name" claude --from ":$PROJECT_DIR" --branch main: --label queue=live \
   --message-file "$claimed" --no-connect
 ```
 


### PR DESCRIPTION
Two tweaks to the "Dispatch tasks from a queue directory" recipe in `libs/mngr_usage/docs/cron_recipes.md`, ported from real usage of the demo dispatch script:

- The `mngr create` command now passes `--from ":$PROJECT_DIR" --branch main:`, so each dispatched agent gets its own fresh branch off `main` (empty `:NEW` -> `mngr/<name>`). Concurrent tasks no longer share a working branch.
- Documented the random-selection variant: use `sort -R` instead of `sort` to claim a random queued task rather than the oldest.

`spare-capacity.sh` is left as a separate reusable building block (not inlined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)