### PR TITLE
Make the mngr dev shim sync all workspace packages

### DIFF
--- a/dev/changelog/wz-mngr-shim-all-packages.md
+++ b/dev/changelog/wz-mngr-shim-all-packages.md
@@ -1,0 +1,9 @@
+The `mngr` dev shim (`scripts/mngr`) now runs `uv run --all-packages`, so it keeps the workspace venv complete instead of assuming someone already ran `uv sync --all-packages`.
+
+The workspace root project does not depend on `imbue-mngr` or any of its plugin packages, so a plain `uv run --project <root>` only guarantees the root's own dependencies. A venv synced without `--all-packages` produced two confusing failures:
+
+- A plugin's dependency could be missing while its entry point remained registered, so `mngr` died at startup on an unrelated import (e.g. `ModuleNotFoundError: No module named 'hypercorn'`, a dependency of `imbue-mngr-forward` only) no matter which subcommand you ran.
+
+- If `mngr` itself was missing from the venv, `uv run mngr` resolved `mngr` off `PATH`, found the shim, and re-executed it until uv aborted with "`uv run` was recursively invoked 101 times".
+
+Both now self-heal on the next `mngr` invocation. There is no measurable startup cost when the venv is already up to date.

--- a/dev/changelog/wz-mngr-shim-all-packages.md
+++ b/dev/changelog/wz-mngr-shim-all-packages.md
@@ -1,9 +1,12 @@
-The `mngr` dev shim (`scripts/mngr`) now runs `uv run --all-packages`, so it keeps the workspace venv complete instead of assuming someone already ran `uv sync --all-packages`.
+The `mngr` dev shim (`scripts/mngr`) now runs `uv run --all-packages`, so pulling a commit that adds a dependency to an mngr plugin no longer breaks the `mngr` command until you hand-run `uv sync --all-packages`.
 
-The workspace root project does not depend on `imbue-mngr` or any of its plugin packages, so a plain `uv run --project <root>` only guarantees the root's own dependencies. A venv synced without `--all-packages` produced two confusing failures:
+The workspace root project does not depend on `imbue-mngr` or any of its plugin packages, so the shim's `uv run --project <root>` never considered them and never installed their dependencies. Because plugins are editable workspace installs, a plugin kept its registered entry point across a pull while a newly declared dependency of it stayed missing -- and since `mngr` imports every entry point at startup, that broke *every* subcommand, not just the plugin's own:
 
-- A plugin's dependency could be missing while its entry point remained registered, so `mngr` died at startup on an unrelated import (e.g. `ModuleNotFoundError: No module named 'hypercorn'`, a dependency of `imbue-mngr-forward` only) no matter which subcommand you ran.
+```
+% mngr create my-agent
+ModuleNotFoundError: No module named 'hypercorn'
+```
 
-- If `mngr` itself was missing from the venv, `uv run mngr` resolved `mngr` off `PATH`, found the shim, and re-executed it until uv aborted with "`uv run` was recursively invoked 101 times".
+`hypercorn` is a dependency of `imbue-mngr-forward` alone, so nothing about `mngr create` hints at why it is needed.
 
-Both now self-heal on the next `mngr` invocation. There is no measurable startup cost when the venv is already up to date.
+The shim now converges the venv on each invocation, so this resolves itself on the next `mngr` call. There is no measurable startup cost when the venv is already up to date.

--- a/scripts/mngr
+++ b/scripts/mngr
@@ -42,4 +42,8 @@ else
     fi
 fi
 
-exec uv run --project "$uv_project" mngr "$@"
+# --all-packages is load-bearing: the workspace root does not depend on imbue-mngr
+# or its plugins, so without it uv only guarantees the root's own dependencies and
+# `mngr` may be absent from the venv -- in which case `uv run mngr` resolves `mngr`
+# off PATH, finds this shim, and re-execs itself until uv's recursion limit trips.
+exec uv run --all-packages --project "$uv_project" mngr "$@"

--- a/scripts/mngr
+++ b/scripts/mngr
@@ -43,7 +43,5 @@ else
 fi
 
 # --all-packages is load-bearing: the workspace root does not depend on imbue-mngr
