### PR TITLE
Auto-merge nightly changelog consolidation PRs

### DIFF
--- a/dev/changelog/mngr-auto-merge-changelogs.md
+++ b/dev/changelog/mngr-auto-merge-changelogs.md
@@ -1,1 +1,1 @@
-Changed: The nightly changelog consolidation automation now squash-merges its PR immediately instead of leaving it for a human to review and merge. The in-run accuracy review remains the quality gate.
+Changed: The nightly changelog consolidation automation now merges its PR immediately instead of leaving it for a human to review and merge. The in-run accuracy review remains the quality gate.

--- a/dev/changelog/mngr-auto-merge-changelogs.md
+++ b/dev/changelog/mngr-auto-merge-changelogs.md
@@ -1,0 +1,1 @@
+Changed: The nightly changelog consolidation automation now squash-merges its PR immediately instead of leaving it for a human to review and merge. The in-run accuracy review remains the quality gate.

--- a/scripts/changelog_consolidation_prompt.md
+++ b/scripts/changelog_consolidation_prompt.md
@@ -208,14 +208,15 @@ the right project's consolidated files.
    JSON object with that stderr content in `notes`.
 
 11. Merge the PR immediately -- this automation no longer waits for a
-   human reviewer; the accuracy review in step 8 is the gate. Squash-merge
-   and delete the branch: `gh pr merge "$PR_URL" --squash --delete-branch`.
-   Squashing collapses the consolidation commit plus any accuracy-review
-   correction commits into a single commit on `main`. If `gh pr merge`
-   exits non-zero, read its stderr; if the error is something you can fix
-   (e.g. a transient failure worth one retry) then retry once, otherwise
-   emit a `failed` JSON object with the merge error in `notes` (include the
-   PR URL so the half-finished run can be merged by hand).
+   human reviewer; the accuracy review in step 8 is the gate. Merge and
+   delete the branch: `gh pr merge "$PR_URL" --merge --delete-branch`. The
+   repo only permits merge commits (squash and rebase are disabled), so the
+   consolidation commit plus any accuracy-review correction commits land
+   under a single merge commit on `main`. If `gh pr merge` exits non-zero,
+   read its stderr; if the error is something you can fix (e.g. a transient
+   failure worth one retry) then retry once, otherwise emit a `failed` JSON
+   object with the merge error in `notes` (include the PR URL so the
+   half-finished run can be merged by hand).
 
 12. Emit your final JSON object: `{"status": "done", "pr_url":
     "<PR_URL>"}`, substituting the PR URL from step 10. Reaching this step

--- a/scripts/changelog_consolidation_prompt.md
+++ b/scripts/changelog_consolidation_prompt.md
@@ -207,5 +207,16 @@ the right project's consolidated files.
    malformed invocation), correct it and retry, otherwise emit a `failed`
    JSON object with that stderr content in `notes`.
 
-11. Emit your final JSON object: `{"status": "done", "pr_url":
-    "<PR_URL>"}`, substituting the PR URL from step 10.
+11. Merge the PR immediately -- this automation no longer waits for a
+   human reviewer; the accuracy review in step 8 is the gate. Squash-merge
+   and delete the branch: `gh pr merge "$PR_URL" --squash --delete-branch`.
+   Squashing collapses the consolidation commit plus any accuracy-review
+   correction commits into a single commit on `main`. If `gh pr merge`
+   exits non-zero, read its stderr; if the error is something you can fix
+   (e.g. a transient failure worth one retry) then retry once, otherwise
+   emit a `failed` JSON object with the merge error in `notes` (include the
+   PR URL so the half-finished run can be merged by hand).
+
+12. Emit your final JSON object: `{"status": "done", "pr_url":
+    "<PR_URL>"}`, substituting the PR URL from step 10. Reaching this step
+    means the PR was both opened and merged.


### PR DESCRIPTION
## What

The nightly changelog consolidation automation currently opens a PR and leaves it for a human to review and merge. This makes it merge its own PR immediately after opening it, removing the human-review bottleneck.

The in-run accuracy review (step 8, the parallel reviewer subagents) remains the quality gate.

## Changes

- `scripts/changelog_consolidation_prompt.md`: new step 11 runs `gh pr merge "$PR_URL" --merge --delete-branch` right after the PR is opened. On failure it retries once, otherwise emits a `failed` JSON object with the merge error and the PR URL so a half-finished run can be merged by hand.

## Notes

- Uses `--merge` (not `--squash`) because the repo only permits merge commits — squash and rebase are disabled in repo settings. This also matches the existing `Merge pull request #…` history.
- Precondition: this works only if `bot@imbue.com` has merge rights and `main` has no required approval/check blocking the merge. If `main` ever requires an approving review, the bot merging its own PR will be rejected and the run will fail at step 11 (would then need `--admin` or a protection carve-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)