### PR TITLE
Migrate GitHub Actions workflows to Vault secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       # Injected as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET into the job env for the
       # offload run below.
       - name: Fetch Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -257,7 +257,7 @@ jobs:
       # imbue Modal workspace token (id + secret) from Vault, migrated off the
       # MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
       - name: Fetch Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -309,7 +309,7 @@ jobs:
       # Injected as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET into the job env for the
       # offload run below.
       - name: Fetch Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -492,7 +492,7 @@ jobs:
       # imbue Modal workspace token (id + secret) from Vault, migrated off the
       # MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
       - name: Fetch Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -754,7 +754,7 @@ jobs:
       # and forwarded into the offload sandbox by the just recipe below. Read via
       # the minds-scoped minds_ci_test_gh role.
       - name: Fetch Anthropic key from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: minds_ci_test_gh
           secrets: |
@@ -766,7 +766,7 @@ jobs:
       # repository-only binding, so minds_ci_test_gh stays scoped to minds/ci.
       # Exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
       - name: Fetch Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       # Default shallow single-ref checkout, then deepen only THIS ref's
       # history in the next step. offload needs the full ancestry of HEAD
@@ -261,8 +261,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       - uses: actions/checkout@v6
 
@@ -313,8 +313,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       # Default shallow single-ref checkout, then deepen only THIS ref's
       # history in the next step. offload needs the full ancestry of HEAD
@@ -496,8 +496,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       # The snapshot script rsyncs the checked-out working tree into the
       # Modal image (it excludes .git), so a default shallow single-ref
@@ -609,8 +609,8 @@ jobs:
           # export it for the modal-profile + deploy steps below, reusing the
           # token just minted (the vault CLI reads VAULT_TOKEN from the env).
           export VAULT_TOKEN
-          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
-          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_SECRET)
           echo "::add-mask::$MODAL_TOKEN_ID"
           echo "::add-mask::$MODAL_TOKEN_SECRET"
           printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
@@ -690,8 +690,8 @@ jobs:
           # export it for the modal-profile + deploy steps below, reusing the
           # token just minted (the vault CLI reads VAULT_TOKEN from the env).
           export VAULT_TOKEN
-          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
-          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_SECRET)
           echo "::add-mask::$MODAL_TOKEN_ID"
           echo "::add-mask::$MODAL_TOKEN_SECRET"
           printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
@@ -753,16 +753,17 @@ jobs:
       # The Anthropic key (for live checks) is always needed; masked in the logs
       # and forwarded into the offload sandbox by the just recipe below. The
       # imbue Modal workspace token (id + secret) is fetched here too -- the
-      # minds_ci_test_gh role also reads mngr/ci/modal/* (shared with the mngr
-      # CI jobs) -- and exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
+      # minds_ci_test_gh role also reads mngr/ci/MODAL_TOKEN_ID and
+      # mngr/ci/MODAL_TOKEN_SECRET (shared with the mngr CI jobs) -- and exported
+      # as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
       - name: Fetch Anthropic key and Modal credentials from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
           role: minds_ci_test_gh
           secrets: |
             minds/ci/litellm/ANTHROPIC_API_KEY
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -926,8 +927,8 @@ jobs:
           # export it for the modal-profile + deploy steps below, reusing the
           # token just minted (the vault CLI reads VAULT_TOKEN from the env).
           export VAULT_TOKEN
-          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
-          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_SECRET)
           echo "::add-mask::$MODAL_TOKEN_ID"
           echo "::add-mask::$MODAL_TOKEN_SECRET"
           printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
@@ -1005,8 +1006,8 @@ jobs:
           # export it for the modal-profile + deploy steps below, reusing the
           # token just minted (the vault CLI reads VAULT_TOKEN from the env).
           export VAULT_TOKEN
-          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
-          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/MODAL_TOKEN_SECRET)
           echo "::add-mask::$MODAL_TOKEN_ID"
           echo "::add-mask::$MODAL_TOKEN_SECRET"
           printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,17 +751,25 @@ jobs:
       - uses: actions/checkout@v6
 
       # The Anthropic key (for live checks) is always needed; masked in the logs
-      # and forwarded into the offload sandbox by the just recipe below. The
-      # imbue Modal workspace token (id + secret) is fetched here too -- the
-      # minds_ci_test_gh role also reads mngr/ci/MODAL_TOKEN_ID and
-      # mngr/ci/MODAL_TOKEN_SECRET (shared with the mngr CI jobs) -- and exported
-      # as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
-      - name: Fetch Anthropic key and Modal credentials from Vault
+      # and forwarded into the offload sandbox by the just recipe below. Read via
+      # the minds-scoped minds_ci_test_gh role.
+      - name: Fetch Anthropic key from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
           role: minds_ci_test_gh
           secrets: |
             minds/ci/litellm/ANTHROPIC_API_KEY
+
+      # The imbue Modal workspace token (id + secret) is fetched via the
+      # monorepo-wide mngr_ci_gh role, not minds_ci_test_gh: this job's
+      # minds-ci-test environment claim still satisfies mngr_ci_gh's
+      # repository-only binding, so minds_ci_test_gh stays scoped to minds/ci.
+      # Exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
+      - name: Fetch Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
             mngr/ci/MODAL_TOKEN_ID
             mngr/ci/MODAL_TOKEN_SECRET
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,21 @@ jobs:
     permissions:
       contents: write
       checks: write
-    env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     steps:
+      # The imbue Modal workspace token (id + secret) from Vault, migrated off
+      # the MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
+      # Injected as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET into the job env for the
+      # offload run below.
+      - name: Fetch Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+
       # Default shallow single-ref checkout, then deepen only THIS ref's
       # history in the next step. offload needs the full ancestry of HEAD
       # (to find its checkpoint commit and thin-diff against it), but not
@@ -239,11 +249,21 @@ jobs:
   # Clean up old Modal test environments left behind by acceptance tests.
   cleanup-modal-environments:
     runs-on: ubuntu-latest
-    env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
+    permissions:
+      contents: read
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     steps:
+      # imbue Modal workspace token (id + secret) from Vault, migrated off the
+      # MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
+      - name: Fetch Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+
       - uses: actions/checkout@v6
 
       - name: Set up Python
@@ -281,11 +301,21 @@ jobs:
     permissions:
       contents: write
       checks: write
