### PR TITLE
Mutate shared Claude config to dismiss startup dialogs (not permissions)

### DIFF
--- a/libs/imbue_common/changelog/mngr-mutate-shared-config.md
+++ b/libs/imbue_common/changelog/mngr-mutate-shared-config.md
@@ -1,0 +1,3 @@
+Updated the `PREVENT_HARDCODED_CLAUDE_DIR` ratchet's guidance text to reference
+the renamed `find_user_config_in_isolated_mode()` accessor (was
+`find_user_claude_config()`). No behavior change.

--- a/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
+++ b/libs/imbue_common/imbue/imbue_common/ratchet_testing/common_ratchets.py
@@ -494,7 +494,7 @@ PREVENT_HARDCODED_CLAUDE_DIR = RegexRatchetRule(
         "Use the accessor functions from claude_config.py instead of hardcoding "
         "Path.home() / '.claude' or Path.home() / '.claude.json'. "
         "For the config directory: get_claude_config_dir() / get_user_claude_config_dir(). "
-        "For the user config file: find_user_claude_config(). "
+        "For the user config file: find_user_config_in_isolated_mode(). "
         "This allows paths to be overridden via CLAUDE_CONFIG_DIR "
         "and ORIGINAL_CLAUDE_CONFIG_DIR environment variables."
     ),

--- a/libs/mngr_claude/README.md
+++ b/libs/mngr_claude/README.md
@@ -26,13 +26,16 @@ When isolation is disabled (shared mode):
 - `CLAUDE_CONFIG_DIR` resolves to the user's shared dir (`$CLAUDE_CONFIG_DIR`, or
   `~/.claude` when unset) and is injected into the agent environment so claude
   reads the user's real config.
-- mngr never writes to the user's Claude config (no trust additions, no dialog
-  dismissal, no per-agent settings.json, no keychain provisioning). The user is
-  responsible for one-time interactive `claude` setup (trust the work_dir,
-  complete onboarding, log in).
-- The repo-settings sync and auto-dismiss fields (`sync_repo_settings`,
-  `override_settings_folder`, `auto_dismiss_dialogs`) are silently ignored since
-  shared mode has no per-agent dir to write into.
+- mngr still writes to the user's Claude config to dismiss the cosmetic startup
+  dialogs (trust the work_dir, onboarding, effort callout, cost threshold) so they
+  don't intercept automated input -- prompting interactively, or silently when
+  `auto_dismiss_dialogs` is set. It writes these into the file claude actually
+  reads (`$CLAUDE_CONFIG_DIR/.claude.json`, or `~/.claude.json` when unset). It
+  does **not** accept bypass-permissions mode there (that is governed by
+  settings.json), and it does no per-agent settings.json or keychain provisioning.
+  The user is still responsible for logging in (credentials).
+- The repo-settings sync fields (`sync_repo_settings`, `override_settings_folder`)
+  are silently ignored since shared mode has no per-agent dir to write into.
 - Reduced settings support (a scoped, documented limitation of this mode). In
   normal mode mngr bakes its hooks and `settings_overrides` into the per-agent
   config-dir `settings.json`, and a user `--settings` passes through so Claude

--- a/libs/mngr_claude/changelog/mngr-mutate-shared-config.md
+++ b/libs/mngr_claude/changelog/mngr-mutate-shared-config.md
@@ -1,0 +1,15 @@
+Shared Claude config mode (`isolate_local_config_dir = false`) now dismisses the
+cosmetic startup dialogs (trust, onboarding, effort callout, cost threshold)
+directly in your default Claude config so they no longer intercept automated
+input. Previously shared mode left the config untouched, so a fresh `~/.claude.json`
+re-triggered the trust/onboarding screens on every agent.
+
+mngr writes these dismissals into the file claude actually reads
+(`$CLAUDE_CONFIG_DIR/.claude.json`, or `~/.claude.json` when the var is unset), and
+honors `auto_dismiss_dialogs` in this mode. It never accepts bypass-permissions
+mode via the global config -- that remains governed by `settings.json` -- and still
+does no per-agent settings.json or keychain provisioning.
+
+Also fixed: in shared mode, mngr's hooks are now installed when shared mode is set
+via the current `isolate_local_config_dir = false` flag (previously they were only
+installed when set via the deprecated `use_env_config_dir = true` alias).

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -132,7 +132,7 @@ def resolve_shared_claude_config_dir() -> Path:
     return get_claude_config_dir()
 
 
-def find_shared_claude_config() -> Path:
+def find_user_config_in_unisolated_mode() -> Path:
     """Find the global ``.claude.json`` that claude reads in shared (non-isolated) mode.
 
     In shared mode (``isolate_local_config_dir=False``) mngr does not provision a
@@ -144,7 +144,7 @@ def find_shared_claude_config() -> Path:
     propagation in ``ClaudeAgent.modify_env_vars`` so that dialog-dismissal writes
     land in the same file the agent's claude will actually read.
 
-    This differs from ``find_user_claude_config``, which keys off
+    This differs from ``find_user_config_in_isolated_mode``, which keys off
     ``$ORIGINAL_CLAUDE_CONFIG_DIR`` (set only *inside* an agent) and is the right
     resolver for the isolated path; it would ignore a shared user's
     ``$CLAUDE_CONFIG_DIR`` and point at the wrong file.
@@ -155,7 +155,7 @@ def find_shared_claude_config() -> Path:
     return Path.home() / ".claude.json"
 
 
-def find_user_claude_config() -> Path:
+def find_user_config_in_isolated_mode() -> Path:
     """Find the user-scope Claude config file (.claude.json).
 
     Returns the first candidate path that exists on disk. If none exist,

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config.py
@@ -132,6 +132,29 @@ def resolve_shared_claude_config_dir() -> Path:
     return get_claude_config_dir()
 
 
