### PR TITLE
Fix macOS forkserver SIGSEGV dropping latchkey permission nudges

### DIFF
--- a/apps/minds/changelog/gabriel-permission-message.md
+++ b/apps/minds/changelog/gabriel-permission-message.md
@@ -1,0 +1,5 @@
+Fixed a macOS bug where approving (or denying) a latchkey permission request could silently fail to notify the waiting agent, leaving it blocked with no confirmation in the chat.
+
+The in-app `mngr` caller forks a child from a pre-warmed forkserver; on macOS that child crashed (SIGSEGV) when `mngr` startup probed the system HTTP proxy, because the underlying Apple frameworks are not fork-safe. The proxy configuration is now resolved once in the parent process and reused in the child, so the child never makes the fork-unsafe call.
+
+Permission/file-sharing nudges are now also confirmed and retried: delivery is verified from `mngr message`'s structured output and retried within a short budget, so a transient failure no longer drops the notification silently.

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging.py
@@ -133,8 +133,8 @@ class MngrMessageSender(MutableModel):
             delivered = self.deliver(target, text)
             if delivered or time.monotonic() >= deadline:
                 break
-            # ``Event().wait`` rather than ``time.sleep`` so the wait is
-            # interruptible and consistent with the sibling onboarding poller.
+            # ``Event().wait`` rather than ``time.sleep``, matching the sibling
+            # onboarding poller's idiom for a plain inter-attempt pause.
             threading.Event().wait(timeout=self.delivery_retry_wait_seconds)
         if delivered:
             if attempt > 1:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging.py
@@ -8,6 +8,8 @@ so neither sibling has to import from the other.
 """
 
 import json
+import threading
+import time
 from typing import Final
 
 from loguru import logger
@@ -21,6 +23,12 @@ from imbue.minds.utils.mngr_caller import get_default_mngr_caller
 from imbue.mngr.primitives import AgentId
 
 _MNGR_MESSAGE_TIMEOUT_SECONDS: Final[float] = 30.0
+
+# A nudge can fail transiently (e.g. a forkserver child that dies before
+# delivering). Retry within this wall-clock budget before giving up so an
+# approval does not silently leave the agent blocked.
+_DEFAULT_DELIVERY_RETRY_BUDGET_SECONDS: Final[float] = 30.0
+_DEFAULT_DELIVERY_RETRY_WAIT_SECONDS: Final[float] = 2.0
 
 
 @pure
@@ -56,9 +64,10 @@ def stdout_reports_message_delivered(stdout: str) -> bool:
 class MngrMessageSender(MutableModel):
     """Wrapper around ``mngr message <agent-id> <text>``.
 
-    Failures are logged at warning level but never raised: the response
-    event has already been written, so an undelivered nudge is recoverable
-    (the agent will eventually wake up on its own).
+    A failed nudge is retried within a bounded budget and, if it still does not
+    land, logged but never raised: the response event has already been written,
+    so an undelivered nudge is recoverable (the agent will eventually wake up on
+    its own).
 
     Each ``mngr message`` runs through a :class:`MngrCaller`, which executes the
     CLI in a child forked from a pre-warmed forkserver rather than spawning a
@@ -74,16 +83,29 @@ class MngrMessageSender(MutableModel):
     concurrency_group: ConcurrencyGroup = Field(
         description="App concurrency group on which :meth:`send` dispatches the (non-blocking) delivery thread.",
     )
+    delivery_retry_budget_seconds: float = Field(
+        default=_DEFAULT_DELIVERY_RETRY_BUDGET_SECONDS,
+        description="Total wall-clock budget for retrying an undelivered nudge on the background thread.",
+    )
+    delivery_retry_wait_seconds: float = Field(
+        default=_DEFAULT_DELIVERY_RETRY_WAIT_SECONDS,
+        description="Wait between delivery retry attempts.",
+    )
 
     model_config = {"arbitrary_types_allowed": True, "frozen": False, "extra": "forbid"}
 
     def send(self, agent_id: AgentId, text: str) -> None:
