### PR TITLE
Bump Latchkey version to 2.20.2.

### DIFF
--- a/apps/minds/changelog/hynek-bump-latchkey-to-2.20.2.md
+++ b/apps/minds/changelog/hynek-bump-latchkey-to-2.20.2.md
@@ -1,0 +1,1 @@
+Update Latchkey to include support for GitHub's GraphQL API.

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@sentry/electron": "^7.13.0",
     "@todesktop/runtime": "^1.6.0",
-    "latchkey": "^2.20.0",
+    "latchkey": "^2.20.2",
     "smol-toml": "^1.6.1"
   },
   "devDependencies": {

--- a/apps/minds/pnpm-lock.yaml
+++ b/apps/minds/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.4
       latchkey:
-        specifier: ^2.20.0
-        version: 2.20.0
+        specifier: ^2.20.2
+        version: 2.20.2
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
@@ -292,8 +292,8 @@ packages:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
 
-  '@imbue-ai/detent@1.8.0':
-    resolution: {integrity: sha512-YSwXcdWYnSRRtEG8FV+yIguwFBA8Hy+g4WFfisBNiimcc8tH52EQSJ2InA06z8X1L6W1zNV285tG0EiWWZrr1w==}
+  '@imbue-ai/detent@1.9.0':
+    resolution: {integrity: sha512-LbzPZNWx+v4JXLw9/v52dlhwO/3ou/jckpsfFjXDyoBbmrMrBBlaRDgwgvoBxy3s0we+8jIM8N82ftnxJGzuZA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -1970,8 +1970,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  latchkey@2.20.0:
-    resolution: {integrity: sha512-jlCdWTa/DksDTqr+qtU5+T5zzFtuwDP7fPumZoKan5hzXphDN/BLSaLsv3Z/QR5UjQwngvp4Ou3CDWCcvuyUNg==}
+  latchkey@2.20.2:
+    resolution: {integrity: sha512-mYTVeF4m6ZHnFvVSnSkVcLF6CFUmh9wnUCbLwmM/ocwghETgzfUKVy32IE87jvtDasq68sOsUJmysbDyHqrEdA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -3266,7 +3266,7 @@ snapshots:
 
   '@humanwhocodes/momoa@2.0.4': {}
 
-  '@imbue-ai/detent@1.8.0':
+  '@imbue-ai/detent@1.9.0':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       commander: 14.0.3
@@ -5137,9 +5137,9 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  latchkey@2.20.0:
+  latchkey@2.20.2:
     dependencies:
-      '@imbue-ai/detent': 1.8.0
+      '@imbue-ai/detent': 1.9.0
       '@napi-rs/keyring': 1.2.0
       commander: 12.1.0
       playwright: 1.60.0

--- a/libs/mngr_latchkey/changelog/hynek-bump-latchkey-to-2.20.2.md
+++ b/libs/mngr_latchkey/changelog/hynek-bump-latchkey-to-2.20.2.md
@@ -1,0 +1,1 @@
+Update Latchkey to include support for GitHub's GraphQL API.

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/core.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/core.py
@@ -103,7 +103,7 @@ _VERSION_CHECK_TIMEOUT_SECONDS: Final[float] = 5.0
 # ``LATCHKEY_VERSION``). 2.18.0 was the first release with the ``auth prepare``
 # subcommand, which the Minds Google OAuth flow (:meth:`Latchkey.auth_prepare`)
 # depends on.
-LATCHKEY_MIN_VERSION: Final[str] = "2.19.1"
+LATCHKEY_MIN_VERSION: Final[str] = "2.20.2"
 
 # Fixed port that every containerized/VM/VPS agent sees on its own 127.0.0.1
 # when reaching the Latchkey gateway. A per-agent SSH reverse tunnel bridges

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/services.json
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/extensions/services.json
@@ -141,7 +141,7 @@
     {
       "scope": "github-rest-api",
       "display_name": "GitHub (REST API)",
-      "description": "Any interaction with the GitHub REST API, excluding GraphQL.",
+      "description": "Any interaction with the GitHub REST API.",
       "permissions": [
         {
           "name": "github-read-all",
@@ -200,6 +200,12 @@
           "description": "Mark notifications as read or manage notification subscriptions."
         }
       ]
+    },
+    {
+      "scope": "github-graphql-api",
+      "display_name": "GitHub (GraphQL API)",
+      "description": "Any interaction with the GitHub GraphQL API.",
+      "permissions": []
     },
     {
       "scope": "github-git",

--- a/libs/mngr_latchkey/imbue/mngr_latchkey/remote_gateway.py
+++ b/libs/mngr_latchkey/imbue/mngr_latchkey/remote_gateway.py
@@ -52,7 +52,7 @@ from imbue.mngr_latchkey.store import permissions_path_for_host
 from imbue.mngr_latchkey.store import plugin_data_dir
 
 # Version of the upstream ``latchkey`` CLI to install on the VPS.
-LATCHKEY_VERSION: Final[str] = "2.20.0"
+LATCHKEY_VERSION: Final[str] = "2.20.2"
 
 # Port inside the container on which the VPS-resident gateway is reachable (the
 # VPS->container reverse tunnel binds it). Deliberately distinct from

--- a/libs/mngr_latchkey/scripts/generate_services_json.py
+++ b/libs/mngr_latchkey/scripts/generate_services_json.py
@@ -70,6 +70,7 @@ _DISPLAY_NAME_BY_SCOPE: Final[Mapping[str, str]] = {
     "slack-api": "Slack",
     "discord-api": "Discord",
     "github-rest-api": "GitHub (REST API)",
+    "github-graphql-api": "GitHub (GraphQL API)",
     "github-git": "GitHub (git)",
     "gitlab-api": "GitLab (REST API)",
     "gitlab-git": "GitLab (git)",


### PR DESCRIPTION
This bumps Latchkey which adds support for GitHub's GraphQL api, as requested by Gabe here: https://imbue-ai.slack.com/archives/C0AAG6UQU57/p1783976648507519

<img width="636" height="443" alt="github-graphql-permission-request" src="https://github.com/user-attachments/assets/9e96fff4-7696-4899-9c49-7644592d6d80" />

