### PR TITLE
Make minds discovery and mngr list callers robust to provider auth errors

### DIFF
--- a/blueprint/robust-minds-list-provider-errors/plan-robust-minds-list-provider-errors.md
+++ b/blueprint/robust-minds-list-provider-errors/plan-robust-minds-list-provider-errors.md
@@ -1,0 +1,48 @@
+# Robust handling of provider errors in minds discovery and `mngr list` callers
+
+## Refined prompt
+
+Make Minds/`mngr list` interactions principled about provider errors, now that unauthenticated providers raise `ProviderNotAuthorizedError` (a `ProviderUnavailableError` subclass) and `mngr list` exits **6** (`EXIT_CODE_PROVIDER_INACCESSIBLE`) instead of warning.
+
+* **Guiding principle:** each caller decides whether a provider error is acceptable. A **blanket** all-providers `mngr list` may treat exit 6 as benign (some providers unauthenticated is OK); a call **scoped** to a single agent / host / provider treats exit 6 as a real failure.
+* **Discovery is already robust — confirm only:** `mngr observe --discovery-only` (used by minds via latchkey-forward, and by FCT `agent_manager`) and FCT `agent_discovery.py` already call `list_agents(error_behavior=ErrorBehavior.CONTINUE)`; per-provider failures surface via `error_by_provider_name`, agents from healthy providers are retained, and the streams never crash.
+* **Fix — FCT `apps/system_interface/.../claude_auth.py`** (separate repo; work in `.external_worktrees/forever-claude-template` on the same branch; do **not** touch or commit `vendor/mngr` — it is synced automatically): this is a blanket caller. Add `--on-error continue` to `_build_list_command`, and treat exit 6 as success (parse the JSON body, use the authenticated providers' agents), keep raising `ClaudeAuthError` on other nonzero exits. Read the `errors[]` body and debug-log each skipped provider. Import the named `EXIT_CODE_PROVIDER_INACCESSIBLE` constant rather than hardcoding `6`.
+* **Fix — monorepo `justfile`** agent-name lookup recipe (`mngr list --format jsonl`): blanket caller — add `--on-error continue`.
+* **Fix — `libs/mngr_forward`**: add a `mngr forward --on-error {abort,continue}` flag (CLI-only, default `abort`, mirroring `mngr list`). Under `continue`, the `--no-observe` startup snapshot passes `--on-error continue` to its `mngr list` call and treats exit 6 as a partial success instead of raising. The flag gates **only** `--no-observe`; observe / `--observe-via-file` modes stay always-tolerant (their continuous nature can't meaningfully "abort"), documented in `--help`. SIGHUP re-snapshot is already tolerant and is unchanged.
+* **minds host-state probe (scoped):** keep exit 6 meaningful (it already feeds `WORKSPACE_UNREACHABLE`) and keep its current warning — no behavior change. minds is confirm-only: no `apps/minds` code change.
+* **FCT `agent_manager.py`:** keep the cwd workaround but update its now-stale comment (observe tolerates provider errors via `CONTINUE`; the cwd is kept only to scope to project providers / reduce noise).
+* **Tests:** unit-test the changed callers (FCT `claude_auth` argv includes `--on-error continue` and exit 6 yields agents instead of raising; `mngr_forward` snapshot argv includes `--on-error continue` under `continue` and treats exit 6 as partial success vs raises under `abort`). No new acceptance tests.
+* **Changelog:** entries for `dev/` (justfile), `libs/mngr_forward` (new flag), and FCT `apps/system_interface` (in its own repo). No `apps/minds` entry (confirm-only).
+
+## Overview
+
+- Background work already landed on the base branch (`josh/consistent-provider-auth-failures`): a consistent `ProviderNotAuthorizedError`, `mngr list --on-error continue` aggregation, and the granular `EXIT_CODE_PROVIDER_INACCESSIBLE = 6`. This branch makes the *callers* robust to that new contract.
+- The core principle is caller-local: an unauthenticated provider is acceptable for a blanket "show me everything" listing, but a real failure for a listing scoped to one agent/host/provider. We apply exit-6 tolerance only to blanket callers.
+- The continuous discovery paths (mngr observe stream consumed by minds and by FCT) are already tolerant; this branch confirms that and changes nothing there.
+- The remaining fragile callers are three blanket `mngr list` invocations that still inherit the default abort and/or raise on any nonzero exit: FCT `claude_auth.py`, the monorepo `justfile` lookup recipe, and `mngr forward --no-observe`'s startup snapshot.
+- minds itself needs no code change: its single `mngr list` call (the provider-scoped host-state probe) already passes `--on-error continue` and already classifies exit 6 as `WORKSPACE_UNREACHABLE`.
+
+## Expected behavior
+
+- An enabled-but-unauthenticated provider (e.g. `modal` configured in `~/.mngr` but not logged in) no longer breaks any blanket `mngr list` consumer.
+- **FCT claude auth recovery:** `list_claude_agent_names()` returns the `type: claude` agents from the authenticated providers even when another provider is unauthenticated; it raises `ClaudeAuthError` only on genuinely-bad exits (non-provider errors, exit 1) or unparseable output. Skipped providers are logged at debug.
+- **`just` agent-name lookup:** resolves a local agent's id even when an unrelated provider is unauthenticated, instead of returning empty / "no agent found".
+- **`mngr forward --no-observe`:** with `--on-error continue`, the forward server starts and serves the agents from healthy providers even if a provider is unauthenticated; with the default `--on-error abort`, behavior is unchanged (fails fast on the first provider error at startup).
+- **`mngr forward` observe / `--observe-via-file`:** unchanged — already tolerate provider errors and keep forwarding healthy agents; `--on-error` has no effect on these modes (and `--help` says so).
+- **minds workspace recovery:** unchanged — a workspace whose own (scoped) provider is unauthenticated still surfaces as `WORKSPACE_UNREACHABLE` with the existing warning, since exit 6 on a scoped probe is a real signal.
+- **minds continuous discovery:** unchanged — still degrades gracefully, retaining agents from errored providers and surfacing per-provider errors in the providers panel and workspace staleness.
+
+## Changes
+
+- **FCT `apps/system_interface/imbue/system_interface/claude_auth.py`** (in `.external_worktrees/forever-claude-template`):
+  - `_build_list_command` adds `--on-error continue`.
+  - `list_claude_agent_names` treats exit `EXIT_CODE_PROVIDER_INACCESSIBLE` (6) as success: parse the JSON body, debug-log each provider in `errors[]`, return the authenticated agents; keep raising `ClaudeAuthError` on other nonzero exits and on non-JSON / malformed output.
+  - Import `EXIT_CODE_PROVIDER_INACCESSIBLE` from mngr rather than hardcoding `6`.
+- **Monorepo `justfile`** agent-name lookup recipe: add `--on-error continue` to the `mngr list --format jsonl` invocation.
+- **`libs/mngr_forward`**:
+  - Add `--on-error {abort,continue}` (default `abort`) to the `forward` CLI options and the `ForwardCliOptions` dataclass; CLI-only (no `ForwardPluginConfig` field). Document in `--help` that it affects only `--no-observe`.
+  - Thread the choice from `_seed_resolver_from_snapshot` into `mngr_list_snapshot`, which under `continue` appends `--on-error continue` and treats exit 6 as a partial success (parse stdout) instead of raising `ForwardSubprocessError`; under `abort`, behavior is unchanged.
+- **FCT `apps/system_interface/imbue/system_interface/agent_manager.py`**: update the stale comment on the observe cwd workaround (no code change).
+- **minds**: confirm-only — no code change to the scoped host-state probe or discovery consumers.
+- **Tests**: unit tests for the FCT `claude_auth` argv + exit-6-as-success path, and for the `mngr_forward` snapshot argv + exit-6 handling under both flag values.
+- **Changelog**: per-PR entries for `dev/` (justfile), `libs/mngr_forward`, and FCT `apps/system_interface` (its own repo). No `apps/minds` entry.

--- a/dev/changelog/mngr-fix-minds-providers-errors.md
+++ b/dev/changelog/mngr-fix-minds-providers-errors.md
@@ -1,0 +1,7 @@
+- The `forward-system-interface` justfile recipe now resolves an agent's id with
+  `mngr list --on-error continue`, so an unauthenticated/unreachable provider no
+  longer aborts the lookup of a local agent.
+
+- Added the design blueprint for robust provider-error handling across minds
+  discovery and `mngr list` callers under
+  `blueprint/robust-minds-list-provider-errors/`.

--- a/justfile
+++ b/justfile
@@ -647,7 +647,9 @@ forward-system-interface agent_name:
     # hostname uniqueness, so the full id is what we want here -- not the
     # short name (which would let two agents with the same name across
     # different hosts collide in the tunnel namespace).
-    AGENT_ID=$(uv run mngr list --format jsonl 2>/dev/null \
+    # --on-error continue: this is a blanket listing, so an unauthenticated
+    # provider should not abort the lookup of a local agent.
+    AGENT_ID=$(uv run mngr list --format jsonl --on-error continue 2>/dev/null \
         | jq -r --arg n "$AGENT_NAME" 'select(.resource_type == "agent" and .name == $n) | .id' \
         | head -1)
     if [ -z "$AGENT_ID" ]; then

--- a/libs/mngr/changelog/mngr-fix-minds-providers-errors.md
+++ b/libs/mngr/changelog/mngr-fix-minds-providers-errors.md
@@ -1,0 +1,2 @@
+Regenerated the `mngr forward` command reference to document its new
+`--on-error {abort,continue}` option (provided by the mngr_forward plugin).

--- a/libs/mngr/docs/commands/secondary/forward.md
+++ b/libs/mngr/docs/commands/secondary/forward.md
@@ -55,6 +55,7 @@ mngr forward [OPTIONS]
 | `--reverse` | text | Reverse tunnel pair REMOTE:LOCAL. Repeatable. REMOTE may be 0 (sshd-assigned). | None |
 | `--no-observe` | boolean | Do not spawn `mngr observe` / `mngr event`; take a single `mngr list` snapshot instead. Requires --forward-port. | `False` |
 | `--observe-via-file` | boolean | Do not spawn `mngr observe`; instead tail the shared discovery events file written by another `mngr observe --discovery-only` (e.g. the one `mngr latchkey forward` runs). Per-agent `mngr event` streams are still spawned. Mutually exclusive with --no-observe. | `False` |
+| `--on-error` | choice (`abort` &#x7C; `continue`) | What to do when a provider errors during the `--no-observe` `mngr list` snapshot (both the startup snapshot and SIGHUP re-snapshots): abort (fail fast, the default) or continue (tolerate unauthenticated/unreachable providers and forward the agents the healthy providers reported). Has no effect in the observe / --observe-via-file modes, which always tolerate provider errors. | `abort` |
 | `--agent-include` | text | CEL expression to include agents (repeatable). Default: include every discovered agent. | None |
 | `--agent-exclude` | text | CEL expression to exclude agents (repeatable). | None |
 | `--event-include` | text | CEL expression to include `mngr event` source streams (repeatable). | None |

--- a/libs/mngr_forward/changelog/mngr-fix-minds-providers-errors.md
+++ b/libs/mngr_forward/changelog/mngr-fix-minds-providers-errors.md
@@ -1,0 +1,6 @@
+Added a `mngr forward --on-error {abort,continue}` flag (default `abort`). Under
+`continue`, the `--no-observe` startup snapshot tolerates an
+unauthenticated/unreachable provider: it runs `mngr list --on-error continue` and
+forwards the agents the healthy providers reported instead of failing to start.
+The flag affects only `--no-observe`; the observe and `--observe-via-file` modes
+already tolerate provider errors and are unchanged.

--- a/libs/mngr_forward/imbue/mngr_forward/cli.py
+++ b/libs/mngr_forward/imbue/mngr_forward/cli.py
@@ -25,6 +25,7 @@ from imbue.mngr.cli.help_formatter import CommandHelpMetadata
 from imbue.mngr.cli.help_formatter import add_pager_help_option
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.utils.cel_utils import apply_cel_filters_to_context
 from imbue.mngr.utils.cel_utils import compile_cel_filters
 from imbue.mngr.utils.parent_process import start_parent_death_watcher
@@ -60,6 +61,7 @@ class ForwardCliOptions(CommonCliOptions):
     reverse: tuple[str, ...] = ()
     no_observe: bool = False
     observe_via_file: bool = False
+    on_error: str = "abort"
     agent_include: tuple[str, ...] = ()
     agent_exclude: tuple[str, ...] = ()
     event_include: tuple[str, ...] = ()
@@ -180,6 +182,15 @@ def _bind_listen_socket(host: str, requested_port: int | None) -> socket.socket:
     help="Do not spawn `mngr observe`; instead tail the shared discovery events file written by another "
     "`mngr observe --discovery-only` (e.g. the one `mngr latchkey forward` runs). Per-agent `mngr event` "
     "streams are still spawned. Mutually exclusive with --no-observe.",
+)
+@click.option(
+    "--on-error",
+    type=click.Choice(["abort", "continue"], case_sensitive=False),
+    default="abort",
+    help="What to do when a provider errors during the `--no-observe` startup snapshot: abort (fail "
+    "fast, the default) or continue (tolerate unauthenticated/unreachable providers and forward the "
+    "agents the healthy providers reported). Has no effect in the observe / --observe-via-file modes, "
+    "which always tolerate provider errors.",
 )
 @click.option(
     "--agent-include",
@@ -419,7 +430,7 @@ def _seed_resolver_from_snapshot(
     on ``SIGHUP`` (``require_non_empty=False``: keeps the previous set on an
     empty snapshot, treating it as a transient).
     """
-    snapshot = mngr_list_snapshot()
+    snapshot = mngr_list_snapshot(error_behavior=ErrorBehavior(opts.on_error.upper()))
     kept = _filter_snapshot(snapshot, opts.agent_include, opts.agent_exclude)
     if not kept.agents:
         if require_non_empty:

--- a/libs/mngr_forward/imbue/mngr_forward/cli.py
+++ b/libs/mngr_forward/imbue/mngr_forward/cli.py
@@ -187,10 +187,10 @@ def _bind_listen_socket(host: str, requested_port: int | None) -> socket.socket:
     "--on-error",
     type=click.Choice(["abort", "continue"], case_sensitive=False),
     default="abort",
-    help="What to do when a provider errors during the `--no-observe` startup snapshot: abort (fail "
-    "fast, the default) or continue (tolerate unauthenticated/unreachable providers and forward the "
-    "agents the healthy providers reported). Has no effect in the observe / --observe-via-file modes, "
-    "which always tolerate provider errors.",
+    help="What to do when a provider errors during the `--no-observe` `mngr list` snapshot (both the "
+    "startup snapshot and SIGHUP re-snapshots): abort (fail fast, the default) or continue (tolerate "
+    "unauthenticated/unreachable providers and forward the agents the healthy providers reported). Has "
+    "no effect in the observe / --observe-via-file modes, which always tolerate provider errors.",
 )
 @click.option(
     "--agent-include",

--- a/libs/mngr_forward/imbue/mngr_forward/snapshot.py
+++ b/libs/mngr_forward/imbue/mngr_forward/snapshot.py
@@ -10,13 +10,14 @@ subprocess call.
 import json
 import os
 import subprocess
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
+from imbue.mngr.cli.exit_codes import EXIT_CODE_PROVIDER_INACCESSIBLE
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr_forward.data_types import ForwardAgentSnapshot
 from imbue.mngr_forward.data_types import ForwardListSnapshot
 from imbue.mngr_forward.errors import ForwardSubprocessError
@@ -28,19 +29,25 @@ def mngr_list_snapshot(
     mngr_binary: str = MNGR_BINARY,
     timeout_seconds: float = 30.0,
     extra_env: dict[str, str] | None = None,
+    error_behavior: ErrorBehavior = ErrorBehavior.ABORT,
 ) -> ForwardListSnapshot:
     """Run ``mngr list --format json`` once and parse the result.
 
     Returns a ``ForwardListSnapshot`` carrying every agent the user's mngr
     config currently sees, including labels and SSH info for remote hosts.
     Raises ``ForwardSubprocessError`` if the subprocess fails to spawn or
-    exits non-zero.
+    exits non-zero. Under ``ErrorBehavior.CONTINUE`` the snapshot passes
+    ``--on-error continue`` and tolerates an inaccessible/unauthenticated
+    provider (exit ``EXIT_CODE_PROVIDER_INACCESSIBLE``), forwarding the agents
+    the healthy providers still reported.
     """
-    command: Sequence[str] = (mngr_binary, "list", "--format", "json")
+    command: list[str] = [mngr_binary, "list", "--format", "json"]
+    if error_behavior == ErrorBehavior.CONTINUE:
+        command += ["--on-error", "continue"]
     cwd = Path.home()
     try:
         result = subprocess.run(  # noqa: S603 - command is fully controlled
-            list(command),
+            command,
             check=False,
             capture_output=True,
             text=True,
@@ -51,9 +58,21 @@ def mngr_list_snapshot(
     except (OSError, subprocess.TimeoutExpired) as e:
         raise ForwardSubprocessError(f"Failed to run `{' '.join(command)}`: {e}") from e
 
-    if result.returncode != 0:
+    # Under CONTINUE, an unauthenticated/unreachable provider makes `mngr list`
+    # exit EXIT_CODE_PROVIDER_INACCESSIBLE while still emitting the healthy
+    # providers' agents on stdout. Treat that as a partial success and forward
+    # what we can; any other nonzero exit is still a hard failure.
+    is_tolerated_provider_failure = (
+        error_behavior == ErrorBehavior.CONTINUE and result.returncode == EXIT_CODE_PROVIDER_INACCESSIBLE
+    )
+    if result.returncode != 0 and not is_tolerated_provider_failure:
         raise ForwardSubprocessError(
             f"`{' '.join(command)}` exited with code {result.returncode}: {result.stderr.strip()}"
+        )
+    if is_tolerated_provider_failure:
+        logger.debug(
+            "Tolerated inaccessible providers from `mngr list` (exit {}); forwarding agents from the healthy providers",
+            result.returncode,
         )
 
     return _parse_snapshot(result.stdout)

--- a/libs/mngr_forward/imbue/mngr_forward/snapshot_test.py
+++ b/libs/mngr_forward/imbue/mngr_forward/snapshot_test.py
@@ -1,9 +1,35 @@
 import json
+import stat
 from pathlib import Path
 
+import pytest
+
+from imbue.mngr.cli.exit_codes import EXIT_CODE_PROVIDER_INACCESSIBLE
+from imbue.mngr.primitives import ErrorBehavior
+from imbue.mngr_forward.errors import ForwardSubprocessError
 from imbue.mngr_forward.snapshot import _parse_snapshot
+from imbue.mngr_forward.snapshot import mngr_list_snapshot
 from imbue.mngr_forward.testing import TEST_AGENT_ID_1
 from imbue.mngr_forward.testing import TEST_AGENT_ID_2
+
+
+def _write_fake_mngr(script_path: Path, argv_record_path: Path, stdout_payload: str, exit_code: int) -> None:
+    """Write an executable fake `mngr` that records its argv and emits a fixed payload.
+
+    Lets the snapshot tests exercise the real subprocess + exit-code path
+    without mocking: `mngr_list_snapshot` accepts the binary path directly.
+    """
+    script_path.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" > {argv_record_path}\n'
+        f"cat <<'PAYLOAD_EOF'\n{stdout_payload}\nPAYLOAD_EOF\n"
+        f"exit {exit_code}\n"
+    )
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _single_agent_payload() -> str:
+    return json.dumps({"agents": [{"id": str(TEST_AGENT_ID_1), "labels": {}}], "errors": []})
 
 
 def test_parse_empty_snapshot_returns_no_agents() -> None:
@@ -104,3 +130,44 @@ def test_parse_snapshot_defaults_missing_filter_fields_to_empty_string() -> None
     assert entry.agent_name == ""
     assert entry.host_id == ""
     assert entry.provider_name == ""
+
+
+def test_mngr_list_snapshot_omits_on_error_under_abort(tmp_path: Path) -> None:
+    script = tmp_path / "fake_mngr"
+    argv_record = tmp_path / "argv.txt"
+    _write_fake_mngr(script, argv_record, _single_agent_payload(), exit_code=0)
+    mngr_list_snapshot(mngr_binary=str(script), error_behavior=ErrorBehavior.ABORT)
+    assert "--on-error" not in argv_record.read_text()
+
+
+def test_mngr_list_snapshot_passes_on_error_continue(tmp_path: Path) -> None:
+    script = tmp_path / "fake_mngr"
+    argv_record = tmp_path / "argv.txt"
+    _write_fake_mngr(script, argv_record, _single_agent_payload(), exit_code=0)
+    mngr_list_snapshot(mngr_binary=str(script), error_behavior=ErrorBehavior.CONTINUE)
+    assert "--on-error continue" in argv_record.read_text()
+
+
+def test_mngr_list_snapshot_tolerates_provider_inaccessible_exit_under_continue(tmp_path: Path) -> None:
+    script = tmp_path / "fake_mngr"
+    argv_record = tmp_path / "argv.txt"
+    _write_fake_mngr(script, argv_record, _single_agent_payload(), exit_code=EXIT_CODE_PROVIDER_INACCESSIBLE)
+    result = mngr_list_snapshot(mngr_binary=str(script), error_behavior=ErrorBehavior.CONTINUE)
+    assert len(result.agents) == 1
+    assert result.agents[0].agent_id == TEST_AGENT_ID_1
+
+
+def test_mngr_list_snapshot_raises_on_provider_inaccessible_exit_under_abort(tmp_path: Path) -> None:
+    script = tmp_path / "fake_mngr"
+    argv_record = tmp_path / "argv.txt"
+    _write_fake_mngr(script, argv_record, _single_agent_payload(), exit_code=EXIT_CODE_PROVIDER_INACCESSIBLE)
+    with pytest.raises(ForwardSubprocessError):
+        mngr_list_snapshot(mngr_binary=str(script), error_behavior=ErrorBehavior.ABORT)
+
+
+def test_mngr_list_snapshot_raises_on_other_nonzero_exit_under_continue(tmp_path: Path) -> None:
+    script = tmp_path / "fake_mngr"
+    argv_record = tmp_path / "argv.txt"
+    _write_fake_mngr(script, argv_record, _single_agent_payload(), exit_code=1)
+    with pytest.raises(ForwardSubprocessError):
+        mngr_list_snapshot(mngr_binary=str(script), error_behavior=ErrorBehavior.CONTINUE)


### PR DESCRIPTION
## Summary

Now that unauthenticated providers raise `ProviderNotAuthorizedError` and `mngr list` exits `EXIT_CODE_PROVIDER_INACCESSIBLE` (6) instead of warning, make the blanket `mngr list` callers tolerate that exit code. Scoped callers (single agent/host/provider) still treat it as a real failure.

Plan: `blueprint/robust-minds-list-provider-errors/plan-robust-minds-list-provider-errors.md`.

## Changes (this repo)

- **`libs/mngr_forward`**: new `mngr forward --on-error {abort,continue}` flag (default `abort`). Under `continue`, the `--no-observe` startup snapshot runs `mngr list --on-error continue` and tolerates exit 6, forwarding the agents the healthy providers reported. The flag affects only `--no-observe`; observe / `--observe-via-file` modes already tolerate provider errors and are unchanged.
- **`justfile`**: the `forward-system-interface` agent-lookup recipe now runs `mngr list --on-error continue`.

## Companion change (forever-claude-template repo)

The FCT `system_interface` `claude_auth.py` change (list with `--on-error continue`, treat exit 6 as benign) is committed on the same branch in that repo; it reaches this repo's `vendor/mngr` automatically and is not committed here.

## Confirmed already-robust (no change)

- minds continuous discovery (`mngr observe --discovery-only` via latchkey-forward) and FCT `agent_discovery.py` already use `ErrorBehavior.CONTINUE`.
- minds' only `mngr list` call (the provider-scoped host-state probe) already passes `--on-error continue` and correctly treats exit 6 as `WORKSPACE_UNREACHABLE`.

## Testing

- `libs/mngr_forward`: 241 fast tests + 56 ratchets pass; `ty check` clean. New snapshot tests cover argv and exit-6 handling under both flag values.
- FCT `system_interface`: 468 tests + new claude_auth tests pass (run in the FCT repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)