### PR TITLE
Fix Lima host-key mismatch when apt install fails transiently

### DIFF
--- a/libs/mngr_lima/changelog/mngr-lima-hostkey-before-apt.md
+++ b/libs/mngr_lima/changelog/mngr-lima-hostkey-before-apt.md
@@ -1,0 +1,5 @@
+Fixed a Lima workspace-creation failure that surfaced as a confusing `SSH host key error (Host key for 127.0.0.1 does not match.)`.
+
+The VM provisioning script installed the pre-trusted SSH host key *after* a network-dependent `apt-get install`, all under `set -e`. A transient Debian mirror hiccup (`apt-get` failing to fetch package indexes) would abort the whole script before the host key was installed, so the VM kept its default host key while mngr had already pinned the key it expected -- causing a strict host-key-check mismatch on connect.
+
+The host-key swap (and sshd tuning) now runs first, before any package fetch, so SSH host-key trust no longer depends on the network. The package install is additionally wrapped in a retry loop to ride out transient apt mirror failures; if it still fails, the error now surfaces clearly on an SSH-reachable host instead of as a host-key mismatch.

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml.py
@@ -161,7 +161,16 @@ def _build_provisioning_script(
     host_data_disk_name: str | None = None,
     root_authorized_public_key: str | None = None,
 ) -> str:
-    """Build the Lima ``provision[mode=system]`` script that installs required packages, configures sshd, optionally lands the btrfs host-data disk at the canonical mount point, optionally enables key-based root login (when running the agent as root), and (when a keypair is supplied) installs it as the guest's ed25519 sshd host key."""
+    """Build the Lima ``provision[mode=system]`` script.
+
+    The script first establishes SSH host-key trust -- installing the
+    caller-supplied ed25519 sshd host key (when given), tightening sshd limits,
+    and optionally enabling key-based root login -- because mngr pins that key
+    and connects with strict host-key checking, so it must not depend on any
+    network-fetched package. Only then does it install the required packages
+    (with retries, to ride out transient apt mirror failures) and optionally
+    land the btrfs host-data disk at the canonical mount point.
+    """
     host_key_block = _build_host_key_block(host_private_key_pem, host_public_key_openssh)
     host_data_disk_block = _build_host_data_disk_block(host_data_disk_name, host_dir)
     root_authorized_keys_block = _build_root_authorized_keys_block(root_authorized_public_key)
