### PR TITLE
Fix Intel (x86_64) minds build: stage per-arch native helpers via afterPack

### DIFF
--- a/apps/minds/changelog/mngr-tart.md
+++ b/apps/minds/changelog/mngr-tart.md
@@ -1,0 +1,15 @@
+Fixed the Intel (x86_64) desktop build, which previously bundled arm64 native
+helpers (`uv`, `lima`, `restic`, `desync`) into every build and so failed to
+launch on Intel Macs.
+
+Root cause: the bundled helpers were downloaded for the *build host's* arch,
+never the *target* arch. `build.js` and the `beforeInstall` hook both keyed off
+`process.arch`, and `beforeInstall` receives no target-arch parameter, so the
+arm64 build machine's binaries ended up in the arm64, x64, and universal
+builds alike.
+
+The native-helper download now honors an explicit target arch and runs from a
+new `afterPack` hook (which does receive the build's `arch`): each per-arch
+build stages its own arch's helpers, and the universal build is lipo-merged
+from the x64 and arm64 builds by `@electron/universal`. The downloaders also
+support `arch: 'universal'` (lipo of both slices) as a fallback.

--- a/apps/minds/changelog/mngr-tart.md
+++ b/apps/minds/changelog/mngr-tart.md
@@ -13,3 +13,14 @@ new `afterPack` hook (which does receive the build's `arch`): each per-arch
 build stages its own arch's helpers, and the universal build is lipo-merged
 from the x64 and arm64 builds by `@electron/universal`. The downloaders also
 support `arch: 'universal'` (lipo of both slices) as a fallback.
+
+Also fixed the packaged Python environment failing to set up on Intel Macs.
+`cbor2` 6.x (pulled in via `modal`) and `cryptography` 49.x dropped their macOS
+x86_64 wheels (arm64-only), so during env-setup on an Intel Mac `uv sync` fell
+back to a Rust source build, which a normal user machine can't do -- setup
+failed with "Backend exited before emitting login URL" and the app never came
+up. The packaged env now caps `cbor2<6` and `cryptography<49` (the last
+Intel-friendly releases; no dependency requires the newer ones), keeping
+env-setup wheel-only on x86_64. A new `build_test.py` guard
+(`test_lock_has_no_intel_missing_wheels`) fails the build if any dependency
+again ships only a macOS arm64 wheel.

--- a/apps/minds/electron/pyproject/pyproject.toml
+++ b/apps/minds/electron/pyproject/pyproject.toml
@@ -37,6 +37,17 @@ dependencies = [
 [tool.uv]
 exclude-newer = "14 days"
 
+# Keep the packaged env installable on Intel Macs. cbor2 6.x (via modal) and
+# cryptography 49.x dropped their macOS x86_64 wheels (arm64-only), so on an
+# Intel Mac uv would fall back to a Rust source build during env-setup, which
+# a normal user machine can't do -- `uv sync` fails and the backend never
+# starts. Capping to the last releases that publish an Intel wheel keeps
+# env-setup wheel-only on x86_64. Neither cap is required by any dependency
+# floor (max floor is cryptography>=42.0; modal imposes no cbor2 floor). The
+# test_lock_has_no_intel_missing_wheels guard fails the build if any dep
+# regresses this.
+constraint-dependencies = ["cbor2<6", "cryptography<49"]
+
 [tool.uv.sources]
 minds = { path = "../../../../apps/minds", editable = true }
 imbue-mngr = { path = "../../../../libs/mngr", editable = true }

--- a/apps/minds/electron/pyproject/uv.lock
+++ b/apps/minds/electron/pyproject/uv.lock
@@ -6,6 +6,12 @@ requires-python = "==3.12.13"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
+[manifest]
+constraints = [
+    { name = "cbor2", specifier = "<6" },
+    { name = "cryptography", specifier = "<49" },
+]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -744,9 +750,11 @@ name = "imbue-common"
 version = "0.1.20"
 source = { editable = "../../../../libs/imbue_common" }
 dependencies = [
+    { name = "argon2-cffi" },
     { name = "boto3" },
     { name = "click" },
     { name = "cowsay-python" },
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "pydantic" },
@@ -757,9 +765,11 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.0" },
     { name = "cowsay-python", specifier = ">=1.0.2" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "inline-snapshot", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "loguru", specifier = ">=0.7" },
@@ -818,7 +828,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
     { name = "paramiko", specifier = ">=3.0" },
     { name = "pluggy", specifier = ">=1.5.0" },
-    { name = "psutil", specifier = ">=5.9" },
+    { name = "psutil", specifier = ">=7.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygtail", specifier = ">=0.14.0" },
     { name = "pyinfra", specifier = ">=3.0" },

--- a/apps/minds/package.json
+++ b/apps/minds/package.json
@@ -14,6 +14,7 @@
     "watch:css": "tailwindcss -i imbue/minds/desktop_client/static/app.css -o imbue/minds/desktop_client/static/app.min.css --watch",
     "dist": "pnpm build && pnpm exec todesktop build",
     "todesktop:beforeInstall": "./scripts/download-binaries.js",
+    "todesktop:afterPack": "./scripts/after-pack.js",
     "test:unit": "node --test test/unit/*.test.js",
     "test:e2e": "playwright test --config=test/e2e/playwright.config.js"
   },

--- a/apps/minds/scripts/after-pack.js
+++ b/apps/minds/scripts/after-pack.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * ToDesktop `afterPack` hook: stage the TARGET-architecture native helpers
+ * (uv, lima, git, restic, desync) into the packed .app's Contents/Resources,
+ * after packaging and before code signing.
+ *
+ * Runs once per target arch on ToDesktop's build server, so each per-arch
+ * build carries its own arch's binaries; @electron/universal then lipo-merges
+ * the x64 and arm64 builds into the universal one. This is why the earlier
+ * `beforeInstall` hook could not fix the arch -- it receives no `arch`, so it
+ * only ever staged the build server's host arch.
+ *
+ * `arch` is the electron-builder Arch enum: x64=1, arm64=3, universal=4.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const download = require('./download-binaries.js');
+const { downloadLima } = require('./build.js');
+
+const ARCH_BY_ENUM = { 1: 'x86_64', 3: 'aarch64', 4: 'universal' };
+
+function findAppResources(appOutDir) {
+  const app = fs.readdirSync(appOutDir).find((entry) => entry.endsWith('.app'));
+  if (!app) {
+    throw new Error(`after-pack: no .app bundle found in ${appOutDir}`);
+  }
+  return path.join(appOutDir, app, 'Contents', 'Resources');
+}
+
+module.exports = async function afterPack({ appOutDir, arch }) {
+  const archName = ARCH_BY_ENUM[arch];
+  if (!archName) {
+    throw new Error(`after-pack: unsupported arch enum ${arch} (expected x64=1, arm64=3, universal=4)`);
+  }
+  const resourcesDir = findAppResources(appOutDir);
+  const platform = 'darwin';
+  console.log(`[after-pack] staging ${archName} native helpers into ${resourcesDir}`);
+  await Promise.all([
+    download.downloadUv(resourcesDir, { platform, arch: archName }),
+    download.downloadGit(resourcesDir, { platform }),
+    download.downloadRestic(resourcesDir, { platform, arch: archName }),
+    download.downloadDesync(resourcesDir, { platform, arch: archName }),
+    downloadLima(resourcesDir, { platform, arch: archName }),
+  ]);
+  console.log(`[after-pack] done (${archName}).`);
+};

--- a/apps/minds/scripts/after-pack.js
+++ b/apps/minds/scripts/after-pack.js
@@ -22,18 +22,26 @@ const ARCH_BY_ENUM = { 1: 'x86_64', 3: 'aarch64', 4: 'universal' };
 
 function findAppResources(appOutDir) {
   const app = fs.readdirSync(appOutDir).find((entry) => entry.endsWith('.app'));
-  if (!app) {
-    throw new Error(`after-pack: no .app bundle found in ${appOutDir}`);
-  }
-  return path.join(appOutDir, app, 'Contents', 'Resources');
+  return app ? path.join(appOutDir, app, 'Contents', 'Resources') : null;
 }
 
-module.exports = async function afterPack({ appOutDir, arch }) {
+module.exports = async function afterPack({ appOutDir, arch, electronPlatformName }) {
+  // The native-helper arch split only matters on macOS (Intel vs Apple Silicon).
+  // Linux/Windows are single-arch and are staged by the beforeInstall hook; they
+  // also have no .app bundle, so skip them rather than break their builds.
+  if (electronPlatformName && electronPlatformName !== 'darwin') {
+    console.log(`[after-pack] skipping platform ${electronPlatformName} (macOS-only hook).`);
+    return;
+  }
+  const resourcesDir = findAppResources(appOutDir);
+  if (!resourcesDir) {
+    console.log(`[after-pack] no .app bundle in ${appOutDir}; skipping (non-macOS build).`);
+    return;
+  }
   const archName = ARCH_BY_ENUM[arch];
   if (!archName) {
     throw new Error(`after-pack: unsupported arch enum ${arch} (expected x64=1, arm64=3, universal=4)`);
   }
-  const resourcesDir = findAppResources(appOutDir);
   const platform = 'darwin';
   console.log(`[after-pack] staging ${archName} native helpers into ${resourcesDir}`);
   await Promise.all([

--- a/apps/minds/scripts/build.js
+++ b/apps/minds/scripts/build.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync, execFileSync } = require('child_process');
-const { downloadGit, downloadUv, downloadRestic, download } = require('./download-binaries.js');
+const { downloadGit, downloadUv, downloadRestic, download, lipoCreate, DARWIN_UNIVERSAL_ARCHS } = require('./download-binaries.js');
 
 const ROOT = path.resolve(__dirname, '..');
 const RESOURCES_DIR = path.join(ROOT, 'resources');
@@ -374,18 +374,50 @@ function getLimaDownloadUrl({ platform, arch }) {
   return `https://github.com/lima-vm/lima/releases/download/v${LIMA_VERSION}/lima-${LIMA_VERSION}-${osLabel}-${archLabel}.tar.gz`;
 }
 
-async function downloadLima({ platform, arch }) {
+async function downloadLima(resourcesDir, { platform, arch }) {
   // We keep the full extracted layout (bin/ + share/ + libexec/) because
   // limactl resolves its templates and guest-agent payloads via paths
   // relative to its own executable.
-  const limaDir = path.join(RESOURCES_DIR, 'lima');
-  await downloadAndExtractTarball({
-    destDir: limaDir,
-    url: getLimaDownloadUrl({ platform, arch }),
-    archiveName: 'lima.tar.gz',
-    binaryPath: path.join(limaDir, 'bin', 'limactl'),
-    label: 'Lima',
-  });
+  const limaDir = path.join(resourcesDir, 'lima');
+  const limactlPath = path.join(limaDir, 'bin', 'limactl');
+
+  if (arch === 'universal') {
+    // Fetch both slices and lipo limactl into a universal binary. share/ +
+    // libexec/ hold Linux guest payloads and templates, which are
+    // host-arch-agnostic, so the primary slice's tree suffices.
+    const [primaryArch, ...otherArchs] = DARWIN_UNIVERSAL_ARCHS;
+    await downloadAndExtractTarball({
+      destDir: limaDir,
+      url: getLimaDownloadUrl({ platform, arch: primaryArch }),
+      archiveName: 'lima.tar.gz',
+      binaryPath: limactlPath,
+      label: `Lima (${primaryArch})`,
+    });
+    const sliceBinaries = [limactlPath];
+    for (const sliceArch of otherArchs) {
+      const sliceDir = path.join(limaDir, `_${sliceArch}`);
+      await downloadAndExtractTarball({
+        destDir: sliceDir,
+        url: getLimaDownloadUrl({ platform, arch: sliceArch }),
+        archiveName: 'lima.tar.gz',
+        binaryPath: path.join(sliceDir, 'bin', 'limactl'),
+        label: `Lima (${sliceArch})`,
+      });
+      sliceBinaries.push(path.join(sliceDir, 'bin', 'limactl'));
+    }
+    lipoCreate(sliceBinaries, limactlPath);
+    for (const sliceArch of otherArchs) {
+      fs.rmSync(path.join(limaDir, `_${sliceArch}`), { recursive: true });
+    }
+  } else {
+    await downloadAndExtractTarball({
+      destDir: limaDir,
+      url: getLimaDownloadUrl({ platform, arch }),
+      archiveName: 'lima.tar.gz',
+      binaryPath: limactlPath,
+      label: 'Lima',
+    });
+  }
 
   // Strip Darwin guest-agents. Each one is a gzipped arm64/x86_64 Mach-O,
   // and Apple's notarytool unzips it and rejects the inner binary because
@@ -602,7 +634,7 @@ async function main() {
   // Download binaries and copy pyproject in parallel
   await Promise.all([
     downloadUv(RESOURCES_DIR, { platform, arch }),
-    downloadLima({ platform, arch }),
+    downloadLima(RESOURCES_DIR, { platform, arch }),
     downloadGit(RESOURCES_DIR, { platform }),
     downloadRestic(RESOURCES_DIR, { platform, arch }),
   ]);
@@ -618,7 +650,11 @@ async function main() {
   console.log(`Resources directory: ${RESOURCES_DIR}`);
 }
 
-main().catch((err) => {
-  console.error('Build failed:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Build failed:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { downloadLima, getPlatformArch, getLimaDownloadUrl };

--- a/apps/minds/scripts/build_test.py
+++ b/apps/minds/scripts/build_test.py
@@ -25,6 +25,7 @@ import plistlib
 import re
 import shutil
 import subprocess
+import tomllib
 import zipfile
 from pathlib import Path
 from typing import Final
@@ -192,6 +193,44 @@ def test_workspace_package_lists_are_consistent() -> None:
         f"build_test.py WORKSPACE_PACKAGES = {sorted(expected)}. "
         f"Differences (symmetric difference vs the test's list) by file: {mismatches}. "
         "Update every file so the package sets match exactly."
+    )
+
+
+def test_lock_has_no_intel_missing_wheels() -> None:
+    """Guard: the packaged env must install wheel-only on Intel (x86_64) macOS.
+
+    A dependency that ships a macOS arm64 wheel but no Intel-usable wheel
+    (macOS x86_64 / universal2 / pure-python) forces uv into a source build
+    during env-setup on an Intel Mac. Native (Rust/C) packages like cbor2 and
+    cryptography then need a compiler the user's machine doesn't have, so
+    `uv sync` fails and the backend never starts (a real user hit exactly this:
+    cbor2 6.x via modal, and cryptography 49.x, both dropped their macOS
+    x86_64 wheels). The `constraint-dependencies` in
+    electron/pyproject/pyproject.toml cap them to the last Intel-friendly
+    releases; this guard fails the build if any dep regresses that.
+
+    This is a pure lock-file audit -- no toolchain, no Intel runner, no Rust.
+    That matters: a GitHub Intel CI runner ships Rust, so it would silently
+    *pass* a source-build-only env and mask this failure.
+    """
+    lock = tomllib.loads((APP_ROOT / "electron" / "pyproject" / "uv.lock").read_text())
+    offenders = []
+    for pkg in lock.get("package", []):
+        wheel_files = [w.get("url", "").rsplit("/", 1)[-1] for w in pkg.get("wheels", [])]
+        if not wheel_files:
+            continue  # sdist-only: pure-python builds without a compiler; no arch wheel to miss
+        ships_mac_arm = any("macosx" in f and "arm64" in f for f in wheel_files)
+        ships_intel = any(
+            ("macosx" in f and "x86_64" in f) or "universal2" in f or f.endswith("none-any.whl") for f in wheel_files
+        )
+        if ships_mac_arm and not ships_intel:
+            offenders.append(f"{pkg['name']}=={pkg['version']}")
+    assert offenders == [], (
+        "Packaged env has dependencies that ship a macOS arm64 wheel but no "
+        f"Intel-usable wheel, so they would source-build on an Intel Mac: {offenders}. "
+        "Cap each in electron/pyproject/pyproject.toml [tool.uv] constraint-dependencies "
+        "to the last version publishing a macOS x86_64 or universal2 wheel, then re-run "
+        "`uv lock` in electron/pyproject/."
     )
 
 

--- a/apps/minds/scripts/download-binaries.js
+++ b/apps/minds/scripts/download-binaries.js
@@ -183,41 +183,98 @@ function verifyChecksum(buffer, filename) {
   console.log(`[download-binaries] ${filename} SHA256 OK`);
 }
 
+// The two macOS slices. Each build downloads its own target arch (the afterPack
+// hook passes it); `arch: 'universal'` fuses both slices with lipo as a fallback
+// for callers that want a single fat binary.
+const DARWIN_UNIVERSAL_ARCHS = ['aarch64', 'x86_64'];
+
+// Apple's `lipo`; combines per-arch Mach-O slices into one universal binary. A
+// single input is copied verbatim, so this is also a no-op wrapper for the
+// one-slice case.
+function lipoCreate(inputBinaries, outputBinary) {
+  const inputs = inputBinaries.map((p) => `"${p}"`).join(' ');
+  execSync(`lipo -create ${inputs} -output "${outputBinary}"`, { stdio: 'inherit' });
+  fs.chmodSync(outputBinary, 0o755);
+}
+
+async function extractUvSlice(destDir, { platform, arch }) {
+  fs.mkdirSync(destDir, { recursive: true });
+  const url = getUvDownloadUrl({ platform, arch });
+  const filename = path.basename(new URL(url).pathname);
+  console.log(`[download-binaries] Downloading uv (${arch}) from ${url}...`);
+  const archive = await download(url);
+  verifyChecksum(archive, filename);
+  const tarPath = path.join(destDir, 'uv.tar.gz');
+  fs.writeFileSync(tarPath, archive);
+  execSync(`tar xzf "${tarPath}" -C "${destDir}" --strip-components=1`, { stdio: 'inherit' });
+  fs.unlinkSync(tarPath);
+  const uvBinary = path.join(destDir, 'uv');
+  if (!fs.existsSync(uvBinary)) {
+    throw new Error(`uv binary not found at ${uvBinary} after extraction`);
+  }
+  return uvBinary;
+}
+
 async function downloadUv(resourcesDir, { platform, arch }) {
   const uvDir = path.join(resourcesDir, 'uv');
   if (fs.existsSync(uvDir)) fs.rmSync(uvDir, { recursive: true });
   fs.mkdirSync(uvDir, { recursive: true });
 
-  const url = getUvDownloadUrl({ platform, arch });
-  const filename = path.basename(new URL(url).pathname);
-  console.log(`[download-binaries] Downloading uv from ${url}...`);
-
-  const archive = await download(url);
-  verifyChecksum(archive, filename);
-
   if (platform === 'win32') {
+    const url = getUvDownloadUrl({ platform, arch });
+    const filename = path.basename(new URL(url).pathname);
+    console.log(`[download-binaries] Downloading uv from ${url}...`);
+    const archive = await download(url);
+    verifyChecksum(archive, filename);
     const zipPath = path.join(uvDir, 'uv.zip');
     fs.writeFileSync(zipPath, archive);
     execSync(`powershell -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${uvDir}'"`, { stdio: 'inherit' });
     fs.unlinkSync(zipPath);
-  } else {
-    const tarPath = path.join(uvDir, 'uv.tar.gz');
-    fs.writeFileSync(tarPath, archive);
-    execSync(`tar xzf "${tarPath}" -C "${uvDir}" --strip-components=1`, { stdio: 'inherit' });
-    fs.unlinkSync(tarPath);
+    const uvExe = path.join(uvDir, 'uv.exe');
+    if (!fs.existsSync(uvExe)) {
+      throw new Error(`uv binary not found at ${uvExe} after extraction`);
+    }
+    // The runtime resolves uv as 'uv' (no .exe). Copy so both names work.
+    fs.copyFileSync(uvExe, path.join(uvDir, 'uv'));
+    console.log(`[download-binaries] uv installed at ${uvExe}`);
+    return;
   }
 
-  const uvBinary = path.join(uvDir, platform === 'win32' ? 'uv.exe' : 'uv');
-  if (!fs.existsSync(uvBinary)) {
-    throw new Error(`uv binary not found at ${uvBinary} after extraction`);
+  if (arch === 'universal') {
+    const sliceBinaries = [];
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      sliceBinaries.push(await extractUvSlice(path.join(uvDir, `_${sliceArch}`), { platform, arch: sliceArch }));
+    }
+    lipoCreate(sliceBinaries, path.join(uvDir, 'uv'));
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      fs.rmSync(path.join(uvDir, `_${sliceArch}`), { recursive: true });
+    }
+    console.log(`[download-binaries] universal uv installed at ${path.join(uvDir, 'uv')}`);
+    return;
   }
-  if (platform === 'win32') {
-    // The runtime resolves uv as 'uv' (no .exe). Copy so both names work.
-    fs.copyFileSync(uvBinary, path.join(uvDir, 'uv'));
-  } else {
-    fs.chmodSync(uvBinary, 0o755);
-  }
+
+  const uvBinary = await extractUvSlice(uvDir, { platform, arch });
+  fs.chmodSync(uvBinary, 0o755);
   console.log(`[download-binaries] uv installed at ${uvBinary}`);
+}
+
+async function extractResticSlice(destDir, { platform, arch }) {
+  // restic ships its bz2 as the bare binary (no tar wrapper). bunzip2 is
+  // available on macOS (BSD) and Linux by default.
+  fs.mkdirSync(destDir, { recursive: true });
+  const url = getResticDownloadUrl({ platform, arch });
+  const filename = path.basename(new URL(url).pathname);
+  console.log(`[download-binaries] Downloading restic (${arch}) from ${url}...`);
+  const archive = await download(url);
+  verifyChecksum(archive, filename);
+  const bzPath = path.join(destDir, 'restic.bz2');
+  fs.writeFileSync(bzPath, archive);
+  execSync(`bunzip2 -f "${bzPath}"`, { stdio: 'inherit' });
+  const resticPath = path.join(destDir, 'restic');
+  if (!fs.existsSync(resticPath)) {
+    throw new Error(`restic binary not found at ${resticPath} after bunzip2`);
+  }
+  return resticPath;
 }
 
 async function downloadRestic(resourcesDir, { platform, arch }) {
@@ -225,17 +282,13 @@ async function downloadRestic(resourcesDir, { platform, arch }) {
   if (fs.existsSync(resticDir)) fs.rmSync(resticDir, { recursive: true });
   fs.mkdirSync(resticDir, { recursive: true });
 
-  const url = getResticDownloadUrl({ platform, arch });
-  const filename = path.basename(new URL(url).pathname);
-  console.log(`[download-binaries] Downloading restic from ${url}...`);
-
-  const archive = await download(url);
-  verifyChecksum(archive, filename);
-
-  const resticName = platform === 'win32' ? 'restic.exe' : 'restic';
-  const resticPath = path.join(resticDir, resticName);
-
   if (platform === 'win32') {
+    const url = getResticDownloadUrl({ platform, arch });
+    const filename = path.basename(new URL(url).pathname);
+    console.log(`[download-binaries] Downloading restic from ${url}...`);
+    const archive = await download(url);
+    verifyChecksum(archive, filename);
+    const resticPath = path.join(resticDir, 'restic.exe');
     const zipPath = path.join(resticDir, 'restic.zip');
     fs.writeFileSync(zipPath, archive);
     execSync(`powershell -Command "Expand-Archive -Path '${zipPath}' -DestinationPath '${resticDir}'"`, { stdio: 'inherit' });
@@ -249,21 +302,44 @@ async function downloadRestic(resourcesDir, { platform, arch }) {
     }
     // Runtime resolves restic as 'restic' (no .exe); duplicate so both names work.
     fs.copyFileSync(resticPath, path.join(resticDir, 'restic'));
-  } else {
-    // restic ships its bz2 as the bare binary (no tar wrapper). bunzip2 is
-    // available on macOS (BSD) and Linux by default; we stage the archive
-    // to a temp .bz2 and decompress in place.
-    const bzPath = path.join(resticDir, 'restic.bz2');
-    fs.writeFileSync(bzPath, archive);
-    execSync(`bunzip2 -f "${bzPath}"`, { stdio: 'inherit' });
-    // bunzip2 strips the .bz2 suffix, leaving resticDir/restic.
-    if (!fs.existsSync(resticPath)) {
-      throw new Error(`restic binary not found at ${resticPath} after bunzip2`);
-    }
-    fs.chmodSync(resticPath, 0o755);
+    console.log(`[download-binaries] restic installed at ${resticPath}`);
+    return;
   }
 
+  if (arch === 'universal') {
+    const sliceBinaries = [];
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      sliceBinaries.push(await extractResticSlice(path.join(resticDir, `_${sliceArch}`), { platform, arch: sliceArch }));
+    }
+    lipoCreate(sliceBinaries, path.join(resticDir, 'restic'));
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      fs.rmSync(path.join(resticDir, `_${sliceArch}`), { recursive: true });
+    }
+    console.log(`[download-binaries] universal restic installed at ${path.join(resticDir, 'restic')}`);
+    return;
+  }
+
+  const resticPath = await extractResticSlice(resticDir, { platform, arch });
+  fs.chmodSync(resticPath, 0o755);
   console.log(`[download-binaries] restic installed at ${resticPath}`);
+}
+
+async function extractDesyncSlice(destDir, { platform, arch }) {
+  fs.mkdirSync(destDir, { recursive: true });
+  const url = getDesyncDownloadUrl({ platform, arch });
+  const filename = path.basename(new URL(url).pathname);
+  console.log(`[download-binaries] Downloading desync (${arch}) from ${url}...`);
+  const archive = await download(url);
+  verifyChecksum(archive, filename);
+  const tarPath = path.join(destDir, 'desync.tar.gz');
+  fs.writeFileSync(tarPath, archive);
+  execSync(`tar xzf "${tarPath}" -C "${destDir}"`, { stdio: 'inherit' });
+  fs.unlinkSync(tarPath);
+  const desyncBinary = path.join(destDir, 'desync');
+  if (!fs.existsSync(desyncBinary)) {
+    throw new Error(`desync binary not found at ${desyncBinary} after extraction`);
+  }
+  return desyncBinary;
 }
 
 async function downloadDesync(resourcesDir, { platform, arch }) {
@@ -277,22 +353,20 @@ async function downloadDesync(resourcesDir, { platform, arch }) {
   if (fs.existsSync(desyncDir)) fs.rmSync(desyncDir, { recursive: true });
   fs.mkdirSync(desyncDir, { recursive: true });
 
-  const url = getDesyncDownloadUrl({ platform, arch });
-  const filename = path.basename(new URL(url).pathname);
-  console.log(`[download-binaries] Downloading desync from ${url}...`);
-
-  const archive = await download(url);
-  verifyChecksum(archive, filename);
-
-  const tarPath = path.join(desyncDir, 'desync.tar.gz');
-  fs.writeFileSync(tarPath, archive);
-  execSync(`tar xzf "${tarPath}" -C "${desyncDir}"`, { stdio: 'inherit' });
-  fs.unlinkSync(tarPath);
-
-  const desyncBinary = path.join(desyncDir, 'desync');
-  if (!fs.existsSync(desyncBinary)) {
-    throw new Error(`desync binary not found at ${desyncBinary} after extraction`);
+  if (arch === 'universal') {
+    const sliceBinaries = [];
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      sliceBinaries.push(await extractDesyncSlice(path.join(desyncDir, `_${sliceArch}`), { platform, arch: sliceArch }));
+    }
+    lipoCreate(sliceBinaries, path.join(desyncDir, 'desync'));
+    for (const sliceArch of DARWIN_UNIVERSAL_ARCHS) {
+      fs.rmSync(path.join(desyncDir, `_${sliceArch}`), { recursive: true });
+    }
+    console.log(`[download-binaries] universal desync installed at ${path.join(desyncDir, 'desync')}`);
+    return;
   }
+
+  const desyncBinary = await extractDesyncSlice(desyncDir, { platform, arch });
   fs.chmodSync(desyncBinary, 0o755);
   console.log(`[download-binaries] desync installed at ${desyncBinary}`);
 }
@@ -459,6 +533,8 @@ beforeInstall.downloadUv = downloadUv;
 beforeInstall.downloadRestic = downloadRestic;
 beforeInstall.downloadDesync = downloadDesync;
 beforeInstall.download = download;
+beforeInstall.lipoCreate = lipoCreate;
+beforeInstall.DARWIN_UNIVERSAL_ARCHS = DARWIN_UNIVERSAL_ARCHS;
 module.exports = beforeInstall;
 
 if (require.main === module) {


### PR DESCRIPTION
## Problem
The Intel (x86_64) minds desktop build does not launch on Intel Macs — it bundles **arm64** native helpers (`uv`, `lima`, `restic`, `desync`), so the x64 Electron shell dies the moment `env-setup` spawns `uv` (`exec format error` / "Bad CPU type").

## Root cause
The helpers were downloaded for the **build host's** arch, not the **target** arch. `scripts/build.js` and the `beforeInstall` hook both key off `process.arch`, and ToDesktop's `beforeInstall` hook receives **no `arch` parameter** — so an arm64 builder's binaries end up in the arm64, x64, **and** universal builds alike. (`git` is exempt: Apple's `xcrun` git is already a universal Mach-O.)

## Fix (canonical)
Move native-helper staging into an arch-aware **`afterPack`** hook (`scripts/after-pack.js`), which *does* receive the build's `arch` (`x64=1, arm64=3, universal=4`). Each per-arch build stages its own arch's helpers; the **universal** build is lipo-merged from the x64 + arm64 sub-builds by `@electron/universal`. The downloaders are reworked to be **arch-parameterized** (single arch, or `'universal'` → `lipo`).

`beforeInstall` + the Stage-A host-arch downloads are kept as a safety baseline (`afterPack` runs later and overrides); they can be removed once `afterPack` is proven.

## Verification
- **Binary level (local, Rosetta):** reproduced the bug (`arch -x86_64 ./uv-arm64` → "Bad CPU type") and proved the fix (x86_64 `uv`/`restic`/`limactl` run under Rosetta; the `'universal'` fallback runs both slices).
- **App level (local, Rosetta):** launched minds as x86 (x64 Electron 40.10.1 + the x64 helpers) — the **full Home/Workspaces UI came up with no exec-format error**. macOS itself flagged the process as an Intel app (Rosetta deprecation banner), confirming it was genuinely x86.

## Not yet verified — why this is a draft
The ToDesktop **packaging** wiring needs one real cloud build to confirm: that ToDesktop invokes `todesktop:afterPack` per-arch, that `@electron/universal` merges the per-arch `Contents/Resources` cleanly, and that `additionalBinariesToSign` still resolves.

## Follow-ups
- Confirm end-to-end with one `pnpm dist`.
- Move the `build` job off the self-hosted `minds-runner` onto a GitHub `macos-latest` runner + add a `macos-13-large` Intel launch smoke leg (`minds-launch-to-msg.yml`).
- Remove the now-redundant `beforeInstall` / Stage-A host-arch downloads once `afterPack` is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)