### PR TITLE
mngr: bound per-host discovery reads (no abandoned-thread leak)

### DIFF
--- a/blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md
+++ b/blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md
@@ -1,6 +1,8 @@
 # Spec: bound per-host discovery reads (no unbounded abandoned-thread leak)
 
-Status: proposed follow-up to the per-provider-discovery branch (`mngr/per-provider-discovery`, PR #2335). Not yet implemented.
+Status: implemented on branch `mngr/bounded-per-host-discovery` (stacked on
+`mngr/per-provider-discovery`, PR #2335). Both changes below are in place; the
+connect-phase timeouts were deliberately left untouched per the non-goals.
 
 ## Context
 

--- a/blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md
+++ b/blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md
@@ -1,8 +1,22 @@
 # Spec: bound per-host discovery reads (no unbounded abandoned-thread leak)
 
-Status: implemented on branch `mngr/bounded-per-host-discovery` (stacked on
-`mngr/per-provider-discovery`, PR #2335). Both changes below are in place; the
-connect-phase timeouts were deliberately left untouched per the non-goals.
+Status: implemented on branch `mngr/bounded-per-host-discovery` (PR #2353,
+stacked on `mngr/per-provider-discovery` / PR #2335). Both changes below are in
+place; the connect-phase timeouts were deliberately left untouched per the
+non-goals.
+
+Correction (post-implementation): the original draft of this spec assumed the
+per-file `data.json` read (`read_text_file`) also went through
+`execute_idempotent_command` / pyinfra `_timeout`. It does not -- `read_text_file`
+reads over an SFTP channel (`_get_file` -> paramiko `SFTPClient`), not an SSH exec
+command. Only the directory listing (`_list_directory` -> `ls`) uses
+`execute_idempotent_command`. The implementation therefore bounds the two reads by
+two different mechanisms (see Change 1 below): the `ls` via
+`execute_idempotent_command`'s `_timeout`, and the SFTP read via
+`channel.settimeout(...)` on the SFTP channel. Both still surface a stall as
+`HostConnectionError` (via the existing transient-retry + `_translate_ssh_errors`
+path) and land in the offline fallback, so the end-to-end behavior matches the
+intent below.
 
 ## Context
 
@@ -29,17 +43,23 @@ pyinfra's SSH connector.
   So the connect path does **not** accumulate threads. **Explicitly out of scope: do
   not touch the connect timeouts.**
 
-- **The exec/read phase is unbounded.** `_list_directory` / `read_text_file` call
-  `execute_idempotent_command` with `_timeout=None`. pyinfra threads `_timeout` into
-  `read_output_buffers(..., timeout=_timeout)`, which does
-  `gevent.wait((stdout_reader, stderr_reader), timeout=timeout)` and `raise
-  timeout_error()` on elapse. With `_timeout=None` there is no bound, so a connection
-  that establishes and then stalls mid-command (sshd hung after auth, network drops
-  mid-read) blocks the read **indefinitely** -> the abandoned thread never returns ->
-  threads accumulate on every poll.
+- **The exec/read phase is unbounded**, via two distinct paths:
+  - `_list_directory` (the `ls`) calls `execute_idempotent_command` with
+    `_timeout=None`. pyinfra threads `_timeout` into
+    `read_output_buffers(..., timeout=_timeout)`, which does
+    `gevent.wait((stdout_reader, stderr_reader), timeout=timeout)` and `raise
+    timeout_error()` on elapse. With `_timeout=None` there is no bound.
+  - `read_text_file` (each `data.json`) does **not** go through
+    `execute_idempotent_command` -- it reads over an SFTP channel
+    (`read_file` -> `_get_file` -> paramiko `SFTPClient`), which has no read timeout
+    set, so a stalled transfer blocks indefinitely on the channel socket.
 
-So the only genuinely-unbounded case is the mid-read stall, and it is caused by
-`_timeout=None` on the discovery reads.
+  Either way, a connection that establishes and then stalls mid-read (sshd hung after
+  auth, network drops mid-read) blocks **indefinitely** -> the abandoned thread never
+  returns -> threads accumulate on every poll.
+
+So the only genuinely-unbounded case is the mid-read stall, caused by the missing read
+timeout on both the `ls` exec and the SFTP file read.
 
 ## Purpose
 
@@ -56,19 +76,25 @@ offline last-known agents) without leaking threads or hiding the problem.
 - **Producer-side intervening-event immediate re-poll** — a separate, deferred
   convergence-speed optimization; correctness is already handled by the aggregator.
 
-## Change 1: bound the per-host exec read with a hard timeout
+## Change 1: bound the per-host reads with a hard timeout
 
-Thread `host_discovery_timeout_seconds` down as the pyinfra `_timeout` on the SSH
-commands that discovery issues, so each command self-terminates instead of hanging.
+Thread `host_discovery_timeout_seconds` down as a per-read wall-clock on the reads that
+discovery issues, so each read self-terminates instead of hanging. As implemented:
 
-- Give `Host.discover_agents` (and the `_list_directory` / `read_text_file` calls it
-  makes on the discovery path) an explicit per-command timeout sourced from the
-  provider's `host_discovery_timeout_seconds`. Do **not** change the default timeout of
-  the shared `_list_directory` / `read_text_file` methods for their other callers -- add
-  a timeout-carrying discovery path (e.g. a `timeout_seconds` parameter threaded through
-  `discover_agents`, or a discovery-specific read helper) so only discovery is affected.
-- On timeout, pyinfra raises `TimeoutError`, which the existing code at `hosts/host.py`
-  already converts to `HostConnectionError`. The discovery path
+- `Host.discover_agents` gained an optional `timeout_seconds` (the per-host-bounded path
+  passes it; other callers leave it `None` for prior, unbounded behavior). It threads the
+  timeout into the two reads it makes:
+  - the directory listing, via `_list_directory(..., timeout_seconds=...)` ->
+    `execute_idempotent_command(timeout_seconds=...)` (pyinfra `_timeout` on the `ls`);
+  - each `data.json` read, via a **discovery-specific read helper** on `OuterHost`
+    (`read_text_file_within_timeout` / `read_file_within_timeout`) that flows through the
+    private `_get_file` chain to `channel.settimeout(timeout_seconds)` on the SFTP channel.
+- The shared `read_file` / `read_text_file` methods (and the `HostFileReadInterface`) are
+  left **untouched**, so no other caller is affected; only the new bounded variants and
+  the private `_get_file*` chain gained an optional `timeout_seconds`.
+- On timeout, pyinfra / paramiko raise (`TimeoutError` / `socket.timeout`), which the
+  existing code (`hosts/host.py` for the exec path, `_translate_ssh_errors(timed_out=...)`
+  for the SFTP path) converts to `HostConnectionError`. The discovery path
   (`_discover_agents_on_host_with_offline_fallback`) already catches `HostConnectionError`
   and falls back to the provider's offline (last-known) agents. So a slow host resolves
   to its offline agents *within the timeout* rather than hanging -- a better outcome than
@@ -140,9 +166,15 @@ orphan future.
   `read_host_agents_for_bounded_discovery`, `_discover_agents_on_host_with_offline_fallback`.
 - `libs/mngr/imbue/mngr/api/provider_discovery_stream.py` - `_ProviderDiscoveryPoller`
   (the existing provider-level single-orphan pattern to mirror).
-- `libs/mngr/imbue/mngr/hosts/host.py` - `discover_agents`, `_list_directory`,
-  `read_text_file`, `_run_shell_command` (`_timeout` plumbing; existing `TimeoutError`
-  -> `HostConnectionError` handling).
+- `libs/mngr/imbue/mngr/hosts/host.py` - `discover_agents` (now takes `timeout_seconds`),
+  `_list_directory` (now takes `timeout_seconds`), `_run_shell_command` (`_timeout`
+  plumbing; existing `TimeoutError` -> `HostConnectionError` handling).
+- `libs/mngr/imbue/mngr/hosts/outer_host.py` - `read_file_within_timeout` /
+  `read_text_file_within_timeout` (the discovery-specific bounded read helpers), the
+  private `_get_file` / `_get_file_with_transient_retry` / `_get_file_via_paramiko` chain
+  (SFTP `channel.settimeout`), and `_translate_ssh_errors` (SFTP `TimeoutError` ->
+  `HostConnectionError`).
 - pyinfra `connectors/ssh.py` (`run_shell_command` passes `_timeout` to
   `read_output_buffers`) and `connectors/util.py` (`read_output_buffers` raises on
-  timeout).
+  timeout) -- the exec (`ls`) path only; the SFTP read is bounded by paramiko's channel
+  socket timeout instead.

--- a/dev/changelog/mngr-bounded-per-host-discovery.md
+++ b/dev/changelog/mngr-bounded-per-host-discovery.md
@@ -1,0 +1,1 @@
+Recorded the follow-up spec for bounding per-host discovery reads as implemented (`blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md`).

--- a/libs/mngr/changelog/mngr-bounded-per-host-discovery.md
+++ b/libs/mngr/changelog/mngr-bounded-per-host-discovery.md
@@ -1,0 +1,7 @@
+Bounded per-host discovery reads so a wedged host can no longer leak background threads or be re-read on every poll.
+
+- The per-host-bounded discovery path now threads the provider's `host_discovery_timeout_seconds` down as a hard per-command timeout on the discovery reads (the agent-directory listing and each `data.json` read). A host that connects and then stalls mid-read now self-terminates its reads (surfacing as a connection error that falls back to the host's last-known offline agents) instead of leaving an abandoned discovery thread running forever.
+
+- Added cross-poll per-host de-duplication: a host whose previous discovery read is still in flight is not re-read on the next poll (its still-running read is reused), bounding accumulation to at most one in-flight read per host. Each such skip is logged as a warning -- with the per-command timeout in place this should essentially never fire, so it acts as a precise "host wedged past its timeout" alarm.
+
+- Connect-phase timeouts are unchanged (already bounded); batch providers (modal / vps / imbue_cloud) are unaffected (they read all hosts in one bounded pass and spawn no per-host reads).

--- a/libs/mngr/imbue/mngr/api/gc_test.py
+++ b/libs/mngr/imbue/mngr/api/gc_test.py
@@ -2343,7 +2343,7 @@ class _RemoteHost(Host):
     def is_local(self) -> bool:
         return False
 
-    def discover_agents(self) -> list[DiscoveredAgent]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
         return []
 
     def get_certified_data(self) -> CertifiedHostData:
@@ -2366,14 +2366,14 @@ class _RemoteHost(Host):
 class _RemoteAuthErrorOnDiscoverHost(_RemoteHost):
     """Remote host where discover_agents raises HostAuthenticationError."""
 
-    def discover_agents(self) -> list[DiscoveredAgent]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
         raise HostAuthenticationError("simulated auth failure from test")
 
 
 class _RemoteConnectionErrorOnDiscoverHost(_RemoteHost):
     """Remote host where discover_agents raises HostConnectionError."""
 
-    def discover_agents(self) -> list[DiscoveredAgent]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
         raise HostConnectionError("simulated connection failure from test")
 
 

--- a/libs/mngr/imbue/mngr/api/provider_discovery_stream.py
+++ b/libs/mngr/imbue/mngr/api/provider_discovery_stream.py
@@ -23,6 +23,7 @@ from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.errors import MngrError
 from imbue.mngr.errors import ProviderError
 from imbue.mngr.interfaces.data_types import BoundedProviderDiscoveryResult
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.providers.base_provider import BaseProviderInstance
 from imbue.mngr.utils.jsonl_warn import MalformedJsonLineWarner
@@ -51,17 +52,20 @@ def _discover_one_provider(
     host_discovery_timeout_seconds: float,
     agent_discovery_timeout_seconds: float,
     include_destroyed: bool,
+    registry: HostDiscoveryReadRegistry,
 ) -> BoundedProviderDiscoveryResult:
     """Run a single provider's per-host-bounded discovery. Raises on failure.
 
     A slow/wedged host is marked UNKNOWN within the returned result rather than
-    stalling the whole provider's snapshot.
+    stalling the whole provider's snapshot. ``registry`` carries in-flight per-host
+    reads across polls so a wedged host is not re-read on every poll.
     """
     return provider.discover_hosts_and_agents_within_timeouts(
         cg=mngr_ctx.concurrency_group,
         host_discovery_timeout_seconds=host_discovery_timeout_seconds,
         agent_discovery_timeout_seconds=agent_discovery_timeout_seconds,
         include_destroyed=include_destroyed,
+        registry=registry,
     )
 
 
@@ -86,6 +90,9 @@ class _ProviderDiscoveryPoller(MutableModel):
 
     _in_flight_future: Future[BoundedProviderDiscoveryResult] | None = PrivateAttr(default=None)
     _in_flight_started_at: datetime | None = PrivateAttr(default=None)
+    # Carries in-flight per-host reads across this poller's polls so a wedged host is not
+    # re-read every poll (bounding accumulation to at most one abandoned read per host).
+    _host_read_registry: HostDiscoveryReadRegistry = PrivateAttr(default_factory=HostDiscoveryReadRegistry)
 
     @property
     def _discovered_provider(self) -> DiscoveredProvider:
@@ -228,6 +235,7 @@ class _ProviderDiscoveryPoller(MutableModel):
                                 self.config.host_discovery_timeout_seconds,
                                 self.config.agent_discovery_timeout_seconds,
                                 self.include_destroyed,
+                                self._host_read_registry,
                             )
                         )
                 except (OSError, MngrError) as e:

--- a/libs/mngr/imbue/mngr/api/provider_discovery_stream_test.py
+++ b/libs/mngr/imbue/mngr/api/provider_discovery_stream_test.py
@@ -15,6 +15,7 @@ from imbue.mngr.api.provider_discovery_stream import _discover_one_provider
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.interfaces.data_types import BoundedProviderDiscoveryResult
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.interfaces.provider_instance import bounded_result_from_agents_by_host
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import AgentName
@@ -46,6 +47,7 @@ class _ControllableProvider(MockProviderInstance):
         host_discovery_timeout_seconds: float,
         agent_discovery_timeout_seconds: float,
         include_destroyed: bool = False,
+        registry: HostDiscoveryReadRegistry | None = None,
     ) -> BoundedProviderDiscoveryResult:
         self.discovery_call_count = self.discovery_call_count + 1
         self._release_gate.wait()
@@ -86,6 +88,7 @@ def _submit_discovery(
         poller.config.host_discovery_timeout_seconds,
         poller.config.agent_discovery_timeout_seconds,
         True,
+        poller._host_read_registry,
     )
 
 

--- a/libs/mngr/imbue/mngr/cli/destroy_test.py
+++ b/libs/mngr/imbue/mngr/cli/destroy_test.py
@@ -376,7 +376,7 @@ class _StubOnlineHost:
             raise self._raise_on_get_agents
         return list(self._remaining_agents)
 