-        """Fire-and-forget nudge: dispatch the message without blocking the caller.
+        """Fire-and-forget nudge: dispatch delivery (verify-and-retry) without blocking the caller.
 
-        The send runs on a thread tracked by :attr:`concurrency_group` and never raises -- failures are logged.
+        Runs on a thread tracked by :attr:`concurrency_group` and never raises.
+        The background work retries until the target confirms receipt (a
+        ``message_sent`` event, see :meth:`deliver`) or
+        :attr:`delivery_retry_budget_seconds` is exhausted, so a transient
+        failure -- e.g. a forkserver child that dies before delivering -- no
+        longer silently leaves the agent blocked. Failures are logged, not raised.
         """
         self.concurrency_group.start_new_thread(
-            self.try_send,
+            self._deliver_with_retries,
             args=(str(agent_id), text),
             name="mngr-message-send",
             is_checked=False,
@@ -92,38 +114,49 @@ class MngrMessageSender(MutableModel):
             ),
         )
 
-    def try_send(self, target: str, text: str) -> bool:
-        """Send a message to ``target`` (an agent id or name); return whether it succeeded.
+    def _deliver_with_retries(self, target: str, text: str) -> bool:
+        """Retry :meth:`deliver` until ``target`` confirms receipt or the budget runs out.
 
-        ``target`` is matched by ``mngr message`` against agent ids and
-        names, so onboarding can address the bootstrap-created chat agent
-        by its host name before its canonical id is known. Returns ``True``
-        when the invocation exits 0; logs the failure and returns ``False``
-        otherwise so pollers can retry.
+        Returns whether the message was ultimately delivered. Delivery is judged
+        by the ``message_sent`` event (not the exit code), so this recovers both
+        hard failures (a child that crashes without delivering) and the
+        "agent not matched yet" case. At least one attempt always runs; on
+        exhaustion it logs an error -- the response event is already persisted, so
+        the agent can still wake on its own, but the dropped nudge is now visible
+        rather than silent.
         """
