### PR TITLE
Bump offload from 0.9.7 to 0.9.9 (latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.7-${{ runner.os }}
+          key: cargo-offload-0.9.9-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.7'; then
-            cargo install offload@0.9.7 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.9'; then
+            cargo install offload@0.9.9 --force
           fi
 
       - name: Restore offload test durations from previous run
@@ -311,12 +311,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.7-${{ runner.os }}
+          key: cargo-offload-0.9.9-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.7'; then
-            cargo install offload@0.9.7 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.9'; then
+            cargo install offload@0.9.9 --force
           fi
 
       - name: Restore offload test durations from previous run

--- a/dev/changelog/danver-upgrade-to-offload-v0.9.9.md
+++ b/dev/changelog/danver-upgrade-to-offload-v0.9.9.md
@@ -1,0 +1,1 @@
+Bumped the offload CI pin in `.github/workflows/ci.yml` from `0.9.7` to `0.9.9` (the latest release), updating the cargo cache key, the version check, and the `cargo install` invocation.

--- a/libs/mngr/changelog/danver-upgrade-to-offload-v0.9.9.md
+++ b/libs/mngr/changelog/danver-upgrade-to-offload-v0.9.9.md
@@ -1,0 +1,1 @@
+Bumped the offload version baked into `libs/mngr/imbue/mngr/resources/Dockerfile` from `0.9.7` to `0.9.9` to track the CI pin.

--- a/libs/mngr/imbue/mngr/resources/Dockerfile
+++ b/libs/mngr/imbue/mngr/resources/Dockerfile
@@ -103,7 +103,7 @@ ENV UV_LINK_MODE=copy
 # call (per-layer caching, see `_build_image_from_dockerfile_contents`). ARGs
 # don't carry across separate calls, so an ARG above would expand to empty in
 # the RUN below and `cargo install offload@` would error.
-RUN export OFFLOAD_VERSION=0.9.7 \
+RUN export OFFLOAD_VERSION=0.9.9 \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
     && /root/.cargo/bin/cargo install offload@${OFFLOAD_VERSION} --locked --root /opt/offload \


### PR DESCRIPTION
Bumps the pinned [offload](https://crates.io/crates/offload) version from `0.9.7` to `0.9.9` (the latest release).

Offload is a Rust crate pinned in two places, both updated here:

- `.github/workflows/ci.yml` — cargo cache key, the `offload --version` check, and the `cargo install offload@...` invocation (in both jobs).
- `libs/mngr/imbue/mngr/resources/Dockerfile` — `OFFLOAD_VERSION`, the binary baked into the Modal sandbox image (which is documented to track the CI pin).

Historical `CHANGELOG.md` entries and the feature-availability comments in `scripts/snapshot_minds_e2e_state.py` ("offload v0.9.7+") are left untouched, as they document when a feature was introduced rather than pinning a version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)