### PR TITLE
Add the document-review donation skill

### DIFF
--- a/.claude/skills/document-review/.gitignore
+++ b/.claude/skills/document-review/.gitignore
@@ -1,0 +1,9 @@
+# Per-worker live config (copy from skill_config.example.yaml). Holds worker_id/server_url.
+skill_config.yaml
+# Prompts are pulled fresh at run time from the skill's upstream repo by `mngr donate`
+# (see mngr_donate) -- they are NOT committed here, so the source of truth stays the lab's repo.
+prompts/
+# Runtime artifacts
+result.json
+__pycache__/
+*.pyc

--- a/.claude/skills/document-review/SKILL.md
+++ b/.claude/skills/document-review/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: document-review
+version: 1.2.0
+description: >
+  Pull a paper, grant, or data-access application from the review coordinator,
+  read the linked source documents (PubMed/MEDLINE/PMC/NIH RePORTER/bioRxiv),
+  run YOUR local versioned prompt, and submit the structured JSON review back.
+---
+
+# Document Review Skill
+
+You are a reviewer worker for a central coordination server. **The prompt lives
+here, in `./prompts` (one file per version).** The client hashes the active
+prompt and sends that hash to the server when leasing work. The server tracks
+replication per **(item, prompt)** — so you can run the whole corpus under
+several prompts and complete each one independently.
+
+The **server chooses which item you get** — you never pass an ID. `GET /next`
+leases one for your active prompt; `POST /reviews` receives the result.
+
+## When to use
+When the user asks to "run the next document", "review the next item", "process
+the review queue", or "score papers/grants from the review server".
+
+## Setup (once)
+1. `pip install -r requirements.txt` (installs `requests`, `pyyaml`).
+2. Copy `skill_config.example.yaml` to `skill_config.yaml`; set `server_url` to
+   your coordinator's **IP:port**, a stable `worker_id`, and `prompt_version`
+   (the file stem in `prompts/`).
+3. Recommended for polite/faster NCBI access: set `NCBI_API_KEY` and `NCBI_EMAIL`.
+
+## Workflow: manual mode (Claude-in-the-loop)
+The reviewer is **this session** — there is no separate API call and no
+`ANTHROPIC_API_KEY`, so a run only ever spends Claude subscription quota. Per item:
+1. `python client.py fetch` — prints the work packet
+   (`{assignment_id, item_id, prompt{version,hash,text}, documents[], context, ...}`).
+   If there's nothing to do it prints `assignments: []` with `prompt_complete`
+   (true → this prompt is finished; false → items leased to others, retry shortly).
+2. Apply `packet.prompt.text` to `packet.context` **yourself** and write the JSON to
+   `result.json`, basing every field strictly on the provided documents.
+3. `python client.py submit --assignment-id "<id>" --item-id "<id>" --result result.json`
+
+Submitting is idempotent per assignment, so a retry after a network blip won't
+double-count. **Report the printed submit status to the user.** To drain the queue,
+repeat the fetch → review → submit cycle until `fetch` reports `prompt_complete: true`.
+
+## Running multiple prompts
+Drop a new file in `prompts/` (e.g. `triage_v2.txt`), set
+`prompt_version: triage_v2`, and run the loop again. The server treats it as
+separate work and drives it to completion independently; each prompt reports its
+own `prompt_complete`.
+
+## Notes
+- The slash command follows the skill `name` (`/document-review`). To type
+  `/run-document` literally, rename this skill's folder and `name:` to
+  `run-document`.
+- Always submit against the `assignment_id` you were given — the server keys
+  replication accounting off the lease's prompt hash (not any client value), so
+  reviews can't be mis-attributed.
+- Watch `server_prompt_echo.version_conflict`: if true, the same version *label*
+  has been seen under a different hash — usually a prompt file edited without
+  bumping its version name.
+- Documents may return an `error` (e.g. not in the PMC open-access subset, or a
+  bioRxiv full-text miss). Review from whatever text resolved and lower
+  `confidence` if the material is thin.
+- Supported document sources: `pubmed`, `medline`, `pmc`, `nih_reporter`,
+  `biorxiv`, `medrxiv`, and `text` (inline).