-        # ``-m`` and ``--`` are required: ``mngr message`` treats every
-        # positional argument as an agent identifier (``nargs=-1``), so passing
-        # the text as a positional would be parsed as a second agent and the
-        # actual message content would be read from stdin (silently empty here).
-        result = self.mngr_caller.call(["message", "-m", text, "--", target], timeout=_MNGR_MESSAGE_TIMEOUT_SECONDS)
-        if result.returncode != 0:
-            logger.error(
-                "mngr message to target {} exited {}: {}",
-                target,
-                result.returncode,
-                result.stderr.strip(),
-            )
-            return False
-        return True
+        deadline = time.monotonic() + self.delivery_retry_budget_seconds
+        attempt = 0
+        delivered = False
+        while not delivered:
+            attempt += 1
+            delivered = self.deliver(target, text)
+            if delivered or time.monotonic() >= deadline:
+                break
+            # ``Event().wait`` rather than ``time.sleep`` so the wait is
+            # interruptible and consistent with the sibling onboarding poller.
+            threading.Event().wait(timeout=self.delivery_retry_wait_seconds)
+        if delivered:
+            if attempt > 1:
+                logger.info("mngr message to target {} delivered on attempt {}", target, attempt)
+            return True
+        logger.error(
+            "mngr message to target {} not delivered after {} attempt(s) within {:.0f}s; "
+            "the agent may stay blocked until it wakes on its own",
+            target,
+            attempt,
+            self.delivery_retry_budget_seconds,
+        )
+        return False
 
     def deliver(self, target: str, text: str) -> bool:
         """Send a message and return whether the TARGET agent actually received it.
 
-        Unlike :meth:`try_send`, delivery is judged from the structured
-        ``--format jsonl`` output (a ``message_sent`` event) rather than the
-        process exit code. ``mngr message`` exits 0 both when it delivers and
-        when no agent matches the target, so a caller that retries until the
-        agent exists must inspect the output, not the exit code.
+        Delivery is judged from the structured ``--format jsonl`` output (a
+        ``message_sent`` event) rather than the process exit code. ``mngr
+        message`` exits 0 both when it delivers and when no agent matches the
+        target, so a caller that retries until the agent exists (see
+        :meth:`_deliver_with_retries`) must inspect the output, not the exit code.
         """
         result = self.mngr_caller.call(
             ["message", "--format", "jsonl", "-m", text, "--", target], timeout=_MNGR_MESSAGE_TIMEOUT_SECONDS

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/messaging_test.py
@@ -21,26 +21,13 @@ def test_stdout_reports_delivered_ignores_non_json_and_error_events() -> None:
     assert stdout_reports_message_delivered(stdout) is False
 
 
-def test_try_send_builds_message_argv(root_concurrency_group: ConcurrencyGroup) -> None:
-    caller = RecordingMngrCaller()
-    sender = MngrMessageSender(mngr_caller=caller, concurrency_group=root_concurrency_group)
-
-    assert sender.try_send("some-agent", "hello") is True
-    # The text must go through ``-m`` and the target after ``--`` so it is not
-    # parsed as a second agent identifier.
-    assert caller.calls == [["message", "-m", "hello", "--", "some-agent"]]
-
-
-def test_try_send_returns_false_on_nonzero_exit(root_concurrency_group: ConcurrencyGroup) -> None:
-    caller = RecordingMngrCaller(result=MngrCallResult(returncode=1, stderr="agent missing"))
-    sender = MngrMessageSender(mngr_caller=caller, concurrency_group=root_concurrency_group)
-
-    assert sender.try_send("missing-agent", "hello") is False
-
-
-def test_send_does_not_raise_on_failure(root_concurrency_group: ConcurrencyGroup) -> None:
-    caller = RecordingMngrCaller(result=MngrCallResult(returncode=1, stderr="agent missing"))
-    sender = MngrMessageSender(mngr_caller=caller, concurrency_group=root_concurrency_group)
+def test_send_does_not_raise_when_delivery_never_succeeds(root_concurrency_group: ConcurrencyGroup) -> None:
+    # Exit 0 with no message_sent event => never "delivered"; with a zero retry
+    # budget the background loop makes one attempt, logs, and gives up.
+    caller = RecordingMngrCaller(result=MngrCallResult(returncode=0, stdout=""))
+    sender = MngrMessageSender(
+        mngr_caller=caller, concurrency_group=root_concurrency_group, delivery_retry_budget_seconds=0.0
+    )
 
     # Fire-and-forget: dispatching an eventually-failing send must not raise.
     sender.send(AgentId(), "hello")
@@ -48,7 +35,9 @@ def test_send_does_not_raise_on_failure(root_concurrency_group: ConcurrencyGroup
     assert caller.called_event.wait(5.0)
 
 
-def test_send_dispatches_on_concurrency_group_thread(root_concurrency_group: ConcurrencyGroup) -> None:
+def test_send_dispatches_verified_delivery_on_concurrency_group_thread(
+    root_concurrency_group: ConcurrencyGroup,
+) -> None:
     caller = RecordingMngrCaller()
     sender = MngrMessageSender(mngr_caller=caller, concurrency_group=root_concurrency_group)
     agent_id = AgentId()
@@ -57,7 +46,44 @@ def test_send_dispatches_on_concurrency_group_thread(root_concurrency_group: Con
     sender.send(agent_id, "hello")
 
     assert caller.called_event.wait(5.0)
-    assert caller.calls == [["message", "-m", "hello", "--", str(agent_id)]]
+    # send now verifies delivery via the structured (jsonl) output, and the
+    # default recording result reports a successful delivery, so it stops after
+    # one attempt.
+    assert caller.calls == [["message", "--format", "jsonl", "-m", "hello", "--", str(agent_id)]]
+
+
+def test_deliver_with_retries_succeeds_after_transient_failures(
+    root_concurrency_group: ConcurrencyGroup,
+) -> None:
+    delivered = MngrCallResult(returncode=0, stdout='{"event": "message_sent", "agent": "assistant"}\n')
+    # First two calls fail (a crashed child reports exit 1 / no message_sent
+    # event); the third delivers.
+    caller = RecordingMngrCaller(
+        result=delivered,
+        results=(MngrCallResult(returncode=1, stderr="boom"), MngrCallResult(returncode=1, stderr="boom"), delivered),
+    )
+    sender = MngrMessageSender(
+        mngr_caller=caller,
+        concurrency_group=root_concurrency_group,
+        delivery_retry_budget_seconds=5.0,
+        delivery_retry_wait_seconds=0.0,
+    )
+
+    assert sender._deliver_with_retries("assistant", "hello") is True
+    assert len(caller.calls) == 3
+
+
+def test_deliver_with_retries_gives_up_when_budget_exhausted(
+    root_concurrency_group: ConcurrencyGroup,
+) -> None:
+    caller = RecordingMngrCaller(result=MngrCallResult(returncode=1, stderr="boom"))
+    sender = MngrMessageSender(
+        mngr_caller=caller, concurrency_group=root_concurrency_group, delivery_retry_budget_seconds=0.0
+    )
+
+    # A zero budget still runs exactly one attempt before giving up.
+    assert sender._deliver_with_retries("assistant", "hello") is False
+    assert len(caller.calls) == 1
 
 
 def test_deliver_uses_jsonl_output_and_reports_delivered(root_concurrency_group: ConcurrencyGroup) -> None:

--- a/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined_test.py
+++ b/apps/minds/imbue/minds/desktop_client/latchkey/handlers/predefined_test.py
@@ -75,6 +75,11 @@ def _wait_for_recorded_mngr_argvs(handler: LatchkeyPermissionGrantHandler, timeo
     return caller.calls
 
 
+def _message_text(argv: list[str]) -> str:
+    """Return the message body passed to ``mngr message`` (the value after ``-m``)."""
+    return argv[argv.index("-m") + 1]
+
+
 def _read_recording(report_path: Path) -> list[dict[str, list[str] | str]]:
     """Parse the JSONL recording emitted by the fake latchkey binary."""
     if not report_path.exists():
@@ -633,7 +638,7 @@ def test_deny_sends_mngr_message(tmp_path: Path) -> None:
     mngr_argvs = _wait_for_recorded_mngr_argvs(handler)
     assert len(mngr_argvs) == 1
     argv = mngr_argvs[0]
-    assert "denied" in argv[2].lower()
+    assert "denied" in _message_text(argv).lower()
 
 
 def test_grant_calls_gateway_client_set_permission_and_delete_request(tmp_path: Path) -> None:
@@ -768,8 +773,9 @@ def test_apply_deny_request_succeeds_for_unknown_scope(tmp_path: Path) -> None:
     mngr_argvs = _wait_for_recorded_mngr_argvs(handler)
     assert len(mngr_argvs) == 1
     argv = mngr_argvs[0]
-    assert "denied" in argv[2].lower()
-    assert "not-in-catalog-scope" in argv[2]
+    message_text = _message_text(argv)
+    assert "denied" in message_text.lower()
+    assert "not-in-catalog-scope" in message_text
 
 
 def test_grant_preserves_existing_schemas_block_in_permissions_file(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/utils/mngr_caller.py
+++ b/apps/minds/imbue/minds/utils/mngr_caller.py
@@ -24,11 +24,13 @@ inherit the dynamic ``sys.path`` additions that pytest makes for test modules.
 """
 
 import contextlib
+import functools
 import io
 import os
 import sys
 import threading
 import traceback
+import urllib.request
 from collections.abc import Mapping
 from collections.abc import Sequence
 from multiprocessing.connection import Connection
@@ -61,6 +63,72 @@ _TERMINATE_JOIN_SECONDS: Final[float] = 5.0
 
 # Sentinel returncode used when a call is terminated for exceeding its timeout.
 _TIMEOUT_RETURNCODE: Final[int] = -1
+
+
+# Parent-resolved macOS proxy state handed to each child: the
+# ``urllib.request._get_proxies()`` result (scheme -> proxy URL) and the
+# ``urllib.request._get_proxy_settings()`` result (the raw settings dict
+# ``proxy_bypass`` consumes). ``None`` off macOS, where neither is fork-unsafe.
+_MacosProxyState = tuple[dict[str, str], dict[str, object]] | None
+
+
+@functools.cache
+def _resolve_macos_proxy_state() -> _MacosProxyState:
+    """Resolve macOS system-proxy state in the (fork-safe) parent process.
+
+    On macOS, ``urllib.request`` reaches the system proxy configuration through
+    two ``_scproxy`` C functions -- ``_get_proxies()`` (used by
+    ``getproxies()``/``getproxies_macosx_sysconf()``) and ``_get_proxy_settings()``
+    (used by ``proxy_bypass()``/``proxy_bypass_macosx_sysconf()``). Both call into
+    SystemConfiguration -> CoreFoundation -> libdispatch, which is NOT fork-safe:
+    invoking either from a forkserver child (forked without a following ``exec``)
+    segfaults (SIGSEGV via ``dispatch_apply``) before the child can return its
+    result -- exactly how the ``mngr message`` permission nudge was silently
+    dropped on macOS, because ``mngr`` startup makes an HTTP request whose client
+    calls ``proxy_bypass()``.
+
+    We therefore resolve both values HERE, in the long-lived parent process, which
+    was started via ``exec`` (not forked without exec) and so can call into
+    SystemConfiguration safely. (Doing so does not poison the forkserver: it is a
+    separate long-lived process, started before the first call, and CF state in
+    this parent does not propagate to it.) The result is handed to each child via
+    :func:`_neutralize_macos_proxy_lookup` so the child never probes the OS.
+
+    Cached because proxy configuration is effectively static for a process's
+    lifetime and each lookup is a SystemConfiguration syscall. Returns ``None``
+    off macOS, where these ``_scproxy`` functions do not exist and the proxy
+    lookup is already fork-safe.
+    """
+    if sys.platform != "darwin":
+        return None
+    # ``_get_proxies`` / ``_get_proxy_settings`` are darwin-only ``_scproxy``
+    # bindings that typeshed does not model.
+    proxies = urllib.request._get_proxies()  # ty: ignore[unresolved-attribute]
+    settings = urllib.request._get_proxy_settings()  # ty: ignore[unresolved-attribute]
+    return (dict(proxies), dict(settings))
+
+
+def _neutralize_macos_proxy_lookup(proxy_state: _MacosProxyState) -> None:
+    """Replace the fork-unsafe ``_scproxy`` calls with parent-resolved values.
+
+    Runs inside the throwaway forkserver child before the ``mngr`` CLI starts. It
+    overwrites ``urllib.request._get_proxies`` and
+    ``urllib.request._get_proxy_settings`` -- the two ``_scproxy`` C entry points
+    that segfault a forked-without-exec child -- with constant functions returning
+    the values the parent already resolved (see :func:`_resolve_macos_proxy_state`).
+    Every higher-level path (``getproxies()``, ``proxy_bypass()``) then keeps its
+    exact semantics (environment variables still take precedence) without ever
+    calling into SystemConfiguration.
+
+    Mutating module state like this in the long-lived backend would be
+    unacceptable, but this child is discarded after the single call. A no-op off
+    macOS (``proxy_state is None``).
+    """
+    if proxy_state is None:
+        return
+    proxies, settings = proxy_state
+    urllib.request._get_proxies = lambda: dict(proxies)  # ty: ignore[unresolved-attribute]
+    urllib.request._get_proxy_settings = lambda: dict(settings)  # ty: ignore[unresolved-attribute]
 
 
 class MngrCallResult(MutableModel):
@@ -97,6 +165,7 @@ def _run_mngr_cli_in_child(
     conn: Connection,
     argv: tuple[str, ...],
     env_overrides: Mapping[str, str],
+    macos_proxy_state: _MacosProxyState,
 ) -> None:
     """Run ``mngr <argv>`` in this forked child and send the result back over ``conn``.
 
@@ -104,10 +173,19 @@ def _run_mngr_cli_in_child(
     here is instant. All of mngr's global-state mutation (loguru, ``sys.argv``,
     stdout/stderr) is confined to this throwaway process, so it never affects
     the minds backend.
+
+    ``macos_proxy_state`` is the parent-resolved macOS system-proxy state;
+    installing it here keeps mngr's startup proxy lookup off the fork-unsafe
+    ``_scproxy`` path that would otherwise segfault this child (see
+    :func:`_neutralize_macos_proxy_lookup`).
     """
     stdout_buffer = io.StringIO()
     stderr_buffer = io.StringIO()
     returncode = 0
+    # Must run before the CLI starts: mngr's startup hooks make an HTTP request,
+    # whose client probes the system proxy, and on macOS that probe is fork-unsafe
+    # in this forked-without-exec child.
+    _neutralize_macos_proxy_lookup(macos_proxy_state)
     os.environ.update(env_overrides)
     sys.argv = ["mngr", *argv]
     # This inline import is the whole point of the forkserver: importing
@@ -225,7 +303,9 @@ class MngrCaller(MutableModel):
         try:
             child = context.Process(
                 target=_run_mngr_cli_in_child,
-                args=(send_conn, tuple(argv), dict(env_overrides or {})),
+                # ``_resolve_macos_proxy_state`` MUST be evaluated here in the
+                # parent: the same lookup inside the forked child segfaults on macOS.
+                args=(send_conn, tuple(argv), dict(env_overrides or {}), _resolve_macos_proxy_state()),
                 name="mngr-call",
             )
             child.start()

--- a/apps/minds/imbue/minds/utils/mngr_caller.py
+++ b/apps/minds/imbue/minds/utils/mngr_caller.py
@@ -97,7 +97,9 @@ def _resolve_macos_proxy_state() -> _MacosProxyState:
     Cached because proxy configuration is effectively static for a process's
     lifetime and each lookup is a SystemConfiguration syscall. Returns ``None``
     off macOS, where these ``_scproxy`` functions do not exist and the proxy
-    lookup is already fork-safe.
+    lookup is already fork-safe -- and also on macOS if those undocumented
+    functions are ever dropped or renamed (logging a warning), since there is
+    then nothing fork-unsafe for the child to neutralize.
     """
     if sys.platform != "darwin":
         return None

--- a/apps/minds/imbue/minds/utils/mngr_caller.py
+++ b/apps/minds/imbue/minds/utils/mngr_caller.py
@@ -102,9 +102,18 @@ def _resolve_macos_proxy_state() -> _MacosProxyState:
     if sys.platform != "darwin":
         return None
     # ``_get_proxies`` / ``_get_proxy_settings`` are darwin-only ``_scproxy``
-    # bindings that typeshed does not model.
-    proxies = urllib.request._get_proxies()  # ty: ignore[unresolved-attribute]
-    settings = urllib.request._get_proxy_settings()  # ty: ignore[unresolved-attribute]
+    # bindings that typeshed does not model. They are undocumented CPython
+    # internals; if a future interpreter drops or renames them there is nothing
+    # for the child to neutralize (the fork-unsafe call we guard against goes
+    # through these very functions), so skip cleanly rather than raising.
+    if not hasattr(urllib.request, "_get_proxies") or not hasattr(urllib.request, "_get_proxy_settings"):
+        logger.warning(
+            "urllib.request._get_proxies/_get_proxy_settings missing on this macOS Python; "
+            "skipping forkserver proxy neutralization (mngr CLI children may probe the system proxy)"
+        )
+        return None
+    proxies = urllib.request._get_proxies()
+    settings = urllib.request._get_proxy_settings()
     return (dict(proxies), dict(settings))
 
 

--- a/apps/minds/imbue/minds/utils/mngr_caller_test.py
+++ b/apps/minds/imbue/minds/utils/mngr_caller_test.py
@@ -1,5 +1,7 @@
 import multiprocessing.forkserver
 import multiprocessing.resource_tracker
+import sys
+import urllib.request
 from collections.abc import Iterator
 
 import pytest
@@ -7,6 +9,8 @@ import pytest
 from imbue.minds.utils.mngr_caller import MngrCallResult
 from imbue.minds.utils.mngr_caller import MngrCaller
 from imbue.minds.utils.mngr_caller import _coerce_exit_code
+from imbue.minds.utils.mngr_caller import _neutralize_macos_proxy_lookup
+from imbue.minds.utils.mngr_caller import _resolve_macos_proxy_state
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +51,42 @@ def test_call_result_defaults() -> None:
     assert result.stdout == ""
     assert result.stderr == ""
     assert result.is_timed_out is False
+
+
+def test_resolve_macos_proxy_state_matches_platform() -> None:
+    # macOS must resolve a (proxies, settings) pair from _scproxy in the parent;
+    # everywhere else the proxy lookup is already fork-safe, so there is nothing
+    # to resolve and the child neutralization is skipped.
+    state = _resolve_macos_proxy_state()
+    if sys.platform == "darwin":
+        assert state is not None
+        proxies, settings = state
+        assert isinstance(proxies, dict)
+        assert isinstance(settings, dict)
+    else:
+        assert state is None
+
+
+def test_neutralize_macos_proxy_lookup_is_noop_for_none() -> None:
+    # The off-macOS / nothing-to-install path must not raise.
+    _neutralize_macos_proxy_lookup(None)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="exercises the macOS _scproxy neutralization")
+def test_neutralize_macos_proxy_lookup_replaces_scproxy_entry_points() -> None:
+    # After neutralization, the macOS proxy lookups return the injected state and
+    # never call into SystemConfiguration (the call that segfaults a fork child).
+    sentinel_proxies = {"http": "http://proxy.example:8080"}
+    sentinel_settings: dict[str, object] = {"exclude_simple": True}
+    saved_get_proxies = urllib.request._get_proxies  # ty: ignore[unresolved-attribute]
+    saved_get_proxy_settings = urllib.request._get_proxy_settings  # ty: ignore[unresolved-attribute]
+    try:
+        _neutralize_macos_proxy_lookup((sentinel_proxies, sentinel_settings))
+        assert urllib.request.getproxies_macosx_sysconf() == sentinel_proxies  # ty: ignore[unresolved-attribute]
+        assert urllib.request._get_proxy_settings() == sentinel_settings  # ty: ignore[unresolved-attribute]
+    finally:
+        urllib.request._get_proxies = saved_get_proxies  # ty: ignore[unresolved-attribute]
+        urllib.request._get_proxy_settings = saved_get_proxy_settings  # ty: ignore[unresolved-attribute]
 
 
 # These two tests start a real multiprocessing forkserver and preload

--- a/apps/minds/imbue/minds/utils/testing.py
+++ b/apps/minds/imbue/minds/utils/testing.py
@@ -21,11 +21,26 @@ class RecordingMngrCaller(MngrCaller):
     Avoids forking a real forkserver child (which would import the full ``mngr``
     CLI), so tests stay fast and deterministic while still being able to assert
     on the argv the caller was invoked with.
+
+    The default result models a *successful* ``mngr message`` delivery (exit 0
+    with a ``message_sent`` event on stdout) so that
+    :meth:`MngrMessageSender.deliver` reports success and its verify-and-retry
+    loop completes on the first attempt. Tests exercising failure or retry pass
+    explicit results via :attr:`result` / :attr:`results`.
     """
 
     result: MngrCallResult = Field(
-        default_factory=lambda: MngrCallResult(returncode=0),
-        description="Canned result returned by every call.",
+        default_factory=lambda: MngrCallResult(
+            returncode=0, stdout='{"event": "message_sent", "agent": "recorded"}\n'
+        ),
+        description="Result returned for each call once ``results`` is exhausted (or for every call if ``results`` is empty).",
+    )
+    results: tuple[MngrCallResult, ...] = Field(
+        default=(),
+        description=(
+            "Optional per-call results returned in order; calls past the last one fall back to ``result``. "
+            "Lets a test model a call that fails then succeeds on retry."
+        ),
     )
     _calls: list[list[str]] = PrivateAttr(default_factory=list)
     _called_event: threading.Event = PrivateAttr(default_factory=threading.Event)
@@ -36,8 +51,11 @@ class RecordingMngrCaller(MngrCaller):
         timeout: float | None = None,
         env_overrides: Mapping[str, str] | None = None,
     ) -> MngrCallResult:
+        call_index = len(self._calls)
         self._calls.append(list(argv))
         self._called_event.set()
+        if call_index < len(self.results):
+            return self.results[call_index]
         return self.result
 
     @property


### PR DESCRIPTION
## Problem

On macOS, approving (or denying) a latchkey permission request in the minds desktop client silently failed to notify the waiting agent: the grant succeeded on the backend (permissions written, gateway request cleared) but no confirmation was injected into the agent's chat and the agent stayed `WAITING`.

## Root cause

The in-app `mngr` caller (`apps/minds/imbue/minds/utils/mngr_caller.py`) runs `mngr` in a child forked **without exec** from a multiprocessing forkserver (to avoid mngr's multi-second import cost per call). On macOS, mngr startup makes an HTTP request whose client calls `urllib.request.proxy_bypass(host)` → `proxy_bypass_macosx_sysconf` → `_scproxy._get_proxy_settings()` → `SCDynamicStoreCopyProxiesWithOptions`, which uses CoreFoundation / libdispatch. Those Apple frameworks are not fork-safe in a forked-without-exec process, so the child segfaulted (`dispatch_apply`, exit `-11`) before it could return its result. The parent saw EOF and logged `mngr child process exited without returning a result`; the `send()` nudge was fire-and-forget with no retry, so the failure was silent.

Confirmed by reproducing the crash and reading the macOS crash report's faulting stack — the unsafe path is `proxy_bypass` → `_get_proxy_settings`, not `getproxies_macosx_sysconf`.

## Fix

- **`mngr_caller.py`**: resolve the macOS proxy state once in the fork-safe parent process (`_resolve_macos_proxy_state`, `functools.cache`) and install it in each forkserver child (`_neutralize_macos_proxy_lookup`), replacing **both** `_scproxy` entry points (`urllib.request._get_proxies` and `urllib.request._get_proxy_settings`) before the CLI runs. `getproxies()`/`proxy_bypass()` keep their exact semantics (environment-variable proxies still take precedence); the OS is never probed from the child. Darwin-gated; a no-op elsewhere.
- **`messaging.py`** (hardening): `MngrMessageSender.send` now verifies delivery via the structured `message_sent` jsonl event (`deliver()`) and retries within a bounded time budget (`_deliver_with_retries`) instead of firing once. An exhausted budget logs at error level rather than dropping the nudge silently. Removed the now-dead `try_send`.

## Testing

- Reproduced the SIGSEGV and confirmed the corrected fix resolves it (manual, macOS): the real `mngr message` startup path now returns cleanly cold and prewarmed where it previously crashed.
- Added/updated unit tests for the proxy-state resolution/neutralization and the verify-and-retry loop.
- Targeted minds tests pass (mngr_caller, messaging, predefined, file_sharing, permission_routes, onboarding, ratchets); ruff, `ty`, and minds ratchets clean.

Note: the crash is macOS-only and cannot be reproduced in CI (Linux); it was reproduced and the fix verified manually on macOS during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)