### PR TITLE
Fix minds landing dropping users with workspaces onto the create form (Stream B of 3)

### DIFF
--- a/apps/minds/changelog/gleb-minds-landing-discovering-not-create.md
+++ b/apps/minds/changelog/gleb-minds-landing-discovering-not-create.md
@@ -1,0 +1,7 @@
+Fix an intermittent bug where restarting the minds app (especially via a ToDesktop auto-update) could drop a user with existing workspaces onto the terminal "create a new workspace" screen instead of their workspace list.
+
+On a cold start, discovery marks itself "complete" on the first event from the first provider. If that arrives before the provider hosting the user's workspace has surfaced it, the landing handler (`/`) previously saw an empty live workspace list and fell through to the create form, a terminal page with no auto-refresh -- stranding the user.
+
+The landing fallback now consults `list_restorable_workspace_ids()` (the live primary agents unioned with the persisted last-good topology). When that set is non-empty -- we know workspaces exist even though a partial cold-start snapshot hasn't re-surfaced them -- it renders the auto-refreshing "Discovering agents..." page (which self-heals into the workspace list) instead of the create form. The create form is now only shown when discovery has completed and nothing anywhere (live, remote, or last-good) says a workspace exists, i.e. a genuine first-run user.
+
+As defense-in-depth, the create form, when it is the landing fallback at `/`, now also subscribes to the chrome SSE and navigates to `/` the moment a workspace appears, so a user shown the form on a cold-start race is taken to their workspace list. The explicit `/create` page keeps its previous behavior (no self-heal SSE) so a deliberate "create another workspace" flow is never bounced away by existing workspaces.

--- a/apps/minds/imbue/minds/desktop_client/app.py
+++ b/apps/minds/imbue/minds/desktop_client/app.py
@@ -1012,11 +1012,32 @@ def _handle_landing_page() -> Response:
         )
         return make_html_response(content=html)
 
-    # No agents discovered yet. If discovery is still in progress, show a
-    # "Discovering agents..." page with auto-refresh. Once discovery has
-    # completed with no agents found, show the create form so the user can
-    # create their first agent instead of polling forever.
-    if not backend_resolver.has_completed_initial_discovery():
+    # No live workspaces and no remote tiles. Choose between the auto-refreshing
+    # "Discovering agents..." page and the terminal create form.
+    #
+    # Never strand a user who has workspaces on the terminal create form. Show
+    # the auto-refreshing Landing page (which self-heals into the workspace list
+    # via its reload timer + chrome SSE) when either:
+    #   - discovery has not completed yet (the agent list may still be filling
+    #     in), or
+    #   - the restorable set (live primary agents unioned with the persisted
+    #     last-good topology) is non-empty -- we know workspaces exist but a
+    #     slow/partial cold-start snapshot has not re-surfaced them yet.
+    # Only show the create form once discovery has completed AND nothing anywhere
+    # (live, remote, or last-good) says a workspace exists, i.e. a genuine
+    # first-run user creating their first workspace.
+    restorable_agent_ids = backend_resolver.list_restorable_workspace_ids()
+    is_discovery_complete = backend_resolver.has_completed_initial_discovery()
+    is_showing_create_form = is_discovery_complete and not restorable_agent_ids
+    logger.debug(
+        "Resolved landing fallback: active={} remote={} discovery_complete={} restorable={} -> {}",
+        len(all_agent_ids),
+        len(remote_workspaces),
+        is_discovery_complete,
+        len(restorable_agent_ids),
+        "create-form" if is_showing_create_form else "discovering",
+    )
+    if not is_showing_create_form:
         html = render_landing_page(
             accessible_agent_ids=(),
             mngr_forward_origin=_get_mngr_forward_origin(),
@@ -1043,6 +1064,10 @@ def _handle_landing_page() -> Response:
         # visible; otherwise start on the simple preset cards.
         start_advanced=bool(git_url or branch),
         color=_suggested_create_color(backend_resolver),
+        # This create form is the landing fallback (shown at "/" when no
+        # workspace exists), so wire its self-heal SSE: if a workspace appears
+        # while it is open, it navigates to "/" instead of stranding the user.
+        is_landing_fallback=True,
     )
     return make_html_response(content=html)
 