--- a/.claude/skills/document-review/client.py
+++ b/.claude/skills/document-review/client.py
@@ -1,0 +1,176 @@
+"""
+client.py -- the worker/skill side of the review system.
+
+The PROMPT lives here (in ./prompts, one file per version). The client computes
+the prompt's SHA-256, sends it to the server as ``prompt_hash`` when leasing
+work, and records it with every review. Replication is tracked per (item,
+prompt_hash) on the server, so you can drive several prompts to completion.
+
+Manual mode only (no ANTHROPIC_API_KEY / direct-API path): Claude-in-the-loop is
+the reviewer, so a run only ever spends Claude subscription quota.
+
+Subcommands:
+  fetch   Lease one item *for the active prompt*, pull its document text, and
+          print a work packet (JSON) with the local prompt + documents. Claude
+          reads this, runs the prompt, then calls `submit`.
+  submit  POST a review result for a leased assignment, with metadata (host,
+          run id, skill version, timings, prompt version + hash).
+
+Config: skill_config.yaml (see skill_config.example.yaml). Env overrides:
+REVIEW_SERVER_URL, REVIEW_WORKER_ID.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import socket
+import sys
+import time
+import uuid
+
+import requests
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+import sources
+from prompts import PromptStore
+
+SKILL_VERSION = "1.2.0"
+RUN_ID = uuid.uuid4().hex
+HOST = socket.gethostname()
+
+
+def load_cfg(path):
+    cfg = {
+        "server_url": os.getenv("REVIEW_SERVER_URL", "http://api.elsichecklist.org"),
+        "worker_id": os.getenv("REVIEW_WORKER_ID", f"{HOST}:{os.getpid()}"),
+        "count": 1,
+        "item_type": None,
+        "prompts_dir": "./prompts",
+        "prompt_version": "triage_v1",
+    }
+    if path and yaml and os.path.exists(path):
+        with open(path) as fh:
+            cfg.update(yaml.safe_load(fh) or {})
+    return cfg
+
+
+def active_prompt(cfg) -> dict:
+    """{'version','hash','text'} for the prompt this worker runs."""
+    return PromptStore(cfg["prompts_dir"], cfg["prompt_version"]).active()
+
+
+# --------------------------------------------------------------------------- #
+# Server I/O
+# --------------------------------------------------------------------------- #
+def get_work(cfg, prompt) -> dict:
+    params = {
+        "prompt_hash": prompt["hash"],
+        "prompt_version": prompt["version"],
+        "count": cfg["count"],
+        "worker": cfg["worker_id"],
+    }
+    if cfg.get("item_type"):
+        params["type"] = cfg["item_type"]
+    r = requests.get(f"{cfg['server_url']}/next", params=params, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def submit_review(cfg, *, assignment, prompt, result, started_at, finished_at) -> dict:
+    payload = {
+        "assignment_id": assignment["assignment_id"],
+        "item_id": assignment.get("item_id"),
+        "prompt_version": prompt["version"],
+        "prompt_hash": prompt["hash"],
+        "result": result,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "worker": {
+            "id": cfg["worker_id"],
+            "host": HOST,
+            "run_id": RUN_ID,
+            "skill_version": SKILL_VERSION,
+            "python": platform.python_version(),
+        },
+    }
+    r = requests.post(f"{cfg['server_url']}/reviews", json=payload, timeout=30)
+    return {"http_status": r.status_code, "body": r.json()}
+
+
+# --------------------------------------------------------------------------- #
+# Packet assembly
+# --------------------------------------------------------------------------- #
+def build_packet(work, prompt) -> list[dict]:
+    """Turn a /next response into self-contained packets, attaching the LOCAL
+    prompt text (the server only echoes hash/version)."""
+    packets = []
+    for a in work["assignments"]:
+        docs = sources.fetch_documents(a["documents"])
+        context = "\n\n".join(
+            f"===== DOCUMENT {i + 1} ({d['source']}:{d['external_id']}) =====\n"
+            + (d["text"] if d["text"] else f"(fetch error: {d['error']})")
+            for i, d in enumerate(docs)
+        )
+        packets.append({
+            "assignment_id": a["assignment_id"],
+            "item_id": a["item_id"],
+            "item_type": a["item_type"],
+            "prompt": prompt,                 # {version, hash, text} -- local source of truth
+            "server_prompt_echo": work["prompt"],   # {hash, version, version_conflict, ...}
+            "documents": docs,
+            "context": context,
+            "meta": a.get("meta", {}),
+        })
+    return packets
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def cmd_fetch(cfg, args):
+    prompt = active_prompt(cfg)
+    work = get_work(cfg, prompt)
+    if not work["assignments"]:
+        print(json.dumps({"assignments": [], "prompt_complete": work["prompt_complete"],
+                          "prompt": work["prompt"]}))
+        return
+    print(json.dumps(build_packet(work, prompt), indent=2))
+
+
+def cmd_submit(cfg, args):
+    prompt = active_prompt(cfg)
+    raw = sys.stdin.read() if args.result == "-" else open(args.result).read()
+    result = json.loads(raw)
+    assignment = {"assignment_id": args.assignment_id, "item_id": args.item_id}
+    out = submit_review(cfg, assignment=assignment, prompt=prompt, result=result,
+                        started_at=args.started_at, finished_at=time.time())
+    print(json.dumps(out, indent=2))
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Review skill client")
+    ap.add_argument("--config", default="skill_config.yaml")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("fetch", help="lease work for the active prompt and print a work packet")
+
+    ps = sub.add_parser("submit", help="submit a review result")
+    ps.add_argument("--assignment-id", required=True)
+    ps.add_argument("--item-id", default=None)
+    ps.add_argument("--started-at", type=float, default=None)
+    ps.add_argument("--result", default="-", help="path to result JSON, or - for stdin")
+
+    args = ap.parse_args()
+    cfg = load_cfg(args.config)
+    {"fetch": cmd_fetch, "submit": cmd_submit}[args.cmd](cfg, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/document-review/prompts.py
+++ b/.claude/skills/document-review/prompts.py
@@ -1,0 +1,54 @@
+"""
+prompts.py -- versioned, content-hashed prompt registry, owned by the CLIENT.
+
+The client is the source of truth for prompt text. Each file in the prompts
+directory is one version (stem = version name); the SHA-256 of its bytes is the
+hash we send to the server (as ``prompt_hash``) and record with every review.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Optional
+
+
+class PromptStore:
+    def __init__(self, directory: str, active_version: str):
+        self.directory = directory
+        self.active_version = active_version
+        self._by_version: dict[str, dict] = {}
+        self.reload()
+
+    def reload(self) -> None:
+        loaded: dict[str, dict] = {}
+        if not os.path.isdir(self.directory):
+            raise FileNotFoundError(f"prompts dir not found: {self.directory}")
+        for name in os.listdir(self.directory):
+            if name.startswith("."):
+                continue
+            path = os.path.join(self.directory, name)
+            if not os.path.isfile(path):
+                continue
+            with open(path, "rb") as fh:
+                raw = fh.read()
+            version = os.path.splitext(name)[0]
+            loaded[version] = {
+                "version": version,
+                "hash": "sha256:" + hashlib.sha256(raw).hexdigest(),
+                "text": raw.decode("utf-8"),
+            }
+        if not loaded:
+            raise FileNotFoundError(f"no prompt files in {self.directory}")
+        if self.active_version not in loaded:
+            raise KeyError(f"active prompt '{self.active_version}' not among {sorted(loaded)}")
+        self._by_version = loaded
+
+    def get(self, version: str) -> Optional[dict]:
+        return self._by_version.get(version)
+
+    def active(self) -> dict:
+        return self._by_version[self.active_version]
+
+    def versions(self) -> list[str]:
+        return sorted(self._by_version)

