### PR TITLE
minds: [Part 2] relabel and reorganize the workspace backup settings section

### DIFF
--- a/apps/minds/changelog/shiyan-backup-settings-buttons.md
+++ b/apps/minds/changelog/shiyan-backup-settings-buttons.md
@@ -1,0 +1,3 @@
+Reorganized the "Backups" section of the workspace Settings page into three clearly labeled subsections and rewrote its buttons, options, and status text in plain language. This is a presentation-only change: no backend or behavioral changes.
+
+Controls are now grouped under "Where your backups are stored", "Backup service verification", and "Fix backup problems" (check-first, then-fix ordering). Several controls were relabeled: "Configure backups..." to "Change storage location", "Apply" to "Save", "Update backup service" to "Update backup software", and "Stop all chats and retry" to "Stop chats and try again", along with plainer provider options and form labels.

--- a/apps/minds/imbue/minds/desktop_client/static/workspace_backups.js
+++ b/apps/minds/imbue/minds/desktop_client/static/workspace_backups.js
@@ -1,14 +1,14 @@
 // Backup section of the workspace settings page: shows the combined
 // snapshot status + backup-service verification breakdown from this
 // workspace's /api/v1/workspaces/<id>/backups, and drives the actions:
-//   - the verification Enable/Disable button (top of the section: the whole
-//     breakdown below it only exists while verification is on),
-//   - "Update backup service" (one idempotent converge; tracked operation
+//   - the verification Enable/Disable button (the whole problem/version
+//     breakdown only exists while it is on),
+//   - "Update backup software" (one idempotent converge; tracked operation
 //     polled at /api/v1/workspaces/operations/backup/<id>, with a
-//     "Stop all chats and retry" follow-up when running chats block it and
+//     "Stop chats and try again" follow-up when running chats block it and
 //     a Cancel that works while the update is still waiting),
-//   - "Configure backups..." (enable, change destination, or disable via the
-//     "None" provider; same tracked-operation polling).
+//   - "Change storage location" (enable, change destination, or disable via
+//     the "None" provider; same tracked-operation polling).
 //
 // Conditional buttons are shown/hidden via their wrapper spans (a `hidden`
 // class directly on a Button loses to its inline-flex display class).
@@ -43,13 +43,16 @@
   // The latest known verification state, driving the Enable/Disable label.
   var isVerificationEnabled = true;
 
+  // Plain-language problem descriptions; each ends with what to do about it.
+  // "Update backup software" fixes all of the fixable ones, so they all point
+  // there.
   var PROBLEM_LABELS = {
-    NOT_CONFIGURED: 'Backups are not configured for this workspace.',
-    CODE_OUTDATED: 'The backup service code is outdated.',
-    ENV_MISSING: 'The backup credentials file is missing on the workspace.',
-    ENV_MISMATCH: "The workspace's backup credentials don't match the expected configuration.",
-    SERVICE_NOT_RUNNING: 'The backup service is not running.',
-    UNVERIFIABLE: 'The backup service could not be verified.',
+    NOT_CONFIGURED: 'Backups are turned off for this workspace. Use "Change storage location" to turn them on.',
+    CODE_OUTDATED: 'The backup software in this workspace is out of date. Click "Update backup software" to fix this.',
+    ENV_MISSING: 'This workspace has lost its backup storage settings. Click "Update backup software" to restore them.',
+    ENV_MISMATCH: 'This workspace is set up to back up somewhere different than expected. Click "Update backup software" to fix this.',
+    SERVICE_NOT_RUNNING: 'The backup software in this workspace is not running. Click "Update backup software" to restart it.',
+    UNVERIFIABLE: "minds couldn't check on this workspace's backups. Click \"Update backup software\" to reset them.",
   };
 
   function setShown(el, isShown) {
@@ -100,17 +103,20 @@
       return;
     }
     if (entry.check_state === 'OFFLINE') {
-      statusLine.textContent += ' The workspace is offline; its backup service will be verified when it is back.';
+      statusLine.textContent += ' This workspace is offline; its backups will be checked when it is back online.';
       return;
     }
