### PR TITLE
fix test that was broken if sh points to dash

### DIFF
--- a/libs/mngr/changelog/ev-dash-syntax-check.md
+++ b/libs/mngr/changelog/ev-dash-syntax-check.md
@@ -1,0 +1,3 @@
+Fixed the `_build_remote_lock_command` tests so their intended shell syntax check no longer executes the command.
+
+The tests validated the generated lock command with `sh -n -c <cmd>`, but dash (the default `/bin/sh` on Debian/Ubuntu) ignores `-n` for `-c` scripts and actually runs them, so the command's `mkdir -p` executed and failed on an unprivileged or read-only `/`. The script is now fed via stdin (`sh -n` with `input=cmd`), where dash honors `-n` and performs a true no-exec syntax check.

--- a/libs/mngr/imbue/mngr/hosts/host_test.py
+++ b/libs/mngr/imbue/mngr/hosts/host_test.py
@@ -2825,7 +2825,10 @@ def test_host_lock_cooperatively_acquires_and_releases(
 def test_build_remote_lock_command_blocking_holds_flock_until_stdin_closes() -> None:
     """The blocking remote lock command must be valid shell, flock the path, and signal acquisition."""
     cmd = _build_remote_lock_command(Path("/mngr/host_lock"), timeout_seconds=None)
-    assert subprocess.run(["sh", "-n", "-c", cmd], capture_output=True).returncode == 0
+    # Feed the script via stdin, not ``-c``: dash ignores ``-n`` (no-exec syntax
+    # check) for ``-c`` scripts and actually runs them, so ``-c`` would execute
+    # the ``mkdir -p`` in the command and fail on a read-only or unprivileged ``/``.
+    assert subprocess.run(["sh", "-n"], input=cmd, text=True, capture_output=True).returncode == 0
     assert "flock 9" in cmd
     assert "/mngr/host_lock" in cmd
     assert _LOCK_ACQUIRED_MARKER in cmd
@@ -2836,7 +2839,10 @@ def test_build_remote_lock_command_blocking_holds_flock_until_stdin_closes() -> 
 def test_build_remote_lock_command_with_timeout_uses_flock_wait() -> None:
     """A bounded remote lock command must use ``flock -w`` and emit the timeout marker."""
     cmd = _build_remote_lock_command(Path("/mngr/host_lock"), timeout_seconds=12.0)
-    assert subprocess.run(["sh", "-n", "-c", cmd], capture_output=True).returncode == 0
+    # Feed the script via stdin, not ``-c``: dash ignores ``-n`` (no-exec syntax
+    # check) for ``-c`` scripts and actually runs them, so ``-c`` would execute
+    # the ``mkdir -p`` in the command and fail on a read-only or unprivileged ``/``.
+    assert subprocess.run(["sh", "-n"], input=cmd, text=True, capture_output=True).returncode == 0
     assert "flock -w 12 9" in cmd
     assert _LOCK_ACQUIRED_MARKER in cmd
     assert _LOCK_TIMED_OUT_MARKER in cmd


### PR DESCRIPTION
or could just ensure it doesn't use dash

---

## Problem

`libs/mngr/imbue/mngr/hosts/host_test.py`'s `test_build_remote_lock_command_*` tests validated the generated remote lock command with `subprocess.run(["sh", "-n", "-c", cmd])`, intending a no-exec syntax check.

But **dash ignores `-n` when the script comes via `-c`** (it only honors `-n` for stdin/file input). Since `/bin/sh` -> dash on Debian/Ubuntu, the command actually *ran*, executing its `mkdir -p /mngr/...`. This passed on CI (root, writable `/`) but failed locally on an unprivileged or read-only `/` with `mkdir: cannot create directory '/mngr': Permission denied`.

## Fix

Feed the script via stdin (`subprocess.run(["sh", "-n"], input=cmd, text=True, ...)`), where dash honors `-n` and performs a genuine no-exec syntax check. Verified: dash executes `sh -n -c 'echo X'` (prints X) but does not execute `echo X | sh -n`, while still catching syntax errors (rc 2).

Latent test fragility, not a product bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)