### PR TITLE
[experiment] test-offload affinity baseline (affinity OFF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,18 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.10-${{ runner.os }}
+          key: cargo-offload-affinity-0e1f926-${{ runner.os }}
 
       - name: Install offload
+        # EXPERIMENT: test the unreleased test-affinity branch of offload
+        # (imbue-ai/offload#235) instead of the crates.io release. Pinned to
+        # an exact commit for reproducibility. Unconditional --force because
+        # the branch shares version 0.9.10 with the crates.io release, so a
+        # version check would falsely match a cached release build and skip it.
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.10'; then
-            cargo install offload@0.9.10 --force
-          fi
+          cargo install --git https://github.com/imbue-ai/offload \
+            --rev 0e1f9264100134bd8b67056d13716dffa536a77a --locked --force
+          offload --version
 
       - name: Restore offload test durations from previous run
         uses: actions/cache/restore@v5

--- a/offload-modal.toml
+++ b/offload-modal.toml
@@ -47,6 +47,10 @@ build_inputs = [
 type = "pytest"
 command = "uv run pytest"
 run_args = "--cov-fail-under=0 -p no:xdist"
+# EXPERIMENT baseline: disable test-affinity so batching matches the pre-feature
+# behavior. Compare this run against the treatment branch (default 2.0s) to
+# isolate the affinity effect with the same offload binary.
+affinity_overhead_secs = 0.0
 
 [groups.all]
 retry_count = 0


### PR DESCRIPTION
**Experiment — do not merge. Baseline for the affinity A/B.**

Identical to `test-offload-affinity-on` (same offload binary, pinned commit
`0e1f926`) except `offload-modal.toml` sets `affinity_overhead_secs = 0.0`,
which disables test-affinity and reproduces the pre-feature batching
byte-for-byte. The makespan delta vs the treatment PR is the affinity effect.