-    var versionParts = [];
-    if (entry.installed_version) versionParts.push('Installed backup service: ' + entry.installed_version);
-    if (entry.minimum_version) versionParts.push('minimum required: ' + entry.minimum_version);
-    if (entry.update_target_version && entry.update_target_version !== entry.minimum_version) {
-      versionParts.push('update installs: ' + entry.update_target_version);
-    }
-    if (versionParts.length > 0) {
-      versionsEl.textContent = versionParts.join(' / ');
+    // One friendly sentence instead of the old installed/minimum/target
+    // triple: whether an update is available is the only thing a user can act
+    // on (the CODE_OUTDATED problem below covers "too old to work").
+    if (entry.installed_version) {
+      if (entry.update_target_version && entry.update_target_version !== entry.installed_version) {
+        versionsEl.textContent =
+          'Backup software version: ' + entry.installed_version +
+          ' (an update to ' + entry.update_target_version + ' is available).';
+      } else {
+        versionsEl.textContent = 'Backup software version: ' + entry.installed_version + '.';
+      }
       versionsEl.classList.remove('hidden');
     }
     // The update is an idempotent converge, so the button is always offered
@@ -239,7 +245,7 @@
         if (op.blocked_chats && op.blocked_chats.length > 0) {
           showError(
             'Chats are running in this workspace (' + op.blocked_chats.join(', ') +
-            '). Stop them before updating the backup service; they resume on your next message.'
+            '). Stop them before continuing; they resume on your next message.'
           );
           setShown(stopChatsBtnWrap, true);
           return;

--- a/apps/minds/imbue/minds/desktop_client/static/workspace_backups.js
+++ b/apps/minds/imbue/minds/desktop_client/static/workspace_backups.js
@@ -43,9 +43,6 @@
   // The latest known verification state, driving the Enable/Disable label.
   var isVerificationEnabled = true;
 
-  // Plain-language problem descriptions; each ends with what to do about it.
-  // "Update backup software" fixes all of the fixable ones, so they all point
-  // there.
   var PROBLEM_LABELS = {
     NOT_CONFIGURED: 'Backups are turned off for this workspace. Use "Change storage location" to turn them on.',
     CODE_OUTDATED: 'The backup software in this workspace is out of date. Click "Update backup software" to fix this.',
@@ -106,17 +103,14 @@
       statusLine.textContent += ' This workspace is offline; its backups will be checked when it is back online.';
       return;
     }
-    // One friendly sentence instead of the old installed/minimum/target
-    // triple: whether an update is available is the only thing a user can act
-    // on (the CODE_OUTDATED problem below covers "too old to work").
-    if (entry.installed_version) {
-      if (entry.update_target_version && entry.update_target_version !== entry.installed_version) {
-        versionsEl.textContent =
-          'Backup software version: ' + entry.installed_version +
-          ' (an update to ' + entry.update_target_version + ' is available).';
-      } else {
-        versionsEl.textContent = 'Backup software version: ' + entry.installed_version + '.';
-      }
+    var versionParts = [];
+    if (entry.installed_version) versionParts.push('Installed backup service: ' + entry.installed_version);
+    if (entry.minimum_version) versionParts.push('minimum required: ' + entry.minimum_version);
+    if (entry.update_target_version && entry.update_target_version !== entry.minimum_version) {
+      versionParts.push('update installs: ' + entry.update_target_version);
+    }
+    if (versionParts.length > 0) {
+      versionsEl.textContent = versionParts.join(' / ');
       versionsEl.classList.remove('hidden');
     }
     // The update is an idempotent converge, so the button is always offered

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
@@ -238,9 +238,9 @@
         <p id="backup-error" class="hidden type-body text-important mb-2" role="alert"></p>
         <div id="backup-configure" class="mb-6">
           <h3 class="type-label text-secondary mb-2">Where your backups are stored</h3>
-          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
-            Backups are encrypted before they leave your computer, so only you can read them.
-            You can let Imbue store them for you, or use your own cloud storage.
+          <p class="type-body text-secondary mb-2 max-w-[560px]">
+            Backups are encrypted on your computer, so only you can read them.
+            Store them with Imbue or use your own cloud storage.
           </p>
           <Button variant="secondary" id="backup-configure-toggle-btn">Change storage location</Button>
           <div id="backup-configure-form" class="hidden mt-3 flex flex-col gap-2">
@@ -269,9 +269,9 @@
         </div>
         <div class="mb-6">
           <h3 class="type-label text-secondary mb-2">Backup service verification</h3>
-          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
-            minds regularly checks that this workspace's backups are working and
-            warns you below if something needs attention.
+          <p class="type-body text-secondary mb-2 max-w-[560px]">
+            minds checks your backups regularly and warns you below if anything
+            needs attention.
           </p>
           <div class="flex items-center gap-2">
             <span id="backup-verification-btn-wrap" class="hidden">
@@ -282,10 +282,9 @@
         </div>
         <div class="mb-2">
           <h3 class="type-label text-secondary mb-2">Fix backup problems</h3>
-          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
-            If backups stop working, this reinstalls the backup software inside the workspace
-            and restarts it. It is safe to run any time. It never touches your files or your
-            existing backups.
+          <p class="type-body text-secondary mb-2 max-w-[560px]">
+            If backups stop working, this reinstalls and restarts the backup software.
+            It's safe to run any time and never touches your files or existing backups.
           </p>
           <div id="backup-versions" class="hidden type-helper text-tertiary mb-2"></div>
           <ul id="backup-problems" class="hidden type-body text-important mb-2 list-disc pl-4"></ul>

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
@@ -220,56 +220,90 @@
 
       <SectionHeader divider>Backups</SectionHeader>
       <div id="backup-section">
-        {# Verification comes first: the service-status breakdown below only
-           exists while verification is enabled. The conditional buttons are
-           wrapped in plain spans because a `hidden` class loses to the Button
-           component's own inline-flex (see templates/README.md). #}
-        <div class="flex items-center gap-2 mb-2">
-          <span class="type-body text-primary">Backup service verification</span>
-          <span id="backup-verification-btn-wrap" class="hidden">
-            <Button variant="secondary" id="backup-verification-btn">Disable</Button>
-          </span>
-          <span id="backup-verification-spinner" class="hidden type-section text-secondary"></span>
-        </div>
-        <p id="backup-status-line" class="type-body text-secondary mb-2">Loading backup status...</p>
-        <div id="backup-versions" class="hidden type-helper text-tertiary mb-2"></div>
-        <ul id="backup-problems" class="hidden type-body text-important mb-2 list-disc pl-4"></ul>
-        <div class="flex items-center gap-2 mb-2">
-          <span id="backup-update-btn-wrap" class="hidden">
-            <Button variant="secondary" id="backup-update-btn">Update backup service</Button>
-          </span>
+        <p id="backup-status-line" class="type-body text-secondary mb-4">Loading backup status...</p>
+
+        {# Operation controls shared by the update and storage-change actions.
+           Conditional buttons are wrapped in plain spans because a `hidden`
+           class loses to the Button component's own inline-flex display (see
+           templates/README.md). #}
+        <div class="flex flex-wrap items-center gap-2 mb-2">
+          <span id="backup-op-spinner" class="hidden type-section text-secondary">Working...</span>
           <span id="backup-stop-chats-btn-wrap" class="hidden">
-            <Button variant="secondary" id="backup-stop-chats-btn">Stop all chats and retry</Button>
+            <Button variant="secondary" id="backup-stop-chats-btn">Stop chats and try again</Button>
           </span>
           <span id="backup-cancel-btn-wrap" class="hidden">
             <Button variant="secondary" id="backup-cancel-btn">Cancel</Button>
           </span>
-          <span id="backup-op-spinner" class="hidden type-section text-secondary">Working...</span>
         </div>
         <p id="backup-op-progress" class="hidden type-helper text-tertiary mb-2" aria-live="polite"></p>
         <p id="backup-error" class="hidden type-body text-important mb-2" role="alert"></p>
 
-        <div id="backup-configure" class="mb-3">
-          <Button variant="secondary" id="backup-configure-toggle-btn">Configure backups...</Button>
+        {# Setting 1: where backups go. The form element IDs are load-bearing
+           (test_sync_e2e.py drives this flow by ID), so relabel freely but do
+           not rename them. #}
+        <div id="backup-configure" class="mb-6">
+          <h3 class="type-label text-secondary mb-2">Where your backups are stored</h3>
+          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
+            Backups are encrypted before they leave your computer, so only you can read them.
+            You can let Imbue store them for you, or use your own cloud storage.
+          </p>
+          <Button variant="secondary" id="backup-configure-toggle-btn">Change storage location</Button>
           <div id="backup-configure-form" class="hidden mt-3 flex flex-col gap-2">
             <div class="flex items-center gap-2">
-              <FormLabel target="backup-provider-select">Provider</FormLabel>
+              <FormLabel target="backup-provider-select">Keep my backups in</FormLabel>
               <select id="backup-provider-select" class="h-[34px] px-3 rounded-full type-body bg-surface-secondary text-primary">
-                <option value="IMBUE_CLOUD" {% if not has_account %}disabled{% endif %}>Imbue Cloud{% if not has_account %} (requires an account){% endif %}</option>
-                <option value="API_KEY" {% if not has_account %}selected{% endif %}>Bring my own (restic env)</option>
-                <option value="NONE">None (disable backups)</option>
+                <option value="IMBUE_CLOUD" {% if not has_account %}disabled{% endif %}>Imbue Cloud (recommended){% if not has_account %} -- requires an account{% endif %}</option>
+                <option value="API_KEY" {% if not has_account %}selected{% endif %}>My own cloud storage (advanced)</option>
+                <option value="NONE">Nowhere -- turn backups off</option>
               </select>
             </div>
             <div id="backup-api-key-row" class="hidden">
-              <FormLabel target="backup-api-key-env-input">Restic env (KEY=VALUE per line; no RESTIC_PASSWORD)</FormLabel>
+              <FormLabel target="backup-api-key-env-input">Connection details for your storage</FormLabel>
+              <p class="type-helper text-tertiary mb-1 max-w-[560px]">
+                Paste the restic environment variables for your storage, one KEY=VALUE per line.
+                Leave out RESTIC_PASSWORD -- minds manages the encryption password for you.
+              </p>
               <textarea id="backup-api-key-env-input" rows="4" spellcheck="false"
                         class="w-full px-3 py-2 rounded-md type-body font-mono bg-surface-secondary text-primary"
                         placeholder="RESTIC_REPOSITORY=&#10;AWS_ACCESS_KEY_ID=&#10;AWS_SECRET_ACCESS_KEY="></textarea>
             </div>
             <div>
-              <Button variant="secondary" id="backup-configure-submit-btn">Apply</Button>
+              <Button variant="secondary" id="backup-configure-submit-btn">Save</Button>
             </div>
           </div>
+        </div>
+
+        {# Setting 2: backup service verification -- the checks that produce the
+           problem/version breakdown in "Fix backup problems" below, so it sits
+           above that section (check first, then fix). #}
+        <div class="mb-6">
+          <h3 class="type-label text-secondary mb-2">Backup service verification</h3>
+          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
+            minds regularly checks that this workspace's backups are working and
+            warns you below if something needs attention.
+          </p>
+          <div class="flex items-center gap-2">
+            <span id="backup-verification-btn-wrap" class="hidden">
+              <Button variant="secondary" id="backup-verification-btn">Disable</Button>
+            </span>
+            <span id="backup-verification-spinner" class="hidden type-section text-secondary"></span>
+          </div>
+        </div>
+
+        {# Setting 3: fix/refresh the backup software inside the workspace. Last
+           because it acts on problems the checks above find. #}
+        <div class="mb-2">
+          <h3 class="type-label text-secondary mb-2">Fix backup problems</h3>
+          <p class="type-helper text-tertiary mb-2 max-w-[560px]">
+            If backups stop working, this reinstalls the backup software inside the workspace
+            and restarts it. It is safe to run any time. It never touches your files or your
+            existing backups.
+          </p>
+          <div id="backup-versions" class="hidden type-helper text-tertiary mb-2"></div>
+          <ul id="backup-problems" class="hidden type-body text-important mb-2 list-disc pl-4"></ul>
+          <span id="backup-update-btn-wrap" class="hidden">
+            <Button variant="secondary" id="backup-update-btn">Update backup software</Button>
+          </span>
         </div>
       </div>
 

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/WorkspaceSettings.jinja
@@ -222,10 +222,9 @@
       <div id="backup-section">
         <p id="backup-status-line" class="type-body text-secondary mb-4">Loading backup status...</p>
 
-        {# Operation controls shared by the update and storage-change actions.
-           Conditional buttons are wrapped in plain spans because a `hidden`
-           class loses to the Button component's own inline-flex display (see
-           templates/README.md). #}
+        {# Shared operation controls (update + storage change). Conditional buttons use
+          wrapper spans because a `hidden` class loses to the Button's inline-flex
+          display. #}
         <div class="flex flex-wrap items-center gap-2 mb-2">
           <span id="backup-op-spinner" class="hidden type-section text-secondary">Working...</span>
           <span id="backup-stop-chats-btn-wrap" class="hidden">
@@ -237,10 +236,6 @@
         </div>
         <p id="backup-op-progress" class="hidden type-helper text-tertiary mb-2" aria-live="polite"></p>
         <p id="backup-error" class="hidden type-body text-important mb-2" role="alert"></p>
-
-        {# Setting 1: where backups go. The form element IDs are load-bearing
-           (test_sync_e2e.py drives this flow by ID), so relabel freely but do
-           not rename them. #}
         <div id="backup-configure" class="mb-6">
           <h3 class="type-label text-secondary mb-2">Where your backups are stored</h3>
           <p class="type-helper text-tertiary mb-2 max-w-[560px]">
@@ -272,10 +267,6 @@
             </div>
           </div>
         </div>
-
-        {# Setting 2: backup service verification -- the checks that produce the
-           problem/version breakdown in "Fix backup problems" below, so it sits
-           above that section (check first, then fix). #}
         <div class="mb-6">
           <h3 class="type-label text-secondary mb-2">Backup service verification</h3>
           <p class="type-helper text-tertiary mb-2 max-w-[560px]">
@@ -289,9 +280,6 @@
             <span id="backup-verification-spinner" class="hidden type-section text-secondary"></span>
           </div>
         </div>
-
-        {# Setting 3: fix/refresh the backup software inside the workspace. Last
-           because it acts on problems the checks above find. #}
         <div class="mb-2">
           <h3 class="type-label text-secondary mb-2">Fix backup problems</h3>
           <p class="type-helper text-tertiary mb-2 max-w-[560px]">


### PR DESCRIPTION
## Summary
Reorganizes the Backups section of the workspace settings page into three clearly labeled subsections and rewrites the buttons, options, and status text in plain language. Presentation-only: no backend or behavioral changes.

- Groups controls under "Where your backups are stored", "Backup service verification", and "Fix backup problems" (check-first, then-fix ordering).
- Relabels controls: "Configure backups..." to "Change storage location", "Apply" to "Save", "Update backup service" to "Update backup software", "Stop all chats and retry" to "Stop chats and try again", plus plainer provider options and form labels.
- Rewrites the problem descriptions and version line into friendly, action-oriented sentences.

### Before
<img width="741" height="293" alt="Screenshot 2026-07-15 at 8 31 53 PM" src="https://github.com/user-attachments/assets/4e86a4ad-84ab-4d6b-ad95-dadfd149f4b6" />

### After
<img width="725" height="561" alt="Screenshot 2026-07-16 at 10 58 31 AM" src="https://github.com/user-attachments/assets/565df02f-bfe5-4ca6-97a8-c47dd48e6ba0" />



## Problem
- The Backups settings section was difficult to understand. It was unclear what each button did, how the settings related, or in what order to use them.

## Fix
Restructure the section into three labeled subsections with plain-language labels and short helper text, and reword the status/problem messages accordingly. Element IDs are preserved (they are load-bearing for e2e tests), so this is purely a labeling and layout change with no functional impact.

## Related PRs
https://github.com/imbue-ai/mngr/pull/2503
https://github.com/imbue-ai/mngr/pull/2504
https://github.com/shiyanboxer/mngr/pull/2
https://github.com/shiyanboxer/mngr/pull/4
https://github.com/shiyanboxer/mngr/pull/5