-    env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     steps:
+      # The imbue Modal workspace token (id + secret) from Vault, migrated off
+      # the MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
+      # Injected as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET into the job env for the
+      # offload run below.
+      - name: Fetch Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+
       # Default shallow single-ref checkout, then deepen only THIS ref's
       # history in the next step. offload needs the full ancestry of HEAD
       # (to find its checkpoint commit and thin-diff against it), but not
@@ -453,14 +483,22 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     # Exposes the freshly-built snapshot image id to the dependent test job.
     outputs:
       image_id: ${{ steps.snapshot.outputs.image_id }}
-    env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
     steps:
+      # imbue Modal workspace token (id + secret) from Vault, migrated off the
+      # MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret.
+      - name: Fetch Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+
       # The snapshot script rsyncs the checked-out working tree into the
       # Modal image (it excludes .git), so a default shallow single-ref
       # checkout is all it needs -- no history deepening required.
@@ -526,13 +564,13 @@ jobs:
       contents: read
       id-token: write
     env:
-      # The ci tier deploys to the minds-dev Modal workspace, so use that
-      # workspace's tokens. The default MODAL_TOKEN_ID is the imbue workspace,
-      # and Modal env tokens override the ~/.modal.toml profile -- using imbue
-      # here makes `modal deploy` report imbue-* hostnames that mismatch the
-      # computed minds-dev-* URLs and aborts the deploy.
-      MODAL_TOKEN_ID: ${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}
+      # The ci tier deploys to the minds-dev Modal workspace, so the deploy
+      # authenticates with that workspace's token, fetched from Vault in the
+      # "Authenticate to Vault via GitHub OIDC" step below and exported as
+      # MODAL_TOKEN_ID / MODAL_TOKEN_SECRET (migrated off the
+      # MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret). The default
+      # imbue-workspace token would make `modal deploy` report imbue-* hostnames
+      # that mismatch the computed minds-dev-* URLs and abort the deploy.
       VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
       VAULT_NAMESPACE: admin
     steps:
@@ -566,16 +604,27 @@ jobs:
           VAULT_TOKEN=$(vault write -field=token auth/jwt_github_actions/login role=minds_ci_env_gh jwt="$OIDC")
           echo "::add-mask::$VAULT_TOKEN"
           printf '%s' "$VAULT_TOKEN" > "$HOME/.vault-token"
+          # Fetch the minds-dev Modal workspace token from Vault (migrated off
+          # the MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret) and
+          # export it for the modal-profile + deploy steps below, reusing the
+          # token just minted (the vault CLI reads VAULT_TOKEN from the env).
+          export VAULT_TOKEN
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          echo "::add-mask::$MODAL_TOKEN_ID"
+          echo "::add-mask::$MODAL_TOKEN_SECRET"
+          printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
+          printf 'MODAL_TOKEN_SECRET<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_SECRET" >> "$GITHUB_ENV"
       # `minds env deploy` for the ci tier requires deploy-mode activation, which
       # pins MODAL_PROFILE to the tier's modal_workspace (minds-dev) and
       # validates it against ~/.modal.toml. CI has no ~/.modal.toml, so synthesize
       # a throwaway one from the Modal token env.
       - name: Write throwaway Modal profile
         run: |
-          cat > "$HOME/.modal.toml" <<'EOF'
+          cat > "$HOME/.modal.toml" <<EOF
           [minds-dev]
-          token_id = "${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}"
-          token_secret = "${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}"
+          token_id = "${MODAL_TOKEN_ID}"
+          token_secret = "${MODAL_TOKEN_SECRET}"
           active = true
           EOF
       - name: Deploy the per-run ci env
@@ -606,8 +655,8 @@ jobs:
       id-token: write
     env:
       # ci envs live in the minds-dev Modal workspace (see build-minds-ci-env).
-      MODAL_TOKEN_ID: ${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}
+      # The minds-dev Modal token is fetched from Vault in the auth step below
+      # and exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
       VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
       VAULT_NAMESPACE: admin
     steps:
@@ -636,12 +685,23 @@ jobs:
           VAULT_TOKEN=$(vault write -field=token auth/jwt_github_actions/login role=minds_ci_env_gh jwt="$OIDC")
           echo "::add-mask::$VAULT_TOKEN"
           printf '%s' "$VAULT_TOKEN" > "$HOME/.vault-token"
+          # Fetch the minds-dev Modal workspace token from Vault (migrated off
+          # the MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret) and
+          # export it for the modal-profile + deploy steps below, reusing the
+          # token just minted (the vault CLI reads VAULT_TOKEN from the env).
+          export VAULT_TOKEN
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          echo "::add-mask::$MODAL_TOKEN_ID"
+          echo "::add-mask::$MODAL_TOKEN_SECRET"
+          printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
+          printf 'MODAL_TOKEN_SECRET<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_SECRET" >> "$GITHUB_ENV"
       - name: Write throwaway Modal profile
         run: |
-          cat > "$HOME/.modal.toml" <<'EOF'
+          cat > "$HOME/.modal.toml" <<EOF
           [minds-dev]
-          token_id = "${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}"
-          token_secret = "${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}"
+          token_id = "${MODAL_TOKEN_ID}"
+          token_secret = "${MODAL_TOKEN_SECRET}"
           active = true
           EOF
       - name: Sweep leaked ci-* envs older than 1 hour
@@ -678,8 +738,10 @@ jobs:
       checks: write
       id-token: write
     env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+      # The imbue Modal workspace token (id + secret) is fetched from Vault in
+      # the "Fetch Anthropic key and Modal credentials from Vault" step below
+      # and exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET (migrated off the
+      # MODAL_TOKEN_ID variable + MODAL_TOKEN_SECRET GitHub Actions secret).
       # The minds_services fixtures read the per-env secrets back from Vault
       # (keyed by env name, available in the downloaded deployment_envs.json).
       VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
@@ -689,13 +751,18 @@ jobs:
       - uses: actions/checkout@v6
 
       # The Anthropic key (for live checks) is always needed; masked in the logs
-      # and forwarded into the offload sandbox by the just recipe below.
-      - name: Fetch Anthropic key from Vault
+      # and forwarded into the offload sandbox by the just recipe below. The
+      # imbue Modal workspace token (id + secret) is fetched here too -- the
+      # minds_ci_test_gh role also reads mngr/ci/modal/* (shared with the mngr
+      # CI jobs) -- and exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET.
+      - name: Fetch Anthropic key and Modal credentials from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
           role: minds_ci_test_gh
           secrets: |
             minds/ci/litellm/ANTHROPIC_API_KEY
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -819,13 +886,13 @@ jobs:
       contents: read
       id-token: write
     env:
