### PR TITLE
[experiment] test-offload on offload test-affinity branch (affinity ON)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,18 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.10-${{ runner.os }}
+          key: cargo-offload-affinity-0e1f926-${{ runner.os }}
 
       - name: Install offload
+        # EXPERIMENT: test the unreleased test-affinity branch of offload
+        # (imbue-ai/offload#235) instead of the crates.io release. Pinned to
+        # an exact commit for reproducibility. Unconditional --force because
+        # the branch shares version 0.9.10 with the crates.io release, so a
+        # version check would falsely match a cached release build and skip it.
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.10'; then
-            cargo install offload@0.9.10 --force
-          fi
+          cargo install --git https://github.com/imbue-ai/offload \
+            --rev 0e1f9264100134bd8b67056d13716dffa536a77a --locked --force
+          offload --version
 
       - name: Restore offload test durations from previous run
         uses: actions/cache/restore@v5


### PR DESCRIPTION
**Experiment — do not merge.** Gathers real `test-offload` data for the offload
test-affinity feature (imbue-ai/offload#235).

This branch swaps the `test-offload` job's offload install from the crates.io
release to the unreleased test-affinity branch, pinned to commit
`0e1f9264100134bd8b67056d13716dffa536a77a`. mngr uses `framework type = "pytest"`,
so affinity is **active at the default 2.0s/module**.

Pair with the baseline PR (`test-offload-affinity-off`), which is identical
except `affinity_overhead_secs = 0.0`. Comparing the two `test-offload` runs
isolates the affinity effect on the same binary — look at total makespan and the
batch-size distribution in the `--trace` output / job logs.

Unchanged: the `test-offload-acceptance` job and the in-sandbox offload binary
(the Modal image) stay on the release — affinity is an orchestrator-only
scheduling decision, so the sandbox image does not need rebuilding.