### PR TITLE
imbue_cloud: build FCT image once per box, docker-load per slice

### DIFF
--- a/blueprint/accelerate-slice-bake/plan-accelerate-slice-bake.md
+++ b/blueprint/accelerate-slice-bake/plan-accelerate-slice-bake.md
@@ -1,0 +1,109 @@
+# Plan: Accelerate imbue_cloud slice bakes (build-once-per-box + load)
+
+Accelerate imbue_cloud bare-metal slice bakes by building the forever-claude-template (FCT) Docker image **once per bare-metal box** and loading it into each slice's dockerd, instead of every slice rebuilding it from the Dockerfile. Also bake Playwright/Chromium into the cached image so the deferred first-boot install becomes a no-op. The whole change is **mngr-only / single repo** (no forever-claude-template change).
+
+## Overview
+
+- **Problem:** every slice bake runs an inner `mngr create --template main --template pool_host` that builds the FCT image from the Dockerfile inside the slice (10-20 min, network-bound; `pool_bake.py:60-62`), plus a per-slice deferred Playwright/Chromium install (capped 900s; `pool_bake.py:79-84`). This is the bulk of slice-bake latency and is paid per slice.
+- **Key decision:** keep the build, but pay it **once per box**. The first bake on a box (per tag) builds + saves the image as a `docker save` tar on the box; subsequent bakes `docker load` that tar into their slice's dockerd. Target: ~25-35 min/slice of setup → a single ~1-3 min local `docker load`.
+- **Build-vs-load decision lives entirely in the slice provider** (`SliceVpsDockerProvider`). The `pool_host` template's `build_arg` is untouched (it must keep building for non-default templates / other providers).
+- **Box-local transfer:** the box runs `docker save`/`docker load` against its own `localhost:<vm_port>`, so the ~11 GiB never leaves the box, regardless of where the bake is orchestrated. Uses a **unique ephemeral SSH key per transfer**, destroyed afterward.
+- **Cloud-only / no FCT change:** the load mechanism is pure mngr; Playwright is baked in cloud-side via a thin derived image during the seed step (`FROM <fct-built> ; RUN playwright install …`). FCT's shared scripts (used by the desktop Lima path) are not touched.
+- **Scope:** pool bakes only. Lease-time slow-path rebuilds (`_rebuild_leased_container`) keep building. Caching applies only to production `--from-tag` bakes; dev `--workspace-dir` bakes always build.
+- **Motivation:** this is a latency optimization for cloud slice provisioning; minimalism and low blast radius are explicit goals (single repo, opt-in realizer flag, self-healing where cheap, hard-fail where silent fallback would hide problems).
+
+## Expected behavior
+
+- **First production slice bake on a box** (for a given `minds-v<version>` tag): acquires the per-box lock, builds the FCT image as today, builds the Playwright-derived `fct:<tag>` image, `docker save`s it to the box tar, prunes the builder slice's build cache, releases the lock, then runs the container from `fct:<tag>`. Logs `Built + seeded box tar fct:<tag>`.
+- **Subsequent production slice bakes on the same box (same tag):** block until the tar exists, then `docker load` it and run the container from `fct:<tag>` — no build, no Playwright download. Logs `Loaded fct:<tag> from box tar (Ns)`.
+- **Concurrent bakes during the first build:** only the lock holder builds; others block-then-load (poll for the tar up to the create budget, ~1800s).
+- **Dead builder:** a lock marker older than the TTL is reclaimable, so a crashed builder doesn't wedge the pool — the next bake promotes itself to builder.
+- **Playwright is already present** in every loaded slice's image (`/root/.cache/ms-playwright` + the `done.playwright` marker), so `[program:deferred-install]` finds the marker and no-ops on first container boot. The first-boot ~900s install disappears for all cached slices.
+- **Desktop (Lima) users are unaffected** — no FCT/script change; they still run `deferred-install` exactly as before.
+- **New tag bake:** rebuilds, replaces the box tar, and prunes the prior tag's tar (single tag retained per box).
+- **Dev `--workspace-dir` bakes:** always build from the Dockerfile (mutable content) and never read or write a box tar.
+- **Failure modes:**
+  - A failed `docker load` **hard-fails the bake** (no silent fallback to building); the slice is then torn down by the existing failure path.
+  - A failed Playwright derived build retries 3× (exponential backoff) then **hard-fails the seed** (lock releases; next bake retries).
+  - Insufficient box disk before a save **fails early** with a clear error (the pre-check never deletes to make room).
+  - The ephemeral transfer key is always destroyed (box private key removed, slice `authorized_keys` entry removed) whether the transfer succeeds or fails.
+- **OVH / vultr / aws docker providers:** behavior unchanged (the realizer's new skip-if-present is opt-in and off for them).
+
+## Implementation plan
+
+### `libs/mngr_vps` (realizer skip-if-present)
+
+- `imbue/mngr_vps/data_types.py` — add `allow_local_image: bool = Field(default=False, …)` to `RealizePlacementContext` (alongside `base_image`/`docker_build_args` at `:44,46`). When true, an already-present local image is run as-is.
+- `imbue/mngr_vps/container_setup.py` — add `image_exists(outer, image) -> bool` near `pull_image` (`:767-769`): wraps `run_docker(outer, ["image", "inspect", image])` and returns False on `MngrError`. No behavior change to `pull_image`/`run_container`.
+- `imbue/mngr_vps/docker_realizer.py` — in `realize_placement` (the build-vs-pull branch at `:319-325`), short-circuit **before** build/pull: `if ctx.allow_local_image and image_exists(outer, ctx.base_image): pass  # already present → just run`. The build branch is unreachable here because the slice provider passes empty `docker_build_args` on the cache path.
+- `imbue/mngr_vps/instance.py` — `create_host_on_existing_vps` (`:841-861`): add an `allow_local_image: bool = False` parameter, thread it into the `RealizePlacementContext(...)` construction. Default keeps OVH/vultr/aws unchanged.
+
+### `libs/mngr_imbue_cloud` (orchestration + box cache + Playwright)
+
+- **New interface + impls — box image cache** (so the orchestration is unit-testable without a real box):
+  - `imbue/mngr_imbue_cloud/interfaces.py` (or extend) — `BoxImageCacheInterface(MutableModel, ABC)` with methods:
+    - `try_acquire_build_lock(tag) -> bool` (atomic `mkdir` of a per-box lock dir; reclaims a marker older than the TTL).
+    - `release_build_lock(tag) -> None`.
+    - `wait_for_tar(tag, timeout) -> bool` (poll for the tar; returns False on timeout; detects builder death → caller may re-acquire).
+    - `has_tar(tag) -> bool`.
+    - `check_free_disk(required_bytes) -> None` (raises if insufficient; never deletes).
+    - `save_image_from_slice(tag, vm_ssh_port, ephemeral_key) -> None` (box-local `ssh root@localhost:<port> docker save | atomic mv`; prune other-tag tars on success).
+    - `load_image_into_slice(tag, vm_ssh_port, ephemeral_key) -> None` (box-local `cat tar | ssh root@localhost:<port> docker load`).
+    - `clean_stale_tmp(tag) -> None`.
+  - `imbue/mngr_imbue_cloud/slices/box_image_cache.py` — `LimaBoxImageCache` impl: runs all box-side commands through the existing `LimaSliceVpsClient._run_on_box` / `_box_ssh_command` (`lima_slice_client.py:139-172`). Tar dir `~/<lima_user>/.cache/mngr-slice-fct/` (sibling of `slice_base_image_path`, `bare_metal.py:75-80`); tar `fct-<sanitized-tag>.tar`; lock dir `…/.lock-<tag>.d`.
+  - `imbue/mngr_imbue_cloud/slices/mock_box_image_cache_test.py` — in-memory `MockBoxImageCache` for unit tests (tracks tar presence, lock state, save/load calls, simulated failures).
+- **Ephemeral transfer key:**
+  - Box generates a unique keypair per transfer (`ssh-keygen` via `_run_on_box`), the orchestrator reads the public key and appends it to the slice's VM-root `authorized_keys` via the existing `outer` (`_make_outer_for_vps_ip`, `slice_provider.py:318-337`).
+  - Save/load on the box uses the ephemeral private key against `localhost:<outer_ssh_port>` (the VM-root forwarded port; `lima_slice.py` guest `2200`).
+  - Teardown in a `finally`: box removes the keypair; orchestrator removes the `authorized_keys` line — on success or failure.
+- **Playwright cloud-side bake (seed path only):**
+  - After the base FCT image is built on the builder slice, build a thin derived image tagged `fct:<tag>`:
+    `FROM <base> ; RUN cd /docker_build_code && uv run playwright install --with-deps chromium && mkdir -p /var/lib/minds/deferred-install && touch /var/lib/minds/deferred-install/done.playwright`.
+  - Build via `run_docker(outer, ["build", "-t", f"fct:{tag}", …])` on the slice; retry 3× with exponential backoff (tenacity), then hard-fail the seed.
+  - `/root/.cache/ms-playwright` and `/var/lib/minds/deferred-install/done.playwright` are image layers outside `/mngr` and outside `/docker_build_code`, so they survive `fct_seed` and are inherited by every loaded slice (deferred-install no-ops).
+- **Slice provider decision (`imbue/mngr_imbue_cloud/providers/slice_provider.py`):**
+  - Add `fct_cache_tag: str | None` to `SliceVpsDockerProviderConfig` (`:45-117`) — set only for production `--from-tag` bakes.
+  - In `create_host` (`:248-312`), after the VM + dockerd are up (`wait_for_sshd` at `:282`) and inside the `with … as outer:` (`:284`):
+    - If `fct_cache_tag` is None (dev bake): unchanged — pass the template's build args (build path).
+    - If set: ensure `fct:<tag>` is present in the slice dockerd:
+      - `try_acquire_build_lock`: if acquired → build base (reuse `_build_image_on_vps` / `build_image_on_outer_from_build_args`) → build Playwright-derived `fct:<tag>` → `check_free_disk` → `save_image_from_slice` (atomic + prune) → `docker builder prune -af` on the slice → `release_build_lock`.
+      - else → `wait_for_tar` then `load_image_into_slice`; on builder death, re-acquire and become builder; on timeout, hard-fail.
+    - Then call `create_host_on_existing_vps(..., image=f"fct:{tag}", build_args=(), allow_local_image=True)` → realizer skip-present → run.
+- **Bake orchestration (`imbue/mngr_imbue_cloud/cli/server.py`):**
+  - `_build_slice_create_args` (`:472-530`): when the bake source is `--from-tag` (production), emit `-S providers.<inst>.fct_cache_tag=fct:<repo_branch_or_tag>` (tag from `BakeSource.repo_branch_or_tag` / advertised attributes, `data_types.py:61`, `server.py:638`). Omit for dev bakes.
+  - Emit explicit info logs for the built-vs-loaded outcome.
+- **Box prep (`imbue/mngr_imbue_cloud/slices/bare_metal_prep.py`):**
+  - In `build_box_prep_script` (`:34-156`, near the cache-dir block `:103-114`): create + chown `~/.cache/mngr-slice-fct/`. No Docker on the box (it only holds/serves a tar file).
+
+## Implementation phases
+
+1. **Realizer skip-if-present (mngr_vps).** Add `allow_local_image` to `RealizePlacementContext`, `image_exists` helper, the skip branch in `realize_placement`, and the `create_host_on_existing_vps` parameter. Unit-test `image_exists` and the skip branch. System still behaves identically (flag off everywhere). Changelog: `mngr_vps`.
+2. **Box image cache interface + impls.** `BoxImageCacheInterface`, `LimaBoxImageCache`, `MockBoxImageCache`. Box prep creates the cache dir. Unit-test lock acquire/reclaim, tar presence, disk pre-check, stale `.tmp` cleanup, single-tag prune (against the mock + a thin real-command-shape test).
+3. **Load path (cache hit).** Slice provider reads `fct_cache_tag`; when the tar is present, load it (with ephemeral key lifecycle) and run via the present-image path. `cli/server.py` passes `fct_cache_tag` for from-tag bakes. End state: a box that already has a tar serves loads; a box without one still builds (phase 4 not yet wired) — so guard the load path behind "tar present" only.
+4. **Seed path (cache miss) + Playwright bake.** Lock holder builds base → Playwright-derived `fct:<tag>` (with retries) → save (atomic, disk pre-check, prune) → builder-cache prune → release. Block-then-load for waiters; builder-death reclaim. End state: full build-once-per-box behavior.
+5. **Polish + verification.** Explicit built-vs-loaded logging, ephemeral-key teardown hardened in `finally`, changelog entries for `mngr_imbue_cloud` + `mngr_vps`, two-slice real-box verification.
+
+## Testing strategy
+
+- **Unit (primary)** — `slice_provider_test.py` + `box_image_cache_test.py` against `MockBoxImageCache`:
+  - Cache hit → load path invoked, no build; container runs `fct:<tag>`.
+  - Cache miss → lock acquired, base+Playwright built, tar saved (atomic), builder cache pruned, lock released.
+  - Lock contention → waiter blocks then loads once the tar appears.
+  - Stale lock (marker > TTL) → reclaimed; builder death → waiter promotes and builds.
+  - Disk pre-check fails → hard error, no save, nothing deleted.
+  - Ephemeral key destroyed in `finally` on both success and failure (assert teardown calls).
+  - Playwright derived build fails → 3 retries then hard-fail (assert no partial tar saved).
+  - Dev `--workspace-dir` bake → build path, cache untouched (no save/load).
+  - `--from-tag` bake → `fct_cache_tag` emitted by `_build_slice_create_args`.
+- **mngr_vps unit** — `image_exists` true/false; `realize_placement` skips build+pull when `allow_local_image` and image present; unchanged when flag off.
+- **Edge cases** — leftover `.tmp` from an interrupted save cleaned on next seed; single-tag prune removes a prior tag's tar; re-cut tag (documented limitation — stale tar served).
+- **Real-box verification (manual, the e2e bar)** — bake ≥2 production slices on a real box at a `minds-v*` tag: confirm slice #1 logs `Built + seeded`, slice #2 logs `Loaded … from box tar`, slice #2 boots a working agent (launch-to-msg-style round-trip), and record the wall-clock saved. No automated acceptance/release test (genuinely hard to exercise without real bare metal).
+
+## Open questions
+
+- **Seeding slice image identity (chosen: unified):** the builder slice runs `fct:<tag>` (with Playwright) via the present path, so even the first slice skips deferred-install. Simpler alternative: let the realizer build+run `mngr-build-<host_id>` normally and save a separate `fct:<tag>` — then only the first slice on a box runs deferred-install. Confirm the unified approach is worth the extra wiring.
+- **Disk pre-check sizing:** measure the slice image size (`docker image inspect` size) before save, or use a fixed conservative threshold (e.g. require ≥15 GiB free)? Measured is more accurate; fixed is simpler.
+- **Lock TTL vs build time:** TTL = create budget (1800s). A ~20 min build + save could approach it; confirm the waiter timeout exceeds worst-case build+save (or set waiter timeout > builder TTL with margin).
+- **Ephemeral key generation site (chosen: box-generated):** box runs `ssh-keygen` so the private key never leaves the box; orchestrator only handles the public key. Confirm vs orchestrator-generated.
+- **vultr / aws remote-docker:** they also build the FCT Dockerfile remotely and could reuse the realizer skip-if-present + a per-host tar cache later. Out of scope for this plan — flag as a future follow-up.
+- **Multi-release on one box:** single-tag policy assumes a box serves one active release at a time. If a box must host slices from multiple minds envs/releases simultaneously, the box would need N tars (bounded GC) — revisit if that becomes a real deployment.

--- a/dev/changelog/mngr-accelerate-bake.md
+++ b/dev/changelog/mngr-accelerate-bake.md
@@ -1,0 +1,1 @@
+Added an implementation plan for accelerating imbue_cloud slice bakes (build the FCT image once per box, docker-load it per slice) at `blueprint/accelerate-slice-bake/plan-accelerate-slice-bake.md`.

--- a/libs/mngr_imbue_cloud/changelog/mngr-accelerate-bake.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-accelerate-bake.md
@@ -1,0 +1,5 @@
+Accelerated imbue_cloud bare-metal slice bakes by building the forever-claude-template (FCT) image once per box instead of once per slice.
+
+The first production (`--from-tag`) slice baked on a box builds the FCT image, bakes Playwright/Chromium into it, and saves it to a box-local tar; every subsequent slice on that box `docker load`s that tar instead of rebuilding from the Dockerfile. This removes the per-slice 10-20 minute image build and the per-slice ~900s first-boot Playwright install for all but the first slice.
+
+The image is transferred entirely over the box's own loopback (no external bandwidth, nothing left reachable from a leased slice), using a unique ephemeral SSH key per transfer that is destroyed afterward. Dev (`--workspace-dir`) bakes are unchanged and always build from the Dockerfile.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/cli/server.py
@@ -480,6 +480,7 @@ def _build_slice_create_args(
     ssh_user: str,
     port_range_start: int,
     port_range_end: int,
+    fct_cache_tag: str | None,
 ) -> list[str]:
     """Render the ``-S`` provider-config overrides that point one slice bake at this box.
 
@@ -524,6 +525,10 @@ def _build_slice_create_args(
     # absent, so the provider falls back to legacy un-stamped names.
     if env_name is not None:
         overrides["slice_env_name"] = env_name
+    # Production (--from-tag) bakes enable the per-box FCT image cache: the first
+    # slice builds + seeds the box tar, the rest docker-load it. Omitted for dev bakes.
+    if fct_cache_tag is not None:
+        overrides["fct_cache_tag"] = fct_cache_tag
     args: list[str] = []
     for key, value in overrides.items():
         args.extend(["-S", f"{prefix}.{key}={value}"])
@@ -620,6 +625,7 @@ def _bake_one_slice(
     port_range_start: int,
     port_range_end: int,
     is_deferred_install_wait_skipped: bool,
+    fct_cache_tag: str | None,
 ) -> dict[str, Any]:
     """Bake one slice (laptop-driven ``mngr create`` against the slice provider) + insert its pool row.
 
@@ -653,6 +659,7 @@ def _bake_one_slice(
                 ssh_user=ssh_user,
                 port_range_start=port_range_start,
                 port_range_end=port_range_end,
+                fct_cache_tag=fct_cache_tag,
             ),
             mngr_create_timeout_seconds=_SLICE_MNGR_CREATE_TIMEOUT_SECONDS,
         )