-      # The ci tier deploys to the minds-dev Modal workspace, so use that
-      # workspace's tokens. The default MODAL_TOKEN_ID is the imbue workspace,
-      # and Modal env tokens override the ~/.modal.toml profile -- using imbue
-      # here makes `modal deploy` report imbue-* hostnames that mismatch the
-      # computed minds-dev-* URLs and aborts the deploy.
-      MODAL_TOKEN_ID: ${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}
+      # The ci tier deploys to the minds-dev Modal workspace, so the deploy
+      # authenticates with that workspace's token, fetched from Vault in the
+      # "Authenticate to Vault via GitHub OIDC" step below and exported as
+      # MODAL_TOKEN_ID / MODAL_TOKEN_SECRET (migrated off the
+      # MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret). The default
+      # imbue-workspace token would make `modal deploy` report imbue-* hostnames
+      # that mismatch the computed minds-dev-* URLs and abort the deploy.
       VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
       VAULT_NAMESPACE: admin
     steps:
@@ -854,12 +921,23 @@ jobs:
           VAULT_TOKEN=$(vault write -field=token auth/jwt_github_actions/login role=minds_ci_env_gh jwt="$OIDC")
           echo "::add-mask::$VAULT_TOKEN"
           printf '%s' "$VAULT_TOKEN" > "$HOME/.vault-token"
+          # Fetch the minds-dev Modal workspace token from Vault (migrated off
+          # the MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret) and
+          # export it for the modal-profile + deploy steps below, reusing the
+          # token just minted (the vault CLI reads VAULT_TOKEN from the env).
+          export VAULT_TOKEN
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          echo "::add-mask::$MODAL_TOKEN_ID"
+          echo "::add-mask::$MODAL_TOKEN_SECRET"
+          printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
+          printf 'MODAL_TOKEN_SECRET<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_SECRET" >> "$GITHUB_ENV"
       - name: Write throwaway Modal profile
         run: |
-          cat > "$HOME/.modal.toml" <<'EOF'
+          cat > "$HOME/.modal.toml" <<EOF
           [minds-dev]
-          token_id = "${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}"
-          token_secret = "${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}"
+          token_id = "${MODAL_TOKEN_ID}"
+          token_secret = "${MODAL_TOKEN_SECRET}"
           active = true
           EOF
       - name: Download deployment env config
@@ -891,8 +969,9 @@ jobs:
       contents: read
       id-token: write
     env:
-      MODAL_TOKEN_ID: ${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}
+      # The minds-dev Modal token is fetched from Vault in the auth step below
+      # and exported as MODAL_TOKEN_ID / MODAL_TOKEN_SECRET (migrated off the
+      # MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret).
       VAULT_ADDR: https://vault-cluster-public-vault-df29b16f.9b573ab7.z1.hashicorp.cloud:8200
       VAULT_NAMESPACE: admin
     steps:
@@ -921,12 +1000,23 @@ jobs:
           VAULT_TOKEN=$(vault write -field=token auth/jwt_github_actions/login role=minds_ci_env_gh jwt="$OIDC")
           echo "::add-mask::$VAULT_TOKEN"
           printf '%s' "$VAULT_TOKEN" > "$HOME/.vault-token"
+          # Fetch the minds-dev Modal workspace token from Vault (migrated off
+          # the MINDS_DEV_MODAL_TOKEN_* GitHub Actions variable/secret) and
+          # export it for the modal-profile + deploy steps below, reusing the
+          # token just minted (the vault CLI reads VAULT_TOKEN from the env).
+          export VAULT_TOKEN
+          MODAL_TOKEN_ID=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_ID)
+          MODAL_TOKEN_SECRET=$(vault kv get -field=value -mount=secrets minds/ci/modal/MODAL_TOKEN_SECRET)
+          echo "::add-mask::$MODAL_TOKEN_ID"
+          echo "::add-mask::$MODAL_TOKEN_SECRET"
+          printf 'MODAL_TOKEN_ID<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_ID" >> "$GITHUB_ENV"
+          printf 'MODAL_TOKEN_SECRET<<__EOF__\n%s\n__EOF__\n' "$MODAL_TOKEN_SECRET" >> "$GITHUB_ENV"
       - name: Write throwaway Modal profile
         run: |
-          cat > "$HOME/.modal.toml" <<'EOF'
+          cat > "$HOME/.modal.toml" <<EOF
           [minds-dev]
-          token_id = "${{ vars.MINDS_DEV_MODAL_TOKEN_ID }}"
-          token_secret = "${{ secrets.MINDS_DEV_MODAL_TOKEN_SECRET }}"
+          token_id = "${MODAL_TOKEN_ID}"
+          token_secret = "${MODAL_TOKEN_SECRET}"
           active = true
           EOF
       - name: Run minds release-tier tests (minds_deployment)

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -198,7 +198,7 @@ jobs:
       # role. NOTE: this self-hosted macOS runner must have curl + jq on PATH,
       # which the use-vault-secrets action shells out to.
       - name: Fetch ToDesktop credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: minds_release_gh
           secrets: |
@@ -438,7 +438,7 @@ jobs:
       # Actions secret). This self-hosted macOS runner must have curl + jq on
       # PATH, which the use-vault-secrets action shells out to.
       - name: Fetch Anthropic key from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -1092,7 +1092,7 @@ jobs:
       # webhook was unset.
       - name: Fetch Slack webhook from Vault
         continue-on-error: true
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -161,7 +161,7 @@ jobs:
   build:
     needs: [check_should_run]
     if: needs.check_should_run.outputs.should_run == 'true'
-    # Gated behind the `minds-release` GitHub Environment: the mngr_release_gh
+    # Gated behind the `minds-release` GitHub Environment: the minds_release_gh
     # Vault role that mints the ToDesktop credentials binds on this environment
     # claim, so only a job that declares it can fetch them. The environment must
     # exist in the repo settings with NO required reviewers, so the nightly
@@ -193,17 +193,17 @@ jobs:
     steps:
       # ToDesktop signing/publishing credentials from Vault (migrated off the
       # TODESKTOP_ACCESS_TOKEN / TODESKTOP_EMAIL GitHub Actions secrets). These
