### PR TITLE
Fix test-docker-electron CI failure from discovery-health watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,3 +467,28 @@ jobs:
         # `@pytest.mark.timeout(900)`, so the suite budget cannot kill
         # the pytest run before the per-test marker fires.
         run: xvfb-run -a env PYTEST_MAX_DURATION_SECONDS=900 uv run pytest -n 0 --timeout 900 --no-cov --cov-fail-under=0 -v --tb=short -m 'minds_electron and not release'
+
+      # DIAGNOSTIC (temporary): the local `latchkey gateway` never binds its
+      # port on this headless runner, so the detached `mngr latchkey forward`
+      # exits before stamping it and discovery produces no snapshot. The job
+      # doesn't capture the gateway's own stderr (unlike minds-launch-to-msg),
+      # so dump every latchkey log/record the e2e test left under its pytest
+      # tmp tree to surface the real gateway-startup error. Remove once the
+      # root cause is fixed.
+      - name: Dump latchkey logs (diagnostic)
+        if: always()
+        run: |
+          found=0
+          while IFS= read -r f; do
+            found=1
+            echo ""
+            echo "================================================================"
+            echo "FILE: $f"
+            echo "================================================================"
+            cat "$f" || echo "(could not read $f)"
+          done < <(find /tmp/pytest-of-runner -path '*latchkey*' -type f \
+            \( -name '*.log' -o -name '*.json' -o -name '*.jsonl' \) 2>/dev/null)
+          if [ "$found" -eq 0 ]; then
+            echo "No latchkey log files found under /tmp/pytest-of-runner; listing any latchkey paths:"
+            find /tmp/pytest-of-runner -path '*latchkey*' 2>/dev/null || true
+          fi

--- a/dev/changelog/gabriel-fix-ci.md
+++ b/dev/changelog/gabriel-fix-ci.md
@@ -1,0 +1,3 @@
+Investigating the `test-docker-electron` CI failure introduced by the minds discovery-health watchdog (#2252): the local `latchkey gateway` never binds its port on the headless runner, so the detached `mngr latchkey forward` exits before stamping it, discovery produces no snapshot, and the new watchdog escalates to a fatal app-global BLOCKED takeover that closes the Electron page mid-test.
+
+Added a temporary diagnostic step to the `test-docker-electron` job that dumps the latchkey forward/gateway logs left under the e2e test's pytest tmp tree, so the gateway's real startup error is visible in the job log. To be removed once the root cause is fixed.


### PR DESCRIPTION
## Context

CI on `main` went red after #2252 (minds discovery-health watchdog). The `test-docker-electron` job fails deterministically with `TargetClosedError`.

## Root cause (in progress)

The local `latchkey gateway` never binds its port on the headless CI runner, so the detached `mngr latchkey forward` exits before stamping it -> discovery produces no snapshot -> the new watchdog's cold-start backstop escalates to a fatal app-global BLOCKED takeover that closes the Electron page mid-test. The gateway-down condition is pre-existing and was tolerated until the watchdog began reacting to it.

Ruled out: encryption key (Linux auto-creates a file key; keychain is macOS-only) and browser priming (non-fatal to the port bind).

## This commit

Temporary diagnostic only: dumps the latchkey forward/gateway logs from the e2e test's pytest tmp tree into the job log to surface the gateway's real startup error. The fix follows once the error is known; this diagnostic step will be removed.