### PR TITLE
make tabcomplete get config keys from the schema

### DIFF
--- a/libs/mngr/changelog/ev-tab-complete-schema.md
+++ b/libs/mngr/changelog/ev-tab-complete-schema.md
@@ -1,0 +1,11 @@
+Tab-completion of config keys (`mngr config set/get/unset <TAB>` and `-S <TAB>`) is now schema-driven for the dict-container namespaces instead of only completing keys already present in your config:
+
+- `commands.<command>.<param>` completes every option of the command before you have set anything under it (e.g. `commands.destroy.<TAB>`), with boolean/choice options also completing their value. Group subcommands use their `<group>_<sub>` bucket (e.g. `commands.snapshot_create.*`).
+
+- `commands.<group>.default_subcommand` completes for each group that supports a configurable default, offering that group's subcommand names as values.
+
+- `pre_command_scripts.<command>` completes for every command, including the `<group>_<sub>` subcommand buckets.
+
+- `plugins.<name>.*` completes from the plugin config schema for every installed plugin, and a configured `providers.<name>.*` / `create_templates.<name>.*` now offers all settable fields from the schema, not just the ones already written.
+
+Fixed: completion previously emitted the internal `commands.<name>.defaults.<param>` and `create_templates.<name>.options.<param>` shapes, which do not round-trip through `mngr config set` (the parameter would be read literally as `defaults`/`options` and ignored at runtime). Completion now emits the correct user-facing `commands.<name>.<param>` / `create_templates.<name>.<param>` keys.

--- a/libs/mngr/imbue/mngr/cli/command_names.py
+++ b/libs/mngr/imbue/mngr/cli/command_names.py
@@ -1,0 +1,85 @@
+"""Authoritative registry of the ``command_name`` values used across the CLI.
+
+``command_name`` is the identifier each command passes to
+``setup_command_context`` / ``handle_common_options_and_run`` (``cli/common_opts.py``).
+It is the key under which a command draws its ``[commands.<name>]`` parameter
+defaults and runs its ``[pre_command_scripts.<name>]`` hooks.
+
+These values are *not* the click command names. Group subcommands are namespaced
+``<group>_<subcommand>`` (e.g. ``snapshot_create``, ``git_pull``) so that their
+flat, single-string config key cannot collide with a top-level command of the
+same leaf name. The ``config`` and ``plugin`` groups deliberately share one
+group-level bucket (``config`` / ``plugin``) across all their subcommands, since
+per-subcommand parameter defaults are not meaningful for those meta-commands.
+
+Because the mapping is a per-call-site convention with deliberate exceptions, it
+cannot be derived from the click tree. This frozenset is the single source of
+truth; ``command_names_test.py`` asserts it stays in exact sync with the
+``command_name="..."`` literals in the (non-test) source, so adding, renaming, or
+removing a command forces an update here. The completion writer consumes it to
+offer ``pre_command_scripts.<name>`` keys and to recognise which tree commands own
+a ``[commands.<name>]`` defaults bucket (so it does not offer keys for the
+group-level ``config`` / ``plugin`` subcommands, whose derived ``<group>_<sub>``
+names are absent here).
+"""
+
+from typing import Final
+
+import click
+
+from imbue.mngr.cli.default_command_group import DefaultCommandGroup
+from imbue.mngr.utils.click_utils import detect_alias_to_canonical
+
+KNOWN_CONFIG_COMMAND_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "archive",
+        "ask",
+        "capture",
+        "cleanup",
+        "clone",
+        "config",
+        "connect",
+        "create",
+        "destroy",
+        "event",
+        "exec",
+        "gc",
+        "git_pull",
+        "git_push",
+        "label",
+        "limit",
+        "list",
+        "message",
+        "migrate",
+        "observe",
+        "plugin",
+        "rename",
+        "rsync",
+        "snapshot_create",
+        "snapshot_destroy",
+        "snapshot_list",
+        "start",
+        "stop",
+        "transcript",
+    }
+)
+
+
+def build_default_subcommand_choices(cli_group: click.Group) -> dict[str, list[str]]:
+    """Map each ``DefaultCommandGroup._config_key`` to its canonical subcommand names.
+
+    These are the ``[commands.<config_key>].default_subcommand`` completion
+    targets: a group that supports a configurable default subcommand, keyed by the
+    config key it reads (the root group's key is ``mngr``), with its alias-free
+    subcommand names as the value choices. This lives in the cli layer -- where
+    ``DefaultCommandGroup`` is defined -- so the config-layer completion writer can
+    receive it as plain data rather than importing the class.
+    """
+    groups: list[click.Group] = [cli_group]
+    groups.extend(cmd for cmd in cli_group.commands.values() if isinstance(cmd, click.Group))
+    choices: dict[str, list[str]] = {}
+    for group in groups:
+        if isinstance(group, DefaultCommandGroup) and group._config_key is not None:
+            aliases = detect_alias_to_canonical(group)
+            choices[group._config_key] = sorted(name for name in group.commands.keys() if name not in aliases)
+    return choices

