### PR TITLE
minds: robust window-state persistence (Stream A of 3)

### DIFF
--- a/apps/minds/changelog/gleb-minds-window-state-robust-persist.md
+++ b/apps/minds/changelog/gleb-minds-window-state-robust-persist.md
@@ -1,0 +1,7 @@
+Fixed a bug where restarting the app -- especially via the "Install and Restart" auto-update prompt -- could drop you on the "create a new workspace" screen instead of restoring your open workspace windows.
+
+The desktop shell now persists its window layout continuously (debounced) as you move, resize, and navigate windows, instead of only at quit. So however the app exits (auto-update restart, crash, or force-quit), the saved layout reflects your live windows and is restored on the next launch.
+
+It also no longer lets a non-graceful quit -- which tears windows down while the save is running -- overwrite a good saved layout with an empty one, which was the direct cause of landing on the create screen.
+
+The startup log now records why the app chose its landing screen (authenticated, account/workspace counts, restorable-window count, and the chosen route), making a bad restore diagnosable from `~/.minds/logs`.

--- a/apps/minds/electron/main.js
+++ b/apps/minds/electron/main.js
@@ -9,6 +9,7 @@ const { runEnvSetup } = require('./env-setup');
 const { startBackend, shutdown, getBackendProcess } = require('./backend');
 const { decideStartupRoute } = require('./startup-routing');
 const { computeBundleViewBounds } = require('./view-layout');
+const { shouldWriteSessionState, createDebouncedSaver } = require('./session-persistence');
 
 // Tee console output into ~/.minds/logs/electron.log and record uncaught
 // main-process failures BEFORE anything else runs, so startup output (including
@@ -541,7 +542,14 @@ function wireBundleWindowEvents(bundle) {
 
   win.on('maximize', () => { bundle._maximizedByUs = true; });
   win.on('unmaximize', () => { bundle._maximizedByUs = false; });
-  win.on('resize', () => updateBundleBounds(bundle));
+  // Reflow the child views on resize, and persist the new geometry (debounced)
+  // so a non-graceful quit still restores the last-known bounds. Moves don't
+  // affect layout, but they do change the saved x/y, so they persist too.
+  win.on('resize', () => {
+    updateBundleBounds(bundle);
+    scheduleSessionSave();
+  });
+  win.on('move', () => scheduleSessionSave());
 
   // Run cleanup on `close` (before views are detached) rather than `closed`
   // so we can still reach the child webContents. BaseWindow does not guarantee
@@ -748,6 +756,9 @@ function wireContentViewEvents(bundle, contentView) {
     if (!bundle.isErrorState) {
       bundle.currentContentUrl = url;
       bundle.preErrorUrl = url;
+      // The persisted url is derived from these fields, so re-persist the
+      // session (debounced) whenever a navigation changes them.
+      scheduleSessionSave();
     }
     const newAgentId = parseWorkspaceId(url);
     // Recompute workspace reachability from the HTTP status. The mngr_forward
@@ -1412,6 +1423,9 @@ function loadUrlIntoBundleContentView(bundle, url) {
     bundle.preErrorUrl = url;
     updateOsTitle(bundle);
     sendCurrentWorkspaceToBundleViews(bundle);
+    // The persisted url is derived from these fields, so re-persist the session
+    // (debounced) whenever we stamp a new intended workspace url.
+    scheduleSessionSave();
   }
   // Stamp the accent source from the URL (the wider
   // ``parseAccentSourceAgentId`` set), so workspace-scoped settings / sharing
@@ -1774,12 +1788,42 @@ function saveSessionState() {
         displayId: display ? display.id : null,
       });
     }
+    // Empty-clobber guard: never let an empty snapshot overwrite a non-empty
+    // on-disk file. Saves now run continuously (debounced on move/resize/nav),
+    // so a save can land while windows are being torn down by a non-graceful
+    // quit (ToDesktop "Install and Restart", crash, force-quit) -- the live
+    // window set momentarily reads empty, and writing it would drop the user on
+    // the create screen next launch. shouldWriteSessionState only permits an
+    // empty write when the persisted file is already empty. See
+    // session-persistence.js for the full reasoning (the normal last-window
+    // close saves through the quit sequence while the window is still alive, so
+    // it produces a non-empty snapshot and is unaffected).
+    const persistedWindowCount = loadSessionState().windows.length;
+    if (!shouldWriteSessionState({ computedWindowCount: windows.length, persistedWindowCount })) {
+      console.log(`[session] Skipping empty save; ${persistedWindowCount} window(s) already persisted (teardown race guard)`);
+      return;
+    }
     const p = getSessionStatePath();
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.writeFileSync(p, JSON.stringify({ windows }, null, 2));
   } catch (err) {
     console.log('[session] Failed to save state:', err.message);
   }
