### PR TITLE
[experiment] test-offload affinity at 0.25s overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,16 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin/offload
-          key: cargo-offload-0.9.10-${{ runner.os }}
+          key: cargo-offload-affinity-p25-0e1f926-${{ runner.os }}
 
       - name: Install offload
+        # EXPERIMENT: unreleased test-affinity branch (imbue-ai/offload#235),
+        # pinned commit, unconditional --force (shares version 0.9.10 with the
+        # crates.io release so a version check would skip it).
         run: |
-          if ! command -v offload &> /dev/null || ! offload --version | grep -q '0.9.10'; then
-            cargo install offload@0.9.10 --force
-          fi
+          cargo install --git https://github.com/imbue-ai/offload \
+            --rev 0e1f9264100134bd8b67056d13716dffa536a77a --locked --force
+          offload --version
 
       - name: Restore offload test durations from previous run
         uses: actions/cache/restore@v5

--- a/offload-modal.toml
+++ b/offload-modal.toml
@@ -47,6 +47,10 @@ build_inputs = [
 type = "pytest"
 command = "uv run pytest"
 run_args = "--cov-fail-under=0 -p no:xdist"
+# EXPERIMENT: lower the affinity overhead from the 2.0s pytest default to 0.25s,
+# closer to the ~0.15s/module import cost measured on this suite. Tests whether a
+# better-calibrated overhead keeps batches balanced (vs over-concentrating at 2.0s).
+affinity_overhead_secs = 0.25
 
 [groups.all]
 retry_count = 0


### PR DESCRIPTION
Experiment — do not merge. Third arm for imbue-ai/offload#235: same pinned offload binary (`0e1f926`), `affinity_overhead_secs = 0.25` (vs 2.0s ON and 0.0s OFF). Tests whether a better-calibrated per-module overhead (~0.15s measured on this suite) keeps batches balanced. Branched off the same base (ed436488d) as the ON/OFF arms.