### PR TITLE
Never tombstone records before their provider's first snapshot; resurrect premature tombstones

### DIFF
--- a/apps/minds/changelog/mngr-fix-absent-tombstone-race.md
+++ b/apps/minds/changelog/mngr-fix-absent-tombstone-race.md
@@ -1,0 +1,3 @@
+Fixed synced workspaces being silently de-associated by a startup race: the absent-host tombstone pass could tombstone a workspace record while its provider was merely slow to produce its first discovery listing (e.g. a stopped lima VM right after app start), pushing a spurious "destroyed" state to the connector. The pass now requires the record's specific provider to have produced at least one snapshot before treating absence as evidence.
+
+Added the inverse safety net: a tombstoned record hosted by this install whose workspace is live in local discovery is automatically re-activated and re-pushed (self-healing rows tombstoned by the old race), guarded so an in-flight destroy or a genuinely-destroyed host lingering in discovery is never resurrected.

--- a/apps/minds/imbue/minds/desktop_client/destroying.py
+++ b/apps/minds/imbue/minds/desktop_client/destroying.py
@@ -383,6 +383,15 @@ def list_destroying(
     return records
 
 
+def has_destroying_marker(agent_id: AgentId, paths: WorkspacePaths) -> bool:
+    """Whether a destroy has been requested for this workspace (marker dir exists).
+
+    Cheaper than :func:`read_destroying` when only "is a destroy in flight or
+    recently finished?" matters (e.g. the record-resurrection guard).
+    """
+    return _destroying_dir(paths, agent_id).exists()
+
+
 def delete_destroying(agent_id: AgentId, paths: WorkspacePaths) -> bool:
     """Remove ``<paths.data_dir>/destroying/<agent_id>/``. Idempotent.
 

--- a/apps/minds/imbue/minds/desktop_client/test_workspace_sync.py
+++ b/apps/minds/imbue/minds/desktop_client/test_workspace_sync.py
@@ -11,6 +11,8 @@ tests.
 import json
 import os
 import time
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from uuid import uuid4
 
@@ -33,6 +35,7 @@ from imbue.minds.desktop_client.sync_scheduler import WorkspaceSyncScheduler
 from imbue.minds.desktop_client.workspace_record_store import WorkspaceRecordStore
 from imbue.mngr.primitives import AgentId
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import ProviderInstanceName
 
 _USER_ID = "11111111-2222-3333-4444-555555555555"
 _EMAIL = "sync-user@example.com"
@@ -215,7 +218,15 @@ def test_scheduler_pass_converts_legacy_state_and_tombstones_absent_rows(tmp_pat
     assert _EMAIL in cli.sync_bundle_by_email
 
     # The workspace disappears locally (definitively absent) -> tombstoned.
+    # Absence only counts once the record's provider has produced a snapshot
+    # (a provider that never reported proves nothing), so seed one.
     empty_resolver = make_resolver_with_data(agents_json=json.dumps({"agents": []}))
+    empty_resolver.update_providers(
+        provider_name=ProviderInstanceName("local"),
+        provider=None,
+        error=None,
+        last_snapshot_at=datetime.now(timezone.utc),
+    )
     scheduler_after = WorkspaceSyncScheduler(record_store=store, session_store=session, resolver=empty_resolver)
     scheduler_after.run_one_pass()
     assert cli.sync_records_by_email[_EMAIL][str(host_id)]["state"] == "destroyed"

--- a/apps/minds/imbue/minds/desktop_client/workspace_record_store.py
+++ b/apps/minds/imbue/minds/desktop_client/workspace_record_store.py
@@ -48,11 +48,13 @@ from imbue.minds.desktop_client import dek_store
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.backup_env_store import read_canonical_env
 from imbue.minds.desktop_client.backup_env_store import write_canonical_env
+from imbue.minds.desktop_client.destroying import has_destroying_marker
 from imbue.minds.desktop_client.imbue_cloud_cli import ImbueCloudCli
 from imbue.minds.desktop_client.imbue_cloud_cli import ImbueCloudCliError
 from imbue.minds.desktop_client.imbue_cloud_cli import ImbueCloudSyncConflictCliError
 from imbue.minds.errors import WorkspaceSyncError
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import ProviderInstanceName
 
 _RECORDS_DIRNAME = "workspace_records"
 _LEGACY_ASSOCIATIONS_FILENAME = "workspace_associations.json"
@@ -1076,6 +1078,7 @@ class WorkspaceRecordStore(MutableModel):
                                 "discovery yet); keeping the legacy file for a retry",
                                 agent_id,
                             )
+                self._resurrect_locally_hosted_tombstones(user_id, resolver)
                 self._refresh_local_metadata(user_id, account_email, resolver)
                 self._tombstone_definitively_absent(user_id, account_email, resolver)
                 self.push_dirty(user_id, account_email)
@@ -1195,19 +1198,62 @@ class WorkspaceRecordStore(MutableModel):
             with self._lock:
                 self._set_record_unlocked(user_id, merged)
 
+    def _resurrect_locally_hosted_tombstones(self, user_id: str, resolver: BackendResolverInterface) -> None:
+        """Re-activate this device's tombstoned rows whose workspace is live in local discovery.
+
+        The inverse safety net for the absent-host tombstone pass: a row
+        tombstoned while its provider was slow to report (the startup race the
+        per-provider snapshot gate narrows but cannot fully close for rows
+        tombstoned by earlier versions) leaves a live workspace silently
+        de-associated. A DESTROYED row hosted by this device whose agent is
+        among the ACTIVE ids -- not merely the known ids, which retain
+        genuinely-destroyed hosts for the provider's grace window -- is proof
+        the tombstone was premature. Rows with a destroy in flight (or
+        recently finished) are skipped: the destroy flow tombstones the record
+        before the host actually goes down, and that window must not undo it.
+        """
+        if not resolver.has_completed_initial_discovery():
+            return
+        if not self.device_id:
+            return
+        active_ids = {str(aid) for aid in resolver.list_active_workspace_ids()}
+        for record in self.list_records(user_id):
+            if record.state != RECORD_STATE_DESTROYED or record.hosting_device_id != self.device_id:
+                continue
+            if record.agent_id not in active_ids:
+                continue
+            if has_destroying_marker(AgentId(record.agent_id), self.paths):
+                continue
+            logger.info(
+                "Re-activating workspace record {} ({}): its host is live in local discovery",
+                record.agent_id,
+                record.display_name,
+            )
+            resurrected = record.model_copy_update(
+                to_update(record.field_ref().state, RECORD_STATE_ACTIVE),
+                to_update(record.field_ref().is_dirty, True),
+            )
+            with self._lock:
+                self._set_record_unlocked(user_id, resurrected)
+
     def _tombstone_definitively_absent(
         self, user_id: str, account_email: str, resolver: BackendResolverInterface
     ) -> None:
         """Tombstone this device's ACTIVE rows whose host is definitively gone locally.
 
         Definitively absent means: discovery completed, the record's provider
-        did not error this poll, and the workspace is not among the known ids
-        (which still include DESTROYED-but-lingering hosts, so the provider's
-        grace window is honored). Cloud rows are skipped -- their lifecycle is
-        driven by lease state, and any device may see them. Rows with an empty
-        provider_kind are skipped too: those are create-path seeds discovery
-        has never enriched, so "absent from discovery" says nothing about the
-        host (the create just finished and the next poll hasn't seen it yet).
+        has produced at least one snapshot AND did not error this poll, and
+        the workspace is not among the known ids (which still include
+        DESTROYED-but-lingering hosts, so the provider's grace window is
+        honored). The per-provider snapshot gate matters because a provider
+        that is merely slow after startup is indistinguishable from a healthy
+        one via the error map alone -- a host missing from a listing that
+        never happened is not evidence of anything. Cloud rows are skipped --
+        their lifecycle is driven by lease state, and any device may see them.
+        Rows with an empty provider_kind are skipped too: those are
+        create-path seeds discovery has never enriched, so "absent from
+        discovery" says nothing about the host (the create just finished and
+        the next poll hasn't seen it yet).
         """
         if not resolver.has_completed_initial_discovery():
             return
@@ -1225,6 +1271,14 @@ class WorkspaceRecordStore(MutableModel):
             if not record.provider_kind:
                 continue
             if record.agent_id in known_ids or record.provider_kind in errored_providers:
+                continue
+            try:
+                record_provider_name = ProviderInstanceName(record.provider_kind)
+            except ValueError:
+                # A provider name this install cannot even represent has
+                # certainly never produced a snapshot here.
+                continue
+            if resolver.get_last_snapshot_at_for_provider(record_provider_name) is None:
                 continue
             logger.info(
                 "Tombstoning workspace record {} ({}): host no longer exists on this device",

--- a/apps/minds/imbue/minds/desktop_client/workspace_record_store_test.py
+++ b/apps/minds/imbue/minds/desktop_client/workspace_record_store_test.py
@@ -1,4 +1,6 @@
 import json
+from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 from uuid import uuid4
 
@@ -425,8 +427,20 @@ def test_reconcile_tombstones_definitively_absent_local_rows(paths: WorkspacePat
     # make_resolver_with_data runs update_agents, which marks initial discovery complete.
     resolver = make_resolver_with_data(agents_json=make_agents_json(AgentId.generate(), host_name="other"))
 
+    # Before the record's provider has produced a single snapshot, absence is
+    # not evidence: the row must survive (the slow-first-poll startup race).
     store.reconcile({user_id: _EMAIL}, resolver)
+    assert store.list_records(user_id)[0].state == RECORD_STATE_ACTIVE
 
+    # Once the provider has reported a snapshot that lacks the host, the
+    # absence is definitive and the row tombstones.
+    resolver.update_providers(
+        provider_name=ProviderInstanceName("local"),
+        provider=None,
+        error=None,
+        last_snapshot_at=datetime.now(timezone.utc),
+    )
+    store.reconcile({user_id: _EMAIL}, resolver)
     assert store.list_records(user_id)[0].state == RECORD_STATE_DESTROYED
 
 
@@ -611,3 +625,73 @@ def test_derive_openssh_public_key_line_roundtrips_mngrs_traditional_pem_rsa_key
 
 def test_derive_openssh_public_key_line_returns_none_for_garbage() -> None:
     assert derive_openssh_public_key_line("not a key at all") is None
+
+
+def test_reconcile_resurrects_a_locally_hosted_tombstone_whose_workspace_is_live(paths: WorkspacePaths) -> None:
+    """A DESTROYED row hosted here whose agent is live in discovery was tombstoned
+    prematurely (e.g. by an install predating the per-provider snapshot gate) --
+    the reconcile must re-activate and push it."""
+    cli = make_fake_imbue_cloud_cli()
+    store = _make_store(paths, cli)
+    user_id = _user_id()
+    live_agent = AgentId.generate()
+    tombstoned = ReplicaRecord(
+        host_id="host-back",
+        agent_id=str(live_agent),
+        display_name="docker-2",
+        provider_kind="local",
+        hosting_device_id="device-test-1",
+        state=RECORD_STATE_DESTROYED,
+    )
+    cli.sync_records_by_email[_EMAIL] = {"host-back": tombstoned.to_wire(4)}
+    resolver = make_resolver_with_data(agents_json=make_agents_json(live_agent, host_name="docker-2"))
+
+    store.reconcile({user_id: _EMAIL}, resolver)
+
+    record = store.list_records(user_id)[0]
+    assert record.state == RECORD_STATE_ACTIVE
+    assert record.is_dirty is False
+    assert cli.sync_records_by_email[_EMAIL]["host-back"]["state"] == RECORD_STATE_ACTIVE
+
+
+def test_reconcile_never_resurrects_while_a_destroy_is_in_flight(paths: WorkspacePaths) -> None:
+    """The destroy flow tombstones the record before the host actually goes down;
+    a reconcile in that window must not undo the tombstone."""
+    cli = make_fake_imbue_cloud_cli()
+    store = _make_store(paths, cli)
+    user_id = _user_id()
+    doomed_agent = AgentId.generate()
+    tombstoned = ReplicaRecord(
+        host_id="host-doomed",
+        agent_id=str(doomed_agent),
+        provider_kind="local",
+        hosting_device_id="device-test-1",
+        state=RECORD_STATE_DESTROYED,
+    )
+    cli.sync_records_by_email[_EMAIL] = {"host-doomed": tombstoned.to_wire(2)}
+    (paths.data_dir / "destroying" / str(doomed_agent)).mkdir(parents=True)
+    resolver = make_resolver_with_data(agents_json=make_agents_json(doomed_agent, host_name="doomed"))
+
+    store.reconcile({user_id: _EMAIL}, resolver)
+
+    assert store.list_records(user_id)[0].state == RECORD_STATE_DESTROYED
+
+
+def test_reconcile_never_resurrects_other_device_tombstones(paths: WorkspacePaths) -> None:
+    cli = make_fake_imbue_cloud_cli()
+    store = _make_store(paths, cli)
+    user_id = _user_id()
+    foreign_agent = AgentId.generate()
+    tombstoned = ReplicaRecord(
+        host_id="host-foreign",
+        agent_id=str(foreign_agent),
+        provider_kind="local",
+        hosting_device_id="device-someone-else",
+        state=RECORD_STATE_DESTROYED,
+    )
+    cli.sync_records_by_email[_EMAIL] = {"host-foreign": tombstoned.to_wire(2)}
+    resolver = make_resolver_with_data(agents_json=make_agents_json(foreign_agent, host_name="foreign"))
+
+    store.reconcile({user_id: _EMAIL}, resolver)
+
+    assert store.list_records(user_id)[0].state == RECORD_STATE_DESTROYED


### PR DESCRIPTION
## Summary

Fixes a workspace-sync race observed live: right after app start, the absent-host tombstone pass judged a stopped lima workspace "definitively absent" — because a provider that hasn't produced its first listing yet is indistinguishable, via the error map alone, from a healthy provider with no such host — and pushed a spurious `destroyed` record to the connector, silently de-associating the workspace.

- **(a) Per-provider snapshot gate**: `_tombstone_definitively_absent` now also requires the record's *specific* provider to have produced at least one discovery snapshot before absence counts as evidence.
- **(b) Resurrection safety net**: a `DESTROYED` row hosted by this install whose agent is live among the **ACTIVE** discovery ids (not the known ids, which retain genuinely-destroyed hosts for the provider's grace window) is re-activated and re-pushed. Guarded by the destroying marker so an in-flight destroy is never undone. This self-heals rows tombstoned by the old race (e.g. the docker-2 record that triggered this fix).

## Testing

- `just test-quick apps/minds` — 1918 passed, 0 failed, including new tests: tombstone skipped before the provider's first snapshot (then fires after), resurrection of a live-again tombstone (re-pushed as active), no resurrection while a destroy marker exists, no resurrection of other-device tombstones.
- Ratchets, ruff, and `ty` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)