-    def discover_agents(self) -> list[object]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[object]:
         # Plugin-hook short-circuit: an empty discover list means the hook
         # has nothing to preserve / no sessions to save.
         return []

--- a/libs/mngr/imbue/mngr/hosts/host.py
+++ b/libs/mngr/imbue/mngr/hosts/host.py
@@ -703,14 +703,20 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         result = self.execute_idempotent_command(f"test -d '{str(path)}'")
         return result.success
 
-    def _list_directory(self, path: Path) -> list[str]:
-        """List files in a directory on the host."""
+    def _list_directory(self, path: Path, timeout_seconds: float | None = None) -> list[str]:
+        """List files in a directory on the host.
+
+        When ``timeout_seconds`` is set, the remote ``ls`` self-terminates on a
+        stall (surfacing as ``HostConnectionError`` after transient retries)
+        rather than blocking forever. Used by the per-host-bounded discovery read;
+        other callers leave it ``None`` (unbounded, prior behavior).
+        """
         if self.is_local:
             try:
                 return list(entry.name for entry in path.iterdir())
             except (FileNotFoundError, OSError):
                 return []
-        result = self.execute_idempotent_command(f"ls -1 '{str(path)}' 2>/dev/null")
+        result = self.execute_idempotent_command(f"ls -1 '{str(path)}' 2>/dev/null", timeout_seconds=timeout_seconds)
         if result.success and result.stdout.strip():
             return result.stdout.strip().split("\n")
         return []
@@ -1258,7 +1264,7 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
         logger.trace("Loaded {} agent(s) from host {}", len(agents), self.id)
         return agents
 
-    def discover_agents(self) -> list[DiscoveredAgent]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
         """Get lightweight references to all agents on this host.
 
         This method reads only the data.json files for each agent, avoiding the
@@ -1267,13 +1273,20 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
 
         Note that we override the base method in order to read more directly from the host,
         since that data is more likely to be up-to-date.
+
+        When ``timeout_seconds`` is set (the per-host-bounded discovery path), each
+        remote SSH read (the directory listing and every ``data.json`` read) is
+        bounded by that wall-clock so a wedged host self-terminates its reads
+        rather than leaving the discovery thread running forever. The bound is
+        per-command, so a host with N agents can take up to ~N x the timeout; the
+        outer per-host wall-clock wait remains the overall guarantee.
         """
         with log_span("Loading all agents from host {}", self.id):
             agents_dir = get_agents_root_dir(self.host_dir)
 
             with log_span("Listing agent dir for host {}", self.id):
                 try:
-                    dir_listing = self._list_directory(agents_dir)
+                    dir_listing = self._list_directory(agents_dir, timeout_seconds=timeout_seconds)
                 except FileNotFoundError:
                     logger.trace("Failed to find agents directory for host {}", self.id)
                     return []
@@ -1284,7 +1297,10 @@ class Host(OuterHost, BaseHost, OnlineHostInterface):
                     agent_dir = agents_dir / dir_name
                     data_path = agent_dir / "data.json"
                     try:
-                        content = self.read_text_file(data_path)
+                        if timeout_seconds is not None:
+                            content = self.read_text_file_within_timeout(data_path, timeout_seconds)
+                        else:
+                            content = self.read_text_file(data_path)
                     except FileNotFoundError:
                         if not self._is_directory(agent_dir):
                             logger.warning("Could not load agent reference from {}", data_path)

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -1869,6 +1869,7 @@ def test_get_file_wraps_timeout_error_in_host_connection_error(
             remote_filename: str,
             filename_or_io: str | IO[bytes],
             remote_temp_filename: str | None = None,
+            timeout_seconds: float | None = None,
         ) -> bool:
             raise TimeoutError("Timed out reading output")
 