--- a/.claude/skills/document-review/requirements.txt
+++ b/.claude/skills/document-review/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+PyYAML>=6.0

--- a/.claude/skills/document-review/skill_config.example.yaml
+++ b/.claude/skills/document-review/skill_config.example.yaml
@@ -1,0 +1,16 @@
+# Copy to skill_config.yaml. Env vars REVIEW_SERVER_URL / REVIEW_WORKER_ID override these.
+
+# Coordination API: hands out item IDs via GET /next and receives reviews via
+# POST /reviews. Point this at your server's IP:port (env REVIEW_SERVER_URL wins).
+server_url: "http://api.elsichecklist.org"     # e.g. http://<your-server-ip>:8888
+# worker_id: "reviewer-01"      # if you want a fixed worker ID, defaults to host:PID
+count: 10                        # items to lease per /next call (server caps at max_batch)
+item_type: null                 # or "paper" | "grant" | "data_application" to filter
+
+# The prompt is owned here. Its SHA-256 is what the server keys replication off.
+prompts_dir: "./prompts"
+prompt_version: "population-descriptors_v1"     # file stem in prompts_dir; switch to run a different prompt
+
+auto:                           # only used by `client.py auto`
+  model: "claude-opus-4-8"
+  max_tokens: 2000

--- a/.claude/skills/document-review/sources.py
+++ b/.claude/skills/document-review/sources.py
@@ -1,0 +1,203 @@
+"""
+sources.py -- fetch document text from external APIs referenced by the server.
+
+Each work item carries a list of document refs like:
+    {"source": "pmc",          "external_id": "PMC7239701"}
+    {"source": "pubmed",       "external_id": "38123456"}
+    {"source": "medline",      "external_id": "38123456"}
+    {"source": "nih_reporter", "external_id": "5R01AI123456"}
+    {"source": "biorxiv",      "external_id": "10.1101/2023.12.01.569666"}
+    {"source": "medrxiv",      "external_id": "10.1101/2020.09.09.20191205"}
+    {"source": "text",         "external_id": "...", "text": "inline text"}
+
+Verified endpoints (checked 2026-07):
+- E-utilities base: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/
+    efetch.fcgi?db=pubmed&id=..&retmode=text&rettype=abstract   (PubMed abstract)
+    efetch.fcgi?db=pubmed&id=..&retmode=text&rettype=medline    (MEDLINE record)
+- PMC full text (BioC JSON):
+    https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pmcoa.cgi/BioC_json/<PMCID|PMID>/unicode
+- NIH RePORTER (no auth): POST https://api.reporter.nih.gov/v2/projects/search
+- bioRxiv/medRxiv (no auth): https://api.biorxiv.org/details/<server>/<DOI>/na/json
+
+NCBI politeness: <=3 requests/sec without an API key, <=10/sec with one. Set
+NCBI_API_KEY (and optionally NCBI_TOOL / NCBI_EMAIL) in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Optional
+
+import requests
+
+EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+BIOC_PMC = "https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pmcoa.cgi/BioC_json"
+REPORTER = "https://api.reporter.nih.gov/v2/projects/search"
+BIORXIV = "https://api.biorxiv.org/details"   # /{server}/{doi}/na/json  (server: biorxiv|medrxiv)
+
+_SESSION = requests.Session()
+_SESSION.headers.update({"User-Agent": os.getenv("NCBI_TOOL", "paper-review-skill/1.0")})
+
+
+class RateLimiter:
+    """Simple thread-safe minimum-interval limiter."""
+
+    def __init__(self, per_second: float):
+        self._min_interval = 1.0 / per_second
+        self._lock = threading.Lock()
+        self._next = 0.0
+
+    def wait(self):
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next:
+                time.sleep(self._next - now)
+            self._next = max(now, self._next) + self._min_interval
+
+
+# NCBI rate: 10/s with a key, 3/s without.
+_HAS_KEY = bool(os.getenv("NCBI_API_KEY"))
+_NCBI = RateLimiter(9.0 if _HAS_KEY else 2.5)
+# bioRxiv/medRxiv: no documented limit, but be polite.
+_BIORXIV = RateLimiter(3.0)
+
+
+def _ncbi_params(extra: dict) -> dict:
+    p = dict(extra)
+    if os.getenv("NCBI_API_KEY"):
+        p["api_key"] = os.getenv("NCBI_API_KEY")
+    if os.getenv("NCBI_EMAIL"):
+        p["email"] = os.getenv("NCBI_EMAIL")
+    p["tool"] = os.getenv("NCBI_TOOL", "paper-review-skill")
+    return p
+
+
+def _get(url, *, params=None, timeout=30):
+    _NCBI.wait()
+    r = _SESSION.get(url, params=params, timeout=timeout)
+    r.raise_for_status()
+    return r
+
+
+def fetch_pubmed_abstract(pmid: str) -> str:
+    r = _get(f"{EUTILS}/efetch.fcgi",
+             params=_ncbi_params({"db": "pubmed", "id": pmid,
+                                  "retmode": "text", "rettype": "abstract"}))
+    return r.text.strip()
+
+
+def fetch_medline(pmid: str) -> str:
+    r = _get(f"{EUTILS}/efetch.fcgi",
+             params=_ncbi_params({"db": "pubmed", "id": pmid,
+                                  "retmode": "text", "rettype": "medline"}))
+    return r.text.strip()
+
+
+def fetch_pmc_fulltext(pmc_id: str) -> str:
+    """Full text via the BioC JSON service (PMC Open Access subset).
+    Falls back to the PubMed abstract if the article isn't in the OA subset."""
+    _NCBI.wait()
+    r = _SESSION.get(f"{BIOC_PMC}/{pmc_id}/unicode", timeout=60)
+    if r.status_code == 200 and r.headers.get("content-type", "").startswith("application/json"):
+        try:
+            return _bioc_to_text(r.json())
+        except Exception:
+            pass
+    # Fallback: strip the PMC prefix and pull the abstract from PubMed's PMC db.
+    r = _get(f"{EUTILS}/efetch.fcgi",
+             params=_ncbi_params({"db": "pmc", "id": pmc_id.replace("PMC", ""),
+                                  "retmode": "xml"}))
+    return r.text.strip()
+
+
+def _bioc_to_text(doc: object) -> str:
+    """Flatten a BioC JSON response into plain passage text."""
+    collection = doc[0] if isinstance(doc, list) else doc
+    parts: list[str] = []
+    for document in collection.get("documents", []):
+        for passage in document.get("passages", []):
+            section = passage.get("infons", {}).get("section_type", "")
+            text = passage.get("text", "").strip()
+            if text:
+                parts.append(f"[{section}] {text}" if section else text)
+    return "\n\n".join(parts).strip()
+
+
+def fetch_nih_reporter(core_project_num: str) -> str:
+    """Fetch a grant's title, abstract, and terms from NIH RePORTER."""
+    payload = {
+        "criteria": {"project_nums": [core_project_num]},
+        "include_fields": ["ProjectTitle", "AbstractText", "PhrText", "Terms",
+                           "FiscalYear", "Organization", "PrincipalInvestigators"],
+        "limit": 1,
+    }
+    r = _SESSION.post(REPORTER, json=payload, timeout=30)
+    r.raise_for_status()
+    results = r.json().get("results", [])
+    if not results:
+        return f"(no NIH RePORTER record for {core_project_num})"
+    p = results[0]
+    lines = [f"TITLE: {p.get('project_title', '')}"]
+    if p.get("abstract_text"):
+        lines.append(f"ABSTRACT: {p['abstract_text']}")
+    if p.get("phr_text"):
+        lines.append(f"PUBLIC HEALTH RELEVANCE: {p['phr_text']}")
+    if p.get("terms"):
+        lines.append(f"TERMS: {p['terms']}")
+    return "\n\n".join(lines).strip()
+
+
+def fetch_biorxiv(doi: str, server: str = "biorxiv") -> str:
+    """Title + abstract for a bioRxiv/medRxiv preprint by DOI (e.g.
+    ``10.1101/2023.12.01.569666``). Uses the latest posted version. The full
+    JATS XML path is appended as a pointer for optional deeper retrieval."""
+    server = "medrxiv" if server.lower() == "medrxiv" else "biorxiv"
+    _BIORXIV.wait()
+    r = _SESSION.get(f"{BIORXIV}/{server}/{doi}/na/json", timeout=30)
+    r.raise_for_status()
+    coll = r.json().get("collection", [])
+    if not coll:
+        return f"(no {server} record for {doi})"
+    latest = coll[-1]  # collection is ordered by version
+    lines = [f"TITLE: {latest.get('title', '')}",
+             f"ABSTRACT: {latest.get('abstract', '')}"]
+    if latest.get("category"):
+        lines.append(f"CATEGORY: {latest['category']}")
+    if latest.get("jatsxml"):
+        lines.append(f"FULL_TEXT_JATS_XML: {latest['jatsxml']}")
+    return "\n\n".join(lines).strip()
+
+
+_FETCHERS = {
+    "pubmed": fetch_pubmed_abstract,
+    "medline": fetch_medline,
+    "pmc": fetch_pmc_fulltext,
+    "nih_reporter": fetch_nih_reporter,
+    # biorxiv / medrxiv are handled in fetch_document (they need a server arg).
+}
+
+
+def fetch_document(ref: dict) -> dict:
+    """Resolve one document ref to text. Never raises: failures are returned in
+    the dict so a single bad id doesn't sink the whole item."""
+    source = ref.get("source", "").lower()
+    ext_id = ref.get("external_id", "")
+    out = {"source": source, "external_id": ext_id, "text": "", "error": None}
+    try:
+        if source == "text":
+            out["text"] = ref.get("text", "")
+        elif source in ("biorxiv", "medrxiv"):
+            out["text"] = fetch_biorxiv(ext_id, server=ref.get("server", source))
+        elif source in _FETCHERS:
+            out["text"] = _FETCHERS[source](ext_id)
+        else:
+            out["error"] = f"unknown source: {source}"
+    except Exception as e:  # network / API errors surface here
+        out["error"] = f"{type(e).__name__}: {e}"
+    return out
+
+
+def fetch_documents(refs: list[dict]) -> list[dict]:
+    return [fetch_document(r) for r in refs]


