### PR TITLE
Consolidate vendor/mngr sync docs (git archive / rsync)

### DIFF
--- a/.claude/skills/minds-dev-workflow/SKILL.md
+++ b/.claude/skills/minds-dev-workflow/SKILL.md
@@ -170,7 +170,7 @@ If this chain breaks (orphaned `mngr observe`/`mngr event` processes appear), so
 
 ### Editable installs
 
-The Dockerfile uses `uv tool install -e` for mngr (vendored under `vendor/mngr/`) and for the system_interface (at `apps/system_interface/`), so Python code changes in either location are picked up immediately after rsync. Frontend changes require the `npm run build` step (done automatically by `propagate_changes`).
+The FCT Docker build installs mngr (`vendor/mngr/libs/mngr`) and the system_interface (`apps/system_interface/`) editable via `uv tool install -e`, run by `scripts/build_workspace.sh` (which the Dockerfile invokes with `RUN bash`), so Python code changes in either location are picked up immediately after rsync. Frontend changes require the `npm run build` step (done automatically by `propagate_changes`).
 
 ### Template settings
 

--- a/.claude/skills/minds-dev-workflow/SKILL.md
+++ b/.claude/skills/minds-dev-workflow/SKILL.md
@@ -164,18 +164,7 @@ If this chain breaks (orphaned `mngr observe`/`mngr event` processes appear), so
 
 ### Rsync exclusions
 