--- a/libs/mngr/imbue/mngr/cli/command_names_test.py
+++ b/libs/mngr/imbue/mngr/cli/command_names_test.py
@@ -1,0 +1,53 @@
+"""Keep ``KNOWN_CONFIG_COMMAND_NAMES`` in exact sync with the source literals.
+
+``command_name`` values are call-site literals with a deliberate convention
+(``<group>_<subcommand>`` for group subcommands, group-level buckets for
+``config`` / ``plugin``) that cannot be derived from the click tree, so the
+registry is maintained by hand. This test statically collects every
+``command_name="..."`` keyword argument in the (non-test) ``imbue.mngr`` source
+and asserts the registry matches it, so a new/renamed/removed command cannot
+silently drift the registry the completion writer relies on.
+"""
+
+import ast
+from pathlib import Path
+
+import imbue.mngr
+from imbue.mngr.cli.command_names import KNOWN_CONFIG_COMMAND_NAMES
+
+
+def _collect_command_name_literals(package_root: Path) -> set[str]:
+    """Return every ``command_name="<literal>"`` call keyword arg under ``package_root``.
+
+    Skips ``*_test.py`` / ``test_*.py`` files (their literals are fixtures, e.g.
+    ``command_name="test"``) and ignores non-constant ``command_name=`` arguments
+    (the ``on_before_command(command_name=command_name)`` variable pass-throughs),
+    so only real command-definition literals are collected.
+    """
+    literals: set[str] = set()
+    for py_file in package_root.rglob("*.py"):
+        if py_file.name.endswith("_test.py") or py_file.name.startswith("test_"):
+            continue
+        tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "command_name" and isinstance(keyword.value, ast.Constant):
+                    if isinstance(keyword.value.value, str):
+                        literals.add(keyword.value.value)
+    return literals
+
+
+def test_registry_matches_source_command_name_literals() -> None:
+    package_root = Path(imbue.mngr.__file__).parent
+    actual = _collect_command_name_literals(package_root)
+    registry = set(KNOWN_CONFIG_COMMAND_NAMES)
+
+    missing_from_registry = actual - registry
+    stale_in_registry = registry - actual
+    assert not missing_from_registry and not stale_in_registry, (
+        "KNOWN_CONFIG_COMMAND_NAMES is out of sync with the source. "
+        f"Add to the registry: {sorted(missing_from_registry)}. "
+        f"Remove from the registry (no longer used): {sorted(stale_in_registry)}."
+    )

--- a/libs/mngr/imbue/mngr/cli/list.py
+++ b/libs/mngr/imbue/mngr/cli/list.py
@@ -23,6 +23,8 @@ from imbue.mngr.api.list import ErrorInfo
 from imbue.mngr.api.list import ProviderErrorInfo
 from imbue.mngr.api.list import build_agent_cel_context
 from imbue.mngr.api.list import list_agents as api_list_agents
+from imbue.mngr.cli.command_names import KNOWN_CONFIG_COMMAND_NAMES
+from imbue.mngr.cli.command_names import build_default_subcommand_choices
 from imbue.mngr.cli.common_opts import add_common_options
 from imbue.mngr.cli.common_opts import setup_command_context
 from imbue.mngr.cli.completion_install import write_managed_completion_scripts
@@ -268,6 +270,8 @@ def _list_impl(ctx: click.Context, **kwargs) -> None:
                 "registered_agent_types": registered_agent_types,
                 "topic_names": topic_names,
                 "installed_plugin_packages": installed_plugin_packages,
+                "config_command_names": sorted(KNOWN_CONFIG_COMMAND_NAMES),
+                "default_subcommand_choices": build_default_subcommand_choices(cli_group),
             },
             name="completion-cache-writer",
             is_checked=False,

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -666,9 +666,7 @@ def _build_dynamic_completions(
         cli_group.commands.get("create"),
         {"agent_type_names": agent_type_names, "template_names": template_names, "provider_names": provider_names},
     )