--- a/apps/minds/imbue/minds/desktop_client/templates.py
+++ b/apps/minds/imbue/minds/desktop_client/templates.py
@@ -454,6 +454,7 @@ def render_create_form(
     selected_preset: str | None = None,
     start_advanced: bool = False,
     color: str = DEFAULT_WORKSPACE_COLOR,
+    is_landing_fallback: bool = False,
 ) -> str:
     """Render the agent creation form page.
 
@@ -487,6 +488,15 @@ def render_create_form(
     palette entry); ``color`` is the ``#rrggbb`` hex carried in the hidden
     ``color`` input the form POSTs, defaulting to ``DEFAULT_WORKSPACE_COLOR`` so
     callers that don't care about color (e.g. some tests) can omit it.
+
+    ``is_landing_fallback`` marks this form as the landing fallback rendered at
+    ``/`` when no workspace exists (as opposed to the explicit ``/create``
+    page). When True the page wires a chrome-SSE subscription that navigates to
+    ``/`` once a workspace appears, so a user who was shown the create form on a
+    cold-start race (discovery hadn't re-surfaced their workspace yet) is taken
+    to their workspace list instead of being trapped. It is left False on the
+    explicit ``/create`` page so a deliberate "create another workspace" flow is
+    never bounced away by the user's existing workspaces.
     """
     effective_url = git_url if git_url else _operator_workspace_default("MINDS_WORKSPACE_GIT_URL", _FALLBACK_GIT_URL)
     effective_branch = branch if branch else _operator_workspace_default("MINDS_WORKSPACE_BRANCH", FALLBACK_BRANCH)
@@ -545,6 +555,7 @@ def render_create_form(
         selected_preset=effective_preset,
         start_advanced=start_advanced,
         color=color,
+        is_landing_fallback=is_landing_fallback,
     )
 
 

--- a/apps/minds/imbue/minds/desktop_client/templates/pages/Create.jinja
+++ b/apps/minds/imbue/minds/desktop_client/templates/pages/Create.jinja
@@ -1,4 +1,4 @@
-{#def git_url, branch, host_name, launch_modes, selected_launch_mode, ai_providers, selected_ai_provider, docker_runtimes, selected_docker_runtime, backup_providers, selected_backup_provider, backup_api_key_env, accounts, default_account_id, anthropic_api_key, error_message, region_options_by_launch_mode, region_selected_by_launch_mode, selected_preset="remote", start_advanced=False, color="#0b292b" #}
+{#def git_url, branch, host_name, launch_modes, selected_launch_mode, ai_providers, selected_ai_provider, docker_runtimes, selected_docker_runtime, backup_providers, selected_backup_provider, backup_api_key_env, accounts, default_account_id, anthropic_api_key, error_message, region_options_by_launch_mode, region_selected_by_launch_mode, selected_preset="remote", start_advanced=False, color="#0b292b", is_landing_fallback=False #}
 {#
   Workspace creation form.
 
@@ -75,6 +75,10 @@
     var createError = document.getElementById('create-error');
     // The field highlighted by the last create error, cleared before the next try.
     var lastErrorField = null;
+    // Set once a create actually POSTs (the point of no return that redirects to
+    // /creating). The landing-fallback self-heal SSE reads it so an in-flight
+    // submission is never interrupted by a navigation to "/".
+    var hasStartedCreate = false;
     var REGION_OPTIONS = {{ region_options_by_launch_mode | tojson }};
     var REGION_SELECTED = {{ region_selected_by_launch_mode | tojson }};
 
@@ -414,6 +418,7 @@
         hostNameInput.focus();
         return;
       }
+      hasStartedCreate = true;
       submitBtn.disabled = true;
       submitBtn.textContent = 'Creating...';
       submitCreate();
@@ -521,6 +526,47 @@
     update();
     // Validate any pre-filled name on load (e.g. a re-rendered submit error).
     validateHostName();
+
+{% if is_landing_fallback %}
+    // ---- Landing-fallback self-heal ------------------------------------
+    // This create form was shown at "/" only because no workspace was known
+    // when the page rendered -- which, on a cold-start race, can happen even
+    // though the user HAS workspaces (a slow provider hadn't re-surfaced them
+    // yet). Subscribe to the chrome SSE and, the moment a workspace exists
+    // (live, remote, or restorable from the last-good topology), navigate to
+    // "/" so the user lands on their workspace list instead of being trapped on
+    // this terminal form. Mirrors the Landing page's own SSE self-heal. Skipped
+    // once a create has started so an in-flight submission (which redirects to
+    // /creating) is never interrupted.
+    function workspaceNowExists(data) {
+      if (Array.isArray(data.workspaces) && data.workspaces.length > 0) return true;
+      if (data.remote_workspace_states && Object.keys(data.remote_workspace_states).length > 0) return true;
+      if (Array.isArray(data.restorable_workspace_ids) && data.restorable_workspace_ids.length > 0) return true;
+      return false;
+    }
+    var selfHealEs = null;
+    function connectSelfHeal() {
+      if (selfHealEs) selfHealEs.close();
+      selfHealEs = new EventSource('/_chrome/events');
+      selfHealEs.onmessage = function (event) {
+        if (hasStartedCreate) return;
+        var data;
+        try { data = JSON.parse(event.data); } catch (e) { return; }
+        if (data.type !== 'workspaces') return;
+        if (workspaceNowExists(data)) {
+          selfHealEs.close();
+          window.location = '/';
+        }
+      };
+      selfHealEs.onerror = function () {
+        if (!selfHealEs) return;
+        selfHealEs.close();
+        selfHealEs = null;
+        setTimeout(connectSelfHeal, 5000);
+      };
+    }
+    connectSelfHeal();
+{% endif %}
   })();
 </script>
 {% endset %}

