### PR TITLE
Bump offload pin from 0.9.9 to 0.9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.9-${{ runner.os }}
+          key: cargo-offload-0.9.10-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.9'; then
-            cargo install offload@0.9.9 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.10'; then
+            cargo install offload@0.9.10 --force
           fi
 
       - name: Restore offload test durations from previous run
@@ -311,12 +311,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.9-${{ runner.os }}
+          key: cargo-offload-0.9.10-${{ runner.os }}
 
       - name: Install offload
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.9'; then
-            cargo install offload@0.9.9 --force
+          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.10'; then
+            cargo install offload@0.9.10 --force
           fi
 
       - name: Restore offload test durations from previous run

--- a/dev/changelog/mngr-bump-offload.md
+++ b/dev/changelog/mngr-bump-offload.md
@@ -1,0 +1,1 @@
+Changed: Bumped the offload CI pin in `.github/workflows/ci.yml` from `0.9.9` to `0.9.10` (cargo cache key, version check, and `cargo install` invocation updated to match).

--- a/libs/mngr/changelog/mngr-bump-offload.md
+++ b/libs/mngr/changelog/mngr-bump-offload.md
@@ -1,0 +1,1 @@
+Changed: Bumped the offload version baked into `libs/mngr/imbue/mngr/resources/Dockerfile` from `0.9.9` to `0.9.10` to track the CI pin.

--- a/libs/mngr/imbue/mngr/resources/Dockerfile
+++ b/libs/mngr/imbue/mngr/resources/Dockerfile
@@ -103,7 +103,7 @@ ENV UV_LINK_MODE=copy
 # call (per-layer caching, see `_build_image_from_dockerfile_contents`). ARGs
 # don't carry across separate calls, so an ARG above would expand to empty in
 # the RUN below and `cargo install offload@` would error.
-RUN export OFFLOAD_VERSION=0.9.9 \
+RUN export OFFLOAD_VERSION=0.9.10 \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
     && /root/.cargo/bin/cargo install offload@${OFFLOAD_VERSION} --locked --root /opt/offload \


### PR DESCRIPTION
Bumps the offload version pin from `0.9.9` to `0.9.10`.

- `.github/workflows/ci.yml`: cargo cache key, version check, and `cargo install offload@...` invocation.
- `libs/mngr/imbue/mngr/resources/Dockerfile`: `OFFLOAD_VERSION` baked into the host image, kept in lockstep with the CI pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)