### PR TITLE
minds: don't let a malformed permission-request agent_id crash the requests consumer

### DIFF
--- a/apps/minds/imbue/minds/cli/run.py
+++ b/apps/minds/imbue/minds/cli/run.py
@@ -33,6 +33,7 @@ from pydantic import Field
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.ids import InvalidRandomIdError
 from imbue.minds.bootstrap import env_name_from_root_name
 from imbue.minds.bootstrap import is_minds_root_name_set_to_active_env
 from imbue.minds.bootstrap import minds_data_dir_for
@@ -599,7 +600,21 @@ class _StreamedPermissionRequestHandler(FrozenModel):
         target = event.permissions_target_path
         if target is None:
             return
-        agent_id = AgentId(event.agent_id)
+        try:
+            agent_id = AgentId(event.agent_id)
+        except InvalidRandomIdError:
+            # A permission request whose agent_id isn't a valid 'agent-...' id (e.g. an
+            # agent that hand-crafted the request body and supplied a placeholder like
+            # 'ENV_AGENT') cannot be resolved to a host. Skip recovery for it rather than
+            # let the exception kill the whole permission-requests consumer thread, which
+            # would silently stop every subsequent request from ever reaching the UI.
+            logger.warning(
+                "Skipping host-permission recovery for permission request {}: malformed "
+                "agent_id {!r} (not a valid 'agent-...' id).",
+                event.event_id,
+                event.agent_id,
+            )
+            return
         host_id = self._resolve_host_id(agent_id)
         if host_id is None:
             return

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -32,6 +32,7 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ConcurrencyGroupError
 from imbue.imbue_common.enums import UpperCaseStrEnum
 from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.ids import InvalidRandomIdError
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.minds.bootstrap import is_imbue_cloud_provider_enabled_for_account
 from imbue.minds.bootstrap import list_disabled_provider_names
@@ -2554,7 +2555,18 @@ def _displayable_pending_requests(
     request's host is discovered).
     """
     pending = inbox.get_pending_requests() if inbox else []
-    return [req for req in pending if backend_resolver.get_agent_display_info(AgentId(req.agent_id)) is not None]
+    displayable: list[RequestEvent] = []
+    for req in pending:
+        try:
+            agent_id = AgentId(req.agent_id)
+        except InvalidRandomIdError:
+            # A request with a malformed agent_id (not a valid 'agent-...' id) can't
+            # resolve to a real agent, so it isn't displayable. Skip it rather than let
+            # the AgentId() validation raise and take down the whole request panel.
+            continue
+        if backend_resolver.get_agent_display_info(agent_id) is not None:
+            displayable.append(req)
+    return displayable
 
 
 def _build_requests_payload(


### PR DESCRIPTION
## Problem
A latchkey permission request whose `agent_id` is **not** a valid `agent-…` id crashes the `latchkey-permission-requests-consumer` thread. `_maybe_recover_host_permissions` does `AgentId(event.agent_id)` with no guard, and `AgentId` requires the `agent-` prefix:

```
File ".../minds/cli/run.py", line ~561, in _maybe_recover_host_permissions
    agent_id = AgentId(event.agent_id)
imbue.imbue_common.ids.InvalidRandomIdError: AgentId must start with 'agent-', got 'ENV_AGENT'
```

Once that thread dies, **no permission request — for any agent or service — is ever surfaced to the UI again**, and it re-crashes on the same persisted record on every restart. We hit this when an agent hand-crafted a `POST /permission-requests` body and supplied a placeholder id (`ENV_AGENT`); the gateway accepts it because `permission_requests.mjs` only validates the field is a non-empty string, never that it's a real agent id. `_displayable_pending_requests` has the same unguarded `AgentId(req.agent_id)`.

## Fix
Guard both spots that build an `AgentId` from a streamed/stored request:
- `run.py` `_maybe_recover_host_permissions`: skip recovery (with a warning) on a malformed `agent_id` instead of letting it kill the consumer thread.
- `app.py` `_displayable_pending_requests`: skip such requests rather than raising and taking down the whole request panel.

A malformed/hand-crafted request now degrades gracefully (it just isn't surfaced) instead of wedging the entire permission system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)