### PR TITLE
Release minds v0.3.7: bump version + FALLBACK_BRANCH

### DIFF
--- a/apps/minds/changelog/mngr-release37.md
+++ b/apps/minds/changelog/mngr-release37.md
@@ -1,0 +1,1 @@
+Release minds v0.3.7: bump the app version and the baked default-workspace-template tag (`FALLBACK_BRANCH`) to `minds-v0.3.7`. This release pairs the current mngr `main` with a default-workspace-template snapshot that includes the earlyoom OOM-prioritization changes.

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -285,7 +285,7 @@ _FALLBACK_GIT_URL: Final[str] = DEFAULT_WORKSPACE_TEMPLATE_GIT_URL
 # Pin to an annotated DEFAULT_WORKSPACE_TEMPLATE tag so a shipped binary clones the exact DEFAULT_WORKSPACE_TEMPLATE
 # snapshot it was verified against. Bump to a newer tag only after
 # re-verifying launch-to-msg CI against (this binary, the new tag).
-FALLBACK_BRANCH: Final[str] = "minds-v0.3.6"
+FALLBACK_BRANCH: Final[str] = "minds-v0.3.7"
 
 # Env var (set by ``just minds-start`` and the e2e workspace runner) that opts a
 # launch into the operator's local-worktree create-form defaults. Gating on an

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minds",
   "productName": "Minds",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Minds - Self-improving, persistent AI agents",
   "homepage": "https://github.com/imbue-ai/mngr",
   "author": "Imbue <dev@imbue.com>",


### PR DESCRIPTION
Bumps `apps/minds/package.json` version 0.3.6 -> 0.3.7 and `templates.py` `FALLBACK_BRANCH` to `minds-v0.3.7`. Pairs current mngr `main` with a default-workspace-template snapshot that includes the earlyoom OOM changes (dwt PR #220). No functional mngr/minds code change; this is the release bump for `minds-v0.3.7`.

Verification is via `minds-launch-to-msg.yml` on the release SHA + the paired dwt `vendor/mngr` refresh, not this PR's traditional CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqDWjbY29bAJ8tmPbfShFS