### PR TITLE
minds 0.3.2: bump version + FALLBACK_BRANCH to minds-v0.3.2

### DIFF
--- a/apps/minds/changelog/mngr-minds-v0.3.2.md
+++ b/apps/minds/changelog/mngr-minds-v0.3.2.md
@@ -1,0 +1,1 @@
+Bump the minds desktop app to 0.3.2 and point `FALLBACK_BRANCH` at the `minds-v0.3.2` forever-claude-template tag, so a shipped 0.3.2 binary clones the FCT snapshot it was verified against.

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -244,7 +244,7 @@ _FALLBACK_HOST_NAME: Final[str] = "assistant"
 # Pin to an annotated FCT tag so a shipped binary clones the exact FCT
 # snapshot it was verified against. Bump to a newer tag only after
 # re-verifying launch-to-msg CI against (this binary, the new tag).
-FALLBACK_BRANCH: Final[str] = "minds-v0.3.1"
+FALLBACK_BRANCH: Final[str] = "minds-v0.3.2"
 
 # Env var (set by ``just minds-start`` and the e2e workspace runner) that opts a
 # launch into the operator's local-worktree create-form defaults. Gating on an

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minds",
   "productName": "Minds",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",
   "author": "Imbue <dev@imbue.com>",


### PR DESCRIPTION
mngr side of the **minds 0.3.2** release, following `apps/minds/docs/release.md`.

**Step 1 (this PR):**
- `apps/minds/package.json` `version` → `0.3.2`
- `apps/minds/imbue/minds/desktop_client/templates.py` `FALLBACK_BRANCH` → `minds-v0.3.2`

The `minds-v0.3.2` FCT tag does not exist yet; it is created at step 7 after the verified pair is tagged. Until then, launch-to-msg overrides the FCT ref via `template_ref`, so the baked tag is only exercised at step 8.

**Remaining release steps (tracked, not done here):**
- [ ] 2. `ci.yml` green on this branch (and the FCT PR branch)
- [ ] 3. FCT PR: refresh `vendor/mngr` from this branch's green SHA (`just sync-vendor-mngr`)
- [ ] 4. Prove the pair green pre-merge (`minds-launch-to-msg` dispatch, `commit_sha`=this SHA, `template_ref`=FCT PR branch)
- [ ] 5. Review + approve both PRs
- [ ] 6. Merge both to `main` (merge commit, not squash)
- [ ] 7. Tag the verified mngr SHA + matching FCT commit `minds-v0.3.2` (annotated)
- [ ] 8. Close the loop: launch-to-msg on the two tags
- [ ] 9. Optional: dev verify + ship via ToDesktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)