### PR TITLE
Document first-time minds-from-source setup in the minds README

### DIFF
--- a/apps/minds/README.md
+++ b/apps/minds/README.md
@@ -14,8 +14,47 @@ The minds app creates and manages persistent Claude agents running in Docker con
 ## Getting started
 
 minds ships as a desktop app (Electron, packaged via ToDesktop; see
-[docs/desktop-app.md](./docs/desktop-app.md)). To run it from source in this
-monorepo, activate a minds env and start the dev client:
+[docs/desktop-app.md](./docs/desktop-app.md)). The sections below cover
+running it from source in this monorepo.
+
+### First-time setup
+
+There is no single command that installs everything: the toolchain and
+environment steps need interactive input (version-manager setup, browser
+auth), so run these once, in order. Each `just` recipe fails with an
+actionable hint if a prerequisite is missing.
+
+1. Install the pinned Node.js and pnpm versions (`engine-strict` rejects
+   any others; see "Installing the pinned toolchain" in
+   [docs/desktop-app.md](./docs/desktop-app.md)), then install the
+   Electron dependencies:
+
+   ```bash
+   just minds-install
+   ```
+
+2. Create the default-workspace-template worktree that the dev client
+   launches against:
+
+   ```bash
+   just default-workspace-template-worktree
+   ```
+
+3. Bootstrap your personal dev environment. This provisions per-developer
+   cloud resources and is interactive; see "Bootstrap a brand-new dev env"
+   in [docs/environments.md](./docs/environments.md) for what it creates:
+
+   ```bash
+   eval "$(uv run minds env activate --create --deploy dev-<your-user>)"
+   uv run minds env deploy
+   ```
+
+4. Have Docker running if you want local workspaces (each one is a Docker
+   container).
+
+### Running the app
+
+In each fresh shell, activate a minds env and start the dev client:
 
 ```bash
 eval "$(uv run minds env activate <name>)"   # e.g. dev-<your-user>

--- a/apps/minds/changelog/danver-minds-first-time-setup-docs.md
+++ b/apps/minds/changelog/danver-minds-first-time-setup-docs.md
@@ -1,0 +1,5 @@
+Documented the first-time setup for running minds from source in the minds README: a step-by-step checklist (pinned Node/pnpm toolchain via `just minds-install`, the default-workspace-template worktree, personal dev env bootstrap, Docker) with links to the authoritative toolchain and environment docs. Previously the only end-to-end sequence lived in an agent-facing skill file and the README's Getting started skipped every prerequisite.
+
+Also added a note to docs/desktop-app.md's "Running locally" section pointing at `just minds-install` / `just minds-start` as the preferred dev-loop entry points over bare `pnpm install` / `pnpm start`.
+
+No installer automation was added: the toolchain and environment steps are inherently interactive (version-manager setup, browser auth, per-shell env activation), so the README documents them as manual steps instead.

--- a/apps/minds/docs/desktop-app.md
+++ b/apps/minds/docs/desktop-app.md
@@ -223,6 +223,11 @@ pnpm install        # Install Electron and ToDesktop CLI
 pnpm start          # Launch the Electron app in dev mode
 ```
 
+**Note:** for the full dev loop (env activation, syncing your live mngr
+tree into the workspace template), prefer `just minds-install` and
+`just minds-start` from the repo root -- see "Getting started" in the
+[minds README](../README.md).
+
 In dev mode, the Electron app skips `uv sync` and uses the monorepo's workspace venv directly (via `uv run --package minds` from the repo root). This means all mngr plugins (claude, modal, etc.) are available without any extra setup, and changes to the Python code are picked up immediately on restart.
 
 ### Building for distribution


### PR DESCRIPTION
Investigated whether a fully automated "install all minds prerequisites" just target is feasible. Verdict: no -- the chain is inherently interactive (Node version-manager setup by design never auto-installs, dev env bootstrap needs browser auth for Vault/Modal, `minds env activate` must be eval'd in the user's own shell, Docker install is out of scope for a recipe). So instead of a partial installer, this documents the manual sequence properly:

- `apps/minds/README.md`: new "First-time setup" checklist under Getting started -- pinned toolchain + `just minds-install`, `just default-workspace-template-worktree`, dev env bootstrap (`minds env activate --create --deploy` + `minds env deploy`), Docker -- with links to the authoritative details in docs/desktop-app.md and docs/environments.md, followed by the every-time "Running the app" steps.

- `apps/minds/docs/desktop-app.md`: "Running locally" now points to `just minds-install` / `just minds-start` as the preferred dev-loop entry points over bare `pnpm install` / `pnpm start`.

Docs-only change. Stacked on #2500 (justfile grouping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)