### PR TITLE
minds: blinking tab for Caretaker-created agents + capture user timezone

### DIFF
--- a/apps/minds/changelog/preston-nightly-agent-phase5-minds.md
+++ b/apps/minds/changelog/preston-nightly-agent-phase5-minds.md
@@ -1,0 +1,3 @@
+Workspaces that the nightly Caretaker agent creates now announce themselves: their sidebar tab gently pulses in the workspace accent color until you open it for the first time, then stops for good (tracked per device). Hand-made workspaces and your day-1 chat tab never pulse -- only agents the Caretaker scheduler auto-creates (labeled `auto_created` / `caretaker`).
+
+The create form now captures your browser's local timezone and stores it on the new workspace, so the workspace's scheduler runs nightly tasks (like the Caretaker's 3 AM run) in your local time rather than the host clock. If the timezone can't be determined it falls back to the host clock, so nothing breaks.

--- a/apps/minds/imbue/minds/desktop_client/agent_creator.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator.py
@@ -9,10 +9,12 @@ Callers can poll creation status via get_creation_info() or stream logs
 via get_log_queue().
 """
 
+import base64
 import json
 import os
 import queue
 import re
+import shlex
 import shutil
 import tempfile
 import threading
@@ -513,6 +515,35 @@ _FAST_MODE_PREVENT: Final[str] = "prevent"
 # human-formatted error text) to fall back to the slow path. Kept in sync with
 # ``imbue.mngr_imbue_cloud.errors.FastPathUnavailableError``.
 _FAST_PATH_UNAVAILABLE_ERROR_CLASS: Final[str] = "FastPathUnavailableError"
+
+# Repo-root-relative path the scheduler service reads to resolve "3 AM" in the
+# user's local timezone (frozen by the caretaker-scheduler contract). Written
+# once, right after create, from the desktop client's browser IANA tz. The
+# scheduler falls back to the host clock when this file is absent.
+_SCHEDULER_TIMEZONE_REMOTE_PATH: Final[str] = "runtime/scheduler/timezone"
+
+# Per-attempt timeout for the post-create ``mngr exec`` that writes the
+# timezone file, and the bounded retry budget / wait for a slow host whose
+# ``mngr exec`` briefly races the agent's reachability after create returns.
+_TIMEZONE_WRITE_EXEC_TIMEOUT_SECONDS: Final[float] = 30.0
+_TIMEZONE_WRITE_RETRY_BUDGET_SECONDS: Final[float] = 120.0
+_TIMEZONE_WRITE_RETRY_WAIT_SECONDS: Final[float] = 5.0
+
+
+def build_timezone_write_script(timezone_name: str) -> str:
+    """Build the remote bash that writes ``timezone_name`` to the scheduler tz file.
+
+    The name is base64-encoded so it survives ``mngr exec``'s single
+    command-string argument intact (the base64 alphabet has no
+    shell-significant characters, so single-quoting it is safe). Writes a
+    single trailing-newline-terminated line, creating the parent dir.
+    """
+    encoded = base64.b64encode(f"{timezone_name}\n".encode()).decode("ascii")
+    parent_dir = os.path.dirname(_SCHEDULER_TIMEZONE_REMOTE_PATH) or "."
+    return (
+        f"set -e; mkdir -p {shlex.quote(parent_dir)}; "
+        f"printf %s '{encoded}' | base64 -d > {shlex.quote(_SCHEDULER_TIMEZONE_REMOTE_PATH)}"
+    )
 
 
 def _build_mngr_create_command(
@@ -1263,6 +1294,7 @@ class AgentCreator(MutableModel):
         on_created: Callable[[AgentId], None] | None = None,
         backup_request: BackupSetupRequest | None = None,
         color: str | None = None,
+        timezone: str = "",
     ) -> CreationId:
         """Start creating an agent from a git URL or local path in a background thread.
 
@@ -1334,6 +1366,7 @@ class AgentCreator(MutableModel):
                 on_created,
                 backup_request,
                 color,
+                timezone,
             ),
             daemon=True,
             name="agent-creator-{}".format(creation_id),
@@ -1395,6 +1428,7 @@ class AgentCreator(MutableModel):
         on_created: Callable[[AgentId], None] | None = None,
         backup_request: BackupSetupRequest | None = None,
         color: str | None = None,