### PR DESCRIPTION
## What

Adds the **`document-review`** Claude Code skill under `.claude/skills/document-review/` — a self-contained worker for a central review-coordination server (the Sinnott-Armstrong lab's ELSI-checklist project).

Per item, the skill:
1. Leases one assignment for the active prompt (`GET /next`), the server picks the item.
2. Fetches the linked document text from public biomedical APIs (PubMed/MEDLINE/PMC/NIH RePORTER/bioRxiv/medRxiv).
3. Applies the active versioned ELSI prompt to the documents.
4. Submits a structured JSON review back (`POST /reviews`) with the prompt version+hash and worker metadata.

## Notes for review

- **Manual mode only.** The reviewing model is the in-loop Claude session — there is **no `ANTHROPIC_API_KEY` / direct-API path** (the `run`/`auto` subcommands were stripped). A run can therefore only ever spend Claude **subscription** quota, never billable API tokens.
- **Prompts are not committed.** `prompts/` is gitignored; the prompts (the experiment rubrics) are pulled fresh from the lab's upstream git repo at run time by `mngr donate` (see the follow-up PR). This keeps the lab's repo the source of truth for experiments, so a reworded rubric doesn't need an mngr change.
- The skill code (`client.py`, `sources.py`, `prompts.py`) lives under `.claude/skills/` deliberately — it's the reviewed, pinned code that `mngr donate` copies + runs; it's not part of a `libs/*` package.

## Follow-up

A stacked PR adds the **`mngr_donate` plugin** that schedules this skill against spare Claude capacity and pulls its prompts dynamically. This PR is just the skill itself and is reviewable on its own (e.g. by the science collaborators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
