### PR TITLE
minds: skip Docker state-container ops when the daemon is unreachable

### DIFF
--- a/apps/minds/changelog/mngr-minds-docker-daemon-probe.md
+++ b/apps/minds/changelog/mngr-minds-docker-daemon-probe.md
@@ -1,0 +1,3 @@
+Fixed a ~60s hang on app launch and on quit when the local Docker daemon is unresponsive. Minds starts and stops an mngr Docker "state container" around its lifecycle; if the Docker daemon was wedged (its socket accepts connections but never replies -- e.g. Docker Desktop still starting up, resuming from sleep, or stuck), each `docker start`/`docker stop` blocked until its 60-second command timeout, delaying the backend coming up (launch) and the app closing (quit).
+
+Launch and quit now probe daemon reachability first (`docker version`, bounded to 5 seconds) and skip the state-container operation when the daemon is unreachable, wedged, or absent. A healthy daemon answers in well under a second, so normal launches are unaffected.

--- a/apps/minds/imbue/minds/envs/docker_cleanup.py
+++ b/apps/minds/imbue/minds/envs/docker_cleanup.py
@@ -42,6 +42,11 @@ _USER_ID_FILENAME: Final[str] = "user_id"
 
 _DOCKER_CMD_TIMEOUT_SECONDS: Final[float] = 60.0
 
+# A wedged Docker daemon (socket present but unresponsive) makes a docker command
+# block until its full timeout; a liveness probe bounded to this shorter timeout
+# lets state-container ops skip fast instead of hanging for the command timeout.
+_DOCKER_DAEMON_PROBE_TIMEOUT_SECONDS: Final[float] = 5.0
+
 
 class DockerCleanupError(MindError):
     """Raised when a present Docker state container / volume cannot be removed."""
@@ -87,6 +92,7 @@ def _run_docker_command(
     *,
     parent_concurrency_group: ConcurrencyGroup,
     scope_name: str,
+    timeout: float = _DOCKER_CMD_TIMEOUT_SECONDS,
 ) -> FinishedProcess:
     """Run one ``docker`` subprocess to completion in its own CG scope, returning the result *after* the CG exits.
 
@@ -108,7 +114,7 @@ def _run_docker_command(
         try:
             result = cg.run_process_to_completion(
                 command=command,
-                timeout=_DOCKER_CMD_TIMEOUT_SECONDS,
+                timeout=timeout,
                 is_checked_after=False,
                 env=dict(os.environ),
             )
@@ -118,6 +124,29 @@ def _run_docker_command(
         raise setup_error
     assert result is not None
     return result
+
+
+def _is_docker_daemon_reachable(
+    parent_concurrency_group: ConcurrencyGroup,
+    *,
+    timeout: float = _DOCKER_DAEMON_PROBE_TIMEOUT_SECONDS,
+) -> bool:
+    """Whether the Docker daemon answers ``docker version`` within ``timeout``.
+
+    False for a missing docker CLI, an unreachable daemon, or a *wedged* daemon
+    (socket present but unresponsive). Gating a state-container op on this bounds
+    the wedged-daemon case to the probe timeout instead of the command timeout.
+    """
+    try:
+        probe = _run_docker_command(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            parent_concurrency_group=parent_concurrency_group,
+            scope_name="docker-daemon-probe",
+            timeout=timeout,
+        )
+    except ProcessSetupError:
+        return False
+    return probe.returncode == 0 and not probe.is_timed_out
 
 
 def remove_state_container(
@@ -133,8 +162,12 @@ def remove_state_container(
     a success. But when the container is present and ``docker rm`` fails,
     this raises :class:`DockerCleanupError` so a real failure surfaces.
     """
