### PR TITLE
Bare-metal slices: explicit order options + server-id, prep cache-ownership fix, disk reap

### DIFF
--- a/apps/minds/changelog/mngr-new-production-west.md
+++ b/apps/minds/changelog/mngr-new-production-west.md
@@ -1,0 +1,4 @@
+`minds pool create --backend slice` now requires `--server-id` (the bare-metal
+box to bake the slices onto, from `mngr imbue_cloud admin server list`), forwarded
+to the underlying `mngr imbue_cloud admin pool create`. Slice baking now targets
+an explicitly-chosen, ready server rather than auto-selecting one.

--- a/apps/minds/imbue/minds/cli/pool.py
+++ b/apps/minds/imbue/minds/cli/pool.py
@@ -129,6 +129,7 @@ def build_create_admin_args(
     is_recycle_enabled: bool,
     is_dry_run: bool,
     is_deferred_install_wait_skipped: bool,
+    server_id: str | None = None,
     max_concurrency: int | None = None,
 ) -> list[str]:
     """Compose the ``mngr imbue_cloud admin pool create`` argv from minds-side inputs.
@@ -153,8 +154,9 @@ def build_create_admin_args(
     activated minds env's ``secrets.toml`` (which the deploy wrote).
 
     ``--no-recycle`` (when ``is_recycle_enabled`` is False) is ovh_vps-only;
-    ``--dry-run`` (when ``is_dry_run`` is True) and ``--max-concurrency`` (when
-    non-None) are slice-only; both are forwarded only when set.
+    ``--server-id`` (the explicitly-chosen bare-metal box), ``--dry-run`` (when
+    ``is_dry_run`` is True), and ``--max-concurrency`` (when non-None) are
+    slice-only; each is forwarded only when set.
     """
     args = [
         "create",
@@ -185,6 +187,8 @@ def build_create_admin_args(
         args.extend(["--mngr-source", mngr_source])
     if backend == _BACKEND_OVH_VPS and not is_recycle_enabled:
         args.append("--no-recycle")
+    if backend == _BACKEND_SLICE and server_id is not None:
+        args.extend(["--server-id", server_id])
     if backend == _BACKEND_SLICE and is_dry_run:
         args.append("--dry-run")
     if backend == _BACKEND_SLICE and max_concurrency is not None:
@@ -574,6 +578,7 @@ def _run_slice_pool_create(
     database_url: str | None,
     mngr_source: str | None,
     is_recycle_enabled: bool,
+    server_id: str | None,
     is_dry_run: bool,
     is_deferred_install_wait_skipped: bool,
     max_concurrency: int | None,
@@ -582,8 +587,8 @@ def _run_slice_pool_create(
 
     Rejects the ovh_vps-only flags up front (clearer than silently dropping them):
     slices authorize the pool key from the tier's Vault entry at carve time and
-    never recycle an OVH VPS. The slice backend picks the ready bare-metal box with
-    the most free slots (see ``mngr imbue_cloud admin server``).
+    never recycle an OVH VPS. Slice baking targets the explicitly-chosen
+    ``--server-id`` bare-metal box (see ``mngr imbue_cloud admin server list``).
     """
     if management_public_key_file is not None:
         raise click.UsageError(
@@ -592,6 +597,11 @@ def _run_slice_pool_create(
         )
     if not is_recycle_enabled:
         raise click.UsageError("--no-recycle is not applicable to --backend slice")
+    if not server_id:
+        raise click.UsageError(
+            "--server-id is required for --backend slice (the bare-metal box to bake onto; "
+            "see `mngr imbue_cloud admin server list`)"
+        )
     try:
         pool_private_key = read_pool_private_key_from_vault(env_name)
     except VaultReadError as exc:
@@ -612,6 +622,7 @@ def _run_slice_pool_create(
         database_url=database_url,
         mngr_source=mngr_source,
         is_recycle_enabled=is_recycle_enabled,
+        server_id=server_id,
         is_dry_run=is_dry_run,
         is_deferred_install_wait_skipped=is_deferred_install_wait_skipped,
         max_concurrency=max_concurrency,
@@ -721,6 +732,15 @@ def pool() -> None:
     ),
 )
 @click.option(
+    "--server-id",
+    "server_id",
+    default=None,
+    help=(
+        "[slice only, required] The bare_metal_servers row id to bake the slices onto (from "
+        "`mngr imbue_cloud admin server list`). Slice baking targets an explicitly-chosen, ready box."
+    ),
+)
+@click.option(
     "--dry-run",
     "is_dry_run",
     is_flag=True,
@@ -761,6 +781,7 @@ def pool_create(
     database_url: str | None,
     mngr_source: str | None,
     is_recycle_enabled: bool,
+    server_id: str | None,
     is_dry_run: bool,
     max_concurrency: int | None,
     is_deferred_install_wait_skipped: bool,
@@ -780,6 +801,8 @@ def pool_create(
         raise click.UsageError("--dry-run is only supported for --backend slice")
     if backend == _BACKEND_OVH_VPS and max_concurrency is not None:
         raise click.UsageError("--max-concurrency is only supported for --backend slice")
+    if backend == _BACKEND_OVH_VPS and server_id is not None:
+        raise click.UsageError("--server-id is only supported for --backend slice")
     effective_database_url = resolve_host_pool_dsn(env_name, database_url)
     if backend == _BACKEND_SLICE:
         _run_slice_pool_create(
@@ -795,6 +818,7 @@ def pool_create(
             database_url=effective_database_url,
             mngr_source=mngr_source,
             is_recycle_enabled=is_recycle_enabled,
+            server_id=server_id,
             is_dry_run=is_dry_run,
             is_deferred_install_wait_skipped=is_deferred_install_wait_skipped,
             max_concurrency=max_concurrency,

--- a/apps/minds/imbue/minds/cli/pool_test.py
+++ b/apps/minds/imbue/minds/cli/pool_test.py
@@ -275,6 +275,28 @@ def test_build_create_admin_args_slice_forwards_dry_run() -> None:
     assert "--dry-run" in args
 
 
+def test_build_create_admin_args_slice_forwards_server_id() -> None:
+    args = build_create_admin_args(
+        env_name="alice",
+        backend=_BACKEND_SLICE,
+        count=1,
+        region="US-WEST-OR",
+        from_tag="minds-v0.3.1",
+        repo_url=None,
+        repo_branch_or_tag_override=None,
+        attributes_json=None,
+        workspace_dir=None,
+        management_public_key_file=None,
+        database_url="postgres://example",
+        mngr_source=None,
+        is_recycle_enabled=True,
+        is_dry_run=False,
+        is_deferred_install_wait_skipped=False,
+        server_id="feb11eae-a20a-4d9e-a0a3-ce06a526956c",
+    )
+    assert args[args.index("--server-id") + 1] == "feb11eae-a20a-4d9e-a0a3-ce06a526956c"
+
+
 def test_build_create_admin_args_omits_dry_run_for_ovh_backend() -> None:
     """--dry-run is slice-only; the ovh_vps path must never forward it."""
     args = build_create_admin_args(

--- a/libs/mngr/changelog/mngr-new-production-west.md
+++ b/libs/mngr/changelog/mngr-new-production-west.md
@@ -1,0 +1,4 @@
+Regenerated the bundled `mngr imbue_cloud` CLI reference docs to cover the new
+`admin server order --option` flag (explicit choice for multi-offer mandatory
+option families like bandwidth/vrack) and the now-required `admin pool create
+--backend slice --server-id` flag (explicitly chosen bare-metal box).

--- a/libs/mngr/docs/commands/secondary/imbue_cloud.md
+++ b/libs/mngr/docs/commands/secondary/imbue_cloud.md
@@ -666,6 +666,7 @@ mngr imbue_cloud admin pool create [OPTIONS]
 | `--database-url` | text | Neon PostgreSQL direct connection string for the pool DB. Defaults to MINDS_HOST_POOL_DSN env var, or the activated minds env's secrets.toml NEON_HOST_POOL_DSN field (so `minds env activate <dev-env>` is enough). Pass this explicitly when operating outside an activated env. | None |
 | `--mngr-source` | path | Path to the mngr monorepo root. If provided, rsyncs into the template's vendor/mngr/ before creating hosts. | None |
 | `--no-recycle` | boolean | [ovh_vps only] Force a fresh OVH VPS order instead of reclaiming a cancelled VPS. By default the OVH provider recycles a cancelled (still-billable) VPS when one is available; pass this to test the fresh-provision path. Sets MNGR__PROVIDERS__OVH__ENABLE_RECYCLE_CANCELLED=false on the inner `mngr create`. | `True` |
+| `--server-id` | text | [slice only, required] The bare_metal_servers row id to bake the slices onto (from `admin server list`). Slice baking targets an explicitly-chosen, ready box -- it never auto-selects one. | None |
 | `--dry-run` | boolean | [slice only] Report placement + per-slice sizing; do not bake. | `False` |
 | `--max-concurrency` | integer | [slice only] Max slices baked at once; the rest queue and start as slots free. Bounds box CPU/IO/network contention so each `mngr create` stays under its timeout. | `4` |
 | `--skip-deferred-install-wait` | boolean | [dev only] Don't wait for the FCT deferred-install (heavy apt + Playwright/Chromium) to finish before stopping the baked services agent. Saves a few minutes per bake, but the baked container's deferred-install may be left incomplete (stopping mid-apt can corrupt dpkg). Safe for dev/throwaway bakes; NEVER use for production pool hosts. | `False` |
@@ -957,6 +958,7 @@ mngr imbue_cloud admin server order [OPTIONS]
 | `--storage` | text | Storage option short code (the pricing table's BASE_STORAGE, e.g. softraid-2x512nvme). | None |
 | `--memory-per-slice-gb` | integer | RAM (GB) each slice will advertise; sets slot_count = floor(server RAM / this). | `8` |
 | `--cpu-overcommit` | float | CPU overcommit factor recorded for slice sizing on this box. | `2.0` |
+| `--option` | text | Explicit planCode for a mandatory option family that offers more than one choice (e.g. bandwidth, vrack). Repeatable. Required when the plan offers a real choice -- run once without it and the error lists each family's offers + monthly prices so you can re-run with --option. | None |
 | `--yes` | boolean | Skip the interactive confirmation and place the order. | `False` |
 | `--database-url` | text | Pool DSN (else resolved from env/activated minds env). | None |
 

--- a/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
@@ -1,0 +1,7 @@
+`mngr imbue_cloud admin server order` can now order plans whose mandatory option
+families (e.g. bandwidth, vrack) offer more than one choice. Previously the cart
+build failed with "expected exactly one X option to auto-pick" on such plans
+(e.g. the `24sys*` SYS line). It now auto-picks the cheapest month-to-month offer
+in each multi-offer mandatory family -- the included baseline, which is exactly
+the configuration the `admin server pricing` table quotes. It still refuses to
+guess when offers lack comparable prices or tie at the cheapest price.

--- a/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
@@ -1,7 +1,12 @@
-`mngr imbue_cloud admin server order` can now order plans whose mandatory option
-families (e.g. bandwidth, vrack) offer more than one choice. Previously the cart
-build failed with "expected exactly one X option to auto-pick" on such plans
-(e.g. the `24sys*` SYS line). It now auto-picks the cheapest month-to-month offer
-in each multi-offer mandatory family -- the included baseline, which is exactly
-the configuration the `admin server pricing` table quotes. It still refuses to
-guess when offers lack comparable prices or tie at the cheapest price.
+`mngr imbue_cloud admin server order` now lets you order plans whose mandatory
+option families (e.g. bandwidth, vrack) offer more than one choice. Previously the
+cart build failed with "expected exactly one X option to auto-pick" on such plans
+(e.g. the `24sys*` SYS line). Choose the offer per family explicitly with the new
+repeatable `--option <planCode>` flag; single-offer families are still auto-selected.
+Run `order` without it once and the error lists each ambiguous family's offers and
+their monthly prices so you can re-run with the right `--option` values.
+
+`mngr imbue_cloud admin pool create --backend slice` now requires `--server-id`
+(the bare-metal box to bake the slices onto, from `admin server list`). It no
+longer auto-selects the box with the most free slots -- baking always targets an
+explicitly-chosen, ready server.

--- a/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
@@ -10,3 +10,10 @@ their monthly prices so you can re-run with the right `--option` values.
 (the bare-metal box to bake the slices onto, from `admin server list`). It no
 longer auto-selects the box with the most free slots -- baking always targets an
 explicitly-chosen, ready server.
+
+Fixed a bare-metal box-prep bug that made every slice bake fail with `mkdir
+~/.cache/lima: permission denied`. The prep script (run as root) staged the slice
+base image under the lima user's `~/.cache` but left `~/.cache` itself root-owned,
+so `limactl` (run as the lima user) could not create `~/.cache/lima`. Prep now
+creates and chowns the cache dir chain to the lima user (and repairs an
+already-root-owned `~/.cache` when re-run on an existing box).

--- a/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-new-production-west.md
@@ -17,3 +17,9 @@ base image under the lima user's `~/.cache` but left `~/.cache` itself root-owne
 so `limactl` (run as the lima user) could not create `~/.cache/lima`. Prep now
 creates and chowns the cache dir chain to the lima user (and repairs an
 already-root-owned `~/.cache` when re-run on an existing box).
+
+The post-bake orphan reap now also reaps leaked lima **data disks**, not just VM
+instances. A failed carve whose rollback `limactl delete` could not unlock the
+disk leaves the disk behind (the VM is gone but the disk keeps holding the box
+slot); the reap now reconciles the box's disks against the pool DB and force-deletes
+(unlocking first) any slice disk with no row.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin.py
@@ -500,6 +500,16 @@ def _create_single_pool_host(
     ),
 )
 @click.option(
+    "--server-id",
+    "server_id",
+    default=None,
+    help=(
+        "[slice only, required] The bare_metal_servers row id to bake the slices onto (from "
+        "`admin server list`). Slice baking targets an explicitly-chosen, ready box -- it never "
+        "auto-selects one."
+    ),
+)
+@click.option(
     "--dry-run",
     "is_dry_run",
     is_flag=True,
@@ -543,6 +553,7 @@ def pool_create(
     database_url: str | None,
     mngr_source: str | None,
     is_recycle_enabled: bool,
+    server_id: str | None,
     is_dry_run: bool,
     max_concurrency: int,
     is_deferred_install_wait_skipped: bool,
@@ -569,9 +580,17 @@ def pool_create(
             )
         if not is_recycle_enabled:
             fail_with_json("--no-recycle is not applicable to --backend slice", error_class="UsageError")
+        if not server_id:
+            fail_with_json(
+                "--server-id is required for --backend slice (the bare-metal box to bake onto; "
+                "see `mngr imbue_cloud admin server list`)",
+                error_class="UsageError",
+            )
     elif backend == "ovh_vps":
         if is_dry_run:
             fail_with_json("--dry-run is only supported for --backend slice", error_class="UsageError")
+        if server_id is not None:
+            fail_with_json("--server-id is only supported for --backend slice", error_class="UsageError")
         if not management_public_key_file:
             fail_with_json("--management-public-key-file is required for --backend ovh_vps", error_class="UsageError")
         # Validate ``--tag`` shapes up front so we don't bake the first host and
@@ -596,8 +615,11 @@ def pool_create(
         ) as bake_source:
             attributes = merge_bake_identity_attributes(parsed_attributes, bake_source)
             if backend == "slice":
+                # ``server_id`` presence is enforced above for the slice backend.
+                assert server_id is not None
                 allocate_slices(
                     count=count,
+                    server_id=server_id,
                     lease_attributes=attributes,
                     region=region,
                     workspace_dir=bake_source.workspace_dir,

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/admin_test.py
@@ -196,7 +196,7 @@ def test_pool_create_rejects_malformed_tag(tmp_path: Any) -> None:
 
 
 def _slice_create_args(extra: list[str]) -> list[str]:
-    """Base ``pool create --backend slice`` argv (with a DSN so resolution succeeds).
+    """Base ``pool create --backend slice`` argv (with a DSN + server-id so resolution succeeds).
 
     Carries no identity attributes: repo_url / repo_branch_or_tag are derived from
     the bake source (--from-tag / --workspace-dir), never passed in --attributes.
@@ -209,10 +209,58 @@ def _slice_create_args(extra: list[str]) -> list[str]:
         "1",
         "--region",
         "US-EAST-VA",
+        "--server-id",
+        "11111111-1111-1111-1111-111111111111",
         "--database-url",
         "postgres://example",
         *extra,
     ]
+
+
+def test_pool_create_slice_backend_requires_server_id() -> None:
+    """``--server-id`` is required for the slice backend (we never auto-select a box)."""
+    args = [
+        "create",
+        "--backend",
+        "slice",
+        "--count",
+        "1",
+        "--region",
+        "US-EAST-VA",
+        "--database-url",
+        "postgres://example",
+        "--from-tag",
+        "v0.3.0",
+    ]
+    result = CliRunner().invoke(pool, args)
+    assert result.exit_code != 0
+    assert "--server-id is required for --backend slice" in result.output
+
+
+def test_pool_create_ovh_backend_rejects_server_id(tmp_path: Any) -> None:
+    """``--server-id`` is slice-only; passing it to the OVH backend is a usage error."""
+    key_file = tmp_path / "mgmt.pub"
+    key_file.write_text("ssh-ed25519 AAAA... operator@host\n")
+    result = CliRunner().invoke(
+        pool,
+        [
+            "create",
+            "--backend",
+            "ovh_vps",
+            "--count",
+            "1",
+            "--region",
+            "US-EAST-VA",
+            "--database-url",
+            "postgres://example",
+            "--management-public-key-file",
+            str(key_file),
+            "--server-id",
+            "11111111-1111-1111-1111-111111111111",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--server-id is only supported for --backend slice" in result.output
 
 
 def test_pool_create_requires_a_bake_source_selector() -> None:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
@@ -66,6 +66,7 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_MEMORY_PER_SLICE_GB
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_CPU_OVERCOMMIT_RATIO
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_PORT_RANGE_END
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_PORT_RANGE_START
+from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_disk_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_instance_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_gib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_memory_mib
@@ -78,6 +79,7 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_instance_name
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import build_slice_pool_host_insert_values
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import fetch_server_by_id
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import fetch_server_capacities
+from imbue.mngr_imbue_cloud.slices.bare_metal_db import fetch_slice_disk_names_for_server
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import fetch_slice_instance_names_for_server
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import insert_bare_metal_server
 from imbue.mngr_imbue_cloud.slices.bare_metal_db import insert_slice_pool_host
@@ -732,15 +734,18 @@ def _kill_bake_worker_processes(grace_seconds: float = 5.0) -> None:
             pass
 
 
-def _reap_orphan_slice_vms(*, server: BareMetalServer, private_key_path: Path, database_url: str) -> None:
-    """Delete slice VMs on the box that have no pool_hosts row (orphans from killed bakes).
+def _reap_orphan_slice_resources(*, server: BareMetalServer, private_key_path: Path, database_url: str) -> None:
+    """Delete slice VMs AND data disks on the box that have no pool_hosts row (orphans from failed bakes).
 
-    Reconciles the box's lima instances against the DB: any ``mngr-slice-`` VM with
-    no row (any status) is an orphan -- typically a ``mngr create`` killed by its own
-    timeout after carving the VM but before the row insert, so the provider's rollback
-    never ran. Best-effort: logs and continues on any error so it never fails the bake.
-    Assumes no other bake invocation is concurrently mid-carve against this box (an
-    in-flight VM not yet inserted would otherwise look orphaned).
+    Reconciles the box's lima instances and disks against the DB: any ``mngr-slice-``
+    resource with no row (any status) is an orphan -- a ``mngr create`` killed by its own
+    timeout after carving but before the row insert (the provider's rollback never ran),
+    or a disk left behind when a rollback ``limactl delete`` could not unlock it (so the
+    VM is gone but its disk leaked, permanently holding the box slot). Disks are reconciled
+    independently of instances so a disk that outlived its VM is still reaped. Best-effort:
+    logs and continues on any error so it never fails the bake. Assumes no other bake
+    invocation is concurrently mid-carve against this box (an in-flight resource not yet
+    inserted would otherwise look orphaned).
     """
     ssh_user = server.lima_service_user or "limahost"
     client = LimaSliceVpsClient(
@@ -748,31 +753,65 @@ def _reap_orphan_slice_vms(*, server: BareMetalServer, private_key_path: Path, d
         box_ssh_user=ssh_user,
         private_key_path=str(private_key_path),
     )
+
+    # Reap orphan VM instances.
     try:
         box_instance_names = client.list_instance_names()
     except (MngrError, OSError) as exc:
         logger.warning("Orphan reap skipped: could not list slice VMs on {}: {}", server.public_address, exc)
+        box_instance_names = None
+    if box_instance_names is not None:
+        conn = psycopg2.connect(database_url)
+        try:
+            tracked_instance_names = fetch_slice_instance_names_for_server(conn, server.id)
+        finally:
+            conn.close()
+        instance_orphans = compute_orphan_slice_instance_names(box_instance_names, tracked_instance_names)
+        if not instance_orphans:
+            logger.info("Orphan reap: no untracked slice VMs on {}", server.public_address)
+        else:
+            logger.info(
+                "Orphan reap: deleting {} untracked slice VM(s) on {}: {}",
+                len(instance_orphans),
+                server.public_address,
+                sorted(instance_orphans),
+            )
+            for instance_name in sorted(instance_orphans):
+                try:
+                    client.destroy_instance(VpsInstanceId(instance_name))
+                except (MngrError, OSError) as exc:
+                    logger.warning(
+                        "Orphan reap: failed to delete VM {} on {}: {}", instance_name, server.public_address, exc
+                    )
+
+    # Reap orphan data disks (a disk can outlive its instance when the rollback delete
+    # could not unlock it). Done after the VM reap so a just-deleted VM's disk -- which
+    # destroy_instance already removes -- is no longer present to look orphaned.
+    try:
+        box_disk_names = client.list_disk_names()
+    except (MngrError, OSError) as exc:
+        logger.warning("Orphan disk reap skipped: could not list slice disks on {}: {}", server.public_address, exc)
         return
     conn = psycopg2.connect(database_url)
     try:
-        tracked_instance_names = fetch_slice_instance_names_for_server(conn, server.id)
+        tracked_disk_names = fetch_slice_disk_names_for_server(conn, server.id)
     finally:
         conn.close()
-    orphans = compute_orphan_slice_instance_names(box_instance_names, tracked_instance_names)
-    if not orphans:
-        logger.info("Orphan reap: no untracked slice VMs on {}", server.public_address)
+    disk_orphans = compute_orphan_slice_disk_names(box_disk_names, tracked_disk_names)
+    if not disk_orphans:
+        logger.info("Orphan reap: no untracked slice disks on {}", server.public_address)
         return
     logger.info(
-        "Orphan reap: deleting {} untracked slice VM(s) on {}: {}",
-        len(orphans),
+        "Orphan reap: deleting {} untracked slice disk(s) on {}: {}",
+        len(disk_orphans),
         server.public_address,
-        sorted(orphans),
+        sorted(disk_orphans),
     )
-    for instance_name in sorted(orphans):
+    for disk_name in sorted(disk_orphans):
         try:
-            client.destroy_instance(VpsInstanceId(instance_name))
+            client.destroy_disk(disk_name)
         except (MngrError, OSError) as exc:
-            logger.warning("Orphan reap: failed to delete {} on {}: {}", instance_name, server.public_address, exc)
+            logger.warning("Orphan reap: failed to delete disk {} on {}: {}", disk_name, server.public_address, exc)
 
 
 def allocate_slices(
@@ -930,7 +969,7 @@ def allocate_slices(
             # join -- an individual-create timeout (already a 'failed' outcome by now)
             # is cleaned here; the except above handles a top-level kill. Restore the
             # signal handlers last so the reap itself isn't interrupted.
-            _reap_orphan_slice_vms(server=server, private_key_path=private_key_path, database_url=database_url)
+            _reap_orphan_slice_resources(server=server, private_key_path=private_key_path, database_url=database_url)
             if is_main_thread:
                 signal.signal(signal.SIGTERM, previous_sigterm)
                 signal.signal(signal.SIGINT, previous_sigint)

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
@@ -66,12 +66,12 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_MEMORY_PER_SLICE_GB
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_CPU_OVERCOMMIT_RATIO
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_PORT_RANGE_END
 from imbue.mngr_imbue_cloud.slices.bare_metal import DEFAULT_SLICE_PORT_RANGE_START
-from imbue.mngr_imbue_cloud.slices.bare_metal import choose_server_for_new_slice
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_instance_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_gib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_memory_mib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_vcpus
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slot_count
+from imbue.mngr_imbue_cloud.slices.bare_metal import find_server_capacity_by_id
 from imbue.mngr_imbue_cloud.slices.bare_metal import partition_port_range
 from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_disk_name
 from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_instance_name
@@ -778,6 +778,7 @@ def _reap_orphan_slice_vms(*, server: BareMetalServer, private_key_path: Path, d
 def allocate_slices(
     *,
     count: int,
+    server_id: str,
     lease_attributes: dict[str, Any],
     region: str,
     workspace_dir: Path,
@@ -787,10 +788,10 @@ def allocate_slices(
     is_deferred_install_wait_skipped: bool,
     max_concurrency: int,
 ) -> None:
-    """Bake ``count`` slices onto a single ready bare-metal server and insert their pool rows.
+    """Bake ``count`` slices onto the explicitly chosen bare-metal server and insert their pool rows.
 
-    The slice backend of ``admin pool create``. Picks the ready server with the
-    most free slots (one server per invocation: a server's per-slice vCPU/RAM/disk
+    The slice backend of ``admin pool create``. Bakes onto the operator-named
+    ``server_id`` (one server per invocation: a server's per-slice vCPU/RAM/disk
     are fixed by its registration, so a batch is homogeneous), vendors this branch's
     mngr into the FCT workspace once, then bakes the slices concurrently -- at most
     ``max_concurrency`` at a time (the rest queue) so the box isn't over-contended,
@@ -815,16 +816,19 @@ def allocate_slices(
         capacities = fetch_server_capacities(conn)
     finally:
         conn.close()
-    # One server per batch (homogeneous sizing): pick the ready box with the most
-    # free slots and require it to hold the whole batch. Server selection is NOT
-    # filtered by ``region`` today (single-fleet assumption); multi-region fleet
-    # filtering is future work.
-    chosen = choose_server_for_new_slice(capacities)
+    # One explicitly-chosen server per batch (homogeneous sizing): the operator names the box via
+    # ``--server-id``; we never auto-select. Require it to be ready and to hold the whole batch.
+    chosen = find_server_capacity_by_id(capacities, BareMetalServerDbId(server_id))
     server = chosen.server
+    if str(server.status) != SERVER_STATUS_READY:
+        raise click.UsageError(
+            f"server {server.id} is '{server.status}', not '{SERVER_STATUS_READY}'; "
+            "finish `admin server await-delivery` + `setup` before baking slices on it"
+        )
     if chosen.free_slots < count:
         raise click.UsageError(
             f"server {server.id} has only {chosen.free_slots} free slot(s); cannot bake {count} "
-            "(allocate on one server per invocation -- run again to use another server)"
+            "(allocate on one server per invocation -- run again, or choose another --server-id)"
         )
     sizing = compute_server_slice_sizing(server)
 
@@ -1155,6 +1159,16 @@ def _wait_for_ssh_ready(server_address: str, ssh_user: str, private_key_path: Pa
     show_default=True,
     help="CPU overcommit factor recorded for slice sizing on this box.",
 )
+@click.option(
+    "--option",
+    "option_codes",
+    multiple=True,
+    help=(
+        "Explicit planCode for a mandatory option family that offers more than one choice (e.g. "
+        "bandwidth, vrack). Repeatable. Required when the plan offers a real choice -- run once without "
+        "it and the error lists each family's offers + monthly prices so you can re-run with --option."
+    ),
+)
 @click.option("--yes", is_flag=True, default=False, help="Skip the interactive confirmation and place the order.")
 @click.option("--database-url", default=None, help="Pool DSN (else resolved from env/activated minds env).")
 def order(
@@ -1164,6 +1178,7 @@ def order(
     storage: str,
     memory_per_slice_gb: int,
     cpu_overcommit: float,
+    option_codes: tuple[str, ...],
     yes: bool,
     database_url: str | None,
 ) -> None:
@@ -1171,7 +1186,8 @@ def order(
 
     Builds + assigns the eco cart, shows the real OVH price preview for confirmation, places the order, and
     inserts a bare_metal_servers row (specs derived from the catalog). Then run ``await-delivery`` + ``setup``.
-    Needs OVH_* credentials and the pool DSN.
+    Any mandatory option family with more than one offer (e.g. bandwidth, vrack) must be chosen explicitly
+    via ``--option``; needs OVH_* credentials and the pool DSN.
     """
     config = _require_ovh_config()
     client = build_ovh_client(config)
@@ -1185,7 +1201,12 @@ def order(
         )
 
     cart_id, preview, _option_codes = build_and_assign_eco_cart(
-        client, plan_code=plan_code, datacenter=region, memory_gb=memory_gb, storage_short=storage
+        client,
+        plan_code=plan_code,
+        datacenter=region,
+        memory_gb=memory_gb,
+        storage_short=storage,
+        explicit_option_codes=option_codes,
     )
     write_human_line(
         f"About to order {plan_code} in {region}: {memory_gb}GB RAM, {storage}, {cpu_cores}c/{cpu_threads}t, "

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
@@ -206,6 +206,19 @@ def slice_lima_disk_name(host_id: HostId) -> str:
 
 
 @pure
+def _orphan_slice_resource_names(
+    box_names: AbstractSet[str],
+    tracked_names: AbstractSet[str],
+) -> set[str]:
+    """Slice-owned lima resource names on the box (``mngr-slice-`` prefix) with no pool DB row.
+
+    Shared by the instance and disk reconciliation: filter to slice-owned names so we
+    never touch an unrelated lima resource, then subtract the tracked set.
+    """
+    return {name for name in box_names if name.startswith(SLICE_LIMA_INSTANCE_PREFIX) and name not in tracked_names}
+
+
+@pure
 def compute_orphan_slice_instance_names(
     box_instance_names: AbstractSet[str],
     tracked_instance_names: AbstractSet[str],
@@ -220,11 +233,23 @@ def compute_orphan_slice_instance_names(
     is concurrently mid-carve against the same box (an in-flight VM not yet inserted
     would otherwise look like an orphan).
     """
-    return {
-        name
-        for name in box_instance_names
-        if name.startswith(SLICE_LIMA_INSTANCE_PREFIX) and name not in tracked_instance_names
-    }
+    return _orphan_slice_resource_names(box_instance_names, tracked_instance_names)
+
+
+@pure
+def compute_orphan_slice_disk_names(
+    box_disk_names: AbstractSet[str],
+    tracked_disk_names: AbstractSet[str],
+) -> set[str]:
+    """Slice data disks present on the box but absent from the pool DB -- safe to reap.
+
+    The disk analogue of :func:`compute_orphan_slice_instance_names`. Reaped separately
+    because a disk can outlive its instance: if a failed carve's rollback ``limactl
+    delete`` errors for a non-absent reason (e.g. the data disk is locked), it raises
+    before deleting the disk, leaving the disk behind even though the VM is gone -- and
+    a leaked disk permanently holds the box slot until reclaimed.
+    """
+    return _orphan_slice_resource_names(box_disk_names, tracked_disk_names)
 
 
 @pure

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
@@ -9,6 +9,7 @@ from imbue.mngr_imbue_cloud.data_types import BareMetalServer
 from imbue.mngr_imbue_cloud.data_types import BareMetalServerCapacity
 from imbue.mngr_imbue_cloud.errors import BareMetalConfigError
 from imbue.mngr_imbue_cloud.errors import SliceCapacityError
+from imbue.mngr_imbue_cloud.primitives import BareMetalServerDbId
 from imbue.mngr_imbue_cloud.primitives import BareMetalServerStatus
 from imbue.mngr_imbue_cloud.primitives import SERVER_STATUS_DELIVERED
 from imbue.mngr_imbue_cloud.primitives import SERVER_STATUS_FAILED
@@ -312,16 +313,19 @@ def compute_capacity(server: BareMetalServer, used_slots: int) -> BareMetalServe
 
 
 @pure
-def choose_server_for_new_slice(capacities: Sequence[BareMetalServerCapacity]) -> BareMetalServerCapacity:
-    """Pick the ready server with the most free slots to bake the next slice onto.
+def find_server_capacity_by_id(
+    capacities: Sequence[BareMetalServerCapacity], server_id: BareMetalServerDbId
+) -> BareMetalServerCapacity:
+    """Return the capacity row for the explicitly chosen ``server_id``.
 
-    Raises ``SliceCapacityError`` if no ready server has any free slots.
+    Slice baking targets one operator-named box per invocation (its per-slice sizing is fixed at
+    registration), rather than auto-selecting a server. Raises ``SliceCapacityError`` if no server in
+    ``capacities`` has that id -- the readiness + free-slot checks are the caller's, so the error can
+    name the count it needed.
     """
-    eligible = [
-        capacity
-        for capacity in capacities
-        if str(capacity.server.status) == SERVER_STATUS_READY and capacity.free_slots > 0
-    ]
-    if not eligible:
-        raise SliceCapacityError("no ready bare-metal server has free slots; order or install more capacity")
-    return max(eligible, key=lambda capacity: capacity.free_slots)
+    for capacity in capacities:
+        if capacity.server.id == server_id:
+            return capacity
+    raise SliceCapacityError(
+        f"no bare-metal server with id {server_id}; run `mngr imbue_cloud admin server list` to see the fleet"
+    )

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_db.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_db.py
@@ -55,6 +55,13 @@ _SELECT_SLICE_INSTANCE_NAMES_SQL: Final[str] = (
     "WHERE bare_metal_server_id = %s AND backend_kind = 'slice' AND lima_instance_name IS NOT NULL"
 )
 
+# Sibling of the instance-name query, for reconciling the box's lima data disks
+# against the DB and reaping orphan disks (disks with no row).
+_SELECT_SLICE_DISK_NAMES_SQL: Final[str] = (
+    "SELECT lima_disk_name FROM pool_hosts "
+    "WHERE bare_metal_server_id = %s AND backend_kind = 'slice' AND lima_disk_name IS NOT NULL"
+)
+
 
 @pure
 def build_bare_metal_server_insert_values(server: BareMetalServer) -> tuple[Any, ...]:
@@ -203,6 +210,13 @@ def fetch_slice_instance_names_for_server(conn: Any, server_id: BareMetalServerD
     """Return the lima_instance_name of every slice pool_hosts row for ``server_id`` (any status)."""
     with conn.cursor() as cur:
         cur.execute(_SELECT_SLICE_INSTANCE_NAMES_SQL, (str(server_id),))
+        return {row[0] for row in cur.fetchall() if row[0]}
+
+
+def fetch_slice_disk_names_for_server(conn: Any, server_id: BareMetalServerDbId) -> set[str]:
+    """Return the lima_disk_name of every slice pool_hosts row for ``server_id`` (any status)."""
+    with conn.cursor() as cur:
+        cur.execute(_SELECT_SLICE_DISK_NAMES_SQL, (str(server_id),))
         return {row[0] for row in cur.fetchall() if row[0]}
 
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep.py
@@ -101,7 +101,17 @@ sudo -u {lima_service_user} bash -lc 'command -v uv >/dev/null 2>&1 || curl -fsS
 #    user that limactl reads it as. Referenced via file:// so VM boots never hit the
 #    Debian mirror. To re-stage with a new customization, delete the image and re-run.
 img={base_image_path}
-install -d -m 755 -o {lima_service_user} -g {lima_service_user} "$(dirname "$img")"
+# Create the image dir AND its parent (the user's ~/.cache) owned by the lima user.
+# This script runs as root, so a freshly-created ~/.cache would be root-owned --
+# which blocks `limactl` (run as the lima user) from creating ~/.cache/lima and fails
+# every VM start. `install -d` only sets ownership on the leaf it's given, so create
+# the whole chain and chown it (chown also repairs a ~/.cache left root-owned by an
+# earlier prep run, since mkdir -p won't change an existing dir's ownership).
+image_dir="$(dirname "$img")"
+cache_dir="$(dirname "$image_dir")"
+mkdir -p "$image_dir"
+chown {lima_service_user}:{lima_service_user} "$cache_dir" "$image_dir"
+chmod 755 "$cache_dir" "$image_dir"
 if [ ! -f "$img" ]; then
     curl -fsSL --retry 8 --retry-delay 15 --retry-all-errors --retry-connrefused -o "$img.tmp" {slice_base_image_url}
     qemu-img info "$img.tmp" >/dev/null

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep_test.py
@@ -27,6 +27,16 @@ def test_prep_script_stages_base_image_under_lima_user_via_file_path() -> None:
     assert 'if [ ! -f "$img" ]; then' in script
 
 
+def test_prep_script_chowns_cache_dir_to_lima_user() -> None:
+    script = _script()
+    # The script runs as root; staging the image under ~/.cache must leave ~/.cache
+    # owned by the lima user, or `limactl` (run as that user) cannot create
+    # ~/.cache/lima and every VM start fails. The parent cache dir must be chowned,
+    # not just the leaf image dir.
+    assert 'cache_dir="$(dirname "$image_dir")"' in script
+    assert 'chown limahost:limahost "$cache_dir" "$image_dir"' in script
+
+
 def test_prep_script_installs_qemu_and_lima() -> None:
     script = _script()
     assert "qemu-system-x86" in script

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_test.py
@@ -18,7 +18,6 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import DISK_RESERVE_GB
 from imbue.mngr_imbue_cloud.slices.bare_metal import SLICE_BOOT_DISK_GIB
 from imbue.mngr_imbue_cloud.slices.bare_metal import allocate_slice_ports
 from imbue.mngr_imbue_cloud.slices.bare_metal import choose_raid_level
-from imbue.mngr_imbue_cloud.slices.bare_metal import choose_server_for_new_slice
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_capacity
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_instance_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_budget_gib
@@ -26,6 +25,7 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_gib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_memory_mib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_vcpus
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slot_count
+from imbue.mngr_imbue_cloud.slices.bare_metal import find_server_capacity_by_id
 from imbue.mngr_imbue_cloud.slices.bare_metal import is_valid_status_transition
 from imbue.mngr_imbue_cloud.slices.bare_metal import next_server_status
 from imbue.mngr_imbue_cloud.slices.bare_metal import partition_port_range
@@ -33,10 +33,14 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_disk_name
 from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_instance_name
 
 
-def _server(status: str, slot_count: int = 8) -> BareMetalServer:
+def _server(
+    status: str,
+    slot_count: int = 8,
+    server_id: str = "11111111-1111-1111-1111-111111111111",
+) -> BareMetalServer:
     now = datetime.now(timezone.utc)
     return BareMetalServer(
-        id=BareMetalServerDbId("11111111-1111-1111-1111-111111111111"),
+        id=BareMetalServerDbId(server_id),
         plan_code="24rise02-v1-us",
         region="vin",
         slot_count=slot_count,
@@ -242,18 +246,19 @@ def test_compute_capacity_rejects_negative_used() -> None:
         compute_capacity(_server(SERVER_STATUS_READY), used_slots=-1)
 
 
-def test_choose_server_for_new_slice_picks_most_free_ready_server() -> None:
-    nearly_full = compute_capacity(_server(SERVER_STATUS_READY, slot_count=8), used_slots=7)
-    roomy = compute_capacity(_server(SERVER_STATUS_READY, slot_count=16), used_slots=2)
-    chosen = choose_server_for_new_slice([nearly_full, roomy])
+def test_find_server_capacity_by_id_returns_the_matching_server() -> None:
+    target_id = BareMetalServerDbId("22222222-2222-2222-2222-222222222222")
+    other = compute_capacity(_server(SERVER_STATUS_READY, slot_count=8), used_slots=1)
+    target = compute_capacity(_server(SERVER_STATUS_READY, slot_count=16, server_id=str(target_id)), used_slots=2)
+    chosen = find_server_capacity_by_id([other, target], target_id)
+    assert chosen.server.id == target_id
     assert chosen.free_slots == 14
 
 
-def test_choose_server_for_new_slice_ignores_non_ready_and_full_servers() -> None:
-    installing = compute_capacity(_server(SERVER_STATUS_INSTALLING, slot_count=16), used_slots=0)
-    full_ready = compute_capacity(_server(SERVER_STATUS_READY, slot_count=8), used_slots=8)
+def test_find_server_capacity_by_id_raises_when_absent() -> None:
+    only = compute_capacity(_server(SERVER_STATUS_READY, slot_count=8), used_slots=0)
     with pytest.raises(SliceCapacityError):
-        choose_server_for_new_slice([installing, full_ready])
+        find_server_capacity_by_id([only], BareMetalServerDbId("99999999-9999-9999-9999-999999999999"))
 
 
 def test_compute_orphan_slice_instance_names_returns_untracked_slice_vms() -> None:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_test.py
@@ -19,6 +19,7 @@ from imbue.mngr_imbue_cloud.slices.bare_metal import SLICE_BOOT_DISK_GIB
 from imbue.mngr_imbue_cloud.slices.bare_metal import allocate_slice_ports
 from imbue.mngr_imbue_cloud.slices.bare_metal import choose_raid_level
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_capacity
+from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_disk_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_orphan_slice_instance_names
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_budget_gib
 from imbue.mngr_imbue_cloud.slices.bare_metal import compute_slice_disk_gib
@@ -279,3 +280,17 @@ def test_compute_orphan_slice_instance_names_empty_when_all_tracked() -> None:
     box = {"mngr-slice-aaa", "mngr-slice-bbb"}
     tracked = {"mngr-slice-aaa", "mngr-slice-bbb", "mngr-slice-ccc"}
     assert compute_orphan_slice_instance_names(box, tracked) == set()
+
+
+def test_compute_orphan_slice_disk_names_returns_untracked_slice_disks() -> None:
+    # On-box data disks not present in the DB (and only slice-prefixed ones) are orphans.
+    box = {"mngr-slice-aaa-data", "mngr-slice-bbb-data"}
+    tracked = {"mngr-slice-aaa-data"}
+    assert compute_orphan_slice_disk_names(box, tracked) == {"mngr-slice-bbb-data"}
+
+
+def test_compute_orphan_slice_disk_names_ignores_non_slice_disks() -> None:
+    # A non-slice lima disk on the box must never be considered an orphan to reap.
+    box = {"some-other-disk", "mngr-slice-bbb-data"}
+    tracked: set[str] = set()
+    assert compute_orphan_slice_disk_names(box, tracked) == {"mngr-slice-bbb-data"}

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client.py
@@ -295,6 +295,49 @@ class LimaSliceVpsClient(VpsClientInterface):
                 names.add(name)
         return names
 
+    def list_disk_names(self) -> set[str]:
+        """Return the names of all lima disks currently on the box."""
+        list_rc, list_out, list_err = self._run_on_box(
+            "limactl disk list --json", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="disk-list"
+        )
+        if list_rc != 0:
+            raise LimaCommandError("disk list", list_rc or 1, list_err)
+        names: set[str] = set()
+        for line in list_out.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                disk = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                logger.warning("Failed to parse Lima disk JSON: {}", exc)
+                continue
+            name = disk.get("name")
+            if name:
+                names.add(name)
+        return names
+
+    def destroy_disk(self, disk_name: str) -> None:
+        """Delete a lima data disk on the box, unlocking it first so a leaked locked disk still goes.
+
+        Used to reap an orphan disk (one with no pool DB row) left behind when a failed
+        carve's ``limactl delete`` could not unlock the disk. ``limactl disk delete``
+        refuses a locked disk, so we ``disk unlock`` first (best-effort -- it errors when
+        the disk is not actually locked, which is fine), then force-delete, tolerating the
+        disk already being absent.
+        """
+        self._run_on_box(
+            f"limactl disk unlock {shlex.quote(disk_name)}", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="disk-unlock"
+        )
+        delete_rc, _out, delete_err = self._run_on_box(
+            f"limactl disk delete --force {shlex.quote(disk_name)}",
+            timeout=_LIMA_SHORT_TIMEOUT_SECONDS,
+            label="disk-delete",
+        )
+        if delete_rc != 0 and not _is_already_absent_error(delete_err):
+            raise LimaCommandError("disk delete", delete_rc or 1, delete_err)
+        logger.info("Destroyed orphan slice disk {} on {}", disk_name, self.box_address)
+
     def get_instance_status(self, instance_id: VpsInstanceId) -> VpsInstanceStatus:
         list_rc, list_out, list_err = self._run_on_box(
             "limactl list --json", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="list"

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
@@ -95,6 +95,37 @@ def test_destroy_instance_raises_on_genuine_delete_failure() -> None:
         client.destroy_instance(VpsInstanceId("mngr-slice-abc"))
 
 
+def test_list_disk_names_parses_jsonl_names() -> None:
+    disk_json = '{"name": "mngr-slice-aaa-data"}\n{"name": "mngr-slice-bbb-data"}\n'
+    client = _recording_client({"limactl disk list --json": (0, disk_json, "")})
+    assert client.list_disk_names() == {"mngr-slice-aaa-data", "mngr-slice-bbb-data"}
+
+
+def test_destroy_disk_unlocks_then_force_deletes() -> None:
+    # A leaked orphan disk is typically locked, so destroy_disk must unlock first.
+    client = _recording_client({})
+    client.destroy_disk("mngr-slice-abc-data")
+    recorded = client.recorded_commands
+    unlock_idx = next(
+        i for i, cmd in enumerate(recorded) if "limactl disk unlock" in cmd and "mngr-slice-abc-data" in cmd
+    )
+    delete_idx = next(
+        i for i, cmd in enumerate(recorded) if "limactl disk delete --force" in cmd and "mngr-slice-abc-data" in cmd
+    )
+    assert unlock_idx < delete_idx
+
+
+def test_destroy_disk_tolerates_already_absent_disk() -> None:
+    client = _recording_client({"limactl disk delete": (1, "", "disk does not exist")})
+    client.destroy_disk("mngr-slice-abc-data")  # must not raise
+
+
+def test_destroy_disk_raises_on_genuine_delete_failure() -> None:
+    client = _recording_client({"limactl disk delete": (1, "", "permission denied")})
+    with pytest.raises(LimaCommandError):
+        client.destroy_disk("mngr-slice-abc-data")
+
+
 def test_parse_listening_ports_extracts_ipv4_ipv6_and_wildcard() -> None:
     ss_output = (
         "LISTEN 0      128          0.0.0.0:22         0.0.0.0:*\n"

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
@@ -117,7 +117,8 @@ def test_destroy_disk_unlocks_then_force_deletes() -> None:
 
 def test_destroy_disk_tolerates_already_absent_disk() -> None:
     client = _recording_client({"limactl disk delete": (1, "", "disk does not exist")})
-    client.destroy_disk("mngr-slice-abc-data")  # must not raise
+    # An already-absent disk must not raise.
+    client.destroy_disk("mngr-slice-abc-data")
 
 
 def test_destroy_disk_raises_on_genuine_delete_failure() -> None:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
@@ -10,6 +10,7 @@ client-driven steps are exercised live against a real order.
 from collections import defaultdict
 from collections.abc import Mapping
 from collections.abc import Sequence
+from collections.abc import Set as AbstractSet
 from decimal import Decimal
 from typing import Any
 from typing import Final
@@ -71,29 +72,39 @@ def _eco_option_monthly_price(option: Mapping[str, Any]) -> Decimal | None:
 
 
 @pure
-def _pick_cheapest_mandatory_option_code(family: str, family_options: Sequence[Mapping[str, Any]]) -> str:
-    """Pick the single cheapest offer (by month-to-month price) for a multi-offer mandatory family.
+def _format_eco_offers(family_options: Sequence[Mapping[str, Any]]) -> str:
+    """Render a family's offers as ``planCode ($X/mo)`` entries (cheapest first) for an error message."""
+    described: list[tuple[Decimal, str]] = []
+    for option in family_options:
+        price = _eco_option_monthly_price(option)
+        price_text = f"${price}/mo" if price is not None else "price n/a"
+        sort_key = price if price is not None else Decimal("Infinity")
+        described.append((sort_key, f"{option['planCode']} ({price_text})"))
+    return ", ".join(text for _sort_key, text in sorted(described, key=lambda item: item[0]))
 
-    OVH groups the included baseline and its paid upgrades in the same mandatory family (e.g. bandwidth:
-    the free 1Gbps baseline plus a paid 2Gbps upgrade). The pricing table prices every plan at its
-    cheapest mandatory options, so auto-picking the cheapest here reproduces exactly what was quoted.
-    Raises ``BareMetalConfigError`` if any offer lacks a comparable price or if the cheapest is tied
-    (so we never silently guess which of two equally-priced upgrades was intended).
+
+@pure
+def _resolve_explicit_option_for_family(
+    family: str,
+    family_options: Sequence[Mapping[str, Any]],
+    explicit_option_codes: AbstractSet[str],
+) -> str:
+    """Resolve the chosen planCode for one multi-offer mandatory family from the operator's explicit choices.
+
+    Requires exactly one of the family's offers to appear in ``explicit_option_codes`` -- we never pick
+    among real alternatives on the operator's behalf. Raises ``BareMetalConfigError`` (listing the offers
+    and their monthly prices) when none or more than one of the family's offers was selected.
     """
-    priced = [(str(option["planCode"]), _eco_option_monthly_price(option)) for option in family_options]
-    if any(price is None for _code, price in priced):
+    family_codes = {str(option["planCode"]) for option in family_options}
+    selected = sorted(family_codes & explicit_option_codes)
+    if len(selected) == 1:
+        return selected[0]
+    if not selected:
         raise BareMetalConfigError(
-            f"cannot auto-pick the {family} option: offers {sorted(code for code, _p in priced)} "
-            "lack comparable monthly prices"
+            f"plan offers multiple {family} options; choose one with --option. "
+            f"Offered: {_format_eco_offers(family_options)}"
         )
-    cheapest_price = min(price for _code, price in priced if price is not None)
-    cheapest_codes = sorted(code for code, price in priced if price == cheapest_price)
-    if len(cheapest_codes) != 1:
-        raise BareMetalConfigError(
-            f"cannot auto-pick the {family} option: {cheapest_codes} tie at the cheapest monthly price; "
-            "none is unambiguously the included baseline"
-        )
-    return cheapest_codes[0]
+    raise BareMetalConfigError(f"choose exactly one --option for the {family} family, got {selected}")
 
 
 @pure
@@ -101,15 +112,17 @@ def select_eco_option_codes(
     eco_options: Sequence[Mapping[str, Any]],
     memory_gb: int,
     storage_short: str,
+    explicit_option_codes: Sequence[str],
 ) -> list[str]:
     """Choose the eco cart option planCodes: the requested memory + storage, plus every other mandatory family.
 
     ``eco_options`` is the ``GET /order/cart/{id}/eco/options`` payload (each item has ``family``,
     ``planCode``, ``mandatory``, and ``prices``). Memory is matched by parsed GB; storage by the
-    availability short code (prefix). Every *other* family OVH flags mandatory (e.g. bandwidth, vrack)
-    is auto-picked: a single-offer family takes its only offer, and a multi-offer family takes its
-    cheapest month-to-month offer (the included baseline -- the same config the pricing table quotes).
-    Optional families are skipped. Raises ``BareMetalConfigError`` if a required choice can't be resolved.
+    availability short code (prefix). Every *other* mandatory family (e.g. bandwidth, vrack) is resolved
+    explicitly: a single-offer family takes its only offer, but a multi-offer family requires the operator
+    to name the chosen offer in ``explicit_option_codes`` (the ``--option`` flag) -- we never pick among
+    real alternatives automatically. Optional families are skipped. Raises ``BareMetalConfigError`` if a
+    required choice is missing/ambiguous or an explicit code is not an available mandatory option.
     """
     options_by_family: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
     is_family_mandatory: dict[str, bool] = {}
@@ -136,20 +149,32 @@ def select_eco_option_codes(
             f"storage {storage_short!r} not offered for this plan; offered: {sorted(_codes_for('storage'))}"
         )
 
-    # Auto-pick every other mandatory family (e.g. bandwidth, and vrack on the plans that include it):
-    # the only offer when there is one, else the cheapest offer. Optional families are skipped.
+    # Resolve every other mandatory family (e.g. bandwidth, and vrack on the plans that include it): the
+    # only offer when there is one, else the explicit --option the operator named. Optional families are
+    # skipped. Track which explicit codes we consume so stray/typo'd ones are rejected, not silently ignored.
+    explicit_set = set(explicit_option_codes)
+    consumed_explicit_codes: set[str] = set()
     chosen = [memory_code, storage_code]
-    auto_pick_families = sorted(
+    auto_resolve_families = sorted(
         family
         for family, is_mandatory in is_family_mandatory.items()
         if is_mandatory and family not in _USER_SELECTED_OPTION_FAMILIES
     )
-    for family in auto_pick_families:
+    for family in auto_resolve_families:
         family_options = options_by_family.get(family, [])
         if len(family_options) == 1:
             chosen.append(str(family_options[0]["planCode"]))
         else:
-            chosen.append(_pick_cheapest_mandatory_option_code(family, family_options))
+            picked = _resolve_explicit_option_for_family(family, family_options, explicit_set)
+            chosen.append(picked)
+            consumed_explicit_codes.add(picked)
+
+    unknown_codes = sorted(explicit_set - consumed_explicit_codes - set(chosen))
+    if unknown_codes:
+        raise BareMetalConfigError(
+            f"--option value(s) {unknown_codes} are not a multi-offer mandatory option for this plan "
+            "(memory/storage use --memory-gb/--storage; single-offer families are auto-selected)"
+        )
     return chosen
 
 
@@ -221,12 +246,14 @@ def build_and_assign_eco_cart(
     datacenter: str,
     memory_gb: int,
     storage_short: str,
+    explicit_option_codes: Sequence[str],
 ) -> tuple[str, dict[str, Any], list[str]]:
     """Build a single-server eco cart, assign it, and return (cart_id, checkout_preview, option_codes).
 
     Assigning attaches the cart to the account but does NOT place the order (only ``POST checkout`` does),
     so the returned preview can be shown for confirmation. The caller must then either ``checkout_eco_cart``
-    or ``delete_cart_quietly``.
+    or ``delete_cart_quietly``. ``explicit_option_codes`` names the chosen offer for each multi-offer
+    mandatory option family (see :func:`select_eco_option_codes`).
     """
     with log_span("Building OVH eco cart for plan={} datacenter={}", plan_code, datacenter):
         cart_id = str(client.call_api("POST", "/order/cart", ovhSubsidiary=client.subsidiary).get("cartId", ""))
@@ -255,7 +282,7 @@ def build_and_assign_eco_cart(
         # call_api sends kwargs as the request body, so a GET's query params must go in the path.
         options_path = f"/order/cart/{cart_id}/eco/options?{urlencode({'planCode': plan_code})}"
         eco_options = client.call_api("GET", options_path)
-        option_codes = select_eco_option_codes(eco_options, memory_gb, storage_short)
+        option_codes = select_eco_option_codes(eco_options, memory_gb, storage_short, explicit_option_codes)
         for option_code in option_codes:
             client.call_api(
                 "POST",

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
@@ -132,21 +132,18 @@ def select_eco_option_codes(
         # A family counts as mandatory if any of its offers is flagged mandatory.
         is_family_mandatory[family] = is_family_mandatory.get(family, False) or bool(option.get("mandatory"))
 
-    def _codes_for(family: str) -> list[str]:
-        return [str(option["planCode"]) for option in options_by_family.get(family, [])]
-
-    memory_code = next((code for code in _codes_for("memory") if parse_memory_gb(code) == memory_gb), None)
+    memory_codes = [str(option["planCode"]) for option in options_by_family.get("memory", [])]
+    storage_codes = [str(option["planCode"]) for option in options_by_family.get("storage", [])]
+    memory_code = next((code for code in memory_codes if parse_memory_gb(code) == memory_gb), None)
     if memory_code is None:
-        raise BareMetalConfigError(
-            f"no {memory_gb}GB memory option for this plan; offered: {sorted(_codes_for('memory'))}"
-        )
+        raise BareMetalConfigError(f"no {memory_gb}GB memory option for this plan; offered: {sorted(memory_codes)}")
     storage_code = next(
-        (code for code in _codes_for("storage") if code == storage_short or code.startswith(storage_short + "-")),
+        (code for code in storage_codes if code == storage_short or code.startswith(storage_short + "-")),
         None,
     )
     if storage_code is None:
         raise BareMetalConfigError(
-            f"storage {storage_short!r} not offered for this plan; offered: {sorted(_codes_for('storage'))}"
+            f"storage {storage_short!r} not offered for this plan; offered: {sorted(storage_codes)}"
         )
 
     # Resolve every other mandatory family (e.g. bandwidth, and vrack on the plans that include it): the

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering.py
@@ -10,6 +10,7 @@ client-driven steps are exercised live against a real order.
 from collections import defaultdict
 from collections.abc import Mapping
 from collections.abc import Sequence
+from decimal import Decimal
 from typing import Any
 from typing import Final
 from urllib.parse import urlencode
@@ -53,6 +54,49 @@ _TERMINAL_TASK_STATUSES: Final[frozenset[str]] = frozenset({"done", "ovhError", 
 
 
 @pure
+def _eco_option_monthly_price(option: Mapping[str, Any]) -> Decimal | None:
+    """Return an eco option's month-to-month recurring price (the cart's pricingMode + duration), or None.
+
+    The eco-options payload carries a ``prices`` list per offer; we read the price for the SAME
+    ``pricingMode`` / ``duration`` the cart is built with so "cheapest" compares like-for-like monthly
+    cost. Returns None when no matching priced entry is present (so the caller can treat it as
+    not-comparable rather than free).
+    """
+    for price_entry in option.get("prices") or []:
+        if price_entry.get("pricingMode") == ECO_PRICING_MODE and price_entry.get("duration") == ECO_DURATION:
+            value = (price_entry.get("price") or {}).get("value")
+            if value is not None:
+                return Decimal(str(value))
+    return None
+
+
+@pure
+def _pick_cheapest_mandatory_option_code(family: str, family_options: Sequence[Mapping[str, Any]]) -> str:
+    """Pick the single cheapest offer (by month-to-month price) for a multi-offer mandatory family.
+
+    OVH groups the included baseline and its paid upgrades in the same mandatory family (e.g. bandwidth:
+    the free 1Gbps baseline plus a paid 2Gbps upgrade). The pricing table prices every plan at its
+    cheapest mandatory options, so auto-picking the cheapest here reproduces exactly what was quoted.
+    Raises ``BareMetalConfigError`` if any offer lacks a comparable price or if the cheapest is tied
+    (so we never silently guess which of two equally-priced upgrades was intended).
+    """
+    priced = [(str(option["planCode"]), _eco_option_monthly_price(option)) for option in family_options]
+    if any(price is None for _code, price in priced):
+        raise BareMetalConfigError(
+            f"cannot auto-pick the {family} option: offers {sorted(code for code, _p in priced)} "
+            "lack comparable monthly prices"
+        )
+    cheapest_price = min(price for _code, price in priced if price is not None)
+    cheapest_codes = sorted(code for code, price in priced if price == cheapest_price)
+    if len(cheapest_codes) != 1:
+        raise BareMetalConfigError(
+            f"cannot auto-pick the {family} option: {cheapest_codes} tie at the cheapest monthly price; "
+            "none is unambiguously the included baseline"
+        )
+    return cheapest_codes[0]
+
+
+@pure
 def select_eco_option_codes(
     eco_options: Sequence[Mapping[str, Any]],
     memory_gb: int,
@@ -61,41 +105,39 @@ def select_eco_option_codes(
     """Choose the eco cart option planCodes: the requested memory + storage, plus every other mandatory family.
 
     ``eco_options`` is the ``GET /order/cart/{id}/eco/options`` payload (each item has ``family``,
-    ``planCode``, and ``mandatory``). Memory is matched by parsed GB; storage by the availability short
-    code (prefix). Every *other* family OVH flags mandatory (e.g. bandwidth, and vrack where offered) is
-    auto-picked and must have exactly one offer; optional families are skipped. Raises
-    ``BareMetalConfigError`` if a required choice can't be resolved.
+    ``planCode``, ``mandatory``, and ``prices``). Memory is matched by parsed GB; storage by the
+    availability short code (prefix). Every *other* family OVH flags mandatory (e.g. bandwidth, vrack)
+    is auto-picked: a single-offer family takes its only offer, and a multi-offer family takes its
+    cheapest month-to-month offer (the included baseline -- the same config the pricing table quotes).
+    Optional families are skipped. Raises ``BareMetalConfigError`` if a required choice can't be resolved.
     """
-    codes_by_family: dict[str, list[str]] = defaultdict(list)
+    options_by_family: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
     is_family_mandatory: dict[str, bool] = {}
     for option in eco_options:
         family = str(option["family"])
-        codes_by_family[family].append(str(option["planCode"]))
+        options_by_family[family].append(option)
         # A family counts as mandatory if any of its offers is flagged mandatory.
         is_family_mandatory[family] = is_family_mandatory.get(family, False) or bool(option.get("mandatory"))
 
-    memory_code = next(
-        (code for code in codes_by_family.get("memory", []) if parse_memory_gb(code) == memory_gb), None
-    )
+    def _codes_for(family: str) -> list[str]:
+        return [str(option["planCode"]) for option in options_by_family.get(family, [])]
+
+    memory_code = next((code for code in _codes_for("memory") if parse_memory_gb(code) == memory_gb), None)
     if memory_code is None:
         raise BareMetalConfigError(
-            f"no {memory_gb}GB memory option for this plan; offered: {sorted(codes_by_family.get('memory', []))}"
+            f"no {memory_gb}GB memory option for this plan; offered: {sorted(_codes_for('memory'))}"
         )
     storage_code = next(
-        (
-            code
-            for code in codes_by_family.get("storage", [])
-            if code == storage_short or code.startswith(storage_short + "-")
-        ),
+        (code for code in _codes_for("storage") if code == storage_short or code.startswith(storage_short + "-")),
         None,
     )
     if storage_code is None:
         raise BareMetalConfigError(
-            f"storage {storage_short!r} not offered for this plan; offered: {sorted(codes_by_family.get('storage', []))}"
+            f"storage {storage_short!r} not offered for this plan; offered: {sorted(_codes_for('storage'))}"
         )
 
-    # Auto-pick the single offer for every other mandatory family (e.g. bandwidth,
-    # and vrack on the plans that include it); optional families are skipped.
+    # Auto-pick every other mandatory family (e.g. bandwidth, and vrack on the plans that include it):
+    # the only offer when there is one, else the cheapest offer. Optional families are skipped.
     chosen = [memory_code, storage_code]
     auto_pick_families = sorted(
         family
@@ -103,12 +145,11 @@ def select_eco_option_codes(
         if is_mandatory and family not in _USER_SELECTED_OPTION_FAMILIES
     )
     for family in auto_pick_families:
-        family_codes = codes_by_family.get(family, [])
-        if len(family_codes) != 1:
-            raise BareMetalConfigError(
-                f"expected exactly one {family} option to auto-pick, got {sorted(family_codes)}"
-            )
-        chosen.append(family_codes[0])
+        family_options = options_by_family.get(family, [])
+        if len(family_options) == 1:
+            chosen.append(str(family_options[0]["planCode"]))
+        else:
+            chosen.append(_pick_cheapest_mandatory_option_code(family, family_options))
     return chosen
 
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering_test.py
@@ -41,12 +41,57 @@ def test_select_eco_option_codes_raises_for_unavailable_storage() -> None:
         select_eco_option_codes(_eco_options(), memory_gb=64, storage_short="softraid-4x3840nvme")
 
 
-def test_select_eco_option_codes_raises_when_mandatory_family_is_ambiguous() -> None:
+def test_select_eco_option_codes_raises_when_mandatory_family_is_ambiguous_without_prices() -> None:
+    # Two bandwidth offers with no comparable prices cannot be auto-picked: there is no basis to
+    # tell the included baseline from a paid upgrade, so we refuse rather than guess.
     options = _eco_options() + [
         {"family": "bandwidth", "planCode": "bandwidth-3000-unguaranteed-rise-gen2-us", "mandatory": True}
     ]
     with pytest.raises(BareMetalConfigError):
         select_eco_option_codes(options, memory_gb=64, storage_short="softraid-2x512nvme")
+
+
+def _priced_option(family: str, plan_code: str, monthly_usd: str) -> dict:
+    # Shape mirrors the OVH `GET /order/cart/{id}/eco/options` payload: each offer carries a `prices`
+    # list keyed by pricingMode + duration. We only price the month-to-month (default / P1M) entry.
+    return {
+        "family": family,
+        "planCode": plan_code,
+        "mandatory": True,
+        "prices": [{"pricingMode": "default", "duration": "P1M", "price": {"value": float(monthly_usd)}}],
+    }
+
+
+def test_select_eco_option_codes_picks_cheapest_offer_for_multi_offer_mandatory_family() -> None:
+    # Models the 24sys032-us plan: bandwidth + vrack are each mandatory with a free included baseline
+    # plus a paid upgrade. Auto-pick must take the free baseline of each (what the pricing table quotes).
+    options = [
+        _priced_option("memory", "ram-128g-ecc-2666-24sys-us", "40.00"),
+        _priced_option("storage", "softraid-2x960nvme-24sys-us", "0.00"),
+        _priced_option("bandwidth", "bandwidth-1000-24sys-us", "0.00"),
+        _priced_option("bandwidth", "bandwidth-2000-24sys-us", "120.00"),
+        _priced_option("vrack", "vrack-bandwidth-500-24sys-us", "0.00"),
+        _priced_option("vrack", "vrack-bandwidth-1000-24sys-us", "23.00"),
+    ]
+    codes = select_eco_option_codes(options, memory_gb=128, storage_short="softraid-2x960nvme")
+    assert set(codes) == {
+        "ram-128g-ecc-2666-24sys-us",
+        "softraid-2x960nvme-24sys-us",
+        "bandwidth-1000-24sys-us",
+        "vrack-bandwidth-500-24sys-us",
+    }
+
+
+def test_select_eco_option_codes_raises_when_cheapest_offer_is_tied() -> None:
+    # Two equally-priced offers in a mandatory family: refuse rather than silently pick one.
+    options = [
+        _priced_option("memory", "ram-128g-ecc-2666-24sys-us", "40.00"),
+        _priced_option("storage", "softraid-2x960nvme-24sys-us", "0.00"),
+        _priced_option("bandwidth", "bandwidth-1000-24sys-us", "0.00"),
+        _priced_option("bandwidth", "bandwidth-1000b-24sys-us", "0.00"),
+    ]
+    with pytest.raises(BareMetalConfigError):
+        select_eco_option_codes(options, memory_gb=128, storage_short="softraid-2x960nvme")
 
 
 def test_select_eco_option_codes_handles_plan_without_vrack() -> None:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/ordering_test.py
@@ -22,7 +22,9 @@ def _eco_options() -> list[dict]:
 
 
 def test_select_eco_option_codes_picks_requested_memory_storage_plus_single_offer_families() -> None:
-    codes = select_eco_option_codes(_eco_options(), memory_gb=64, storage_short="softraid-2x512nvme")
+    codes = select_eco_option_codes(
+        _eco_options(), memory_gb=64, storage_short="softraid-2x512nvme", explicit_option_codes=()
+    )
     assert set(codes) == {
         "ram-64g-ecc-3200-24rise01-v1-us",
         "softraid-2x512nvme-24rise01-v1-us",
@@ -33,22 +35,25 @@ def test_select_eco_option_codes_picks_requested_memory_storage_plus_single_offe
 
 def test_select_eco_option_codes_raises_for_unavailable_memory() -> None:
     with pytest.raises(BareMetalConfigError):
-        select_eco_option_codes(_eco_options(), memory_gb=256, storage_short="softraid-2x512nvme")
+        select_eco_option_codes(
+            _eco_options(), memory_gb=256, storage_short="softraid-2x512nvme", explicit_option_codes=()
+        )
 
 
 def test_select_eco_option_codes_raises_for_unavailable_storage() -> None:
     with pytest.raises(BareMetalConfigError):
-        select_eco_option_codes(_eco_options(), memory_gb=64, storage_short="softraid-4x3840nvme")
+        select_eco_option_codes(
+            _eco_options(), memory_gb=64, storage_short="softraid-4x3840nvme", explicit_option_codes=()
+        )
 
 
-def test_select_eco_option_codes_raises_when_mandatory_family_is_ambiguous_without_prices() -> None:
-    # Two bandwidth offers with no comparable prices cannot be auto-picked: there is no basis to
-    # tell the included baseline from a paid upgrade, so we refuse rather than guess.
+def test_select_eco_option_codes_raises_when_multi_offer_family_has_no_explicit_choice() -> None:
+    # Two bandwidth offers and no --option: refuse rather than pick one on the operator's behalf.
     options = _eco_options() + [
         {"family": "bandwidth", "planCode": "bandwidth-3000-unguaranteed-rise-gen2-us", "mandatory": True}
     ]
     with pytest.raises(BareMetalConfigError):
-        select_eco_option_codes(options, memory_gb=64, storage_short="softraid-2x512nvme")
+        select_eco_option_codes(options, memory_gb=64, storage_short="softraid-2x512nvme", explicit_option_codes=())
 
 
 def _priced_option(family: str, plan_code: str, monthly_usd: str) -> dict:
@@ -62,10 +67,9 @@ def _priced_option(family: str, plan_code: str, monthly_usd: str) -> dict:
     }
 
 
-def test_select_eco_option_codes_picks_cheapest_offer_for_multi_offer_mandatory_family() -> None:
-    # Models the 24sys032-us plan: bandwidth + vrack are each mandatory with a free included baseline
-    # plus a paid upgrade. Auto-pick must take the free baseline of each (what the pricing table quotes).
-    options = [
+def _multi_offer_options() -> list[dict]:
+    # Models the 24sys032-us plan: bandwidth + vrack are each mandatory with a free baseline + a paid upgrade.
+    return [
         _priced_option("memory", "ram-128g-ecc-2666-24sys-us", "40.00"),
         _priced_option("storage", "softraid-2x960nvme-24sys-us", "0.00"),
         _priced_option("bandwidth", "bandwidth-1000-24sys-us", "0.00"),
@@ -73,7 +77,15 @@ def test_select_eco_option_codes_picks_cheapest_offer_for_multi_offer_mandatory_
         _priced_option("vrack", "vrack-bandwidth-500-24sys-us", "0.00"),
         _priced_option("vrack", "vrack-bandwidth-1000-24sys-us", "23.00"),
     ]
-    codes = select_eco_option_codes(options, memory_gb=128, storage_short="softraid-2x960nvme")
+
+
+def test_select_eco_option_codes_uses_explicit_choices_for_multi_offer_families() -> None:
+    codes = select_eco_option_codes(
+        _multi_offer_options(),
+        memory_gb=128,
+        storage_short="softraid-2x960nvme",
+        explicit_option_codes=("bandwidth-1000-24sys-us", "vrack-bandwidth-500-24sys-us"),
+    )
     assert set(codes) == {
         "ram-128g-ecc-2666-24sys-us",
         "softraid-2x960nvme-24sys-us",
@@ -82,16 +94,55 @@ def test_select_eco_option_codes_picks_cheapest_offer_for_multi_offer_mandatory_
     }
 
 
-def test_select_eco_option_codes_raises_when_cheapest_offer_is_tied() -> None:
-    # Two equally-priced offers in a mandatory family: refuse rather than silently pick one.
-    options = [
-        _priced_option("memory", "ram-128g-ecc-2666-24sys-us", "40.00"),
-        _priced_option("storage", "softraid-2x960nvme-24sys-us", "0.00"),
-        _priced_option("bandwidth", "bandwidth-1000-24sys-us", "0.00"),
-        _priced_option("bandwidth", "bandwidth-1000b-24sys-us", "0.00"),
-    ]
+def test_select_eco_option_codes_can_pick_the_paid_upgrade_when_named() -> None:
+    # Explicit selection is honored verbatim -- the operator can choose the paid tier, not just the free one.
+    codes = select_eco_option_codes(
+        _multi_offer_options(),
+        memory_gb=128,
+        storage_short="softraid-2x960nvme",
+        explicit_option_codes=("bandwidth-2000-24sys-us", "vrack-bandwidth-500-24sys-us"),
+    )
+    assert "bandwidth-2000-24sys-us" in codes
+    assert "bandwidth-1000-24sys-us" not in codes
+
+
+def test_select_eco_option_codes_raises_when_multi_offer_family_left_unspecified() -> None:
+    # vrack still ambiguous (no --option for it): refuse even though bandwidth was specified.
     with pytest.raises(BareMetalConfigError):
-        select_eco_option_codes(options, memory_gb=128, storage_short="softraid-2x960nvme")
+        select_eco_option_codes(
+            _multi_offer_options(),
+            memory_gb=128,
+            storage_short="softraid-2x960nvme",
+            explicit_option_codes=("bandwidth-1000-24sys-us",),
+        )
+
+
+def test_select_eco_option_codes_raises_when_two_offers_named_for_one_family() -> None:
+    with pytest.raises(BareMetalConfigError):
+        select_eco_option_codes(
+            _multi_offer_options(),
+            memory_gb=128,
+            storage_short="softraid-2x960nvme",
+            explicit_option_codes=(
+                "bandwidth-1000-24sys-us",
+                "bandwidth-2000-24sys-us",
+                "vrack-bandwidth-500-24sys-us",
+            ),
+        )
+
+
+def test_select_eco_option_codes_raises_for_unknown_explicit_option() -> None:
+    with pytest.raises(BareMetalConfigError):
+        select_eco_option_codes(
+            _multi_offer_options(),
+            memory_gb=128,
+            storage_short="softraid-2x960nvme",
+            explicit_option_codes=(
+                "bandwidth-1000-24sys-us",
+                "vrack-bandwidth-500-24sys-us",
+                "bogus-addon-24sys-us",
+            ),
+        )
 
 
 def test_select_eco_option_codes_handles_plan_without_vrack() -> None:
@@ -102,7 +153,9 @@ def test_select_eco_option_codes_handles_plan_without_vrack() -> None:
         {"family": "memory", "planCode": "ram-256g-ecc-2400-24sk60-us", "mandatory": True},
         {"family": "storage", "planCode": "softraid-2x8000sa-24sk60-us", "mandatory": True},
     ]
-    codes = select_eco_option_codes(options, memory_gb=256, storage_short="softraid-2x8000sa")
+    codes = select_eco_option_codes(
+        options, memory_gb=256, storage_short="softraid-2x8000sa", explicit_option_codes=()
+    )
     assert set(codes) == {
         "ram-256g-ecc-2400-24sk60-us",
         "softraid-2x8000sa-24sk60-us",
@@ -113,7 +166,9 @@ def test_select_eco_option_codes_handles_plan_without_vrack() -> None:
 def test_select_eco_option_codes_skips_optional_addon_families() -> None:
     # An optional (mandatory=False) single-offer add-on family must never be auto-picked into the cart.
     options = _eco_options() + [{"family": "backup", "planCode": "backup-storage-500-us", "mandatory": False}]
-    codes = select_eco_option_codes(options, memory_gb=64, storage_short="softraid-2x512nvme")
+    codes = select_eco_option_codes(
+        options, memory_gb=64, storage_short="softraid-2x512nvme", explicit_option_codes=()
+    )
     assert "backup-storage-500-us" not in codes
 
 


### PR DESCRIPTION
## Summary

Operator-facing improvements to the imbue_cloud bare-metal / slice provisioning flow, made while standing up a new production bare-metal box in US-WEST (OVH `hil`, Hillsboro) and baking `minds-v0.3.1` slices onto it.

## Changes

- **`admin server order` requires explicit option selection.** Plans whose mandatory OVH eco option families (e.g. `bandwidth`, `vrack`) offer more than one choice previously failed to order (`expected exactly one X option to auto-pick`). Added a repeatable `--option <planCode>` flag; single-offer families are still auto-selected, and the error for an unspecified multi-offer family lists each offer with its monthly price so you can re-run. (An interim commit auto-picked the cheapest; that was replaced with the explicit flag per review.)

- **Slice baking requires an explicit `--server-id`.** `admin pool create --backend slice` (and the `minds pool create` wrapper) no longer auto-selects the box with the most free slots — you name the target box (from `admin server list`), validated ready + with enough free slots.

- **Fixed a box-prep bug that made every slice bake fail.** The prep script runs as root and staged the slice base image under the lima user's `~/.cache`, leaving `~/.cache` itself root-owned, so `limactl` (run as the lima user) couldn't create `~/.cache/lima` (`permission denied`). Prep now creates + chowns the cache-dir chain to the lima user and repairs an already-root-owned `~/.cache` on re-run.

- **Orphan reap now reclaims leaked data disks, not just VMs.** A failed carve whose rollback `limactl delete` can't unlock the disk leaves the disk behind (VM gone, disk still holding the box slot). The end-of-bake reap now reconciles the box's lima disks against the pool DB and force-deletes (unlocking first) any slice disk with no row.

## Testing

- Targeted unit suites green (ordering, bare_metal, bare_metal_db, bare_metal_prep, lima_slice_client, cli/admin, cli/server, minds cli/pool); `ty` type-check clean; CLI docs regenerated.
- Exercised end-to-end against real production OVH: ordered + delivered + set up the US-WEST box and baked 8 `minds-v0.3.1` slices (8/14 slots) successfully after these fixes.
- Full `just test-offload` not yet run locally — relying on CI here.

Changelog entries added for `mngr_imbue_cloud`, `minds`, and `mngr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
