### PR TITLE
Bundle the overlay workspace package in the minds build

### DIFF
--- a/apps/minds/changelog/mngr-fix-minds-build-overlay-package.md
+++ b/apps/minds/changelog/mngr-fix-minds-build-overlay-package.md
@@ -1,0 +1,3 @@
+Fix `just minds-build` failing during `uv lock` with "no version of overlay==0.1.0".
+
+`imbue-mngr` now depends on the unpublished workspace package `overlay`, but it was missing from the build's hand-maintained bundled-package lists, so no wheel was built for it and uv fell back to (nonexistent) PyPI. Added `overlay` to all four mirrored lists (`scripts/build.js`, `electron/env-setup.js`, `scripts/build_test.py`, and `electron/pyproject/pyproject.toml`) so it is bundled as a wheel and resolved locally.

--- a/apps/minds/electron/env-setup.js
+++ b/apps/minds/electron/env-setup.js
@@ -58,6 +58,7 @@ function runEnvSetup(onProgress) {
       'concurrency-group',
       'resource-guards',
       'modal-proxy',
+      'overlay',
     ];
 
     const args = [

--- a/apps/minds/electron/pyproject/pyproject.toml
+++ b/apps/minds/electron/pyproject/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "concurrency-group>=0.1.0",
     "resource-guards>=0.1.0",
     "modal-proxy>=0.1.0",
+    "overlay>=0.1.0",
 ]
 
 # Supply-chain hardening: rolling 14-day cooldown. Refuses any wheel /
@@ -52,3 +53,4 @@ imbue-common = { path = "../../../../libs/imbue_common", editable = true }
 concurrency-group = { path = "../../../../libs/concurrency_group", editable = true }
 resource-guards = { path = "../../../../libs/resource_guards", editable = true }
 modal-proxy = { path = "../../../../libs/modal_proxy", editable = true }
+overlay = { path = "../../../../libs/overlay", editable = true }

--- a/apps/minds/scripts/build.js
+++ b/apps/minds/scripts/build.js
@@ -61,6 +61,7 @@ const WORKSPACE_PACKAGES = {
   'concurrency-group':      'libs/concurrency_group',
   'resource-guards':        'libs/resource_guards',
   'modal-proxy':            'libs/modal_proxy',
+  'overlay':                'libs/overlay',
 };
 
 /**

--- a/apps/minds/scripts/build_test.py
+++ b/apps/minds/scripts/build_test.py
@@ -56,6 +56,7 @@ WORKSPACE_PACKAGES = [
     "concurrency-group",
     "resource-guards",
     "modal-proxy",
+    "overlay",
 ]
 
 APP_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Problem

`just minds-build` fails during `uv lock`:

```
Because there is no version of overlay==0.1.0 and imbue-mngr==0.2.17
depends on overlay==0.1.0, we can conclude that imbue-mngr==0.2.17
cannot be used.
```

## Root cause

`imbue-mngr` recently gained a dependency on the workspace package `overlay` (`libs/overlay`), an internal, unpublished lib. The minds build bundles each workspace package as a wheel and stages a runtime `pyproject.toml` with path-overrides to those wheels. But `overlay` was never added to the four hand-maintained bundled-package lists, so no `overlay` wheel was built and it had no path source. As the comment in the staged pyproject warns, uv ignores source overrides for transitive-only packages and falls back to PyPI -- where `overlay` does not exist -- so resolution fails.

## Fix

Add `overlay` (-> `libs/overlay`) to all four lists the `test_workspace_package_lists_are_consistent` drift guard enforces:

- `apps/minds/scripts/build.js` (`WORKSPACE_PACKAGES` object)
- `apps/minds/electron/env-setup.js` (`WORKSPACE_PACKAGES` array)
- `apps/minds/scripts/build_test.py` (`WORKSPACE_PACKAGES` list)
- `apps/minds/electron/pyproject/pyproject.toml` (`[project] dependencies` and `[tool.uv.sources]`)

## Testing

- `just test-quick apps/minds/scripts/build_test.py` -- 4 passed, 0 failed (includes the drift guard).
- `uv build --package overlay --wheel` builds `overlay-0.1.0-py3-none-any.whl`.
- Reproduced the failing build step: staged the runtime pyproject with `overlay` added pointing at the bundled wheel and ran `uv lock` -- resolves cleanly (140 packages), with `overlay` resolved from `../wheels/overlay-0.1.0-py3-none-any.whl`. The original failure no longer occurs.