-# or its plugins, so without it uv only guarantees the root's own dependencies and
-# `mngr` may be absent from the venv -- in which case `uv run mngr` resolves `mngr`
-# off PATH, finds this shim, and re-execs itself until uv's recursion limit trips.
+# or its plugins, so uv would otherwise leave their dependencies uninstalled.
 exec uv run --all-packages --project "$uv_project" mngr "$@"


### PR DESCRIPTION
## Problem

`scripts/mngr` (the dev shim on `PATH`) ran `uv run --project "$uv_project" mngr "$@"`.

The workspace root project `imbue` depends only on `pytest-xdist`, `ty`, and `click` -- **not** on `imbue-mngr` or any of its plugin packages. So `uv run --project <root>` never considered the plugins at all, and never installed their dependencies. The shim silently relied on the developer having run `uv sync --all-packages` at some earlier point, and never re-established that invariant itself.

### What this actually costs us

This is not an exotic drift scenario. It fires whenever anyone adds a dependency to an mngr plugin, for every developer who then pulls:

```
60277504dd 2026-07-09 Gabriel Guralnick  Add TLS + HTTP/2 for the workspace UI at the `mngr forward` proxy
```

That commit (on main since 3618ee1d54) added `hypercorn` to `imbue-mngr-forward`'s dependencies. `mngr_forward` has been an editable workspace install since 2026-05-04, so across a `git pull` its dist-info and entry point stay valid and its source stays importable -- only the *newly declared* dependency is absent. And mngr imports every registered `mngr` entry point at startup, so a dependency belonging to *one* plugin breaks *every* subcommand:

```
% mngr c repro-2457 --branch main
  File "libs/mngr_forward/imbue/mngr_forward/cli.py", line 18, in <module>
    from hypercorn.asyncio import serve as hypercorn_serve
ModuleNotFoundError: No module named 'hypercorn'
```

Nothing about `mngr create` suggests why it would need an ASGI server. The shim will not fix this on any number of subsequent invocations; it stays broken until someone hand-runs `uv sync --all-packages`.

### A second, sharper failure mode

Not observed in the wild, but reachable and demonstrated below: if `mngr` is missing from the venv *entirely* (e.g. after a bare `uv sync`, which is exact and prunes every workspace member), then `uv run mngr` falls back to resolving `mngr` off `PATH` -- where it finds this shim, which re-execs `uv run mngr`:

```
error: `uv run` was recursively invoked 101 times which exceeds the limit of 100
```

## Fix

Pass `--all-packages`, so the shim converges the venv on every invocation instead of assuming it:

```diff
-exec uv run --project "$uv_project" mngr "$@"
+exec uv run --all-packages --project "$uv_project" mngr "$@"
```

Both failure modes now resolve themselves on the next `mngr` call. This also brings the shim in line with `CLAUDE.md`, which already tells developers never to run bare `uv sync`.

## Verification

Driven against a scratch `UV_PROJECT_ENVIRONMENT` so the real `.venv` was never touched (confirmed afterward: `uv sync --all-packages --dry-run` -> "Would make no changes").

- Pre-fix, root-only env: reproduces the recursion abort above.
- Post-fix, from no venv at all: `Installed 303 packages in 419ms` / `mngr 0.2.17`, with `hypercorn` present.
- Startup cost on an already-current venv: 1.29s vs 1.31s across 3 runs each -- no measurable difference. mngr's own import time dominates; uv's consistency check is ~20ms.
- `shellcheck scripts/mngr` clean; the `MNGR_DEV_SHIM_V1` marker that `scripts/check_mngr_shim.sh` greps for is unchanged.

## Note for reviewers

There is no automated test here. Covering this means constructing a deliberately-incomplete venv and asserting `mngr` still runs, which is slow and awkward for a dev-only script -- I judged it not worth a release test, but am happy to add one if you disagree.

Related: the justfile has the same latent assumption in `uv run minds env deploy` and friends (`minds` is a workspace member, not a root dep). Those fail with a plain "command not found" rather than recursing, so they are far less confusing, and I left them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)