### PR TITLE
separate hints for disabled vs not installed provider

### DIFF
--- a/libs/mngr/changelog/ev-provider-error-hint.md
+++ b/libs/mngr/changelog/ev-provider-error-hint.md
@@ -1,0 +1,5 @@
+Improved the "Provider 'X' references unknown backend 'X'" configuration error when the backend's plugin is not installed at all.
+
+Previously the message unconditionally advised adding `plugin = "<plugin-name>"` to the provider block whenever any plugin was disabled. That advice cannot resolve a backend whose plugin is not installed, so users who followed it hit the same error again, and the "Currently disabled plugins" list (which did not include the missing backend) added to the confusion.
+
+The message now distinguishes the two cases: when the backend maps to an installed-but-disabled plugin, it still suggests enabling it or opting out with `plugin =`; when the backend is not registered at all, it leads with the concrete install hint (e.g. naming `imbue-mngr-azure`) and only mentions the `plugin =` path as a secondary "if instead" option when other plugins happen to be disabled.

--- a/libs/mngr/imbue/mngr/config/loader.py
+++ b/libs/mngr/imbue/mngr/config/loader.py
@@ -675,19 +675,29 @@ def _parse_providers(
         except UnknownBackendError as e:
             msg = f"Provider '{name}' references unknown backend '{backend}'."
             if backend in disabled_plugins:
+                # The backend maps directly to an installed-but-disabled plugin, so
+                # enabling it (or opting out with `plugin =`) is the actionable fix.
                 msg += (
                     f" The '{backend}' plugin is currently disabled. Either enable"
                     f' the plugin or add `plugin = "{backend}"` to this provider'
                     f" block so it is skipped when the plugin is disabled."
                 )
-            elif disabled_plugins:
-                msg += (
-                    f" If this backend is provided by a disabled plugin, either enable"
-                    f' the plugin or add `plugin = "<plugin-name>"` to this provider'
-                    f" block. Currently disabled plugins: {', '.join(sorted(disabled_plugins))}"
-                )
             else:
+                # The backend is not registered at all, so the primary fix is to
+                # install the plugin that provides it. Suggesting `plugin = "<name>"`
+                # here would be wrong: that field only skips a provider when its
+                # named plugin is installed-but-disabled, and an uninstalled backend
+                # stays unresolved no matter what `plugin` is set to.
                 msg += f" {get_plugin_install_hint(backend, kind=PluginKind.PROVIDER)}"
+                if disabled_plugins:
+                    # A disabled plugin whose name differs from the backend could
+                    # still be the provider, so offer that path as a secondary fix.
+                    msg += (
+                        f" If instead this backend is provided by one of the"
+                        f" currently disabled plugins"
+                        f" ({', '.join(sorted(disabled_plugins))}), enable that plugin"
+                        f' or add `plugin = "<plugin-name>"` to this provider block.'
+                    )
             if strict:
                 raise ConfigParseError(msg) from e
             if not silent:

--- a/libs/mngr/imbue/mngr/config/loader_test.py
+++ b/libs/mngr/imbue/mngr/config/loader_test.py
@@ -309,8 +309,35 @@ def test_parse_providers_explicit_plugin_field_not_disabled() -> None:
 def test_parse_providers_unknown_backend_mentions_disabled_plugins() -> None:
     """_parse_providers error message should mention disabled plugins when they exist."""
     raw = {"my-provider": {"backend": "nonexistent"}}
-    with pytest.raises(ConfigParseError, match="Currently disabled plugins: modal"):
+    with pytest.raises(ConfigParseError, match="currently disabled plugins.*modal"):
         _parse_providers(raw, disabled_plugins=frozenset({"modal"}))
+
+
+def test_parse_providers_uninstalled_backend_suggests_install_not_plugin_field() -> None:
+    """An uninstalled backend should point at installing the plugin, not `plugin =`.
+
+    Setting `plugin = "<name>"` cannot resolve a backend whose plugin is not
+    installed at all, so the primary remediation must be the install hint. The
+    `plugin =` advice may only appear framed as a secondary "if instead" path.
+    """
+    raw = {"azure": {"backend": "azure"}}
+    with pytest.raises(ConfigParseError) as exc_info:
+        _parse_providers(raw, disabled_plugins=frozenset({"claude_subagent_proxy"}))
+    message = str(exc_info.value)
+    # The catalog names the concrete package to install.
+    assert "imbue-mngr-azure" in message
+    # The install hint must come before any secondary `plugin =` suggestion.
+    assert "plugin =" not in message.split("If instead")[0]
+
+
+def test_parse_providers_uninstalled_backend_no_disabled_plugins_omits_plugin_field() -> None:
+    """With no disabled plugins, the message must not mention `plugin =` at all."""
+    raw = {"azure": {"backend": "azure"}}
+    with pytest.raises(ConfigParseError) as exc_info:
+        _parse_providers(raw, disabled_plugins=frozenset())
+    message = str(exc_info.value)
+    assert "imbue-mngr-azure" in message
+    assert "plugin =" not in message
 
 
 def test_parse_providers_skips_disabled_provider_with_unknown_backend() -> None:


### PR DESCRIPTION
## Summary

The `Provider 'X' references unknown backend 'X'` config error told users to add `plugin = "<plugin-name>"` to the provider block whenever any plugin was disabled — advice that cannot resolve a backend whose plugin is **not installed at all**. Users who followed it hit the same error again, and the "Currently disabled plugins" list (which didn't include the missing backend) added to the confusion.

### Repro (before)
```
$ mngr config set --scope local providers.azure.plugin azure
ERROR Invalid configuration: Provider 'azure' references unknown backend 'azure'.
If this backend is provided by a disabled plugin, either enable the plugin or add
plugin = "<plugin-name>" to this provider block. Currently disabled plugins: claude_subagent_proxy
```

### After
```
Provider 'azure' references unknown backend 'azure'. This plugin is provided by
'imbue-mngr-azure' (Azure Virtual Machines provider backend plugin for mngr). Install
it (e.g. reinstall the mngr uv tool with '--with imbue-mngr-azure') and ensure the
plugin is enabled. If instead this backend is provided by one of the currently disabled
plugins (claude_subagent_proxy), enable that plugin or add plugin = "<plugin-name>" to
this provider block.
```

## Changes

- `config/loader.py` `_parse_providers`: an unregistered backend now leads with the concrete plugin install hint (via the existing catalog-backed `get_plugin_install_hint`), and only mentions the `plugin =` path as a secondary "if instead" option, and only when other plugins are disabled. The installed-but-disabled branch (backend name maps directly to a disabled plugin) is unchanged.
- Updated `test_parse_providers_unknown_backend_mentions_disabled_plugins` for the new phrasing; added two tests asserting the install hint is primary and that `plugin =` is not suggested when the plugin is uninstalled.
- Changelog entry.

## Testing

`uv run pytest libs/mngr/imbue/mngr/config/loader_test.py -k parse_providers` — 18 passed. Full `loader_test.py` run: 134 passed (40 errors are a local-environment artifact — a fixture runs `git init -b main` and this machine resolves an old Windows git without `-b`; unrelated to this change and green in CI sandboxes). Also manually verified all three message paths end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)