--- a/apps/minds/imbue/minds/desktop_client/templates_test.py
+++ b/apps/minds/imbue/minds/desktop_client/templates_test.py
@@ -261,6 +261,26 @@ def test_render_create_form_shows_preset_cards() -> None:
     assert "Advanced Configuration" in html
 
 
+def test_render_create_form_landing_fallback_wires_self_heal_sse() -> None:
+    # The landing fallback (create form shown at "/" when no workspace is known)
+    # subscribes to the chrome SSE and navigates to "/" once a workspace appears,
+    # so a user stranded here by a cold-start discovery race is not trapped.
+    html = render_create_form(is_landing_fallback=True)
+    assert "/_chrome/events" in html
+    assert "EventSource" in html
+    assert "workspaceNowExists" in html
+    assert "window.location = '/'" in html
+
+
+def test_render_create_form_explicit_page_omits_self_heal_sse() -> None:
+    # The explicit /create page (the default, is_landing_fallback False) must not
+    # wire the self-heal SSE, so a deliberate "create another workspace" flow is
+    # never bounced away by the user's existing workspaces.
+    html = render_create_form()
+    assert "/_chrome/events" not in html
+    assert "workspaceNowExists" not in html
+
+
 def test_render_create_form_opens_signin_modal_via_overlay_relay() -> None:
     # Choosing Imbue Cloud while signed out opens the sign-in modal in the
     # desktop client's shared overlay layer (so it covers the title bar), not an

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -24,6 +24,7 @@ from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import AgentDisplayInfo
 from imbue.minds.desktop_client.backend_resolver import BackendResolverInterface
 from imbue.minds.desktop_client.backend_resolver import MngrCliBackendResolver
+from imbue.minds.desktop_client.backend_resolver import ParsedAgentsResult
 from imbue.minds.desktop_client.backend_resolver import StaticBackendResolver
 from imbue.minds.desktop_client.conftest import DEFAULT_SERVICE_NAME
 from imbue.minds.desktop_client.conftest import make_agents_json
@@ -63,7 +64,10 @@ from imbue.minds.utils.mngr_caller import MngrCallResult
 from imbue.minds.utils.mngr_caller import MngrCaller
 from imbue.minds.utils.testing import RecordingMngrCaller
 from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import DiscoveredAgent
 from imbue.mngr.primitives import HostId
