### PR TITLE
fix `mngr plugin list` mislabeling blocked claude_subagent_proxy as enabled

### DIFF
--- a/libs/mngr/changelog/mngr-subagent-proxy-begone.md
+++ b/libs/mngr/changelog/mngr-subagent-proxy-begone.md
@@ -1,1 +1,5 @@
-Fixed `mngr plugin list` mislabeling opt-in plugins (e.g. `claude_subagent_proxy`) as `enabled=true` when they are actually blocked. The reported `enabled` state now reflects the plugin's real block state: opt-in plugins that were not explicitly enabled show `enabled=false`, while a plugin enabled via `[plugins.<name>] enabled = true` still shows `enabled=true`.
+Fixed `mngr plugin list` mislabeling opt-in plugins (e.g. `claude_subagent_proxy`) as `enabled=true` when they are actually blocked.
+
+The reported `enabled` state now reflects the plugin's real block state: opt-in plugins that were not explicitly enabled show `enabled=false`, while a plugin enabled via `[plugins.<name>] enabled = true` still shows `enabled=true`.
+
+Underlying this, `config.disabled_plugins` now faithfully includes opt-in plugins that are disabled by default, so every consumer of that field (not just the plugin list) sees the correct effective disabled set. This is suppressed under `MNGR_LOAD_ALL_PLUGINS`, matching plugin-manager startup, so doc/tooling runs still load every plugin.

--- a/libs/mngr/changelog/mngr-subagent-proxy-begone.md
+++ b/libs/mngr/changelog/mngr-subagent-proxy-begone.md
@@ -1,0 +1,1 @@
+Fixed `mngr plugin list` mislabeling opt-in plugins (e.g. `claude_subagent_proxy`) as `enabled=true` when they are actually blocked. The reported `enabled` state now reflects the plugin's real block state: opt-in plugins that were not explicitly enabled show `enabled=false`, while a plugin enabled via `[plugins.<name>] enabled = true` still shows `enabled=true`.

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -130,12 +130,13 @@ def _gather_plugin_info(mngr_ctx: MngrContext) -> list[PluginInfo]:
             version = metadata.get("version")
             description = metadata.get("summary")
 
