### PR TITLE
mngr create --reuse: drop redundant target_host_ref, scope by address host only

### DIFF
--- a/libs/mngr/changelog/mngr-followup-1.md
+++ b/libs/mngr/changelog/mngr-followup-1.md
@@ -1,0 +1,3 @@
+Simplified the internal `--reuse` agent-lookup scoping introduced for `mngr create <agent>@<host>.<provider>`: the lookup is now driven entirely by the host named in the create address. No user-visible behavior change -- a fresh-host create still skips same-named agents on other hosts, an existing-host re-create still reuses the agent on the named host, and a bare-name `--reuse` with multiple matches still raises the disambiguation error.
+
+The redundant `target_host_ref` parameter (which scoped by host id only for already-resolved existing hosts) has been removed; its constraint was already covered by the address's host name plus provider. Host-in-scope matching now lives in a single pure `_is_host_in_reuse_scope` helper.

--- a/libs/mngr/imbue/mngr/cli/create.py
+++ b/libs/mngr/imbue/mngr/cli/create.py
@@ -974,7 +974,6 @@ def _create_agent(
         reuse_result = _try_reuse_existing_agent(
             agent_name=agent_opts.name,
             provider_name=address.provider_name,
-            target_host_ref=target_host if isinstance(target_host, DiscoveredHost) else None,
             host_name=address.host_name,
             mngr_ctx=mngr_ctx,
             agent_and_host_loader=setup.agent_and_host_loader,
@@ -1290,10 +1289,36 @@ def _parse_project_name(
     )
 
 
+@pure
+def _is_host_in_reuse_scope(
+    discovered_host: DiscoveredHost,
+    provider_name: ProviderInstanceName | None,
+    host_name: HostName | HostId | None,
+) -> bool:
+    """Whether ``discovered_host`` matches the address parts that were specified.
+
+    An unspecified (``None``) provider or host does not constrain the match.
+
+    Examples (caller args -> which discovered hosts are in scope):
+
+    - ``provider_name=None, host_name=None`` -> every host
+    - ``provider_name="modal", host_name=None`` -> every host on modal
+    - ``provider_name=None, host_name=HostName("h2")`` -> every host named "h2"
+    - ``provider_name="modal", host_name=HostName("h2")`` -> the "h2" host on modal
+    - ``provider_name=None, host_name=HostId("host-1")`` -> the host with that exact id
+    """
+    if provider_name is not None and discovered_host.provider_name != provider_name:
+        return False
+    if host_name is None:
+        return True
+    if isinstance(host_name, HostId):
+        return discovered_host.host_id == host_name
+    return discovered_host.host_name == host_name
+
+
 def _try_reuse_existing_agent(
     agent_name: AgentName,
     provider_name: ProviderInstanceName | None,
-    target_host_ref: DiscoveredHost | None,
     host_name: HostName | HostId | None,
     mngr_ctx: MngrContext,
     agent_and_host_loader: Callable[[], dict[DiscoveredHost, list[DiscoveredAgent]]],
@@ -1312,31 +1337,14 @@ def _try_reuse_existing_agent(
     names every workspace's primary agent the constant ``system-services`` and
     relies on the host name for identity): without host scoping the lookup would
     match every same-named agent on the provider and fail to disambiguate.
-    ``target_host_ref`` is the already-resolved host for an existing-host create;
-    it scopes by host id when present and co-occurs with ``host_name``.
     """
     agents_by_host = agent_and_host_loader()
 
     matching_agents: list[tuple[DiscoveredHost, DiscoveredAgent]] = []
 
     for host_ref, agent_refs in agents_by_host.items():
-        # Skip hosts that don't match the provider filter (if specified)
-        if provider_name is not None and host_ref.provider_name != provider_name:
+        if not _is_host_in_reuse_scope(host_ref, provider_name, host_name):
             continue
-
-        # Skip hosts that don't match the target host filter (if specified)
-        if target_host_ref is not None and host_ref.host_id != target_host_ref.host_id:
-            continue
-
-        # Skip hosts that don't match the host named in the address (if specified).
-        # The address host may be a HostId (exact id) or a HostName (the host's name).
-        if host_name is not None:
-            if isinstance(host_name, HostId):
-                host_matches_address = host_ref.host_id == host_name
-            else:
-                host_matches_address = host_ref.host_name == host_name
-            if not host_matches_address:
-                continue
 
         for agent_ref in agent_refs:
             if agent_ref.agent_name == agent_name:

--- a/libs/mngr/imbue/mngr/cli/create_test.py
+++ b/libs/mngr/imbue/mngr/cli/create_test.py
@@ -23,6 +23,7 @@ from imbue.mngr.cli.create import _compute_loader_provider_filter
 from imbue.mngr.cli.create import _editor_cleanup_scope
 from imbue.mngr.cli.create import _get_source_remote_url
 from imbue.mngr.cli.create import _is_creating_new_host
+from imbue.mngr.cli.create import _is_host_in_reuse_scope
 from imbue.mngr.cli.create import _parse_agent_opts
 from imbue.mngr.cli.create import _parse_branch_flag
 from imbue.mngr.cli.create import _parse_host_lifecycle_options
@@ -335,7 +336,6 @@ def test_try_reuse_existing_agent_no_agents_found(temp_mngr_ctx: MngrContext) ->
     result = _try_reuse_existing_agent(
         agent_name=AgentName("nonexistent"),
         provider_name=None,
-        target_host_ref=None,
         host_name=None,
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {},
@@ -352,7 +352,6 @@ def test_try_reuse_existing_agent_no_matching_name(temp_mngr_ctx: MngrContext) -
     result = _try_reuse_existing_agent(
         agent_name=AgentName("test-agent"),
         provider_name=None,
-        target_host_ref=None,
         host_name=None,
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {host_ref: [agent_ref]},
@@ -369,7 +368,6 @@ def test_try_reuse_existing_agent_filters_by_provider(temp_mngr_ctx: MngrContext
     result = _try_reuse_existing_agent(
         agent_name=AgentName("test-agent"),
         provider_name=ProviderInstanceName("local"),
-        target_host_ref=None,
         host_name=None,
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {host_ref: [agent_ref]},
@@ -378,23 +376,65 @@ def test_try_reuse_existing_agent_filters_by_provider(temp_mngr_ctx: MngrContext
     assert result is None
 
 
-def test_try_reuse_existing_agent_filters_by_host(temp_mngr_ctx: MngrContext) -> None:
-    """Returns None when agent exists but on different host."""
-    host_ref = _make_discovered_host(host_id=TEST_HOST_ID_1)
+def test_try_reuse_existing_agent_filters_by_address_host_id(temp_mngr_ctx: MngrContext) -> None:
+    """Returns None when agent exists but on a host whose id differs from the address's host id."""
+    host_ref = _make_discovered_host(host_id=TEST_HOST_ID_1, host_name="h1")
     agent_ref = _make_discovered_agent(agent_name="test-agent", host_id=TEST_HOST_ID_1)
-
-    target_host_ref = _make_discovered_host(host_id=TEST_HOST_ID_2)
 
     result = _try_reuse_existing_agent(
         agent_name=AgentName("test-agent"),
         provider_name=None,
-        target_host_ref=target_host_ref,
-        host_name=None,
+        host_name=HostId(TEST_HOST_ID_2),
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {host_ref: [agent_ref]},
     )
 
     assert result is None
+
+
+def test_try_reuse_existing_agent_filters_by_address_host_name(temp_mngr_ctx: MngrContext) -> None:
+    """Returns None when agent exists on a host whose name differs from the address's host name."""
+    host_ref = _make_discovered_host(host_name="h1")
+    agent_ref = _make_discovered_agent(agent_name="test-agent")
+
+    result = _try_reuse_existing_agent(
+        agent_name=AgentName("test-agent"),
+        provider_name=None,
+        host_name=HostName("h2"),
+        mngr_ctx=temp_mngr_ctx,
+        agent_and_host_loader=lambda: {host_ref: [agent_ref]},
+    )
+
+    assert result is None
+
+
+def test_is_host_in_reuse_scope_matches_documented_examples() -> None:
+    """Direct coverage of ``_is_host_in_reuse_scope``'s scoping matrix.
+
+    An unspecified provider or host name does not constrain the match; a
+    specified one must agree with the discovered host. ``host_name`` may be a
+    :class:`HostName` (match by name) or a :class:`HostId` (match by exact id).
+    """
+    host = _make_discovered_host(provider="modal", host_id=TEST_HOST_ID_1, host_name="h2")
+
+    # Nothing specified -> every host is in scope.
+    assert _is_host_in_reuse_scope(host, None, None) is True
+
+    # Provider only.
+    assert _is_host_in_reuse_scope(host, ProviderInstanceName("modal"), None) is True
+    assert _is_host_in_reuse_scope(host, ProviderInstanceName("docker"), None) is False
+
+    # Host name only.
+    assert _is_host_in_reuse_scope(host, None, HostName("h2")) is True
+    assert _is_host_in_reuse_scope(host, None, HostName("h1")) is False
+
+    # Provider and host name together.
+    assert _is_host_in_reuse_scope(host, ProviderInstanceName("modal"), HostName("h2")) is True
+    assert _is_host_in_reuse_scope(host, ProviderInstanceName("docker"), HostName("h2")) is False
+
+    # Host id matches by exact id, not by name.
+    assert _is_host_in_reuse_scope(host, None, HostId(TEST_HOST_ID_1)) is True
+    assert _is_host_in_reuse_scope(host, None, HostId(TEST_HOST_ID_2)) is False
 
 
 def test_try_reuse_existing_agent_scopes_to_address_host_name_when_new_host(
@@ -404,8 +444,8 @@ def test_try_reuse_existing_agent_scopes_to_address_host_name_when_new_host(
     agent on a *different* host is not matched.
 
     This is the regression guard: minds names every workspace's primary agent the
-    constant ``system-services`` and passes ``--new-host`` (so ``target_host_ref``
-    is None). Several discoverable ``system-services`` agents on other hosts must
+    constant ``system-services`` and passes ``--new-host`` (so the address names a
+    fresh, not-yet-created host). Several discoverable ``system-services`` agents on other hosts must
     not make the lookup ambiguous -- it should return None (nothing to reuse on the
     brand-new host) so the caller creates a fresh agent, rather than raising
     "Multiple agents found".
@@ -422,7 +462,6 @@ def test_try_reuse_existing_agent_scopes_to_address_host_name_when_new_host(
     result = _try_reuse_existing_agent(
         agent_name=AgentName("system-services"),
         provider_name=ProviderInstanceName("docker"),
-        target_host_ref=None,
         host_name=HostName("fresh-workspace"),
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {other_host_a: [agent_a], other_host_b: [agent_b]},
@@ -451,7 +490,6 @@ def test_try_reuse_existing_agent_raises_on_ambiguous_match_without_host_scope(
         _try_reuse_existing_agent(
             agent_name=AgentName("system-services"),
             provider_name=ProviderInstanceName("docker"),
-            target_host_ref=None,
             host_name=None,
             mngr_ctx=temp_mngr_ctx,
             agent_and_host_loader=lambda: {host_a: [agent_a], host_b: [agent_b]},
@@ -498,7 +536,6 @@ def test_try_reuse_existing_agent_found_and_started(
         result = _try_reuse_existing_agent(
             agent_name=agent.name,
             provider_name=None,
-            target_host_ref=None,
             host_name=None,
             mngr_ctx=temp_mngr_ctx,
             agent_and_host_loader=lambda: {host_ref: [agent_ref]},
@@ -561,7 +598,6 @@ def test_try_reuse_existing_agent_scopes_to_address_host_name_among_many(
         result = _try_reuse_existing_agent(
             agent_name=agent.name,
             provider_name=None,
-            target_host_ref=None,
             host_name=local_host.get_name(),
             mngr_ctx=temp_mngr_ctx,
             agent_and_host_loader=lambda: {
@@ -601,7 +637,6 @@ def test_try_reuse_existing_agent_not_found_on_host(
     result = _try_reuse_existing_agent(
         agent_name=AgentName("ghost-agent"),
         provider_name=None,
-        target_host_ref=None,
         host_name=None,
         mngr_ctx=temp_mngr_ctx,
         agent_and_host_loader=lambda: {host_ref: [agent_ref]},


### PR DESCRIPTION
## Context

Follow-up to PR #2085 review comment [r3390807364](https://github.com/imbue-ai/mngr/pull/2085#discussion_r3390807364):

> I think `target_host_ref` is now redundant once you pass in `address.host_name`. Everything can be now derived from the address.host_name. (See at #1694)

PR #2085 fixed the `--reuse` ambiguity bug by threading `address.host_name` into `_try_reuse_existing_agent`, but left the pre-existing `target_host_ref` parameter in place, so the function scoped by host twice.

## Why `target_host_ref` is redundant

`target_host_ref` was only ever non-`None` when `target_host` is a `DiscoveredHost`, which happens only on the existing-host path of `_parse_target_host`, where the host is resolved via `_find_existing_host(address.host_name, address.provider_name, ...)`. That resolver returns **exactly one** host matching the address (raising before reuse is ever reached if the address is ambiguous). So whenever `target_host_ref` was set, the `host_name` filter (plus `provider_name`) already narrowed the candidate set to that exact same single host -- the `host_id` filter added no further constraint.

## Change

- Remove the `target_host_ref` parameter from `_try_reuse_existing_agent` and its call site.
- Adopt PR #1694's approach: a single pure `_is_host_in_reuse_scope(discovered_host, provider_name, host_name)` helper holds the provider/host-in-scope predicate; the lookup loop calls it.

No user-visible behavior change. Fresh-host create still skips same-named agents on other hosts; existing-host re-create still reuses the agent on the named host; bare-name `--reuse` with multiple matches still raises the disambiguation error.

## Tests

`libs/mngr/imbue/mngr/cli/create_test.py`:

- Replaced `test_try_reuse_existing_agent_filters_by_host` (which constructed a `target_host_ref`) with `..._filters_by_address_host_id` and `..._filters_by_address_host_name`, covering both branches of the host filter via the address.
- Added `test_is_host_in_reuse_scope_matches_documented_examples`, a direct unit test of the new pure helper across the full scoping matrix.
- Dropped the `target_host_ref=None` argument from the remaining call sites.

Local run: `create_test.py` fast subset -- 131 passed; tmux reuse subset -- 2 passed; `mngr` ratchets -- 56 passed. `ty check` clean on both changed files. `vet` (agentic) -- no issues. Full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)