@@ -179,29 +188,23 @@ def _build_provisioning_script(
 #!/bin/bash
 set -eux -o pipefail
 
-# Install required packages if missing
-PKGS_TO_INSTALL=""
-command -v tmux >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL tmux"
-command -v git >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL git"
-command -v jq >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL jq"
-command -v rsync >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL rsync"
-command -v curl >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL curl"
-command -v xxd >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL xxd"
-command -v flock >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL util-linux"
-test -x /usr/sbin/sshd || PKGS_TO_INSTALL="$PKGS_TO_INSTALL openssh-server"
-test -f /etc/ssl/certs/ca-certificates.crt || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ca-certificates"{btrfs_pkg_line}
-
-if [ -n "$PKGS_TO_INSTALL" ]; then
-    apt-get update -qq && apt-get install -y -qq $PKGS_TO_INSTALL
-fi
-
 mkdir -p /run/sshd
 
 # Create /code directory for agent work directories (writable by all users).
 # Lima VMs run as a regular user, not root, so /code must be pre-created.
 mkdir -p /code && chmod 777 /code
 
-# Install the caller-provided sshd host key (when given).
+# Establish SSH host-key trust FIRST, before any network-dependent step.
+#
+# mngr pins this VM's host key in its per-host known_hosts and connects with
+# StrictHostKeyChecking=yes, so the guest MUST present exactly the injected
+# key. This block (and the sshd_config tweak below) only uses coreutils plus
+# the already-present sshd -- no packages, no network -- so it can never be
+# skipped by a failed package fetch. Ordering it ahead of the apt install
+# keeps host-key trust independent of the network: a transient apt mirror
+# failure previously aborted the whole `set -e` script *before* the key swap
+# ran, leaving the VM on its default host keys and surfacing on connect as a
+# baffling "host key does not match" instead of a clear provisioning error.
 SSH_KEY_CHANGED=0
 {host_key_block}
 
@@ -227,9 +230,43 @@ if [ "$SSH_KEY_CHANGED" = "1" ] || [ "$SSHD_CONFIG_CHANGED" = "1" ]; then
     systemctl restart sshd 2>/dev/null || service ssh restart 2>/dev/null || true
 fi
 
+# Install required packages if missing. Retry to ride out transient apt mirror
+# failures (deb.debian.org intermittently drops index fetches). This runs
+# *after* host-key trust is established, so even a hard failure here surfaces
+# as a clear provisioning error on an SSH-reachable host rather than as a
+# host-key mismatch.
+apt_get_retry() {{
+    local attempt
+    for attempt in 1 2 3 4 5; do
+        if apt-get "$@"; then
+            return 0
+        fi
+        echo "apt-get $* failed (attempt $attempt/5); retrying in $((attempt * 5))s" >&2
+        sleep "$((attempt * 5))"
+    done
+    return 1
+}}
+
+PKGS_TO_INSTALL=""
+command -v tmux >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL tmux"
+command -v git >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL git"
+command -v jq >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL jq"
+command -v rsync >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL rsync"
+command -v curl >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL curl"
+command -v xxd >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL xxd"
+command -v flock >/dev/null 2>&1 || PKGS_TO_INSTALL="$PKGS_TO_INSTALL util-linux"
+test -x /usr/sbin/sshd || PKGS_TO_INSTALL="$PKGS_TO_INSTALL openssh-server"
+test -f /etc/ssl/certs/ca-certificates.crt || PKGS_TO_INSTALL="$PKGS_TO_INSTALL ca-certificates"{btrfs_pkg_line}
+
+if [ -n "$PKGS_TO_INSTALL" ]; then
+    apt_get_retry update -qq
+    apt_get_retry install -y -qq $PKGS_TO_INSTALL
+fi
+
 # Optional: if a btrfs additional disk was attached, format + mount it at the
 # canonical path and symlink host_dir to it. No-op when the block below is the
-# inert comment placeholder.
+# inert comment placeholder. Runs last because it needs mkfs.btrfs from the
+# btrfs-progs package installed above.
 {host_data_disk_block}
 """
 

--- a/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
+++ b/libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py
@@ -105,6 +105,35 @@ def test_generate_default_lima_yaml_with_host_key_injects_block(tmp_path: Path) 
     assert "SSH_KEY_CHANGED=1" in script
 
 
+def test_provision_script_installs_host_key_before_apt(tmp_path: Path) -> None:
+    """Host-key trust must be established before the network-dependent apt
+    install: mngr pins the injected key and connects with strict host-key
+    checking, so a transient apt mirror failure (which aborts the `set -e`
+    script) must not be able to run *before* the key swap and leave the VM on
+    its default keys -- that surfaces as a baffling "host key does not match".
+    The package install is also wrapped in a retry to ride out mirror blips.
+    """
+    volume_path = tmp_path / "volume"
+    volume_path.mkdir()
+    fake_private = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC...\n-----END OPENSSH PRIVATE KEY-----\n"
+    fake_public = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPv... mngr-lima@host\n"
+    config = generate_default_lima_yaml(
+        volume_host_path=volume_path,
+        host_dir="/mngr",
+        host_private_key_pem=fake_private,
+        host_public_key_openssh=fake_public,
+    )
+    script = config["provision"][0]["script"]
+    # The host-key swap (and its sshd restart) must precede the apt install.
+    key_swap_index = script.index("/etc/ssh/ssh_host_ed25519_key")
+    apt_install_index = script.index("apt_get_retry install")
+    assert key_swap_index < apt_install_index
+    # apt is retried rather than run once, so a transient mirror failure does
+    # not abort provisioning on the first attempt.
+    assert "apt_get_retry update" in script
+    assert "apt_get_retry install" in script
+
+
 def test_write_lima_yaml(tmp_path: Path) -> None:
     config = {"images": [{"location": "test.qcow2", "arch": "x86_64"}]}
     output_path = tmp_path / "test.yaml"


### PR DESCRIPTION
## Problem

Creating a local Lima workspace intermittently failed with:

```
Error: Failed to connect to host: SSH host key error (Host key for 127.0.0.1 does not match.)
```

The Lima `provision[mode=system]` script installed the pre-trusted sshd host key **after** a network-dependent `apt-get install`, all under `set -eux -o pipefail`. When a Debian mirror transiently failed to serve package indexes, `apt-get` returned non-zero and `set -e` aborted the whole script **before** the host-key swap ran. The VM then kept its own default host key, while mngr had already pinned the key it *intended* to inject and connects with `StrictHostKeyChecking=yes` -- so the strict check rejected the connection.

Verified on a failing VM: the served ed25519 key differed from the injected one, the rsa/ecdsa/dsa keys were never removed, `tmux` was missing, and `cloud-init-output.log` showed `apt-get install` failing right before "scripts-per-boot failed".

## Fix

- Reorder the provision script so SSH host-key trust (key swap + sshd tuning + restart) is established **first**, before any package fetch. That block only uses coreutils and the already-present sshd, so host-key trust no longer depends on the network.
- Wrap the package install in a retry loop to ride out transient apt mirror failures. If it still fails, the error surfaces clearly on an SSH-reachable host instead of as a host-key mismatch.

## Tests

- New `test_provision_script_installs_host_key_before_apt` asserts the key swap precedes the apt install and that apt is retried.
- `just test-quick libs/mngr_lima/imbue/mngr_lima/lima_yaml_test.py`: 18 passed.

## Note

Split out of #2382 (onboarding fixes) so the Lima fix lands on its own; the macOS desktop-launch change from that branch is being kept as a local-only workaround instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)