+from imbue.mngr.primitives import ProviderInstanceName
 from imbue.mngr_forward.ssh_tunnel import RemoteSSHInfo
 
 
@@ -451,6 +455,79 @@ def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path
     assert response.status_code == 200
     assert "Where should it run?" in response.text
     assert "git_url" in response.text
+
+
+def _make_cold_start_resolver_with_only_restorable_workspace() -> MngrCliBackendResolver:
+    """A resolver whose live snapshot is empty but whose last-good topology remembers a workspace.
+
+    Models the cold-start race the landing fallback must survive: a complete
+    enumeration lands the workspace in the last-good topology, then a subsequent
+    empty snapshot (a slow provider hasn't re-listed it yet) drops it from the
+    live/active set while keeping it in the restorable set. Discovery has
+    completed, so the raw fallback would wrongly show the terminal create form.
+    """
+    host = HostId.generate()
+    agent = AgentId.generate()
+    primary_agent = DiscoveredAgent(
+        host_id=host,
+        agent_id=agent,
+        agent_name=AgentName("system-services"),
+        provider_name=ProviderInstanceName("docker"),
+        certified_data={"labels": {"workspace": "true", "is_primary": "true"}},
+    )
+    resolver = MngrCliBackendResolver()
+    resolver.update_agents(ParsedAgentsResult(agent_ids=(agent,), discovered_agents=(primary_agent,)))
+    resolver.update_agents(ParsedAgentsResult())
+    return resolver
+
+
+def test_landing_page_shows_discovering_when_only_restorable_workspaces_remain(tmp_path: Path) -> None:
+    """A cold-start race (live empty, last-good remembers a workspace) shows the discovering page.
+
+    The user HAS a workspace (known via the persisted last-good topology), so
+    the auto-refreshing "Discovering agents..." page -- which self-heals into the
+    workspace list -- must be shown instead of the terminal create form.
+    """
+    backend_resolver = _make_cold_start_resolver_with_only_restorable_workspace()
+    # Precondition: active/known live set is empty but the workspace is restorable.
+    assert backend_resolver.list_active_workspace_ids() == ()
+    assert backend_resolver.list_restorable_workspace_ids() != ()
+    assert backend_resolver.has_completed_initial_discovery() is True
+    client, auth_store = _create_test_desktop_client(
+        tmp_path=tmp_path,
+        backend_resolver=backend_resolver,
+        http_client=None,
+    )
+    _authenticate_client(client=client, auth_store=auth_store)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Discovering agents" in response.text
+    assert "Where should it run?" not in response.text
+
+
+def test_landing_page_shows_create_form_when_restorable_set_is_empty(tmp_path: Path) -> None:
+    """Discovery complete with a genuinely empty restorable set still shows the create form.
+
+    The first-run case: nothing is known live, remote, or in the last-good
+    topology, so the terminal create form (unchanged behavior) is correct.
+    """
+    backend_resolver = MngrCliBackendResolver()
+    # Complete discovery with an empty snapshot: nothing known anywhere.
+    backend_resolver.update_agents(ParsedAgentsResult())
+    assert backend_resolver.has_completed_initial_discovery() is True
+    assert backend_resolver.list_restorable_workspace_ids() == ()
+    client, auth_store = _create_test_desktop_client(
+        tmp_path=tmp_path,
+        backend_resolver=backend_resolver,
+        http_client=None,
+    )
+    _authenticate_client(client=client, auth_store=auth_store)
+
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Where should it run?" in response.text
+    assert "Discovering agents" not in response.text
 
 
 def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes the intermittent bug where restarting the minds app (especially via a ToDesktop auto-update) sometimes lands a user with existing workspaces on the terminal "create a new workspace" screen instead of their workspace list.

