### PR TITLE
Make remote host-lock acquisition resilient to transient SSH failures

### DIFF
--- a/libs/mngr/changelog/mngr-mapreduce-launch-resilience.md
+++ b/libs/mngr/changelog/mngr-mapreduce-launch-resilience.md
@@ -1,0 +1,5 @@
+Acquiring a remote host's cooperative lock (part of every `mngr create`/`start` on a remote host) is now resilient to transient SSH failures. Previously, if the SSH connection to a host dropped ("Connection reset by peer" leaving a dead transport), opening the lock channel raised a raw paramiko `SSHException: SSH session not active` that leaked past callers.
+
+The lock path now retries transient SSH errors after rebuilding the dropped connection (matching how remote shell/file operations already behave), and surfaces a failure that survives the retries as a structured `HostConnectionError` instead of a raw paramiko exception.
+
+This keeps a single unreachable machine from crashing an operation that spans many hosts at once: the mapreduce/TMR orchestrator launches one agent per task and already isolates per-agent `MngrError`s, so one host with a flaky connection is now recorded as a single failed launch rather than aborting the entire run.

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -22,6 +22,7 @@ from typing import assert_never
 from uuid import uuid4
 
 from loguru import logger
+from paramiko import Channel
 from paramiko import SSHException
 from paramiko import Transport
 from pydantic import Field
@@ -858,25 +859,29 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         A long-lived exec channel opens the lock fd, waits for the lock, and then
         waits for stdin EOF. Closing the channel on exit sends that EOF, so the
         remote shell exits, the fd closes, and the lock releases.