-    template_keys, template_choices = _create_template_schema_completions(
-        config, dynamic_values, create_param_choices
-    )
+    template_keys, template_choices = _create_template_schema_completions(config, dynamic_values, create_param_choices)
     pre_command_script_keys = [
         f"pre_command_scripts.{name}"
         for name in sorted(command_name_set | {str(k) for k in config.pre_command_scripts.keys()})

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -344,6 +344,29 @@ def _is_container_namespace_key(key: str) -> bool:
     return key.split(".", 1)[0] in _CONTAINER_NAMESPACES
 
 
+def _collect_model_field_completions(
+    config_class: type[BaseModel],
+    prefix: tuple[str, ...],
+    dynamic_values: dict[str, list[str]],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Walk one config model's schema into completion keys and constrained-value choices.
+
+    Returns ``(keys, choices)``: one key per settable leaf field (dotted, under
+    ``prefix``), plus a value-choices entry for each field whose annotation
+    constrains its value (bool, enum, or a dynamic-source type). Shared by the
+    ``agent_types`` / ``plugins`` / ``providers`` namespace builders, which differ
+    only in how they resolve each entry's config class.
+    """
+    keys: list[str] = []
+    choices: dict[str, list[str]] = {}
+    for path, annotation, _description in walk_model_fields(config_class, prefix=prefix, recurse_optional=True):
+        keys.append(path)
+        value_choices = _value_choices_for_annotation(annotation, dynamic_values)
+        if value_choices is not None:
+            choices[path] = value_choices
+    return keys, choices
+
+
 def _agent_type_schema_completions(
     agent_type_names: list[str],
     config: MngrConfig,
@@ -366,13 +389,9 @@ def _agent_type_schema_completions(
     for name in agent_type_names:
         existing = config.agent_types.get(AgentTypeName(name))
         config_class = type(existing) if existing is not None else get_agent_config_class(name)
-        for path, annotation, _description in walk_model_fields(
-            config_class, prefix=("agent_types", name), recurse_optional=True
-        ):
-            keys.append(path)
-            value_choices = _value_choices_for_annotation(annotation, dynamic_values)
-            if value_choices is not None:
-                choices[path] = value_choices
+        sub_keys, sub_choices = _collect_model_field_completions(config_class, ("agent_types", name), dynamic_values)
+        keys.extend(sub_keys)
+        choices.update(sub_choices)
     return keys, choices
 
 
@@ -394,13 +413,9 @@ def _plugin_schema_completions(
     for name in names:
         existing = config.plugins.get(PluginName(name))
         config_class = type(existing) if existing is not None else PluginConfig
-        for path, annotation, _description in walk_model_fields(
-            config_class, prefix=("plugins", name), recurse_optional=True
-        ):
-            keys.append(path)
-            value_choices = _value_choices_for_annotation(annotation, dynamic_values)
-            if value_choices is not None:
-                choices[path] = value_choices
+        sub_keys, sub_choices = _collect_model_field_completions(config_class, ("plugins", name), dynamic_values)
+        keys.extend(sub_keys)
+        choices.update(sub_choices)
     return keys, choices
 
 
@@ -419,13 +434,11 @@ def _provider_schema_completions(
     keys: list[str] = []
     choices: dict[str, list[str]] = {}
     for name, instance in config.providers.items():
-        for path, annotation, _description in walk_model_fields(
-            type(instance), prefix=("providers", str(name)), recurse_optional=True
-        ):
-            keys.append(path)
-            value_choices = _value_choices_for_annotation(annotation, dynamic_values)
-            if value_choices is not None:
-                choices[path] = value_choices
+        sub_keys, sub_choices = _collect_model_field_completions(
+            type(instance), ("providers", str(name)), dynamic_values
+        )
+        keys.extend(sub_keys)
+        choices.update(sub_choices)
     return keys, choices
 
 

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -432,6 +432,7 @@ def _provider_schema_completions(
 def _create_template_schema_completions(
     config: MngrConfig,
     dynamic_values: dict[str, list[str]],
+    create_param_choices: dict[str, list[str]],
 ) -> tuple[list[str], dict[str, list[str]]]:
     """Build ``create_templates.<name>.*`` keys/choices for configured templates.
 
@@ -442,6 +443,11 @@ def _create_template_schema_completions(
     transparently unwrapped, user-facing key -- rather than only the params
     already present (and rather than the internal ``.options.<param>`` shape the
     instance dump would produce, which does not round-trip through ``config set``).
+
+    Value choices come from ``create_param_choices`` -- the ``create`` command's own
+    option choices, static and dynamic -- so a template option completes to the same
+    values ``mngr create --<opt>`` does (e.g. ``type`` -> agent type names). Fields
+    with no create-option choice fall back to what the annotation alone constrains.
     """
     keys: list[str] = []
     choices: dict[str, list[str]] = {}
@@ -449,7 +455,9 @@ def _create_template_schema_completions(
         for field_name, field_info in CreateCliOptions.model_fields.items():
             key = f"create_templates.{name}.{field_name}"
             keys.append(key)
-            value_choices = _value_choices_for_annotation(field_info.annotation, dynamic_values)
+            value_choices = create_param_choices.get(field_name)
+            if value_choices is None:
+                value_choices = _value_choices_for_annotation(field_info.annotation, dynamic_values)
             if value_choices is not None:
                 choices[key] = value_choices
     return keys, choices
@@ -466,6 +474,38 @@ def _option_value_choices(option: click.Option) -> list[str] | None:
     if option.is_flag:
         return ["true", "false"]
     return None
+
+
+def _create_command_param_choices(
+    create_cmd: click.Command | None,
+    dynamic_choice_values: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Map each ``create`` option's param name to its value choices (static + dynamic).
+
+    A create template's options are exactly the ``create`` command's options (a
+    template is validated against ``CreateCliOptions``), so a template option should
+    complete to the same values ``mngr create --<opt>`` does. Static choices come
+    from the option itself (booleans, ``click.Choice``); dynamic choices come from
+    ``_DYNAMIC_CHOICE_OPTIONS`` (e.g. ``--type`` -> agent type names, ``--provider``
+    -> provider names), looked up in ``dynamic_choice_values``. Returns an empty map
+    when the ``create`` command is absent (e.g. disabled).
+    """
+    if create_cmd is None:
+        return {}
+    choices: dict[str, list[str]] = {}
+    for param in create_cmd.params:
+        if not isinstance(param, click.Option) or not param.name:
+            continue
+        static_choices = _option_value_choices(param)
+        if static_choices is not None:
+            choices[param.name] = static_choices
+            continue
+        for opt in param.opts:
+            data_key = _DYNAMIC_CHOICE_OPTIONS.get(f"create.{opt}")
+            if data_key is not None and data_key in dynamic_choice_values:
+                choices[param.name] = dynamic_choice_values[data_key]
+                break
+    return choices
 
 
 def _iter_leaf_commands(cli_group: click.Group) -> Iterator[tuple[str | None, str, click.Command]]:
@@ -607,7 +647,15 @@ def _build_dynamic_completions(
     command_keys, command_choices = _command_defaults_completions(
         cli_group, config, command_name_set, default_subcommand_choices, dynamic_values
     )
-    template_keys, template_choices = _create_template_schema_completions(config, dynamic_values)
+    # A create template's option values complete like ``mngr create --<opt>``, so
+    # reuse the create command's own choices (incl. the dynamic ``--type`` etc.).
+    create_param_choices = _create_command_param_choices(
+        cli_group.commands.get("create"),
+        {"agent_type_names": agent_type_names, "template_names": template_names, "provider_names": provider_names},
+    )
+    template_keys, template_choices = _create_template_schema_completions(
+        config, dynamic_values, create_param_choices
+    )
     pre_command_script_keys = [
         f"pre_command_scripts.{name}"
         for name in sorted(command_name_set | {str(k) for k in config.pre_command_scripts.keys()})

--- a/libs/mngr/imbue/mngr/config/completion_writer.py
+++ b/libs/mngr/imbue/mngr/config/completion_writer.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from enum import Enum
 from typing import Any
 from typing import Final
@@ -12,11 +13,14 @@ from imbue.mngr.config.agent_config_registry import get_agent_config_class
 from imbue.mngr.config.completion_cache import COMPLETION_CACHE_FILENAME
 from imbue.mngr.config.completion_cache import CompletionCacheData
 from imbue.mngr.config.completion_cache import get_completion_cache_dir
+from imbue.mngr.config.data_types import CreateCliOptions
 from imbue.mngr.config.data_types import MngrConfig
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.data_types import PluginConfig
 from imbue.mngr.config.provider_config_registry import list_registered_provider_backend_names
 from imbue.mngr.plugin_catalog import get_installable_packages
 from imbue.mngr.primitives import AgentTypeName
+from imbue.mngr.primitives import PluginName
 from imbue.mngr.primitives import ProviderBackendName
 from imbue.mngr.utils.click_utils import detect_alias_to_canonical
 from imbue.mngr.utils.file_utils import atomic_write
@@ -325,9 +329,19 @@ def _is_excluded_config_key(key: str) -> bool:
     return any(key == prefix or key.startswith(f"{prefix}.") for prefix in _EXCLUDED_CONFIG_KEY_PREFIXES)
 
 
-def _is_agent_types_key(key: str) -> bool:
-    """Return True for the ``agent_types`` container key and any key under it."""
-    return key == "agent_types" or key.startswith("agent_types.")
+# Dict-container config namespaces whose completion keys are built from the
+# config *schema* (and enumerable key sources) rather than by flattening the
+# config instance. Their instance-dump keys use the internal
+# ``.defaults.``/``.options.`` shape and drop unset fields, so they are excluded
+# from the flattened base key set and re-emitted correctly per namespace.
+_CONTAINER_NAMESPACES: Final[frozenset[str]] = frozenset(
+    {"agent_types", "providers", "plugins", "commands", "create_templates", "pre_command_scripts"}
+)
+
+
+def _is_container_namespace_key(key: str) -> bool:
+    """Return True for any key under a schema-completed dict-container namespace."""
+    return key.split(".", 1)[0] in _CONTAINER_NAMESPACES
 
 
 def _agent_type_schema_completions(
@@ -362,14 +376,208 @@ def _agent_type_schema_completions(
     return keys, choices
 
 
+def _plugin_schema_completions(
+    plugin_names: list[str],
+    config: MngrConfig,
+    dynamic_values: dict[str, list[str]],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Build ``plugins.<name>.*`` keys/choices from each plugin's config schema.
+
+    Plugin names are enumerable (installed plugins), so each plugin's config
+    fields are offered even before anything is set for it. A configured plugin
+    with a plugin-specific ``PluginConfig`` subclass uses that subclass's schema;
+    otherwise the base ``PluginConfig`` (``enabled``) is walked.
+    """
+    keys: list[str] = []
+    choices: dict[str, list[str]] = {}
+    names = sorted(set(plugin_names) | {str(k) for k in config.plugins.keys()})
+    for name in names:
+        existing = config.plugins.get(PluginName(name))
+        config_class = type(existing) if existing is not None else PluginConfig
+        for path, annotation, _description in walk_model_fields(
+            config_class, prefix=("plugins", name), recurse_optional=True
+        ):
+            keys.append(path)
+            value_choices = _value_choices_for_annotation(annotation, dynamic_values)
+            if value_choices is not None:
+                choices[path] = value_choices
+    return keys, choices
+
+
+def _provider_schema_completions(
+    config: MngrConfig,
+    dynamic_values: dict[str, list[str]],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Build ``providers.<name>.*`` keys/choices from each configured provider's schema.
+
+    Provider instance names are user-chosen (not enumerable), so only configured
+    providers contribute -- but each is walked from its config *schema*, so all
+    settable fields (e.g. the discovery timeouts) are offered even when unset,
+    not just the fields the user already wrote (which is all the instance dump
+    would surface).
+    """
+    keys: list[str] = []
+    choices: dict[str, list[str]] = {}
+    for name, instance in config.providers.items():
+        for path, annotation, _description in walk_model_fields(
+            type(instance), prefix=("providers", str(name)), recurse_optional=True
+        ):
+            keys.append(path)
+            value_choices = _value_choices_for_annotation(annotation, dynamic_values)
+            if value_choices is not None:
+                choices[path] = value_choices
+    return keys, choices
+
+
+def _create_template_schema_completions(
+    config: MngrConfig,
+    dynamic_values: dict[str, list[str]],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Build ``create_templates.<name>.*`` keys/choices for configured templates.
+
+    Template names are user-chosen (not enumerable), so only configured templates
+    contribute. A template's options are validated against ``CreateCliOptions``
+    (see ``loader._parse_create_templates``), so every ``CreateCliOptions`` field
+    is offered as a settable ``create_templates.<name>.<param>`` -- the
+    transparently unwrapped, user-facing key -- rather than only the params
+    already present (and rather than the internal ``.options.<param>`` shape the
+    instance dump would produce, which does not round-trip through ``config set``).
+    """
+    keys: list[str] = []
+    choices: dict[str, list[str]] = {}
+    for name in config.create_templates.keys():
+        for field_name, field_info in CreateCliOptions.model_fields.items():
+            key = f"create_templates.{name}.{field_name}"
+            keys.append(key)
+            value_choices = _value_choices_for_annotation(field_info.annotation, dynamic_values)
+            if value_choices is not None:
+                choices[key] = value_choices
+    return keys, choices
+
+
+def _option_value_choices(option: click.Option) -> list[str] | None:
+    """Return the constrained value set for a click option, or None if freeform.
+
+    A ``click.Choice`` yields its choices; a boolean flag yields
+    ``["true", "false"]``. Everything else has no fixed value set.
+    """
+    if isinstance(option.type, click.Choice):
+        return [str(choice) for choice in option.type.choices]
+    if option.is_flag:
+        return ["true", "false"]
+    return None
+
+
+def _iter_leaf_commands(cli_group: click.Group) -> Iterator[tuple[str | None, str, click.Command]]:
+    """Yield ``(group_name, leaf_name, command)`` for every non-group command in the tree.
+
+    ``group_name`` is None for a top-level command and the group's canonical name
+    for a subcommand. Alias entries (registered under a name other than the
+    command's canonical name) are skipped so each command is yielded once, under
+    its canonical name.
+    """
+    top_aliases = detect_alias_to_canonical(cli_group)
+    for name, cmd in cli_group.commands.items():
+        if name in top_aliases:
+            continue
+        if isinstance(cmd, click.Group) and cmd.commands:
+            group_name = cmd.name or name
+            sub_aliases = detect_alias_to_canonical(cmd)
+            for sub_name, sub_cmd in cmd.commands.items():
+                if sub_name in sub_aliases:
+                    continue
+                yield group_name, (sub_cmd.name or sub_name), sub_cmd
+        else:
+            yield None, (cmd.name or name), cmd
+
+
+def _derive_command_name(group_name: str | None, leaf_name: str) -> str:
+    """Derive a command's ``command_name`` bucket from its position in the tree.
+
+    Top-level commands use their own name; group subcommands are namespaced
+    ``<group>_<subcommand>`` (matching the call-site literals -- see
+    ``cli/command_names.py``). Callers gate the result on the authoritative
+    registry, so a derived name that does not correspond to a real bucket (e.g.
+    ``config_set`` for the group-level ``config`` bucket) is discarded.
+    """
+    return leaf_name if group_name is None else f"{group_name}_{leaf_name}"
+
+
+def _command_defaults_completions(
+    cli_group: click.Group,
+    config: MngrConfig,
+    config_command_names: frozenset[str],
+    default_subcommand_choices: dict[str, list[str]],
+    dynamic_values: dict[str, list[str]],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Build ``commands.*`` completion keys/choices in the user-facing key shape.
+
+    Users set ``commands.<name>.<param>`` (the ``defaults`` wrapper is transparent
+    -- see ``config/key_resolver.py``), so keys are emitted flat, never in the
+    internal ``commands.<name>.defaults.<param>`` shape (which does not round-trip
+    through ``config set``). Three sources:
+
+    - Per-command parameter defaults: for every tree command whose derived
+      ``command_name`` (``<group>_<sub>`` for subcommands) owns a defaults bucket
+      (is in ``config_command_names``), each click option is offered as
+      ``commands.<command_name>.<param>`` -- discoverable before anything is set.
+      Boolean/choice options also complete their value. Gating on the registry
+      excludes the group-level ``config`` / ``plugin`` buckets, whose derived
+      per-subcommand names are absent from it.
+    - ``default_subcommand``: for every configurable-default group,
+      ``commands.<config_key>.default_subcommand`` with the group's subcommand
+      names as value choices. The (config_key -> subcommand names) mapping is
+      computed in the cli layer and passed in as ``default_subcommand_choices``.
+    - Already-configured params: any ``commands.<name>.<param>`` present in the
+      user's config, covering plugin-added options and the group-level buckets
+      that have no per-command tree entry.
+    """
+    keys: list[str] = []
+    choices: dict[str, list[str]] = {}
+
+    for group_name, leaf_name, cmd in _iter_leaf_commands(cli_group):
+        command_name = _derive_command_name(group_name, leaf_name)
+        if command_name not in config_command_names:
+            continue
+        for param in cmd.params:
+            if isinstance(param, click.Option) and param.expose_value and param.name:
+                key = f"commands.{command_name}.{param.name}"
+                keys.append(key)
+                value_choices = _option_value_choices(param)
+                if value_choices is not None:
+                    choices[key] = value_choices
+
+    for config_key, subcommand_names in default_subcommand_choices.items():
+        key = f"commands.{config_key}.default_subcommand"
+        keys.append(key)
+        if subcommand_names:
+            choices[key] = subcommand_names
+
+    for name, command_defaults in config.commands.items():
+        for param_name in command_defaults.defaults.keys():
+            keys.append(f"commands.{name}.{param_name}")
+
+    return keys, choices
+
+
 def _build_dynamic_completions(
     mngr_ctx: MngrContext,
     registered_agent_types: list[str],
+    cli_group: click.Group,
+    config_command_names: list[str],
+    default_subcommand_choices: dict[str, list[str]],
 ) -> _DynamicCompletions:
     """Build dynamic completion data from the runtime context.
 
     Extracts agent type names, template names, provider names, plugin names,
     and config keys from the live MngrContext for injection into the cache.
+
+    The dict-container config namespaces (``agent_types``, ``providers``,
+    ``plugins``, ``commands``, ``create_templates``, ``pre_command_scripts``) are
+    completed from the config *schema* and enumerable key sources (registered
+    agent/plugin names, the ``command_name`` registry, the command tree) rather
+    than from flattening the config instance, so every settable key -- not just
+    the already-configured ones -- is offered, in the correct user-facing shape.
     """
     config = mngr_ctx.config
 
@@ -387,21 +595,52 @@ def _build_dynamic_completions(
         "provider_backend_names": provider_backend_names,
     }
 
-    # The instance dump only covers agent types present in the user's config and
-    # drops unset container fields, so the ``agent_types.*`` keys/choices are
-    # instead derived from each known agent type's config *schema* (covering
-    # builtin types and fields like ``config_overrides`` even when unset).
+    command_name_set = frozenset(config_command_names)
+
+    # Each dict-container namespace's keys/choices come from the config schema
+    # (and its enumerable key source), not the instance dump -- so unset fields
+    # and, where the key source is authoritative (agent/plugin names, the command
+    # registry), unconfigured entries are still offered.
     schema_agent_keys, schema_agent_choices = _agent_type_schema_completions(agent_type_names, config, dynamic_values)
+    plugin_keys, plugin_choices = _plugin_schema_completions(plugin_names, config, dynamic_values)
+    provider_keys, provider_choices = _provider_schema_completions(config, dynamic_values)
+    command_keys, command_choices = _command_defaults_completions(
+        cli_group, config, command_name_set, default_subcommand_choices, dynamic_values
+    )
+    template_keys, template_choices = _create_template_schema_completions(config, dynamic_values)
+    pre_command_script_keys = [
+        f"pre_command_scripts.{name}"
+        for name in sorted(command_name_set | {str(k) for k in config.pre_command_scripts.keys()})
+    ]
 
-    instance_keys = [k for k in flatten_dict_keys(config.model_dump(mode="json")) if not _is_agent_types_key(k)]
-    config_keys = [k for k in (instance_keys + sorted(schema_agent_keys)) if not _is_excluded_config_key(k)]
+    # Non-container keys come from the instance dump unchanged; container keys are
+    # dropped here and replaced by the schema-derived keys above.
+    base_keys = [k for k in flatten_dict_keys(config.model_dump(mode="json")) if not _is_container_namespace_key(k)]
+    all_keys = (
+        base_keys
+        + schema_agent_keys
+        + plugin_keys
+        + provider_keys
+        + command_keys
+        + template_keys
+        + pre_command_script_keys
+    )
+    config_keys = sorted({k for k in all_keys if not _is_excluded_config_key(k)})
 
-    instance_choices = {
-        k: v for k, v in _extract_config_value_choices(config, dynamic_values).items() if not _is_agent_types_key(k)
+    base_choices = {
+        k: v
+        for k, v in _extract_config_value_choices(config, dynamic_values).items()
+        if not _is_container_namespace_key(k)
     }
-    config_value_choices = {
-        k: v for k, v in {**instance_choices, **schema_agent_choices}.items() if not _is_excluded_config_key(k)
+    merged_choices = {
+        **base_choices,
+        **schema_agent_choices,
+        **plugin_choices,
+        **provider_choices,
+        **command_choices,
+        **template_choices,
     }
+    config_value_choices = {k: v for k, v in merged_choices.items() if not _is_excluded_config_key(k)}
 
     return _DynamicCompletions(
         agent_type_names=agent_type_names,
@@ -420,6 +659,8 @@ def write_cli_completions_cache(
     registered_agent_types: list[str] | None = None,
     topic_names: list[str] | None = None,
     installed_plugin_packages: list[str] | None = None,
+    config_command_names: list[str] | None = None,
+    default_subcommand_choices: dict[str, list[str]] | None = None,
 ) -> None:
     """Write all CLI commands, options, and choices to the completions cache (best-effort).
 
@@ -445,6 +686,20 @@ def write_cli_completions_cache(
     ``mngr plugin remove`` positional argument. The caller passes these for the
     same layering reason as topic_names: the uv-tool receipt helper transitively
     imports the cli layer, which this writer must not depend on.
+
+    config_command_names is the authoritative set of ``command_name`` values
+    (``cli.command_names.KNOWN_CONFIG_COMMAND_NAMES``): the keys under which a
+    command owns its ``[commands.<name>]`` parameter defaults and
+    ``[pre_command_scripts.<name>]`` hooks. The caller passes it for the same
+    layering reason as topic_names (the registry lives in the cli layer); the
+    completion of ``commands.*`` / ``pre_command_scripts.*`` keys relies on it to
+    recognise which tree commands own a defaults bucket.
+
+    default_subcommand_choices maps each configurable-default group's config key
+    (see ``cli.command_names.build_default_subcommand_choices``) to its subcommand
+    names, so ``commands.<config_key>.default_subcommand`` completes with the right
+    values. The caller computes it because it depends on the cli-layer
+    ``DefaultCommandGroup`` type, which this writer must not import.
 
     Catches OSError from cache writes so filesystem failures do not break
     CLI commands. Other exceptions are allowed to propagate.
@@ -527,7 +782,17 @@ def write_cli_completions_cache(
             help_targets = sorted(canonical_names | set(topic_names or []))
 
         # Inject dynamic choice values from runtime context (config, registries)
-        dynamic = _build_dynamic_completions(mngr_ctx, registered_agent_types or []) if mngr_ctx is not None else None
+        dynamic = (
+            _build_dynamic_completions(
+                mngr_ctx,
+                registered_agent_types or [],
+                cli_group,
+                config_command_names or [],
+                default_subcommand_choices or {},
+            )
+            if mngr_ctx is not None
+            else None
+        )
         if dynamic is not None:
             dynamic_as_dict = dynamic._asdict()
             for opt_key, data_key in _DYNAMIC_CHOICE_OPTIONS.items():

--- a/libs/mngr/imbue/mngr/config/test_completion.py
+++ b/libs/mngr/imbue/mngr/config/test_completion.py
@@ -11,13 +11,24 @@ from pathlib import Path
 
 import click
 
+from imbue.imbue_common.model_update import to_update
 from imbue.mngr.agents.agent_registry import list_registered_agent_types
+from imbue.mngr.cli.command_names import KNOWN_CONFIG_COMMAND_NAMES
+from imbue.mngr.cli.command_names import build_default_subcommand_choices
 from imbue.mngr.cli.help_topics import get_all_topics
 from imbue.mngr.config.completion_cache import COMPLETION_CACHE_FILENAME
 from imbue.mngr.config.completion_cache import CompletionCacheData
 from imbue.mngr.config.completion_writer import write_cli_completions_cache
+from imbue.mngr.config.data_types import CommandDefaults
+from imbue.mngr.config.data_types import CreateTemplate
+from imbue.mngr.config.data_types import CreateTemplateName
 from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.data_types import PluginConfig
+from imbue.mngr.config.data_types import ProviderInstanceConfig
 from imbue.mngr.main import cli
+from imbue.mngr.primitives import PluginName
+from imbue.mngr.primitives import ProviderBackendName
+from imbue.mngr.primitives import ProviderInstanceName
 
 
 def _read_cache(cache_dir: Path) -> CompletionCacheData:
@@ -277,3 +288,171 @@ def test_every_option_is_classified(completion_cache_dir: Path) -> None:
     assert not missing, "The following CLI options are not in options_by_command in the cache:\n" + "\n".join(
         f"  {m}" for m in missing
     )
+
+
+def _schema_cache(completion_cache_dir: Path, mngr_ctx: MngrContext) -> CompletionCacheData:
+    """Write and read the cache for ``mngr_ctx`` with the full command-name registry.
+
+    The registry is what lets ``commands.*`` / ``pre_command_scripts.*`` keys be
+    offered for command buckets that are not yet configured, so pass it just as
+    the ``list`` command does.
+    """
+    write_cli_completions_cache(
+        cli_group=cli,
+        mngr_ctx=mngr_ctx,
+        registered_agent_types=list_registered_agent_types(),
+        config_command_names=sorted(KNOWN_CONFIG_COMMAND_NAMES),
+        default_subcommand_choices=build_default_subcommand_choices(cli),
+    )
+    return _read_cache(completion_cache_dir)
+
+
+def test_command_defaults_keys_are_schema_discoverable(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """``commands.<cmd>.<param>`` keys are offered before anything is configured.
+
+    Options complete from the command's click params (not from a flattened config
+    instance), so a param under an unconfigured command is discoverable, and a
+    boolean option completes ``true``/``false``. Group subcommands are namespaced
+    ``<group>_<sub>`` to match their ``command_name`` bucket.
+    """
+    assert "destroy" not in temp_mngr_ctx.config.commands
+    cache = _schema_cache(completion_cache_dir, temp_mngr_ctx)
+
+    # A top-level command's option is discoverable pre-config, and a boolean
+    # option (``--headless``, on every command) completes its value.
+    assert "commands.destroy.headless" in cache.config_keys
+    assert cache.config_value_choices.get("commands.destroy.headless") == ["true", "false"]
+
+    # A group subcommand uses the ``<group>_<sub>`` bucket name.
+    assert "commands.snapshot_create.headless" in cache.config_keys
+
+    # The group itself owns no per-command param bucket (only its subcommands do),
+    # so no ``commands.snapshot.<param>`` param keys are fabricated.
+    assert not any(
+        key.startswith("commands.snapshot.") and not key.endswith(".default_subcommand")
+        for key in cache.config_keys
+    )
+    # And the group-level ``config`` / ``plugin`` buckets, whose derived
+    # ``<group>_<sub>`` names are absent from the registry, contribute no params.
+    assert "commands.config_set.headless" not in cache.config_keys
+
+
+def test_default_subcommand_keys_come_from_group_config_keys(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Each ``DefaultCommandGroup`` offers ``commands.<config_key>.default_subcommand``.
+
+    The value choices are the group's canonical subcommand names (aliases are
+    excluded, since a default is best chosen by canonical name).
+    """
+    cache = _schema_cache(completion_cache_dir, temp_mngr_ctx)
+
+    assert "commands.snapshot.default_subcommand" in cache.config_keys
+    assert cache.config_value_choices.get("commands.snapshot.default_subcommand") == ["create", "destroy", "list"]
+
+    # The top-level group's default subcommand completes to canonical command
+    # names; alias entries (e.g. ``ls`` for ``list``) are filtered out.
+    mngr_choices = cache.config_value_choices.get("commands.mngr.default_subcommand")
+    assert mngr_choices is not None
+    assert "create" in mngr_choices
+    assert "list" in mngr_choices
+    assert "ls" not in mngr_choices
+
+
+def test_pre_command_scripts_keys_cover_registry(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Every ``command_name`` bucket is offered as a ``pre_command_scripts.<name>`` key.
+
+    These are complete leaf keys (the value is a free-form list of scripts), so
+    the whole set is discoverable before anything is configured, including the
+    ``<group>_<sub>`` subcommand buckets.
+    """
+    cache = _schema_cache(completion_cache_dir, temp_mngr_ctx)
+
+    expected = {f"pre_command_scripts.{name}" for name in KNOWN_CONFIG_COMMAND_NAMES}
+    assert expected <= set(cache.config_keys)
+    # Spot-check the namespaced subcommand buckets specifically.
+    assert "pre_command_scripts.snapshot_create" in cache.config_keys
+    assert "pre_command_scripts.git_pull" in cache.config_keys
+
+
+def test_provider_instance_keys_come_from_schema(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """A configured provider exposes all settable fields, not just the ones it set.
+
+    Provider instance names are user-chosen, so only configured providers appear
+    -- but each is walked from ``ProviderInstanceConfig``'s schema, so an unset
+    field is still offered and ``backend`` completes to the known backend names.
+    """
+    config = temp_mngr_ctx.config.model_copy_update(
+        to_update(
+            temp_mngr_ctx.config.field_ref().providers,
+            {ProviderInstanceName("myprov"): ProviderInstanceConfig(backend=ProviderBackendName("local"))},
+        )
+    )
+    mngr_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().config, config))
+    cache = _schema_cache(completion_cache_dir, mngr_ctx)
+
+    # An unset field of the configured provider is discoverable from the schema.
+    assert "providers.myprov.discovery_poll_interval_seconds" in cache.config_keys
+    # backend (a ProviderBackendName field) completes to the registered backends
+    # (only builtin backends are registered in the test env; plugin backends like
+    # docker are not loaded).
+    backend_choices = cache.config_value_choices.get("providers.myprov.backend")
+    assert backend_choices is not None
+    assert "local" in backend_choices
+
+
+def test_plugin_keys_come_from_schema(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """A configured plugin's fields complete from the ``PluginConfig`` schema."""
+    config = temp_mngr_ctx.config.model_copy_update(
+        to_update(temp_mngr_ctx.config.field_ref().plugins, {PluginName("claude"): PluginConfig(enabled=True)})
+    )
+    mngr_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().config, config))
+    cache = _schema_cache(completion_cache_dir, mngr_ctx)
+
+    assert "plugins.claude.enabled" in cache.config_keys
+    assert cache.config_value_choices.get("plugins.claude.enabled") == ["true", "false"]
+
+
+def test_configured_command_and_template_params_use_unwrapped_keys(
+    completion_cache_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Configured ``commands`` / ``create_templates`` params use the user-facing key shape.
+
+    Users set ``commands.<cmd>.<param>`` and ``create_templates.<name>.<param>``;
+    the internal ``defaults`` / ``options`` wrappers must never leak into the
+    completion keys (those don't round-trip through ``config set``). Templates
+    additionally expose all ``CreateCliOptions`` fields, so an unset one is
+    discoverable once the template exists.
+    """
+    config = temp_mngr_ctx.config.model_copy_update(
+        to_update(temp_mngr_ctx.config.field_ref().commands, {"create": CommandDefaults(defaults={"branch": "main"})}),
+        to_update(
+            temp_mngr_ctx.config.field_ref().create_templates,
+            {CreateTemplateName("dev"): CreateTemplate(options={"new_host": True})},
+        ),
+    )
+    mngr_ctx = temp_mngr_ctx.model_copy_update(to_update(temp_mngr_ctx.field_ref().config, config))
+    cache = _schema_cache(completion_cache_dir, mngr_ctx)
+
+    assert "commands.create.branch" in cache.config_keys
+    assert "create_templates.dev.new_host" in cache.config_keys
+    # An unset template option is still discoverable from CreateCliOptions.
+    assert "create_templates.dev.target_path" in cache.config_keys
+
+    # The internal wrapper segments must never appear.
+    assert not any(".defaults." in key for key in cache.config_keys)
+    assert not any(".options." in key for key in cache.config_keys)

--- a/libs/mngr/imbue/mngr/config/test_completion.py
+++ b/libs/mngr/imbue/mngr/config/test_completion.py
@@ -332,8 +332,7 @@ def test_command_defaults_keys_are_schema_discoverable(
     # The group itself owns no per-command param bucket (only its subcommands do),
     # so no ``commands.snapshot.<param>`` param keys are fabricated.
     assert not any(
-        key.startswith("commands.snapshot.") and not key.endswith(".default_subcommand")
-        for key in cache.config_keys
+        key.startswith("commands.snapshot.") and not key.endswith(".default_subcommand") for key in cache.config_keys
     )
     # And the group-level ``config`` / ``plugin`` buckets, whose derived
     # ``<group>_<sub>`` names are absent from the registry, contribute no params.

--- a/libs/mngr/imbue/mngr/config/test_completion.py
+++ b/libs/mngr/imbue/mngr/config/test_completion.py
@@ -453,6 +453,12 @@ def test_configured_command_and_template_params_use_unwrapped_keys(
     # An unset template option is still discoverable from CreateCliOptions.
     assert "create_templates.dev.target_path" in cache.config_keys
 
+    # A template option completes to the same values as the create command's
+    # option: ``type`` -> agent type names (a builtin like ``command``).
+    type_choices = cache.config_value_choices.get("create_templates.dev.type")
+    assert type_choices is not None
+    assert "command" in type_choices
+
     # The internal wrapper segments must never appear.
     assert not any(".defaults." in key for key in cache.config_keys)
     assert not any(".options." in key for key in cache.config_keys)


### PR DESCRIPTION
## Summary

`mngr config` tab-completion only completed keys already present in your config, so schema-discoverable keys under `commands.*`, `create_templates.*`, `plugins.*`, `pre_command_scripts.*` (and `providers.*`) were invisible until you'd already set something under them — backwards for a discovery feature.

Completion for the dict-container config namespaces is now schema-driven and sourced from enumerable key sources instead of a flattened config instance:

- **`commands.<cmd>.<param>`** — every option of a command, discoverable before anything is configured (e.g. `commands.destroy.<TAB>`); boolean/choice options also complete their value. Group subcommands use their `<group>_<sub>` bucket (e.g. `commands.snapshot_create.*`).
- **`commands.<group>.default_subcommand`** — for each `DefaultCommandGroup`, with that group's subcommand names as value choices.
- **`pre_command_scripts.<cmd>`** — for every `command_name` bucket, including the `<group>_<sub>` subcommands.
- **`plugins.<name>.*`** — from the `PluginConfig` schema for every installed plugin.
- **`providers.<name>.*` / `create_templates.<name>.*`** — all settable fields of a *configured* instance from the schema, not just the ones already written (same win `agent_types.*` already had). A template option also completes to the same values as the corresponding `mngr create --<opt>` (e.g. `create_templates.<name>.type` → agent type names, `.template` → template names, `.provider` → provider names).

### Bug fixed along the way

The old instance-dump completion emitted the **internal** `commands.<name>.defaults.<param>` and `create_templates.<name>.options.<param>` shapes. Those don't round-trip through `mngr config set` — the wrapper (`defaults`/`options`) is transparent to users (see `config/key_resolver.py`), so setting that key stores a parameter literally named `defaults`, which is silently ignored at runtime (with an "Unknown parameter" warning). Completion now emits the correct user-facing `commands.<name>.<param>` / `create_templates.<name>.<param>` keys.

### Why a command_name registry

The valid `commands.*` / `pre_command_scripts.*` bucket names are the `command_name` values passed at each call site, which are **not** derivable from the click tree: group subcommands are namespaced `<group>_<sub>` (`snapshot_create`, `git_pull`), while the `config` / `plugin` groups deliberately share one group-level bucket. So they're maintained as an authoritative registry (`cli/command_names.py::KNOWN_CONFIG_COMMAND_NAMES`) with a CI test (`command_names_test.py`) that statically asserts it stays in exact sync with the `command_name="..."` literals in the source — adding/renaming/removing a command forces an update.

Layering is preserved: the config-layer completion writer receives the registry and the `DefaultCommandGroup` default-subcommand mapping as data from the cli-layer caller (same pattern as `topic_names` / `installed_plugin_packages`).

## Testing

- New/updated unit tests in `config/test_completion.py` (schema discovery for each namespace, `<group>_<sub>` bucketing, `default_subcommand` choices minus aliases, template option value choices, and that no internal `.defaults.`/`.options.` keys leak) and `cli/command_names_test.py` (registry sync). All pass.
- Manually verified generated keys against a configured context, and verified round-trip: the new keys validate through `parse_config` while the old `.defaults.` shape is silently ineffective.
- `ruff`, `ty`, import-layer and getattr/inline-import/model_copy ratchets pass.
- Full local `just test-quick libs/mngr` run: the only failures/errors are pre-existing environment issues unrelated to this change (an older local `git` that predates `git init -b`, and tests that shell out to `sh -n -c` which executes rather than syntax-checks under dash). CI runs the suite on modern tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
