### PR TITLE
Fix stale workspace docs: a workspace is a host, not an agent

### DIFF
--- a/apps/minds/changelog/mngr-fix-workspace-glossary.md
+++ b/apps/minds/changelog/mngr-fix-workspace-glossary.md
@@ -1,0 +1,7 @@
+Fixed: documentation drift around what a workspace is. The glossary described a workspace as a single mngr *agent* labeled `workspace=<name>`, but a workspace is a mngr *host* holding several agents, and the `workspace` label was removed some time ago (discovery keys off `is_primary`).
+
+The glossary now defines a workspace as a host, and adds entries for the four agent kinds that live in one: the primary `system-services` agent, chat agents, worktree agents, and worker agents.
+
+Fixed: the launch mode glossary entry listed a nonexistent `CLOUD` mode (the real one is `VULTR`) and omitted `AWS` and `MODAL`.
+
+Fixed: `design.md` and `user_story.md` showed a `mngr create` command with the removed `--label workspace=<name>` flag and no `--new-host`, so following them would not reproduce what minds actually runs.

--- a/apps/minds/docs/design.md
+++ b/apps/minds/docs/design.md
@@ -42,7 +42,7 @@ See [the desktop client design doc](../imbue/minds/desktop_client/README.md) for
 When a user visits the desktop client and no agents exist, they are shown a creation form where they can provide a git repository URL or local path. The desktop client:
 
 1. Clones the repository to a temp directory (if a URL) or uses the local path directly
-2. Runs `mngr create <name> --no-connect --label workspace=<name> --template main --template <mode>` to create the agent (the agent id is read back from the `created` JSONL event; minds does not pre-generate one)
+2. Runs `mngr create system-services@<host> --new-host --no-connect --label workspace_display_name=<name> --label is_primary=true --template main --template <mode>` to create the workspace host and its primary agent (the agent id is read back from the `created` JSONL event; minds does not pre-generate one)
 3. Creates a Cloudflare tunnel (if configured) and injects the tunnel token into the agent via `mngr exec`
 4. Redirects the user to the newly created agent (the user is already authenticated via the global session)
 

--- a/apps/minds/docs/user_story.md
+++ b/apps/minds/docs/user_story.md
@@ -3,9 +3,9 @@ This is the primary flow for how a user would create a workspace for the first t
 1. User starts the desktop client: `minds run`
 2. The server prints a one-time login URL to the terminal
 3. User visits the login URL to authenticate (sets a global session cookie)
-4. Since no agents exist, the landing page shows a creation form with fields for agent name, git repository URL (or local path), branch, and launch mode (DOCKER/LIMA/CLOUD/IMBUE_CLOUD)
+4. Since no workspaces exist, the landing page shows a creation form with fields for workspace name, git repository URL (or local path), branch, and launch mode (DOCKER/LIMA/VULTR/AWS/IMBUE_CLOUD/MODAL)
 5. User fills in the form and clicks Create
-6. The desktop client clones the repository to a temp directory (if a URL) or uses the local path directly, and runs `mngr create <name> --no-connect --label workspace=<name> --template main --template <mode>` (the agent id is read back from the `created` JSONL event rather than pre-generated). If Cloudflare credentials are configured, it also creates a tunnel and injects the tunnel token into the agent.
+6. The desktop client clones the repository to a temp directory (if a URL) or uses the local path directly, and runs `mngr create system-services@<host> --new-host --no-connect --label workspace_display_name=<name> --label is_primary=true --template main --template <mode>` (the agent id is read back from the `created` JSONL event rather than pre-generated). If Cloudflare credentials are configured, it also creates a tunnel and injects the tunnel token into the agent.
 7. While creating, the user sees a progress page that polls for status
 8. When creation completes, the user is redirected to their workspace's web interface at `/agents/<agent-id>/web/`
 

--- a/apps/minds/docs/workspace/glossary.md
+++ b/apps/minds/docs/workspace/glossary.md
@@ -2,7 +2,15 @@
 
 Key concepts in the minds system:
 
