### PR TITLE
Release minds v0.3.3 (version bump + FALLBACK_BRANCH)

### DIFF
--- a/apps/minds/changelog/mngr-minds-v0.3.3.md
+++ b/apps/minds/changelog/mngr-minds-v0.3.3.md
@@ -1,0 +1,1 @@
+Released minds v0.3.3. Bumped the app version and pinned the baked `FALLBACK_BRANCH` to the `minds-v0.3.3` forever-claude-template tag. This release also carries the Tailwind v4 CSS migration fix: CSS is now compiled at its real consumption points (packaging, dev, e2e) instead of in a `postinstall` hook, so ToDesktop's `pnpm recursive install --prod` cloud build no longer fails.

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -253,7 +253,7 @@ _FALLBACK_HOST_NAME: Final[str] = "assistant"
 # Pin to an annotated FCT tag so a shipped binary clones the exact FCT
 # snapshot it was verified against. Bump to a newer tag only after
 # re-verifying launch-to-msg CI against (this binary, the new tag).
-FALLBACK_BRANCH: Final[str] = "minds-v0.3.2"
+FALLBACK_BRANCH: Final[str] = "minds-v0.3.3"
 
 # Env var (set by ``just minds-start`` and the e2e workspace runner) that opts a
 # launch into the operator's local-worktree create-form defaults. Gating on an

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minds",
   "productName": "Minds",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",
   "author": "Imbue <dev@imbue.com>",


### PR DESCRIPTION
## Release minds v0.3.3

mngr side of the minds v0.3.3 release (see `apps/minds/docs/release.md`).

- `apps/minds/package.json` version `0.3.2` -> `0.3.3`
- `templates.py` `FALLBACK_BRANCH` -> `minds-v0.3.3` (the FCT tag created later in the release)

Cut from `main` @ `7328301fd6`, which already contains the Tailwind v4 CSS-postinstall fix (#2257). The `minds-v0.3.3` tag does not exist yet; pre-merge launch-to-msg verification overrides the FCT ref via `template_ref` (release runbook step 4).

Paired FCT PR (vendor/mngr refresh + `minds-v0.3.3` tag) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)