@@ -767,6 +774,7 @@ def _bake_into_outcomes(
     port_range_start: int,
     port_range_end: int,
     is_deferred_install_wait_skipped: bool,
+    fct_cache_tag: str | None,
     semaphore: "threading.Semaphore",
     total: int,
     outcomes: list[dict[str, Any]],
@@ -792,6 +800,7 @@ def _bake_into_outcomes(
             port_range_start=port_range_start,
             port_range_end=port_range_end,
             is_deferred_install_wait_skipped=is_deferred_install_wait_skipped,
+            fct_cache_tag=fct_cache_tag,
         )
     with outcomes_lock:
         outcomes.append(outcome)
@@ -1130,6 +1139,12 @@ def allocate_slices(
             sync_mngr_into_template(mngr_source_to_vendor, workspace_dir)
 
         pool_public_key = _derive_public_key(private_key_path)
+        # Enable the per-box FCT image cache only for production (--from-tag) bakes, whose
+        # content is an immutable tag: the first slice builds + seeds a box-local tar
+        # (tagged fct:<tag>), the rest docker-load it. Dev (--workspace-dir) bakes have
+        # mutable content under a branch label, so they always build (fct_cache_tag=None).
+        repo_branch_or_tag = lease_attributes.get("repo_branch_or_tag")
+        fct_cache_tag = f"fct:{repo_branch_or_tag}" if (is_from_tag and repo_branch_or_tag) else None
         # Spawn one thread per slice but cap how many bake at once with a semaphore
         # (``max_concurrency``): each thread blocks on it before its ``mngr create``,
         # so the box is never contended by more than K simultaneous carves+builds
@@ -1155,6 +1170,7 @@ def allocate_slices(
                     port_range_start=DEFAULT_SLICE_PORT_RANGE_START,
                     port_range_end=DEFAULT_SLICE_PORT_RANGE_END,
                     is_deferred_install_wait_skipped=is_deferred_install_wait_skipped,
+                    fct_cache_tag=fct_cache_tag,
                     semaphore=bake_semaphore,
                     total=count,
                     outcomes=outcomes,

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/errors.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/errors.py
@@ -95,6 +95,10 @@ class SliceReserveOutputError(BareMetalProvisioningError):
     """Raised when the on-box slice reservation script produces no/garbled port output."""
 
 
+class BoxImageCacheError(ImbueCloudError):
+    """Raised when a box-local cached-FCT-image operation (lock, save, load, disk) fails."""
+
+
 class InvalidBuildArgError(ImbueCloudError, ValueError):
     """Raised when a recognized imbue_cloud build arg has a malformed value."""
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
@@ -463,6 +463,7 @@ class SliceVpsDockerProvider(VpsProvider):
         retry=retry_if_exception_type(MngrError),
         stop=stop_after_attempt(_PLAYWRIGHT_BUILD_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
     )
     def _build_playwright_derived_image(self, *, outer: OuterHostInterface, base_image: str, target_tag: str) -> None:
         """Build target_tag as base_image + a baked Playwright/Chromium layer (and the done marker).

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
@@ -68,6 +68,10 @@ _PLAYWRIGHT_BUILD_ATTEMPTS: Final[int] = 3
 _PLAYWRIGHT_BUILD_TIMEOUT_SECONDS: Final[float] = 900.0
 _PLAYWRIGHT_CTX_DIR: Final[str] = "/tmp/fct-playwright-ctx"
 _BUILDER_PRUNE_TIMEOUT_SECONDS: Final[float] = 120.0
+# The FCT Dockerfile relocates the built workspace here (off the /mngr volume mount)
+# before first boot; the Playwright derive runs ``uv run`` from it. This is an FCT image
+# contract -- if FCT moves it, the derive's guard fails fast with a clear message.
+_FCT_BUILD_CODE_DIR: Final[str] = "/docker_build_code"
 # Where the FCT deferred-install service writes its success marker; baking it into
 # the seeded image makes ``[program:deferred-install]`` a no-op on every loaded slice.
 _DEFERRED_INSTALL_MARKER_DIR: Final[str] = "/var/lib/minds/deferred-install"
@@ -442,6 +446,11 @@ class SliceVpsDockerProvider(VpsProvider):
         """Build the FCT image (+ baked Playwright) and seed the box tar; this slice runs that image too."""
         logger.info("Building + seeding box tar {} (first slice on this box for this tag)", image_tag)
         parsed = self._parse_build_args(build_args)
+        # Build the base FCT image via the same shared helper the realizer's build path
+        # uses (DockerRealizer._build_image_on_vps) -- so any future build preprocessing
+        # belongs in build_image_on_outer_from_build_args, not the per-caller wrapper, and
+        # is picked up here too. We pass a longer timeout than the realizer default because
+        # the FCT build is the seed's long pole.
         base_image = build_image_on_outer_from_build_args(
             outer,
             self.mngr_ctx.concurrency_group,
@@ -473,10 +482,20 @@ class SliceVpsDockerProvider(VpsProvider):
         unchanged while letting every loaded slice skip the deferred install. The
         browser cache lands in /root/.cache/ms-playwright -- outside the /mngr volume
         and untouched by fct-seed, so it survives into every container.
+
+        The RUN first guards that the FCT build-code dir exists, so a future FCT image
+        that relocates it fails fast with a clear message instead of a confusing
+        ``cd``-not-found build failure buried in retries.
         """
+        guard = (
+            f"test -d {_FCT_BUILD_CODE_DIR} || "
+            f"{{ echo 'FCT build-code dir {_FCT_BUILD_CODE_DIR} missing; FCT image layout changed -- "
+            "update _FCT_BUILD_CODE_DIR' >&2; exit 1; }"
+        )
         dockerfile = (
             f"FROM {base_image}\n"
-            "RUN cd /docker_build_code && uv run playwright install --with-deps chromium "
+            f"RUN {guard} "
+            f"&& cd {_FCT_BUILD_CODE_DIR} && uv run playwright install --with-deps chromium "
             f"&& mkdir -p {_DEFERRED_INSTALL_MARKER_DIR} && touch {_DEFERRED_INSTALL_MARKER}\n"
         )
         encoded_dockerfile = base64.b64encode(dockerfile.encode()).decode()

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider.py
@@ -1,12 +1,19 @@
+import base64
+import shlex
 from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import Sequence
 from contextlib import contextmanager
+from typing import Final
 
 from loguru import logger
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import PrivateAttr
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_exponential
 
 from imbue.mngr.errors import MngrError
 from imbue.mngr.hosts.host import Host
@@ -23,13 +30,21 @@ from imbue.mngr.primitives import SnapshotName
 from imbue.mngr.providers.ssh_utils import add_host_to_known_hosts
 from imbue.mngr.providers.ssh_utils import create_pyinfra_host
 from imbue.mngr.providers.ssh_utils import wait_for_sshd
+from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
 from imbue.mngr_imbue_cloud.slices.bare_metal import SLICE_BOOT_DISK_GIB
+from imbue.mngr_imbue_cloud.slices.bare_metal import box_fct_cache_dir
 from imbue.mngr_imbue_cloud.slices.bare_metal import slice_lima_instance_name
+from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
+from imbue.mngr_imbue_cloud.slices.box_image_cache import TransferKey
+from imbue.mngr_imbue_cloud.slices.box_image_cache import WAIT_FOR_TAR_TIMEOUT_SECONDS
+from imbue.mngr_imbue_cloud.slices.lima_box_image_cache import LimaBoxImageCache
 from imbue.mngr_imbue_cloud.slices.lima_slice_client import LimaSliceVpsClient
 from imbue.mngr_vps.build_args import ParsedVpsBuildOptions
 from imbue.mngr_vps.build_args import extract_git_depth
 from imbue.mngr_vps.build_args import raise_if_vps_migration_arg
 from imbue.mngr_vps.config import VpsProviderConfig
+from imbue.mngr_vps.container_setup import build_image_on_outer_from_build_args
+from imbue.mngr_vps.container_setup import run_docker
 from imbue.mngr_vps.instance import VpsProvider
 from imbue.mngr_vps.interfaces import HostRealizer
 from imbue.mngr_vps.primitives import VpsInstanceId
@@ -40,6 +55,23 @@ from imbue.mngr_vps.primitives import VpsInstanceId
 # unknown; the slice bake always passes the real region via ``slice_region``.
 _FALLBACK_SLICE_REGION: str = "lima"
 _SLICE_PLAN: str = "slice"
+
+# Conservative free-disk requirement (bytes) checked on the box before saving the
+# FCT image tar -- the box boot disk is shared, so fail early rather than fill it.
+_ESTIMATED_FCT_IMAGE_BYTES: Final[int] = 15 * 1024**3
+# Generous cap for the seeding slice's base FCT image build (the inner create budget
+# is 45 min; the build is the long pole, the Playwright derive + save the rest).
+_SEED_BASE_BUILD_TIMEOUT_SECONDS: Final[float] = 1800.0
+# The Playwright-derived image RUNs a chromium download + apt; retry transient
+# failures a few times before hard-failing the seed.
+_PLAYWRIGHT_BUILD_ATTEMPTS: Final[int] = 3
+_PLAYWRIGHT_BUILD_TIMEOUT_SECONDS: Final[float] = 900.0
+_PLAYWRIGHT_CTX_DIR: Final[str] = "/tmp/fct-playwright-ctx"
+_BUILDER_PRUNE_TIMEOUT_SECONDS: Final[float] = 120.0
+# Where the FCT deferred-install service writes its success marker; baking it into
+# the seeded image makes ``[program:deferred-install]`` a no-op on every loaded slice.
+_DEFERRED_INSTALL_MARKER_DIR: Final[str] = "/var/lib/minds/deferred-install"
+_DEFERRED_INSTALL_MARKER: Final[str] = f"{_DEFERRED_INSTALL_MARKER_DIR}/done.playwright"
 
 
 class SliceVpsDockerProviderConfig(VpsProviderConfig):
@@ -114,6 +146,15 @@ class SliceVpsDockerProviderConfig(VpsProviderConfig):
     )
     slice_port_range_start: int | None = Field(default=None, description="Box host-port range start (no default)")
     slice_port_range_end: int | None = Field(default=None, description="Box host-port range end (no default)")
+    fct_cache_tag: str | None = Field(
+        default=None,
+        description=(
+            "When set (production --from-tag bakes only, e.g. 'fct:minds-v0.3.2'), enable the per-box FCT "
+            "image cache: the first slice on the box builds + seeds a box-local 'docker save' tar under this "
+            "tag, and subsequent slices 'docker load' it instead of rebuilding. None disables caching "
+            "(dev --workspace-dir bakes always build)."
+        ),
+    )
 
 
 class SliceVpsDockerProvider(VpsProvider):
@@ -282,6 +323,26 @@ class SliceVpsDockerProvider(VpsProvider):
             wait_for_sshd(hostname=box, port=vm_ssh_port, timeout_seconds=self.config.ssh_connect_timeout)
 
             with self._make_outer_for_vps_ip(box) as outer:
+                # Production (--from-tag) bakes use the per-box FCT image cache: ensure the
+                # tagged image is present in the slice's dockerd (build + seed it as the first
+                # slice on the box, or docker-load the box tar), then run it as-is instead of
+                # rebuilding. Dev bakes leave fct_cache_tag None and build from the Dockerfile.
+                fct_cache_tag = self.slice_config.fct_cache_tag
+                if fct_cache_tag is not None:
+                    self._ensure_cached_image_present(
+                        outer=outer,
+                        host_id=host_id,
+                        vm_ssh_port=vm_ssh_port,
+                        image_tag=fct_cache_tag,
+                        build_args=build_args,
+                    )
+                    create_image: ImageReference | None = ImageReference(fct_cache_tag)
+                    create_build_args: Sequence[str] | None = ()
+                    is_local_image_used = True
+                else:
+                    create_image = image
+                    create_build_args = build_args
+                    is_local_image_used = False
                 host = self.create_host_on_existing_vps(
                     outer=outer,
                     host_id=host_id,
@@ -292,13 +353,14 @@ class SliceVpsDockerProvider(VpsProvider):
                     vps_host_public_key=vps_host_public_key,
                     region=region,
                     plan=_SLICE_PLAN,
-                    image=image,
+                    image=create_image,
                     tags=tags,
-                    build_args=build_args,
+                    build_args=create_build_args,
                     start_args=start_args,
                     lifecycle=lifecycle,
                     known_hosts=known_hosts,
                     authorized_keys=effective_authorized_keys,
+                    allow_local_image=is_local_image_used,
                 )
             logger.info("Slice host {} created (instance {})", name, instance_id)
             is_baked = True
@@ -310,6 +372,167 @@ class SliceVpsDockerProvider(VpsProvider):
                     self.lima_client.destroy_instance(instance_id)
                 except MngrError as cleanup_err:
                     logger.warning("Failed to clean up slice VM {}: {}", instance_id, cleanup_err)
+
+    # ------------------------------------------------------------------
+    # Per-box FCT image cache (build once per box, docker-load per slice)
+    # ------------------------------------------------------------------
+
+    def _make_box_image_cache(self) -> BoxImageCacheInterface:
+        return LimaBoxImageCache(
+            slice_client=self.lima_client, cache_dir=box_fct_cache_dir(self.slice_config.box_ssh_user)
+        )
+
+    def _ensure_cached_image_present(
+        self,
+        *,
+        outer: OuterHostInterface,
+        host_id: HostId,
+        vm_ssh_port: int,
+        image_tag: str,
+        build_args: Sequence[str] | None,
+    ) -> None:
+        """Make image_tag present in the slice's dockerd: load the box tar, or seed it as the first slice.
+
+        Block-then-load: only the build-lock holder builds + seeds; everyone else
+        waits for the tar then loads. At most two rounds, so a stale lock left by a
+        builder that died mid-seed is reclaimed (try_acquire_build_lock reclaims it)
+        rather than wedging the box's pool fill.
+        """
+        cache = self._make_box_image_cache()
+        if cache.has_tar(image_tag):
+            self._load_cached_image(cache=cache, outer=outer, vm_ssh_port=vm_ssh_port, image_tag=image_tag)
+            return
+        for _attempt in range(2):
+            if cache.try_acquire_build_lock(image_tag):
+                try:
+                    self._seed_box_image(
+                        cache=cache,
+                        outer=outer,
+                        host_id=host_id,
+                        vm_ssh_port=vm_ssh_port,
+                        image_tag=image_tag,
+                        build_args=build_args,
+                    )
+                finally:
+                    cache.release_build_lock(image_tag)
+                return
+            if cache.wait_for_tar(image_tag, timeout_seconds=WAIT_FOR_TAR_TIMEOUT_SECONDS):
+                self._load_cached_image(cache=cache, outer=outer, vm_ssh_port=vm_ssh_port, image_tag=image_tag)
+                return
+        raise BoxImageCacheError(f"timed out waiting for the box FCT image tar for {image_tag}")
+
+    def _load_cached_image(
+        self, *, cache: BoxImageCacheInterface, outer: OuterHostInterface, vm_ssh_port: int, image_tag: str
+    ) -> None:
+        logger.info("Loading FCT image {} from box tar into slice", image_tag)
+        with self._transfer_key_authorized(cache, outer) as transfer_key:
+            cache.load_image_into_slice(image_tag, vm_ssh_port=vm_ssh_port, transfer_key=transfer_key)
+        logger.info("Loaded FCT image {} from box tar", image_tag)
+
+    def _seed_box_image(
+        self,
+        *,
+        cache: BoxImageCacheInterface,
+        outer: OuterHostInterface,
+        host_id: HostId,
+        vm_ssh_port: int,
+        image_tag: str,
+        build_args: Sequence[str] | None,
+    ) -> None:
+        """Build the FCT image (+ baked Playwright) and seed the box tar; this slice runs that image too."""
+        logger.info("Building + seeding box tar {} (first slice on this box for this tag)", image_tag)
+        parsed = self._parse_build_args(build_args)
+        base_image = build_image_on_outer_from_build_args(
+            outer,
+            self.mngr_ctx.concurrency_group,
+            host_id=host_id,
+            docker_build_args=parsed.docker_build_args,
+            git_depth=parsed.git_depth,
+            builder=self.config.builder,
+            build_timeout_seconds=_SEED_BASE_BUILD_TIMEOUT_SECONDS,
+        )
+        self._build_playwright_derived_image(outer=outer, base_image=base_image, target_tag=image_tag)
+        cache.check_free_disk(_ESTIMATED_FCT_IMAGE_BYTES)
+        with self._transfer_key_authorized(cache, outer) as transfer_key:
+            cache.save_image_from_slice(image_tag, vm_ssh_port=vm_ssh_port, transfer_key=transfer_key)
+        # Reclaim the builder slice's build-cache headroom so it matches a loading slice.
+        run_docker(outer, ["builder", "prune", "-af"], timeout_seconds=_BUILDER_PRUNE_TIMEOUT_SECONDS)
+        logger.info("Built + seeded box tar {}", image_tag)
+
+    @retry(
+        retry=retry_if_exception_type(MngrError),
+        stop=stop_after_attempt(_PLAYWRIGHT_BUILD_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+    )
+    def _build_playwright_derived_image(self, *, outer: OuterHostInterface, base_image: str, target_tag: str) -> None:
+        """Build target_tag as base_image + a baked Playwright/Chromium layer (and the done marker).
+
+        Playwright is deliberately not in the FCT Dockerfile (it is shared with the
+        desktop Lima path); baking it cloud-side here keeps the desktop path
+        unchanged while letting every loaded slice skip the deferred install. The
+        browser cache lands in /root/.cache/ms-playwright -- outside the /mngr volume
+        and untouched by fct-seed, so it survives into every container.
+        """
+        dockerfile = (
+            f"FROM {base_image}\n"
+            "RUN cd /docker_build_code && uv run playwright install --with-deps chromium "
+            f"&& mkdir -p {_DEFERRED_INSTALL_MARKER_DIR} && touch {_DEFERRED_INSTALL_MARKER}\n"
+        )
+        encoded_dockerfile = base64.b64encode(dockerfile.encode()).decode()
+        stage_command = (
+            f"rm -rf {_PLAYWRIGHT_CTX_DIR} && mkdir -p {_PLAYWRIGHT_CTX_DIR} && "
+            f"echo {shlex.quote(encoded_dockerfile)} | base64 -d > {_PLAYWRIGHT_CTX_DIR}/Dockerfile"
+        )
+        stage_result = outer.execute_idempotent_command(stage_command, timeout_seconds=30.0)
+        if not stage_result.success:
+            raise BoxImageCacheError(
+                f"failed to stage the Playwright Dockerfile on the slice: {stage_result.stderr.strip()}"
+            )
+        run_docker(
+            outer,
+            ["build", "-t", target_tag, "-f", f"{_PLAYWRIGHT_CTX_DIR}/Dockerfile", _PLAYWRIGHT_CTX_DIR],
+            timeout_seconds=_PLAYWRIGHT_BUILD_TIMEOUT_SECONDS,
+        )
+
+    @contextmanager
+    def _transfer_key_authorized(
+        self, cache: BoxImageCacheInterface, outer: OuterHostInterface
+    ) -> Iterator[TransferKey]:
+        """Yield a unique ephemeral transfer key authorized on the slice's VM root; tear it down after.
+
+        The box uses the key to docker save/load over its own loopback to the slice's
+        VM-root sshd. The key is destroyed (private key off the box, public key out of
+        the slice's authorized_keys) whether the transfer succeeds or fails, so no
+        standing box->slice root key survives the bake.
+        """
+        transfer_key = cache.create_transfer_key()
+        try:
+            self._authorize_transfer_key(outer, transfer_key.public_key)
+            yield transfer_key
+        finally:
+            cache.destroy_transfer_key(transfer_key)
+            self._deauthorize_transfer_key(outer, transfer_key.public_key)
+
+    def _authorize_transfer_key(self, outer: OuterHostInterface, public_key: str) -> None:
+        command = (
+            f"install -d -m 700 /root/.ssh && printf '%s\\n' {shlex.quote(public_key)} >> /root/.ssh/authorized_keys"
+        )
+        result = outer.execute_idempotent_command(command, timeout_seconds=30.0)
+        if not result.success:
+            raise BoxImageCacheError(f"failed to authorize the transfer key on the slice: {result.stderr.strip()}")
+
+    def _deauthorize_transfer_key(self, outer: OuterHostInterface, public_key: str) -> None:
+        # Best-effort: teardown runs in a finally and must not mask a prior error.
+        command = (
+            "if [ -f /root/.ssh/authorized_keys ]; then "
+            f"grep -vF {shlex.quote(public_key)} /root/.ssh/authorized_keys > /root/.ssh/authorized_keys.tmp "
+            "&& mv /root/.ssh/authorized_keys.tmp /root/.ssh/authorized_keys; fi"
+        )
+        result = outer.execute_idempotent_command(command, timeout_seconds=30.0)
+        if not result.success:
+            logger.warning(
+                "Failed to remove the transfer key from the slice authorized_keys: {}", result.stderr.strip()
+            )
 
     # ------------------------------------------------------------------
     # Per-host-port seam overrides (the bake reaches the VM via box:port)

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
@@ -66,7 +66,8 @@ def _ensure(provider: _OrchestrationProvider) -> None:
     )
 
 
-_FAKE_OUTER: Any = object()  # never used by the overridden seed/load seams
+# Never used by the overridden seed/load seams; passed only to satisfy the signature.
+_FAKE_OUTER: Any = object()
 
 
 def test_loads_when_tar_already_present() -> None:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
@@ -1,0 +1,102 @@
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from pydantic import ConfigDict
+from pydantic import Field
+
+from imbue.mngr.interfaces.host import OuterHostInterface
+from imbue.mngr.primitives import HostId
+from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
+from imbue.mngr_imbue_cloud.providers.slice_provider import SliceVpsDockerProvider
+from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
+from imbue.mngr_imbue_cloud.slices.mock_box_image_cache_test import MockBoxImageCache
+
+_TAG = "fct:minds-v0.3.2"
+
+
+class _OrchestrationProvider(SliceVpsDockerProvider):
+    """Slice provider whose box cache + seed/load steps are recorded, to test the decision branching.
+
+    Overrides the three seams ``_ensure_cached_image_present`` drives -- the cache
+    factory and the seed/load actions -- so the branch logic can be exercised
+    without a real box, slice dockerd, or image build.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    test_cache: MockBoxImageCache = Field(description="Injected in-memory cache")
+    seeded_tags: list[str] = Field(default_factory=list)
+    loaded_tags: list[str] = Field(default_factory=list)
+
+    def _make_box_image_cache(self) -> BoxImageCacheInterface:
+        return self.test_cache
+
+    def _seed_box_image(
+        self,
+        *,
+        cache: BoxImageCacheInterface,
+        outer: OuterHostInterface,
+        host_id: HostId,
+        vm_ssh_port: int,
+        image_tag: str,
+        build_args: Sequence[str] | None,
+    ) -> None:
+        self.seeded_tags.append(image_tag)
+
+    def _load_cached_image(
+        self, *, cache: BoxImageCacheInterface, outer: OuterHostInterface, vm_ssh_port: int, image_tag: str
+    ) -> None:
+        self.loaded_tags.append(image_tag)
+
+
+def _provider(cache: MockBoxImageCache) -> _OrchestrationProvider:
+    # model_construct skips the heavy VpsProvider field wiring; the overridden seams
+    # the test exercises touch only the injected cache + the record lists.
+    return _OrchestrationProvider.model_construct(test_cache=cache, seeded_tags=[], loaded_tags=[])
+
+
+def _ensure(provider: _OrchestrationProvider) -> None:
+    provider._ensure_cached_image_present(
+        outer=_FAKE_OUTER,
+        host_id=HostId.generate(),
+        vm_ssh_port=2200,
+        image_tag=_TAG,
+        build_args=("--file=Dockerfile", "."),
+    )
+
+
+_FAKE_OUTER: Any = object()  # never used by the overridden seed/load seams
+
+
+def test_loads_when_tar_already_present() -> None:
+    provider = _provider(MockBoxImageCache(tars_present={_TAG}))
+    _ensure(provider)
+    assert provider.loaded_tags == [_TAG]
+    assert provider.seeded_tags == []
+
+
+def test_seeds_when_no_tar_and_lock_is_acquired() -> None:
+    provider = _provider(MockBoxImageCache())
+    _ensure(provider)
+    assert provider.seeded_tags == [_TAG]
+    assert provider.loaded_tags == []
+
+
+def test_waits_then_loads_when_another_slice_is_seeding() -> None:
+    # The lock is held by an in-flight builder, and the tar appears while we wait.
+    cache = MockBoxImageCache(locks_held={_TAG}, tars_present={_TAG})
+    provider = _provider(cache)
+    _ensure(provider)
+    assert provider.loaded_tags == [_TAG]
+    assert provider.seeded_tags == []
+
+
+def test_raises_when_lock_held_and_tar_never_appears() -> None:
+    # Lock held by a builder, but the tar never materializes within the wait budget.
+    cache = MockBoxImageCache(locks_held={_TAG})
+    provider = _provider(cache)
+    with pytest.raises(BoxImageCacheError):
+        _ensure(provider)
+    assert provider.seeded_tags == []
+    assert provider.loaded_tags == []

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
@@ -1,4 +1,5 @@
 import base64
+import subprocess
 from collections.abc import Mapping
 from collections.abc import Sequence
 from pathlib import Path
@@ -16,6 +17,7 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
 from imbue.mngr_imbue_cloud.providers.slice_provider import SliceVpsDockerProvider
 from imbue.mngr_imbue_cloud.providers.slice_provider import _DEFERRED_INSTALL_MARKER
+from imbue.mngr_imbue_cloud.providers.slice_provider import _FCT_BUILD_CODE_DIR
 from imbue.mngr_imbue_cloud.providers.slice_provider import _PLAYWRIGHT_CTX_DIR
 from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
 from imbue.mngr_imbue_cloud.slices.mock_box_image_cache_test import MockBoxImageCache
@@ -146,6 +148,12 @@ def test_build_playwright_derived_image_renders_marker_and_build_command() -> No
     assert dockerfile.startswith("FROM mngr-build-xyz")
     assert "playwright install --with-deps chromium" in dockerfile
     assert _DEFERRED_INSTALL_MARKER in dockerfile
+    # Guards the FCT build-code path so a relocated layout fails fast with a clear message.
+    assert f"test -d {_FCT_BUILD_CODE_DIR}" in dockerfile
+    # The RUN body must be valid shell -- catches f-string brace-escaping bugs in the guard.
+    run_body = next(line for line in dockerfile.splitlines() if line.startswith("RUN "))[len("RUN ") :]
+    syntax_check = subprocess.run(["bash", "-n", "-c", run_body], capture_output=True, text=True)
+    assert syntax_check.returncode == 0, syntax_check.stderr
     build_command = next(c for c in outer.recorded if "docker build" in c)
     assert _TAG in build_command
     assert f"{_PLAYWRIGHT_CTX_DIR}/Dockerfile" in build_command

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
@@ -1,14 +1,22 @@
+import base64
+from collections.abc import Mapping
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
+from typing import cast
 
 import pytest
 from pydantic import ConfigDict
 from pydantic import Field
 
+from imbue.imbue_common.mutable_model import MutableModel
+from imbue.mngr.interfaces.data_types import CommandResult
 from imbue.mngr.interfaces.host import OuterHostInterface
 from imbue.mngr.primitives import HostId
 from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
 from imbue.mngr_imbue_cloud.providers.slice_provider import SliceVpsDockerProvider
+from imbue.mngr_imbue_cloud.providers.slice_provider import _DEFERRED_INSTALL_MARKER
+from imbue.mngr_imbue_cloud.providers.slice_provider import _PLAYWRIGHT_CTX_DIR
 from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
 from imbue.mngr_imbue_cloud.slices.mock_box_image_cache_test import MockBoxImageCache
 
@@ -103,3 +111,54 @@ def test_raises_when_lock_held_and_tar_never_appears() -> None:
         _ensure(provider)
     assert provider.seeded_tags == []
     assert provider.loaded_tags == []
+
+
+class _RecordingOuter(MutableModel):
+    """Outer host that records every command and reports success, for command-render assertions."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    recorded: list[str] = Field(default_factory=list)
+
+    def execute_idempotent_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        self.recorded.append(command)
+        return CommandResult(stdout="", stderr="", success=True)
+
+
+def test_build_playwright_derived_image_renders_marker_and_build_command() -> None:
+    provider = SliceVpsDockerProvider.model_construct()
+    outer = _RecordingOuter()
+    provider._build_playwright_derived_image(
+        outer=cast(OuterHostInterface, outer), base_image="mngr-build-xyz", target_tag=_TAG
+    )
+    # The staged context Dockerfile is shipped base64-encoded; decode it and assert the
+    # baked-Playwright + deferred-install-marker contract every loaded slice relies on.
+    stage_command = next(c for c in outer.recorded if "base64 -d" in c)
+    encoded = stage_command.split("echo ")[1].split(" | base64 -d")[0].strip().strip("'")
+    dockerfile = base64.b64decode(encoded).decode()
+    assert dockerfile.startswith("FROM mngr-build-xyz")
+    assert "playwright install --with-deps chromium" in dockerfile
+    assert _DEFERRED_INSTALL_MARKER in dockerfile
+    build_command = next(c for c in outer.recorded if "docker build" in c)
+    assert _TAG in build_command
+    assert f"{_PLAYWRIGHT_CTX_DIR}/Dockerfile" in build_command
+
+
+def test_transfer_key_authorize_and_deauthorize_render_expected_commands() -> None:
+    provider = SliceVpsDockerProvider.model_construct()
+    outer = _RecordingOuter()
+    public_key = "ssh-ed25519 AAAATESTKEY"
+    provider._authorize_transfer_key(cast(OuterHostInterface, outer), public_key)
+    provider._deauthorize_transfer_key(cast(OuterHostInterface, outer), public_key)
+    authorize_command, deauthorize_command = outer.recorded
+    assert ">> /root/.ssh/authorized_keys" in authorize_command
+    assert public_key in authorize_command
+    assert "grep -vF" in deauthorize_command
+    assert public_key in deauthorize_command

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/slice_provider_test.py
@@ -85,8 +85,10 @@ def test_seeds_when_no_tar_and_lock_is_acquired() -> None:
 
 
 def test_waits_then_loads_when_another_slice_is_seeding() -> None:
-    # The lock is held by an in-flight builder, and the tar appears while we wait.
-    cache = MockBoxImageCache(locks_held={_TAG}, tars_present={_TAG})
+    # No tar yet and the lock is held by an in-flight builder, so we must take the
+    # try_acquire (fails) -> wait_for_tar (tar appears) -> load path rather than the
+    # has_tar() fast path.
+    cache = MockBoxImageCache(locks_held={_TAG}, is_tar_published_on_wait=True)
     provider = _provider(cache)
     _ensure(provider)
     assert provider.loaded_tags == [_TAG]

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal.py
@@ -74,10 +74,22 @@ DEFAULT_SLICE_PORT_RANGE_END: Final[int] = 32000
 # slice provider so they always agree.
 _SLICE_BASE_IMAGE_RELPATH: Final[str] = ".cache/mngr-slice-base/debian-base.qcow2"
 
+# Box dir holding the per-box cached FCT image tar (a ``docker save`` of the built
+# image), so slices on the box ``docker load`` it instead of each rebuilding from
+# the Dockerfile. Under the lima service user's home (the box has no Docker, only a
+# tar file); created once at ``server prep``. Shared by the prep script and the box
+# image cache so they always agree.
+_SLICE_FCT_CACHE_RELDIR: Final[str] = ".cache/mngr-slice-fct"
+
 
 def slice_base_image_path(lima_service_user: str) -> str:
     """Absolute path of the box-staged slice guest OS image for ``lima_service_user``."""
     return f"/home/{lima_service_user}/{_SLICE_BASE_IMAGE_RELPATH}"
+
+
+def box_fct_cache_dir(lima_service_user: str) -> str:
+    """Absolute path of the box dir holding the cached FCT image tar for ``lima_service_user``."""
+    return f"/home/{lima_service_user}/{_SLICE_FCT_CACHE_RELDIR}"
 
 
 def slice_base_image_file_url(lima_service_user: str) -> str:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/bare_metal_prep.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 from imbue.imbue_common.pure import pure
+from imbue.mngr_imbue_cloud.slices.bare_metal import box_fct_cache_dir
 from imbue.mngr_imbue_cloud.slices.bare_metal import slice_base_image_path
 from imbue.mngr_vps.host_setup import PINNED_DOCKER_APT_VERSION
 
@@ -55,6 +56,7 @@ def build_box_prep_script(
     lima_tarball = f"lima-{lima_version}-Linux-x86_64.tar.gz"
     lima_url = f"https://github.com/lima-vm/lima/releases/download/v{lima_version}/{lima_tarball}"
     base_image_path = slice_base_image_path(lima_service_user)
+    fct_cache_dir = box_fct_cache_dir(lima_service_user)
     swapfile_path = _SWAPFILE_PATH
     swapfile_size_gib = _SWAPFILE_SIZE_GIB
     return f"""\
@@ -139,6 +141,10 @@ MNGR_SLICE_CUSTOMIZE
     chown {lima_service_user}:{lima_service_user} "$img.tmp"
     mv "$img.tmp" "$img"
 fi
+
+# 6b. Create the per-box FCT image cache dir (owned by the lima user) where the box
+#     keeps the single ``docker save`` tar slices ``docker load`` instead of rebuilding.
+install -d -m 755 -o {lima_service_user} -g {lima_service_user} {fct_cache_dir}
 
 # 7. Provision a real swapfile (idempotent). Slice hosts run RAM near capacity; the
 #    OS-install default swap (two ~0.5GiB partitions) is too small to cushion spikes.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/box_image_cache.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/box_image_cache.py
@@ -1,0 +1,69 @@
+import re
+from abc import ABC
+from abc import abstractmethod
+from typing import Final
+
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.mutable_model import MutableModel
+
+# How long a seed build may hold the per-box build lock before its marker is
+# considered stale and reclaimable (matches the inner ``mngr create`` budget, so a
+# builder that died mid-seed does not wedge the box's pool fill).
+BUILD_LOCK_TTL_SECONDS: Final[int] = 1800
+# How long a non-builder bake waits for the in-flight seed to publish the tar.
+WAIT_FOR_TAR_TIMEOUT_SECONDS: Final[int] = 1800
+
+
+class TransferKey(FrozenModel):
+    """A unique ephemeral SSH keypair generated on the box for a single image transfer."""
+
+    private_key_path_on_box: str = Field(description="Path of the ephemeral private key on the box")
+    public_key: str = Field(description="OpenSSH public key to authorize on the slice's VM root for the transfer")
+
+
+def box_image_tar_name(image_tag: str) -> str:
+    """Filesystem-safe tar filename for an image ref (``fct:minds-v0.3.2`` -> ``fct-minds-v0.3.2.tar``)."""
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", image_tag).strip("-")
+    return f"{safe}.tar"
+
+
+class BoxImageCacheInterface(MutableModel, ABC):
+    """Manages the single cached FCT image tar a bare-metal box keeps to skip per-slice image builds."""
+
+    @abstractmethod
+    def has_tar(self, image_tag: str) -> bool:
+        """Return whether the box already holds a saved image tar for image_tag."""
+
+    @abstractmethod
+    def try_acquire_build_lock(self, image_tag: str) -> bool:
+        """Atomically become the seed builder for image_tag (reclaiming a stale lock); True if acquired."""
+
+    @abstractmethod
+    def release_build_lock(self, image_tag: str) -> None:
+        """Release the seed build lock for image_tag (no-op if not held)."""
+
+    @abstractmethod
+    def wait_for_tar(self, image_tag: str, *, timeout_seconds: int) -> bool:
+        """Block until the tar for image_tag exists; True if it appeared, False on timeout."""
+
+    @abstractmethod
+    def check_free_disk(self, required_bytes: int) -> None:
+        """Raise BoxImageCacheError if the box has less than required_bytes free for the tar."""
+
+    @abstractmethod
+    def create_transfer_key(self) -> TransferKey:
+        """Generate a unique ephemeral keypair on the box for one save/load transfer."""
+
+    @abstractmethod
+    def destroy_transfer_key(self, transfer_key: TransferKey) -> None:
+        """Remove the ephemeral private key from the box (idempotent)."""
+
+    @abstractmethod
+    def save_image_from_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        """docker save image_tag from the slice into the box tar atomically (box-local), then prune other tags."""
+
+    @abstractmethod
+    def load_image_into_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        """docker load the box's cached tar for image_tag into the slice's dockerd (box-local)."""

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache.py
@@ -1,0 +1,167 @@
+import shlex
+from typing import Final
+from uuid import uuid4
+
+from pydantic import ConfigDict
+from pydantic import Field
+
+from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
+from imbue.mngr_imbue_cloud.slices.box_image_cache import BUILD_LOCK_TTL_SECONDS
+from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
+from imbue.mngr_imbue_cloud.slices.box_image_cache import TransferKey
+from imbue.mngr_imbue_cloud.slices.box_image_cache import box_image_tar_name
+from imbue.mngr_imbue_cloud.slices.lima_slice_client import LimaSliceVpsClient
+
+# SSH options for the box's loopback connection into a freshly-carved slice's
+# VM-root sshd: the slice is operator-controlled during the bake and reached over
+# the box's own loopback (the box-forwarded VM ssh port), so we accept its
+# (unpinned) host key rather than fail-closed -- there is no persistent key to pin.
+_SLICE_LOOPBACK_SSH_OPTS: Final[str] = (
+    "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30"
+)
+# A ~11 GiB docker save/load over the box loopback is bounded but not instant.
+_TRANSFER_TIMEOUT_SECONDS: Final[float] = 1200.0
+_SHORT_TIMEOUT_SECONDS: Final[float] = 60.0
+
+
+class LimaBoxImageCache(BoxImageCacheInterface):
+    """BoxImageCache backed by files + box-local docker save/load on a bare-metal box.
+
+    Every operation runs on the box over SSH via the lima client's ``run_on_box``.
+    The box has no Docker daemon; it only stores the ``docker save`` tar and pipes
+    it to/from the slice's VM-root dockerd over the box's own loopback to the
+    box-forwarded VM ssh port.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    slice_client: LimaSliceVpsClient = Field(frozen=True, description="Runs commands on the box over SSH")
+    cache_dir: str = Field(frozen=True, description="Box dir holding the cached image tar(s), lock, and transfer keys")
+
+    def _run(
+        self, command: str, *, timeout: float, label: str, is_streaming: bool = False
+    ) -> tuple[int | None, str, str]:
+        return self.slice_client.run_on_box(command, timeout=timeout, label=label, is_streaming=is_streaming)
+
+    def _tar_path(self, image_tag: str) -> str:
+        return f"{self.cache_dir}/{box_image_tar_name(image_tag)}"
+
+    def _lock_path(self, image_tag: str) -> str:
+        return f"{self.cache_dir}/.lock-{box_image_tar_name(image_tag)}.d"
+
+    def has_tar(self, image_tag: str) -> bool:
+        rc, _out, _err = self._run(
+            f"test -f {shlex.quote(self._tar_path(image_tag))}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-has-tar"
+        )
+        return rc == 0
+
+    def try_acquire_build_lock(self, image_tag: str) -> bool:
+        lock = self._lock_path(image_tag)
+        rc, _out, _err = self._run(f"mkdir {shlex.quote(lock)}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-lock")
+        if rc == 0:
+            return True
+        # The lock dir exists; reclaim it only if it is older than the build TTL (its
+        # builder almost certainly died mid-seed), otherwise a seed is in flight.
+        age_rc, age_out, _err = self._run(
+            f"echo $(( $(date +%s) - $(stat -c %Y {shlex.quote(lock)} 2>/dev/null || echo 0) ))",
+            timeout=_SHORT_TIMEOUT_SECONDS,
+            label="cache-lock-age",
+        )
+        if age_rc != 0:
+            return False
+        try:
+            age_seconds = int(age_out.strip())
+        except ValueError:
+            return False
+        if age_seconds <= BUILD_LOCK_TTL_SECONDS:
+            return False
+        self._run(f"rm -rf {shlex.quote(lock)}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-lock-reclaim")
+        retry_rc, _out, _err = self._run(
+            f"mkdir {shlex.quote(lock)}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-lock-retry"
+        )
+        return retry_rc == 0
+
+    def release_build_lock(self, image_tag: str) -> None:
+        self._run(
+            f"rm -rf {shlex.quote(self._lock_path(image_tag))}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-unlock"
+        )
+
+    def wait_for_tar(self, image_tag: str, *, timeout_seconds: int) -> bool:
+        tar = shlex.quote(self._tar_path(image_tag))
+        poll = f"timeout {int(timeout_seconds)} bash -c {shlex.quote(f'until test -f {tar}; do sleep 5; done')}"
+        rc, _out, _err = self._run(poll, timeout=float(timeout_seconds + 60), label="cache-wait-tar")
+        return rc == 0
+
+    def check_free_disk(self, required_bytes: int) -> None:
+        rc, out, err = self._run(
+            f"df -PB1 {shlex.quote(self.cache_dir)} | tail -1 | awk '{{print $4}}'",
+            timeout=_SHORT_TIMEOUT_SECONDS,
+            label="cache-df",
+        )
+        if rc != 0:
+            raise BoxImageCacheError(f"could not check free disk on box cache dir {self.cache_dir}: {err.strip()}")
+        try:
+            available_bytes = int(out.strip())
+        except ValueError as exc:
+            raise BoxImageCacheError(f"unexpected df output for {self.cache_dir}: {out.strip()!r}") from exc
+        if available_bytes < required_bytes:
+            raise BoxImageCacheError(
+                f"insufficient disk on box for the FCT image tar: need {required_bytes} bytes, "
+                f"have {available_bytes} free in {self.cache_dir}"
+            )
+
+    def create_transfer_key(self) -> TransferKey:
+        key_path = f"{self.cache_dir}/.transfer-{uuid4().hex}"
+        gen_rc, _out, gen_err = self._run(
+            f"ssh-keygen -t ed25519 -N '' -q -f {shlex.quote(key_path)}",
+            timeout=_SHORT_TIMEOUT_SECONDS,
+            label="cache-keygen",
+        )
+        if gen_rc != 0:
+            raise BoxImageCacheError(f"failed to generate transfer key on box: {gen_err.strip()}")
+        pub_rc, pub_out, pub_err = self._run(
+            f"cat {shlex.quote(key_path)}.pub", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-keycat"
+        )
+        if pub_rc != 0:
+            self._run(
+                f"rm -f {shlex.quote(key_path)} {shlex.quote(key_path)}.pub",
+                timeout=_SHORT_TIMEOUT_SECONDS,
+                label="cache-keyrm",
+            )
+            raise BoxImageCacheError(f"failed to read transfer public key on box: {pub_err.strip()}")
+        return TransferKey(private_key_path_on_box=key_path, public_key=pub_out.strip())
+
+    def destroy_transfer_key(self, transfer_key: TransferKey) -> None:
+        quoted = shlex.quote(transfer_key.private_key_path_on_box)
+        self._run(f"rm -f {quoted} {quoted}.pub", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-keyrm")
+
+    def save_image_from_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        tar_path = self._tar_path(image_tag)
+        tmp_path = f"{tar_path}.tmp"
+        key = shlex.quote(transfer_key.private_key_path_on_box)
+        remote_save = (
+            f"ssh -i {key} {_SLICE_LOOPBACK_SSH_OPTS} -p {int(vm_ssh_port)} root@127.0.0.1 "
+            f"{shlex.quote('docker save ' + image_tag)}"
+        )
+        # Clean any stale .tmp from an interrupted prior save, stream the save to a
+        # temp file, atomically rename it into place, then prune every other tag's
+        # tar (the box keeps exactly the current tag).
+        command = (
+            f"rm -f {shlex.quote(tmp_path)}; "
+            f"{remote_save} > {shlex.quote(tmp_path)} && mv {shlex.quote(tmp_path)} {shlex.quote(tar_path)} && "
+            f"find {shlex.quote(self.cache_dir)} -maxdepth 1 -name '*.tar' "
+            f"! -name {shlex.quote(box_image_tar_name(image_tag))} -delete"
+        )
+        rc, _out, err = self._run(command, timeout=_TRANSFER_TIMEOUT_SECONDS, label="cache-save", is_streaming=True)
+        if rc != 0:
+            self._run(f"rm -f {shlex.quote(tmp_path)}", timeout=_SHORT_TIMEOUT_SECONDS, label="cache-save-cleanup")
+            raise BoxImageCacheError(f"failed to save image {image_tag} to box tar: {err.strip()}")
+
+    def load_image_into_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        tar_path = shlex.quote(self._tar_path(image_tag))
+        key = shlex.quote(transfer_key.private_key_path_on_box)
+        remote_load = f"ssh -i {key} {_SLICE_LOOPBACK_SSH_OPTS} -p {int(vm_ssh_port)} root@127.0.0.1 'docker load'"
+        command = f"cat {tar_path} | {remote_load}"
+        rc, _out, err = self._run(command, timeout=_TRANSFER_TIMEOUT_SECONDS, label="cache-load", is_streaming=True)
+        if rc != 0:
+            raise BoxImageCacheError(f"failed to load image {image_tag} from box tar into slice: {err.strip()}")

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache_test.py
@@ -1,0 +1,130 @@
+from collections.abc import Callable
+
+import pytest
+from pydantic import ConfigDict
+from pydantic import Field
+
+from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
+from imbue.mngr_imbue_cloud.slices.box_image_cache import TransferKey
+from imbue.mngr_imbue_cloud.slices.lima_box_image_cache import LimaBoxImageCache
+from imbue.mngr_imbue_cloud.slices.lima_slice_client import LimaSliceVpsClient
+
+_CACHE_DIR = "/home/limahost/.cache/mngr-slice-fct"
+_TAG = "fct:minds-v0.3.2"
+_KEY = TransferKey(private_key_path_on_box=f"{_CACHE_DIR}/.transfer-abc", public_key="ssh-ed25519 AAA")
+
+
+class _ScriptedBoxClient(LimaSliceVpsClient):
+    """LimaSliceVpsClient whose box SSH is replaced by a scripted, recording responder."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    responder: Callable[[str], tuple[int | None, str, str]] = Field(description="Maps a remote command to its result")
+    recorded: list[str] = Field(default_factory=list)
+
+    def run_on_box(
+        self, remote_command: str, *, timeout: float, label: str, is_streaming: bool = False
+    ) -> tuple[int | None, str, str]:
+        self.recorded.append(remote_command)
+        return self.responder(remote_command)
+
+
+def _cache(responder: Callable[[str], tuple[int | None, str, str]]) -> LimaBoxImageCache:
+    client = _ScriptedBoxClient(
+        box_address="box.example",
+        box_ssh_user="limahost",
+        private_key_path="/tmp/id",
+        responder=responder,
+        recorded=[],
+    )
+    return LimaBoxImageCache(slice_client=client, cache_dir=_CACHE_DIR)
+
+
+def test_has_tar_reflects_test_f_exit_code() -> None:
+    assert _cache(lambda cmd: (0, "", "")).has_tar(_TAG) is True
+    assert _cache(lambda cmd: (1, "", "")).has_tar(_TAG) is False
+
+
+def test_try_acquire_build_lock_succeeds_when_mkdir_succeeds() -> None:
+    assert _cache(lambda cmd: (0, "", "")).try_acquire_build_lock(_TAG) is True
+
+
+def test_try_acquire_build_lock_fails_when_lock_is_fresh() -> None:
+    def responder(command: str) -> tuple[int | None, str, str]:
+        if command.startswith("mkdir"):
+            return 1, "", "File exists"
+        if "stat -c %Y" in command:
+            return 0, "100\n", ""  # 100s old, well under the TTL
+        return 0, "", ""
+
+    assert _cache(responder).try_acquire_build_lock(_TAG) is False
+
+
+def test_try_acquire_build_lock_reclaims_a_stale_lock() -> None:
+    state = {"mkdir_calls": 0}
+
+    def responder(command: str) -> tuple[int | None, str, str]:
+        if command.startswith("mkdir"):
+            state["mkdir_calls"] += 1
+            # First mkdir loses (lock present); the post-reclaim retry wins.
+            return (1, "", "File exists") if state["mkdir_calls"] == 1 else (0, "", "")
+        if "stat -c %Y" in command:
+            return 0, "99999\n", ""  # far older than the TTL -> reclaimable
+        return 0, "", ""
+
+    cache = _cache(responder)
+    assert cache.try_acquire_build_lock(_TAG) is True
+    assert state["mkdir_calls"] == 2
+
+
+def test_save_image_renders_atomic_save_and_prune() -> None:
+    cache = _cache(lambda cmd: (0, "", ""))
+    cache.save_image_from_slice(_TAG, vm_ssh_port=2200, transfer_key=_KEY)
+    save_cmd = next(c for c in cache.slice_client.recorded if "docker save" in c)  # type: ignore[attr-defined]
+    assert "docker save fct:minds-v0.3.2" in save_cmd
+    assert "-p 2200 root@127.0.0.1" in save_cmd
+    assert ".tar.tmp" in save_cmd and "mv" in save_cmd
+    assert "-delete" in save_cmd  # prunes other tags
+
+
+def test_save_image_raises_and_cleans_tmp_on_failure() -> None:
+    def responder(command: str) -> tuple[int | None, str, str]:
+        return (1, "", "boom") if "docker save" in command else (0, "", "")
+
+    cache = _cache(responder)
+    with pytest.raises(BoxImageCacheError):
+        cache.save_image_from_slice(_TAG, vm_ssh_port=2200, transfer_key=_KEY)
+    assert any(c.startswith("rm -f") and ".tar.tmp" in c for c in cache.slice_client.recorded)  # type: ignore[attr-defined]
+
+
+def test_load_image_renders_cat_into_docker_load() -> None:
+    cache = _cache(lambda cmd: (0, "", ""))
+    cache.load_image_into_slice(_TAG, vm_ssh_port=2244, transfer_key=_KEY)
+    load_cmd = next(c for c in cache.slice_client.recorded if "docker load" in c)  # type: ignore[attr-defined]
+    assert load_cmd.startswith("cat ")
+    assert "docker load" in load_cmd and "-p 2244 root@127.0.0.1" in load_cmd
+
+
+def test_load_image_raises_on_failure() -> None:
+    cache = _cache(lambda cmd: (1, "", "no such file"))
+    with pytest.raises(BoxImageCacheError):
+        cache.load_image_into_slice(_TAG, vm_ssh_port=2244, transfer_key=_KEY)
+
+
+def test_check_free_disk_raises_when_below_required() -> None:
+    cache = _cache(lambda cmd: (0, "5\n", ""))
+    with pytest.raises(BoxImageCacheError):
+        cache.check_free_disk(required_bytes=10)
+    # Plenty free -> no raise.
+    _cache(lambda cmd: (0, "10000000000\n", "")).check_free_disk(required_bytes=10)
+
+
+def test_create_transfer_key_returns_generated_public_key() -> None:
+    def responder(command: str) -> tuple[int | None, str, str]:
+        if command.startswith("cat "):
+            return 0, "ssh-ed25519 GENERATED\n", ""
+        return 0, "", ""
+
+    transfer_key = _cache(responder).create_transfer_key()
+    assert transfer_key.public_key == "ssh-ed25519 GENERATED"
+    assert transfer_key.private_key_path_on_box.startswith(f"{_CACHE_DIR}/.transfer-")

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_box_image_cache_test.py
@@ -29,7 +29,7 @@ class _ScriptedBoxClient(LimaSliceVpsClient):
         return self.responder(remote_command)
 
 
-def _cache(responder: Callable[[str], tuple[int | None, str, str]]) -> LimaBoxImageCache:
+def _build(responder: Callable[[str], tuple[int | None, str, str]]) -> tuple[_ScriptedBoxClient, LimaBoxImageCache]:
     client = _ScriptedBoxClient(
         box_address="box.example",
         box_ssh_user="limahost",
@@ -37,7 +37,11 @@ def _cache(responder: Callable[[str], tuple[int | None, str, str]]) -> LimaBoxIm
         responder=responder,
         recorded=[],
     )
-    return LimaBoxImageCache(slice_client=client, cache_dir=_CACHE_DIR)
+    return client, LimaBoxImageCache(slice_client=client, cache_dir=_CACHE_DIR)
+
+
+def _cache(responder: Callable[[str], tuple[int | None, str, str]]) -> LimaBoxImageCache:
+    return _build(responder)[1]
 
 
 def test_has_tar_reflects_test_f_exit_code() -> None:
@@ -54,7 +58,8 @@ def test_try_acquire_build_lock_fails_when_lock_is_fresh() -> None:
         if command.startswith("mkdir"):
             return 1, "", "File exists"
         if "stat -c %Y" in command:
-            return 0, "100\n", ""  # 100s old, well under the TTL
+            # 100s old, well under the TTL.
+            return 0, "100\n", ""
         return 0, "", ""
 
     assert _cache(responder).try_acquire_build_lock(_TAG) is False
@@ -69,7 +74,8 @@ def test_try_acquire_build_lock_reclaims_a_stale_lock() -> None:
             # First mkdir loses (lock present); the post-reclaim retry wins.
             return (1, "", "File exists") if state["mkdir_calls"] == 1 else (0, "", "")
         if "stat -c %Y" in command:
-            return 0, "99999\n", ""  # far older than the TTL -> reclaimable
+            # Far older than the TTL -> reclaimable.
+            return 0, "99999\n", ""
         return 0, "", ""
 
     cache = _cache(responder)
@@ -78,29 +84,30 @@ def test_try_acquire_build_lock_reclaims_a_stale_lock() -> None:
 
 
 def test_save_image_renders_atomic_save_and_prune() -> None:
-    cache = _cache(lambda cmd: (0, "", ""))
+    client, cache = _build(lambda cmd: (0, "", ""))
     cache.save_image_from_slice(_TAG, vm_ssh_port=2200, transfer_key=_KEY)
-    save_cmd = next(c for c in cache.slice_client.recorded if "docker save" in c)  # type: ignore[attr-defined]
+    save_cmd = next(c for c in client.recorded if "docker save" in c)
     assert "docker save fct:minds-v0.3.2" in save_cmd
     assert "-p 2200 root@127.0.0.1" in save_cmd
     assert ".tar.tmp" in save_cmd and "mv" in save_cmd
-    assert "-delete" in save_cmd  # prunes other tags
+    # The save also prunes every other tag's tar.
+    assert "-delete" in save_cmd
 
 
 def test_save_image_raises_and_cleans_tmp_on_failure() -> None:
     def responder(command: str) -> tuple[int | None, str, str]:
         return (1, "", "boom") if "docker save" in command else (0, "", "")
 
-    cache = _cache(responder)
+    client, cache = _build(responder)
     with pytest.raises(BoxImageCacheError):
         cache.save_image_from_slice(_TAG, vm_ssh_port=2200, transfer_key=_KEY)
-    assert any(c.startswith("rm -f") and ".tar.tmp" in c for c in cache.slice_client.recorded)  # type: ignore[attr-defined]
+    assert any(c.startswith("rm -f") and ".tar.tmp" in c for c in client.recorded)
 
 
 def test_load_image_renders_cat_into_docker_load() -> None:
-    cache = _cache(lambda cmd: (0, "", ""))
+    client, cache = _build(lambda cmd: (0, "", ""))
     cache.load_image_into_slice(_TAG, vm_ssh_port=2244, transfer_key=_KEY)
-    load_cmd = next(c for c in cache.slice_client.recorded if "docker load" in c)  # type: ignore[attr-defined]
+    load_cmd = next(c for c in client.recorded if "docker load" in c)
     assert load_cmd.startswith("cat ")
     assert "docker load" in load_cmd and "-p 2244 root@127.0.0.1" in load_cmd
 

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client.py
@@ -156,7 +156,7 @@ class LimaSliceVpsClient(VpsClientInterface):
             f"{_BOX_PATH_PREFIX} {remote_command}",
         ]
 
-    def _run_on_box(
+    def run_on_box(
         self, remote_command: str, *, timeout: float, label: str, is_streaming: bool = False
     ) -> tuple[int | None, str, str]:
         """Run a command on the box over SSH; return (returncode, stdout, stderr)."""
@@ -247,7 +247,7 @@ class LimaSliceVpsClient(VpsClientInterface):
         )
         encoded_script = base64.b64encode(reserve_script.encode()).decode()
         reserve_command = f"echo {shlex.quote(encoded_script)} | base64 -d | bash"
-        reserve_rc, reserve_out, reserve_err = self._run_on_box(
+        reserve_rc, reserve_out, reserve_err = self.run_on_box(
             reserve_command, timeout=_LIMA_RESERVE_TIMEOUT_SECONDS, label=f"reserve:{instance_name}", is_streaming=True
         )
         if reserve_rc != 0:
@@ -267,7 +267,7 @@ class LimaSliceVpsClient(VpsClientInterface):
 
         # Phase 2: boot the reserved VM (the long step), with the lock already released.
         try:
-            start_rc, _start_out, start_err = self._run_on_box(
+            start_rc, _start_out, start_err = self.run_on_box(
                 f"limactl --log-level=info start {shlex.quote(instance_name)}",
                 timeout=_LIMA_START_TIMEOUT_SECONDS,
                 label=f"start:{instance_name}",
@@ -299,7 +299,7 @@ class LimaSliceVpsClient(VpsClientInterface):
         instance_name = str(instance_id)
         disk_name = f"{instance_name}{_DISK_NAME_SUFFIX}"
         delete_command = f"limactl delete --force {shlex.quote(instance_name)}"
-        delete_rc, _out, delete_err = self._run_on_box(
+        delete_rc, _out, delete_err = self.run_on_box(
             delete_command, timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="delete"
         )
         if delete_rc != 0:
@@ -311,7 +311,7 @@ class LimaSliceVpsClient(VpsClientInterface):
                 raise LimaCommandError("delete", delete_rc or 1, delete_err)
             logger.debug("Lima instance {} already absent, skipping", instance_name)
         disk_delete_command = f"limactl disk delete --force {shlex.quote(disk_name)}"
-        disk_rc, _disk_out, disk_err = self._run_on_box(
+        disk_rc, _disk_out, disk_err = self.run_on_box(
             disk_delete_command, timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="disk-delete"
         )
         if disk_rc != 0:
@@ -323,7 +323,7 @@ class LimaSliceVpsClient(VpsClientInterface):
 
     def list_instance_names(self) -> set[str]:
         """Return the names of all lima instances currently on the box."""
-        list_rc, list_out, list_err = self._run_on_box(
+        list_rc, list_out, list_err = self.run_on_box(
             "limactl list --json", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="list"
         )
         if list_rc != 0:
@@ -345,7 +345,7 @@ class LimaSliceVpsClient(VpsClientInterface):
 
     def list_disk_names(self) -> set[str]:
         """Return the names of all lima disks currently on the box."""
-        list_rc, list_out, list_err = self._run_on_box(
+        list_rc, list_out, list_err = self.run_on_box(
             "limactl disk list --json", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="disk-list"
         )
         if list_rc != 0:
@@ -374,10 +374,10 @@ class LimaSliceVpsClient(VpsClientInterface):
         the disk is not actually locked, which is fine), then force-delete, tolerating the
         disk already being absent.
         """
-        self._run_on_box(
+        self.run_on_box(
             f"limactl disk unlock {shlex.quote(disk_name)}", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="disk-unlock"
         )
-        delete_rc, _out, delete_err = self._run_on_box(
+        delete_rc, _out, delete_err = self.run_on_box(
             f"limactl disk delete --force {shlex.quote(disk_name)}",
             timeout=_LIMA_SHORT_TIMEOUT_SECONDS,
             label="disk-delete",
@@ -387,7 +387,7 @@ class LimaSliceVpsClient(VpsClientInterface):
         logger.info("Destroyed orphan slice disk {} on {}", disk_name, self.box_address)
 
     def get_instance_status(self, instance_id: VpsInstanceId) -> VpsInstanceStatus:
-        list_rc, list_out, list_err = self._run_on_box(
+        list_rc, list_out, list_err = self.run_on_box(
             "limactl list --json", timeout=_LIMA_SHORT_TIMEOUT_SECONDS, label="list"
         )
         if list_rc != 0:

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/lima_slice_client_test.py
@@ -68,7 +68,7 @@ class _RecordingClient(LimaSliceVpsClient):
     scripted_responses: dict[str, tuple[int | None, str, str]] = {}
     recorded_commands: list[str] = []
 
-    def _run_on_box(
+    def run_on_box(
         self, remote_command: str, *, timeout: float, label: str, is_streaming: bool = False
     ) -> tuple[int | None, str, str]:
         self.recorded_commands.append(remote_command)

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/mock_box_image_cache_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/mock_box_image_cache_test.py
@@ -1,0 +1,60 @@
+from pydantic import Field
+
+from imbue.mngr_imbue_cloud.errors import BoxImageCacheError
+from imbue.mngr_imbue_cloud.slices.box_image_cache import BoxImageCacheInterface
+from imbue.mngr_imbue_cloud.slices.box_image_cache import TransferKey
+
+
+class MockBoxImageCache(BoxImageCacheInterface):
+    """In-memory BoxImageCache for unit-testing the slice provider's seed/load orchestration."""
+
+    tars_present: set[str] = Field(default_factory=set, description="image_tags whose tar 'exists' on the box")
+    locks_held: set[str] = Field(default_factory=set, description="image_tags currently locked")
+    free_bytes: int = Field(default=10**12, description="Simulated free disk on the box")
+    saved_tags: list[str] = Field(default_factory=list, description="image_tags saved, in order")
+    loaded_tags: list[str] = Field(default_factory=list, description="image_tags loaded, in order")
+    created_keys: list[TransferKey] = Field(default_factory=list, description="Ephemeral keys created, in order")
+    destroyed_keys: list[TransferKey] = Field(default_factory=list, description="Ephemeral keys destroyed, in order")
+    is_save_failing: bool = Field(default=False, description="Whether save_image_from_slice raises")
+    is_load_failing: bool = Field(default=False, description="Whether load_image_into_slice raises")
+
+    def has_tar(self, image_tag: str) -> bool:
+        return image_tag in self.tars_present
+
+    def try_acquire_build_lock(self, image_tag: str) -> bool:
+        if image_tag in self.locks_held:
+            return False
+        self.locks_held.add(image_tag)
+        return True
+
+    def release_build_lock(self, image_tag: str) -> None:
+        self.locks_held.discard(image_tag)
+
+    def wait_for_tar(self, image_tag: str, *, timeout_seconds: int) -> bool:
+        return image_tag in self.tars_present
+
+    def check_free_disk(self, required_bytes: int) -> None:
+        if self.free_bytes < required_bytes:
+            raise BoxImageCacheError(f"insufficient disk: need {required_bytes}, have {self.free_bytes}")
+
+    def create_transfer_key(self) -> TransferKey:
+        transfer_key = TransferKey(
+            private_key_path_on_box=f"/box/.transfer-{len(self.created_keys)}",
+            public_key=f"ssh-ed25519 MOCKKEY{len(self.created_keys)}",
+        )
+        self.created_keys.append(transfer_key)
+        return transfer_key
+
+    def destroy_transfer_key(self, transfer_key: TransferKey) -> None:
+        self.destroyed_keys.append(transfer_key)
+
+    def save_image_from_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        if self.is_save_failing:
+            raise BoxImageCacheError(f"mock save failure for {image_tag}")
+        self.saved_tags.append(image_tag)
+        self.tars_present.add(image_tag)
+
+    def load_image_into_slice(self, image_tag: str, *, vm_ssh_port: int, transfer_key: TransferKey) -> None:
+        if self.is_load_failing:
+            raise BoxImageCacheError(f"mock load failure for {image_tag}")
+        self.loaded_tags.append(image_tag)

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/mock_box_image_cache_test.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/slices/mock_box_image_cache_test.py
@@ -17,6 +17,9 @@ class MockBoxImageCache(BoxImageCacheInterface):
     destroyed_keys: list[TransferKey] = Field(default_factory=list, description="Ephemeral keys destroyed, in order")
     is_save_failing: bool = Field(default=False, description="Whether save_image_from_slice raises")
     is_load_failing: bool = Field(default=False, description="Whether load_image_into_slice raises")
+    is_tar_published_on_wait: bool = Field(
+        default=False, description="When set, wait_for_tar publishes the tar (simulates an in-flight seed finishing)"
+    )
 
     def has_tar(self, image_tag: str) -> bool:
         return image_tag in self.tars_present
@@ -31,6 +34,8 @@ class MockBoxImageCache(BoxImageCacheInterface):
         self.locks_held.discard(image_tag)
 
     def wait_for_tar(self, image_tag: str, *, timeout_seconds: int) -> bool:
+        if self.is_tar_published_on_wait:
+            self.tars_present.add(image_tag)
         return image_tag in self.tars_present
 
     def check_free_disk(self, required_bytes: int) -> None:

--- a/libs/mngr_vps/changelog/mngr-accelerate-bake.md
+++ b/libs/mngr_vps/changelog/mngr-accelerate-bake.md
@@ -1,0 +1,3 @@
+The container realizer can now run a base image that is already present in the VPS's local Docker daemon, skipping both the build and the pull.
+
+`RealizePlacementContext` gained an opt-in `allow_local_image` flag (off by default, so OVH/vultr/aws behavior is unchanged); when set and the image is already loaded locally, `realize_placement` runs it as-is. This backs the imbue_cloud slice "build once per box, `docker load` per slice" acceleration.

--- a/libs/mngr_vps/imbue/mngr_vps/container_setup.py
+++ b/libs/mngr_vps/imbue/mngr_vps/container_setup.py
@@ -769,6 +769,15 @@ def pull_image(outer: OuterHostInterface, image: str, timeout_seconds: float = 3
     run_docker(outer, ["pull", image], timeout_seconds=timeout_seconds)
 
 
+def image_exists(outer: OuterHostInterface, image: str) -> bool:
+    """Return whether a Docker image is already present in outer's local daemon."""
+    try:
+        run_docker(outer, ["image", "inspect", image])
+    except MngrError:
+        return False
+    return True
+
+
 def run_container(
     outer: OuterHostInterface,
     *,

--- a/libs/mngr_vps/imbue/mngr_vps/container_setup_test.py
+++ b/libs/mngr_vps/imbue/mngr_vps/container_setup_test.py
@@ -1,10 +1,46 @@
 import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
+from pydantic import ConfigDict
 
+from imbue.imbue_common.mutable_model import MutableModel
+from imbue.mngr.interfaces.data_types import CommandResult
 from imbue.mngr.utils.testing import run_git_command
 from imbue.mngr_vps.container_setup import _clone_build_context_for_self_contained_git
+from imbue.mngr_vps.container_setup import image_exists
+
+
+class _ImageInspectOuter(MutableModel):
+    """Outer host that succeeds only for ``docker image inspect`` of a known-present image."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    present_image: str
+
+    def execute_idempotent_command(
+        self,
+        command: str,
+        user: str | None = None,
+        cwd: Any = None,
+        env: Any = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        is_inspect_of_present = "image inspect" in command and self.present_image in command
+        if is_inspect_of_present:
+            return CommandResult(stdout="[{}]", stderr="", success=True)
+        return CommandResult(stdout="", stderr="No such image", success=False)
+
+
+def test_image_exists_true_when_inspect_succeeds() -> None:
+    outer = _ImageInspectOuter(present_image="fct:minds-v9.9.9")
+    assert image_exists(outer, "fct:minds-v9.9.9") is True
+
+
+def test_image_exists_false_when_inspect_fails() -> None:
+    outer = _ImageInspectOuter(present_image="fct:minds-v9.9.9")
+    assert image_exists(outer, "fct:absent-tag") is False
 
 
 def test_clone_build_context_returns_none_for_non_git_context(tmp_path: Path) -> None:

--- a/libs/mngr_vps/imbue/mngr_vps/container_setup_test.py
+++ b/libs/mngr_vps/imbue/mngr_vps/container_setup_test.py
@@ -1,12 +1,14 @@
 import shutil
 from pathlib import Path
 from typing import Any
+from typing import cast
 
 import pytest
 from pydantic import ConfigDict
 
 from imbue.imbue_common.mutable_model import MutableModel
 from imbue.mngr.interfaces.data_types import CommandResult
+from imbue.mngr.interfaces.host import OuterHostInterface
 from imbue.mngr.utils.testing import run_git_command
 from imbue.mngr_vps.container_setup import _clone_build_context_for_self_contained_git
 from imbue.mngr_vps.container_setup import image_exists
@@ -34,12 +36,12 @@ class _ImageInspectOuter(MutableModel):
 
 
 def test_image_exists_true_when_inspect_succeeds() -> None:
-    outer = _ImageInspectOuter(present_image="fct:minds-v9.9.9")
+    outer = cast(OuterHostInterface, _ImageInspectOuter(present_image="fct:minds-v9.9.9"))
     assert image_exists(outer, "fct:minds-v9.9.9") is True
 
 
 def test_image_exists_false_when_inspect_fails() -> None:
-    outer = _ImageInspectOuter(present_image="fct:minds-v9.9.9")
+    outer = cast(OuterHostInterface, _ImageInspectOuter(present_image="fct:minds-v9.9.9"))
     assert image_exists(outer, "fct:absent-tag") is False
 
 

--- a/libs/mngr_vps/imbue/mngr_vps/data_types.py
+++ b/libs/mngr_vps/imbue/mngr_vps/data_types.py
@@ -44,6 +44,10 @@ class RealizePlacementContext(FrozenModel):
     base_image: str = Field(description="Base image to run/build the agent from (container realizer)")
     effective_start_args: tuple[str, ...] = Field(description="Runtime start args (e.g. docker run flags)")
     docker_build_args: tuple[str, ...] = Field(description="Build args; non-empty triggers an on-VPS image build")
+    allow_local_image: bool = Field(
+        default=False,
+        description="When true, an already-present local base_image is run as-is (skip both build and pull)",
+    )
     git_depth: int | None = Field(default=None, description="Shallow-clone depth for the local build context")
     tags: Mapping[str, str] | None = Field(default=None, description="User tags to stamp onto the placement")
     known_hosts: Sequence[str] | None = Field(default=None, description="Extra known_hosts entries for the agent")

--- a/libs/mngr_vps/imbue/mngr_vps/docker_realizer.py
+++ b/libs/mngr_vps/imbue/mngr_vps/docker_realizer.py
@@ -40,6 +40,7 @@ from imbue.mngr_vps.container_setup import delete_btrfs_subvolume_on_outer
 from imbue.mngr_vps.container_setup import docker_inspect_running
 from imbue.mngr_vps.container_setup import exec_in_container
 from imbue.mngr_vps.container_setup import host_volume_name_for
+from imbue.mngr_vps.container_setup import image_exists
 from imbue.mngr_vps.container_setup import is_running_container_state
 from imbue.mngr_vps.container_setup import prepare_btrfs_on_outer
 from imbue.mngr_vps.container_setup import provision_snapshot_helper_on_outer
@@ -317,7 +318,11 @@ class DockerRealizer(SnapshotCapableRealizer):
         )
 
         image = ctx.base_image
-        if ctx.docker_build_args:
+        if ctx.allow_local_image and image_exists(outer, image):
+            # The caller pre-loaded the image into the daemon (e.g. the imbue_cloud
+            # slice load path); run it as-is rather than building or pulling.
+            logger.log(LogLevel.BUILD.value, "Using image {} already present on VPS", image, source="vps")
+        elif ctx.docker_build_args:
             image = self._build_image_on_vps(outer, host_id, image, ctx.docker_build_args, ctx.git_depth)
         else:
             logger.log(LogLevel.BUILD.value, "Pulling Docker image {} on VPS...", image, source="vps")

--- a/libs/mngr_vps/imbue/mngr_vps/instance.py
+++ b/libs/mngr_vps/imbue/mngr_vps/instance.py
@@ -823,6 +823,7 @@ class VpsProvider(BaseProviderInstance):
         lifecycle: HostLifecycleOptions | None,
         known_hosts: Sequence[str] | None,
         authorized_keys: Sequence[str] | None,
+        allow_local_image: bool = False,
     ) -> Host:
         """Build the container and finalize host state on an already-reachable VPS.
 
@@ -853,6 +854,7 @@ class VpsProvider(BaseProviderInstance):
                 base_image=base_image,
                 effective_start_args=effective_start_args,
                 docker_build_args=parsed.docker_build_args,
+                allow_local_image=allow_local_image,
                 git_depth=parsed.git_depth,
                 tags=tags,
                 known_hosts=known_hosts,


### PR DESCRIPTION
## Summary

Accelerates imbue_cloud bare-metal slice bakes (issue #2305) by paying the forever-claude-template (FCT) Docker image build **once per box** instead of once per slice.

- The first production (`--from-tag`) slice baked on a box builds the FCT image, bakes Playwright/Chromium into it cloud-side, and `docker save`s it to a box-local tar (under a per-box build lock).
- Every subsequent slice on that box `docker load`s that tar into its dockerd instead of rebuilding from the Dockerfile — removing the per-slice 10-20 min build and the per-slice ~900s first-boot Playwright install.
- The ~11 GiB transfer runs entirely over the box's own loopback (no external bandwidth; nothing left reachable from a leased slice), using a unique ephemeral SSH key per transfer that is torn down afterward.
- **mngr-only / single repo** — no forever-claude-template change; the desktop Lima path is untouched. Dev (`--workspace-dir`) bakes always build.

Design/plan: `blueprint/accelerate-slice-bake/plan-accelerate-slice-bake.md`.

## Key changes

- **mngr_vps**: `RealizePlacementContext.allow_local_image` (opt-in, default off → OVH/vultr/aws unchanged); `realize_placement` runs an already-present local image (skip build+pull); `image_exists` helper.
- **mngr_imbue_cloud**: `BoxImageCacheInterface` + `LimaBoxImageCache` (per-box lock with stale reclaim, atomic save + single-tag prune, disk pre-check, box-local docker save/load over ephemeral keys); `SliceVpsDockerProvider` seeds/loads via a new `fct_cache_tag` config knob; cloud-side Playwright derive image; box prep creates the cache dir; `cli/server.py` enables caching only for production `--from-tag` bakes.

## Testing

- Unit tests for the realizer skip-if-present, the box cache command rendering / lock reclaim / disk pre-check / failure handling, and the slice-provider seed-vs-load orchestration. Full `ty` + ratchets green locally.
- Per the design (5b), end-to-end is verified by actually baking ≥2 slices on a real box (slice #1 builds+seeds, slice #2 loads) — not automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)