**This is Stream B of 3.** Stream A (PR #2517) is the Electron `window-state.json` persistence fix; this PR fixes the landing-render half in the Python backend + Jinja templates; Stream C (PR #2533) prunes the resolver's last-good topology on observed `DESTROYED` (see the risk note below).

### Root cause

On a cold start, `has_completed_initial_discovery()` flips `True` on the first discovery event from the first provider. If that event arrives before the provider hosting the user's workspace (e.g. imbue_cloud) has surfaced it, and there are no remote tiles yet, `/` (`_handle_landing_page`) saw an empty live workspace list and fell through to `render_create_form` -- a terminal page with no SSE subscription and no auto-refresh -- so the user was stuck there even though they have workspaces.

### Background: what "Fix D" refers to

[Fix D (commit `dafb06ec3`, "restore windows against last-good topology, not just the live snapshot")](https://github.com/imbue-ai/mngr/commit/dafb06ec3e64ef26c69e1013d6694a4a5858f407) is a prior fix on the *window-restore* path. Providers enumerate at very different speeds on cold start (imbue_cloud returns its host in ~1s; local docker takes ~15-20s to enumerate stopped hosts), so the first discovery snapshot the Electron shell trusts can be provider-incomplete -- and window restore was dropping every not-yet-re-discovered workspace window onto the create form.

Fix D added `backend_resolver.list_restorable_workspace_ids()` -- the live `is_primary` workspace agents **unioned with the persisted last-good `system-services` topology** (a per-host record of the last complete enumeration, kept on disk across restarts). The Electron shell's window-restore filter keeps a saved window as long as its workspace is in that restorable set, so a workspace merely *absent* from a partial cold-start snapshot is no longer mistaken for a destroyed one (the live discovery flow still navigates genuinely-destroyed workspaces away after restore). This PR reuses that same primitive for the landing-render decision below.

### The fix

**B1 (backend, `_handle_landing_page`).** When the live workspace list and remote tiles are both empty, the handler now consults `backend_resolver.list_restorable_workspace_ids()` (the live primary agents unioned with the persisted last-good `system-services` topology -- the same primitive Fix D added for the Electron window-restore filter). When that set is non-empty -- meaning we *know* workspaces exist even though a partial cold-start snapshot hasn't re-surfaced them -- it renders the auto-refreshing "Discovering agents..." Landing page (which self-heals into the workspace list via its reload timer + chrome SSE) instead of the create form. The create form is now shown only when discovery has completed **and** the restorable set is genuinely empty (a true first-run user). No new resolver primitive was added.

**B2 (template defense-in-depth, `Create.jinja`).** When the create form is rendered as the landing fallback at `/` (new `is_landing_fallback` flag), it subscribes to `/_chrome/events` and navigates to `/` the moment a `workspaces` event shows a workspace now exists (live, remote, or restorable), mirroring `Landing.jinja`'s existing SSE self-heal. It is guarded so an in-flight create submission (which redirects to `/creating`) is never interrupted. The explicit `/create` page leaves the flag `False`, so a deliberate "create another workspace" flow is never bounced away by the user's existing workspaces.

**Observability.** Added one concise debug log at the fallback decision point: `active=<N> remote=<M> discovery_complete=<bool> restorable=<K> -> <create-form|discovering>`.

### Tests

- `test_landing_page_shows_discovering_when_only_restorable_workspaces_remain`: live/active empty + no remote tiles + discovery complete + restorable non-empty -> Discovering page, not the create form.
- `test_landing_page_shows_create_form_when_restorable_set_is_empty`: discovery complete + restorable genuinely empty -> create form (unchanged behavior).
- `test_render_create_form_landing_fallback_wires_self_heal_sse` / `test_render_create_form_explicit_page_omits_self_heal_sse`: assert the SSE/reload wiring is present only in the landing-fallback form.

Local runs (all green): the full `apps/minds/imbue/minds/desktop_client` subtree (1462 passed), the minds `test_ratchets.py` (57 passed), `test_no_type_errors`, and `ruff format` + `ruff check`.

### Risk note

`list_restorable_workspace_ids()` includes the persisted last-good topology, which (before Stream C) is never pruned in-process. If a user destroyed all their workspaces while the app was closed, the stale last-good entry could keep `/` on the "Discovering..." page instead of the create form. This is a pre-existing property of `list_restorable_workspace_ids` (Fix D already relies on it for window restore) and degrades to a self-refreshing spinner rather than a hard failure. **Stream C** (PR #2533) fixes this at the source by pruning the last-good topology when a host is observed `DESTROYED` and excluding `DESTROYED`-host agents from the restorable set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