+def find_shared_claude_config() -> Path:
+    """Find the global ``.claude.json`` that claude reads in shared (non-isolated) mode.
+
+    In shared mode (``isolate_local_config_dir=False``) mngr does not provision a
+    per-agent config dir; the agent's claude reads the user's own global config.
+    That file is ``$CLAUDE_CONFIG_DIR/.claude.json`` when the user's shell exports
+    ``CLAUDE_CONFIG_DIR`` (the custom-dir convention) and ``~/.claude.json``
+    otherwise (claude's default, beside ``~/.claude/``). This mirrors the directory
+    resolution in ``resolve_shared_claude_config_dir`` and the ``CLAUDE_CONFIG_DIR``
+    propagation in ``ClaudeAgent.modify_env_vars`` so that dialog-dismissal writes
+    land in the same file the agent's claude will actually read.
+
+    This differs from ``find_user_claude_config``, which keys off
+    ``$ORIGINAL_CLAUDE_CONFIG_DIR`` (set only *inside* an agent) and is the right
+    resolver for the isolated path; it would ignore a shared user's
+    ``$CLAUDE_CONFIG_DIR`` and point at the wrong file.
+    """
+    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_dir:
+        return Path(env_dir) / ".claude.json"
+    return Path.home() / ".claude.json"
+
+
 def find_user_claude_config() -> Path:
     """Find the user-scope Claude config file (.claude.json).
 

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -17,8 +17,8 @@ from imbue.mngr_claude.claude_config import check_source_directory_trusted
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
-from imbue.mngr_claude.claude_config import find_shared_claude_config
-from imbue.mngr_claude.claude_config import find_user_claude_config
+from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
+from imbue.mngr_claude.claude_config import find_user_config_in_isolated_mode
 from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
 from imbue.mngr_claude.claude_config import is_source_directory_trusted
@@ -63,7 +63,7 @@ def test_find_project_config_empty_projects() -> None:
 
 def test_check_source_directory_trusted_succeeds_when_trusted(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted passes when directory is trusted."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -80,7 +80,7 @@ def test_check_source_directory_trusted_succeeds_when_trusted(tmp_path: Path) ->
 
 def test_check_source_directory_trusted_succeeds_for_subdirectory(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted passes for subdirectory of trusted path."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     project_root = tmp_path / "project"
     source_path = project_root / "src" / "components"
     project_root.mkdir()
@@ -99,7 +99,7 @@ def test_check_source_directory_trusted_succeeds_for_subdirectory(tmp_path: Path
 
 def test_check_source_directory_trusted_raises_when_not_trusted(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when hasTrustDialogAccepted=false."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -124,12 +124,12 @@ def test_check_source_directory_trusted_raises_when_no_config_file(tmp_path: Pat
     # Config file doesn't exist (HOME points to tmp_path via autouse fixture)
 
     with pytest.raises(ClaudeDirectoryNotTrustedError):
-        check_source_directory_trusted(find_user_claude_config(), source_path)
+        check_source_directory_trusted(find_user_config_in_isolated_mode(), source_path)
 
 
 def test_check_source_directory_trusted_raises_when_empty_config(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when config file is empty."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -141,7 +141,7 @@ def test_check_source_directory_trusted_raises_when_empty_config(tmp_path: Path)
 
 def test_check_source_directory_trusted_raises_when_not_in_projects(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when source not in projects."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -154,7 +154,7 @@ def test_check_source_directory_trusted_raises_when_not_in_projects(tmp_path: Pa
 
 def test_check_source_directory_trusted_raises_when_trust_field_missing(tmp_path: Path) -> None:
     """Test that check_source_directory_trusted raises when hasTrustDialogAccepted is missing."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -171,7 +171,7 @@ def test_check_source_directory_trusted_raises_when_trust_field_missing(tmp_path
 
 def test_check_source_directory_trusted_raises_json_error_for_invalid_json() -> None:
     """Test that check_source_directory_trusted lets JSONDecodeError bubble up."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
 
     config_file.write_text("{ invalid json }")
 
@@ -188,7 +188,7 @@ def test_add_claude_trust_creates_config_when_none_exists(tmp_path: Path) -> Non
     source_path.mkdir()
 
     # HOME points to a test-isolated temp dir (autouse setup_test_mngr_env)
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     assert not config_file.exists()
 
     add_claude_trust_for_path(config_file, source_path)
@@ -200,7 +200,7 @@ def test_add_claude_trust_creates_config_when_none_exists(tmp_path: Path) -> Non
 
 def test_add_claude_trust_adds_entry_to_existing_config(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path adds entry to existing config."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -219,8 +219,8 @@ def test_add_claude_trust_adds_entry_to_existing_config(tmp_path: Path) -> None:
 
 def test_add_claude_trust_is_noop_when_already_trusted(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path is a no-op when path is already trusted."""
