### PR TITLE
Release minds v0.3.5

### DIFF
--- a/apps/minds/changelog/mngr-release35.md
+++ b/apps/minds/changelog/mngr-release35.md
@@ -1,0 +1,7 @@
+Release minds v0.3.5: bump `apps/minds/package.json` to `0.3.5` and point the shipped binary's `FALLBACK_BRANCH` at the `minds-v0.3.5` forever-claude-template tag. This rolls up all mngr/minds changes that landed on `main` since `minds-v0.3.4`, notably:
+
+- The "get help" flow now spawns an `/assist` chat in the loaded workspace and frames the help modal as an agent submission for agent-escalated reports, with a full loading state that auto-closes on success.
+
+- UI copy renamed from "project" to "workspace" throughout (Login window title, page copy, and the "Back to workspaces" back-link).
+
+- Release tests split by tag: the minds release suite (`minds_deployment` / `minds_services` plus the plain minds `@release` tests) now runs from the minds release job rather than the mngr release workflow.

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -282,7 +282,7 @@ _FALLBACK_GIT_URL: Final[str] = DEFAULT_FOREVER_CLAUDE_GIT_URL
 # Pin to an annotated FCT tag so a shipped binary clones the exact FCT
 # snapshot it was verified against. Bump to a newer tag only after
 # re-verifying launch-to-msg CI against (this binary, the new tag).
-FALLBACK_BRANCH: Final[str] = "minds-v0.3.4"
+FALLBACK_BRANCH: Final[str] = "minds-v0.3.5"
 
 # Env var (set by ``just minds-start`` and the e2e workspace runner) that opts a
 # launch into the operator's local-worktree create-form defaults. Gating on an

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minds",
   "productName": "Minds",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",
   "author": "Imbue <dev@imbue.com>",


### PR DESCRIPTION
Bumps minds to **0.3.5**: `apps/minds/package.json` version and the shipped binary's `FALLBACK_BRANCH` → `minds-v0.3.5`. Rolls up all mngr/minds changes on `main` since `minds-v0.3.4`.

Version-bump-only branch; traditional CI here is a backstop (redundant with a green `main`). The release is gated by `minds-launch-to-msg` and the FCT `vendor/mngr` refresh per `apps/minds/docs/release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)