-    # Probe for the container. This also distinguishes "no docker daemon"
-    # (skip) from "container already gone" (success).
+    if not _is_docker_daemon_reachable(parent_concurrency_group):
+        logger.info("Docker daemon unavailable; skipping state-container cleanup for {}", container_name)
+        return
+
+    # Probe for the container. This distinguishes "container already gone"
+    # (success) from a present container to remove.
     try:
         inspect_result = _run_docker_command(
             ["docker", "container", "inspect", container_name],
@@ -201,6 +234,10 @@ def stop_state_container(
     already stopped is a success. A present, running container that fails to
     stop raises :class:`DockerCleanupError`.
     """
+    if not _is_docker_daemon_reachable(parent_concurrency_group):
+        logger.info("Docker daemon unavailable; skipping state-container stop for {}", container_name)
+        return
+
     try:
         stop_result = _run_docker_command(
             ["docker", "stop", container_name],
@@ -275,6 +312,10 @@ def start_state_container(
     is a success -- it is created lazily on the first ``mngr create``. A present
     container that fails to start raises :class:`DockerCleanupError`.
     """
+    if not _is_docker_daemon_reachable(parent_concurrency_group):
+        logger.info("Docker daemon unavailable; skipping state-container start for {}", container_name)
+        return
+
     try:
         start_result = _run_docker_command(
             ["docker", "start", container_name],

--- a/apps/minds/imbue/minds/envs/docker_cleanup_test.py
+++ b/apps/minds/imbue/minds/envs/docker_cleanup_test.py
@@ -8,6 +8,7 @@ import pytest
 
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.minds.envs.docker_cleanup import DockerCleanupError
+from imbue.minds.envs.docker_cleanup import _is_docker_daemon_reachable
 from imbue.minds.envs.docker_cleanup import _is_docker_daemon_unavailable
 from imbue.minds.envs.docker_cleanup import cleanup_env_state_container
 from imbue.minds.envs.docker_cleanup import read_profile_user_id
@@ -35,19 +36,49 @@ def _write_profile(mngr_host_dir: Path, *, profile_id: str, user_id: str) -> Non
     (profile_dir / "user_id").write_text(f"{user_id}\n")
 
 
-def _install_fake_docker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, exit_code: int, stderr: str) -> None:
+def _install_fake_docker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    exit_code: int,
+    stderr: str,
+    is_daemon_reachable: bool = True,
+) -> None:
     """Put a fake ``docker`` on PATH that prints ``stderr`` and exits ``exit_code``.
 
     Lets the cleanup functions be exercised against a controlled ``docker``
     failure (e.g. a reachable-but-paused daemon) with no real daemon, so the
-    tests are fast and deterministic.
+    tests are fast and deterministic. ``docker version`` (the daemon-reachability
+    probe) succeeds when ``is_daemon_reachable``, so a reachable daemon that
+    refuses the op still reaches the op's failure.
     """
     bin_dir = tmp_path / "fake-bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     docker = bin_dir / "docker"
-    docker.write_text(f"#!/bin/sh\nprintf '%s' {shlex.quote(stderr)} 1>&2\nexit {exit_code}\n")
+    version_branch = 'if [ "$1" = "version" ]; then echo 28.0.0; exit 0; fi\n' if is_daemon_reachable else ""
+    docker.write_text(f"#!/bin/sh\n{version_branch}printf '%s' {shlex.quote(stderr)} 1>&2\nexit {exit_code}\n")
     docker.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+
+def _install_recording_docker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, version_script: str) -> Path:
+    """Put a fake ``docker`` on PATH that appends every invocation's argv to a log it returns.
+
+    ``version_script`` is the shell body for the ``docker version`` branch --
+    ``exit 0`` (reachable), ``exit 1`` (unreachable), or ``sleep N`` (wedged);
+    every other subcommand succeeds. The returned calls-log path lets a test
+    assert which subcommands were (never) attempted.
+    """
+    bin_dir = tmp_path / "fake-bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    calls_log = bin_dir / "calls.log"
+    docker = bin_dir / "docker"
+    docker.write_text(
+        f'#!/bin/sh\necho "$@" >> {shlex.quote(str(calls_log))}\nif [ "$1" = "version" ]; then {version_script}; fi\nexit 0\n'
+    )
+    docker.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    return calls_log
 
 
 # "Docker Desktop is manually paused" is a reachable daemon that *refuses* the