+}
+
+// Continuously persist window-state.json (debounced) so the saved set reflects
+// the live windows regardless of how the app exits. The trailing-throttle
+// coalesces bursts (a window drag fires move/resize every frame) into at most
+// one write per interval, keeping disk churn negligible. Callers schedule via
+// scheduleSessionSave(), which is suppressed once a quit has committed
+// (isShuttingDown) -- the quit sequence performs its own authoritative save and
+// we must not race a debounced write against the teardown.
+const SESSION_SAVE_DEBOUNCE_MS = 1000;
+const debouncedSessionSaver = createDebouncedSaver({ save: saveSessionState, delayMs: SESSION_SAVE_DEBOUNCE_MS });
+
+function scheduleSessionSave() {
+  if (isShuttingDown) return;
+  debouncedSessionSaver.schedule();
 }
 
 // Update a single bundle's ``currentAccentAgentId`` (the accent source of its
@@ -3065,6 +3109,14 @@ async function startBackendWithRetry() {
         workspaceCount: workspaceList.length,
         restorableCount: restorable.length,
       });
+      // Headline diagnostic for "why did I land on create/welcome instead of my
+      // restored workspace": logs every input to the routing decision and the
+      // chosen route, so a bad restore can be traced from ~/.minds/logs.
+      console.log(
+        `[startup] Startup route: ${startupRoute} ` +
+          `(authenticated=${authenticated}, hasAccounts=${!!(chromeState && chromeState.hasAccounts)}, ` +
+          `workspaceCount=${workspaceList.length}, restorableCount=${restorable.length})`,
+      );
 
       const loadInitialContent = (relativePath) => {
         if (initialBundle.contentView && !initialBundle.contentView.webContents.isDestroyed()) {
@@ -3759,6 +3811,11 @@ async function runQuitSequence() {
   // snapshot session state before teardown (the per-window `close` handler
   // skips saving once isShuttingDown is set).
   isShuttingDown = true;
+  // Drop any pending debounced save: the windows are still alive here, so this
+  // save is the authoritative pre-teardown snapshot. A later debounced write
+  // would only race the teardown (the empty-clobber guard would reject it, but
+  // cancelling is cleaner).
+  debouncedSessionSaver.cancel();
   if (!isHeadlessQuit) showQuittingInAllWindows();
   if (bundles.size > 0) saveSessionState();
 

--- a/apps/minds/electron/session-persistence.js
+++ b/apps/minds/electron/session-persistence.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Pure helpers for persisting the desktop client's window-state.json.
+//
+// Kept free of any `electron` imports (like startup-routing.js and
+// view-layout.js) so both pieces can be unit-tested under plain node -- see
+// ../test/unit/session-persistence.test.js. main.js wires these to the real
+// window set: it schedules a debounced save on window move/resize/navigation
+// and applies the empty-clobber guard inside saveSessionState.
+
+/**
+ * Decide whether a freshly-computed session-state window list may be written
+ * over the current on-disk window-state.json.
+ *
+ * Why this guard exists: the window list is captured from the LIVE window set
+ * at save time. A non-graceful quit -- the ToDesktop "Install and Restart"
+ * auto-update path, a crash, or a force-quit -- tears the windows down
+ * concurrently with the save, so the captured list can come back EMPTY even
+ * though the user had windows open. Writing that empty list clobbers a
+ * perfectly good window-state.json, and the next launch computes
+ * ``restorableCount === 0`` and drops the user on the create screen instead of
+ * their restored workspace.
+ *
+ * Rule: an empty computed list may only be written when the on-disk file is
+ * ALSO empty (or missing / unreadable -- ``persistedWindowCount === 0``). If
+ * the computed list is empty but a non-empty set is already persisted, treat it
+ * as a teardown-race artifact and skip the write, preserving the good file.
+ *
+ * This never rejects a legitimate save: while the app is running with windows
+ * open, every save computes a non-empty list. The only in-app path to zero
+ * windows is closing the last window, and that saves through the quit sequence
+ * while the last window is still alive (a non-empty list). So a computed-empty
+ * list while a non-empty file exists is always a race, never a real state.
+ *
+ * @param {object} counts
+ * @param {number} counts.computedWindowCount   Windows in the just-computed snapshot.
+ * @param {number} counts.persistedWindowCount  Windows in the current on-disk file.
+ * @returns {boolean} true if the snapshot should be written to disk.
+ */
+function shouldWriteSessionState({ computedWindowCount, persistedWindowCount }) {
+  if (computedWindowCount > 0) return true;
+  return persistedWindowCount === 0;
+}
+
+/**
+ * Create a trailing-throttle scheduler that coalesces a burst of ``schedule()``
+ * calls into at most one ``save()`` per ``delayMs``.
+ *
+ * Semantics: the first ``schedule()`` after an idle period arms a timer;
+ * further ``schedule()`` calls while that timer is pending are coalesced into
+ * it (no new timer). When the timer fires, ``save()`` runs once and the
+ * scheduler returns to idle. This bounds disk writes to at most one per
+ * interval even under continuous activity (a window drag/resize fires move/
+ * resize events every frame), while still flushing promptly after the burst.
+ *
+ * ``setTimer`` / ``clearTimer`` are injectable so tests can drive it without
+ * real timers; they default to the global timer functions.
+ *
+ * @param {object} options
+ * @param {() => void} options.save          Persist callback (runs the actual write).
+ * @param {number} options.delayMs           Coalescing window in milliseconds.
+ * @param {Function} [options.setTimer]      Defaults to global setTimeout.
+ * @param {Function} [options.clearTimer]    Defaults to global clearTimeout.
+ * @returns {{ schedule: () => void, flush: () => void, cancel: () => void, isPending: () => boolean }}
+ */
+function createDebouncedSaver({ save, delayMs, setTimer, clearTimer }) {
+  const arm = setTimer || setTimeout;
+  const disarm = clearTimer || clearTimeout;
+  let timerId = null;
+
+  function schedule() {
+    if (timerId !== null) return; // a flush is already pending -- coalesce into it
+    timerId = arm(() => {
+      timerId = null;
+      save();
+    }, delayMs);
+  }
+
+  // Cancel any pending timer without saving (e.g. once a quit takes over and
+  // performs its own authoritative save).
+  function cancel() {
+    if (timerId !== null) {
+      disarm(timerId);
+      timerId = null;
+    }
+  }
+
+  // Cancel any pending timer and save immediately (the coalesced work is due).
+  function flush() {
+    const wasPending = timerId !== null;
+    cancel();
+    if (wasPending) save();
+  }
+
+  function isPending() {
+    return timerId !== null;
+  }
+
+  return { schedule, flush, cancel, isPending };
+}
+
+module.exports = { shouldWriteSessionState, createDebouncedSaver };

--- a/apps/minds/test/unit/session-persistence.test.js
+++ b/apps/minds/test/unit/session-persistence.test.js
@@ -1,0 +1,136 @@
+// Unit tests for the window-state.json persistence helpers.
+//
+// Run with: pnpm --dir apps/minds test:unit   (or: node --test test/unit/)
+//
+// session-persistence.js is plain node (no Electron), so it is testable
+// directly. These lock in the two load-bearing behaviors main.js relies on:
+// the debounced saver coalesces a burst of schedule() calls into a single
+// write, and the empty-clobber guard refuses to overwrite a non-empty on-disk
+// file with an empty snapshot (the teardown-race bug that dropped users on the
+// create screen after an auto-update restart).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { shouldWriteSessionState, createDebouncedSaver } = require('../../electron/session-persistence');
+
+// A deterministic stand-in for setTimeout/clearTimeout: records armed
+// callbacks by id and fires them on demand, so debounce timing is exercised
+// without real timers.
+function makeFakeTimer() {
+  let nextId = 1;
+  const pending = new Map();
+  return {
+    setTimer(cb) {
+      const id = nextId++;
+      pending.set(id, cb);
+      return id;
+    },
+    clearTimer(id) {
+      pending.delete(id);
+    },
+    fireAll() {
+      const callbacks = Array.from(pending.values());
+      pending.clear();
+      for (const cb of callbacks) cb();
+    },
+    pendingCount() {
+      return pending.size;
+    },
+  };
+}
+
+test('shouldWriteSessionState permits any non-empty snapshot', () => {
+  // A non-empty computed list is always the live truth -- write it regardless
+  // of what is already on disk.
+  assert.equal(shouldWriteSessionState({ computedWindowCount: 2, persistedWindowCount: 0 }), true);
+  assert.equal(shouldWriteSessionState({ computedWindowCount: 1, persistedWindowCount: 3 }), true);
+});
+
+test('shouldWriteSessionState writes a genuine empty when nothing is persisted', () => {
+  // Empty computed + empty/missing file: writing empty clobbers nothing, so it
+  // is allowed (keeps the file consistent on a fresh install).
+  assert.equal(shouldWriteSessionState({ computedWindowCount: 0, persistedWindowCount: 0 }), true);
+});
+
+test('shouldWriteSessionState rejects an empty snapshot over a non-empty file (teardown race)', () => {
+  // The bug: a save computed an empty list while windows were being torn down
+  // by a non-graceful quit, and it would have zeroed a good file. Skip it.
+  assert.equal(shouldWriteSessionState({ computedWindowCount: 0, persistedWindowCount: 2 }), false);
+});
+
+test('createDebouncedSaver coalesces a burst into a single save', () => {
+  let saves = 0;
+  const timer = makeFakeTimer();
+  const saver = createDebouncedSaver({
+    save: () => { saves++; },
+    delayMs: 1000,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+
+  saver.schedule();
+  saver.schedule();
+  saver.schedule();
+  assert.equal(timer.pendingCount(), 1, 'a burst arms exactly one timer');
+  assert.equal(saves, 0, 'nothing writes until the timer fires');
+
+  timer.fireAll();
+  assert.equal(saves, 1, 'the coalesced burst produced exactly one save');
+  assert.equal(saver.isPending(), false, 'scheduler returns to idle after firing');
+});
+
+test('createDebouncedSaver re-arms for the next burst after firing', () => {
+  let saves = 0;
+  const timer = makeFakeTimer();
+  const saver = createDebouncedSaver({
+    save: () => { saves++; },
+    delayMs: 1000,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+
+  saver.schedule();
+  timer.fireAll();
+  assert.equal(saves, 1);
+
+  saver.schedule();
+  assert.equal(saver.isPending(), true, 'a fresh schedule after firing arms a new timer');
+  timer.fireAll();
+  assert.equal(saves, 2, 'the second burst produced its own single save');
+});
+
+test('createDebouncedSaver cancel drops a pending save without writing', () => {
+  let saves = 0;
+  const timer = makeFakeTimer();
+  const saver = createDebouncedSaver({
+    save: () => { saves++; },
+    delayMs: 1000,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+
+  saver.schedule();
+  saver.cancel();
+  assert.equal(saver.isPending(), false);
+  timer.fireAll();
+  assert.equal(saves, 0, 'a cancelled save never runs (used when a quit takes over)');
+});
+
+test('createDebouncedSaver flush writes a pending save now and is a no-op when idle', () => {
+  let saves = 0;
+  const timer = makeFakeTimer();
+  const saver = createDebouncedSaver({
+    save: () => { saves++; },
+    delayMs: 1000,
+    setTimer: timer.setTimer,
+    clearTimer: timer.clearTimer,
+  });
+
+  saver.flush();
+  assert.equal(saves, 0, 'flushing while idle writes nothing');
+
+  saver.schedule();
+  saver.flush();
+  assert.equal(saves, 1, 'flushing a pending save writes it immediately');
+  assert.equal(saver.isPending(), false, 'flush clears the pending timer');
+});


### PR DESCRIPTION
## Problem

After restarting the minds app -- especially via the ToDesktop auto-update **Install and Restart** prompt -- users sometimes land on the "create a new workspace" screen instead of their restored workspace windows. Intermittent.

Root cause (window-state persistence half): the Electron shell restores previously-open windows from `~/.minds/window-state.json`, which was written **only** at quit/close. `saveSessionState` iterates the live window set and writes `{ windows }` unconditionally. A non-graceful quit (the auto-update restart, a crash, a force-quit) tears the windows down concurrently with that save, so the function iterates already-destroyed windows and overwrites a good file with `{ "windows": [] }`. Next launch computes `restorableCount === 0` and `decideStartupRoute` returns `create`.

Confirmed from a user's `~/.minds/logs/electron.log`: the update-restart quit takes an abnormal path (fires `before-quit isShuttingDown=true` twice) and made no attempt to reload the saved `/goto/agent-.../` window, whereas a normal restart did.

## Fix (Stream A)

- **Continuous, debounced persistence (A1).** Persist `window-state.json` continuously instead of only at quit, triggered on window move, window resize, and content navigation. A trailing-throttle scheduler coalesces bursts (a window drag fires an event per frame) into at most one write per second, so disk churn stays negligible. The saved set now reflects the live windows however the app exits.

- **Empty-clobber guard (A2).** `saveSessionState` now refuses to overwrite a non-empty on-disk file with an empty snapshot -- a teardown-race artifact. An empty snapshot is written only when the on-disk file is already empty, so a genuine empty still persists while a race can't zero out a good file. The normal last-window-close path saves through the quit sequence while the window is still alive (a non-empty snapshot), so it is unaffected.

- **Observability.** Added one `[startup]` log line at the `decideStartupRoute` call site logging `authenticated`, `hasAccounts`, `workspaceCount`, `restorableCount`, and the chosen route -- the headline diagnostic for "why did I land on create".

The debounce scheduler and the guard decision live in a pure, Electron-free module (`electron/session-persistence.js`), mirroring how `startup-routing.js` is kept testable under plain node. New unit tests cover the burst coalescing and the guard.

## Tests

`node --test test/unit/*.test.js` from `apps/minds`: **23 passed, 0 failed** (7 new).

## Scope

Only the Electron shell (`apps/minds/electron/`) and its JS unit tests are touched. No Python or Jinja changes.

**Stream A of 3.** Stream B (PR #2518) fixes the Python backend landing-render half; Stream C (PR #2533) prunes the resolver's persisted last-good topology on observed `DESTROYED` so destroyed workspaces stop counting as restorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
