### PR TITLE
drop incorrect modal/rsync marks from transcript release tests

### DIFF
--- a/libs/mngr/changelog/mngr-fix-transcript-test-marks.md
+++ b/libs/mngr/changelog/mngr-fix-transcript-test-marks.md
@@ -1,0 +1,1 @@
+Removed superfluous `@pytest.mark.modal`/`@pytest.mark.rsync` marks from two transcript release tests (`test_transcript_assistant_only`, `test_tips_transcript_tail_assistant`). Both run entirely against a local command agent with a locally-seeded transcript, so they never invoke modal or rsync; the marks tripped the resource guard and failed the otherwise-passing tests.

--- a/libs/mngr/imbue/mngr/e2e/tutorial/test_advanced.py
+++ b/libs/mngr/imbue/mngr/e2e/tutorial/test_advanced.py
@@ -427,7 +427,6 @@ def _seed_claude_transcript(host_dir: Path, events: list[dict[str, Any]]) -> Non
     (transcript_dir / "events.jsonl").write_text("\n".join(json.dumps(e) for e in events) + "\n")
 
 
-@pytest.mark.rsync
 @pytest.mark.release
 @pytest.mark.tmux
 def test_tips_transcript_tail_assistant(e2e: E2eSession, temp_host_dir: Path) -> None:

--- a/libs/mngr/imbue/mngr/e2e/tutorial/test_transcript.py
+++ b/libs/mngr/imbue/mngr/e2e/tutorial/test_transcript.py
@@ -181,10 +181,8 @@ def test_transcript_default(e2e: E2eSession) -> None:
     )
 
 
-@pytest.mark.rsync
 @pytest.mark.release
 @pytest.mark.tmux
-@pytest.mark.modal
 def test_transcript_assistant_only(e2e: E2eSession, temp_host_dir: Path) -> None:
     e2e.write_tutorial_block("""
         # view only assistant messages


### PR DESCRIPTION
Follow-up to the common-transcript-standard work (#2171), which is already merged into main.

## Problem
`test_transcript_assistant_only` and `test_tips_transcript_tail_assistant` carried `@pytest.mark.modal`/`@pytest.mark.rsync`, but both run entirely against a **local** command agent with a locally-seeded transcript (created via `mngr create --type command`, relabeled to `claude`, with `events.jsonl` seeded directly). They never provision a modal host or rsync to a remote, so the resource guard ("marked with `@pytest.mark.X` but never invoked X") failed both tests even though their assertions passed.

## Fix
Remove the `modal`/`rsync` marks. `@pytest.mark.tmux` is kept because mngr does run the agent in tmux (no tmux guard violation). Both tests now pass locally:

- `test_transcript_assistant_only`: 1 passed in 10.19s
- `test_tips_transcript_tail_assistant`: 1 passed in 8.12s

These are `@pytest.mark.release` tests, so they don't run in CI; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)