@@ -180,6 +211,52 @@ def test_start_state_container_daemon_unavailable_message_is_noop(
     start_state_container(
         container_name=f"minds-staging-docker-state-{uuid4().hex}", parent_concurrency_group=_root_cg
     )
+
+
+def test_is_docker_daemon_reachable_true_when_version_succeeds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    _install_recording_docker(monkeypatch, tmp_path, version_script="exit 0")
+    assert _is_docker_daemon_reachable(_root_cg) is True
+
+
+def test_is_docker_daemon_reachable_false_when_daemon_unreachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    _install_recording_docker(monkeypatch, tmp_path, version_script="exit 1")
+    assert _is_docker_daemon_reachable(_root_cg) is False
+
+
+def test_is_docker_daemon_reachable_false_when_daemon_wedged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    # A wedged daemon accepts the socket connection but never replies, so
+    # ``docker version`` hangs. The probe must give up at its timeout and report
+    # unreachable instead of blocking for the full command timeout -- the launch
+    # / quit hang this fixes.
+    _install_recording_docker(monkeypatch, tmp_path, version_script="sleep 30; exit 0")
+    assert _is_docker_daemon_reachable(_root_cg, timeout=0.5) is False
+
+
+def test_start_state_container_skips_without_attempting_start_when_daemon_unreachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    # The launch-time fix: an unreachable daemon short-circuits before
+    # ``docker start``, so a stuck daemon can never block the container start.
+    calls_log = _install_recording_docker(monkeypatch, tmp_path, version_script="exit 1")
+    start_state_container(
+        container_name=f"minds-staging-docker-state-{uuid4().hex}", parent_concurrency_group=_root_cg
+    )
+    assert "start" not in (calls_log.read_text() if calls_log.exists() else "")
+
+
+def test_stop_state_container_skips_without_attempting_stop_when_daemon_unreachable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _root_cg: ConcurrencyGroup
+) -> None:
+    # The quit-time fix: the same short-circuit before ``docker stop``.
+    calls_log = _install_recording_docker(monkeypatch, tmp_path, version_script="exit 1")
+    stop_state_container(container_name=f"minds-staging-docker-state-{uuid4().hex}", parent_concurrency_group=_root_cg)
+    assert "stop" not in (calls_log.read_text() if calls_log.exists() else "")
 
 
 @pytest.mark.acceptance


### PR DESCRIPTION
## Bug

Minds `docker start`s a Docker "state container" at launch and `docker stop`s it at quit. If the daemon is **wedged** (socket accepts connections but never replies -- Docker Desktop starting up, or a stuck VM), both block the full **60s** command timeout -> 60s slow launch, 60s slow quit.

The old daemon-down fast path only caught a *fast* "Cannot connect" (cleanly-down daemon). A wedge returns nothing, so the 60s elapsed.

## Fix

Gate `start` / `stop` / `remove` on a reachability probe: `docker version --format '{{.Server.Version}}'`, **5s** timeout. Unreachable / wedged / absent -> fast no-op. Healthy daemon answers in <1s -> unchanged. Host-side only; no in-VM agent API change.

## Verified

- **Real wedged Docker Desktop**, real state-container name: patched `start_state_container` / `stop_state_container` returned in **5.0s** each (was ~60s).
- **Original bug, from logs**: launch had a 67s gap ending in `docker start ... exceeded its 60s timeout`; quit had `before-quit` -> `stop-state-container HTTP 500` 67s later.
- **Unit tests** (+5): probe returns True (healthy) / False (unreachable) / False via the 5s timeout (wedged, `sleep`-based fake); `start` / `stop` never invoke `docker start` / `stop` when unreachable. Existing "paused daemon raises" tests updated -- a paused daemon is *reachable* (answers `version`), so the probe lets it through to the real failure.
- **Controlled wedge repro (`kill -STOP`)**: froze all `com.docker.backend` pids on a healthy Docker Desktop -> raw `docker version` hung the full 8s; against that induced wedge the patched `_is_docker_daemon_reachable` returned `False` in 5.1s (probe SIGTERM'd at the 5s bound) and `start_state_container` returned in **5.1s** (was ~60s), logging "Docker daemon unavailable; skipping state-container start"; `kill -CONT` restored the daemon to healthy (0.0s). So the wedge is deterministically reproducible and the fix bounds it to one 5s probe.
- **End-to-end** ([run 29393502938](https://github.com/imbue-ai/mngr/actions/runs/29393502938), build `260715x48qyj0e3`): full ToDesktop build + `launch-to-msg` **green** -- create-agent + first-message round-trip through the built binary, i.e. no regression on a healthy daemon. (CI cannot reproduce a *wedged* daemon, so this covers the healthy path, not the wedge.)

## Dropped

An earlier draft also moved the launch start to a background thread (0s critical path). Dropped -- it re-introduced a discovery race where docker agents could be briefly missing after launch with no obvious cause. The probe gate alone fixes both paths and keeps the original "container up before discovery" ordering.
