### PR TITLE
Pass MINDS_RESTIC_BINARY to dev-mode backends; check desync in ensure-binaries

### DIFF
--- a/apps/minds/changelog/mngr-dev-mode-restic-binary.md
+++ b/apps/minds/changelog/mngr-dev-mode-restic-binary.md
@@ -1,0 +1,3 @@
+Fixed: dev-mode launches (`pnpm start` / `just minds-start`) now pass `MINDS_RESTIC_BINARY` to the Python backend, pointing at the pinned restic that the prestart hook already downloads into `apps/minds/resources/restic/`. Previously only packaged builds set it, so from-source backends fell back to `restic` on PATH and backup provisioning failed on any machine without a system restic (macOS devs were masked by brew's).
+
+Fixed: `scripts/ensure-binaries.js` now includes desync in its required-binaries check, so a partially populated `resources/` directory (e.g. from a checkout that predates the desync bundling) gets desync downloaded instead of being skipped.

--- a/apps/minds/electron/backend.js
+++ b/apps/minds/electron/backend.js
@@ -247,6 +247,11 @@ function startBackend(onProgress, onNotification, onAuthEvent, onMngrForwardStar
           MNGR_PREFIX: mngrPrefix,
           MINDS_LATCHKEY_BINARY: paths.getLatchkeyPath(),
           MINDS_LATCHKEY_DIRECTORY: paths.getLatchkeyDirectory(),
+          // The prestart hook (ensure-binaries.js) downloads the pinned
+          // restic into resources/restic/; without this the backend falls
+          // back to `restic` on PATH, which only works on machines that
+          // happen to have a system restic (packaged mode always sets it).
+          MINDS_RESTIC_BINARY: paths.getResticPath(),
           MINDS_RELEASE_ID: releaseId,
           MINDS_GIT_SHA: gitSha,
         };

--- a/apps/minds/scripts/ensure-binaries.js
+++ b/apps/minds/scripts/ensure-binaries.js
@@ -24,6 +24,7 @@ const REQUIRED = [
   path.join(RESOURCES, 'uv', 'uv'),
   path.join(RESOURCES, 'git', 'bin', 'git'),
   path.join(RESOURCES, 'lima', 'bin', 'limactl'),
+  path.join(RESOURCES, 'desync', 'desync'),
 ];
 
 const missing = REQUIRED.filter((p) => !fs.existsSync(p));


### PR DESCRIPTION
## Summary

Follow-up to #2512, from auditing which bundled binaries a from-source install actually receives.

- **Dev-mode restic wiring**: `backend.js` only passed `MINDS_RESTIC_BINARY` in packaged mode. Dev-mode backends (`pnpm start` / `just minds-start`) fell back to `restic` on PATH, so backup provisioning failed on any machine without a system restic — even though the `prestart` hook downloads the pinned restic into `apps/minds/resources/restic/` precisely so nobody has to install it (macOS devs were masked by brew's restic). Dev mode now sets the variable, matching packaged mode and the documented intent in `paths.js`.
- **ensure-binaries completeness**: the `REQUIRED` list in `scripts/ensure-binaries.js` omitted desync, so a partially populated `resources/` (e.g. a checkout predating the desync bundling) skipped the download and left desync missing.

## Test plan

- `node --test test/unit/*.test.js` (all pass) and `node --check` on both files.
- Manually verified on the WSL test box: relaunched the dev-mode app and confirmed the backend process env contains `MINDS_RESTIC_BINARY=<repo>/apps/minds/resources/restic/restic`, and that binary executes (`restic 0.18.1 ... linux/amd64`). Before the fix the env var was absent and `restic` was not resolvable on the backend's PATH.
- No Python changes; the env assembly is inline in `backend.js`'s spawn path, which has no existing unit-test seam — left as-is rather than refactoring for testability in a two-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)