-        # A blocked plugin is never actually active, so report it as disabled
-        # even when config does not list it. Opt-in plugins (e.g.
-        # claude_subagent_proxy) are blocked in create_plugin_manager via
-        # read_disabled_plugins() but do not reach config.disabled_plugins, and
-        # pluggy still lists their name here with a None plugin object -- without
-        # this check they would be mislabeled enabled.
+        # pm is the ground truth for whether a plugin is active: a blocked plugin
+        # is never registered (pluggy still lists its name here with a None plugin
+        # object), so report it as disabled regardless of config. This catches
+        # blocks that config.disabled_plugins does not record -- e.g. command-default
+        # or create-template --disable-plugin, applied after load_config in
+        # setup_command_context -- without which such plugins would be mislabeled
+        # enabled.
         is_enabled = _is_plugin_enabled(name, mngr_ctx.config) and not pm.is_blocked(name)
 
         plugin_info_by_name[name] = PluginInfo(

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -130,7 +130,13 @@ def _gather_plugin_info(mngr_ctx: MngrContext) -> list[PluginInfo]:
             version = metadata.get("version")
             description = metadata.get("summary")
 
-        is_enabled = _is_plugin_enabled(name, mngr_ctx.config)
+        # A blocked plugin is never actually active, so report it as disabled
+        # even when config does not list it. Opt-in plugins (e.g.
+        # claude_subagent_proxy) are blocked in create_plugin_manager via
+        # read_disabled_plugins() but do not reach config.disabled_plugins, and
+        # pluggy still lists their name here with a None plugin object -- without
+        # this check they would be mislabeled enabled.
+        is_enabled = _is_plugin_enabled(name, mngr_ctx.config) and not pm.is_blocked(name)
 
         plugin_info_by_name[name] = PluginInfo(
             name=name,

--- a/libs/mngr/imbue/mngr/cli/plugin_test.py
+++ b/libs/mngr/imbue/mngr/cli/plugin_test.py
@@ -309,6 +309,62 @@ def test_gather_plugin_info_reflects_disabled_status() -> None:
     assert my_plugin.is_enabled is False
 
 
+def test_gather_plugin_info_reports_blocked_plugin_as_disabled() -> None:
+    """A blocked opt-in plugin must report disabled even when config does not list it.
+
+    Opt-in plugins (e.g. claude_subagent_proxy) are blocked in
+    create_plugin_manager via read_disabled_plugins() but never reach
+    config.disabled_plugins. pluggy still lists the blocked name with a None
+    plugin object, so without consulting pm.is_blocked() the plugin would be
+    mislabeled enabled. This asserts the reported state matches the block state.
+    """
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+
+    # Block a name without registering it and without listing it in config --
+    # exactly the opt-in-plugin shape.
+    pm.set_blocked("opt-in-plugin")
+    assert pm.is_blocked("opt-in-plugin")
+
+    config = MngrConfig()
+    mngr_ctx = MngrContext(
+        config=config,
+        pm=pm,
+        profile_dir=_fake_profile_dir(),
+    )
+
+    plugins = _gather_plugin_info(mngr_ctx)
+    opt_in = next(p for p in plugins if p.name == "opt-in-plugin")
+    assert opt_in.is_enabled is False
+
+
+def test_gather_plugin_info_reports_unblocked_plugin_as_enabled() -> None:
+    """A registered, unblocked plugin not listed as disabled reports enabled.
+
+    The complement of the blocked case: when an opt-in plugin is explicitly
+    enabled it is registered and not blocked, so it must report enabled=true.
+    """
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+
+    class OptInPlugin:
+        pass
+
+    pm.register(OptInPlugin(), name="opt-in-plugin")
+    assert not pm.is_blocked("opt-in-plugin")
+
+    config = MngrConfig()
+    mngr_ctx = MngrContext(
+        config=config,
+        pm=pm,
+        profile_dir=_fake_profile_dir(),
+    )
+
+    plugins = _gather_plugin_info(mngr_ctx)
+    opt_in = next(p for p in plugins if p.name == "opt-in-plugin")
+    assert opt_in.is_enabled is True
+
+
 def test_gather_plugin_info_skips_internal_plugins() -> None:
     """_gather_plugin_info should skip plugins with names starting with underscore."""
     pm = pluggy.PluginManager("mngr")

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -273,15 +273,32 @@ def load_config(
     config_dict["create_templates"] = config.create_templates
 
     # Apply CLI plugin overrides
-    config_dict["plugins"], config_dict["disabled_plugins"] = _apply_plugin_overrides(
+    config_dict["plugins"], cli_disabled_plugins = _apply_plugin_overrides(
         config_dict["plugins"],
         enabled_plugins,
         disabled_plugins,
     )
 
-    # Block disabled plugins so their hooks don't fire. This covers
-    # CLI-level --disable-plugin flags that weren't known at startup.
-    block_disabled_plugins(pm, config_dict["disabled_plugins"], is_strict=True)
+    # Block the CLI/[plugins.*] disabled set so their hooks don't fire. This covers
+    # CLI-level --disable-plugin flags that weren't known at startup; is_strict
+    # catches --disable-plugin typos (a name that is neither registered nor already
+    # blocked). Opt-in plugins are intentionally excluded here: create_plugin_manager
+    # already blocked them, so re-blocking would add nothing in production while
+    # tripping the strict check in the bare-pm path.
+    block_disabled_plugins(pm, cli_disabled_plugins, is_strict=True)
+
+    # Record disabled_plugins as the faithful union with the opt-in-derived set
+    # (OPT_IN_PLUGINS not explicitly enabled). _apply_plugin_overrides only sees
+    # [plugins.*] enabled flags, so on its own the field drops opt-in plugins (e.g.
+    # claude_subagent_proxy) that create_plugin_manager blocks -- which made
+    # `mngr plugin list` mislabel them enabled. Gated on MNGR_LOAD_ALL_PLUGINS
+    # exactly like create_plugin_manager, so tooling that loads every plugin keeps
+    # them enabled here too. Blocking is one-way (there is no unblock), so the union
+    # also stays truthful under --enable-plugin, which cannot un-block an opt-in plugin.
+    if parse_bool_env(os.environ.get("MNGR_LOAD_ALL_PLUGINS", "")):
+        config_dict["disabled_plugins"] = cli_disabled_plugins
+    else:
+        config_dict["disabled_plugins"] = cli_disabled_plugins | config_disabled_plugins
 
     # Include retry if not None
     if config.retry is not None:

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -44,6 +44,7 @@ from imbue.mngr.config.loader import load_config
 from imbue.mngr.config.loader import parse_config
 from imbue.mngr.config.plugin_registry import _plugin_config_registry
 from imbue.mngr.config.plugin_registry import register_plugin_config
+from imbue.mngr.config.pre_readers import OPT_IN_PLUGINS
 from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.plugins import hookspecs
 from imbue.mngr.primitives import AgentTypeName
@@ -941,6 +942,78 @@ def test_load_config_threads_every_field_from_toml(
     assert ".venv" in config.work_dir_extra_paths
     assert ".test_output" in config.work_dir_extra_paths
     assert config.allow_settings_key_assignment_narrowing is True
+
+
+def test_load_config_disabled_plugins_includes_opt_in_plugin(
+    monkeypatch: pytest.MonkeyPatch, temp_git_repo_cwd: Path, cg: ConcurrencyGroup
+) -> None:
+    """config.disabled_plugins must include opt-in plugins blocked by default.
+
+    Opt-in plugins (OPT_IN_PLUGINS) are blocked in create_plugin_manager but are
+    not [plugins.*] config entries, so _apply_plugin_overrides alone drops them.
+    load_config folds the opt-in-derived set back in so the field matches the
+    actual block state.
+    """
+    opt_in_name = next(iter(OPT_IN_PLUGINS))
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+    load_all_registries(pm)
+    # Mirror create_plugin_manager, which blocks opt-in plugins before load_config
+    # (and lets load_config's strict block pass re-affirm the block as a no-op).
+    pm.set_blocked(opt_in_name)
+
+    _isolate_load_config_env(monkeypatch)
+
+    mngr_ctx = load_config(pm=pm, concurrency_group=cg)
+    assert opt_in_name in mngr_ctx.config.disabled_plugins
+
+
+def test_load_config_disabled_plugins_excludes_explicitly_enabled_opt_in_plugin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, temp_git_repo_cwd: Path, cg: ConcurrencyGroup
+) -> None:
+    """An opt-in plugin explicitly enabled in config is not in disabled_plugins.
+
+    Mirrors the runtime: read_disabled_plugins() omits an opt-in plugin whose
+    config sets enabled = true, so create_plugin_manager does not block it and
+    the union must not add it back.
+    """
+    opt_in_name = next(iter(OPT_IN_PLUGINS))
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+    load_all_registries(pm)
+
+    _isolate_load_config_env(monkeypatch)
+
+    mngr_dir = tmp_path / ".mngr"
+    mngr_dir.mkdir(parents=True, exist_ok=True)
+    profile_dir = get_or_create_profile_dir(mngr_dir)
+    (profile_dir / "settings.toml").write_text(
+        f"is_allowed_in_pytest = true\n[plugins.{opt_in_name}]\nenabled = true\n"
+    )
+
+    mngr_ctx = load_config(pm=pm, concurrency_group=cg)
+    assert opt_in_name not in mngr_ctx.config.disabled_plugins
+
+
+def test_load_config_disabled_plugins_omits_opt_in_plugin_when_loading_all(
+    monkeypatch: pytest.MonkeyPatch, temp_git_repo_cwd: Path, cg: ConcurrencyGroup
+) -> None:
+    """MNGR_LOAD_ALL_PLUGINS keeps opt-in plugins out of disabled_plugins.
+
+    Doc/tooling runs set MNGR_LOAD_ALL_PLUGINS so create_plugin_manager blocks
+    nothing; the union must be gated the same way or it would mark opt-in plugins
+    disabled even though they are loaded.
+    """
+    opt_in_name = next(iter(OPT_IN_PLUGINS))
+    pm = pluggy.PluginManager("mngr")
+    pm.add_hookspecs(hookspecs)
+    load_all_registries(pm)
+
+    _isolate_load_config_env(monkeypatch)
+    monkeypatch.setenv("MNGR_LOAD_ALL_PLUGINS", "1")
+
+    mngr_ctx = load_config(pm=pm, concurrency_group=cg)
+    assert opt_in_name not in mngr_ctx.config.disabled_plugins
 
 
 # Sample values used by the regression tests above. When adding a new field to


### PR DESCRIPTION
claude_subagent_proxy keeps causing trouble by not being disabled in weird edge cases...

(here it was actually disabled it just didn't report that correctly)

---

## Problem

`mngr plugin list --fields name,enabled` reported `claude_subagent_proxy` (an opt-in plugin) as `enabled=true` even though it is actually blocked: after `create_plugin_manager()`, `pm.is_blocked("claude_subagent_proxy")` is `True` and its hooks never fire.

## Root cause

There were two divergent representations of "disabled":
- `read_disabled_plugins()` (the pre-reader) is opt-in-aware and is what `create_plugin_manager` uses to actually `set_blocked`.
- `config.disabled_plugins` is rebuilt by `_apply_plugin_overrides` from only the `[plugins.*]` enabled flags, so it **drops** the opt-in-derived set.

Separately, pluggy's `set_blocked` leaves the blocked name in `list_name_plugin()` with a `None` plugin object, so `_gather_plugin_info` still emitted it and `_is_plugin_enabled` (config-only) reported it enabled. Because blocking is strictly one-way (there is no `set_unblocked`), the field could diverge from `pm` in both directions.

## Fix

Two parts:

1. **Root fix (`loader.py`):** `load_config` now folds the opt-in-derived disabled set into `config.disabled_plugins`, so the field is faithful for *all* consumers (provider filtering, config validation, completion, the plugin list). Gated on `MNGR_LOAD_ALL_PLUGINS` exactly like `create_plugin_manager`, so doc/tooling runs still load every plugin. The CLI/`[plugins.*]` block pass is left untouched (opt-in plugins are already blocked at startup), preserving the strict `--disable-plugin` typo check.

2. **Display backstop (`plugin.py`):** `_gather_plugin_info` ANDs the config check with `not pm.is_blocked(name)`. `pm` is the runtime ground truth, and this catches blocks that never reach `config.disabled_plugins` — e.g. command-default / create-template `--disable-plugin`, applied after `load_config` in `setup_command_context`.

## Behavior

- Default (no explicit enable): `claude_subagent_proxy` → `enabled=false`; `pm.is_blocked()` is `True`. Agrees.
- `[plugins.claude_subagent_proxy] enabled = true`: → `enabled=true`, and actually loads. Agrees.
- `MNGR_LOAD_ALL_PLUGINS=1`: → `enabled=true` (loaded for tooling); not marked disabled.

All three verified end-to-end against a throwaway `MNGR_HOST_DIR` in a non-git cwd.

## Tests

- `loader_test.py`: opt-in plugin included in `disabled_plugins` by default; excluded when explicitly enabled; excluded under `MNGR_LOAD_ALL_PLUGINS`.
- `plugin_test.py`: blocked plugin reports disabled (fails without the display fix); unblocked complement reports enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)