### PR TITLE
make config-editing hints use `mngr config` whenever possible + shared hint helpers

### DIFF
--- a/libs/mngr/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,7 @@
+Standardized user-facing configuration remediation hints. Error and warning messages now always suggest a runnable `mngr config set` / `mngr config unset` command instead of telling you to hand-edit `settings.toml`.
+
+A new shared helper (`imbue.mngr.remediations`) renders these hints in one canonical form, so flag order and scope no longer drift between call sites.
+
+Provider-disable hints now recommend `--scope local` rather than `--scope user`. Because config precedence is user < project < local, a `--scope user` suggestion was silently overridden (and thus ineffective) whenever the provider was enabled at the project or local layer; writing to the local scope always takes effect.
+
+Updated the affected messages in `mngr create --template`, the custom-agent-type "no command" error, and the provider-unavailable / not-authorized errors.

--- a/libs/mngr/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr/changelog/ev-standardize-config-tips.md
@@ -5,3 +5,5 @@ A new shared helper (`imbue.mngr.remediations`) renders these hints in one canon
 Provider-disable hints now recommend `--scope local` rather than `--scope user`. Because config precedence is user < project < local, a `--scope user` suggestion was silently overridden (and thus ineffective) whenever the provider was enabled at the project or local layer; writing to the local scope always takes effect.
 
 Updated the affected messages in `mngr create --template`, the custom-agent-type "no command" error, and the provider-unavailable / not-authorized errors.
+
+The "agent type has no command to run" error's example now uses the agent type you actually ran (`mngr create foo --type <your-type> -- ...`) instead of always suggesting `--type command`.

--- a/libs/mngr/imbue/mngr/agents/base_agent.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent.py
@@ -41,6 +41,7 @@ from imbue.mngr.interfaces.host import OnlineHostInterface
 from imbue.mngr.primitives import ActivitySource
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import CommandString
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr.utils.env_utils import parse_env_file
 
 _CAPTURE_PANE_TIMEOUT_SECONDS: Final[float] = 10.0
@@ -112,11 +113,12 @@ class BaseAgent(AgentInterface[AgentConfigT]):
         parts.extend(quote_agent_args(agent_args))
 
         if not parts:
+            set_command_hint = format_config_set(f"agent_types.{self.agent_type}.command", "'<command>'")
             raise UserInputError(
                 f"Agent type '{self.agent_type}' has no command to run. "
                 f"Pass a shell command after `--` "
                 f"(e.g. `mngr create foo --type command -- sleep 99999`), "
-                f"or set `command = '...'` on a custom `[agent_types.X]` in your config."
+                f"or set a command on a custom agent type with `{set_command_hint}`."
             )
 
         command = CommandString(" ".join(parts))

--- a/libs/mngr/imbue/mngr/agents/base_agent.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent.py
@@ -117,7 +117,7 @@ class BaseAgent(AgentInterface[AgentConfigT]):
             raise UserInputError(
                 f"Agent type '{self.agent_type}' has no command to run. "
                 f"Pass a shell command after `--` "
-                f"(e.g. `mngr create foo --type command -- sleep 99999`), "
+                f"(e.g. `mngr create foo --type {self.agent_type} -- sleep 99999`), "
                 f"or set a command on a custom agent type with `{set_command_hint}`."
             )
 

--- a/libs/mngr/imbue/mngr/agents/base_agent.py
+++ b/libs/mngr/imbue/mngr/agents/base_agent.py
@@ -113,7 +113,7 @@ class BaseAgent(AgentInterface[AgentConfigT]):
         parts.extend(quote_agent_args(agent_args))
 
         if not parts:
-            set_command_hint = format_config_set(f"agent_types.{self.agent_type}.command", "'<command>'")
+            set_command_hint = format_config_set(f"agent_types.{self.agent_type}.command", "'<command>'", scope=None)
             raise UserInputError(
                 f"Agent type '{self.agent_type}' has no command to run. "
                 f"Pass a shell command after `--` "

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -793,7 +793,7 @@ def apply_create_template(
                 raise UserInputError(
                     f"Template '{template_name}' not found. No templates are configured. "
                     f"Define it with e.g. "
-                    f"`{format_config_set(f'create_templates.{template_name}.options.<param>', '<value>')}`"
+                    f"`{format_config_set(f'create_templates.{template_name}.options.<param>', '<value>', scope=None)}`"
                 )
 
         template = config.create_templates[template_key]

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -37,6 +37,7 @@ from imbue.mngr.errors import ParseSpecError
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.primitives import LogLevel
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr.utils.logging import LoggingConfig
 from imbue.mngr.utils.logging import setup_logging
 from imbue.mngr.utils.thread_cleanup import mngr_executor
@@ -791,7 +792,7 @@ def apply_create_template(
             else:
                 raise UserInputError(
                     f"Template '{template_name}' not found. No templates are configured. "
-                    "Add templates to your settings.toml under [create_templates.<name>]"
+                    f"Define one with e.g. `{format_config_set('create_templates.<name>.options.<param>', '<value>')}`"
                 )
 
         template = config.create_templates[template_key]

--- a/libs/mngr/imbue/mngr/cli/common_opts.py
+++ b/libs/mngr/imbue/mngr/cli/common_opts.py
@@ -792,7 +792,8 @@ def apply_create_template(
             else:
                 raise UserInputError(
                     f"Template '{template_name}' not found. No templates are configured. "
-                    f"Define one with e.g. `{format_config_set('create_templates.<name>.options.<param>', '<value>')}`"
+                    f"Define it with e.g. "
+                    f"`{format_config_set(f'create_templates.{template_name}.options.<param>', '<value>')}`"
                 )
 
         template = config.create_templates[template_key]

--- a/libs/mngr/imbue/mngr/cli/config.py
+++ b/libs/mngr/imbue/mngr/cli/config.py
@@ -28,7 +28,6 @@ from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.urwid_picker import run_single_select_picker
 from imbue.mngr.cli.urwid_utils import has_interactive_terminal
 from imbue.mngr.config.data_types import CommonCliOptions
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.config.external_settings import MNGR_MERGE_KEY
@@ -42,6 +41,7 @@ from imbue.mngr.config.pre_readers import get_user_config_path
 from imbue.mngr.config.pre_readers import resolve_project_config_dir
 from imbue.mngr.errors import ConfigKeyNotFoundError
 from imbue.mngr.errors import ConfigNotFoundError
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.utils.file_utils import atomic_write
 from imbue.mngr.utils.interactive_subprocess import run_interactive_subprocess

--- a/libs/mngr/imbue/mngr/cli/config_test.py
+++ b/libs/mngr/imbue/mngr/cli/config_test.py
@@ -22,9 +22,9 @@ from imbue.mngr.cli.config import _get_nested_value
 from imbue.mngr.cli.config import _unset_nested_value
 from imbue.mngr.cli.config import _wizard_claude_config_isolation
 from imbue.mngr.cli.config import config
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.errors import ConfigKeyNotFoundError
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.utils.toml_config import load_config_file_tomlkit
 from imbue.mngr.utils.toml_config import save_config_file

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -57,6 +57,7 @@ from imbue.mngr.errors import ProviderUnavailableError
 from imbue.mngr.interfaces.data_types import AgentDetails
 from imbue.mngr.primitives import ErrorBehavior
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.remediations import format_disable_provider
 from imbue.mngr.utils.cel_utils import compile_cel_sort_keys
 from imbue.mngr.utils.cel_utils import evaluate_cel_sort_key
 from imbue.mngr.utils.terminal import ANSI_DIM_GRAY
@@ -839,7 +840,7 @@ def _format_provider_error_line(error: ProviderErrorInfo) -> str:
     line = f"{error.provider_name}: {reason}"
     if error.short_remediation:
         line = f"{line} — {error.short_remediation}"
-    return f"{line} (disable: mngr config set --scope user providers.{error.provider_name}.is_enabled false)"
+    return f"{line} (disable: {format_disable_provider(error.provider_name)})"
 
 
 @pure

--- a/libs/mngr/imbue/mngr/cli/list_test.py
+++ b/libs/mngr/imbue/mngr/cli/list_test.py
@@ -1786,7 +1786,7 @@ def test_format_provider_error_line_includes_reason_remediation_and_disable_hint
     line = _format_provider_error_line(error)
     assert line == (
         "aws: AWS credentials not configured — run `aws configure` "
-        "(disable: mngr config set --scope user providers.aws.is_enabled false)"
+        "(disable: mngr config set --scope local providers.aws.is_enabled false)"
     )
 
 

--- a/libs/mngr/imbue/mngr/cli/plugin.py
+++ b/libs/mngr/imbue/mngr/cli/plugin.py
@@ -31,12 +31,12 @@ from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.cli.output_helpers import write_json_line
 from imbue.mngr.cli.plugin_install_wizard import install_wizard
 from imbue.mngr.config.data_types import CommonCliOptions
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
 from imbue.mngr.config.provider_config_registry import list_registered_provider_backend_names
 from imbue.mngr.errors import PluginSpecifierError
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import PluginName
 from imbue.mngr.utils.toml_config import set_plugin_enabled

--- a/libs/mngr/imbue/mngr/cli/plugin_test.py
+++ b/libs/mngr/imbue/mngr/cli/plugin_test.py
@@ -31,7 +31,6 @@ from imbue.mngr.cli.plugin import _project_to_provider_entries
 from imbue.mngr.cli.plugin import _read_package_name_from_pyproject
 from imbue.mngr.cli.plugin import _validate_plugin_name_is_known
 from imbue.mngr.config.data_types import AgentTypeConfig
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.config.data_types import OutputOptions
@@ -42,6 +41,7 @@ from imbue.mngr.config.provider_config_registry import reset_provider_config_reg
 from imbue.mngr.errors import PluginSpecifierError
 from imbue.mngr.plugins import hookspecs
 from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import OutputFormat
 from imbue.mngr.primitives import PluginName
 

--- a/libs/mngr/imbue/mngr/config/data_types.py
+++ b/libs/mngr/imbue/mngr/config/data_types.py
@@ -119,19 +119,6 @@ class WorkDirExtraPathMode(UpperCaseStrEnum):
     COPY = auto()
 
 
-class ConfigScope(UpperCaseStrEnum):
-    """A settings-file layer: the user profile, the project, or the local override.
-
-    The lowercased member name is the value accepted by ``mngr config set
-    --scope`` and surfaced in diagnostics; ``get_config_path`` (cli/config.py)
-    and ``read_config_layers`` (pre_readers.py) both map these to the same files.
-    """
-
-    USER = auto()
-    PROJECT = auto()
-    LOCAL = auto()
-
-
 # === Value Types ===
 
 

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -26,7 +26,6 @@ from imbue.mngr.config.consts import PROFILES_DIRNAME
 from imbue.mngr.config.consts import ROOT_CONFIG_FILENAME
 from imbue.mngr.config.data_types import AgentTypeConfig
 from imbue.mngr.config.data_types import CommandDefaults
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import CreateCliOptions
 from imbue.mngr.config.data_types import CreateTemplate
 from imbue.mngr.config.data_types import CreateTemplateName
@@ -54,6 +53,7 @@ from imbue.mngr.errors import UnknownBackendError
 from imbue.mngr.errors import UserInputError
 from imbue.mngr.plugin_catalog import get_plugin_install_hint
 from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import PluginKind
 from imbue.mngr.primitives import PluginName
 from imbue.mngr.primitives import ProviderInstanceName

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -19,7 +19,6 @@ from imbue.mngr.config.agent_config_registry import register_agent_config
 from imbue.mngr.config.agent_config_registry import reset_agent_config_registry
 from imbue.mngr.config.data_types import AgentTypeConfig
 from imbue.mngr.config.data_types import CommandDefaults
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.data_types import CreateTemplateName
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import PluginConfig
@@ -52,6 +51,7 @@ from imbue.mngr.config.pre_readers import OPT_IN_PLUGINS
 from imbue.mngr.errors import ConfigParseError
 from imbue.mngr.plugins import hookspecs
 from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import LogLevel
 from imbue.mngr.primitives import PluginName
 from imbue.mngr.primitives import ProviderBackendName

--- a/libs/mngr/imbue/mngr/config/pre_readers.py
+++ b/libs/mngr/imbue/mngr/config/pre_readers.py
@@ -7,9 +7,9 @@ from typing import Final
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr.config.consts import PROFILES_DIRNAME
 from imbue.mngr.config.consts import ROOT_CONFIG_FILENAME
-from imbue.mngr.config.data_types import ConfigScope
 from imbue.mngr.config.host_dir import read_default_host_dir
 from imbue.mngr.errors import ConfigParseError
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.utils.git_utils import find_git_worktree_root
 
 # Filenames of the per-scope settings files, relative to their containing

--- a/libs/mngr/imbue/mngr/errors.py
+++ b/libs/mngr/imbue/mngr/errors.py
@@ -19,6 +19,7 @@ from imbue.mngr.primitives import ImageReference
 from imbue.mngr.primitives import PluginKind
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.primitives import SnapshotId
+from imbue.mngr.remediations import format_disable_provider
 
 
 class MngrError(ClickException):
@@ -267,7 +268,7 @@ class ProviderUnavailableError(ProviderError):
         # the user is not told to "start Docker" for an auth problem.
         self.user_help_text = user_help_text or (
             f"Ensure the provider backend is running (e.g. start Docker), or disable the provider:\n"
-            f"  mngr config set --scope user providers.{provider_name}.is_enabled false"
+            f"  {format_disable_provider(provider_name)}"
         )
 
 
@@ -333,7 +334,7 @@ class ProviderNotAuthorizedError(ProviderUnavailableError):
     ) -> None:
         default_help = (
             f"To disable this provider, run:\n"
-            f"  mngr config set --scope user providers.{provider_name}.is_enabled false\n"
+            f"  {format_disable_provider(provider_name)}\n"
             f"Or disable the provider backend entirely by removing it from enabled_backends in your config."
         )
         super().__init__(

--- a/libs/mngr/imbue/mngr/primitives.py
+++ b/libs/mngr/imbue/mngr/primitives.py
@@ -33,6 +33,19 @@ class DockerBuilder(UpperCaseStrEnum):
     DEPOT = auto()
 
 
+class ConfigScope(UpperCaseStrEnum):
+    """A settings-file layer: the user profile, the project, or the local override.
+
+    The lowercased member name is the value accepted by ``mngr config set
+    --scope`` and surfaced in diagnostics; ``get_config_path`` (cli/config.py)
+    and ``read_config_layers`` (pre_readers.py) both map these to the same files.
+    """
+
+    USER = auto()
+    PROJECT = auto()
+    LOCAL = auto()
+
+
 class AgentNameStyle(UpperCaseStrEnum):
     """Style for auto-generated agent names."""
 

--- a/libs/mngr/imbue/mngr/remediations.py
+++ b/libs/mngr/imbue/mngr/remediations.py
@@ -12,31 +12,33 @@ impossible: there is exactly one place that decides the flag order and the
 recommended scope.
 """
 
-from typing import Literal
-
-# The scope names accepted by ``mngr config set/unset --scope`` (CLI spelling).
-ConfigScopeName = Literal["user", "project", "local"]
+from imbue.mngr.primitives import ConfigScope
 
 
-def format_config_set(key: str, value: str, *, scope: ConfigScopeName | None = None) -> str:
+def _scope_flag(scope: ConfigScope | None) -> str:
+    """Render the ``--scope <scope> `` prefix (trailing space included), or ``""``.
+
+    ``--scope`` is placed immediately after the subcommand -- the one canonical
+    flag position -- so it is shared by both ``set`` and ``unset``.
+    """
+    return f"--scope {scope.name.lower()} " if scope is not None else ""
+
+
+def format_config_set(key: str, value: str, *, scope: ConfigScope | None) -> str:
     """Return a runnable ``mngr config set`` command setting ``key`` to ``value``.
 
-    When ``scope`` is given it is rendered as ``--scope <scope>`` immediately
-    after ``set`` -- the one canonical flag position. When ``None`` no
-    ``--scope`` flag is emitted and ``mngr config set`` writes to its default
-    (project) scope.
+    Pass ``scope=None`` to omit the ``--scope`` flag (``mngr config set`` then
+    writes to its default, project, scope).
     """
-    scope_flag = f"--scope {scope} " if scope is not None else ""
-    return f"mngr config set {scope_flag}{key} {value}"
+    return f"mngr config set {_scope_flag(scope)}{key} {value}"
 
 
-def format_config_unset(key: str, *, scope: ConfigScopeName | None = None) -> str:
+def format_config_unset(key: str, *, scope: ConfigScope | None) -> str:
     """Return a runnable ``mngr config unset`` command clearing ``key``.
 
-    ``scope`` follows the same rules as :func:`format_config_set`.
+    Pass ``scope=None`` to omit the ``--scope`` flag.
     """
-    scope_flag = f"--scope {scope} " if scope is not None else ""
-    return f"mngr config unset {scope_flag}{key}"
+    return f"mngr config unset {_scope_flag(scope)}{key}"
 
 
 def format_disable_provider(provider_name: str) -> str:
@@ -49,4 +51,4 @@ def format_disable_provider(provider_name: str) -> str:
     and therefore ineffective -- whenever the provider is enabled at the
     project or local layer.
     """
-    return format_config_set(f"providers.{provider_name}.is_enabled", "false", scope="local")
+    return format_config_set(f"providers.{provider_name}.is_enabled", "false", scope=ConfigScope.LOCAL)

--- a/libs/mngr/imbue/mngr/remediations.py
+++ b/libs/mngr/imbue/mngr/remediations.py
@@ -1,0 +1,52 @@
+"""Canonical rendering of user-facing configuration remediation hints.
+
+Error and warning messages routinely need to tell users how to change their
+configuration. Historically each call site hand-wrote its own ``mngr config
+set`` suggestion (or, worse, told users to open ``settings.toml`` by hand),
+which drifted over time in flag order, scope, and whether a runnable command
+was offered at all.
+
+Every such hint should be produced here instead. Routing all sites through
+these helpers keeps the spelling consistent and makes that drift structurally
+impossible: there is exactly one place that decides the flag order and the
+recommended scope.
+"""
+
+from typing import Literal
+
+# The scope names accepted by ``mngr config set/unset --scope`` (CLI spelling).
+ConfigScopeName = Literal["user", "project", "local"]
+
+
+def format_config_set(key: str, value: str, *, scope: ConfigScopeName | None = None) -> str:
+    """Return a runnable ``mngr config set`` command setting ``key`` to ``value``.
+
+    When ``scope`` is given it is rendered as ``--scope <scope>`` immediately
+    after ``set`` -- the one canonical flag position. When ``None`` no
+    ``--scope`` flag is emitted and ``mngr config set`` writes to its default
+    (project) scope.
+    """
+    scope_flag = f"--scope {scope} " if scope is not None else ""
+    return f"mngr config set {scope_flag}{key} {value}"
+
+
+def format_config_unset(key: str, *, scope: ConfigScopeName | None = None) -> str:
+    """Return a runnable ``mngr config unset`` command clearing ``key``.
+
+    ``scope`` follows the same rules as :func:`format_config_set`.
+    """
+    scope_flag = f"--scope {scope} " if scope is not None else ""
+    return f"mngr config unset {scope_flag}{key}"
+
+
+def format_disable_provider(provider_name: str) -> str:
+    """Return a runnable command that disables the named provider instance.
+
+    Always recommends ``--scope local``. Config precedence is
+    user < project < local (local wins), so a write to the local scope takes
+    effect regardless of which layer currently enables the provider. A hint
+    recommending a lower scope (e.g. ``user``) would be silently overridden --
+    and therefore ineffective -- whenever the provider is enabled at the
+    project or local layer.
+    """
+    return format_config_set(f"providers.{provider_name}.is_enabled", "false", scope="local")

--- a/libs/mngr/imbue/mngr/remediations_test.py
+++ b/libs/mngr/imbue/mngr/remediations_test.py
@@ -1,0 +1,31 @@
+from imbue.mngr.remediations import format_config_set
+from imbue.mngr.remediations import format_config_unset
+from imbue.mngr.remediations import format_disable_provider
+
+
+def test_format_config_set_without_scope_omits_flag() -> None:
+    assert format_config_set("providers.gcp.project_id", "<id>") == "mngr config set providers.gcp.project_id <id>"
+
+
+def test_format_config_set_renders_scope_immediately_after_set() -> None:
+    # The scope flag is the canonical position: right after ``set``, before the key.
+    assert (
+        format_config_set("agent_types.claude.isolate_local_config_dir", "false", scope="user")
+        == "mngr config set --scope user agent_types.claude.isolate_local_config_dir false"
+    )
+
+
+def test_format_config_unset_without_scope_omits_flag() -> None:
+    assert (
+        format_config_unset("providers.azure.subscription_id") == "mngr config unset providers.azure.subscription_id"
+    )
+
+
+def test_format_config_unset_renders_scope_immediately_after_unset() -> None:
+    assert format_config_unset("enabled_backends", scope="local") == "mngr config unset --scope local enabled_backends"
+
+
+def test_format_disable_provider_recommends_local_scope() -> None:
+    # Local is the highest-precedence scope, so the disable always takes effect
+    # regardless of which layer currently enables the provider.
+    assert format_disable_provider("azure") == "mngr config set --scope local providers.azure.is_enabled false"

--- a/libs/mngr/imbue/mngr/remediations_test.py
+++ b/libs/mngr/imbue/mngr/remediations_test.py
@@ -1,28 +1,36 @@
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.remediations import format_config_set
 from imbue.mngr.remediations import format_config_unset
 from imbue.mngr.remediations import format_disable_provider
 
 
 def test_format_config_set_without_scope_omits_flag() -> None:
-    assert format_config_set("providers.gcp.project_id", "<id>") == "mngr config set providers.gcp.project_id <id>"
+    assert (
+        format_config_set("providers.gcp.project_id", "<id>", scope=None)
+        == "mngr config set providers.gcp.project_id <id>"
+    )
 
 
 def test_format_config_set_renders_scope_immediately_after_set() -> None:
     # The scope flag is the canonical position: right after ``set``, before the key.
     assert (
-        format_config_set("agent_types.claude.isolate_local_config_dir", "false", scope="user")
+        format_config_set("agent_types.claude.isolate_local_config_dir", "false", scope=ConfigScope.USER)
         == "mngr config set --scope user agent_types.claude.isolate_local_config_dir false"
     )
 
 
 def test_format_config_unset_without_scope_omits_flag() -> None:
     assert (
-        format_config_unset("providers.azure.subscription_id") == "mngr config unset providers.azure.subscription_id"
+        format_config_unset("providers.azure.subscription_id", scope=None)
+        == "mngr config unset providers.azure.subscription_id"
     )
 
 
 def test_format_config_unset_renders_scope_immediately_after_unset() -> None:
-    assert format_config_unset("enabled_backends", scope="local") == "mngr config unset --scope local enabled_backends"
+    assert (
+        format_config_unset("enabled_backends", scope=ConfigScope.LOCAL)
+        == "mngr config unset --scope local enabled_backends"
+    )
 
 
 def test_format_disable_provider_recommends_local_scope() -> None:

--- a/libs/mngr_aws/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_aws/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+The AWS "could not be reached" error's provider-disable hint now recommends `--scope local` (which always takes effect regardless of which config layer enabled the provider) rather than `--scope user`.

--- a/libs/mngr_aws/imbue/mngr_aws/backend.py
+++ b/libs/mngr_aws/imbue/mngr_aws/backend.py
@@ -21,6 +21,7 @@ from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.remediations import format_disable_provider
 from imbue.mngr_aws import hookimpl
 from imbue.mngr_aws.cli import aws_cli_group
 from imbue.mngr_aws.client import AwsVpsClient
@@ -363,7 +364,7 @@ def _aws_not_authorized_error(
         "  - credentials: run `aws configure` (or set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, "
         "or AWS_PROFILE);\n"
         "  - one-time setup: run `mngr aws prepare` if you have not yet.\n"
-        f"Or disable the provider: mngr config set --scope user providers.{name}.is_enabled false"
+        f"Or disable the provider: {format_disable_provider(name)}"
     )
     return ProviderNotAuthorizedError(
         name, reason=reason, short_remediation=short_remediation, user_help_text=help_text

--- a/libs/mngr_azure/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_azure/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+Azure "could not be reached" and "no subscription resolved" errors now suggest a runnable `mngr config set providers.<name>.subscription_id <id>` command instead of telling you to hand-edit the `[providers.azure]` block in `settings.toml`. The provider-disable hint now recommends `--scope local` (which always takes effect) rather than `--scope user`.

--- a/libs/mngr_azure/imbue/mngr_azure/backend.py
+++ b/libs/mngr_azure/imbue/mngr_azure/backend.py
@@ -27,6 +27,8 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.remediations import format_config_set
+from imbue.mngr.remediations import format_disable_provider
 from imbue.mngr_azure import hookimpl
 from imbue.mngr_azure.cli import azure_cli_group
 from imbue.mngr_azure.client import AzureVpsClient
@@ -153,12 +155,12 @@ def _azure_not_authorized_error(
     """
     help_text = (
         "Azure could not be reached. Check, in order:\n"
-        "  - subscription: set AZURE_SUBSCRIPTION_ID, set `subscription_id` in [providers.azure], "
+        f"  - subscription: set AZURE_SUBSCRIPTION_ID, run `{format_config_set(f'providers.{name}.subscription_id', '<id>')}`, "
         "or run `az account set --subscription <id>`;\n"
         "  - credentials: run `az login` (or set AZURE_CLIENT_ID / AZURE_TENANT_ID / "
         "AZURE_CLIENT_SECRET for a service principal);\n"
         "  - one-time setup: run `mngr azure prepare` if you have not yet.\n"
-        f"Or disable the provider: mngr config set --scope user providers.{name}.is_enabled false"
+        f"Or disable the provider: {format_disable_provider(name)}"
     )
     return ProviderNotAuthorizedError(
         name,

--- a/libs/mngr_azure/imbue/mngr_azure/backend.py
+++ b/libs/mngr_azure/imbue/mngr_azure/backend.py
@@ -155,7 +155,7 @@ def _azure_not_authorized_error(
     """
     help_text = (
         "Azure could not be reached. Check, in order:\n"
-        f"  - subscription: set AZURE_SUBSCRIPTION_ID, run `{format_config_set(f'providers.{name}.subscription_id', '<id>')}`, "
+        f"  - subscription: set AZURE_SUBSCRIPTION_ID, run `{format_config_set(f'providers.{name}.subscription_id', '<id>', scope=None)}`, "
         "or run `az account set --subscription <id>`;\n"
         "  - credentials: run `az login` (or set AZURE_CLIENT_ID / AZURE_TENANT_ID / "
         "AZURE_CLIENT_SECRET for a service principal);\n"

--- a/libs/mngr_azure/imbue/mngr_azure/config.py
+++ b/libs/mngr_azure/imbue/mngr_azure/config.py
@@ -10,6 +10,7 @@ from loguru import logger
 from pydantic import Field
 
 from imbue.mngr.primitives import ProviderBackendName
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr.utils.polling import poll_for_value
 from imbue.mngr_azure.errors import AzureSubscriptionError
 from imbue.mngr_azure.state_bucket import BlobStateBucket
@@ -244,7 +245,7 @@ class AzureProviderConfig(PublicIpVpsProviderConfig):
         raise AzureSubscriptionError(
             "No Azure subscription resolved. Set one of:\n"
             "  - run `az login` (optionally `az account set --subscription <id>`) to use the active subscription;\n"
-            "  - `mngr config set providers.azure.subscription_id <id>`;\n"
+            f"  - `{format_config_set('providers.azure.subscription_id', '<id>')}`;\n"
             "  - the AZURE_SUBSCRIPTION_ID environment variable."
         )
 

--- a/libs/mngr_azure/imbue/mngr_azure/config.py
+++ b/libs/mngr_azure/imbue/mngr_azure/config.py
@@ -245,7 +245,7 @@ class AzureProviderConfig(PublicIpVpsProviderConfig):
         raise AzureSubscriptionError(
             "No Azure subscription resolved. Set one of:\n"
             "  - run `az login` (optionally `az account set --subscription <id>`) to use the active subscription;\n"
-            f"  - `{format_config_set('providers.azure.subscription_id', '<id>')}`;\n"
+            f"  - `{format_config_set('providers.azure.subscription_id', '<id>', scope=None)}`;\n"
             "  - the AZURE_SUBSCRIPTION_ID environment variable."
         )
 

--- a/libs/mngr_claude/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_claude/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+The Claude subscription-credential isolation warning now renders its `mngr config set` suggestion with the `--scope user` flag in the canonical position (immediately after `set`), matching the standardized remediation-hint format used elsewhere.

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -89,6 +89,7 @@ from imbue.mngr.primitives import CommandString
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import TransferMode
 from imbue.mngr.primitives import WaitingReason
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr.utils.git_utils import find_git_source_path
 from imbue.mngr.utils.polling import poll_until
 from imbue.mngr_claude import hookimpl
@@ -1925,7 +1926,7 @@ class ClaudeCoreAgent(
             "isolation is enabled. Isolated agents use a separate keychain entry whose copy of your "
             "subscription credentials goes stale as the tokens refresh, so this agent will likely hit "
             "authentication errors later. To share your default Claude config (and credentials) instead, run:\n"
-            "    mngr config set agent_types.claude.isolate_local_config_dir false --scope user"
+            f"    {format_config_set('agent_types.claude.isolate_local_config_dir', 'false', scope='user')}"
         )
 
     def provision(

--- a/libs/mngr_claude/imbue/mngr_claude/plugin.py
+++ b/libs/mngr_claude/imbue/mngr_claude/plugin.py
@@ -86,6 +86,7 @@ from imbue.mngr.plugins.hookspecs import OnBeforeCreateArgs
 from imbue.mngr.primitives import AgentLifecycleState
 from imbue.mngr.primitives import AgentTypeName
 from imbue.mngr.primitives import CommandString
+from imbue.mngr.primitives import ConfigScope
 from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import TransferMode
 from imbue.mngr.primitives import WaitingReason
@@ -1926,7 +1927,7 @@ class ClaudeCoreAgent(
             "isolation is enabled. Isolated agents use a separate keychain entry whose copy of your "
             "subscription credentials goes stale as the tokens refresh, so this agent will likely hit "
             "authentication errors later. To share your default Claude config (and credentials) instead, run:\n"
-            f"    {format_config_set('agent_types.claude.isolate_local_config_dir', 'false', scope='user')}"
+            f"    {format_config_set('agent_types.claude.isolate_local_config_dir', 'false', scope=ConfigScope.USER)}"
         )
 
     def provision(

--- a/libs/mngr_gcp/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_gcp/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+GCP "could not be reached" / "no project resolved" errors (and the no-project-id info log) now suggest a runnable `mngr config set providers.<name>.project_id <id>` command instead of telling you to hand-edit the `[providers.gcp]` block in `settings.toml`. The provider-disable hint now recommends `--scope local` (which always takes effect) rather than `--scope user`.

--- a/libs/mngr_gcp/imbue/mngr_gcp/backend.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/backend.py
@@ -102,7 +102,7 @@ def _gcp_not_authorized_error(
         "GCP could not be reached. Check, in order:\n"
         "  - credentials: run `gcloud auth application-default login` (or set "
         "GOOGLE_APPLICATION_CREDENTIALS to a service-account key);\n"
-        f"  - project: run `{format_config_set(f'providers.{name}.project_id', '<id>')}`, or run `gcloud config set project <id>`;\n"
+        f"  - project: run `{format_config_set(f'providers.{name}.project_id', '<id>', scope=None)}`, or run `gcloud config set project <id>`;\n"
         "  - one-time setup: run `mngr gcp prepare` if you have not yet.\n"
         f"Or disable the provider: {format_disable_provider(name)}"
     )
@@ -226,7 +226,7 @@ class GcpProvider(OfflineCapableVpsProvider):
                 "Application Default Credentials (gcloud config / GOOGLE_CLOUD_PROJECT). Run "
                 "'{}' to pin it explicitly.",
                 self.gcp_client.project_id,
-                format_config_set("providers.gcp.project_id", "<your-project>"),
+                format_config_set("providers.gcp.project_id", "<your-project>", scope=None),
             )
         if "PYTEST_CURRENT_TEST" in os.environ:
             seconds = self._get_effective_auto_shutdown_seconds()

--- a/libs/mngr_gcp/imbue/mngr_gcp/backend.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/backend.py
@@ -28,6 +28,8 @@ from imbue.mngr.primitives import HostState
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.ssh_utils import wait_for_expected_host_key
+from imbue.mngr.remediations import format_config_set
+from imbue.mngr.remediations import format_disable_provider
 from imbue.mngr_gcp import hookimpl
 from imbue.mngr_gcp.cli import gcp_cli_group
 from imbue.mngr_gcp.client import GcpVpsClient
@@ -100,9 +102,9 @@ def _gcp_not_authorized_error(
         "GCP could not be reached. Check, in order:\n"
         "  - credentials: run `gcloud auth application-default login` (or set "
         "GOOGLE_APPLICATION_CREDENTIALS to a service-account key);\n"
-        "  - project: set `project_id` in [providers.gcp], or run `gcloud config set project <id>`;\n"
+        f"  - project: run `{format_config_set(f'providers.{name}.project_id', '<id>')}`, or run `gcloud config set project <id>`;\n"
         "  - one-time setup: run `mngr gcp prepare` if you have not yet.\n"
-        f"Or disable the provider: mngr config set --scope user providers.{name}.is_enabled false"
+        f"Or disable the provider: {format_disable_provider(name)}"
     )
     return ProviderNotAuthorizedError(
         name,
@@ -222,8 +224,9 @@ class GcpProvider(OfflineCapableVpsProvider):
             logger.info(
                 "No GCP project_id configured; creating instances in project {!r} resolved from "
                 "Application Default Credentials (gcloud config / GOOGLE_CLOUD_PROJECT). Run "
-                "'mngr config set providers.gcp.project_id <your-project>' to pin it explicitly.",
+                "'{}' to pin it explicitly.",
                 self.gcp_client.project_id,
+                format_config_set("providers.gcp.project_id", "<your-project>"),
             )
         if "PYTEST_CURRENT_TEST" in os.environ:
             seconds = self._get_effective_auto_shutdown_seconds()

--- a/libs/mngr_gcp/imbue/mngr_gcp/cli.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/cli.py
@@ -31,6 +31,7 @@ from imbue.mngr.cli.output_helpers import emit_operator_result
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import OutputFormat
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr_gcp.client import FirewallPrepareResult
 from imbue.mngr_gcp.client import GcpVpsClient
 from imbue.mngr_gcp.config import GcpProviderConfig
@@ -130,9 +131,9 @@ def _build_operator_client(
     resolved_project = project_id or base.project_id or adc_project
     if not resolved_project:
         raise GcpProjectError(
-            "No GCP project resolved. Pass --project, set project_id on the selected "
-            "[providers.<name>] block (or run 'mngr config set providers.gcp.project_id "
-            "<your-project>'), set the GOOGLE_CLOUD_PROJECT environment variable, or run "
+            "No GCP project resolved. Pass --project, run "
+            f"`{format_config_set('providers.gcp.project_id', '<your-project>')}`, "
+            "set the GOOGLE_CLOUD_PROJECT environment variable, or run "
             "'gcloud config set project <your-project>' (the active gcloud project is used "
             "automatically when Application Default Credentials are present)."
         )

--- a/libs/mngr_gcp/imbue/mngr_gcp/cli.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/cli.py
@@ -132,7 +132,7 @@ def _build_operator_client(
     if not resolved_project:
         raise GcpProjectError(
             "No GCP project resolved. Pass --project, run "
-            f"`{format_config_set('providers.gcp.project_id', '<your-project>')}`, "
+            f"`{format_config_set('providers.gcp.project_id', '<your-project>', scope=None)}`, "
             "set the GOOGLE_CLOUD_PROJECT environment variable, or run "
             "'gcloud config set project <your-project>' (the active gcloud project is used "
             "automatically when Application Default Credentials are present)."

--- a/libs/mngr_gcp/imbue/mngr_gcp/config.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/config.py
@@ -249,7 +249,7 @@ class GcpProviderConfig(OfflineCapableVpsProviderConfig):
         if not project_id:
             raise GcpProjectError(
                 "No GCP project_id configured and none was resolved from the environment. Run "
-                f"`{format_config_set('providers.gcp.project_id', '<your-project>')}`, set the "
+                f"`{format_config_set('providers.gcp.project_id', '<your-project>', scope=None)}`, set the "
                 "GOOGLE_CLOUD_PROJECT environment variable, or run 'gcloud config set project "
                 "<your-project>' (the active gcloud project is used automatically when Application "
                 "Default Credentials are present)."

--- a/libs/mngr_gcp/imbue/mngr_gcp/config.py
+++ b/libs/mngr_gcp/imbue/mngr_gcp/config.py
@@ -9,6 +9,7 @@ from pydantic import Field
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.concurrency_group.errors import ConcurrencyGroupError
 from imbue.mngr.primitives import ProviderBackendName
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr_gcp.errors import GcpCredentialsError
 from imbue.mngr_gcp.errors import GcpProjectError
 from imbue.mngr_gcp.errors import GcpZoneRegionMismatchError
@@ -248,7 +249,7 @@ class GcpProviderConfig(OfflineCapableVpsProviderConfig):
         if not project_id:
             raise GcpProjectError(
                 "No GCP project_id configured and none was resolved from the environment. Run "
-                "'mngr config set providers.gcp.project_id <your-project>', set the "
+                f"`{format_config_set('providers.gcp.project_id', '<your-project>')}`, set the "
                 "GOOGLE_CLOUD_PROJECT environment variable, or run 'gcloud config set project "
                 "<your-project>' (the active gcloud project is used automatically when Application "
                 "Default Credentials are present)."

--- a/libs/mngr_modal/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_modal/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+The Modal "not authorized" error's provider-disable hint is now rendered through the shared remediation helper. It continues to recommend `--scope local`, which is now the standardized scope for all provider-disable hints across providers.

--- a/libs/mngr_modal/imbue/mngr_modal/backend.py
+++ b/libs/mngr_modal/imbue/mngr_modal/backend.py
@@ -32,6 +32,7 @@ from imbue.mngr.interfaces.provider_instance import ProviderInstanceInterface
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr.providers.deploy_utils import collect_provider_profile_files
+from imbue.mngr.remediations import format_disable_provider
 from imbue.mngr.utils.env_utils import TEST_ENV_PATTERN
 from imbue.mngr_modal import hookimpl
 from imbue.mngr_modal.config import ModalMode
@@ -587,7 +588,7 @@ Supported build arguments for the modal provider:
                 user_help_text=(
                     "Modal is not authorized: run `modal token new` to authenticate (or set "
                     "MODAL_TOKEN_ID / MODAL_TOKEN_SECRET), or disable this provider with "
-                    f"`mngr config set --scope local providers.{name}.is_enabled false`."
+                    f"`{format_disable_provider(name)}`."
                 ),
             ) from e
         except ModalProxyNotFoundError as e:

--- a/libs/mngr_notifications/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_notifications/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+The notifications "no terminal configured" message now lists runnable `mngr config set plugins.notifications.<option> <value>` commands instead of telling you to set the options in `settings.toml`.

--- a/libs/mngr_notifications/imbue/mngr_notifications/cli.py
+++ b/libs/mngr_notifications/imbue/mngr_notifications/cli.py
@@ -19,6 +19,7 @@ from imbue.mngr.cli.output_helpers import write_human_line
 from imbue.mngr.config.data_types import CommonCliOptions
 from imbue.mngr.config.data_types import MngrContext
 from imbue.mngr.primitives import PluginName
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr_notifications.config import NotificationsPluginConfig
 from imbue.mngr_notifications.notification_verifier import DEFAULT_VERIFY_TIMEOUT
 from imbue.mngr_notifications.notification_verifier import VerifyNotificationResult
@@ -147,7 +148,10 @@ def notify(ctx: click.Context, **kwargs: object) -> None:
     else:
         write_human_line("No terminal configured -- notifications will not have click-to-connect.")
         write_human_line(
-            "Set plugins.notifications.terminal_app, custom_terminal_command, or notification_only in settings.toml."
+            "Enable it by running one of:\n"
+            f"  {format_config_set('plugins.notifications.terminal_app', '<app>')}\n"
+            f"  {format_config_set('plugins.notifications.custom_terminal_command', '<command>')}\n"
+            f"  {format_config_set('plugins.notifications.notification_only', 'true')}"
         )
 
     notifier = get_notifier()

--- a/libs/mngr_notifications/imbue/mngr_notifications/cli.py
+++ b/libs/mngr_notifications/imbue/mngr_notifications/cli.py
@@ -149,9 +149,9 @@ def notify(ctx: click.Context, **kwargs: object) -> None:
         write_human_line("No terminal configured -- notifications will not have click-to-connect.")
         write_human_line(
             "Enable it by running one of:\n"
-            f"  {format_config_set('plugins.notifications.terminal_app', '<app>')}\n"
-            f"  {format_config_set('plugins.notifications.custom_terminal_command', '<command>')}\n"
-            f"  {format_config_set('plugins.notifications.notification_only', 'true')}"
+            f"  {format_config_set('plugins.notifications.terminal_app', '<app>', scope=None)}\n"
+            f"  {format_config_set('plugins.notifications.custom_terminal_command', '<command>', scope=None)}\n"
+            f"  {format_config_set('plugins.notifications.notification_only', 'true', scope=None)}"
         )
 
     notifier = get_notifier()

--- a/libs/mngr_ovh/changelog/ev-standardize-config-tips.md
+++ b/libs/mngr_ovh/changelog/ev-standardize-config-tips.md
@@ -1,0 +1,1 @@
+The OVH "credentials not configured" hint now suggests a runnable `mngr config set providers.<name>.<key> <value>` command instead of telling you to set credentials in the `[providers.<name>]` block of `settings.toml`.

--- a/libs/mngr_ovh/imbue/mngr_ovh/backend.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/backend.py
@@ -647,8 +647,9 @@ class OvhProviderBackend(ProviderBackendInterface):
                 name,
                 reason="OVH credentials not configured",
                 short_remediation=(
-                    "set OVH_* env vars, configure ~/.ovh.conf, or run "
-                    f"`{format_config_set(f'providers.{name}.<key>', '<value>')}`"
+                    "set OVH_* env vars, configure ~/.ovh.conf, or set application_key / "
+                    "application_secret / consumer_key, e.g. "
+                    f"`{format_config_set(f'providers.{name}.application_key', '<value>', scope=None)}`"
                 ),
             )
         return OvhProvider(

--- a/libs/mngr_ovh/imbue/mngr_ovh/backend.py
+++ b/libs/mngr_ovh/imbue/mngr_ovh/backend.py
@@ -22,6 +22,7 @@ from imbue.mngr.primitives import HostId
 from imbue.mngr.primitives import HostName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.primitives import ProviderInstanceName
+from imbue.mngr.remediations import format_config_set
 from imbue.mngr_ovh import hookimpl
 from imbue.mngr_ovh.bootstrap import bootstrap_root_authorized_keys_via_user
 from imbue.mngr_ovh.bootstrap import pin_host_key_via_tofu
@@ -645,7 +646,10 @@ class OvhProviderBackend(ProviderBackendInterface):
             raise ProviderNotAuthorizedError(
                 name,
                 reason="OVH credentials not configured",
-                short_remediation="set OVH_* env vars, configure ~/.ovh.conf, or set credentials in [providers.<name>]",
+                short_remediation=(
+                    "set OVH_* env vars, configure ~/.ovh.conf, or run "
+                    f"`{format_config_set(f'providers.{name}.<key>', '<value>')}`"
+                ),
             )
         return OvhProvider(
             name=name,


### PR DESCRIPTION
ideally we never tell the users to hand-edit config; this PR removes all but one instance of that (for editing `enabled_backends` there's no good config command to remove just one backend; it seemed worse to suggest a command which contained a list of all backends except the one to disable)

---

## What

Standardizes user-facing configuration remediation hints so error and warning messages always point users at a runnable `mngr config set` / `mngr config unset` command instead of telling them to hand-edit `settings.toml`.

Two goals: eliminate the "edit settings.toml" hints, and route every site through one helper so flag-order and scope drift are structurally impossible.

## How

- New helper `imbue.mngr.remediations` with `format_config_set`, `format_config_unset`, and `format_disable_provider`. One canonical flag order (`--scope` immediately after `set`/`unset`), factored into a shared `_scope_flag` renderer.
- Scope is typed with the canonical `ConfigScope` enum rather than a re-declared string literal. To let the low-level `remediations` module import it without an `errors -> remediations -> data_types -> errors` cycle, `ConfigScope` moved from `config/data_types.py` down to `primitives.py` (which `errors.py` already depends on); all importers now pull it from there.
- `format_config_set` / `format_config_unset` take no default scope (per the style guide) — every caller passes `scope=` explicitly.
- `format_disable_provider` always recommends `--scope local`. Config precedence is user < project < local (local wins), so a `--scope user` suggestion was silently overridden — and thus ineffective — whenever the provider was enabled at the project or local layer. Writing to local always takes effect. This also unifies the previous split where most providers used `--scope user` but modal used `--scope local`.
- Routed all the drifting sites through the helper: `mngr create --template` (no templates), custom-agent-type "no command", provider unavailable/not-authorized errors, the list-error disable hint, notifications terminal config, and the azure/gcp/aws/modal/ovh/claude provider hints.
- Made two hints reflect the user's actual input rather than generic placeholders: the "no command" example now uses the agent type they ran (not always `--type command`), and the "template not found / none configured" hint scaffolds the specific template name they asked for. The OVH hint now names the real credential keys (`application_key` / `application_secret` / `consumer_key`) instead of a vague `<key>`.

## Notes / deliberately left alone

- `ProviderNotAuthorizedError`'s "or remove it from `enabled_backends`" line is kept as prose: `enabled_backends` is an allowlist with no single-command remove operation, so a file reference is the honest guidance there. (Possible follow-up: only show that line when a non-empty allowlist actually exists.)
- Value-set hints (subscription_id, project_id, etc.) pass `scope=None` (no `--scope`), letting `config set` use its default (project) scope; only disable hints force `local`.
- The claude "share your Claude config" hint keeps its existing `--scope user` (a per-machine credential preference), now just rendered in canonical flag order.

## Testing

- New unit tests: `libs/mngr/imbue/mngr/remediations_test.py`.
- Updated `list_test.py` disable-hint assertion (`--scope user` → `--scope local`).
- `ty` type-check and `ruff` clean on all touched files. Targeted message-assertion and config-loader/`ConfigScope` unit tests pass. Full suite runs via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