+        timezone: str = "",
     ) -> None:
         """Background thread that resolves the repo source and creates an mngr agent.
 
@@ -1704,6 +1738,22 @@ class AgentCreator(MutableModel):
                 if on_created is not None:
                     on_created(canonical_id)
 
+                # Capture the user's local timezone for the scheduler service
+                # on a detached thread. A slow host's ``mngr exec`` can still
+                # race the agent's reachability just after create returns, so
+                # this is retried within a bounded budget and is non-fatal --
+                # the scheduler falls back to the host clock if the file never
+                # lands. Skipped (no thread) when the client sent no timezone.
+                if timezone.strip():
+                    self.root_concurrency_group.start_new_thread(
+                        target=self._write_scheduler_timezone,
+                        kwargs={"agent_id": canonical_id, "timezone": timezone.strip()},
+                        name=f"timezone-write-{canonical_id}",
+                        # is_checked=False so a failing optional write never
+                        # poisons the root CG; failures are logged only.
+                        is_checked=False,
+                    )
+
                 # Configure restic backups asynchronously on a detached
                 # thread (mirrors the Cloudflare tunnel-token path): bucket
                 # creation + injection is a multi-second round-trip we don't
@@ -1838,6 +1888,46 @@ class AgentCreator(MutableModel):
                     urgency=NotificationUrgency.NORMAL,
                 ),
                 agent_display_name=str(agent_id)[:8],
+            )
+
+    def _write_scheduler_timezone(self, *, agent_id: AgentId, timezone: str) -> None:
+        """Detached-thread entry point: write the user's tz to the scheduler tz file.
+
+        Writes ``runtime/scheduler/timezone`` (one line) on the new agent's
+        host via ``mngr exec`` so the scheduler service resolves "3 AM" in the
+        user's local time. The host can briefly be unreachable for ``mngr
+        exec`` right after create returns, so transient failures are retried
+        within a bounded budget. Best-effort and non-fatal to the workspace:
+        if it never lands, the scheduler falls back to the host clock.
+        """
+        script = build_timezone_write_script(timezone)
+        try:
+            for attempt in Retrying(
+                retry=retry_if_exception_type((MngrCommandError, OSError)),
+                stop=stop_after_delay(_TIMEZONE_WRITE_RETRY_BUDGET_SECONDS),
+                wait=wait_fixed(_TIMEZONE_WRITE_RETRY_WAIT_SECONDS),
+                reraise=True,
+            ):
+                with attempt:
+                    cg = self.root_concurrency_group.make_concurrency_group(name=f"timezone-write-{agent_id}")
+                    with cg:
+                        result = cg.run_process_to_completion(
+                            command=[MNGR_BINARY, "exec", str(agent_id), script],
+                            timeout=_TIMEZONE_WRITE_EXEC_TIMEOUT_SECONDS,
+                            is_checked_after=False,
+                        )
+                    if result.returncode != 0:
+                        raise MngrCommandError(
+                            f"mngr exec to write timezone for agent {agent_id} exited {result.returncode}: "
+                            f"{result.stderr.strip() or result.stdout.strip()}"
+                        )
+            logger.debug("Wrote scheduler timezone {!r} to agent {}", timezone, agent_id)
+        except (MngrCommandError, OSError) as exc:
+            logger.opt(exception=exc).warning(
+                "Failed to write scheduler timezone for agent {} after {:.0f}s of retries; "
+                "the scheduler will fall back to the host clock",
+                agent_id,
+                _TIMEZONE_WRITE_RETRY_BUDGET_SECONDS,
             )
 
     def _build_redirect_url(self, agent_id: AgentId) -> str:

--- a/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
+++ b/apps/minds/imbue/minds/desktop_client/agent_creator_test.py
@@ -7,6 +7,7 @@ suite (``libs/mngr_imbue_cloud``) covers the lease + adopt path; this
 file covers minds' command-building and helpers.
 """
 
+import base64
 import queue
 import subprocess
 import threading
@@ -34,6 +35,7 @@ from imbue.minds.desktop_client.agent_creator import _is_local_path
 from imbue.minds.desktop_client.agent_creator import _redact_url_credentials
 from imbue.minds.desktop_client.agent_creator import _redact_url_credentials_in_text
 from imbue.minds.desktop_client.agent_creator import _rsync_worktree_over_clone
+from imbue.minds.desktop_client.agent_creator import build_timezone_write_script
 from imbue.minds.desktop_client.agent_creator import checkout_branch
 from imbue.minds.desktop_client.agent_creator import clone_git_repo
 from imbue.minds.desktop_client.agent_creator import extract_repo_name
@@ -197,6 +199,20 @@ def test_build_mngr_create_command_omits_color_label_when_unset() -> None:
     )
     joined = " ".join(command)
     assert "color=" not in joined
+
+
+def test_build_timezone_write_script_targets_the_scheduler_tz_file() -> None:
+    """The post-create write targets the frozen scheduler tz path and base64-decodes the value."""
+    script = build_timezone_write_script("America/New_York")
+    # Writes to the contract-frozen path, relative to the agent work_dir.
+    assert "runtime/scheduler/timezone" in script
+    # Creates the parent dir and base64-decodes (so arbitrary content survives
+    # the mngr exec single-arg shell round-trip).
+    assert "mkdir -p" in script
+    assert "base64 -d" in script
+    # The encoded payload round-trips back to the tz name plus a trailing newline.
+    encoded = script.split("printf %s '", 1)[1].split("'", 1)[0]
+    assert base64.b64decode(encoded).decode("utf-8") == "America/New_York\n"
 
 
 def test_build_mngr_create_command_does_not_inject_minds_api_key() -> None:

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -16,6 +16,8 @@ from typing import Any
 from typing import Final
 from typing import assert_never
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfoNotFoundError
 
 import httpx
 from flask import Flask