-    config_file = find_user_claude_config()
-    backup_file = find_user_claude_config().with_suffix(".json.bak")
+    config_file = find_user_config_in_isolated_mode()
+    backup_file = find_user_config_in_isolated_mode().with_suffix(".json.bak")
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -243,7 +243,7 @@ def test_add_claude_trust_is_noop_when_already_trusted(tmp_path: Path) -> None:
 
 def test_add_claude_trust_updates_entry_when_trust_is_false(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path updates entry when hasTrustDialogAccepted is False."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -267,7 +267,7 @@ def test_add_claude_trust_updates_entry_when_trust_is_false(tmp_path: Path) -> N
 
 def test_add_claude_trust_handles_empty_config_file(tmp_path: Path) -> None:
     """Test that add_claude_trust_for_path handles empty config file."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -284,7 +284,7 @@ def test_add_claude_trust_handles_empty_config_file(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_removes_mngr_created_entry(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path removes mngr-created entries."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -312,7 +312,7 @@ def test_remove_claude_trust_removes_mngr_created_entry(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_skips_non_mngr_entry(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path skips entries not created by mngr."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -334,7 +334,7 @@ def test_remove_claude_trust_skips_non_mngr_entry(tmp_path: Path) -> None:
 
 def test_remove_claude_trust_returns_false_when_not_found(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path returns False when entry doesn't exist."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -357,7 +357,7 @@ def test_remove_claude_trust_returns_false_when_no_config(tmp_path: Path) -> Non
 
     # Config file doesn't exist (HOME points to tmp_path via autouse fixture)
 
-    result = remove_claude_trust_for_path(find_user_claude_config(), worktree_path)
+    result = remove_claude_trust_for_path(find_user_config_in_isolated_mode(), worktree_path)
 
     assert result is False
 
@@ -367,7 +367,7 @@ def test_remove_claude_trust_returns_false_on_invalid_json(tmp_path: Path) -> No
 
     The JSON-decode path is the only error the production code catches.
     """
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -381,7 +381,7 @@ def test_remove_claude_trust_returns_false_on_invalid_json(tmp_path: Path) -> No
 
 def test_remove_claude_trust_returns_false_when_empty_config(tmp_path: Path) -> None:
     """Test that remove_claude_trust_for_path returns False when config file is empty."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     worktree_path = tmp_path / "worktree"
     worktree_path.mkdir()
 
@@ -397,7 +397,7 @@ def test_remove_claude_trust_returns_false_when_empty_config(tmp_path: Path) -> 
 
 def test_check_effort_callout_dismissed_succeeds_when_dismissed() -> None:
     """Test that check_effort_callout_dismissed passes when effortCalloutDismissed is true."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config = {"effortCalloutDismissed": True}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -407,7 +407,7 @@ def test_check_effort_callout_dismissed_succeeds_when_dismissed() -> None:
 
 def test_check_effort_callout_dismissed_raises_when_not_dismissed() -> None:
     """Test that check_effort_callout_dismissed raises when effortCalloutDismissed is false."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config = {"effortCalloutDismissed": False}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -417,7 +417,7 @@ def test_check_effort_callout_dismissed_raises_when_not_dismissed() -> None:
 
 def test_check_effort_callout_dismissed_raises_when_field_missing() -> None:
     """Test that check_effort_callout_dismissed raises when effortCalloutDismissed is absent."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -428,12 +428,12 @@ def test_check_effort_callout_dismissed_raises_when_field_missing() -> None:
 def test_check_effort_callout_dismissed_raises_when_no_config() -> None:
     """Test that check_effort_callout_dismissed raises when config file doesn't exist."""
     with pytest.raises(ClaudeEffortCalloutNotDismissedError):
-        check_effort_callout_dismissed(find_user_claude_config())
+        check_effort_callout_dismissed(find_user_config_in_isolated_mode())
 
 
 def test_check_effort_callout_dismissed_raises_when_empty_config() -> None:
     """Test that check_effort_callout_dismissed raises when config file is empty."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config_file.write_text("")
 
     with pytest.raises(ClaudeEffortCalloutNotDismissedError):
@@ -442,7 +442,7 @@ def test_check_effort_callout_dismissed_raises_when_empty_config() -> None:
 
 def test_dismiss_effort_callout_sets_field() -> None:
     """Test that dismiss_effort_callout sets effortCalloutDismissed to true."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -455,8 +455,8 @@ def test_dismiss_effort_callout_sets_field() -> None:
 
 def test_dismiss_effort_callout_is_noop_when_already_set() -> None:
     """Test that dismiss_effort_callout is a no-op when already dismissed."""
-    config_file = find_user_claude_config()
-    backup_file = find_user_claude_config().with_suffix(".json.bak")
+    config_file = find_user_config_in_isolated_mode()
+    backup_file = find_user_config_in_isolated_mode().with_suffix(".json.bak")
     config = {"effortCalloutDismissed": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
     content_before = config_file.read_text()
@@ -471,7 +471,7 @@ def test_dismiss_effort_callout_is_noop_when_already_set() -> None:
 
 def test_dismiss_effort_callout_creates_config_when_none_exists() -> None:
     """Test that dismiss_effort_callout creates config file if it doesn't exist."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     assert not config_file.exists()
 
     dismiss_effort_callout(config_file)
@@ -483,7 +483,7 @@ def test_dismiss_effort_callout_creates_config_when_none_exists() -> None:
 
 def test_dismiss_effort_callout_handles_empty_config() -> None:
     """Test that dismiss_effort_callout handles empty config file."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config_file.write_text("")
 
     dismiss_effort_callout(config_file)
@@ -497,7 +497,7 @@ def test_dismiss_effort_callout_handles_empty_config() -> None:
 
 def test_acknowledge_cost_threshold_sets_field() -> None:
     """Test that acknowledge_cost_threshold sets hasAcknowledgedCostThreshold to true."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config = {"projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
 
@@ -510,8 +510,8 @@ def test_acknowledge_cost_threshold_sets_field() -> None:
 
 def test_acknowledge_cost_threshold_is_noop_when_already_set() -> None:
     """Test that acknowledge_cost_threshold is a no-op when already acknowledged."""
-    config_file = find_user_claude_config()
-    backup_file = find_user_claude_config().with_suffix(".json.bak")
+    config_file = find_user_config_in_isolated_mode()
+    backup_file = find_user_config_in_isolated_mode().with_suffix(".json.bak")
     config = {"hasAcknowledgedCostThreshold": True, "projects": {}}
     config_file.write_text(json.dumps(config, indent=2))
     content_before = config_file.read_text()
@@ -526,7 +526,7 @@ def test_acknowledge_cost_threshold_is_noop_when_already_set() -> None:
 
 def test_acknowledge_cost_threshold_creates_config_when_none_exists() -> None:
     """Test that acknowledge_cost_threshold creates config file if it doesn't exist."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     assert not config_file.exists()
 
     acknowledge_cost_threshold(config_file)
@@ -538,7 +538,7 @@ def test_acknowledge_cost_threshold_creates_config_when_none_exists() -> None:
 
 def test_acknowledge_cost_threshold_handles_empty_config() -> None:
     """Test that acknowledge_cost_threshold handles empty config file."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     config_file.write_text("")
 
     acknowledge_cost_threshold(config_file)
@@ -552,7 +552,7 @@ def test_acknowledge_cost_threshold_handles_empty_config() -> None:
 
 def test_check_claude_dialogs_dismissed_checks_trust(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed checks trust for source_path."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -566,7 +566,7 @@ def test_check_claude_dialogs_dismissed_checks_trust(tmp_path: Path) -> None:
 
 def test_check_claude_dialogs_dismissed_checks_effort_callout(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed checks effort callout."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -588,7 +588,7 @@ def test_check_claude_dialogs_dismissed_checks_effort_callout(tmp_path: Path) ->
 
 def test_check_claude_dialogs_dismissed_passes_when_all_set(tmp_path: Path) -> None:
     """Test that check_claude_dialogs_dismissed passes when all dialogs are set."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -607,7 +607,7 @@ def test_check_claude_dialogs_dismissed_passes_when_all_set(tmp_path: Path) -> N
 
 def test_auto_dismiss_claude_dialogs_sets_all(tmp_path: Path) -> None:
     """Test that auto_dismiss_claude_dialogs sets all dialog fields."""
-    config_file = find_user_claude_config()
+    config_file = find_user_config_in_isolated_mode()
     source_path = tmp_path / "source"
     source_path.mkdir()
 
@@ -648,7 +648,7 @@ def test_functions_work_with_non_global_config_path(tmp_path: Path) -> None:
     assert updated["effortCalloutDismissed"] is True
 
     # Global config should be untouched
-    global_config = find_user_claude_config()
+    global_config = find_user_config_in_isolated_mode()
     assert not global_config.exists()
 
 
@@ -793,41 +793,41 @@ def test_resolve_shared_claude_config_dir_falls_back_when_empty(monkeypatch: pyt
     assert resolve_shared_claude_config_dir() == Path.home() / ".claude"
 
 
-# Tests for find_shared_claude_config
+# Tests for find_user_config_in_unisolated_mode
 
 
-def test_find_shared_claude_config_uses_env_dir_when_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_unisolated_mode_uses_env_dir_when_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With CLAUDE_CONFIG_DIR set, the shared config file lives inside that dir."""
     target = tmp_path / "shared-claude"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(target))
-    assert find_shared_claude_config() == target / ".claude.json"
+    assert find_user_config_in_unisolated_mode() == target / ".claude.json"
 
 
-def test_find_shared_claude_config_falls_back_to_home_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_unisolated_mode_falls_back_to_home_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without CLAUDE_CONFIG_DIR, the shared config file is claude's default ~/.claude.json."""
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
-    assert find_shared_claude_config() == Path.home() / ".claude.json"
+    assert find_user_config_in_unisolated_mode() == Path.home() / ".claude.json"
 
 
-# Tests for find_user_claude_config
+# Tests for find_user_config_in_isolated_mode
 
 
-def test_find_user_claude_config_defaults_to_home() -> None:
+def test_find_user_config_in_isolated_mode_defaults_to_home() -> None:
     """Without env vars and no file on disk, returns ~/.claude.json."""
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == Path.home() / ".claude.json"
 
 
-def test_find_user_claude_config_returns_default_path() -> None:
+def test_find_user_config_in_isolated_mode_returns_default_path() -> None:
     """Without env vars, returns ~/.claude.json when it exists."""
     config = Path.home() / ".claude.json"
     config.write_text(json.dumps({}, indent=2))
 
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == config
 
 
-def test_find_user_claude_config_defaults_to_inside_dir_with_original_dir_but_no_files(
+def test_find_user_config_in_isolated_mode_defaults_to_inside_dir_with_original_dir_but_no_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """With ORIGINAL_CLAUDE_CONFIG_DIR set but no config files, returns the inside-dir path."""
@@ -835,11 +835,11 @@ def test_find_user_claude_config_defaults_to_inside_dir_with_original_dir_but_no
     user_dir.mkdir()
     monkeypatch.setenv("ORIGINAL_CLAUDE_CONFIG_DIR", str(user_dir))
 
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == user_dir / ".claude.json"
 
 
-def test_find_user_claude_config_finds_inside_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_isolated_mode_finds_inside_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With ORIGINAL_CLAUDE_CONFIG_DIR set, finds .claude.json inside it."""
     user_dir = tmp_path / "user-claude"
     user_dir.mkdir()
@@ -848,11 +848,11 @@ def test_find_user_claude_config_finds_inside_dir(tmp_path: Path, monkeypatch: p
     inside = user_dir / ".claude.json"
     inside.write_text(json.dumps({}, indent=2))
 
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == inside
 
 
-def test_find_user_claude_config_finds_beside_dir(
+def test_find_user_config_in_isolated_mode_finds_beside_dir(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Finds ~/.claude.json (beside ~/.claude/) when only beside-dir config exists.
@@ -869,11 +869,11 @@ def test_find_user_claude_config_finds_beside_dir(
     beside_config = Path.home() / ".claude.json"
     beside_config.write_text(json.dumps({"projects": {}}, indent=2))
 
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == beside_config
 
 
-def test_find_user_claude_config_prefers_inside_dir_when_both_exist(
+def test_find_user_config_in_isolated_mode_prefers_inside_dir_when_both_exist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When both inside-dir and beside-dir configs exist, prefers inside-dir."""
@@ -886,11 +886,11 @@ def test_find_user_claude_config_prefers_inside_dir_when_both_exist(
     beside_config = Path.home() / ".claude.json"
     beside_config.write_text(json.dumps({"beside": True}, indent=2))
 
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == inside_config
 
 
-def test_find_user_claude_config_ignores_claude_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_isolated_mode_ignores_claude_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Without ORIGINAL_CLAUDE_CONFIG_DIR, ignores CLAUDE_CONFIG_DIR (per-agent dir)."""
     custom_dir = tmp_path / "custom-claude"
     custom_dir.mkdir()
@@ -901,7 +901,7 @@ def test_find_user_claude_config_ignores_claude_config_dir(tmp_path: Path, monke
     config.write_text(json.dumps({}, indent=2))
 
     # Should return the default user path, not the per-agent path
-    result = find_user_claude_config()
+    result = find_user_config_in_isolated_mode()
     assert result == Path.home() / ".claude.json"
 
 

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -17,6 +17,7 @@ from imbue.mngr_claude.claude_config import check_source_directory_trusted
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
+from imbue.mngr_claude.claude_config import find_shared_claude_config
 from imbue.mngr_claude.claude_config import find_user_claude_config
 from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
@@ -790,6 +791,22 @@ def test_resolve_shared_claude_config_dir_falls_back_when_empty(monkeypatch: pyt
     """Empty CLAUDE_CONFIG_DIR is treated the same as unset and falls back to ``~/.claude/``."""
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
     assert resolve_shared_claude_config_dir() == Path.home() / ".claude"
+
+
+# Tests for find_shared_claude_config
+
+
+def test_find_shared_claude_config_uses_env_dir_when_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With CLAUDE_CONFIG_DIR set, the shared config file lives inside that dir."""
+    target = tmp_path / "shared-claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(target))
+    assert find_shared_claude_config() == target / ".claude.json"
+
+
+def test_find_shared_claude_config_falls_back_to_home_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without CLAUDE_CONFIG_DIR, the shared config file is claude's default ~/.claude.json."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    assert find_shared_claude_config() == Path.home() / ".claude.json"
 
 
 # Tests for find_user_claude_config

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -17,8 +17,8 @@ from imbue.mngr_claude.claude_config import check_source_directory_trusted
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
-from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
 from imbue.mngr_claude.claude_config import find_user_config_in_isolated_mode
+from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
 from imbue.mngr_claude.claude_config import get_claude_config_dir
 from imbue.mngr_claude.claude_config import get_user_claude_config_dir
 from imbue.mngr_claude.claude_config import is_source_directory_trusted

--- a/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/claude_config_test.py
@@ -796,7 +796,9 @@ def test_resolve_shared_claude_config_dir_falls_back_when_empty(monkeypatch: pyt
 # Tests for find_user_config_in_unisolated_mode
 
 
-def test_find_user_config_in_unisolated_mode_uses_env_dir_when_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_unisolated_mode_uses_env_dir_when_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """With CLAUDE_CONFIG_DIR set, the shared config file lives inside that dir."""
     target = tmp_path / "shared-claude"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(target))
@@ -890,7 +892,9 @@ def test_find_user_config_in_isolated_mode_prefers_inside_dir_when_both_exist(
     assert result == inside_config
 
 
-def test_find_user_config_in_isolated_mode_ignores_claude_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_find_user_config_in_isolated_mode_ignores_claude_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Without ORIGINAL_CLAUDE_CONFIG_DIR, ignores CLAUDE_CONFIG_DIR (per-agent dir)."""
     custom_dir = tmp_path / "custom-claude"
     custom_dir.mkdir()

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -108,8 +108,8 @@ from imbue.mngr_claude.claude_config import complete_onboarding
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
-from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
 from imbue.mngr_claude.claude_config import find_user_config_in_isolated_mode
+from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
 from imbue.mngr_claude.claude_config import fold_hook_configs
 from imbue.mngr_claude.claude_config import get_agent_claude_config_dir
 from imbue.mngr_claude.claude_config import get_agent_claude_plugin_dir

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -108,6 +108,7 @@ from imbue.mngr_claude.claude_config import complete_onboarding
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
+from imbue.mngr_claude.claude_config import find_shared_claude_config
 from imbue.mngr_claude.claude_config import find_user_claude_config
 from imbue.mngr_claude.claude_config import fold_hook_configs
 from imbue.mngr_claude.claude_config import get_agent_claude_config_dir
@@ -334,14 +335,14 @@ class ClaudeAgentConfig(AgentTypeConfig):
         default=True,
         description="When True (the default), provision a per-agent Claude config dir so each local agent is "
         "isolated and mngr never has to touch your default Claude config. When False, share the user's "
-        "$CLAUDE_CONFIG_DIR across all claude agents instead of provisioning a per-agent config dir; mngr then "
-        "leaves your Claude config alone and you are responsible for interactive `claude` setup (trust dialogs, "
-        "onboarding, credentials) ahead of time, but credentials stay in sync (which is what Claude "
-        "subscriptions on macOS need). Only meaningful for local hosts: a non-local agent always uses an "
-        "isolated config dir (the user's config and keychain live on the local machine), so this flag is "
-        "ignored for remote agents. When False (and local), other sync/override/auto-dismiss fields on this "
-        "config are silently ignored. See the imbue-mngr-claude README for the shared-mode setup requirements "
-        "and reduced-support limitations (including the `--settings` collision).",
+        "$CLAUDE_CONFIG_DIR across all claude agents instead of provisioning a per-agent config dir. In shared "
+        "mode mngr still writes to your default Claude config to dismiss the cosmetic startup dialogs (trust, "
+        "onboarding, effort callout, cost threshold) -- honoring auto_dismiss_dialogs -- so they don't intercept "
+        "automated input; it never accepts bypass-permissions mode there (that is handled via settings.json). "
+        "Credentials stay in sync (which is what Claude subscriptions on macOS need). Only meaningful for local "
+        "hosts: a non-local agent always uses an isolated config dir (the user's config and keychain live on the "
+        "local machine), so this flag is ignored for remote agents. See the imbue-mngr-claude README for the "
+        "shared-mode setup requirements and reduced-support limitations (including the `--settings` collision).",
     )
     use_env_config_dir: bool | None = Field(
         default=None,
@@ -1579,6 +1580,23 @@ class ClaudeCoreAgent(
         """
         return self.agent_config.resolve_isolate_local_config_dir() or not self.host.is_local
 
+    def _dialog_dismissal_config_path(self) -> Path:
+        """Return the global ``.claude.json`` whose startup-dialog state this agent dismisses.
+
+        Both modes record dialog dismissals (trust, onboarding, effort callout, cost
+        threshold) in the user's *global* config -- these are cosmetic first-run prompts,
+        never tool-permission grants (``bypassPermissionsModeAccepted`` is deliberately
+        left untouched; see ``auto_dismiss_claude_dialogs``).
+
+        Isolated mode writes to ``find_user_claude_config`` (the per-agent config dir is
+        built from it via ``sync_local``, so it inherits the dismissals). Shared mode
+        writes to ``find_shared_claude_config``, the file the agent's claude reads
+        directly, resolved the same way ``modify_env_vars`` resolves ``CLAUDE_CONFIG_DIR``.
+        """
+        if self._is_isolated_config_dir():
+            return find_user_claude_config()
+        return find_shared_claude_config()
+
     def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
         """Add CLAUDE_CONFIG_DIR and ORIGINAL_CLAUDE_CONFIG_DIR.
 
@@ -1925,10 +1943,12 @@ class ClaudeCoreAgent(
         - rsync/none: trust is prompted for the work_dir
         - auto_dismiss_dialogs=True: trust is auto-added for work_dir
 
-        In shared mode (``isolate_local_config_dir=False``): skip all writes to
-        the user's Claude config -- no plugin path sentinel resolution, no dialog
-        dismissal, no cost-threshold acknowledgement, and no per-agent config dir
-        setup. The user takes responsibility for their own config.
+        In shared mode (``isolate_local_config_dir=False``): mngr still dismisses
+        the cosmetic startup dialogs (trust, onboarding, effort callout, cost
+        threshold) directly in the user's global config so they don't intercept
+        tmux input -- writing there is the whole point of shared mode, and these
+        are not tool-permission grants. It still skips per-agent-only work: plugin
+        path sentinel resolution and per-agent config dir setup.
         """
         config = self.agent_config
 
@@ -1985,10 +2005,10 @@ class ClaudeCoreAgent(
                 ensure_cli_installed(host, mngr_ctx, self.get_install_binary_name(), self.get_install_command())
                 self.reconcile_installed_version(host, mngr_ctx)
 
-            # no matter what, *always* dismiss the cost popup, it's pointless.
-            # Skipped in shared mode -- mngr never writes to the user's config.
-            if self._is_isolated_config_dir():
-                acknowledge_cost_threshold(find_user_claude_config())
+            # no matter what, *always* dismiss the cost popup, it's pointless. In
+            # shared mode this targets the user's global config (the file claude
+            # actually reads); in isolated mode the per-agent config inherits it.
+            acknowledge_cost_threshold(self._dialog_dismissal_config_path())
 
             # Transfer plugin data from source agent before config setup (if cloning via --from).
             # This copies sessions, memory, transcript offsets, etc. The subsequent config setup
@@ -2001,11 +2021,13 @@ class ClaudeCoreAgent(
             if self._is_isolated_config_dir():
                 self._setup_per_agent_config_dir(host, options, mngr_ctx)
 
-            # Configure mngr's hooks. In normal mode they are baked into the
+            # Configure mngr's hooks. In isolated mode they are baked into the
             # per-agent config-dir settings.json by _setup_per_agent_config_dir
-            # (-> _build_settings_json) above. In use_env_config_dir mode there is
-            # no per-agent config dir, so write the managed --settings file instead.
-            if config.use_env_config_dir:
+            # (-> _build_settings_json) above. In shared mode there is no per-agent
+            # config dir, so write the managed --settings file instead. Keyed off the
+            # resolved predicate (not the deprecated use_env_config_dir alias) so it
+            # also fires when shared mode is set via isolate_local_config_dir=False.
+            if not self._is_isolated_config_dir():
                 self._configure_agent_hooks(host, mngr_ctx)
 
             # should be done by now, just wanted to do in parallel for latency reasons
@@ -2101,8 +2123,11 @@ class ClaudeCoreAgent(
         ``get_claude_config_dir()`` resolves to the user's shared $CLAUDE_CONFIG_DIR,
         which exists, so the per-agent-keychain branch would otherwise compute the
         same label hash Claude Code itself uses and delete the user's real
-        credentials. Since provision() never wrote any per-agent keychain or
-        trust entries in this mode, there is nothing for us to clean up. Session
+        credentials. provision() does write dialog-dismissal markers (trust,
+        onboarding, effort, cost) into the user's global config in this mode, but we
+        deliberately leave them: they are merged into the user's own global state
+        (reverting onboarding/effort would harm the user), and the per-agent
+        isolated path likewise leaves its global trust markers behind. Session
         preservation also skips copying the ``projects/`` directory in this mode
         (it lives in the user's persistent dir and contains all of their
         cross-project session history); only transcripts and the session-id
@@ -2113,9 +2138,10 @@ class ClaudeCoreAgent(
             self.preserve_session_state(host)
 
         if not self._is_isolated_config_dir():
-            # Shared-config mode: mngr never wrote per-agent keychain entries or
-            # ~/.claude.json trust markers, so there is nothing to clean up. Any
-            # keychain delete here would target the user's own credentials.
+            # Shared-config mode: mngr never wrote per-agent keychain entries, and the
+            # dialog markers it did write to the global config are intentionally left
+            # in place (see docstring). Any keychain delete here would target the
+            # user's own credentials.
             return
 
         config_dir = self.get_claude_config_dir()
@@ -2356,10 +2382,12 @@ class ClaudeAgent(
         # the end of assemble_command would spawn a fresh `claude --session-id
         # <agent_uuid>` without surfacing any error -- so an adopted session
         # would appear to do nothing.
-        # mngr injects its own --settings only in use_env_config_dir mode (the managed
-        # hooks file). In normal mode the hooks are baked into the config-dir settings.json,
-        # so mngr adds no --settings here.
-        mngr_settings_arg = f" {MANAGED_SETTINGS_LAUNCH_ARG}" if self.agent_config.use_env_config_dir else ""
+        # mngr injects its own --settings only in shared mode (the managed hooks file
+        # written by _configure_agent_hooks). In isolated mode the hooks are baked into
+        # the config-dir settings.json, so mngr adds no --settings here. Keyed off the
+        # resolved predicate (not the deprecated use_env_config_dir alias) so it matches
+        # the write gate in provision() for shared mode set via isolate_local_config_dir=False.
+        mngr_settings_arg = f" {MANAGED_SETTINGS_LAUNCH_ARG}" if not self._is_isolated_config_dir() else ""
         resume_cmd = f'( find "${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}" -name "$MAIN_CLAUDE_SESSION_ID.jsonl" | grep . ) && {base}{mngr_settings_arg} --resume "$MAIN_CLAUDE_SESSION_ID"'
         create_cmd = f"{base}{mngr_settings_arg} --session-id {agent_uuid}"
 
@@ -2399,12 +2427,10 @@ class ClaudeAgent(
         Interactive and auto-approve runs skip these checks because
         provision() will handle them.
 
-        ``isolate_local_config_dir`` only governs local agents; remote agents
-        always use a per-agent isolated config dir regardless of the flag, so no
-        local-only validation is needed here. In shared mode (local +
-        ``isolate_local_config_dir=False``) the dialog-dismissal validation is
-        skipped entirely -- the user is responsible for their own config and
-        mngr makes no writes to it.
+        The dialog-dismissal validation runs for any local agent (both config
+        modes), since provision() dismisses dialogs in the user's global config in
+        either mode. Remote agents have no local user config to validate against,
+        so ``host.is_local`` gates the check.
 
         Also surfaces the ``use_env_config_dir`` deprecation: warns once if the
         old key is set, and raises early if it contradicts ``isolate_local_config_dir``.
@@ -2441,12 +2467,12 @@ class ClaudeAgent(
             )
 
         # Validate dialogs for non-interactive local runs so we fail early with
-        # a clear message. Skip in shared mode (mngr does not write to the user's
-        # config), when auto_dismiss_dialogs is True (provision() auto-dismisses),
-        # and for remote hosts (no local user config to validate).
+        # a clear message. Skip when auto_dismiss_dialogs is True (provision()
+        # auto-dismisses) and for remote hosts (no local user config to validate).
+        # Both config modes are validated -- provision() dismisses against the
+        # user's global config in either mode.
         if (
             host.is_local
-            and self._is_isolated_config_dir()
             and not mngr_ctx.is_interactive
             and not mngr_ctx.is_auto_approve
             and not config.auto_dismiss_dialogs
@@ -2457,7 +2483,7 @@ class ClaudeAgent(
                 trust_path = source_path if source_path is not None else self.work_dir
             else:
                 trust_path = self.work_dir
-            check_claude_dialogs_dismissed(find_user_claude_config(), trust_path)
+            check_claude_dialogs_dismissed(self._dialog_dismissal_config_path(), trust_path)
         if not config.check_installation:
             logger.debug("Skipped claude installation check (check_installation=False)")
             return
@@ -2474,13 +2500,15 @@ class ClaudeAgent(
         self, host: OnlineHostInterface, options: CreateAgentOptions, mngr_ctx: MngrContext
     ) -> None:
         """Dismiss blocking Claude startup dialogs before the agent starts so they don't
-        intercept tmux input. Only acts on local hosts running in isolated
-        (per-agent) config mode; ``auto_dismiss_dialogs`` silently approves,
-        otherwise routes through ``interactively_dismiss_claude_dialogs``
-        (prompt/validate per mode).
+        intercept tmux input. Acts on local hosts in either config mode (isolated
+        writes to the user's global config that the per-agent dir inherits; shared
+        writes to the global config claude reads directly). Remote hosts have no
+        local user config to dismiss against, so they are skipped.
+        ``auto_dismiss_dialogs`` silently approves, otherwise routes through
+        ``interactively_dismiss_claude_dialogs`` (prompt/validate per mode).
         """
         config = self.agent_config
-        if not (host.is_local and config.resolve_isolate_local_config_dir()):
+        if not host.is_local:
             return
         # Determine the source path for trust extension.
         source_path: Path | None = None
@@ -2488,7 +2516,7 @@ class ClaudeAgent(
             source_path = self._find_git_source_path(mngr_ctx.concurrency_group)
         if config.auto_dismiss_dialogs:
             # Auto-approve all dialogs for agents that opt into dismissal.
-            auto_dismiss_claude_dialogs(find_user_claude_config(), self.work_dir)
+            auto_dismiss_claude_dialogs(self._dialog_dismissal_config_path(), self.work_dir)
         else:
             # source_path=None (clone/no-git) means trust is prompted for work_dir.
             self.interactively_dismiss_claude_dialogs(source_path, mngr_ctx)
@@ -2498,8 +2526,9 @@ class ClaudeAgent(
 
         All dialogs that could intercept tmux input must be dismissed before
         starting an agent, otherwise mngr message will break. Writes to the
-        global config (~/.claude.json) to record user intent; the per-agent
-        config inherits these settings.
+        user's global config to record intent. In isolated mode the per-agent
+        config dir inherits these settings; in shared mode the agent's claude
+        reads the global config directly (see ``_dialog_dismissal_config_path``).
 
         For auto-approve mode, silently dismisses all dialogs. For interactive
         mode, prompts the user for each undismissed dialog. For non-interactive
@@ -2508,7 +2537,7 @@ class ClaudeAgent(
         source_path is the trusted source directory (for git-worktree/git-mirror modes).
         When None (rsync/none mode), trust is prompted for work_dir instead.
         """
-        global_config_path = find_user_claude_config()
+        global_config_path = self._dialog_dismissal_config_path()
         trust_path = source_path if source_path is not None else self.work_dir
 
         if mngr_ctx.is_auto_approve:

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -108,8 +108,8 @@ from imbue.mngr_claude.claude_config import complete_onboarding
 from imbue.mngr_claude.claude_config import dismiss_effort_callout
 from imbue.mngr_claude.claude_config import encode_claude_project_dir_name
 from imbue.mngr_claude.claude_config import find_project_config
-from imbue.mngr_claude.claude_config import find_shared_claude_config
-from imbue.mngr_claude.claude_config import find_user_claude_config
+from imbue.mngr_claude.claude_config import find_user_config_in_unisolated_mode
+from imbue.mngr_claude.claude_config import find_user_config_in_isolated_mode
 from imbue.mngr_claude.claude_config import fold_hook_configs
 from imbue.mngr_claude.claude_config import get_agent_claude_config_dir
 from imbue.mngr_claude.claude_config import get_agent_claude_plugin_dir
@@ -652,7 +652,7 @@ def _build_claude_json(
     """
     disable_auto_update = is_self_update_disabled(config.update_policy, is_unattended=ctx.is_unattended)
     if sync_local:
-        local_config = read_claude_config(find_user_claude_config())
+        local_config = read_claude_config(find_user_config_in_isolated_mode())
         data: dict[str, Any] = (
             local_config
             if local_config
@@ -897,7 +897,7 @@ def _prompt_user_for_onboarding_completion() -> bool:
 
 def _claude_json_has_primary_api_key() -> bool:
     """Check if ~/.claude.json contains a non-empty primaryApiKey."""
-    claude_json_path = find_user_claude_config()
+    claude_json_path = find_user_config_in_isolated_mode()
     try:
         config_data = read_claude_config(claude_json_path)
     except (json.JSONDecodeError, OSError) as e:
@@ -1588,14 +1588,14 @@ class ClaudeCoreAgent(
         never tool-permission grants (``bypassPermissionsModeAccepted`` is deliberately
         left untouched; see ``auto_dismiss_claude_dialogs``).
 
-        Isolated mode writes to ``find_user_claude_config`` (the per-agent config dir is
+        Isolated mode writes to ``find_user_config_in_isolated_mode`` (the per-agent config dir is
         built from it via ``sync_local``, so it inherits the dismissals). Shared mode
-        writes to ``find_shared_claude_config``, the file the agent's claude reads
+        writes to ``find_user_config_in_unisolated_mode``, the file the agent's claude reads
         directly, resolved the same way ``modify_env_vars`` resolves ``CLAUDE_CONFIG_DIR``.
         """
         if self._is_isolated_config_dir():
-            return find_user_claude_config()
-        return find_shared_claude_config()
+            return find_user_config_in_isolated_mode()
+        return find_user_config_in_unisolated_mode()
 
     def modify_env_vars(self, host: OnlineHostInterface, env_vars: dict[str, str]) -> None:
         """Add CLAUDE_CONFIG_DIR and ORIGINAL_CLAUDE_CONFIG_DIR.
@@ -2159,7 +2159,7 @@ class ClaudeCoreAgent(
                 logger.debug("Removed per-agent OAuth credentials keychain entry")
         elif not per_agent_config_exists:
             # Legacy agent without per-agent config dir -- clean up global file
-            removed = remove_claude_trust_for_path(find_user_claude_config(), self.work_dir)
+            removed = remove_claude_trust_for_path(find_user_config_in_isolated_mode(), self.work_dir)
             if removed:
                 logger.debug("Removed Claude trust entry for {} from global config", self.work_dir)
         else:
@@ -3084,7 +3084,7 @@ def approve_api_key_for_claude(
         if host_key:
             keys_to_approve.append(host_key)
 
-    user_config = read_claude_config(find_user_claude_config())
+    user_config = read_claude_config(find_user_config_in_isolated_mode())
     conf_key = user_config.get("primaryApiKey", "")
     if conf_key:
         keys_to_approve.append(conf_key)

--- a/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin_test.py
@@ -220,6 +220,20 @@ def _write_claude_trust(source_path: Path) -> None:
     config_path.write_text(json.dumps(config))
 
 
+def _write_dialogs_dismissed_at(config_path: Path, trust_path: Path) -> None:
+    """Write a .claude.json at ``config_path`` with all dialogs dismissed and trust for ``trust_path``.
+
+    Used for shared-mode tests where mngr dismisses dialogs against the config file the
+    agent's claude reads ($CLAUDE_CONFIG_DIR/.claude.json), which is not ~/.claude.json.
+    """
+    config = {
+        **_ALL_DIALOGS_DISMISSED,
+        "projects": {str(trust_path.resolve()): {"hasTrustDialogAccepted": True}},
+    }
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+
+
 def _write_mngr_trust_entry(path: Path) -> None:
     """Write ~/.claude.json with a mngr-created trust entry for path and all dialogs dismissed."""
     config_path = Path.home() / ".claude.json"
@@ -554,6 +568,36 @@ def test_claude_agent_assemble_command_injects_mngr_settings_in_env_config_dir_m
     # ...and the user's own --settings also passes through (the collision).
     assert parsed.resume_args == ["--settings", '{"model": "opus"}']
     assert parsed.create_args == ["--settings", '{"model": "opus"}']
+
+
+def test_claude_agent_assemble_command_injects_mngr_settings_for_isolate_false_flag(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared mode set via the current isolate_local_config_dir=False flag (not the deprecated
+    use_env_config_dir alias) must still inject mngr's managed --settings.
+
+    The hooks-write gate and the hooks-load gate both key off the resolved predicate, so the
+    managed hooks file written at provision time is actually loaded by claude at launch.
+    """
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(check_installation=False, isolate_local_config_dir=False),
+    )
+
+    command = agent.assemble_command(host=host, agent_args=(), command_override=None)
+
+    parsed = _ParsedAssembleCommand(str(command), mngr_injects_settings=True)
+    expected_settings = shlex.split(MANAGED_SETTINGS_LAUNCH_ARG)[1]
+    assert parsed.resume_settings == expected_settings
+    assert parsed.create_settings == expected_settings
 
 
 def test_claude_agent_assemble_command_with_command_override(
@@ -1685,6 +1729,9 @@ def test_provision_configures_readiness_hooks_in_env_config_dir_mode(
         agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
     )
     _init_git_with_gitignore(agent.work_dir)
+    # Shared mode dismisses dialogs against the shared config; pre-dismiss them so the
+    # non-interactive provision does not raise on the trust dialog.
+    _write_dialogs_dismissed_at(shared_dir / ".claude.json", agent.work_dir)
 
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
     agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
@@ -1695,6 +1742,45 @@ def test_provision_configures_readiness_hooks_in_env_config_dir_mode(
     settings = json.loads(managed_path.read_text())
     assert "hooks" in settings
     assert "SessionStart" in settings["hooks"]
+
+
+def test_provision_shared_mode_dismisses_dialogs_in_global_config_but_not_permissions(
+    local_provider: LocalProviderInstance,
+    tmp_path: Path,
+    temp_mngr_ctx: MngrContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared mode mutates the user's global config to dismiss the cosmetic startup dialogs
+    (trust, onboarding, effort callout, cost threshold) -- but never the bypass-permissions
+    grant, which must not be silently accepted via the global config."""
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
+    # auto_dismiss_dialogs lets the non-interactive provision silently dismiss dialogs.
+    agent, host = make_claude_agent(
+        local_provider,
+        tmp_path,
+        temp_mngr_ctx,
+        agent_config=ClaudeAgentConfig(
+            check_installation=False, isolate_local_config_dir=False, auto_dismiss_dialogs=True
+        ),
+    )
+    _init_git_with_gitignore(agent.work_dir)
+
+    options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
+    agent.provision(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+
+    # The dismissals land in the shared config file (the one the agent's claude reads),
+    # NOT in ~/.claude.json.
+    shared_config = json.loads((shared_dir / ".claude.json").read_text())
+    assert shared_config["hasCompletedOnboarding"] is True
+    assert shared_config["effortCalloutDismissed"] is True
+    assert shared_config["hasAcknowledgedCostThreshold"] is True
+    assert shared_config["projects"][str(agent.work_dir.resolve())]["hasTrustDialogAccepted"] is True
+
+    # The bypass-permissions grant is never written to the global config.
+    assert "bypassPermissionsModeAccepted" not in shared_config
+    assert not (Path.home() / ".claude.json").exists()
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
@@ -1976,32 +2062,31 @@ def test_on_before_provisioning_skips_trust_check_when_git_common_dir_is_none(
     assert config_path.read_text() == config_before
 
 
-def test_on_before_provisioning_shared_mode_succeeds_without_dialog_checks(
+def test_on_before_provisioning_shared_mode_validates_dialogs_against_shared_config(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """In shared mode, on_before_provisioning does NOT validate dialog dismissal in user config."""
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    """In shared mode, on_before_provisioning validates dialog dismissal against the shared
+    config file (``$CLAUDE_CONFIG_DIR/.claude.json``), the file the agent's claude reads."""
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
     agent, host = make_claude_agent(
         local_provider,
         tmp_path,
         temp_mngr_ctx,
         agent_config=ClaudeAgentConfig(check_installation=False, isolate_local_config_dir=False),
     )
-    # Deliberately leave ~/.claude.json absent (no dialogs dismissed, no trust) --
-    # a non-shared agent would raise during the dialog-dismissal check here.
-    config_path = Path.home() / ".claude.json"
-    assert not config_path.exists()
-
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
 
-    agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
+    # With no dialogs dismissed in the shared config, the non-interactive check raises.
+    with pytest.raises(ClaudeDirectoryNotTrustedError):
+        agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
-    # Shared mode skips the dialog check entirely and writes nothing to the user's
-    # config, so the file must still be absent.
-    assert not config_path.exists()
+    # Dismissing the dialogs in the shared config (not ~/.claude.json) makes it pass.
+    _write_dialogs_dismissed_at(shared_dir / ".claude.json", agent.work_dir)
+    agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
 
 def _make_remote_claude_agent(
@@ -2075,14 +2160,14 @@ def test_remote_agent_modify_env_vars_uses_isolated_dir_despite_shared_flag(
     assert "ORIGINAL_CLAUDE_CONFIG_DIR" in env_vars
 
 
-def test_on_before_provisioning_shared_mode_passes_when_env_unset(
+def test_on_before_provisioning_shared_mode_validates_default_config_when_env_unset(
     local_provider: LocalProviderInstance,
     tmp_path: Path,
     temp_mngr_ctx: MngrContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With isolate_local_config_dir=False and $CLAUDE_CONFIG_DIR unset, on_before_provisioning falls
-    back to ``~/.claude/`` and does not raise (it's the "don't touch the config" path)."""
+    """With isolate_local_config_dir=False and $CLAUDE_CONFIG_DIR unset, on_before_provisioning
+    validates dialogs against the default ``~/.claude.json`` (where claude reads them)."""
     monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     agent, host = make_claude_agent(
         local_provider,
@@ -2090,17 +2175,17 @@ def test_on_before_provisioning_shared_mode_passes_when_env_unset(
         temp_mngr_ctx,
         agent_config=ClaudeAgentConfig(check_installation=False, isolate_local_config_dir=False),
     )
-
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
 
-    # Shared mode does not touch the user's config; with no ~/.claude.json present
-    # it must neither raise nor create one (the "don't touch the config" path).
+    # No ~/.claude.json present -> the non-interactive dialog check raises.
     config_path = Path.home() / ".claude.json"
     assert not config_path.exists()
+    with pytest.raises(ClaudeDirectoryNotTrustedError):
+        agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
 
+    # Dismissing the dialogs in ~/.claude.json (the default location) makes it pass.
+    _write_all_dialogs_dismissed(agent.work_dir)
     agent.on_before_provisioning(host=host, options=options, mngr_ctx=temp_mngr_ctx)
-
-    assert not config_path.exists()
 
 
 def test_on_destroy_removes_trust(
@@ -2822,13 +2907,17 @@ def test_on_before_provisioning_warns_when_use_env_config_dir_is_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Setting the deprecated use_env_config_dir emits a deprecation warning at provisioning time."""
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "shared"))
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(shared_dir))
     agent, host = make_claude_agent(
         local_provider,
         tmp_path,
         temp_mngr_ctx,
         agent_config=ClaudeAgentConfig(check_installation=False, use_env_config_dir=True),
     )
+    # Shared mode now validates dialogs against the shared config, so dismiss them
+    # there to reach the deprecation warning without raising.
+    _write_dialogs_dismissed_at(shared_dir / ".claude.json", agent.work_dir)
 
     options = CreateAgentOptions(agent_type=AgentTypeName("claude"))
     with capture_loguru() as log_output:


### PR DESCRIPTION
## Summary

For Claude shared config mode (`isolate_local_config_dir=False`), mngr now mutates the user's global Claude config to dismiss the cosmetic startup dialogs, instead of leaving it untouched.

Previously, shared mode made no writes to the user's config, so a fresh `~/.claude.json` (or a stub) re-triggered the trust/onboarding/effort screens on every agent and could intercept tmux input.

### What changed

- Shared mode dismisses the cosmetic startup dialogs (trust, onboarding, effort callout, cost threshold) directly in the config file claude actually reads: `$CLAUDE_CONFIG_DIR/.claude.json`, or `~/.claude.json` when the var is unset. New `find_shared_claude_config()` resolver mirrors `modify_env_vars`' `CLAUDE_CONFIG_DIR` resolution; new `_dialog_dismissal_config_path()` picks the right file per mode.
- `_dismiss_start_dialogs`, the `on_before_provisioning` validation, and the cost-threshold ack now run for local shared agents (still skipped for remote, which are always isolated).
- It honors `auto_dismiss_dialogs` in shared mode.
- It **never** accepts bypass-permissions mode (`bypassPermissionsModeAccepted`) through the global config — that remains governed by `settings.json` (`skipDangerousModePermissionPrompt`), per the existing `auto_dismiss_claude_dialogs` contract.
- Fixed the hooks write **and** load gates (`provision` and `assemble_command`) to key off the resolved predicate `not _is_isolated_config_dir()` rather than the deprecated `use_env_config_dir` alias, so mngr's managed `--settings` hooks are both written and loaded when shared mode is set via the current `isolate_local_config_dir=False` flag.

Updated the field description and README accordingly.

## Testing

- `just test-quick libs/mngr_claude` (offload-excluded markers): 612 passed.
- New tests: `find_shared_claude_config` resolution, shared-mode provision dismisses dialogs in the global config but not the permission flag, shared-mode `on_before_provisioning` validation against the shared/default config, and managed `--settings` injection via the `isolate_local_config_dir=False` flag.
- vet (agentic) reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)