### PR TITLE
release all the new agent usage plugins at 0.1.0

### DIFF
--- a/dev/changelog/mngr-packages-v0.md
+++ b/dev/changelog/mngr-packages-v0.md
@@ -1,0 +1,1 @@
+Regenerated `uv.lock` to match the version revert of `imbue-mngr-opencode-usage` and `imbue-mngr-pi-coding-usage` back to 0.1.0.

--- a/libs/mngr_opencode_usage/changelog/mngr-packages-v0.md
+++ b/libs/mngr_opencode_usage/changelog/mngr-packages-v0.md
@@ -1,0 +1,1 @@
+Corrected the package version back to 0.1.0 (it had been bumped to 0.1.1, but that version was never actually released).

--- a/libs/mngr_opencode_usage/pyproject.toml
+++ b/libs/mngr_opencode_usage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbue-mngr-opencode-usage"
-version = "0.1.1"
+version = "0.1.0"
 description = "OpenCode usage data provider for `mngr usage` (per-agent in-process plugin that captures per-message cost + tokens)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/mngr_pi_coding_usage/changelog/mngr-packages-v0.md
+++ b/libs/mngr_pi_coding_usage/changelog/mngr-packages-v0.md
@@ -1,0 +1,1 @@
+Corrected the package version back to 0.1.0 (it had been bumped to 0.1.1, but that version was never actually released).

--- a/libs/mngr_pi_coding_usage/pyproject.toml
+++ b/libs/mngr_pi_coding_usage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imbue-mngr-pi-coding-usage"
-version = "0.1.1"
+version = "0.1.0"
 description = "pi usage data provider for `mngr usage` (reader + writer gate; the per-message writer lives in mngr_pi_coding's lifecycle extension)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2407,7 +2407,7 @@ requires-dist = [{ name = "imbue-mngr", editable = "libs/mngr" }]
 
 [[package]]
 name = "imbue-mngr-opencode-usage"
-version = "0.1.1"
+version = "0.1.0"
 source = { editable = "libs/mngr_opencode_usage" }
 dependencies = [
     { name = "imbue-mngr" },
@@ -2467,7 +2467,7 @@ requires-dist = [{ name = "imbue-mngr", editable = "libs/mngr" }]
 
 [[package]]
 name = "imbue-mngr-pi-coding-usage"
-version = "0.1.1"
+version = "0.1.0"
 source = { editable = "libs/mngr_pi_coding_usage" }
 dependencies = [
     { name = "imbue-mngr" },


### PR DESCRIPTION
Revert the version of `imbue-mngr-opencode-usage` and `imbue-mngr-pi-coding-usage` from 0.1.1 back to 0.1.0, since 0.1.1 was never actually released.

- Updated both `pyproject.toml` versions
- Regenerated `uv.lock`
- Added changelog entries for both projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)