+
+        Acquiring the channel retries transient SSH failures (rebuilding a dropped
+        connection) and, if they survive the retries, surfaces them as a
+        ``HostConnectionError`` instead of a raw paramiko ``SSHException``. This
+        keeps a single unreachable host from crashing a caller that operates on many
+        hosts at once (e.g. the mapreduce orchestrator launching one agent per task):
+        the failure is a structured ``MngrError`` it can catch and isolate per host.
         """
-        # Establish the SSH connection before grabbing the transport: it is opened
-        # lazily, and the lock can be the first thing to touch it (so the transport
-        # would otherwise be None). Mirrors every other transport user.
-        self._ensure_connected()
-        transport = self._get_paramiko_transport()
-        channel = transport.open_session()
-        is_lock_acquired = False
+        with (
+            self._notify_on_connection_error(),
+            self._translate_ssh_errors(
+                failed="Could not acquire host lock due to connection error",
+                closed="Connection was closed while acquiring host lock",
+            ),
+        ):
+            channel = self._open_remote_lock_channel(lock_file_path, timeout_seconds)
         try:
-            with log_span("acquiring host lock at {} (over SSH)", lock_file_path):
-                channel.exec_command(_build_remote_lock_command(lock_file_path, timeout_seconds))
-                _wait_for_remote_lock_acquired(channel)
-            is_lock_acquired = True
             yield
         except BaseException:
             # If an operation that held the lock fails, optionally keep the host
             # alive for debugging: launch a detached holder that re-grabs the flock
             # after our channel releases it (it blocks on flock until we release).
-            if is_lock_acquired and _is_retain_lock_for_debug_enabled():
+            if _is_retain_lock_for_debug_enabled():
                 logger.debug(
                     "Launching detached host-lock holder for debugging "
                     "(MNGR_DEBUG_RETAIN_LOCK_FOR_FAILED_HOSTS_DURING_CREATE=1)"
@@ -892,6 +897,52 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
                 logger.debug("Failed to send EOF when releasing remote host lock: {}", shutdown_error)
             channel.close()
             logger.trace("Released host lock (over SSH)")
+
+    @_retry_on_transient_ssh_error
+    def _open_remote_lock_channel(self, lock_file_path: Path, timeout_seconds: float | None) -> Channel:
+        """Open an SSH channel that holds the remote host flock, retrying transient SSH failures.
+
+        Returns only once the lock has actually been acquired; the caller owns the
+        returned channel and releases the lock by closing it.
+
+        Mirrors ``_run_shell_command_with_transient_retry``: a dropped connection
+        leaves a dead transport whose ``open_session`` raises ``SSHException("SSH
+        session not active")`` on every subsequent call, so on a transient SSH error
+        we disconnect -- forcing the next attempt to rebuild the connection from
+        scratch -- and re-raise for the retry decorator. Failures that survive the
+        retries are translated to ``HostConnectionError`` by the caller's
+        ``_translate_ssh_errors``.
+        """
+        # Establish the SSH connection before grabbing the transport: it is opened
+        # lazily, and the lock can be the first thing to touch it (so the transport
+        # would otherwise be None). Mirrors every other transport user.
+        self._ensure_connected()
+        transport = self._get_paramiko_transport()
+        try:
+            channel = transport.open_session()
+        except (OSError, EOFError, SSHException) as e:
+            if _is_transient_ssh_error(e):
+                logger.debug("Transient SSH error opening host-lock channel: {}, disconnecting for retry", e)
+                self.connector.host.disconnect()
+            raise
+        is_lock_acquired = False
+        try:
+            with log_span("acquiring host lock at {} (over SSH)", lock_file_path):
+                channel.exec_command(_build_remote_lock_command(lock_file_path, timeout_seconds))
+                _wait_for_remote_lock_acquired(channel)
+            is_lock_acquired = True
+        except (OSError, EOFError, SSHException) as e:
+            if _is_transient_ssh_error(e):
+                logger.debug("Transient SSH error acquiring host lock: {}, disconnecting for retry", e)
+                self.connector.host.disconnect()
+            raise
+        finally:
+            # Close the half-open channel on any failure (transient SSH error, a
+            # bounded-wait LockNotHeldError, flock missing, ...) so we never leak it.
+            # The retry decorator or the caller sees the original exception.
+            if not is_lock_acquired:
+                channel.close()
+        return channel
 
     def _launch_detached_lock_holder(self, lock_file_path: Path) -> None:
         """Launch a detached on-host process that holds the host-lock flock indefinitely.

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import pluggy
 import pytest
+from paramiko import Channel
 from paramiko import ChannelException
 from paramiko import SSHException
 from pyinfra.api.command import StringCommand
@@ -1471,14 +1472,58 @@ def test_is_transient_ssh_error(exception: BaseException, expected: bool) -> Non
     assert _is_transient_ssh_error(exception) is expected
 
 
+class _FakeLockChannel:
+    """Fake paramiko Channel for the SSH host-lock exec path.
+
+    ``recv`` yields the acquired marker so ``_wait_for_remote_lock_acquired``
+    returns immediately; ``shutdown_write``/``close`` are counted so tests can
+    assert the lock is released on exit.
+    """
+
+    def __init__(self) -> None:
+        self.exec_command_call_count = 0
+        self.shutdown_write_call_count = 0
+        self.close_call_count = 0
+        self._recv_chunks = [_LOCK_ACQUIRED_MARKER.encode() + b"\n"]
+        self._recv_call_count = 0
+
+    def exec_command(self, command: str) -> None:
+        self.exec_command_call_count += 1
+
+    def recv(self, num_bytes: int) -> bytes:
+        idx = self._recv_call_count
+        self._recv_call_count += 1
+        if idx < len(self._recv_chunks):
+            return self._recv_chunks[idx]
+        return b""
+
+    def shutdown_write(self) -> None:
+        self.shutdown_write_call_count += 1
+
+    def close(self) -> None:
+        self.close_call_count += 1
+
+
 class _FakeTransport:
     """Fake paramiko transport for testing."""
 
-    def __init__(self, *, is_active: bool = True) -> None:
+    def __init__(self, *, is_active: bool = True, open_session_results: list[object] | None = None) -> None:
         self._is_active = is_active
+        self._open_session_results: list[object] = open_session_results if open_session_results is not None else []
+        self.open_session_call_count = 0
 
     def is_active(self) -> bool:
         return self._is_active
+
+    def open_session(self) -> object:
+        idx = self.open_session_call_count
+        self.open_session_call_count += 1
+        if idx < len(self._open_session_results):
+            result = self._open_session_results[idx]
+            if isinstance(result, Exception):
+                raise result
+            return result
+        raise AssertionError("open_session called more times than configured")
 
 
 class _BaseFakeSFTP:
@@ -2687,6 +2732,61 @@ def test_host_lock_cooperatively_acquires_and_releases_blocking(
     # The lock file persists (stable inode) but is no longer held.
     assert (host.host_dir / "host_lock").exists()
     assert host.is_lock_held() is False
+
+
+def test_hold_remote_host_lock_retries_transient_ssh_error_and_reconnects(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """A dropped connection during lock acquisition should disconnect, reconnect, and retry.
+
+    Reproduces the CI failure where a mapper host's SSH transport died
+    ("Connection reset by peer" -> "SSH session not active"): the first
+    ``open_session`` raises, we disconnect so the retry rebuilds the connection,
+    and the second attempt acquires the lock.
+    """
+    channel = _FakeLockChannel()
+    transport = _FakeTransport(open_session_results=[SSHException("SSH session not active"), channel])
+    fake = _FakeHostWithSSH(ssh_client=_FakeSSHClient(transport_return=transport))
+    host = _create_host_with_fake_connector(local_provider, fake)
+
+    with host.lock_cooperatively(timeout_seconds=None):
+        pass
+
+    assert transport.open_session_call_count == 2
+    assert fake.disconnect_call_count == 1
+    # The acquired channel is released (EOF + close) when the block exits.
+    assert channel.shutdown_write_call_count == 1
+    assert channel.close_call_count == 1
+
+
+def test_hold_remote_host_lock_wraps_persistent_ssh_error_in_host_connection_error(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """A lock-acquisition SSH error that survives the retries must surface as HostConnectionError.
+
+    Wrapping the raw paramiko ``SSHException`` in an ``MngrError`` subclass is what
+    lets a many-host caller (the mapreduce orchestrator) isolate one unreachable
+    host instead of crashing the whole run. ``_open_remote_lock_channel`` is
+    overridden to raise immediately so the test does not pay the real retry backoff.
+    """
+
+    class _HostWithImmediateLockSSHFailure(Host):
+        def _open_remote_lock_channel(self, lock_file_path: Path, timeout_seconds: float | None) -> Channel:
+            raise SSHException("SSH session not active")
+
+    fake = _FakePyinfraHost()
+    connector = PyinfraConnector(cast(PyinfraHost, fake))
+    host = _HostWithImmediateLockSSHFailure(
+        id=HostId.generate(),
+        host_name=HostName("test"),
+        connector=connector,
+        provider_instance=local_provider,
+        mngr_ctx=local_provider.mngr_ctx,
+    )
+
+    with pytest.raises(HostConnectionError, match="Could not acquire host lock"):
+        with host.lock_cooperatively(timeout_seconds=None):
+            pass
 
 
 def test_host_lock_cooperatively_is_mutually_exclusive(

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -1490,7 +1490,7 @@ class _FakeLockChannel:
     def exec_command(self, command: str) -> None:
         self.exec_command_call_count += 1
 
-    def recv(self, num_bytes: int) -> bytes:
+    def recv(self, size: int) -> bytes:
         idx = self._recv_call_count
         self._recv_call_count += 1
         if idx < len(self._recv_chunks):


### PR DESCRIPTION
## Why

A scheduled TMR run ([28506362822](https://github.com/imbue-ai/mngr/actions/runs/28506362822)) crashed the whole orchestrator when a single mapper host's SSH connection dropped:

```
paramiko.ssh_exception.SSHException: SSH session not active
ConcurrencyExceptionGroup: SSH session not active (1 sub-exception)
```

The mapreduce/TMR orchestrator launches one agent per task across many remote hosts and already isolates per-agent failures (`except (MngrError, OSError, BaseExceptionGroup)` in `launch_all_mappers`). But `_hold_remote_host_lock` (reached by every `mngr create` on a remote host, via `create` → `host.lock_cooperatively`) called `transport.open_session()` with **no retry and no error wrapping**. When a host's transport died ("Connection reset by peer" → dead transport → `open_session` raises `SSHException("SSH session not active")`), the raw paramiko exception leaked past the orchestrator's `except`, escaped the `ConcurrencyGroupExecutor` `with` block, and was re-raised as a fatal `ConcurrencyExceptionGroup`.

The lock path was the **one** remote operation that neither retried transient SSH errors nor translated them, unlike `_run_shell_command` and the file-transfer paths.

## What

- Move channel acquisition into `_open_remote_lock_channel`, decorated with the existing `@_retry_on_transient_ssh_error` and disconnecting between attempts so a dropped connection is rebuilt before the retry (mirrors `_run_shell_command_with_transient_retry`).
- Wrap post-retry failures via the existing `_translate_ssh_errors` / `_notify_on_connection_error` so a persistently unreachable host surfaces a structured `HostConnectionError` (a `MngrError`) instead of a raw paramiko exception.
- The channel is closed on every acquisition failure path, so no channel leaks.

No mapreduce code change is needed: its per-agent `except (MngrError, ...)` already isolates failures — it just needs the host layer to raise an `MngrError`, which it now does. So one flaky host becomes a single recorded launch failure instead of a fatal crash.

## Testing

- Two new unit tests in `host_test.py`:
  - a transient `open_session` failure disconnects, reconnects, and retries to success;
  - a persistent SSH failure surfaces as `HostConnectionError`.
- Full `host_test.py`: 193 passed. mngr exception-handling ratchets: pass (no new broad/base `except`). `ty check` clean. vet: no issues.

## Manual testing

- A fresh TMR run should complete end-to-end; if a mapper host's SSH drops, that mapper should appear as a single failed launch in the report while the rest of the run proceeds (rather than the whole run aborting with `SSH session not active`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)