-- **workspace**: a persistent mngr agent created from a template repository via `mngr create`. All configuration lives in the template's `.mngr/settings.toml`. Each workspace is labeled with `workspace=<name>` for discovery.
+- **workspace**: a persistent mngr *host*, created from a template repository via `mngr create --new-host`. All configuration lives in the template's `.mngr/settings.toml`. A workspace holds several agents: exactly one primary agent, plus the chat, worktree, and worker agents created within it over time. It is addressed by its primary agent's id, and discovered via that agent's `is_primary` label.
+
+- **primary agent**: the single `system-services` agent on each workspace host, labeled `is_primary=true`. It runs bootstrap and the background services rather than a user-facing chat -- its window-0 command is `sleep infinity && claude`, so claude never starts there. Its `workspace_display_name` label holds the workspace's human-readable name (the normalized slug is the host's name). Hidden from the UI agent list and protected against direct destroy.
+
+- **chat agent**: a user-facing mngr agent created on demand in a workspace, one per chat tab. Created with `--transfer none`, so it shares the primary agent's work_dir and Claude config dir. Bootstrap seeds the first one on initial container boot; the count grows and shrinks with the user's workload, and is not capped.
+
+- **worktree agent**: a mngr agent created from the "New agent" tab, using `--template worktree` and `--transfer git-worktree` on branch `mngr/<name>`. Unlike a chat agent it lives in its own git worktree, outside the repo-root work_dir. Labeled `user_created=true`.
+
+- **worker agent**: a mngr agent created by *another agent* (not by the user) when it delegates a task to a sub-agent, via the `launch-task` skill. Labeled `agent_created=true`. Not tied to any tab. The `user_created` / `agent_created` distinction drives the OOM shedding bands.
 
 - **template repository**: a git repository (e.g. default-workspace-template) that defines a workspace's entire runtime: Dockerfile, services, skills, scripts, and mngr configuration.
 
@@ -20,4 +28,4 @@ Key concepts in the minds system:
 
 - **service event**: a JSON line in `events/services/events.jsonl` that registers (or deregisters) a service name and URL. The desktop client's MngrStreamManager watches these events to discover agent backends.
 
-- **launch mode**: how the agent runs. DOCKER mode runs in a Docker container on the user's machine. LIMA runs in a Lima VM. CLOUD runs in Docker on a Vultr VPS. IMBUE_CLOUD leases a pre-baked pool host via the imbue_cloud provider plugin.
+- **launch mode**: how the workspace runs; selects the mngr provider instance and create-template. DOCKER runs in a Docker container on the user's machine. LIMA runs in a Lima VM. VULTR runs in Docker on a Vultr VPS. AWS runs on an EC2 instance. IMBUE_CLOUD leases a pre-baked pool host via the imbue_cloud provider plugin. MODAL runs in a Modal sandbox using the local machine's own Modal token; sandboxes are ephemeral (~1 day max), so it is testing-only.

--- a/apps/minds/imbue/minds/desktop_client/api_v1.py
+++ b/apps/minds/imbue/minds/desktop_client/api_v1.py
@@ -210,8 +210,8 @@ def _handle_notification(agent_id: str) -> OkResponse | Response:
 # backups) through the hub. Every route is gated at the gateway by the
 # ``minds-workspaces`` detent scope (see ``mngr_latchkey.agent_setup``); the
 # scope's per-verb permissions decide which of these a given caller may reach.
-# A workspace is addressed by its primary (``is_primary``+``workspace``) agent
-# id, matching minds discovery.
+# A workspace is addressed by its primary (``is_primary``) agent id, matching
+# minds discovery.
 
 
 def _serialize_workspace(agent_id: AgentId) -> WorkspaceSummary:


### PR DESCRIPTION
## Why

While answering a question about how minds concepts map onto mngr primitives, the glossary turned out to state the opposite of what the code does.

`apps/minds/docs/workspace/glossary.md` defined a workspace as "a persistent mngr **agent** created from a template repository via `mngr create`... Each workspace is labeled with `workspace=<name>` for discovery." Both halves are stale:

- A workspace is a mngr **host** (every launch path passes `--new-host`), holding one primary agent plus N chat/worktree/worker agents. The one-agent model was replaced by the services/chat split.
- The `workspace` label was removed entirely when workspace names were split into a `workspace_display_name` label on the primary agent plus a normalized host slug. Discovery now keys off `is_primary`.

## What changed

- **glossary.md**: workspace redefined as a host. Added entries for the four agent kinds that live in one: primary (`system-services`, `is_primary=true`), chat (`--transfer none`, shares the primary's work_dir, one per chat tab, uncapped), worktree (`--template worktree`, own git worktree, `user_created=true`), and worker (agent-created via `launch-task`, `agent_created=true`, not tied to a tab).
- **glossary.md**: the launch mode entry listed a nonexistent `CLOUD` mode (the real enum member is `VULTR`) and omitted `AWS` and `MODAL`.
- **design.md**, **user_story.md**: the shown `mngr create` command still passed the removed `--label workspace=<name>` and lacked `--new-host`, so following it would not reproduce what minds actually runs.
- **api_v1.py**: a comment referenced the removed label (`is_primary`+`workspace`). The code below it already didn't use it.

Docs and one comment only -- no behavior change.

## Left for a follow-up

`_build_worktree_create_command`'s docstring in the default-workspace-template repo (`apps/system_interface/.../agent_manager.py`) says "The **worker** belongs to its workspace by sharing the host" while building the **worktree** agent command. That's a different repo, so it needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)