@@ -410,6 +412,29 @@ def _is_workspace_provider_errored(info: AgentDisplayInfo | None, errored_provid
     return info is not None and info.provider_name is not None and info.provider_name in errored_provider_names
 
 
+# Label values mngr never validates, so a present marker label might carry
+# any string; treat these (case-insensitive) as "not set" so an explicit
+# ``auto_created=false`` doesn't blink. Anything else present counts as set.
+_FALSEY_LABEL_VALUES: Final[frozenset[str]] = frozenset({"", "false", "0", "no", "off"})
+
+# Labels the Caretaker scheduler attaches to an auto-created agent (frozen by
+# the caretaker-scheduler contract). Either being truthy blinks the tab.
+_AUTO_CREATED_LABEL_NAMES: Final[tuple[str, ...]] = ("auto_created", "caretaker")
+
+
+def _is_auto_created_workspace(labels: Mapping[str, str]) -> bool:
+    """True when the agent carries a truthy ``auto_created`` / ``caretaker`` label.
+
+    Drives the blinking-new-tab affordance: only agents the Caretaker
+    scheduler auto-creates blink until first opened. A label counts as set
+    when present with any value outside :data:`_FALSEY_LABEL_VALUES`.
+    """
+    return any(
+        name in labels and labels[name].strip().lower() not in _FALSEY_LABEL_VALUES
+        for name in _AUTO_CREATED_LABEL_NAMES
+    )
+
+
 def _resolved_workspace_color(backend_resolver: BackendResolverInterface, agent_id: AgentId) -> str:
     """The workspace's stored color hex, or the default for label-less workspaces.
 
@@ -441,6 +466,30 @@ def _color_for_new_workspace(raw_color: object) -> str:
     if stripped:
         logger.warning("Ignoring malformed create-request color {!r}; using the default workspace color.", stripped)
     return DEFAULT_WORKSPACE_COLOR
+
+
+def _validate_create_timezone(raw_timezone: object) -> str:
+    """Validate a create request's submitted IANA timezone, or return ``""``.
+
+    The create form/API carries the browser's
+    ``Intl.DateTimeFormat().resolvedOptions().timeZone`` so the scheduler
+    can run "3 AM" in the user's local time. A missing or unrecognized
+    value is treated as "unknown" (returns ``""``) rather than rejecting
+    the create -- the scheduler falls back to the host clock. Validating
+    against the system tz database here also keeps anything unexpected from
+    reaching the ``mngr exec`` write.
+    """
+    stripped = str(raw_timezone).strip() if raw_timezone is not None else ""
+    if not stripped:
+        return ""
+    try:
+        ZoneInfo(stripped)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning(
+            "Ignoring unrecognized create-request timezone {!r}; scheduler will use the host clock.", stripped
+        )
+        return ""
+    return stripped
 
 
 def _suggested_create_color(backend_resolver: BackendResolverInterface) -> str:
@@ -994,6 +1043,7 @@ def _handle_create_form_submit() -> Response:
     account_id = str(form.get("account_id", "")).strip()
     anthropic_api_key = str(form.get("anthropic_api_key", "")).strip()
     color = _color_for_new_workspace(form.get("color", ""))
+    client_timezone = _validate_create_timezone(form.get("timezone", ""))
     try:
         backup_provider = BackupProvider(str(form.get("backup_provider", BackupProvider.CONFIGURE_LATER.value)))
     except ValueError:
@@ -1126,6 +1176,7 @@ def _handle_create_form_submit() -> Response:
         on_created=on_created,
         backup_request=backup_request,
         color=color,
+        timezone=client_timezone,
     )
 
     creating_url = "/creating/{}".format(creation_id)
@@ -1225,6 +1276,7 @@ def _handle_create_agent_api() -> Response:
     account_id = str(body.get("account_id", "")).strip()
     submitted_region = str(body.get("region", "")).strip()
     color = _color_for_new_workspace(body.get("color", ""))
+    client_timezone = _validate_create_timezone(body.get("timezone", ""))
     if not git_url:
         return make_response(
             status_code=400,
@@ -1340,6 +1392,7 @@ def _handle_create_agent_api() -> Response:
         on_created=_persist_region_on_created,
         backup_request=backup_request,
         color=color,
+        timezone=client_timezone,
     )
 
     # Apply any onboarding answers supplied inline by the API caller. Absent
@@ -2557,6 +2610,11 @@ def _build_workspace_list(
         # unverified rather than confirmed healthy.
         if _is_workspace_provider_errored(info, errored_provider_names):
             entry["is_stale"] = "true"
+        # Blink the tab for agents the Caretaker scheduler auto-created
+        # (label ``auto_created`` / ``caretaker``) until the client marks
+        # them seen; hand-made workspaces and the day-1 chat tab never blink.
+        if _is_auto_created_workspace(backend_resolver.get_agent_labels(aid)):
+            entry["is_new"] = "true"
         liveness = liveness_by_agent_id.get(str(aid))
         if liveness is not None:
             entry["supports_shutdown"] = "true"

--- a/apps/minds/imbue/minds/desktop_client/app_create_color_test.py
+++ b/apps/minds/imbue/minds/desktop_client/app_create_color_test.py
@@ -1,8 +1,9 @@
-"""Unit tests for the create-request color parse helper in ``app``."""
+"""Unit tests for the create-request color + timezone parse helpers in ``app``."""
 
 import pytest
 
 from imbue.minds.desktop_client.app import _color_for_new_workspace
+from imbue.minds.desktop_client.app import _validate_create_timezone
 from imbue.minds.desktop_client.workspace_color import DEFAULT_WORKSPACE_COLOR
 
 
@@ -29,3 +30,27 @@ def test_color_for_new_workspace_defaults_silently_for_missing_values(raw_color:
 def test_color_for_new_workspace_defaults_for_malformed_values() -> None:
     assert _color_for_new_workspace("not-a-hex") == DEFAULT_WORKSPACE_COLOR
     assert _color_for_new_workspace("#ffffff80") == DEFAULT_WORKSPACE_COLOR
+
+
+def test_validate_create_timezone_accepts_known_iana_names() -> None:
+    assert _validate_create_timezone("America/New_York") == "America/New_York"
+    assert _validate_create_timezone("UTC") == "UTC"
+    # Surrounding whitespace from the form field is trimmed.
+    assert _validate_create_timezone("  Europe/London  ") == "Europe/London"
+
+
+@pytest.mark.parametrize(
+    "raw_timezone",
+    [
+        # Absent form field / JSON field (handlers default to "").
+        "",
+        # Explicit JSON null.
+        None,
+        # Not a real IANA tz: must not reach the mngr exec write.
+        "Not/AZone",
+        "America/Nowhere",
+    ],
+)
+def test_validate_create_timezone_returns_empty_for_missing_or_unknown(raw_timezone: object) -> None:
+    """Missing or unrecognized values fall back to "" (the scheduler uses the host clock)."""
+    assert _validate_create_timezone(raw_timezone) == ""

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver.py
@@ -175,6 +175,19 @@ class BackendResolverInterface(MutableModel, ABC):
         """
         return None
 
+    def get_agent_labels(self, agent_id: AgentId) -> dict[str, str]:
+        """Return the full label mapping for an agent, or an empty dict.
+
+        Mirrors :meth:`get_workspace_color`'s iteration over discovered
+        agents but exposes every label rather than one. Callers use it to
+        read the ``auto_created`` / ``caretaker`` markers that drive the
+        blinking-new-tab affordance.
+
+        Default implementation returns an empty mapping. Subclasses with
+        access to agent labels should override this.
+        """
+        return {}
+
     def get_system_services_agent_id(self, workspace_agent_id: AgentId) -> AgentId | None:
         """Return the ``system-services`` agent id that shares the workspace agent's host.
 
@@ -847,6 +860,14 @@ class MngrCliBackendResolver(BackendResolverInterface):
                         return DEFAULT_WORKSPACE_COLOR
                     return normalized
             return None
+
+    def get_agent_labels(self, agent_id: AgentId) -> dict[str, str]:
+        """Return the agent's full label mapping (a copy), or an empty dict if unknown."""
+        with self._lock:
+            for agent in self._agents_result.discovered_agents:
+                if agent.agent_id == agent_id:
+                    return dict(agent.labels)
+            return {}
 
     def set_workspace_color_locally(self, agent_id: AgentId, color_hex: str) -> bool:
         """Optimistically update the cached ``color`` label for an agent.

--- a/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
+++ b/apps/minds/imbue/minds/desktop_client/backend_resolver_test.py
@@ -386,6 +386,36 @@ def test_get_workspace_color_returns_none_for_unknown_agent() -> None:
     assert resolver.get_workspace_color(AgentId.generate()) is None
 
 
+# -- get_agent_labels tests -------------------------------------------
+#
+# get_agent_labels is the label-read behind the blinking-new-tab affordance:
+# _build_workspace_list reads it to spot the Caretaker scheduler's
+# ``auto_created`` / ``caretaker`` markers.
+
+
+def test_get_agent_labels_returns_full_label_mapping() -> None:
+    """Every label on the agent (the workspace markers plus extras) is returned."""
+    resolver, agent = _resolver_with_workspace_agent(extra_labels={"auto_created": "true", "caretaker": "true"})
+    labels = resolver.get_agent_labels(agent)
+    assert labels["workspace"] == "true"
+    assert labels["is_primary"] == "true"
+    assert labels["auto_created"] == "true"
+    assert labels["caretaker"] == "true"
+
+
+def test_get_agent_labels_returns_empty_dict_for_unknown_agent() -> None:
+    resolver = MngrCliBackendResolver()
+    assert resolver.get_agent_labels(AgentId.generate()) == {}
+
+
+def test_get_agent_labels_returns_a_copy_not_the_live_labels() -> None:
+    """Mutating the returned dict must not corrupt the resolver's cached labels."""
+    resolver, agent = _resolver_with_workspace_agent(extra_labels={"auto_created": "true"})
+    labels = resolver.get_agent_labels(agent)
+    labels["auto_created"] = "tampered"
+    assert resolver.get_agent_labels(agent)["auto_created"] == "true"
+
+
 def test_set_workspace_color_locally_updates_the_cached_label() -> None:
     """Optimistic write: after a successful CLI mngr label write, the
     resolver's cached snapshot is updated in place so the next SSE

--- a/apps/minds/imbue/minds/desktop_client/providers_panel_test.py
+++ b/apps/minds/imbue/minds/desktop_client/providers_panel_test.py
@@ -410,6 +410,61 @@ def test_build_workspace_list_does_not_mark_stale_for_unrelated_provider_error()
     assert "is_stale" not in workspaces[0]
 
 
+# -- _build_workspace_list new-tab (blink) marking --
+#
+# The Caretaker scheduler creates its agent with ``auto_created=true`` +
+# ``caretaker=true``; the desktop client blinks any such tab until the user
+# opens it (the seen-tracking lives client-side in JS). _build_workspace_list
+# emits ``is_new`` iff the agent carries a truthy auto-created marker.
+
+
+def _build_one_workspace_with_labels(extra_labels: dict[str, str]) -> dict[str, str]:
+    """Build the single-workspace listing entry for an agent carrying ``extra_labels``."""
+    resolver = MngrCliBackendResolver()
+    agent = _make_workspace_agent("docker", extra_labels=extra_labels)
+    resolver.update_agents(ParsedAgentsResult(agent_ids=(agent.agent_id,), discovered_agents=(agent,)))
+    workspaces = _build_workspace_list(resolver)
+    assert len(workspaces) == 1
+    return workspaces[0]
+
+
+def test_build_workspace_list_does_not_mark_new_for_ordinary_workspace() -> None:
+    """A hand-made workspace (no auto-created marker) never blinks."""
+    entry = _build_one_workspace_with_labels({})
+    assert "is_new" not in entry
+
+
+@pytest.mark.parametrize(
+    "marker_labels",
+    [
+        {"auto_created": "true"},
+        {"caretaker": "true"},
+        {"auto_created": "true", "caretaker": "true"},
+        # Any truthy value counts, not just the literal "true".
+        {"auto_created": "1"},
+    ],
+)
+def test_build_workspace_list_marks_new_for_auto_created_agent(marker_labels: dict[str, str]) -> None:
+    """An agent carrying a truthy ``auto_created`` / ``caretaker`` label blinks."""
+    entry = _build_one_workspace_with_labels(marker_labels)
+    assert entry["is_new"] == "true"
+
+
+@pytest.mark.parametrize(
+    "marker_labels",
+    [
+        {"auto_created": "false"},
+        {"caretaker": "0"},
+        {"auto_created": ""},
+        {"caretaker": "no"},
+    ],
+)
+def test_build_workspace_list_does_not_mark_new_for_falsey_marker(marker_labels: dict[str, str]) -> None:
+    """An explicitly falsey marker (e.g. ``auto_created=false``) must not blink."""
+    entry = _build_one_workspace_with_labels(marker_labels)
+    assert "is_new" not in entry
+
+
 # -- _build_workspace_list color emission --
 #
 # These assert the SSE workspaces payload carries the stored color.

--- a/apps/minds/imbue/minds/desktop_client/static/app.css
+++ b/apps/minds/imbue/minds/desktop_client/static/app.css
@@ -472,6 +472,32 @@ html {
 }
 
 /*
+ * New-tab pulse: a workspace the Caretaker scheduler auto-created
+ * (``is_new`` from the server) blinks its accent dot until the user opens
+ * it once. ``.sidebar-new`` is added to the row by buildRow (sidebar_workspace_row.js)
+ * only while the id is not yet in the client's "seen" set (seen_workspaces.js).
+ * The pulse breathes an accent-colored halo around the dot (sized via
+ * box-shadow so it never reflows the row) plus a gentle opacity swell -- a
+ * tasteful "look here, this is new" without the harshness of a hard blink.
+ * The halo color is the same ``--workspace-accent`` the dot is painted with
+ * (set inline per row by buildRow), falling back to the default accent.
+ */
+.sidebar-new .sidebar-dot {
+  animation: pulse-accent 1.4s ease-in-out infinite;
+}
+@keyframes pulse-accent {
+  0%,
+  100% {
+    opacity: 0.65;
+    box-shadow: 0 0 0 0 rgb(from var(--workspace-accent, #0b292b) r g b / 0.55);
+  }
+  50% {
+    opacity: 1;
+    box-shadow: 0 0 0 3px rgb(from var(--workspace-accent, #0b292b) r g b / 0);
+  }
+}
+
+/*
  * Workspace color picker (workspace settings page + create form).
  * The swatch's selected state is conveyed via aria-checked="true" so
  * screen readers see the radio role correctly; the visual ring uses

--- a/apps/minds/imbue/minds/desktop_client/static/chrome.js
+++ b/apps/minds/imbue/minds/desktop_client/static/chrome.js
@@ -111,6 +111,11 @@
   }
 
   function selectWorkspace(agentId) {
+    // Opening a workspace clears its new-tab pulse for good on this client.
+    // Mark it seen and re-render so the row stops pulsing immediately.
+    if (window.mindsSeenWorkspaces && window.mindsSeenWorkspaces.markSeen(agentId)) {
+      renderWorkspaces(lastWorkspaces);
+    }
     navigateContent(mngrForwardOrigin + '/goto/' + agentId + '/');
     closeSidebar();
   }
@@ -454,6 +459,7 @@
         var row = window.mindsSidebarRow.buildRow(w, {
           isCurrent: w.id === currentTitleAgentId,
           withOpenNew: false,
+          isSeen: !window.mindsSeenWorkspaces || window.mindsSeenWorkspaces.has(w.id),
         });
         row.addEventListener('click', function (e) {
           if (e.target.closest('[data-open-settings]')) {
@@ -537,6 +543,12 @@
       if (data.type === 'workspaces') {
         lastWorkspaces = data.workspaces || [];
         rememberWorkspaceAccents(lastWorkspaces);
+        // On a brand-new client, treat every workspace already present at
+        // first sight as "seen" so pre-existing tabs (incl. the day-1 chat
+        // tab) never blink. Idempotent: only the first tick ever seeds.
+        if (window.mindsSeenWorkspaces) {
+          window.mindsSeenWorkspaces.seedIfFresh(lastWorkspaces.map(function (w) { return w.id; }));
+        }
         renderWorkspaces(lastWorkspaces);
         // Replay the most recent ``applyTitleAccent`` call now that the
         // cache has fresh data. Catches two cases:

--- a/apps/minds/imbue/minds/desktop_client/static/seen_workspaces.js
+++ b/apps/minds/imbue/minds/desktop_client/static/seen_workspaces.js
@@ -1,0 +1,102 @@
+// Client-side "seen workspaces" tracker, shared by chrome.js (browser-mode
+// inline sidebar) and sidebar.js (the Electron modal sidebar) so the
+// blinking-new-tab affordance behaves identically in both. Loaded before
+// each of them (see Chrome.jinja / Sidebar.jinja).
+//
+// The server marks a workspace ``is_new`` when the agent carries the
+// Caretaker scheduler's ``auto_created`` / ``caretaker`` label (see
+// _build_workspace_list in app.py). A row only actually blinks while it is
+// ``is_new`` AND not yet in this client's seen set -- so a tab pulses until
+// the user opens it once, then stops forever (per client/device).
+//
+// Seeding rule: on a brand-new client (no stored set) we seed the set with
+// every workspace id currently known, so pre-existing tabs -- including the
+// day-1 chat tab that predates this feature -- never blink. Only genuinely
+// new workspaces that arrive *after* seeding can pulse.
+//
+// Persistence: a versioned localStorage key. localStorage can be unavailable
+// (private mode, a sandboxed context); we degrade to an in-memory set so the
+// feature still works for the session, just without cross-launch memory.
+//
+// Usage:
+//   window.mindsSeenWorkspaces.seedIfFresh(['agent-..', ..]);  // once, idempotent
+//   window.mindsSeenWorkspaces.has('agent-..');                // bool
+//   window.mindsSeenWorkspaces.markSeen('agent-..');           // bool: newly added?
+(function () {
+  var STORAGE_KEY = 'minds.seenWorkspaceIds.v1';
+  // Sentinel value distinguishing "seeded with an empty set" from "never
+  // seeded": once seeding has happened the key is present even if no ids
+  // were known, so a later launch with brand-new tabs blinks correctly.
+  var SEEDED_KEY = 'minds.seenWorkspaceIds.seeded.v1';
+
+  // In-memory mirror; the source of truth when localStorage is usable, and
+  // the only store when it is not.
+  var memoryIds = null;
+  var memorySeeded = false;
+
+  function readStore() {
+    if (memoryIds !== null) return memoryIds;
+    var ids = {};
+    try {
+      var raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        var parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          parsed.forEach(function (id) { if (typeof id === 'string') ids[id] = true; });
+        }
+      }
+      memorySeeded = window.localStorage.getItem(SEEDED_KEY) === '1';
+    } catch (e) {
+      // localStorage unavailable or corrupt; fall back to memory-only.
+    }
+    memoryIds = ids;
+    return memoryIds;
+  }
+
+  function persist() {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.keys(memoryIds)));
+      window.localStorage.setItem(SEEDED_KEY, '1');
+    } catch (e) {
+      // Memory-only mode; nothing to persist.
+    }
+  }
+
+  function isSeeded() {
+    readStore();
+    return memorySeeded;
+  }
+
+  // Seed the seen set with all currently-known ids, but only the first time
+  // ever for this client. After seeding, only ids the user explicitly opens
+  // are added. Idempotent: a second call (or a later launch) is a no-op.
+  function seedIfFresh(workspaceIds) {
+    var ids = readStore();
+    if (memorySeeded) return;
+    (workspaceIds || []).forEach(function (id) { if (typeof id === 'string') ids[id] = true; });
+    memorySeeded = true;
+    persist();
+  }
+
+  function has(id) {
+    return !!readStore()[id];
+  }
+
+  // Mark an id seen. Returns true if it was newly added (so the caller can
+  // re-render to drop the pulse), false if it was already present.
+  function markSeen(id) {
+    if (!id) return false;
+    var ids = readStore();
+    if (ids[id]) return false;
+    ids[id] = true;
+    persist();
+    return true;
+  }
+
+  window.mindsSeenWorkspaces = {
+    seedIfFresh: seedIfFresh,
+    isSeeded: isSeeded,
+    has: has,
+    markSeen: markSeen,
+  };
+})();

--- a/apps/minds/imbue/minds/desktop_client/static/sidebar.js
+++ b/apps/minds/imbue/minds/desktop_client/static/sidebar.js
@@ -26,6 +26,11 @@
   }
 
   function selectWorkspace(agentId) {
+    // Opening a workspace clears its new-tab pulse for good on this client.
+    // Mark it seen and re-render so the row stops pulsing immediately.
+    if (window.mindsSeenWorkspaces && window.mindsSeenWorkspaces.markSeen(agentId)) {
+      renderWorkspaces(lastWorkspaces);
+    }
     navigate(mngrForwardOrigin + '/goto/' + agentId + '/');
   }
 
@@ -70,6 +75,7 @@
           window.mindsSidebarRow.buildRow(w, {
             isCurrent: w.id === currentWorkspaceId,
             withOpenNew: true,
+            isSeen: !window.mindsSeenWorkspaces || window.mindsSeenWorkspaces.has(w.id),
           }),
         );
       });
@@ -166,6 +172,13 @@
   function handleChromeEvent(data) {
     if (data.type !== 'workspaces') return;
     lastWorkspaces = data.workspaces || [];
+    // On a brand-new client, treat every workspace already present at first
+    // sight as "seen" so pre-existing tabs (incl. the day-1 chat tab) never
+    // blink. Shares the same localStorage-backed set as chrome.js (same
+    // origin), and is idempotent: only the first tick ever seeds.
+    if (window.mindsSeenWorkspaces) {
+      window.mindsSeenWorkspaces.seedIfFresh(lastWorkspaces.map(function (w) { return w.id; }));
+    }
     renderWorkspaces(lastWorkspaces);
   }
 

--- a/apps/minds/imbue/minds/desktop_client/static/sidebar_workspace_row.js
+++ b/apps/minds/imbue/minds/desktop_client/static/sidebar_workspace_row.js
@@ -13,18 +13,20 @@
 //
 // Usage:
 //   var row = window.mindsSidebarRow.buildRow(workspace,
-//               { isCurrent: bool, withOpenNew: bool });
+//               { isCurrent: bool, withOpenNew: bool, isSeen: bool });
 //   var btn = window.mindsSidebarRow.buildSettingsBtn(agentId);
 //   var btn = window.mindsSidebarRow.buildOpenNewBtn(agentId);
 //   var btn = window.mindsSidebarRow.buildIconButton(title, pathSvg,
 //                                                    dataAttr, agentId, sizeClass);
 //
-// ``workspace`` is { id, name, accent?, is_stale? }. ``withOpenNew`` adds
-// the "open in new window" arrow (Electron only -- browser mode has no
+// ``workspace`` is { id, name, accent?, is_stale?, is_new? }. ``withOpenNew``
+// adds the "open in new window" arrow (Electron only -- browser mode has no
 // multi-window concept and passes false). Both action icons are always
 // visible. ``isCurrent`` marks the row selected (highlighted background).
-// Event wiring (click / context-menu) is the caller's job -- this builds
-// DOM only.
+// ``isSeen`` suppresses the new-tab pulse for a workspace the user has
+// already opened on this client (see seen_workspaces.js): a row only pulses
+// while ``is_new`` AND not ``isSeen``. Event wiring (click / context-menu) is
+// the caller's job -- this builds DOM only.
 (function () {
   function buildIconButton(title, pathSvg, dataAttr, agentId, sizeClass) {
     var btn = document.createElement('button');
@@ -66,6 +68,7 @@
     var opts = options || {};
     var isCurrent = !!opts.isCurrent;
     var withOpenNew = !!opts.withOpenNew;
+    var isSeen = !!opts.isSeen;
 
     // No outer margin: row-to-row spacing is the parent container's flex
     // ``gap``, keeping this element positioning-free and composable.
@@ -74,6 +77,13 @@
       'sidebar-item group flex items-center gap-2 h-8 px-2 rounded-md cursor-pointer type-body text-primary'
       + (isCurrent ? ' is-current bg-fill-active' : ' hover:bg-fill-hover');
     row.setAttribute('data-agent-id', workspace.id);
+
+    // New tab the Caretaker scheduler auto-created: pulse the accent dot
+    // until the user opens it (``is_new`` from the server, not yet seen by
+    // this client). ``.sidebar-new`` drives the keyframe animation in app.css.
+    if (workspace.is_new && !isSeen) {
+      row.classList.add('sidebar-new');
+    }
 
     var dot = document.createElement('span');
     dot.className = 'sidebar-dot w-2.5 h-2.5 rounded-full shrink-0';

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Chrome.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Chrome.jinja
@@ -30,6 +30,7 @@
 {% set _body_attrs %}data-is-mac="{{ 'true' if is_mac else 'false' }}" data-is-authenticated="{{ 'true' if is_authenticated else 'false' }}" data-mngr-forward-origin="{{ mngr_forward_origin }}"{% endset %}
 {% set _scripts %}
 <script src="/_static/workspace_accent.js" defer></script>
+<script src="/_static/seen_workspaces.js" defer></script>
 <script src="/_static/sidebar_workspace_row.js" defer></script>
 <script src="/_static/chrome.js" defer></script>
 {% endset %}

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Create.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Create.jinja
@@ -36,6 +36,16 @@
       }
     });
 
+    // Capture the browser's IANA timezone into the hidden input the form
+    // POSTs, so the new workspace's scheduler service runs nightly tasks in
+    // the user's local time. Best-effort: if Intl is unavailable the field
+    // stays empty and the server falls back to the host clock.
+    try {
+      var tzInput = document.getElementById('create-timezone-input');
+      var resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (tzInput && resolved) tzInput.value = resolved;
+    } catch (e) {}
+
     // Color picker: palette-only (no custom hex on create). Clicking a
     // swatch updates the hidden ``color`` input the form POSTs, and
     // flips aria-checked so the visual selection ring (driven by an
@@ -248,6 +258,11 @@
 {% endset %}
 <PageNarrowContainer title="Create workspace" padding="form" max_width="max-w-[520px]" scripts={{ _scripts }}>
   <form id="create-form" action="/create" method="post">
+
+      {# The browser's IANA timezone, filled in by the page script below, so the
+         workspace's scheduler service runs nightly tasks in the user's local
+         time. Absent / unrecognized values fall back to the host clock. #}
+      <input type="hidden" name="timezone" id="create-timezone-input" value="">
 
       <div class="flex items-center justify-between gap-4 mb-4">
         <h1 class="type-label text-secondary">Create workspace</h1>

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Sidebar.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Sidebar.jinja
@@ -33,6 +33,7 @@
 {% set _body_attrs %}data-mngr-forward-origin="{{ mngr_forward_origin }}"{% endset %}
 {% set _scripts %}
 <script src="/_static/workspace_accent.js" defer></script>
+<script src="/_static/seen_workspaces.js" defer></script>
 <script src="/_static/sidebar_workspace_row.js" defer></script>
 <script src="/_static/sidebar.js" defer></script>
 {% endset %}


### PR DESCRIPTION
The minds-desktop side of the nightly **Caretaker** feature. Pairs with the forever-claude-template PR (imbue-ai/forever-claude-template#211: scheduler + Caretaker + skills + the in-workspace blinking tab).

## What's in here (all under `apps/minds/`)
- **Surface auto-created agents:** `backend_resolver.get_agent_labels()` + `_build_workspace_list` set `is_new` when an agent carries `auto_created`/`caretaker`. The sidebar row blinks the workspace accent color until first opened, tracked client-side (`seen_workspaces.js`, localStorage) so existing tabs (incl. the day-1 chat) never blink and a seen tab stays quiet across relaunches.
- **Timezone capture:** the create flow captures the browser IANA timezone and writes it to the new workspace's `runtime/scheduler/timezone` (best-effort `mngr exec`), so the scheduler runs "3 AM" in the user's local time (host-clock fallback otherwise).

## Note on surfaces
The minds sidebar shows one tab per *workspace* (`is_primary` agents). The Caretaker is a same-host sub-agent, so its primary blinking surface is the **system_interface tab** (in the paired FCT PR). This minds-sidebar piece is the complementary path for any `is_primary` auto-created workspace and the timezone capture the scheduler needs.

## Testing
- 170 related tests pass (`get_agent_labels`, `_build_workspace_list` `is_new`, timezone validation/write), `ty` + ruff clean, minds ratchets pass.
- The blink animation/seen-tracking is verified by build; full visual confirmation is manual in the dev app.

Draft — open for review alongside the FCT PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)