-      # are release credentials, so they live under mngr/release/* behind the
-      # mngr_release_gh role's environment gate, not the ordinary CI role.
-      # NOTE: this self-hosted macOS runner must have curl + jq on PATH, which
-      # the use-vault-secrets action shells out to.
+      # publish the minds desktop client, so they live under minds/release/*
+      # behind the minds_release_gh role's environment gate, not the ordinary CI
+      # role. NOTE: this self-hosted macOS runner must have curl + jq on PATH,
+      # which the use-vault-secrets action shells out to.
       - name: Fetch ToDesktop credentials from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
-          role: mngr_release_gh
+          role: minds_release_gh
           secrets: |
-            mngr/release/todesktop/TODESKTOP_ACCESS_TOKEN
-            mngr/release/todesktop/TODESKTOP_EMAIL
+            minds/release/todesktop/TODESKTOP_ACCESS_TOKEN
+            minds/release/todesktop/TODESKTOP_EMAIL
       - name: check ToDesktop secrets
         run: |
           missing=0
@@ -216,7 +216,7 @@ jobs:
             missing=1
           fi
           if (( missing )); then
-            echo "Add both to Vault under secrets/mngr/release/todesktop/ (see the use-vault-secrets step above)."
+            echo "Add both to Vault under secrets/minds/release/todesktop/ (see the use-vault-secrets step above)."
             exit 1
           fi
           echo "TODESKTOP_ACCESS_TOKEN length=${#TODESKTOP_ACCESS_TOKEN}, TODESKTOP_EMAIL length=${#TODESKTOP_EMAIL}"

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -47,9 +47,12 @@ concurrency:
 # `notify_slack` to fetch the run's `run_started_at` for the duration
 # field in the slack message. actions/cache uses its own injected
 # cache token, not GITHUB_TOKEN, so no write scope is needed.
+# `id-token: write` lets the use-vault-secrets steps (in `build`,
+# `launch_to_msg`, and `notify_slack`) mint a GitHub OIDC token for Vault.
 permissions:
   contents: read
   actions: read
+  id-token: write
 
 jobs:
   # Free Linux job that decides whether the rest of the pipeline runs.
@@ -158,6 +161,12 @@ jobs:
   build:
     needs: [check_should_run]
     if: needs.check_should_run.outputs.should_run == 'true'
+    # Gated behind the `minds-release` GitHub Environment: the mngr_release_gh
+    # Vault role that mints the ToDesktop credentials binds on this environment
+    # claim, so only a job that declares it can fetch them. The environment must
+    # exist in the repo settings with NO required reviewers, so the nightly
+    # build still runs unattended.
+    environment: minds-release
     # The job's `check for existing ToDesktop build` step short-circuits
     # `pnpm dist` (the 15-min ToDesktop sign + notarize) when a clean
     # ready build for this SHA already exists; otherwise it packages
@@ -174,8 +183,6 @@ jobs:
     # post-failure cancel step to tear an orphaned ToDesktop build down.
     timeout-minutes: 85
     env:
-      TODESKTOP_ACCESS_TOKEN: ${{ secrets.TODESKTOP_ACCESS_TOKEN }}
-      TODESKTOP_EMAIL:        ${{ secrets.TODESKTOP_EMAIL }}
       # Resolved relative to pnpm's CWD (apps/minds), not the repo root.
       MINDS_CLIENT_CONFIG_BUNDLE: imbue/minds/config/envs/production/client.toml
       MINDS_ROOT_NAME_BUNDLE: minds
@@ -184,6 +191,19 @@ jobs:
       build_id:    ${{ steps.existing.outputs.build_id || steps.parse.outputs.build_id }}
       reused:      ${{ steps.existing.outputs.url != '' }}
     steps:
+      # ToDesktop signing/publishing credentials from Vault (migrated off the
+      # TODESKTOP_ACCESS_TOKEN / TODESKTOP_EMAIL GitHub Actions secrets). These
+      # are release credentials, so they live under mngr/release/* behind the
+      # mngr_release_gh role's environment gate, not the ordinary CI role.
+      # NOTE: this self-hosted macOS runner must have curl + jq on PATH, which
+      # the use-vault-secrets action shells out to.
+      - name: Fetch ToDesktop credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_release_gh
+          secrets: |
+            mngr/release/todesktop/TODESKTOP_ACCESS_TOKEN
+            mngr/release/todesktop/TODESKTOP_EMAIL
       - name: check ToDesktop secrets
         run: |
           missing=0
@@ -196,7 +216,7 @@ jobs:
             missing=1
           fi
           if (( missing )); then
-            echo "Add both at Settings -> Secrets and variables -> Actions."
+            echo "Add both to Vault under secrets/mngr/release/todesktop/ (see the use-vault-secrets step above)."
             exit 1
           fi
           echo "TODESKTOP_ACCESS_TOKEN length=${#TODESKTOP_ACCESS_TOKEN}, TODESKTOP_EMAIL length=${#TODESKTOP_EMAIL}"
@@ -413,9 +433,16 @@ jobs:
       launch_to_ready: ${{ steps.timings.outputs.launch_to_ready }}
       w1_create:       ${{ steps.timings.outputs.w1_create }}
       w2_create:       ${{ steps.timings.outputs.w2_create }}
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
+      # Anthropic key from Vault (migrated off the ANTHROPIC_API_KEY GitHub
+      # Actions secret). This self-hosted macOS runner must have curl + jq on
+      # PATH, which the use-vault-secrets action shells out to.
+      - name: Fetch Anthropic key from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
       - uses: actions/checkout@v6
       - name: verify ANTHROPIC_API_KEY injected
         run: |
@@ -1058,9 +1085,21 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      # Slack webhook from Vault (migrated off the SLACK_LAUNCH_TO_MSG_WEBHOOK
+      # GitHub Actions secret). continue-on-error so a Vault hiccup never kills
+      # this always()-run notification: if the fetch fails, WEBHOOK stays empty
+      # and the step below no-ops with a warning -- exactly as before when the
+      # webhook was unset.
+      - name: Fetch Slack webhook from Vault
+        continue-on-error: true
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/SLACK_LAUNCH_TO_MSG_WEBHOOK
       - name: post status to slack
         env:
-          WEBHOOK: ${{ secrets.SLACK_LAUNCH_TO_MSG_WEBHOOK }}
+          WEBHOOK: ${{ env.SLACK_LAUNCH_TO_MSG_WEBHOOK }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOULD_RUN: ${{ needs.check_should_run.outputs.should_run }}
           MNGR_SHA: ${{ needs.check_should_run.outputs.mngr_sha }}

--- a/.github/workflows/minds-launch-to-msg.yml
+++ b/.github/workflows/minds-launch-to-msg.yml
@@ -202,8 +202,8 @@ jobs:
         with:
           role: minds_release_gh
           secrets: |
-            minds/release/todesktop/TODESKTOP_ACCESS_TOKEN
-            minds/release/todesktop/TODESKTOP_EMAIL
+            minds/release/TODESKTOP_ACCESS_TOKEN
+            minds/release/TODESKTOP_EMAIL
       - name: check ToDesktop secrets
         run: |
           missing=0
@@ -216,7 +216,7 @@ jobs:
             missing=1
           fi
           if (( missing )); then
-            echo "Add both to Vault under secrets/minds/release/todesktop/ (see the use-vault-secrets step above)."
+            echo "Add both to Vault under secrets/minds/release/ (see the use-vault-secrets step above)."
             exit 1
           fi
           echo "TODESKTOP_ACCESS_TOKEN length=${#TODESKTOP_ACCESS_TOKEN}, TODESKTOP_EMAIL length=${#TODESKTOP_EMAIL}"

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -87,8 +87,8 @@ jobs:
           role: mngr_ci_gh
           secrets: |
             mngr/ci/ANTHROPIC_API_KEY
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
       - uses: actions/checkout@v6
 
       - name: Set up Python

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -18,10 +18,20 @@ jobs:
   # Filters for release-marked docker tests.
   test-docker-release:
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    permissions:
+      contents: read
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
 
     steps:
+      # Anthropic key from Vault (migrated off the ANTHROPIC_API_KEY GitHub
+      # Actions secret).
+      - name: Fetch Anthropic key from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
       - uses: actions/checkout@v6
 
       - name: Set up Python
@@ -56,10 +66,10 @@ jobs:
   # Release tests - the full `@pytest.mark.release` suite.
   test-release:
     runs-on: ${{ matrix.os }}
-    env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    permissions:
+      contents: read
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +77,18 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
+      # Anthropic key + imbue Modal workspace token (id + secret) from Vault,
+      # migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET GitHub Actions
+      # secrets and the MODAL_TOKEN_ID variable. The GitHub-hosted macOS runners
+      # in this matrix have curl + jq preinstalled, which the action needs.
+      - name: Fetch Anthropic key and Modal credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
       - uses: actions/checkout@v6
 
       - name: Set up Python

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -27,7 +27,7 @@ jobs:
       # Anthropic key from Vault (migrated off the ANTHROPIC_API_KEY GitHub
       # Actions secret).
       - name: Fetch Anthropic key from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -82,7 +82,7 @@ jobs:
       # secrets and the MODAL_TOKEN_ID variable. The GitHub-hosted macOS runners
       # in this matrix have curl + jq preinstalled, which the action needs.
       - name: Fetch Anthropic key and Modal credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -44,7 +44,7 @@ jobs:
       # migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET GitHub Actions
       # secrets and the MODAL_TOKEN_ID variable.
       - name: Fetch credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -57,7 +57,7 @@ jobs:
       # the pre-migration behaviour when the AWS_* secrets were unset.
       - name: Fetch AWS credentials from Vault (optional)
         continue-on-error: true
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -40,9 +40,9 @@ jobs:
 
       - uses: ./.github/actions/tmr-setup
 
-      # ANTHROPIC key, imbue Modal workspace token (id + secret), and AWS creds
-      # from Vault, migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET /
-      # AWS_* GitHub Actions secrets and the MODAL_TOKEN_ID variable.
+      # ANTHROPIC key + imbue Modal workspace token (id + secret) from Vault,
+      # migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET GitHub Actions
+      # secrets and the MODAL_TOKEN_ID variable.
       - name: Fetch credentials from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
@@ -51,6 +51,16 @@ jobs:
             mngr/ci/ANTHROPIC_API_KEY
             mngr/ci/modal/MODAL_TOKEN_ID
             mngr/ci/modal/MODAL_TOKEN_SECRET
+
+      # AWS creds (optional): continue-on-error so a missing entry leaves AWS_*
+      # unset and the orchestrator silently skips the S3 report mirror, matching
+      # the pre-migration behaviour when the AWS_* secrets were unset.
+      - name: Fetch AWS credentials from Vault (optional)
+        continue-on-error: true
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
             mngr/ci/aws/AWS_ACCESS_KEY_ID
             mngr/ci/aws/AWS_SECRET_ACCESS_KEY
 

--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -49,8 +49,8 @@ jobs:
           role: mngr_ci_gh
           secrets: |
             mngr/ci/ANTHROPIC_API_KEY
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       # AWS creds (optional): continue-on-error so a missing entry leaves AWS_*
       # unset and the orchestrator silently skips the S3 report mirror, matching
@@ -61,8 +61,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/aws/AWS_ACCESS_KEY_ID
-            mngr/ci/aws/AWS_SECRET_ACCESS_KEY
+            mngr/ci/AWS_ACCESS_KEY_ID
+            mngr/ci/AWS_SECRET_ACCESS_KEY
 
       - name: Run TMR reintegrator
         run: |

--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -25,14 +25,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       MNGR_USER_ID: ${{ inputs.mngr_user_id != '' && inputs.mngr_user_id || 'tmr-ci' }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # The automatic per-run token, used for `git push` + `gh pr create` on this
+      # same repo. Intentionally NOT migrated to Vault.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v6
@@ -40,6 +39,20 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/tmr-setup
+
+      # ANTHROPIC key, imbue Modal workspace token (id + secret), and AWS creds
+      # from Vault, migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET /
+      # AWS_* GitHub Actions secrets and the MODAL_TOKEN_ID variable.
+      - name: Fetch credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/aws/AWS_ACCESS_KEY_ID
+            mngr/ci/aws/AWS_SECRET_ACCESS_KEY
 
       - name: Run TMR reintegrator
         run: |

--- a/.github/workflows/tmr-scheduled.yml
+++ b/.github/workflows/tmr-scheduled.yml
@@ -36,6 +36,16 @@ concurrency:
   group: tmr-scheduled
   cancel-in-progress: false
 
+# The `run` job below calls the reusable tmr.yml, whose job needs
+# `id-token: write` to authenticate to Vault (it fetches its credentials from
+# Vault now). A job that calls a reusable workflow passes down the caller's
+# workflow-level permissions, so grant them here. The `gate` job sets its own
+# (narrower) permissions and is unaffected.
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -93,7 +93,7 @@ jobs:
       # migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET GitHub Actions
       # secrets and the MODAL_TOKEN_ID variable.
       - name: Fetch credentials from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |
@@ -108,7 +108,7 @@ jobs:
       # behaviour when the AWS_* GitHub Actions secrets were unset.
       - name: Fetch AWS credentials from Vault (optional)
         continue-on-error: true
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -73,16 +73,14 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+      id-token: write
     env:
-      MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
-      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       MNGR_USER_ID: ${{ inputs.mngr_user_id != '' && inputs.mngr_user_id || 'tmr-ci' }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      # The automatic per-run token, used for `git push` + `gh pr create` on this
+      # same repo. Intentionally NOT migrated to Vault (it can't meaningfully
+      # live there and the automatic token is the right fit for same-repo pushes).
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # AWS creds enable mirroring the HTML report to s3://int8-shared-internal/tmr-reports/.
-      # Optional -- the orchestrator silently skips upload when these are absent.
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v6
@@ -90,6 +88,23 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/tmr-setup
+
+      # ANTHROPIC key, imbue Modal workspace token (id + secret), and AWS creds
+      # from Vault, migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET /
+      # AWS_* GitHub Actions secrets and the MODAL_TOKEN_ID variable. The AWS
+      # creds enable mirroring the HTML report to
+      # s3://int8-shared-internal/tmr-reports/ (the orchestrator silently skips
+      # the upload when they are absent).
+      - name: Fetch credentials from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
+            mngr/ci/modal/MODAL_TOKEN_ID
+            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/aws/AWS_ACCESS_KEY_ID
+            mngr/ci/aws/AWS_SECRET_ACCESS_KEY
 
       - name: Run TMR orchestrator
         env:

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -98,8 +98,8 @@ jobs:
           role: mngr_ci_gh
           secrets: |
             mngr/ci/ANTHROPIC_API_KEY
-            mngr/ci/modal/MODAL_TOKEN_ID
-            mngr/ci/modal/MODAL_TOKEN_SECRET
+            mngr/ci/MODAL_TOKEN_ID
+            mngr/ci/MODAL_TOKEN_SECRET
 
       # AWS creds enable mirroring the HTML report to
       # s3://int8-shared-internal/tmr-reports/. Optional: continue-on-error so a
@@ -112,8 +112,8 @@ jobs:
         with:
           role: mngr_ci_gh
           secrets: |
-            mngr/ci/aws/AWS_ACCESS_KEY_ID
-            mngr/ci/aws/AWS_SECRET_ACCESS_KEY
+            mngr/ci/AWS_ACCESS_KEY_ID
+            mngr/ci/AWS_SECRET_ACCESS_KEY
 
       - name: Run TMR orchestrator
         env:

--- a/.github/workflows/tmr.yml
+++ b/.github/workflows/tmr.yml
@@ -89,12 +89,9 @@ jobs:
 
       - uses: ./.github/actions/tmr-setup
 
-      # ANTHROPIC key, imbue Modal workspace token (id + secret), and AWS creds
-      # from Vault, migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET /
-      # AWS_* GitHub Actions secrets and the MODAL_TOKEN_ID variable. The AWS
-      # creds enable mirroring the HTML report to
-      # s3://int8-shared-internal/tmr-reports/ (the orchestrator silently skips
-      # the upload when they are absent).
+      # ANTHROPIC key + imbue Modal workspace token (id + secret) from Vault,
+      # migrated off the ANTHROPIC_API_KEY / MODAL_TOKEN_SECRET GitHub Actions
+      # secrets and the MODAL_TOKEN_ID variable.
       - name: Fetch credentials from Vault
         uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
         with:
@@ -103,6 +100,18 @@ jobs:
             mngr/ci/ANTHROPIC_API_KEY
             mngr/ci/modal/MODAL_TOKEN_ID
             mngr/ci/modal/MODAL_TOKEN_SECRET
+
+      # AWS creds enable mirroring the HTML report to
+      # s3://int8-shared-internal/tmr-reports/. Optional: continue-on-error so a
+      # missing entry (or unreadable path) leaves AWS_* unset and the
+      # orchestrator silently skips the upload -- matching the pre-migration
+      # behaviour when the AWS_* GitHub Actions secrets were unset.
+      - name: Fetch AWS credentials from Vault (optional)
+        continue-on-error: true
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
             mngr/ci/aws/AWS_ACCESS_KEY_ID
             mngr/ci/aws/AWS_SECRET_ACCESS_KEY
 

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -3,6 +3,8 @@ name: Vet
 permissions:
   contents: read
   pull-requests: write
+  # Lets the use-vault-secrets step below mint a GitHub OIDC token for Vault.
+  id-token: write
 
 on:
   pull_request:
@@ -12,9 +14,15 @@ jobs:
   vet:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
+      # Anthropic key from Vault (migrated off the ANTHROPIC_API_KEY GitHub
+      # Actions secret). Injected as ANTHROPIC_API_KEY for the vet action below.
+      - name: Fetch Anthropic key from Vault
+        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        with:
+          role: mngr_ci_gh
+          secrets: |
+            mngr/ci/ANTHROPIC_API_KEY
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -18,7 +18,7 @@ jobs:
       # Anthropic key from Vault (migrated off the ANTHROPIC_API_KEY GitHub
       # Actions secret). Injected as ANTHROPIC_API_KEY for the vet action below.
       - name: Fetch Anthropic key from Vault
-        uses: imbue-ai/use-vault-secrets@2375c28b61513dadebebdce845c109a01777a197
+        uses: imbue-ai/use-vault-secrets@main
         with:
           role: mngr_ci_gh
           secrets: |

--- a/dev/changelog/mngr-use-vault-secrets.md
+++ b/dev/changelog/mngr-use-vault-secrets.md
@@ -1,0 +1,13 @@
+Migrated the GitHub Actions workflows off GitHub-stored secrets and onto HashiCorp Vault (via the `imbue-ai/use-vault-secrets` OIDC action), so CI credentials are managed centrally in Vault instead of the repo's Actions settings.
+
+- CI test/TMR jobs (`ci.yml`, `vet.yml`, `release-tests.yml`, `tmr.yml`, `tmr-reintegrate.yml`) now fetch the Anthropic key, imbue Modal workspace token (both id and secret), and the TMR S3 credentials from Vault under `mngr/ci/*`, using a new repo-bound `mngr_ci_gh` role. The `MODAL_TOKEN_ID` repo variable and the `ANTHROPIC_API_KEY` / `MODAL_TOKEN_SECRET` / `AWS_*` Actions secrets are no longer used.
+
+- The minds CI-env jobs in `ci.yml` now read the minds-dev Modal token from Vault (`minds/ci/modal/*`) via their existing Vault login, replacing the `MINDS_DEV_MODAL_TOKEN_*` variable/secret.
+
+- The `minds-launch-to-msg.yml` build job fetches its ToDesktop signing credentials from a separate, environment-gated release path (`mngr/release/*`, role `mngr_release_gh`, GitHub Environment `minds-release`); its launch and Slack-notify jobs read the Anthropic key and Slack webhook from `mngr/ci/*`.
+
+- The automatic per-run `GITHUB_TOKEN` (used for same-repo `git push` / `gh` calls and check-run reporting) is intentionally left as-is -- it is not a stored secret and cannot meaningfully live in Vault.
+
+- `scripts/changelog_deploy.sh` now reads its bot token from `secrets/mngr/dev/GH_TOKEN` (the developer-direct-access path) and its Anthropic key from the shared `secrets/mngr/ci/ANTHROPIC_API_KEY`, replacing the old `mngr/dev/github` and `mngr/dev/anthropic` paths.
+
+The Vault roles/policies backing these paths are defined in the separate `imbue-ai/vault` Terraform repo. Note: the self-hosted macOS `minds-runner` must have `curl` and `jq` on PATH for the Vault action to run.

--- a/dev/changelog/mngr-use-vault-secrets.md
+++ b/dev/changelog/mngr-use-vault-secrets.md
@@ -4,7 +4,7 @@ Migrated the GitHub Actions workflows off GitHub-stored secrets and onto HashiCo
 
 - The minds CI-env jobs in `ci.yml` now read the minds-dev Modal token from Vault (`minds/ci/modal/*`) via their existing Vault login, replacing the `MINDS_DEV_MODAL_TOKEN_*` variable/secret.
 
-- The `minds-launch-to-msg.yml` build job fetches its ToDesktop signing credentials from a separate, environment-gated release path (`mngr/release/*`, role `mngr_release_gh`, GitHub Environment `minds-release`); its launch and Slack-notify jobs read the Anthropic key and Slack webhook from `mngr/ci/*`.
+- The `minds-launch-to-msg.yml` build job fetches its ToDesktop signing credentials from a separate, environment-gated minds release path (`minds/release/*`, role `minds_release_gh`, GitHub Environment `minds-release`); its launch and Slack-notify jobs read the Anthropic key and Slack webhook from the monorepo-wide `mngr/ci/*` CI-tooling bucket.
 
 - The automatic per-run `GITHUB_TOKEN` (used for same-repo `git push` / `gh` calls and check-run reporting) is intentionally left as-is -- it is not a stored secret and cannot meaningfully live in Vault.
 

--- a/dev/changelog/mngr-use-vault-secrets.md
+++ b/dev/changelog/mngr-use-vault-secrets.md
@@ -2,7 +2,7 @@ Migrated the GitHub Actions workflows off GitHub-stored secrets and onto HashiCo
 
 - CI test/TMR jobs (`ci.yml`, `vet.yml`, `release-tests.yml`, `tmr.yml`, `tmr-reintegrate.yml`) now fetch the Anthropic key, imbue Modal workspace token (both id and secret), and the TMR S3 credentials from Vault under `mngr/ci/*`, using a new repo-bound `mngr_ci_gh` role. The `MODAL_TOKEN_ID` repo variable and the `ANTHROPIC_API_KEY` / `MODAL_TOKEN_SECRET` / `AWS_*` Actions secrets are no longer used.
 
-- The minds CI-env jobs in `ci.yml` now read the minds-dev Modal token from Vault (`minds/ci/modal/*`) via their existing Vault login, replacing the `MINDS_DEV_MODAL_TOKEN_*` variable/secret.
+- The minds CI-env jobs in `ci.yml` now read the minds-dev Modal token from Vault (`minds/ci/MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET`) via their existing Vault login, replacing the `MINDS_DEV_MODAL_TOKEN_*` variable/secret.
 
 - The `minds-launch-to-msg.yml` build job fetches its ToDesktop signing credentials from a separate, environment-gated minds release path (`minds/release/*`, role `minds_release_gh`, GitHub Environment `minds-release`); its launch and Slack-notify jobs read the Anthropic key and Slack webhook from the monorepo-wide `mngr/ci/*` CI-tooling bucket.
 

--- a/scripts/changelog_deploy.sh
+++ b/scripts/changelog_deploy.sh
@@ -92,20 +92,21 @@ if ! command -v vault >/dev/null 2>&1; then
     exit 1
 fi
 
-# Echo the value of the split-layout secret at secrets/<$1>/<$2>, or exit
-# non-zero. Secrets use the split layout: each key is its own leaf at
-# `<service>/<KEY>` holding a single `value` field. pipefail propagates a
+# Echo the `value` field of the secret at secrets/<$1>, or exit non-zero. In our
+# Vault schema the secret name is the last component of the path and the actual
+# value lives in a single `value` field alongside optional metadata like `owner`
+# (see docs/secret_organization.md in the vault repo). pipefail propagates a
 # failed `vault kv get` (e.g. not logged in); `jq -e` with the `// "" | select`
 # guard exits non-zero when the value is absent or empty. The value is never printed.
 read_vault_secret() {
-    vault kv get -format=json -mount=secrets "$1/$2" | jq -er '.data.data.value // "" | select(. != "")'
+    vault kv get -format=json -mount=secrets "$1" | jq -er '.data.data.value // "" | select(. != "")'
 }
 
-if ! GH_TOKEN=$(read_vault_secret mngr/dev GH_TOKEN); then
+if ! GH_TOKEN=$(read_vault_secret mngr/dev/GH_TOKEN); then
     echo "Error: could not read GH_TOKEN from secrets/mngr/dev/GH_TOKEN. Run 'vault login -method=oidc' and confirm the entry exists." >&2
     exit 1
 fi
-if ! ANTHROPIC_API_KEY=$(read_vault_secret mngr/ci ANTHROPIC_API_KEY); then
+if ! ANTHROPIC_API_KEY=$(read_vault_secret mngr/ci/ANTHROPIC_API_KEY); then
     echo "Error: could not read ANTHROPIC_API_KEY from secrets/mngr/ci/ANTHROPIC_API_KEY. Run 'vault login -method=oidc' and confirm the entry exists." >&2
     exit 1
 fi

--- a/scripts/changelog_deploy.sh
+++ b/scripts/changelog_deploy.sh
@@ -26,10 +26,13 @@ set -euo pipefail
 #   ./scripts/changelog_deploy.sh
 #
 # Secrets are read from Vault at deploy time and baked into the schedule via
-# the --pass-env flags below. Run `vault login -method=oidc` first:
-#   secrets/mngr/dev/github    key GH_TOKEN          - token for bot@imbue.com.
-#   secrets/mngr/dev/anthropic key ANTHROPIC_API_KEY - claude key for the cron
-#                                                       container.
+# the --pass-env flags below. Run `vault login -method=oidc` first. Each path
+# stores the actual value in a `value` field (our standard secret layout):
+#   secrets/mngr/dev/GH_TOKEN          - bot@imbue.com token for opening the
+#                                        changelog PR. Lives under the dev
+#                                        (developer-direct-access) path.
+#   secrets/mngr/ci/ANTHROPIC_API_KEY  - claude key for the cron container;
+#                                        shared with the mngr CI workflows.
 #
 # Optional environment:
 #   CHANGELOG_VERIFY             - Verification mode (default: "none"). Set to
@@ -98,12 +101,12 @@ read_vault_secret() {
     vault kv get -format=json -mount=secrets "$1/$2" | jq -er '.data.data.value // "" | select(. != "")'
 }
 
-if ! GH_TOKEN=$(read_vault_secret mngr/dev/github GH_TOKEN); then
-    echo "Error: could not read GH_TOKEN from secrets/mngr/dev/github/GH_TOKEN. Run 'vault login -method=oidc' and confirm the entry exists." >&2
+if ! GH_TOKEN=$(read_vault_secret mngr/dev GH_TOKEN); then
+    echo "Error: could not read GH_TOKEN from secrets/mngr/dev/GH_TOKEN. Run 'vault login -method=oidc' and confirm the entry exists." >&2
     exit 1
 fi
-if ! ANTHROPIC_API_KEY=$(read_vault_secret mngr/dev/anthropic ANTHROPIC_API_KEY); then
-    echo "Error: could not read ANTHROPIC_API_KEY from secrets/mngr/dev/anthropic/ANTHROPIC_API_KEY. Run 'vault login -method=oidc' and confirm the entry exists." >&2
+if ! ANTHROPIC_API_KEY=$(read_vault_secret mngr/ci ANTHROPIC_API_KEY); then
+    echo "Error: could not read ANTHROPIC_API_KEY from secrets/mngr/ci/ANTHROPIC_API_KEY. Run 'vault login -method=oidc' and confirm the entry exists." >&2
     exit 1
 fi
 export GH_TOKEN ANTHROPIC_API_KEY


### PR DESCRIPTION
> [!IMPORTANT]
> **Before merge — remaining manual steps:**
>
> **1. Populate the remaining Vault secrets** (they only exist as GitHub Actions secrets/variables). From the `imbue-ai/vault` checkout run `uv run edit.py mngr/ci minds/ci minds/release`, then add these, each value copied from the matching GitHub Actions secret/variable:
> - `mngr/ci/SLACK_LAUNCH_TO_MSG_WEBHOOK` ← secret `SLACK_LAUNCH_TO_MSG_WEBHOOK`
> - `minds/ci/MODAL_TOKEN_ID` ← variable `MINDS_DEV_MODAL_TOKEN_ID`
> - `minds/ci/MODAL_TOKEN_SECRET` ← secret `MINDS_DEV_MODAL_TOKEN_SECRET`
> - `minds/release/TODESKTOP_ACCESS_TOKEN` ← secret `TODESKTOP_ACCESS_TOKEN`
> - `minds/release/TODESKTOP_EMAIL` ← secret `TODESKTOP_EMAIL`
>
> **2. Create a `minds-release` GitHub Environment** with no required reviewers, so the launch-to-msg build can mint the ToDesktop creds.
>
> **3. Ensure the self-hosted macOS `minds-runner` has `curl` + `jq` on PATH** — the use-vault-secrets action shells out to them.

---

Migrates the repo's GitHub Actions workflows off GitHub-stored secrets/variables and onto HashiCorp Vault, via the `imbue-ai/use-vault-secrets` OIDC action. Also migrates `scripts/changelog_deploy.sh` to the new secret paths.

## What changed

- **CI / test / TMR jobs** (`ci.yml`, `vet.yml`, `release-tests.yml`, `tmr.yml`, `tmr-reintegrate.yml`): fetch the Anthropic key, imbue Modal token (both id and secret), and TMR S3 creds from `mngr/ci/*` using a new repo-bound `mngr_ci_gh` Vault role. Drops `vars.MODAL_TOKEN_ID` and the `ANTHROPIC_API_KEY` / `MODAL_TOKEN_SECRET` / `AWS_*` Actions secrets.
- **minds CI-env jobs** (`ci.yml`): read the minds-dev Modal token (`minds/ci/MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET`) through their existing Vault login (`minds_ci_env_gh`), replacing `MINDS_DEV_MODAL_TOKEN_*`.
- **`minds-launch-to-msg.yml`**: ToDesktop creds now come from the env-gated minds release path (`minds/release/*`, role `minds_release_gh`, GitHub Environment `minds-release`); the launch/notify jobs read the Anthropic key + Slack webhook from the monorepo-wide `mngr/ci/*`.
- The automatic per-run `GITHUB_TOKEN` is intentionally left as-is (not a stored secret).
- `scripts/changelog_deploy.sh`: reads `mngr/dev/GH_TOKEN` (developer-direct-access path) and `mngr/ci/ANTHROPIC_API_KEY`.

The Vault roles/policies live in the `imbue-ai/vault` repo (matching `mngr/use-vault-secrets` branch, already applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