-`just minds-start`, `mngr imbue_cloud admin pool create --mngr-source ...`, and `propagate_changes` all share one form when rsyncing into `vendor/mngr/`:
-
-```
-rsync -a --delete --filter=':- .gitignore' --exclude=.git --exclude=uv.lock ...
-```
-
-`--filter=':- .gitignore'` is rsync's dir-merge filter: it reads `.gitignore` at each directory level under the source and applies its `-` (exclude) rules. That covers `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `.external_worktrees`, and anything else listed in the source repo's gitignore.
-
-The two manual excludes are for things gitignore deliberately doesn't list:
-
-- `.git` -- gitignore never lists it (git's internal dir).
-- `uv.lock` -- intentionally committed at the mngr root, but each install context should regenerate its own.
+`just minds-start`, `mngr imbue_cloud admin pool create --mngr-source ...`, and `propagate_changes` all rsync into `vendor/mngr/` using one shared form (`rsync -a --delete --filter=':- .gitignore' --exclude=.git --exclude=uv.lock`). The form, the rationale for each exclude, and the source-of-truth constants live in `apps/minds/docs/vendor-mngr-sync.md`.
 
 `propagate_changes` additionally protects `runtime/`, `.mngr/`, and `.claude/settings.local.json` from deletion when rsyncing into `/code/`.
 

--- a/.claude/skills/minds-justfile/SKILL.md
+++ b/.claude/skills/minds-justfile/SKILL.md
@@ -80,7 +80,7 @@ Desktop client / dev loop:
 - `just minds-start` / `just minds-stop` / `just minds-build`
 - `just propagate-changes <agent>` -- sync local mngr into a running Docker agent.
 - `just forward-system-interface <agent>` -- Cloudflare tunnel for an agent.
-- `just sync-vendor-mngr [fct]` -- sync `vendor/mngr` in forever-claude-template.
+- `just sync-vendor-mngr [fct]` -- sync `vendor/mngr` in forever-claude-template via `git archive` (committed snapshot; release flow). See `apps/minds/docs/vendor-mngr-sync.md`.
 - `just create-new-mind-repo <name> [parent_dir]` -- new private FCT clone.
 - `just minds-tailwind` -- fetch the Tailwind bundle.
 

--- a/apps/minds/changelog/mngr-doc-update-git.md
+++ b/apps/minds/changelog/mngr-doc-update-git.md
@@ -1,0 +1,3 @@
+Added `apps/minds/docs/vendor-mngr-sync.md` as the single source of truth for how FCT's `vendor/mngr` is synced: the two mechanisms (`git archive` for reproducible, committed release snapshots; `rsync` for working-tree dev iteration and pool bakes), the shared rsync form and where its exclude constants live (`pool_bake.py`), the three paths that populate `vendor/mngr` from the monorepo, and a note that `vendor/mngr` and `vendor/tk` are plain snapshots -- not git subtrees or submodules.
+
+Pointed `release.md` (the vendor-refresh step) and `host-pool-setup.md` (the `--mngr-source` bake rsync) at the new doc instead of partially re-explaining the mechanisms in place.

--- a/apps/minds/docs/host-pool-setup.md
+++ b/apps/minds/docs/host-pool-setup.md
@@ -176,10 +176,11 @@ When a user creates an imbue_cloud workspace, minds makes up to two `mngr create
 So a pool whose rows are baked at an older `repo_branch_or_tag` no longer hard-fails newer workspace creations -- they fall back to the slow path. Keeping the pool baked at the current version is still worthwhile because it keeps creations on the fast path. Only when the pool is genuinely empty (no `available` rows) does creation fail, with `ImbueCloudLeaseUnavailableError`.
 
 To rsync the local mngr working tree into the FCT worktree's `vendor/mngr/`
-for the duration of the bake (dev-loop pattern), forward `--mngr-source
-<monorepo-root>` as an extra flag through the recipe. The bake resets
-`vendor/mngr/` to HEAD when it finishes, so the worktree stays clean wrt mngr
-churn.
+for the duration of the bake (dev-loop pattern; see
+`apps/minds/docs/vendor-mngr-sync.md` for the sync mechanisms), forward
+`--mngr-source <monorepo-root>` as an extra flag through the recipe. The bake
+resets `vendor/mngr/` to HEAD when it finishes, so the worktree stays clean wrt
+mngr churn.
 
 List the rows (with the tier activated):
 

--- a/apps/minds/docs/release.md
+++ b/apps/minds/docs/release.md
@@ -66,7 +66,7 @@ For an iteration of the same version, skip. To bump: set `apps/minds/package.jso
 
 On the FCT PR branch (cut from `origin/main`, clean tree), with the **mngr checkout positioned at the green SHA from step 2** (i.e. on the mngr release PR branch), run the sync recipe.
 
-`just sync-vendor-mngr` reads `FCT_DIR` from your `apps/minds/.env` (Session setup) — no path is baked into the justfile. It does `git archive HEAD` → FCT `vendor/mngr` (tracked files only; keep `apps/minds/`), commits `Sync vendor/mngr to <branch> (<short>)`, aborts if FCT is dirty, and **does not push** — it prints the exact `cd … && git push` line (with the resolved FCT path) for you to run.
+`just sync-vendor-mngr` reads `FCT_DIR` from your `apps/minds/.env` (Session setup) — no path is baked into the justfile. It does `git archive HEAD` → FCT `vendor/mngr` (tracked files only; keep `apps/minds/`), commits `Sync vendor/mngr to <branch> (<short>)`, aborts if FCT is dirty, and **does not push** — it prints the exact `cd … && git push` line (with the resolved FCT path) for you to run. For why releases use `git archive` (vs the dev loop's `rsync`), see `apps/minds/docs/vendor-mngr-sync.md`.
 
 ```bash
 just sync-vendor-mngr                       # reads FCT_DIR from .env

--- a/apps/minds/docs/vendor-mngr-sync.md
+++ b/apps/minds/docs/vendor-mngr-sync.md
@@ -1,0 +1,73 @@
+# How `vendor/mngr` is synced
+
+`forever-claude-template` (FCT) vendors a full copy of the mngr monorepo at
+`vendor/mngr/`. The FCT `Dockerfile` builds the container's `mngr` from that
+directory (`uv tool install -e`), so whatever lands in `vendor/mngr/` *is* the
+mngr that runs inside every agent.
+
+`vendor/mngr/` is a plain copied-in snapshot. It is **not** a git subtree and
+**not** a git submodule -- never run `git subtree` or `git submodule` against
+it. It is refreshed by copying mngr's files in, via one of two mechanisms.
+
+## The two mechanisms
+
+| Mechanism | Form | Carries | Commits in FCT? | Used for |
+|---|---|---|---|---|
+| **`git archive`** | `git archive HEAD` -> wipe `vendor/mngr/` -> untar | committed/tracked files at an exact SHA; permissions normalized; reproducible | yes | releases |
+| **`rsync`** | `rsync -a --delete --filter=':- .gitignore' --exclude=.git --exclude=uv.lock` | the working tree, including uncommitted edits, gitignore-filtered | no | dev iteration and pool bakes |
+
+Use **archive** for a reproducible, committed snapshot tied to an exact mngr SHA
+(the release flow). Use **rsync** to get your *uncommitted* local mngr changes
+into a container without a commit (the dev loop, and baking a pool host from a
+working tree).
+
+## `git archive` -- the release sync
+
+`just sync-vendor-mngr [fct-path]` (root `justfile`) archives mngr `HEAD`,
+replaces `vendor/mngr/` with the snapshot, and commits in FCT. It carries only
+committed content, so position your mngr checkout at the exact commit you want
+to vendor first. The full release procedure -- including the vendor-match
+invariant (FCT `vendor/mngr` must be the `git archive` of the exact mngr SHA it
+is tagged with) -- is in `apps/minds/docs/release.md`.
+
+## `rsync` -- the dev / bake sync
+
+Every rsync path uses one form:
+
+```
+rsync -a --delete --filter=':- .gitignore' --exclude=.git --exclude=uv.lock SRC/ vendor/mngr/
+```
+
+- `--filter=':- .gitignore'` is rsync's dir-merge filter: it reads `.gitignore`
+  at each level under the source and applies its exclude rules, so
+  `__pycache__`, `.venv`, `node_modules`, `.test_output`, `.mypy_cache`,
+  `.ruff_cache`, `.pytest_cache`, `.external_worktrees`, etc. are excluded
+  without being listed.
+- The two manual excludes cover what `.gitignore` deliberately omits: `.git`
+  (git's internal dir) and `uv.lock` (committed at the mngr root, but each
+  install context regenerates its own).
+
+The exclude set is defined once in code, in
+`libs/mngr_imbue_cloud/.../bake/pool_bake.py`
+(`_VENDOR_RSYNC_MANUAL_EXCLUDES` and `_GITIGNORE_RSYNC_FILTER`). Three paths
+populate `vendor/mngr/` from the monorepo with this form; keep them in step with
+those constants:
+
+| Path | Where | Trigger |
+|---|---|---|
+| `just minds-start` | root `justfile` (inline) | every dev-app startup |
+| `sync_mngr_into_template` | `pool_bake.py` (the constants) | `mngr imbue_cloud admin pool create --mngr-source ...` / `minds pool create --mngr-source ...` |
+| `propagate_changes` | `apps/minds/scripts/propagate_changes` (`RSYNC_EXCLUDES`) | each dev-loop iteration into a running container |
+
+`propagate_changes` additionally protects `runtime/`, `.mngr/`, and
+`.claude/settings.local.json` from deletion when rsyncing into `/code/`.
+
+The desktop client's Create flow performs a *separate* rsync -- the FCT worktree
+over a shallow clone into `/code/` -- not a monorepo->`vendor/mngr` sync.
+
+## `vendor/tk`
+
+`vendor/tk/` is a forked-and-modified copy of the
+[tk](https://github.com/wedow/ticket) ticket tracker. We maintain it by hand and
+upgrade it manually; we do not pull from upstream. Like `vendor/mngr`, it is a
+plain snapshot -- not a subtree or submodule.

--- a/apps/minds/docs/vendor-mngr-sync.md
+++ b/apps/minds/docs/vendor-mngr-sync.md
@@ -1,8 +1,9 @@
 # How `vendor/mngr` is synced
 
 `forever-claude-template` (FCT) vendors a full copy of the mngr monorepo at
-`vendor/mngr/`. The FCT `Dockerfile` builds the container's `mngr` from that
-directory (`uv tool install -e`), so whatever lands in `vendor/mngr/` *is* the
+`vendor/mngr/`. The FCT Docker build installs the container's `mngr` from that
+directory editable (`uv tool install -e vendor/mngr/libs/mngr`, run by
+`scripts/build_workspace.sh`), so whatever lands in `vendor/mngr/` *is* the
 mngr that runs inside every agent.
 
 `vendor/mngr/` is a plain copied-in snapshot. It is **not** a git subtree and

--- a/dev/changelog/mngr-doc-update-git.md
+++ b/dev/changelog/mngr-doc-update-git.md
@@ -1,5 +1,3 @@
-Consolidated the docs describing how FCT's `vendor/mngr` is kept in sync, so the `git archive` (release) vs `rsync` (dev/bake) mechanisms are explained in one place instead of being re-described in each consumer.
+Consolidated the docs describing how FCT's `vendor/mngr` is kept in sync, so the `git archive` (release) vs `rsync` (dev/bake) mechanisms are explained in one canonical place (`apps/minds/docs/vendor-mngr-sync.md`) instead of being re-described in each skill.
 
-Fixed a stale cross-reference in the `justfile` `minds-start` recipe: the rsync-exclusions comment pointed at `_RSYNC_MANUAL_EXCLUDES` in `cli/admin.py` / `cli/pool.py`, but the constants are actually `_VENDOR_RSYNC_MANUAL_EXCLUDES` / `_GITIGNORE_RSYNC_FILTER` defined in `bake/pool_bake.py` (which admin/pool call). The comment now names the correct constants and file and points at the new canonical doc.
-
-Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill and pointed the `minds-justfile` skill's `sync-vendor-mngr` entry at `apps/minds/docs/vendor-mngr-sync.md`.
+Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill and pointed the `minds-justfile` skill's `sync-vendor-mngr` entry at the canonical doc.

--- a/dev/changelog/mngr-doc-update-git.md
+++ b/dev/changelog/mngr-doc-update-git.md
@@ -1,3 +1,3 @@
 Consolidated the docs describing how FCT's `vendor/mngr` is kept in sync, so the `git archive` (release) vs `rsync` (dev/bake) mechanisms are explained in one canonical place (`apps/minds/docs/vendor-mngr-sync.md`) instead of being re-described in each skill.
 
-Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill and pointed the `minds-justfile` skill's `sync-vendor-mngr` entry at the canonical doc.
+Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill and pointed the `minds-justfile` skill's `sync-vendor-mngr` entry at the canonical doc. Also corrected the `minds-dev-workflow` skill's "Editable installs" note to attribute `uv tool install -e` to `scripts/build_workspace.sh` (which the Dockerfile invokes) rather than the Dockerfile directly, and to name the actual mngr install target (`vendor/mngr/libs/mngr`).

--- a/dev/changelog/mngr-doc-update-git.md
+++ b/dev/changelog/mngr-doc-update-git.md
@@ -1,0 +1,5 @@
+Consolidated the docs describing how FCT's `vendor/mngr` is kept in sync, so the `git archive` (release) vs `rsync` (dev/bake) mechanisms are explained in one place instead of being re-described in each consumer.
+
+Fixed a stale cross-reference in the `justfile` `minds-start` recipe: the rsync-exclusions comment pointed at `_RSYNC_MANUAL_EXCLUDES` in `cli/admin.py` / `cli/pool.py`, but the constants are actually `_VENDOR_RSYNC_MANUAL_EXCLUDES` / `_GITIGNORE_RSYNC_FILTER` defined in `bake/pool_bake.py` (which admin/pool call). The comment now names the correct constants and file and points at the new canonical doc.
+
+Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill and pointed the `minds-justfile` skill's `sync-vendor-mngr` entry at `apps/minds/docs/vendor-mngr-sync.md`.

--- a/justfile
+++ b/justfile
@@ -392,11 +392,10 @@ minds-start agent_name="mindtest" branch="":
     vendor_mngr="$fct_wt/vendor/mngr"
     mkdir -p "$vendor_mngr"
     echo "Syncing $(pwd) -> $vendor_mngr (rsync, uncommitted-friendly, no FCT commit)"
-    # Exclusions must match the _VENDOR_RSYNC_MANUAL_EXCLUDES + _GITIGNORE_RSYNC_FILTER
-    # constants in libs/mngr_imbue_cloud/.../bake/pool_bake.py (which cli/admin.py and
-    # minds cli/pool.py call) and the RSYNC_EXCLUDES array in
-    # apps/minds/scripts/propagate_changes -- all three populate the same vendor/mngr/
-    # destination. See apps/minds/docs/vendor-mngr-sync.md.
+    # Exclusions must match _RSYNC_MANUAL_EXCLUDES + _GITIGNORE_RSYNC_FILTER
+    # in libs/mngr_imbue_cloud/.../cli/admin.py and apps/minds/.../cli/pool.py,
+    # and the RSYNC_EXCLUDES array in apps/minds/scripts/propagate_changes --
+    # all four paths populate the same vendor/mngr/ destination.
     #
     # `--filter=:- .gitignore` reads .gitignore at each directory level under
     # the source and applies its exclude rules, so __pycache__, .venv,

--- a/justfile
+++ b/justfile
@@ -392,10 +392,11 @@ minds-start agent_name="mindtest" branch="":
     vendor_mngr="$fct_wt/vendor/mngr"
     mkdir -p "$vendor_mngr"
     echo "Syncing $(pwd) -> $vendor_mngr (rsync, uncommitted-friendly, no FCT commit)"
-    # Exclusions must match _RSYNC_MANUAL_EXCLUDES + _GITIGNORE_RSYNC_FILTER
-    # in libs/mngr_imbue_cloud/.../cli/admin.py and apps/minds/.../cli/pool.py,
-    # and the RSYNC_EXCLUDES array in apps/minds/scripts/propagate_changes --
-    # all four paths populate the same vendor/mngr/ destination.
+    # Exclusions must match the _VENDOR_RSYNC_MANUAL_EXCLUDES + _GITIGNORE_RSYNC_FILTER
+    # constants in libs/mngr_imbue_cloud/.../bake/pool_bake.py (which cli/admin.py and
+    # minds cli/pool.py call) and the RSYNC_EXCLUDES array in
+    # apps/minds/scripts/propagate_changes -- all three populate the same vendor/mngr/
+    # destination. See apps/minds/docs/vendor-mngr-sync.md.
     #
     # `--filter=:- .gitignore` reads .gitignore at each directory level under
     # the source and applies its exclude rules, so __pycache__, .venv,


### PR DESCRIPTION
## Summary

Consolidates the scattered documentation of how forever-claude-template's `vendor/mngr` is kept in sync into one canonical doc, and points the existing docs/skills at it.

Motivated by the vendor/mngr Slack discussion: agents kept making different decisions about how `vendor/mngr` should be updated because the mechanism (git archive vs rsync) was explained in pieces across many files, with no single source of truth.

## Changes

- **New** `apps/minds/docs/vendor-mngr-sync.md` -- single source of truth: the two mechanisms (`git archive` for committed/reproducible release snapshots; `rsync` for working-tree dev iteration and pool bakes), the shared rsync form and where its exclude constants live (`pool_bake.py`), the three monorepo -> `vendor/mngr` rsync paths, and the explicit statement that `vendor/mngr` and `vendor/tk` are plain snapshots -- not git subtrees or submodules.
- Trimmed the duplicated rsync-form explanation out of the `minds-dev-workflow` skill; pointed the `minds-justfile` skill, `apps/minds/docs/release.md`, and `apps/minds/docs/host-pool-setup.md` at the canonical doc.

## Scope / non-overlap

Net-new only. Deliberately does **not** touch the `justfile` (owned by #2239) or the `release-minds` skill (owned by #2238). A companion forever-claude-template PR (imbue-ai/forever-claude-template#200) removes the stale "git subtree" guidance in that repo's `CLAUDE.md`/`README.md`.

Changelog entries: `apps/minds`, `dev`.

Generated with [Claude Code](https://claude.com/claude-code)