@@ -1884,6 +1885,55 @@ def test_get_file_wraps_timeout_error_in_host_connection_error(
 
     with pytest.raises(HostConnectionError, match="timed out while reading file"):
         host._get_file("/remote/file.txt", io.BytesIO())
+
+
+def test_discover_agents_threads_timeout_into_directory_and_file_reads(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """When a per-host timeout is given, discover_agents bounds *both* reads it makes.
+
+    Change 1: an unbounded discovery read can leave an abandoned thread running forever.
+    Here we assert discover_agents(timeout_seconds=T) threads T into the directory listing
+    and into the per-agent data.json read (using the timeout-carrying read helper), rather
+    than falling back to the unbounded ``read_text_file`` path.
+    """
+    agent_id = AgentId.generate()
+    agent_data = {
+        "id": str(agent_id),
+        "name": "recorded-agent",
+        "type": "claude",
+        "work_dir": "/tmp/work",
+    }
+    recorded_list_timeouts: list[float | None] = []
+    recorded_read_timeouts: list[float] = []
+
+    class _RecordingReadHost(Host):
+        def _list_directory(self, path: Path, timeout_seconds: float | None = None) -> list[str]:
+            recorded_list_timeouts.append(timeout_seconds)
+            return [str(agent_id)]
+
+        def read_text_file_within_timeout(self, path: Path, timeout_seconds: float, encoding: str = "utf-8") -> str:
+            recorded_read_timeouts.append(timeout_seconds)
+            return json.dumps(agent_data)
+
+        def read_text_file(self, path: Path, encoding: str = "utf-8") -> str:
+            raise AssertionError("bounded discovery must not use the unbounded read_text_file path")
+
+    fake = _FakeHostWithSSH(ssh_client=_FakeSSHClient(transport_return=_FakeTransport()))
+    connector = PyinfraConnector(cast(PyinfraHost, fake))
+    host = _RecordingReadHost(
+        id=HostId.generate(),
+        host_name=HostName("test"),
+        connector=connector,
+        provider_instance=local_provider,
+        mngr_ctx=local_provider.mngr_ctx,
+    )
+
+    refs = host.discover_agents(timeout_seconds=7.0)
+
+    assert [ref.agent_id for ref in refs] == [agent_id]
+    assert recorded_list_timeouts == [7.0]
+    assert recorded_read_timeouts == [7.0]
 
 
 def test_put_file_wraps_timeout_error_in_host_connection_error(
@@ -2062,6 +2112,7 @@ def test_get_file_wraps_ssh_exception_in_host_connection_error(
             remote_filename: str,
             filename_or_io: str | IO[bytes],
             remote_temp_filename: str | None = None,
+            timeout_seconds: float | None = None,
         ) -> bool:
             raise SSHException("connection lost")
 

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -1936,6 +1936,38 @@ def test_discover_agents_threads_timeout_into_directory_and_file_reads(
     assert recorded_read_timeouts == [7.0]
 
 
+def test_read_file_within_timeout_applies_timeout_to_sftp_channel(
+    local_provider: LocalProviderInstance,
+) -> None:
+    """read_file_within_timeout must set the SFTP channel's socket timeout.
+
+    Change 1: bounding the per-agent ``data.json`` read is what stops an abandoned
+    discovery thread from hanging forever on a stalled SFTP transfer. This exercises
+    the real ``read_text_file_within_timeout`` -> ``_get_file`` -> ``_get_file_via_paramiko``
+    path (not a stubbed read) and asserts the timeout actually reaches the channel.
+    """
+    recorded_settimeouts: list[float] = []
+    file_contents = b'{"hello": "world"}'
+
+    class _RecordingChannel:
+        def settimeout(self, timeout_seconds: float) -> None:
+            recorded_settimeouts.append(timeout_seconds)
+
+    class _TimeoutRecordingSFTP(_BaseFakeSFTP):
+        def get_channel(self) -> _RecordingChannel:
+            return _RecordingChannel()
+
+        def getfo(self, remote_path: str, fl: IO[bytes]) -> None:
+            fl.write(file_contents)
+
+    host = _create_host_with_custom_sftp(local_provider, _TimeoutRecordingSFTP)
+
+    result = host.read_text_file_within_timeout(Path("/remote/data.json"), 7.0)
+
+    assert result == file_contents.decode()
+    assert recorded_settimeouts == [7.0]
+
+
 def test_put_file_wraps_timeout_error_in_host_connection_error(
     local_provider: LocalProviderInstance,
 ) -> None:

--- a/libs/mngr/imbue/mngr/hosts/offline_host.py
+++ b/libs/mngr/imbue/mngr/hosts/offline_host.py
@@ -189,12 +189,15 @@ class BaseHost(HostInterface):
         """
         return validate_and_create_discovered_agent(agent_data, self.id, self.provider_instance.name)
 
-    def discover_agents(self) -> list[DiscoveredAgent]:
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
         """Return a list of all agent references for this host.
 
         For offline hosts, get agent information from the provider's persisted data.
         The full agent data.json contents are included as certified_data.
         Malformed agent records are skipped with a log.
+
+        ``timeout_seconds`` is accepted for interface compatibility but ignored:
+        offline discovery reads the provider's persisted records, not the host.
         """
         agent_records = self.provider_instance.list_persisted_agent_data_for_host(self.id)
 

--- a/libs/mngr/imbue/mngr/hosts/outer_host.py
+++ b/libs/mngr/imbue/mngr/hosts/outer_host.py
@@ -601,8 +601,17 @@ class OuterHost(OuterHostInterface):
         remote_filename: str,
         filename_or_io: str | IO[bytes],
         remote_temp_filename: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> bool:
-        """Read a file from the host. Raises FileNotFoundError if not found."""
+        """Read a file from the host. Raises FileNotFoundError if not found.
+
+        When ``timeout_seconds`` is set, the remote SFTP read is bounded by that
+        wall-clock: a stalled transfer raises ``socket.timeout`` on the SFTP
+        channel, which (after transient retries) surfaces as a
+        ``HostConnectionError``. Used by the per-host-bounded discovery read so a
+        wedged host cannot hang the read forever; other callers leave it ``None``
+        (unbounded, prior behavior).
+        """
         with (
             self._notify_on_connection_error(),
             self._translate_ssh_errors(
@@ -611,7 +620,9 @@ class OuterHost(OuterHostInterface):
                 failed="Could not read file due to connection error",
             ),
         ):
-            return self._get_file_with_transient_retry(remote_filename, filename_or_io, remote_temp_filename)
+            return self._get_file_with_transient_retry(
+                remote_filename, filename_or_io, remote_temp_filename, timeout_seconds
+            )
 
     @_retry_on_transient_ssh_error
     def _get_file_with_transient_retry(
@@ -619,6 +630,7 @@ class OuterHost(OuterHostInterface):
         remote_filename: str,
         filename_or_io: str | IO[bytes],
         remote_temp_filename: str | None = None,
+        timeout_seconds: float | None = None,
     ) -> bool:
         self._ensure_connected()
         if not isinstance(filename_or_io, str):
@@ -626,7 +638,7 @@ class OuterHost(OuterHostInterface):
             filename_or_io.truncate(0)
         try:
             if not self.is_local:
-                return self._get_file_via_paramiko(remote_filename, filename_or_io)
+                return self._get_file_via_paramiko(remote_filename, filename_or_io, timeout_seconds)
             return self.connector.host.get_file(
                 remote_filename,
                 filename_or_io,
@@ -671,16 +683,25 @@ class OuterHost(OuterHostInterface):
         self,
         remote_filename: str,
         filename_or_io: str | IO[bytes],
+        timeout_seconds: float | None = None,
     ) -> bool:
         """Download a file using a dedicated paramiko SFTP channel.
 
         Creates a fresh SFTPClient from the shared SSH transport for each call.
         This is thread-safe because paramiko transports can multiplex channels.
+
+        When ``timeout_seconds`` is set, the SFTP channel is given that socket
+        timeout so a stalled transfer raises ``socket.timeout`` (a ``TimeoutError``)
+        instead of blocking forever.
         """
         transport = self._get_paramiko_transport()
         sftp = self._create_sftp_client(transport)
         if sftp is None:
             raise HostConnectionError("Failed to create SFTP channel from transport")
+        if timeout_seconds is not None:
+            channel = sftp.get_channel()
+            if channel is not None:
+                channel.settimeout(timeout_seconds)
         try:
             if isinstance(filename_or_io, str):
                 sftp.get(remote_filename, filename_or_io)
@@ -990,6 +1011,24 @@ class OuterHost(OuterHostInterface):
     def read_text_file(self, path: Path, encoding: str = "utf-8") -> str:
         """Read a file and return its contents as a string."""
         return self.read_file(path).decode(encoding)
+
+    def read_file_within_timeout(self, path: Path, timeout_seconds: float) -> bytes:
+        """Read a file's bytes, bounding the remote read by ``timeout_seconds``.
+
+        Like :meth:`read_file` but the remote SFTP transfer self-terminates on a
+        stall (surfacing as ``HostConnectionError``) instead of hanging. Local
+        reads ignore the timeout. Used by the per-host-bounded discovery read so
+        an abandoned read cannot leak a thread that runs forever.
+        """
+        if self.is_local:
+            return path.read_bytes()
+        output = io.BytesIO()
+        self._get_file(str(path), output, timeout_seconds=timeout_seconds)
+        return output.getvalue()
+
+    def read_text_file_within_timeout(self, path: Path, timeout_seconds: float, encoding: str = "utf-8") -> str:
+        """Read a file's text, bounding the remote read by ``timeout_seconds``."""
+        return self.read_file_within_timeout(path, timeout_seconds).decode(encoding)
 
     def write_text_file(
         self,

--- a/libs/mngr/imbue/mngr/interfaces/host.py
+++ b/libs/mngr/imbue/mngr/interfaces/host.py
@@ -148,8 +148,14 @@ class HostInterface(MutableModel, ABC):
     # =========================================================================
 
     @abstractmethod
-    def discover_agents(self) -> list[DiscoveredAgent]:
-        """Return lightweight data for all agents on this host."""
+    def discover_agents(self, timeout_seconds: float | None = None) -> list[DiscoveredAgent]:
+        """Return lightweight data for all agents on this host.
+
+        When ``timeout_seconds`` is set, online implementations bound each remote
+        read by that wall-clock so a wedged host self-terminates its discovery
+        reads instead of hanging. Offline implementations read local/persisted
+        data and ignore it.
+        """
         ...
 
     @abstractmethod

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance.py
@@ -14,6 +14,7 @@ from typing import Sequence
 from typing import TypeVar
 
 from loguru import logger
+from pydantic import ConfigDict
 from pydantic import Field
 from pyinfra.api.host import Host as PyinfraHost
 
@@ -279,8 +280,14 @@ def connected_host(
 def _discover_agents_on_host(
     provider: "ProviderInstanceInterface",
     host_id: HostId,
+    timeout_seconds: float | None = None,
 ) -> list[DiscoveredAgent]:
-    """Discover agents on a host, disconnecting afterward."""
+    """Discover agents on a host, disconnecting afterward.
+
+    When ``timeout_seconds`` is set (the per-host-bounded discovery path), the
+    host's reads are bounded by that wall-clock so a wedged host self-terminates
+    its reads rather than hanging the (potentially abandoned) discovery thread.
+    """
     # FIXME: wrap this in a bounded retry (e.g. tenacity) so a *transient*
     # connection failure (timeout, connection refused, banner reset) is retried
     # here rather than immediately surfacing to the caller. The retry predicate
@@ -291,12 +298,13 @@ def _discover_agents_on_host(
     # (e.g. SSH), where a transient blip would otherwise propagate as a
     # ProviderDiscoveryError.
     with connected_host(provider, host_id) as host:
-        return host.discover_agents()
+        return host.discover_agents(timeout_seconds=timeout_seconds)
 
 
 def _discover_agents_on_host_with_offline_fallback(
     provider: "ProviderInstanceInterface",
     host_ref: DiscoveredHost,
+    timeout_seconds: float | None = None,
 ) -> list[DiscoveredAgent]:
     """Discover a host's agents, falling back to the provider's offline view on connection error.
 
@@ -305,9 +313,13 @@ def _discover_agents_on_host_with_offline_fallback(
     fail the whole provider, recover the host's agents from the provider's
     persisted/offline records so its workspaces stay visible. Mirrors the
     inline recovery in ``discover_hosts_and_agents``.
+
+    ``timeout_seconds``, when set, bounds the online read (a per-host-timeout hit
+    surfaces as ``HostConnectionError`` and lands in the offline fallback, which
+    is itself bounded because it reads persisted records rather than the host).
     """
     try:
-        return _discover_agents_on_host(provider, host_ref.host_id)
+        return _discover_agents_on_host(provider, host_ref.host_id, timeout_seconds)
     except HostConnectionError as e:
         # Drop any cached per-host handle so the next cycle does not re-hit the
         # wedged connection, then recover the host's agents from the offline view.
@@ -340,22 +352,43 @@ def _set_host_agents_future(
     provider: "ProviderInstanceInterface",
     host_ref: DiscoveredHost,
     future: "Future[list[DiscoveredAgent]]",
+    timeout_seconds: float,
 ) -> None:
     """Read one host's agents on a daemon thread, recording the outcome on ``future``.
 
     Captures the expected discovery failure modes onto the future so a failed
-    host can be treated as UNKNOWN rather than crashing the poll. Always releases
-    thread-local gevent resources, since this thread may be abandoned (left
-    running past the per-host timeout) and only resolves its future late.
+    host can be treated as UNKNOWN rather than crashing the poll. ``timeout_seconds``
+    bounds each of the host's reads so an abandoned thread (left running past the
+    per-host timeout) still self-terminates rather than running forever. Always
+    releases thread-local gevent resources, since this thread may be abandoned and
+    only resolves its future late.
     """
     try:
-        agents = provider.read_host_agents_for_bounded_discovery(host_ref)
+        agents = provider.read_host_agents_for_bounded_discovery(host_ref, timeout_seconds)
     except (MngrError, OSError) as e:
         future.set_exception(e)
     else:
         future.set_result(agents)
     finally:
         cleanup_thread_local_resources()
+
+
+class HostDiscoveryReadRegistry(MutableModel):
+    """Holds in-flight per-host discovery reads so a wedged host is not re-read every poll.
+
+    A long-lived registry (owned by a provider's discovery poller) that maps a
+    host to the ``Future`` of its currently-running bounded read. When a poll finds
+    a host whose prior read is still in flight, it reuses that future instead of
+    spawning a second read, bounding accumulation to at most one abandoned read per
+    host. A per-call (fresh) registry is used for one-shot discovery, where there is
+    nothing to carry across polls.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    future_by_host_id: dict[HostId, "Future[list[DiscoveredAgent]]"] = Field(
+        default_factory=dict, description="In-flight per-host agent-read futures, keyed by host id"
+    )
 
 
 class ProviderInstanceInterface(MutableModel, ABC):
@@ -635,15 +668,20 @@ class ProviderInstanceInterface(MutableModel, ABC):
                 results[host_ref] = offline_agents
         return results
 
-    def read_host_agents_for_bounded_discovery(self, host_ref: DiscoveredHost) -> list[DiscoveredAgent]:
+    def read_host_agents_for_bounded_discovery(
+        self,
+        host_ref: DiscoveredHost,
+        timeout_seconds: float,
+    ) -> list[DiscoveredAgent]:
         """Read one host's agents (with offline fallback) for the per-host-bounded discovery path.
 
         A seam used by ``discover_hosts_and_agents_within_timeouts``: each host's read
         runs through this method on its own daemon thread so a slow host can be
-        abandoned. Tests override it to inject a controllable per-host delay without a
-        live host connection.
+        abandoned. ``timeout_seconds`` bounds each of the host's reads so an abandoned
+        thread self-terminates rather than running forever. Tests override it to inject
+        a controllable per-host delay without a live host connection.
         """
-        return _discover_agents_on_host_with_offline_fallback(self, host_ref)
+        return _discover_agents_on_host_with_offline_fallback(self, host_ref, timeout_seconds)
 
     def discover_hosts_and_agents_within_timeouts(
         self,
@@ -651,14 +689,20 @@ class ProviderInstanceInterface(MutableModel, ABC):
         host_discovery_timeout_seconds: float,
         agent_discovery_timeout_seconds: float,
         include_destroyed: bool = False,
+        registry: "HostDiscoveryReadRegistry | None" = None,
     ) -> BoundedProviderDiscoveryResult:
         """Discover this provider's hosts/agents, bounding each host's agent read by a timeout.
 
         A host whose agent read does not finish within ``host_discovery_timeout_seconds``
         (or fails) is omitted from the result and reported in ``unknown_host_ids`` -- so one
         slow or wedged host cannot stall the whole provider's snapshot. The abandoned read
-        keeps running on a daemon thread (threads cannot be killed) and simply resolves its
-        now-unused future late.
+        keeps running on a daemon thread (threads cannot be killed) but ``host_discovery_timeout_seconds``
+        is threaded down as a per-command bound so it self-terminates instead of hanging forever.
+
+        ``registry`` carries in-flight per-host reads across polls: a host whose prior read is
+        still running is *not* re-spawned (a warning is logged instead), so at most one abandoned
+        read exists per host at a time. When ``None`` (one-shot discovery), a fresh per-call
+        registry is used, so there is no cross-poll state and every host is read.
 
         The default per-host implementation bounds at host granularity, which already
         encompasses that host's agent enumeration, so ``agent_discovery_timeout_seconds`` is
@@ -667,15 +711,41 @@ class ProviderInstanceInterface(MutableModel, ABC):
         ``discover_hosts_and_agents`` (bounded only by the provider-level error timeout).
         """
         host_refs = self.discover_hosts(cg=cg, include_destroyed=include_destroyed)
-        future_by_host_ref: dict[DiscoveredHost, Future[list[DiscoveredAgent]]] = {}
-        # Each host's read runs on its own daemon thread via _set_host_agents_future,
+        active_registry = registry if registry is not None else HostDiscoveryReadRegistry()
+        host_ref_by_id = {host_ref.host_id: host_ref for host_ref in host_refs}
+
+        # Decide, per host, whether to spawn a fresh read or reuse an in-flight one from a
+        # prior poll. Each fresh read runs on its own daemon thread via _set_host_agents_future,
         # which calls read_host_agents_for_bounded_discovery (overridable for testing).
+        future_by_host_ref: dict[DiscoveredHost, Future[list[DiscoveredAgent]]] = {}
+        skipped_unknown_host_ids: list[HostId] = []
         for host_ref in host_refs:
+            in_flight = active_registry.future_by_host_id.get(host_ref.host_id)
+            if in_flight is not None and not in_flight.done():
+                # A prior poll's read for this host is still running. Do not spawn a second
+                # read; with the per-command timeout in place this should essentially never
+                # happen, so warn loudly -- it is a precise "host wedged past its timeout" alarm.
+                # The host is still UNKNOWN this poll (its state is retained by the consumer).
+                logger.warning(
+                    "Skipped discovery for host {} on provider {}: prior read still in flight "
+                    "(host wedged past its {:.0f}s timeout)",
+                    host_ref.host_id,
+                    self.name,
+                    host_discovery_timeout_seconds,
+                )
+                skipped_unknown_host_ids.append(host_ref.host_id)
+                continue
+            if in_flight is not None:
+                # A prior poll's read finished (possibly late). Harvest it this poll; the
+                # harvest loop below clears it so the next poll starts a fresh read.
+                future_by_host_ref[host_ref] = in_flight
+                continue
             host_future: Future[list[DiscoveredAgent]] = Future()
+            active_registry.future_by_host_id[host_ref.host_id] = host_future
             future_by_host_ref[host_ref] = host_future
             cg.start_new_thread(
                 target=_set_host_agents_future,
-                args=(self, host_ref, host_future),
+                args=(self, host_ref, host_future, host_discovery_timeout_seconds),
                 daemon=True,
                 is_checked=False,
                 name=f"discover_host_{host_ref.host_id}",
@@ -695,13 +765,25 @@ class ProviderInstanceInterface(MutableModel, ABC):
             # (not gone): the consumer retains its previously-known state.
             if not host_future.done() or host_future.exception() is not None:
                 unknown_host_ids.append(host_ref.host_id)
+                # A read that finished (with an exception) is cleared so the next poll retries
+                # it fresh; a still-running read is kept so the next poll does not re-spawn it.
+                if host_future.done():
+                    active_registry.future_by_host_id.pop(host_ref.host_id, None)
                 continue
             discovered_hosts.append(host_ref)
             discovered_agents.extend(host_future.result())
+            active_registry.future_by_host_id.pop(host_ref.host_id, None)
+
+        # Drop registry entries for hosts no longer discovered (e.g. destroyed while wedged)
+        # so the registry stays bounded to currently-known hosts.
+        stale_host_ids = [host_id for host_id in active_registry.future_by_host_id if host_id not in host_ref_by_id]
+        for host_id in stale_host_ids:
+            active_registry.future_by_host_id.pop(host_id, None)
+
         return BoundedProviderDiscoveryResult(
             hosts=tuple(discovered_hosts),
             agents=tuple(discovered_agents),
-            unknown_host_ids=tuple(unknown_host_ids),
+            unknown_host_ids=tuple(skipped_unknown_host_ids) + tuple(unknown_host_ids),
         )
 
     @abstractmethod

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from pydantic import PrivateAttr
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.concurrency_group.test_utils import poll_until
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.errors import HostConnectionError
 from imbue.mngr.hosts.offline_host import OfflineHost
@@ -18,6 +19,7 @@ from imbue.mngr.interfaces.data_types import CertifiedHostData
 from imbue.mngr.interfaces.data_types import HostDetails
 from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.interfaces.provider_instance import _discover_agents_on_host
 from imbue.mngr.interfaces.provider_instance import build_agent_details_from_offline_ref
 from imbue.mngr.primitives import ActivitySource
@@ -31,6 +33,7 @@ from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.mock_provider_test import MockProviderInstance
+from imbue.mngr.utils.testing import capture_loguru
 
 
 def _make_certified_data(host_id: HostId) -> CertifiedHostData:
@@ -530,6 +533,10 @@ class _PerHostGatedProvider(MockProviderInstance):
     agents_by_host_id: dict[str, list[DiscoveredAgent]] = Field(default_factory=dict)
 
     _gate: threading.Event = PrivateAttr(default_factory=threading.Event)
+    # Records the ``timeout_seconds`` seen on each per-host read, keyed by host id, so tests
+    # can assert the per-host bound is threaded down (and how many reads were started).
+    _read_timeouts_by_host_id: dict[str, list[float]] = PrivateAttr(default_factory=dict)
+    _record_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     def discover_hosts(
         self,
@@ -538,10 +545,24 @@ class _PerHostGatedProvider(MockProviderInstance):
     ) -> list[DiscoveredHost]:
         return list(self.mock_discovered_hosts)
 
-    def read_host_agents_for_bounded_discovery(self, host_ref: DiscoveredHost) -> list[DiscoveredAgent]:
+    def read_host_agents_for_bounded_discovery(
+        self,
+        host_ref: DiscoveredHost,
+        timeout_seconds: float,
+    ) -> list[DiscoveredAgent]:
+        with self._record_lock:
+            self._read_timeouts_by_host_id.setdefault(str(host_ref.host_id), []).append(timeout_seconds)
         if self.gated_host_id is not None and host_ref.host_id == self.gated_host_id:
             self._gate.wait()
         return list(self.agents_by_host_id.get(str(host_ref.host_id), []))
+
+    def read_count_for_host(self, host_id: HostId) -> int:
+        with self._record_lock:
+            return len(self._read_timeouts_by_host_id.get(str(host_id), []))
+
+    def read_timeouts_for_host(self, host_id: HostId) -> list[float]:
+        with self._record_lock:
+            return list(self._read_timeouts_by_host_id.get(str(host_id), []))
 
     def release(self) -> None:
         self._gate.set()
@@ -614,3 +635,92 @@ def test_discover_within_timeouts_returns_all_when_fast(temp_host_dir: Path, tem
     assert result.unknown_host_ids == ()
     assert {h.host_id for h in result.hosts} == {host.host_id}
     assert {a.agent_id for a in result.agents} == {agent.agent_id}
+
+
+def test_discover_within_timeouts_threads_host_timeout_into_read(
+    temp_host_dir: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """The per-host timeout is threaded into each host's read (bounded), not left as None.
+
+    Change 1: without a hard per-command timeout, an abandoned read runs forever; here we
+    assert the read receives exactly the ``host_discovery_timeout_seconds`` value.
+    """
+    provider = _PerHostGatedProvider(
+        name=ProviderInstanceName("gated"),
+        host_dir=temp_host_dir,
+        mngr_ctx=temp_mngr_ctx,
+    )
+    host = DiscoveredHost(
+        host_id=HostId.generate(),
+        host_name=HostName("h"),
+        provider_name=provider.name,
+        host_state=HostState.RUNNING,
+    )
+    provider.mock_discovered_hosts = [host]
+    provider.agents_by_host_id = {
+        str(host.host_id): [_make_agent_ref(host.host_id, AgentId.generate(), provider.name)]
+    }
+
+    result = provider.discover_hosts_and_agents_within_timeouts(
+        cg=temp_mngr_ctx.concurrency_group,
+        # Deliberately distinct from the agent timeout so a bug that passes the wrong value
+        # (or None) would be caught.
+        host_discovery_timeout_seconds=4.0,
+        agent_discovery_timeout_seconds=9.0,
+    )
+
+    assert result.unknown_host_ids == ()
+    assert provider.read_timeouts_for_host(host.host_id) == [4.0]
+
+
+def test_discover_within_timeouts_reuses_in_flight_read_across_polls(
+    temp_host_dir: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """A host whose prior read is still in flight is not re-read on the next poll, and the
+    skip is logged as a warning.
+
+    Change 2: sharing one registry across two polls, a permanently-gated host's read is
+    started exactly once (the second poll reuses the in-flight future), both polls report it
+    UNKNOWN, and a wedged-host warning is emitted.
+    """
+    provider = _PerHostGatedProvider(
+        name=ProviderInstanceName("gated"),
+        host_dir=temp_host_dir,
+        mngr_ctx=temp_mngr_ctx,
+    )
+    wedged_host = DiscoveredHost(
+        host_id=HostId.generate(),
+        host_name=HostName("wedged"),
+        provider_name=provider.name,
+        host_state=HostState.RUNNING,
+    )
+    provider.mock_discovered_hosts = [wedged_host]
+    provider.gated_host_id = wedged_host.host_id
+    registry = HostDiscoveryReadRegistry()
+
+    try:
+        with capture_loguru() as log_output:
+            first = provider.discover_hosts_and_agents_within_timeouts(
+                cg=temp_mngr_ctx.concurrency_group,
+                host_discovery_timeout_seconds=0.3,
+                agent_discovery_timeout_seconds=0.3,
+                registry=registry,
+            )
+            # The first poll must have actually started the read (and stored its future) before
+            # the second poll, so the second poll sees it as in-flight.
+            assert poll_until(lambda: provider.read_count_for_host(wedged_host.host_id) >= 1)
+            second = provider.discover_hosts_and_agents_within_timeouts(
+                cg=temp_mngr_ctx.concurrency_group,
+                host_discovery_timeout_seconds=0.3,
+                agent_discovery_timeout_seconds=0.3,
+                registry=registry,
+            )
+
+        assert wedged_host.host_id in first.unknown_host_ids
+        assert wedged_host.host_id in second.unknown_host_ids
+        # The read was started exactly once across both polls (the second reused the in-flight one).
+        assert provider.read_count_for_host(wedged_host.host_id) == 1
+        assert "prior read still in flight" in log_output.getvalue()
+    finally:
+        # Release the orphaned read so its daemon thread can exit cleanly.
+        provider.release()

--- a/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
+++ b/libs/mngr/imbue/mngr/interfaces/provider_instance_test.py
@@ -724,3 +724,70 @@ def test_discover_within_timeouts_reuses_in_flight_read_across_polls(
     finally:
         # Release the orphaned read so its daemon thread can exit cleanly.
         provider.release()
+
+
+def test_discover_within_timeouts_harvests_late_finished_read_on_next_poll(
+    temp_host_dir: Path, temp_mngr_ctx: MngrContext
+) -> None:
+    """A wedged host whose read finishes late is harvested (reported discovered) on a later poll.
+
+    Change 2: complements the in-flight-skip path. Sharing one registry, a gated host is
+    UNKNOWN on the first poll (its read is left in flight). After the gate is released and the
+    read completes, the next poll harvests that finished future -- the host is now discovered
+    (its agents surface) rather than UNKNOWN -- and the registry entry is cleared so a third
+    poll starts a fresh read.
+    """
+    provider = _PerHostGatedProvider(
+        name=ProviderInstanceName("gated"),
+        host_dir=temp_host_dir,
+        mngr_ctx=temp_mngr_ctx,
+    )
+    host = DiscoveredHost(
+        host_id=HostId.generate(),
+        host_name=HostName("late"),
+        provider_name=provider.name,
+        host_state=HostState.RUNNING,
+    )
+    agent = _make_agent_ref(host.host_id, AgentId.generate(), provider.name)
+    provider.mock_discovered_hosts = [host]
+    provider.gated_host_id = host.host_id
+    provider.agents_by_host_id = {str(host.host_id): [agent]}
+    registry = HostDiscoveryReadRegistry()
+
+    first = provider.discover_hosts_and_agents_within_timeouts(
+        cg=temp_mngr_ctx.concurrency_group,
+        host_discovery_timeout_seconds=0.3,
+        agent_discovery_timeout_seconds=0.3,
+        registry=registry,
+    )
+    # The first poll left the read in flight (host UNKNOWN, one read started).
+    assert host.host_id in first.unknown_host_ids
+    assert poll_until(lambda: provider.read_count_for_host(host.host_id) >= 1)
+
+    # Let the wedged read complete, then wait until its future is actually done so the next
+    # poll takes the harvest branch rather than the still-in-flight branch.
+    provider.release()
+    in_flight = registry.future_by_host_id[host.host_id]
+    assert poll_until(in_flight.done)
+
+    second = provider.discover_hosts_and_agents_within_timeouts(
+        cg=temp_mngr_ctx.concurrency_group,
+        host_discovery_timeout_seconds=0.3,
+        agent_discovery_timeout_seconds=0.3,
+        registry=registry,
+    )
+    # The finished-late read is harvested: the host is discovered (not UNKNOWN) and its agent
+    # surfaces, without starting a second read.
+    assert host.host_id not in second.unknown_host_ids
+    assert {h.host_id for h in second.hosts} == {host.host_id}
+    assert {a.agent_id for a in second.agents} == {agent.agent_id}
+    assert provider.read_count_for_host(host.host_id) == 1
+    # The harvest cleared the registry entry, so a third poll starts a fresh read.
+    assert host.host_id not in registry.future_by_host_id
+    provider.discover_hosts_and_agents_within_timeouts(
+        cg=temp_mngr_ctx.concurrency_group,
+        host_discovery_timeout_seconds=0.3,
+        agent_discovery_timeout_seconds=0.3,
+        registry=registry,
+    )
+    assert provider.read_count_for_host(host.host_id) == 2

--- a/libs/mngr_imbue_cloud/changelog/mngr-bounded-per-host-discovery.md
+++ b/libs/mngr_imbue_cloud/changelog/mngr-bounded-per-host-discovery.md
@@ -1,0 +1,1 @@
+Updated the per-host-bounded discovery override to accept the new cross-poll read registry parameter (unused by this batch provider, which reads all hosts in one bounded pass). No behavioral change for this provider.

--- a/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/instance.py
+++ b/libs/mngr_imbue_cloud/imbue/mngr_imbue_cloud/providers/instance.py
@@ -81,6 +81,7 @@ from imbue.mngr.interfaces.data_types import VolumeInfo
 from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.host import OuterHostInterface
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.interfaces.provider_instance import bounded_result_from_agents_by_host
 from imbue.mngr.interfaces.provider_instance import build_agent_details_from_offline_ref
 from imbue.mngr.primitives import AgentId
@@ -450,11 +451,14 @@ class ImbueCloudProvider(BaseProviderInstance):
         host_discovery_timeout_seconds: float,
         agent_discovery_timeout_seconds: float,
         include_destroyed: bool = False,
+        registry: HostDiscoveryReadRegistry | None = None,
     ) -> BoundedProviderDiscoveryResult:
         """Delegate to the batch discovery path; bounded only by the provider-level error timeout.
 
         Imbue Cloud discovery reads all leased hosts (and their agents) in one batched
         pass, so individual host reads cannot be bounded; nothing is marked UNKNOWN here.
+        ``registry`` is accepted for interface compatibility but unused: this path spawns
+        no per-host reads to de-duplicate across polls.
         """
         agents_by_host = self.discover_hosts_and_agents(cg=cg, include_destroyed=include_destroyed)
         return bounded_result_from_agents_by_host(agents_by_host)

--- a/libs/mngr_modal/changelog/mngr-bounded-per-host-discovery.md
+++ b/libs/mngr_modal/changelog/mngr-bounded-per-host-discovery.md
@@ -1,0 +1,1 @@
+Updated the per-host-bounded discovery override to accept the new cross-poll read registry parameter (unused by this batch provider, which reads all hosts in one bounded pass). No behavioral change for this provider.

--- a/libs/mngr_modal/imbue/mngr_modal/instance.py
+++ b/libs/mngr_modal/imbue/mngr_modal/instance.py
@@ -70,6 +70,7 @@ from imbue.mngr.interfaces.data_types import SnapshotRecord
 from imbue.mngr.interfaces.data_types import VolumeInfo
 from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.interfaces.provider_instance import bounded_result_from_agents_by_host
 from imbue.mngr.interfaces.volume import HostVolume
 from imbue.mngr.primitives import ActivitySource
@@ -2481,11 +2482,14 @@ log "=== Shutdown script completed ==="
         host_discovery_timeout_seconds: float,
         agent_discovery_timeout_seconds: float,
         include_destroyed: bool = False,
+        registry: HostDiscoveryReadRegistry | None = None,
     ) -> BoundedProviderDiscoveryResult:
         """Delegate to the batch discovery path; bounded only by the provider-level error timeout.
 
         Modal reads all host/agent state from the state volume in one batched pass,
         so individual host reads cannot be bounded; nothing is marked UNKNOWN here.
+        ``registry`` is accepted for interface compatibility but unused: this path
+        spawns no per-host reads to de-duplicate across polls.
         """
         agents_by_host = self.discover_hosts_and_agents(cg=cg, include_destroyed=include_destroyed)
         return bounded_result_from_agents_by_host(agents_by_host)

--- a/libs/mngr_vps/changelog/mngr-bounded-per-host-discovery.md
+++ b/libs/mngr_vps/changelog/mngr-bounded-per-host-discovery.md
@@ -1,0 +1,1 @@
+Updated the per-host-bounded discovery override to accept the new cross-poll read registry parameter (unused by this batch provider, which reads all hosts in one bounded pass). No behavioral change for this provider.

--- a/libs/mngr_vps/imbue/mngr_vps/instance.py
+++ b/libs/mngr_vps/imbue/mngr_vps/instance.py
@@ -63,6 +63,7 @@ from imbue.mngr.interfaces.data_types import VolumeInfo
 from imbue.mngr.interfaces.host import HostInterface
 from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.interfaces.host import OuterHostInterface
+from imbue.mngr.interfaces.provider_instance import HostDiscoveryReadRegistry
 from imbue.mngr.interfaces.provider_instance import bounded_result_from_agents_by_host
 from imbue.mngr.primitives import ActivitySource
 from imbue.mngr.primitives import AgentId
@@ -1585,13 +1586,16 @@ class VpsProvider(BaseProviderInstance):
         host_discovery_timeout_seconds: float,
         agent_discovery_timeout_seconds: float,
         include_destroyed: bool = False,
+        registry: HostDiscoveryReadRegistry | None = None,
     ) -> BoundedProviderDiscoveryResult:
         """Delegate to the batch discovery path; bounded only by the provider-level error timeout.
 
         VPS discovery reads all host records (and their live agents) in one batched
         pass, so individual host reads cannot be bounded; nothing is marked UNKNOWN
         here. Subclasses that override ``discover_hosts_and_agents`` (e.g. the
-        offline-capable provider) are honored via ``self`` dispatch.
+        offline-capable provider) are honored via ``self`` dispatch. ``registry`` is
+        accepted for interface compatibility but unused: this path spawns no per-host
+        reads to de-duplicate across polls.
         """
         agents_by_host = self.discover_hosts_and_agents(cg=cg, include_destroyed=include_destroyed)
         return bounded_result_from_agents_by_host(agents_by_host)


### PR DESCRIPTION
## What & why

Follow-up to per-provider discovery (PR #2335), **stacked on `mngr/per-provider-discovery`**. Implements the two changes specced in `blueprint/per-provider-discovery/spec-bounded-per-host-discovery.md`: make the per-host-bounded discovery read time-bounded so a wedged host cannot leak background threads, and de-duplicate in-flight per-host reads across polls.

Per-provider discovery runs each host's agent read on an abandonable daemon thread and marks a host UNKNOWN if it doesn't finish within `host_discovery_timeout_seconds`. But the abandoned thread kept running until the underlying read returned, and the discovery reads were **not** time-bounded, so a host that connects and then stalls mid-read (sshd hung after auth, network drops mid-transfer) could leak one thread per poll, forever.

## Change 1: bound the per-host read with a hard timeout

`host_discovery_timeout_seconds` is now threaded down as a hard per-command timeout on the two reads discovery issues:

- the agent-directory listing (`ls`, via `execute_idempotent_command(timeout_seconds=...)`), and
- each `data.json` read (SFTP, via a new `read_text_file_within_timeout` that sets the SFTP channel socket timeout).

On timeout, pyinfra/paramiko raises, which the existing `hosts/` machinery converts to `HostConnectionError`; the discovery path already catches that and falls back to the host's last-known offline agents. So a stalled host resolves to its offline agents *within the timeout* rather than hanging. The bound is threaded only through the discovery path (a new optional `timeout_seconds` on `discover_agents` / `_list_directory` / a new `read_*_within_timeout` helper); the shared `read_file` / `read_text_file` methods and their interface are untouched, so all other callers are unaffected.

Semantics: the bound is per-command, so a host with N agents can take up to ~N x the timeout; the outer per-host wall-clock wait remains the overall guarantee. Change 1 only guarantees each op self-terminates, which is what stops unbounded thread accumulation. (The residual `recv_exit_status()` after a read has no timeout -- a narrow corner, left as-is.)

## Change 2: cross-poll per-host in-flight de-duplication + warn

Added `HostDiscoveryReadRegistry`, a long-lived per-host `host_id -> Future` map owned by each provider's discovery poller. On each poll, a host whose prior read is still in flight is **not** re-read -- the in-flight read is reused and the host is reported UNKNOWN again -- so at most one abandoned read exists per host at a time. Every such skip is logged at **warning** with the host id and provider: with Change 1 in place this should essentially never fire, so it is a precise "host wedged past its timeout" alarm. When no registry is passed (one-shot discovery), a fresh per-call registry is used, so there is no cross-poll state.

## Non-goals (unchanged, per the spec)

- **Connect-phase timeouts** -- already bounded (~10s pyinfra `CONNECT_TIMEOUT` + ~15s paramiko banner); left untouched.
- **`complete_names.py`** -- intentionally eventually-consistent; not touched.
- **Batch providers** (modal / vps / imbue_cloud) accept the new `registry` param for interface compatibility but are unaffected: they read all hosts in one bounded pass and spawn no per-host reads.

## Testing

- New unit tests: the per-host timeout is threaded into `read_host_agents_for_bounded_discovery` (not left `None`); `discover_agents(timeout_seconds=T)` uses the bounded directory-listing and bounded file-read helpers (asserts it does *not* fall back to the unbounded `read_text_file`); and two consecutive polls sharing one registry start a permanently-gated host's read exactly once, report it UNKNOWN both times, and emit the wedged-host warning.
- Touched-area suites pass locally (`host_test`, `provider_instance_test`, `provider_discovery_stream_test`, `gc_test`, `destroy_test`, `outer_host_test`), plus the ratchets for all four touched projects. `ty` and `ruff` are clean. Full `just test-offload` is the final gate (CI).
- Per-PR changelog entries added for every touched project (`mngr`, `mngr_modal`, `mngr_vps`, `mngr_imbue_cloud`, `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
