### PR TITLE
minds: [Part 1] add MINDS_RESTIC_BINARY to startBackend

### DIFF
--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -247,6 +247,7 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
           MNGR_PREFIX: mngrPrefix,
           MINDS_LATCHKEY_BINARY: paths.getLatchkeyPath(),
           MINDS_LATCHKEY_DIRECTORY: paths.getLatchkeyDirectory(),
+          MINDS_RESTIC_BINARY: paths.getResticPath(),
           MINDS_RELEASE_ID: releaseId,
           MINDS_GIT_SHA: gitSha,
         };


### PR DESCRIPTION
## Summary
Adds `MINDS_RESTIC_BINARY: paths.getResticPath()` to the environment passed to the backend in dev/source mode in `apps/minds/electron/backend.js`.

## Problem
The packaged-mode branch of `startBackend` already exports `MINDS_RESTIC_BINARY`, but the dev-mode branch did not. When running from source, the backend had no path to the bundled `restic` binary, so restic-backed backup features couldn't locate it.

## Fix
Export `MINDS_RESTIC_BINARY` in dev mode too, matching packaged mode so backups behave consistently in both.

## Related PRs
https://github.com/imbue-ai/mngr/pull/2503
https://github.com/imbue-ai/mngr/pull/2504
https://github.com/shiyanboxer/mngr/pull/2
https://github.com/shiyanboxer/mngr/pull/4
https://github.com/shiyanboxer/mngr/pull/5