### PR TITLE
Wire the minds behavioral-spec corpus into TMR (export, plan, tmr-tasks)

### DIFF
--- a/.claude/skills/minds-behavioral-specs/SKILL.md
+++ b/.claude/skills/minds-behavioral-specs/SKILL.md
@@ -237,6 +237,15 @@ from the repo root):
   scenario outline, or rule), carrying coordinate, unit kind, and location.
 - `query` - the same records, filtered structurally (by tag, name, or step
   text).
+- `export` - enriched JSONL records: everything around each unit a
+  test-writing consumer needs (effective steps with Background folded in,
+  Examples rows, descriptions, prose, and the applicable invariants resolved
+  root -> folder -> file).
+- `plan --for-tmr` - emits one TMR task packet per unit (scenarios and
+  scenario outlines by default; `--include-rules` adds rules) for fanning
+  out witness-test-writing agents via `mngr tmr-tasks`.
+- `check-witnesses` - fails on any `witnesses` marker whose coordinate no
+  corpus unit claims.
 
 `uv run minds specs --help` is authoritative for invocation detail. For
 AST-level needs beyond the CLI, `gherkin-official` (a dependency of

--- a/apps/minds/changelog/danver-minds-specs-tmr.md
+++ b/apps/minds/changelog/danver-minds-specs-tmr.md
@@ -1,0 +1,13 @@
+Added three `minds specs` subcommands that turn the behavioral-spec corpus into a producer for test-writing agents:
+
+- `export` emits enriched JSONL unit records (schema_version 1): beyond the `list` fields, each record carries the unit's description, raw_steps and effective_steps (Background folded in), Examples rows for Scenario Outlines, the Feature name/description, the enclosing Rule's summary, the relevant prose (folder overview.md files from the corpus root down, then the file's sidecar), and the applicable invariants resolved root -> folder -> file (corpus invariants.feature, ancestor folder invariants.feature files, and file-scoped Rules). Stdout stays pure JSONL; unit-omitting violations go to stderr with a nonzero exit, matching `list`/`query`.
+
+- `plan --for-tmr` wraps each exported unit in a TMR task packet (id = coordinate, display_id = coordinate with dots replaced by dashes, kind, and the enriched record as context) for consumption by the new `mngr tmr-tasks` task-file recipe. Scenarios and scenario outlines are planned by default; `--include-rules` opts invariant Rules in.
+
+- `check-witnesses [PATHS...]` (default `apps/minds`) scans Python sources for `@pytest.mark.witnesses` markers (decorator and pytestmark forms) and fails on any marker naming a coordinate no corpus unit claims, or with a non-literal (uncheckable) coordinate. It refuses to run when the corpus itself omits units, since the coordinate set would be incomplete.
+
+The enrichment and invariant-scope resolution live in `imbue.minds.core.behavioral_specs.export` (with the gherkin AST mirrors extracted into a package-private `_gherkin.py` shared with the scanner); the witnesses check lives in `imbue.minds.core.behavioral_specs.witnesses`. `list`/`query` output is unchanged.
+
+Added the minds spec-witnessing prompt variants `apps/minds/tmr/specs_mapper.j2` and `apps/minds/tmr/specs_reducer.j2`: the mapper anchors each agent on one spec unit from its packet (specs are read-only; write the cheapest sufficient witness test; every touched test gets `@pytest.mark.witnesses("<coordinate>", partial=...)`; Scenario Outlines become parametrized tests; tests-only by default, with spec-vs-implementation gaps recorded as BLOCKED outcomes and FIXME(tmr) comments). The reducer integrates qualifying mapper branches and gates the tree: nothing under `apps/minds/specs/` may change, `minds specs validate` and `minds specs check-witnesses` must pass, duplicate generated tests are deduplicated, and the blast-radius pytest subset must pass.
+
+Documented the new subcommands and the TMR fan-out flow in `docs/behavioral-specs.md`, and updated the `minds-behavioral-specs` skill's tooling list.

--- a/apps/minds/docs/behavioral-specs.md
+++ b/apps/minds/docs/behavioral-specs.md
@@ -38,6 +38,47 @@ substring, or by step-text substring:
 uv run minds specs query --tag authentication.fresh-code
 ```
 
+Emit enriched unit records -- everything a test-writing consumer needs around
+each unit: effective steps (Background folded in), Examples rows for Scenario
+Outlines, Feature/Rule descriptions, the relevant prose (folder overviews plus
+the file's sidecar), and the invariants applying to the unit resolved
+root -> folder -> file:
+
+```bash
+uv run minds specs export
+```
+
+Check that every `@pytest.mark.witnesses` marker under the given paths
+(default: `apps/minds`) names a coordinate a corpus unit actually claims:
+
+```bash
+uv run minds specs check-witnesses
+```
+
+## Fanning out witness tests with TMR
+
+`minds specs plan --for-tmr` emits one TMR task packet per spec unit (scenarios
+and scenario outlines by default; `--include-rules` adds invariant Rules) as
+JSONL. Each packet carries the unit's coordinate as its id and the full
+enriched export record as its context. Feed the file to the generic task-file
+recipe (`mngr tmr-tasks`, from the `mngr-tmr` plugin) with the minds
+spec-witnessing prompt variants:
+
+```bash
+uv run minds specs plan --for-tmr > /tmp/spec-tasks.jsonl
+uv run mngr tmr-tasks --tasks-file /tmp/spec-tasks.jsonl --name tmr-minds-specs \
+  --mapper-prompt apps/minds/tmr/specs_mapper.j2 \
+  --reducer-prompt apps/minds/tmr/specs_reducer.j2
+```
+
+(The root justfile wraps this as `just tmr-minds-specs`.) Each mapper agent
+writes the cheapest sufficient test witnessing its unit -- specs are read-only,
+tests-only by default, and every touched test gets the `witnesses` marker. The
+reducer integrates the mapper branches and gates the tree: nothing under
+`apps/minds/specs/` may change, `minds specs validate` and
+`minds specs check-witnesses` must pass, duplicate generated tests are
+deduplicated, and the blast-radius pytest subset must pass.
+
 ## Linking tests to specs
 
 A test that verifies a spec unit declares it with the

--- a/apps/minds/imbue/minds/cli/specs.py
+++ b/apps/minds/imbue/minds/cli/specs.py
@@ -217,7 +217,8 @@ def specs_plan(corpus_root: Path, for_tmr: bool, include_rules: bool) -> None:
     --include-rules to also plan invariant Rules. Stdout carries nothing but
     JSONL; diagnostics go to stderr.
     """
-    del for_tmr  # the only supported plan target for now; the flag keeps the invocation explicit
+    # The only supported plan target for now; the flag keeps the invocation explicit.
+    del for_tmr
     planned_kinds = {SpecUnitKind.SCENARIO, SpecUnitKind.SCENARIO_OUTLINE}
     if include_rules:
         planned_kinds.add(SpecUnitKind.RULE)

--- a/apps/minds/imbue/minds/cli/specs.py
+++ b/apps/minds/imbue/minds/cli/specs.py
@@ -137,9 +137,7 @@ def specs_validate(corpus_root: Path) -> None:
     for violation in scan.violations:
         write_stdout_line(_format_violation(violation))
     if scan.violations:
-        raise SpecValidationFailedError(
-            f"{len(scan.violations)} violation(s) found under {corpus_root}"
-        )
+        raise SpecValidationFailedError(f"{len(scan.violations)} violation(s) found under {corpus_root}")
     write_stdout_line(
         f"OK: {len(scan.units)} units across {scan.feature_file_count} feature file(s) under {corpus_root}"
     )
@@ -207,8 +205,7 @@ def specs_export(corpus_root: Path) -> None:
     "include_rules",
     is_flag=True,
     default=False,
-    help="Also emit packets for Rule units (invariants). By default only scenarios and "
-    "scenario outlines are planned.",
+    help="Also emit packets for Rule units (invariants). By default only scenarios and scenario outlines are planned.",
 )
 def specs_plan(corpus_root: Path, for_tmr: bool, include_rules: bool) -> None:
     """Emit TMR-ready task packets as JSONL, one per spec unit to fan out to agents.

--- a/apps/minds/imbue/minds/cli/specs.py
+++ b/apps/minds/imbue/minds/cli/specs.py
@@ -1,4 +1,4 @@
-"""``minds specs {validate,list,query}`` -- the CLI over the behavioral-spec corpus.
+"""``minds specs {validate,list,query,export,plan,check-witnesses}`` -- the CLI over the behavioral-spec corpus.
 
 The corpus (``apps/minds/specs/`` in this repo) and its language are defined by
 the minds-behavioral-specs skill; ``imbue.minds.core.behavioral_specs`` is the
@@ -28,19 +28,27 @@ from imbue.minds.core.behavioral_specs.corpus import spec_unit_to_record
 from imbue.minds.core.behavioral_specs.data_types import SpecUnit
 from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
 from imbue.minds.core.behavioral_specs.data_types import SpecViolation
+from imbue.minds.core.behavioral_specs.data_types import WitnessProblem
 from imbue.minds.core.behavioral_specs.export import EXPORT_RECORD_SCHEMA_VERSION
 from imbue.minds.core.behavioral_specs.export import export_corpus
 from imbue.minds.core.behavioral_specs.export import exported_unit_to_record
 from imbue.minds.core.behavioral_specs.export import exported_unit_to_tmr_task_packet
+from imbue.minds.core.behavioral_specs.witnesses import check_witness_markers
+from imbue.minds.core.behavioral_specs.witnesses import find_witness_markers_in_paths
 from imbue.minds.errors import SpecCorpusRootNotFoundError
 from imbue.minds.errors import SpecListingIncompleteError
 from imbue.minds.errors import SpecValidationFailedError
+from imbue.minds.errors import WitnessCheckFailedError
 from imbue.minds.utils.output import write_stdout_line
 from imbue.mngr.cli.output_helpers import write_stderr_line
 
 # The real corpus, relative to the repo root (the documented working directory
 # for ``uv run minds specs ...``).
 DEFAULT_CORPUS_ROOT: Final[Path] = Path("apps/minds/specs")
+
+# Where check-witnesses looks for tests when no paths are passed: the minds
+# tree holds the tests that witness minds spec units.
+DEFAULT_WITNESS_CHECK_PATH: Final[Path] = Path("apps/minds")
 
 
 def _root_option(command: Callable[..., None]) -> Callable[..., None]:
@@ -222,6 +230,44 @@ def specs_plan(corpus_root: Path, for_tmr: bool, include_rules: bool) -> None:
             continue
         write_stdout_line(json.dumps(exported_unit_to_tmr_task_packet(unit), ensure_ascii=False))
     _fail_if_units_were_omitted(scan.violations)
+
+
+@pure
+def _format_witness_problem(problem: WitnessProblem) -> str:
+    if problem.line is None:
+        return f"{problem.file}: {problem.message}"
+    return f"{problem.file}:{problem.line}: {problem.message}"
+
+
+@specs.command(name="check-witnesses")
+@_root_option
+@click.argument("paths", nargs=-1, type=click.Path(exists=True, path_type=Path))
+def specs_check_witnesses(corpus_root: Path, paths: tuple[Path, ...]) -> None:
+    """Check that every @pytest.mark.witnesses coordinate names a real spec unit.
+
+    Scans the given Python files/directories (default: apps/minds) for
+    witnesses markers -- both decorator form and pytestmark assignments --
+    and reports every marker whose coordinate no unit of the corpus claims,
+    plus every marker with a non-literal (uncheckable) coordinate. Prints
+    one line per problem and exits nonzero if there are any; otherwise
+    prints a one-line summary. Exits nonzero without checking when the
+    corpus itself has unit-omitting violations (the coordinate set would be
+    incomplete).
+    """
+    scan = scan_corpus(_require_corpus_root(corpus_root))
+    _fail_if_units_were_omitted(scan.violations)
+    valid_coordinates = frozenset(unit.coordinate for unit in scan.units)
+    check_paths = paths if paths else (DEFAULT_WITNESS_CHECK_PATH,)
+    witness_scan = find_witness_markers_in_paths(check_paths)
+    problems = check_witness_markers(witness_scan, valid_coordinates)
+    for problem in problems:
+        write_stdout_line(_format_witness_problem(problem))
+    if problems:
+        raise WitnessCheckFailedError(f"{len(problems)} witnesses problem(s) found under {check_paths}")
+    write_stdout_line(
+        f"OK: {len(witness_scan.markers)} witnesses marker(s) checked against "
+        f"{len(valid_coordinates)} corpus coordinate(s)"
+    )
 
 
 @pure

--- a/apps/minds/imbue/minds/cli/specs.py
+++ b/apps/minds/imbue/minds/cli/specs.py
@@ -25,10 +25,13 @@ from imbue.minds.core.behavioral_specs.corpus import spec_unit_matches_name_subs
 from imbue.minds.core.behavioral_specs.corpus import spec_unit_matches_step_substring
 from imbue.minds.core.behavioral_specs.corpus import spec_unit_matches_tag
 from imbue.minds.core.behavioral_specs.corpus import spec_unit_to_record
-from imbue.minds.core.behavioral_specs.data_types import CorpusScan
 from imbue.minds.core.behavioral_specs.data_types import SpecUnit
 from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
 from imbue.minds.core.behavioral_specs.data_types import SpecViolation
+from imbue.minds.core.behavioral_specs.export import EXPORT_RECORD_SCHEMA_VERSION
+from imbue.minds.core.behavioral_specs.export import export_corpus
+from imbue.minds.core.behavioral_specs.export import exported_unit_to_record
+from imbue.minds.core.behavioral_specs.export import exported_unit_to_tmr_task_packet
 from imbue.minds.errors import SpecCorpusRootNotFoundError
 from imbue.minds.errors import SpecListingIncompleteError
 from imbue.minds.errors import SpecValidationFailedError
@@ -94,9 +97,9 @@ def _emit_unit_records(units: tuple[SpecUnit, ...], unit_kind: SpecUnitKind | No
         write_stdout_line(json.dumps(spec_unit_to_record(unit), ensure_ascii=False))
 
 
-def _fail_if_units_were_omitted(scan: CorpusScan) -> None:
+def _fail_if_units_were_omitted(violations: tuple[SpecViolation, ...]) -> None:
     """Surface unit-omitting problems on stderr and exit nonzero: the emitted listing is incomplete."""
-    omitting_violations = tuple(violation for violation in scan.violations if violation.is_unit_omitted)
+    omitting_violations = tuple(violation for violation in violations if violation.is_unit_omitted)
     if not omitting_violations:
         return
     for violation in omitting_violations:
@@ -158,7 +161,67 @@ def specs_list(corpus_root: Path, unit_kind_value: str | None) -> None:
     scan = scan_corpus(_require_corpus_root(corpus_root))
     unit_kind = None if unit_kind_value is None else _UNIT_KIND_BY_CLI_VALUE[unit_kind_value]
     _emit_unit_records(scan.units, unit_kind)
-    _fail_if_units_were_omitted(scan)
+    _fail_if_units_were_omitted(scan.violations)
+
+
+@specs.command(name="export")
+@_root_option
+def specs_export(corpus_root: Path) -> None:
+    """Emit enriched unit records as JSONL: everything a test-writing consumer needs.
+
+    Each record carries schema_version plus, beyond the `list` fields: the
+    unit's description, raw_steps and effective_steps (Background folded in),
+    Examples rows for Scenario Outlines, the Feature name/description, the
+    enclosing Rule's summary, the relevant prose (folder overview.md files
+    from the corpus root down, then the file's sidecar), and the applicable
+    invariants resolved root -> folder -> file (corpus invariants.feature,
+    ancestor folder invariants.feature files, and file-scoped Rules). Stdout
+    carries nothing but JSONL; diagnostics go to stderr.
+    """
+    scan = export_corpus(_require_corpus_root(corpus_root))
+    for unit in scan.units:
+        record = {"schema_version": EXPORT_RECORD_SCHEMA_VERSION, **exported_unit_to_record(unit)}
+        write_stdout_line(json.dumps(record, ensure_ascii=False))
+    _fail_if_units_were_omitted(scan.violations)
+
+
+@specs.command(name="plan")
+@_root_option
+@click.option(
+    "--for-tmr",
+    "for_tmr",
+    is_flag=True,
+    required=True,
+    help="Emit task packets for the TMR task-file recipe (`mngr tmr-tasks --tasks-file`).",
+)
+@click.option(
+    "--include-rules",
+    "include_rules",
+    is_flag=True,
+    default=False,
+    help="Also emit packets for Rule units (invariants). By default only scenarios and "
+    "scenario outlines are planned.",
+)
+def specs_plan(corpus_root: Path, for_tmr: bool, include_rules: bool) -> None:
+    """Emit TMR-ready task packets as JSONL, one per spec unit to fan out to agents.
+
+    Each packet carries schema_version, id (the unit's coordinate), display_id
+    (the coordinate with dots replaced by dashes, safe for agent/branch
+    names), kind, and context (the full enriched export record for the unit).
+    Scenarios and scenario outlines are planned by default; pass
+    --include-rules to also plan invariant Rules. Stdout carries nothing but
+    JSONL; diagnostics go to stderr.
+    """
+    del for_tmr  # the only supported plan target for now; the flag keeps the invocation explicit
+    planned_kinds = {SpecUnitKind.SCENARIO, SpecUnitKind.SCENARIO_OUTLINE}
+    if include_rules:
+        planned_kinds.add(SpecUnitKind.RULE)
+    scan = export_corpus(_require_corpus_root(corpus_root))
+    for unit in scan.units:
+        if unit.kind not in planned_kinds:
+            continue
+        write_stdout_line(json.dumps(exported_unit_to_tmr_task_packet(unit), ensure_ascii=False))
+    _fail_if_units_were_omitted(scan.violations)
 
 
 @pure
@@ -216,4 +279,4 @@ def specs_query(
         unit for unit in scan.units if _unit_passes_query_filters(unit, tag_filter, name_filter, step_filter)
     )
     _emit_unit_records(matching_units, None)
-    _fail_if_units_were_omitted(scan)
+    _fail_if_units_were_omitted(scan.violations)

--- a/apps/minds/imbue/minds/cli/specs.py
+++ b/apps/minds/imbue/minds/cli/specs.py
@@ -86,9 +86,11 @@ def specs() -> None:
     """Inspect and validate the behavioral-spec corpus (apps/minds/specs).
 
     The corpus language (folders, tags, coordinates, invariants, sidecars) is
-    defined by the minds-behavioral-specs skill; `validate` enforces it, and
+    defined by the minds-behavioral-specs skill; `validate` enforces it,
     `list`/`query` emit one JSONL record per authored unit (Scenario,
-    Scenario Outline, or Rule).
+    Scenario Outline, or Rule), `export` emits enriched records with each
+    unit's full context, `plan --for-tmr` emits TMR task packets, and
+    `check-witnesses` validates test-to-spec back-links.
     """
 
 

--- a/apps/minds/imbue/minds/cli/specs_test.py
+++ b/apps/minds/imbue/minds/cli/specs_test.py
@@ -208,3 +208,93 @@ def test_specs_group_is_registered_on_the_minds_cli() -> None:
     assert result.exit_code == 0, result.output
     assert "validate" in result.output
     assert "query" in result.output
+    assert "export" in result.output
+    assert "plan" in result.output
+
+
+def test_specs_export_emits_enriched_records_with_schema_version(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+
+    result = CliRunner().invoke(specs, ["export", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record["coordinate"] for record in records] == [
+        "authentication.fresh-code",
+        "authentication.missing-code",
+        "authentication.installation-bound",
+        "authentication.foreign-token",
+    ]
+    fresh_code = records[0]
+    assert fresh_code["schema_version"] == 1
+    assert fresh_code["effective_steps"] == fresh_code["raw_steps"]
+    assert fresh_code["feature"]["name"] == "Sign-in"
+    assert fresh_code["rule"] is None
+    assert [prose["kind"] for prose in fresh_code["prose"]] == ["overview"]
+    assert fresh_code["prose"][0]["content"] == "corpus context\n"
+    foreign_token = records[3]
+    assert foreign_token["parent"] == "authentication.installation-bound"
+    assert foreign_token["rule"]["name"] == "Only tokens minted by this installation are accepted"
+    assert [rule["scope"] for rule in foreign_token["applicable_rules"]] == ["file"]
+    outline = records[1]
+    assert outline["examples"][0]["rows"] == [["/login"]]
+
+
+def test_specs_export_reports_omitted_units_on_stderr_and_exits_nonzero(tmp_path: Path) -> None:
+    root = write_spec_corpus(
+        tmp_path / "specs",
+        {
+            "good.feature": "Feature: G\n\n  @works\n  Scenario: s\n    Given a\n",
+            "untagged.feature": "Feature: U\n\n  Scenario: no identity\n    Given a\n",
+        },
+    )
+
+    result = CliRunner().invoke(specs, ["export", "--root", str(root)])
+
+    assert result.exit_code == 1
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record["coordinate"] for record in records] == ["works"]
+    assert "incomplete" in result.stderr
+
+
+def test_specs_plan_emits_tmr_packets_for_scenarios_and_outlines_by_default(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+
+    result = CliRunner().invoke(specs, ["plan", "--for-tmr", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    packets = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [(packet["id"], packet["kind"]) for packet in packets] == [
+        ("authentication.fresh-code", "scenario"),
+        ("authentication.missing-code", "scenario-outline"),
+        ("authentication.foreign-token", "scenario"),
+    ]
+    packet = packets[0]
+    assert packet["schema_version"] == 1
+    assert packet["display_id"] == "authentication-fresh-code"
+    assert packet["context"]["coordinate"] == "authentication.fresh-code"
+    assert packet["context"]["effective_steps"][0]["text"] == "the user is not signed in"
+
+
+def test_specs_plan_includes_rule_packets_only_when_asked(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+
+    result = CliRunner().invoke(specs, ["plan", "--for-tmr", "--include-rules", "--root", str(root)])
+
+    assert result.exit_code == 0, result.output
+    packets = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [(packet["id"], packet["kind"]) for packet in packets] == [
+        ("authentication.fresh-code", "scenario"),
+        ("authentication.missing-code", "scenario-outline"),
+        ("authentication.installation-bound", "rule"),
+        ("authentication.foreign-token", "scenario"),
+    ]
+
+
+def test_specs_plan_requires_an_explicit_target(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+
+    result = CliRunner().invoke(specs, ["plan", "--root", str(root)])
+
+    assert result.exit_code != 0
+    assert "--for-tmr" in result.stderr

--- a/apps/minds/imbue/minds/cli/specs_test.py
+++ b/apps/minds/imbue/minds/cli/specs_test.py
@@ -188,9 +188,7 @@ def test_specs_query_combines_filters_with_and_semantics(tmp_path: Path) -> None
     root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
     runner = CliRunner()
 
-    both_match = runner.invoke(
-        specs, ["query", "--root", str(root), "--tag", "fresh-code", "--step", "login url"]
-    )
+    both_match = runner.invoke(specs, ["query", "--root", str(root), "--tag", "fresh-code", "--step", "login url"])
     tag_matches_step_does_not = runner.invoke(
         specs, ["query", "--root", str(root), "--tag", "fresh-code", "--step", "data directory"]
     )
@@ -304,10 +302,7 @@ def test_specs_check_witnesses_accepts_markers_naming_real_units(tmp_path: Path)
     root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
     test_file = tmp_path / "test_auth.py"
     test_file.write_text(
-        "import pytest\n"
-        "\n"
-        "@pytest.mark.witnesses(\"authentication.fresh-code\")\n"
-        "def test_signs_in() -> None: ...\n"
+        'import pytest\n\n@pytest.mark.witnesses("authentication.fresh-code")\ndef test_signs_in() -> None: ...\n'
     )
 
     result = CliRunner().invoke(specs, ["check-witnesses", "--root", str(root), str(test_file)])
@@ -320,10 +315,7 @@ def test_specs_check_witnesses_reports_unknown_coordinates_and_exits_nonzero(tmp
     root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
     test_file = tmp_path / "test_auth.py"
     test_file.write_text(
-        "import pytest\n"
-        "\n"
-        "@pytest.mark.witnesses(\"authentication.typoo\")\n"
-        "def test_signs_in() -> None: ...\n"
+        'import pytest\n\n@pytest.mark.witnesses("authentication.typoo")\ndef test_signs_in() -> None: ...\n'
     )
 
     result = CliRunner().invoke(specs, ["check-witnesses", "--root", str(root), str(test_file)])

--- a/apps/minds/imbue/minds/cli/specs_test.py
+++ b/apps/minds/imbue/minds/cli/specs_test.py
@@ -298,3 +298,51 @@ def test_specs_plan_requires_an_explicit_target(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "--for-tmr" in result.stderr
+
+
+def test_specs_check_witnesses_accepts_markers_naming_real_units(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+    test_file = tmp_path / "test_auth.py"
+    test_file.write_text(
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.witnesses(\"authentication.fresh-code\")\n"
+        "def test_signs_in() -> None: ...\n"
+    )
+
+    result = CliRunner().invoke(specs, ["check-witnesses", "--root", str(root), str(test_file)])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.startswith("OK: 1 witnesses marker(s) checked")
+
+
+def test_specs_check_witnesses_reports_unknown_coordinates_and_exits_nonzero(tmp_path: Path) -> None:
+    root = write_spec_corpus(tmp_path / "specs", _VALID_CORPUS)
+    test_file = tmp_path / "test_auth.py"
+    test_file.write_text(
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.witnesses(\"authentication.typoo\")\n"
+        "def test_signs_in() -> None: ...\n"
+    )
+
+    result = CliRunner().invoke(specs, ["check-witnesses", "--root", str(root), str(test_file)])
+
+    assert result.exit_code == 1
+    assert "unknown coordinate 'authentication.typoo'" in result.stdout
+    assert "1 witnesses problem(s)" in result.stderr
+
+
+def test_specs_check_witnesses_fails_before_checking_when_the_corpus_omits_units(tmp_path: Path) -> None:
+    root = write_spec_corpus(
+        tmp_path / "specs",
+        {"untagged.feature": "Feature: U\n\n  Scenario: no identity\n    Given a\n"},
+    )
+    test_file = tmp_path / "test_auth.py"
+    test_file.write_text("import pytest\n")
+
+    result = CliRunner().invoke(specs, ["check-witnesses", "--root", str(root), str(test_file)])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "incomplete" in result.stderr

--- a/apps/minds/imbue/minds/core/behavioral_specs/_gherkin.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/_gherkin.py
@@ -18,129 +18,129 @@ from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.minds.core.behavioral_specs.data_types import SpecViolation
 
 
-class _GherkinNode(FrozenModel):
+class GherkinNode(FrozenModel):
     """Base for pydantic mirrors of gherkin AST nodes; unknown AST fields are ignored."""
 
     model_config = ConfigDict(frozen=True, extra="ignore", arbitrary_types_allowed=False)
 
 
-class _GherkinLocation(_GherkinNode):
+class GherkinLocation(GherkinNode):
     """Line/column position of an AST node in its source file."""
 
     line: int = Field(description="1-based source line")
 
 
-class _GherkinTag(_GherkinNode):
+class GherkinTag(GherkinNode):
     """A tag as written in the source, including the '@' sigil."""
 
-    location: _GherkinLocation = Field(description="Position of the tag")
+    location: GherkinLocation = Field(description="Position of the tag")
     name: str = Field(description="Tag text including the leading '@'")
 
 
-class _GherkinStep(_GherkinNode):
+class GherkinStep(GherkinNode):
     """A single step line of a scenario or background."""
 
-    location: _GherkinLocation = Field(description="Position of the step")
+    location: GherkinLocation = Field(description="Position of the step")
     keyword: str = Field(description="Step keyword as parsed, with trailing space (e.g. 'Given ')")
     text: str = Field(description="Step text after the keyword")
 
 
-class _GherkinTableCell(_GherkinNode):
+class GherkinTableCell(GherkinNode):
     """One cell of an Examples table row."""
 
     value: str = Field(description="Cell text")
 
 
-class _GherkinTableRow(_GherkinNode):
+class GherkinTableRow(GherkinNode):
     """One row of an Examples table (header or body)."""
 
-    location: _GherkinLocation = Field(description="Position of the row")
-    cells: tuple[_GherkinTableCell, ...] = Field(description="Cells of the row in order")
+    location: GherkinLocation = Field(description="Position of the row")
+    cells: tuple[GherkinTableCell, ...] = Field(description="Cells of the row in order")
 
 
-class _GherkinExamples(_GherkinNode):
+class GherkinExamples(GherkinNode):
     """An Examples block of a Scenario Outline."""
 
-    location: _GherkinLocation = Field(description="Position of the Examples header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Examples block")
+    location: GherkinLocation = Field(description="Position of the Examples header")
+    tags: tuple[GherkinTag, ...] = Field(description="Tags on the Examples block")
     keyword: str = Field(description="Examples keyword as parsed")
-    table_header: _GherkinTableRow | None = Field(
+    table_header: GherkinTableRow | None = Field(
         default=None, alias="tableHeader", description="Header row of the Examples table, if present"
     )
-    table_body: tuple[_GherkinTableRow, ...] = Field(
+    table_body: tuple[GherkinTableRow, ...] = Field(
         default=(), alias="tableBody", description="Body rows of the Examples table"
     )
 
 
-class _GherkinScenario(_GherkinNode):
+class GherkinScenario(GherkinNode):
     """A Scenario or Scenario Outline node."""
 
-    location: _GherkinLocation = Field(description="Position of the declaration header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the unit")
+    location: GherkinLocation = Field(description="Position of the declaration header")
+    tags: tuple[GherkinTag, ...] = Field(description="Tags on the unit")
     keyword: str = Field(description="Declaration keyword as parsed")
     name: str = Field(description="Unit name after the keyword")
     description: str = Field(default="", description="Free prose under the declaration header")
-    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the unit in order")
-    examples: tuple[_GherkinExamples, ...] = Field(description="Examples blocks (Scenario Outline only)")
+    steps: tuple[GherkinStep, ...] = Field(description="Steps of the unit in order")
+    examples: tuple[GherkinExamples, ...] = Field(description="Examples blocks (Scenario Outline only)")
 
 
-class _GherkinBackground(_GherkinNode):
+class GherkinBackground(GherkinNode):
     """A Background node (never a unit; carried for keyword validation and step folding)."""
 
-    location: _GherkinLocation = Field(description="Position of the declaration header")
+    location: GherkinLocation = Field(description="Position of the declaration header")
     keyword: str = Field(description="Declaration keyword as parsed")
-    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the background in order")
+    steps: tuple[GherkinStep, ...] = Field(description="Steps of the background in order")
 
 
-class _GherkinRuleChild(_GherkinNode):
+class GherkinRuleChild(GherkinNode):
     """One child envelope of a Rule: exactly one of background/scenario is set."""
 
-    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
-    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
+    background: GherkinBackground | None = Field(default=None, description="Background child, if this is one")
+    scenario: GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
 
 
-class _GherkinRule(_GherkinNode):
+class GherkinRule(GherkinNode):
     """A Rule node."""
 
-    location: _GherkinLocation = Field(description="Position of the declaration header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Rule")
+    location: GherkinLocation = Field(description="Position of the declaration header")
+    tags: tuple[GherkinTag, ...] = Field(description="Tags on the Rule")
     keyword: str = Field(description="Declaration keyword as parsed")
     name: str = Field(description="Rule name after the keyword")
     description: str = Field(default="", description="Free prose under the declaration header")
-    children: tuple[_GherkinRuleChild, ...] = Field(description="Child envelopes in document order")
+    children: tuple[GherkinRuleChild, ...] = Field(description="Child envelopes in document order")
 
 
-class _GherkinFeatureChild(_GherkinNode):
+class GherkinFeatureChild(GherkinNode):
     """One child envelope of a Feature: exactly one of background/scenario/rule is set."""
 
-    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
-    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
-    rule: _GherkinRule | None = Field(default=None, description="Rule child, if this is one")
+    background: GherkinBackground | None = Field(default=None, description="Background child, if this is one")
+    scenario: GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
+    rule: GherkinRule | None = Field(default=None, description="Rule child, if this is one")
 
 
-class _GherkinFeature(_GherkinNode):
+class GherkinFeature(GherkinNode):
     """The Feature node of a document."""
 
-    location: _GherkinLocation = Field(description="Position of the Feature header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Feature")
+    location: GherkinLocation = Field(description="Position of the Feature header")
+    tags: tuple[GherkinTag, ...] = Field(description="Tags on the Feature")
     language: str = Field(description="Dialect the document was parsed with (e.g. 'en')")
     keyword: str = Field(description="Feature keyword as parsed")
     name: str = Field(description="Feature name after the keyword")
     description: str = Field(default="", description="Free prose under the Feature header")
-    children: tuple[_GherkinFeatureChild, ...] = Field(description="Child envelopes in document order")
+    children: tuple[GherkinFeatureChild, ...] = Field(description="Child envelopes in document order")
 
 
-class _GherkinDocument(_GherkinNode):
+class GherkinDocument(GherkinNode):
     """A parsed gherkin document."""
 
-    feature: _GherkinFeature | None = Field(default=None, description="The Feature, or None for an empty document")
+    feature: GherkinFeature | None = Field(default=None, description="The Feature, or None for an empty document")
 
 
-def _parse_feature_file(
+def parse_feature_file(
     feature_file: Path,
     source_text: str,
     violations: list[SpecViolation],
-) -> _GherkinDocument | None:
+) -> GherkinDocument | None:
     """Parse one .feature file, recording parse failures as violations and returning None for them."""
     try:
         parsed = Parser().parse(source_text, TokenMatcher())
@@ -165,4 +165,4 @@ def _parse_feature_file(
             )
         )
         return None
-    return _GherkinDocument.model_validate(parsed)
+    return GherkinDocument.model_validate(parsed)

--- a/apps/minds/imbue/minds/core/behavioral_specs/_gherkin.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/_gherkin.py
@@ -1,0 +1,168 @@
+"""Private gherkin-official AST mirrors and the document parse step, shared by corpus.py and export.py.
+
+The gherkin parser returns plain nested dicts; the pydantic models below
+mirror exactly the subset of the AST this package consumes, so the rest of
+the code works with typed, validated objects. Unknown AST fields are ignored.
+"""
+
+from pathlib import Path
+
+from gherkin.errors import CompositeParserException
+from gherkin.errors import ParserError
+from gherkin.parser import Parser
+from gherkin.token_matcher import TokenMatcher
+from pydantic import ConfigDict
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.minds.core.behavioral_specs.data_types import SpecViolation
+
+
+class _GherkinNode(FrozenModel):
+    """Base for pydantic mirrors of gherkin AST nodes; unknown AST fields are ignored."""
+
+    model_config = ConfigDict(frozen=True, extra="ignore", arbitrary_types_allowed=False)
+
+
+class _GherkinLocation(_GherkinNode):
+    """Line/column position of an AST node in its source file."""
+
+    line: int = Field(description="1-based source line")
+
+
+class _GherkinTag(_GherkinNode):
+    """A tag as written in the source, including the '@' sigil."""
+
+    location: _GherkinLocation = Field(description="Position of the tag")
+    name: str = Field(description="Tag text including the leading '@'")
+
+
+class _GherkinStep(_GherkinNode):
+    """A single step line of a scenario or background."""
+
+    location: _GherkinLocation = Field(description="Position of the step")
+    keyword: str = Field(description="Step keyword as parsed, with trailing space (e.g. 'Given ')")
+    text: str = Field(description="Step text after the keyword")
+
+
+class _GherkinTableCell(_GherkinNode):
+    """One cell of an Examples table row."""
+
+    value: str = Field(description="Cell text")
+
+
+class _GherkinTableRow(_GherkinNode):
+    """One row of an Examples table (header or body)."""
+
+    location: _GherkinLocation = Field(description="Position of the row")
+    cells: tuple[_GherkinTableCell, ...] = Field(description="Cells of the row in order")
+
+
+class _GherkinExamples(_GherkinNode):
+    """An Examples block of a Scenario Outline."""
+
+    location: _GherkinLocation = Field(description="Position of the Examples header")
+    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Examples block")
+    keyword: str = Field(description="Examples keyword as parsed")
+    table_header: _GherkinTableRow | None = Field(
+        default=None, alias="tableHeader", description="Header row of the Examples table, if present"
+    )
+    table_body: tuple[_GherkinTableRow, ...] = Field(
+        default=(), alias="tableBody", description="Body rows of the Examples table"
+    )
+
+
+class _GherkinScenario(_GherkinNode):
+    """A Scenario or Scenario Outline node."""
+
+    location: _GherkinLocation = Field(description="Position of the declaration header")
+    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the unit")
+    keyword: str = Field(description="Declaration keyword as parsed")
+    name: str = Field(description="Unit name after the keyword")
+    description: str = Field(default="", description="Free prose under the declaration header")
+    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the unit in order")
+    examples: tuple[_GherkinExamples, ...] = Field(description="Examples blocks (Scenario Outline only)")
+
+
+class _GherkinBackground(_GherkinNode):
+    """A Background node (never a unit; carried for keyword validation and step folding)."""
+
+    location: _GherkinLocation = Field(description="Position of the declaration header")
+    keyword: str = Field(description="Declaration keyword as parsed")
+    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the background in order")
+
+
+class _GherkinRuleChild(_GherkinNode):
+    """One child envelope of a Rule: exactly one of background/scenario is set."""
+
+    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
+    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
+
+
+class _GherkinRule(_GherkinNode):
+    """A Rule node."""
+
+    location: _GherkinLocation = Field(description="Position of the declaration header")
+    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Rule")
+    keyword: str = Field(description="Declaration keyword as parsed")
+    name: str = Field(description="Rule name after the keyword")
+    description: str = Field(default="", description="Free prose under the declaration header")
+    children: tuple[_GherkinRuleChild, ...] = Field(description="Child envelopes in document order")
+
+
+class _GherkinFeatureChild(_GherkinNode):
+    """One child envelope of a Feature: exactly one of background/scenario/rule is set."""
+
+    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
+    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
+    rule: _GherkinRule | None = Field(default=None, description="Rule child, if this is one")
+
+
+class _GherkinFeature(_GherkinNode):
+    """The Feature node of a document."""
+
+    location: _GherkinLocation = Field(description="Position of the Feature header")
+    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Feature")
+    language: str = Field(description="Dialect the document was parsed with (e.g. 'en')")
+    keyword: str = Field(description="Feature keyword as parsed")
+    name: str = Field(description="Feature name after the keyword")
+    description: str = Field(default="", description="Free prose under the Feature header")
+    children: tuple[_GherkinFeatureChild, ...] = Field(description="Child envelopes in document order")
+
+
+class _GherkinDocument(_GherkinNode):
+    """A parsed gherkin document."""
+
+    feature: _GherkinFeature | None = Field(default=None, description="The Feature, or None for an empty document")
+
+
+def _parse_feature_file(
+    feature_file: Path,
+    source_text: str,
+    violations: list[SpecViolation],
+) -> _GherkinDocument | None:
+    """Parse one .feature file, recording parse failures as violations and returning None for them."""
+    try:
+        parsed = Parser().parse(source_text, TokenMatcher())
+    except CompositeParserException as exc:
+        for parse_error in exc.errors:
+            violations.append(
+                SpecViolation(
+                    file=feature_file,
+                    line=parse_error.location["line"],
+                    message=f"gherkin parse error: {parse_error}; the file's units were omitted from records",
+                    is_unit_omitted=True,
+                )
+            )
+        return None
+    except ParserError as exc:
+        violations.append(
+            SpecViolation(
+                file=feature_file,
+                line=None,
+                message=f"gherkin parse error: {exc}; the file's units were omitted from records",
+                is_unit_omitted=True,
+            )
+        )
+        return None
+    return _GherkinDocument.model_validate(parsed)

--- a/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
@@ -7,12 +7,13 @@ one :class:`SpecUnit` per authored unit (Scenario, Scenario Outline, Rule),
 and collects every language violation as data rather than raising. Callers
 decide what to do with violations (the ``minds specs`` CLI prints them).
 
-The gherkin parser returns plain nested dicts; the private ``_Gherkin*``
+The gherkin parser returns plain nested dicts; the ``Gherkin*``
 pydantic models (in ``_gherkin.py``, shared with ``export.py``) mirror
 exactly the subset of the AST this package consumes, so the rest of the code
 works with typed, validated objects.
 """
 
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -24,12 +25,12 @@ from pydantic import Field
 from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinDocument
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinRule
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinScenario
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinStep
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinTag
-from imbue.minds.core.behavioral_specs._gherkin import _parse_feature_file
+from imbue.minds.core.behavioral_specs._gherkin import GherkinDocument
+from imbue.minds.core.behavioral_specs._gherkin import GherkinRule
+from imbue.minds.core.behavioral_specs._gherkin import GherkinScenario
+from imbue.minds.core.behavioral_specs._gherkin import GherkinStep
+from imbue.minds.core.behavioral_specs._gherkin import GherkinTag
+from imbue.minds.core.behavioral_specs._gherkin import parse_feature_file
 from imbue.minds.core.behavioral_specs.data_types import CorpusScan
 from imbue.minds.core.behavioral_specs.data_types import SpecStep
 from imbue.minds.core.behavioral_specs.data_types import SpecUnit
@@ -73,7 +74,7 @@ def _is_kebab_case(name: str) -> bool:
 
 
 def _check_tags_are_kebab_case(
-    tags: tuple[_GherkinTag, ...],
+    tags: tuple[GherkinTag, ...],
     file: Path,
     violations: list[SpecViolation],
 ) -> None:
@@ -117,7 +118,7 @@ def _check_declaration_keyword(
 
 
 def _check_step_keywords(
-    steps: tuple[_GherkinStep, ...],
+    steps: tuple[GherkinStep, ...],
     file: Path,
     violations: list[SpecViolation],
 ) -> None:
@@ -170,7 +171,7 @@ def _claim_coordinate(
 
 
 def _claim_block_tags(
-    tags: tuple[_GherkinTag, ...],
+    tags: tuple[GherkinTag, ...],
     file: Path,
     folder_parts: tuple[str, ...],
     claims: dict[str, _ClaimSite],
@@ -195,7 +196,7 @@ def _missing_tag_violation(file: Path, line: int, unit_keyword: str, unit_name: 
 
 
 def _unit_from_scenario(
-    scenario: _GherkinScenario,
+    scenario: GherkinScenario,
     file: Path,
     folder_parts: tuple[str, ...],
     parent: str | None,
@@ -244,7 +245,7 @@ def _unit_from_scenario(
 
 
 def _unit_from_rule(
-    rule: _GherkinRule,
+    rule: GherkinRule,
     file: Path,
     folder_parts: tuple[str, ...],
     violations: list[SpecViolation],
@@ -271,7 +272,7 @@ def _unit_from_rule(
 
 
 def _extract_units_from_document(
-    document: _GherkinDocument,
+    document: GherkinDocument,
     file: Path,
     folder_parts: tuple[str, ...],
     violations: list[SpecViolation],
@@ -428,7 +429,8 @@ def _scan_corpus_structure(corpus_root: Path, violations: list[SpecViolation]) -
     .feature or .md file.
     """
     feature_files: list[Path] = []
-    for folder, child_folder_names, file_names in corpus_root.walk(top_down=True):
+    for folder_str, child_folder_names, file_names in os.walk(corpus_root):
+        folder = Path(folder_str)
         # Pruning in place steers the walk; sorting keeps traversal deterministic.
         child_folder_names[:] = sorted(name for name in child_folder_names if not name.startswith("."))
         for child_folder_name in child_folder_names:
@@ -520,7 +522,7 @@ def scan_corpus(corpus_root: Path) -> CorpusScan:
         folder_parts = feature_file.relative_to(corpus_root).parent.parts
         source_text = feature_file.read_text(encoding="utf-8")
         _check_no_language_header(source_text, feature_file, violations)
-        document = _parse_feature_file(feature_file, source_text, violations)
+        document = parse_feature_file(feature_file, source_text, violations)
         if document is None:
             continue
         units.extend(_extract_units_from_document(document, feature_file, folder_parts, violations, claims))

--- a/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
@@ -24,7 +24,6 @@ from pydantic import Field
 from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinBackground
 from imbue.minds.core.behavioral_specs._gherkin import _GherkinDocument
 from imbue.minds.core.behavioral_specs._gherkin import _GherkinRule
 from imbue.minds.core.behavioral_specs._gherkin import _GherkinScenario
@@ -37,7 +36,6 @@ from imbue.minds.core.behavioral_specs.data_types import SpecUnit
 from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
 from imbue.minds.core.behavioral_specs.data_types import SpecViolation
 from imbue.minds.errors import SpecCorpusRootNotFoundError
-
 
 # A kebab-case name: lowercase letters/digits in groups separated by single hyphens.
 _KEBAB_CASE_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
@@ -132,8 +130,7 @@ def _check_step_keywords(
                     file=file,
                     line=step.location.line,
                     message=(
-                        f"step keyword '{keyword}' is not part of the spec language "
-                        f"(allowed: {allowed_rendered})"
+                        f"step keyword '{keyword}' is not part of the spec language (allowed: {allowed_rendered})"
                     ),
                     is_unit_omitted=False,
                 )
@@ -209,7 +206,9 @@ def _unit_from_scenario(
     _check_step_keywords(scenario.steps, file, violations)
     _check_tags_are_kebab_case(scenario.tags, file, violations)
     for examples in scenario.examples:
-        _check_declaration_keyword(examples.keyword, _ALLOWED_EXAMPLES_KEYWORDS, file, examples.location.line, violations)
+        _check_declaration_keyword(
+            examples.keyword, _ALLOWED_EXAMPLES_KEYWORDS, file, examples.location.line, violations
+        )
         _check_tags_are_kebab_case(examples.tags, file, violations)
     tags = tuple(_strip_tag_sigil(tag.name) for tag in scenario.tags)
     if not tags:
@@ -308,7 +307,11 @@ def _extract_units_from_document(
     for child in document.feature.children:
         if child.background is not None:
             _check_declaration_keyword(
-                child.background.keyword, _ALLOWED_BACKGROUND_KEYWORDS, file, child.background.location.line, violations
+                child.background.keyword,
+                _ALLOWED_BACKGROUND_KEYWORDS,
+                file,
+                child.background.location.line,
+                violations,
             )
             _check_step_keywords(child.background.steps, file, violations)
         elif child.scenario is not None:

--- a/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/corpus.py
@@ -8,8 +8,9 @@ and collects every language violation as data rather than raising. Callers
 decide what to do with violations (the ``minds specs`` CLI prints them).
 
 The gherkin parser returns plain nested dicts; the private ``_Gherkin*``
-pydantic models below mirror exactly the subset of the AST this module
-consumes, so the rest of the code works with typed, validated objects.
+pydantic models (in ``_gherkin.py``, shared with ``export.py``) mirror
+exactly the subset of the AST this package consumes, so the rest of the code
+works with typed, validated objects.
 """
 
 import re
@@ -18,118 +19,24 @@ from typing import Any
 from typing import Final
 from typing import assert_never
 
-from gherkin.errors import CompositeParserException
-from gherkin.errors import ParserError
-from gherkin.parser import Parser
-from gherkin.token_matcher import TokenMatcher
-from pydantic import ConfigDict
 from pydantic import Field
 
 from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinBackground
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinDocument
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinRule
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinScenario
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinStep
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinTag
+from imbue.minds.core.behavioral_specs._gherkin import _parse_feature_file
 from imbue.minds.core.behavioral_specs.data_types import CorpusScan
 from imbue.minds.core.behavioral_specs.data_types import SpecStep
 from imbue.minds.core.behavioral_specs.data_types import SpecUnit
 from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
 from imbue.minds.core.behavioral_specs.data_types import SpecViolation
 from imbue.minds.errors import SpecCorpusRootNotFoundError
-
-
-class _GherkinNode(FrozenModel):
-    """Base for pydantic mirrors of gherkin AST nodes; unknown AST fields are ignored."""
-
-    model_config = ConfigDict(frozen=True, extra="ignore", arbitrary_types_allowed=False)
-
-
-class _GherkinLocation(_GherkinNode):
-    """Line/column position of an AST node in its source file."""
-
-    line: int = Field(description="1-based source line")
-
-
-class _GherkinTag(_GherkinNode):
-    """A tag as written in the source, including the '@' sigil."""
-
-    location: _GherkinLocation = Field(description="Position of the tag")
-    name: str = Field(description="Tag text including the leading '@'")
-
-
-class _GherkinStep(_GherkinNode):
-    """A single step line of a scenario or background."""
-
-    location: _GherkinLocation = Field(description="Position of the step")
-    keyword: str = Field(description="Step keyword as parsed, with trailing space (e.g. 'Given ')")
-    text: str = Field(description="Step text after the keyword")
-
-
-class _GherkinExamples(_GherkinNode):
-    """An Examples block of a Scenario Outline."""
-
-    location: _GherkinLocation = Field(description="Position of the Examples header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Examples block")
-    keyword: str = Field(description="Examples keyword as parsed")
-
-
-class _GherkinScenario(_GherkinNode):
-    """A Scenario or Scenario Outline node."""
-
-    location: _GherkinLocation = Field(description="Position of the declaration header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the unit")
-    keyword: str = Field(description="Declaration keyword as parsed")
-    name: str = Field(description="Unit name after the keyword")
-    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the unit in order")
-    examples: tuple[_GherkinExamples, ...] = Field(description="Examples blocks (Scenario Outline only)")
-
-
-class _GherkinBackground(_GherkinNode):
-    """A Background node (never a unit; carried only for keyword validation)."""
-
-    location: _GherkinLocation = Field(description="Position of the declaration header")
-    keyword: str = Field(description="Declaration keyword as parsed")
-    steps: tuple[_GherkinStep, ...] = Field(description="Steps of the background in order")
-
-
-class _GherkinRuleChild(_GherkinNode):
-    """One child envelope of a Rule: exactly one of background/scenario is set."""
-
-    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
-    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
-
-
-class _GherkinRule(_GherkinNode):
-    """A Rule node."""
-
-    location: _GherkinLocation = Field(description="Position of the declaration header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Rule")
-    keyword: str = Field(description="Declaration keyword as parsed")
-    name: str = Field(description="Rule name after the keyword")
-    children: tuple[_GherkinRuleChild, ...] = Field(description="Child envelopes in document order")
-
-
-class _GherkinFeatureChild(_GherkinNode):
-    """One child envelope of a Feature: exactly one of background/scenario/rule is set."""
-
-    background: _GherkinBackground | None = Field(default=None, description="Background child, if this is one")
-    scenario: _GherkinScenario | None = Field(default=None, description="Scenario child, if this is one")
-    rule: _GherkinRule | None = Field(default=None, description="Rule child, if this is one")
-
-
-class _GherkinFeature(_GherkinNode):
-    """The Feature node of a document."""
-
-    location: _GherkinLocation = Field(description="Position of the Feature header")
-    tags: tuple[_GherkinTag, ...] = Field(description="Tags on the Feature")
-    language: str = Field(description="Dialect the document was parsed with (e.g. 'en')")
-    keyword: str = Field(description="Feature keyword as parsed")
-    name: str = Field(description="Feature name after the keyword")
-    children: tuple[_GherkinFeatureChild, ...] = Field(description="Child envelopes in document order")
-
-
-class _GherkinDocument(_GherkinNode):
-    """A parsed gherkin document."""
-
-    feature: _GherkinFeature | None = Field(default=None, description="The Feature, or None for an empty document")
 
 
 # A kebab-case name: lowercase letters/digits in groups separated by single hyphens.
@@ -456,38 +363,6 @@ def _check_no_language_header(source_text: str, file: Path, violations: list[Spe
                     is_unit_omitted=False,
                 )
             )
-
-
-def _parse_feature_file(
-    feature_file: Path,
-    source_text: str,
-    violations: list[SpecViolation],
-) -> _GherkinDocument | None:
-    """Parse one .feature file, recording parse failures as violations and returning None for them."""
-    try:
-        parsed = Parser().parse(source_text, TokenMatcher())
-    except CompositeParserException as exc:
-        for parse_error in exc.errors:
-            violations.append(
-                SpecViolation(
-                    file=feature_file,
-                    line=parse_error.location["line"],
-                    message=f"gherkin parse error: {parse_error}; the file's units were omitted from records",
-                    is_unit_omitted=True,
-                )
-            )
-        return None
-    except ParserError as exc:
-        violations.append(
-            SpecViolation(
-                file=feature_file,
-                line=None,
-                message=f"gherkin parse error: {exc}; the file's units were omitted from records",
-                is_unit_omitted=True,
-            )
-        )
-        return None
-    return _GherkinDocument.model_validate(parsed)
 
 
 @pure

--- a/apps/minds/imbue/minds/core/behavioral_specs/corpus_test.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/corpus_test.py
@@ -138,13 +138,7 @@ def test_scan_corpus_reports_parse_errors_with_line_and_skips_the_file(tmp_path:
         tmp_path / "specs",
         {
             "authentication/broken.feature": (
-                "Feature: Broken\n"
-                "\n"
-                "  @a-tag\n"
-                "  Scenario: s\n"
-                "    Given a\n"
-                '    """\n'
-                "    unclosed docstring\n"
+                'Feature: Broken\n\n  @a-tag\n  Scenario: s\n    Given a\n    """\n    unclosed docstring\n'
             ),
             "authentication/good.feature": ("Feature: Good\n\n  @works\n  Scenario: s\n    Given a\n"),
         },
@@ -275,12 +269,7 @@ def test_scan_corpus_rejects_non_english_gherkin_dialects(tmp_path: Path) -> Non
         tmp_path / "specs",
         {
             "connexion.feature": (
-                "# language: fr\n"
-                "Fonctionnalité: Connexion\n"
-                "\n"
-                "  @un-tag\n"
-                "  Scénario: ouverture\n"
-                "    Soit une chose\n"
+                "# language: fr\nFonctionnalité: Connexion\n\n  @un-tag\n  Scénario: ouverture\n    Soit une chose\n"
             ),
         },
     )
@@ -288,9 +277,7 @@ def test_scan_corpus_rejects_non_english_gherkin_dialects(tmp_path: Path) -> Non
     scan = scan_corpus(root)
 
     assert any("# language:" in violation.message and violation.line == 1 for violation in scan.violations)
-    assert any(
-        "English" in violation.message and "'fr'" in violation.message for violation in scan.violations
-    )
+    assert any("English" in violation.message and "'fr'" in violation.message for violation in scan.violations)
 
 
 def test_scan_corpus_rejects_feature_files_without_a_feature(tmp_path: Path) -> None:
@@ -419,7 +406,7 @@ def test_scan_corpus_accepts_a_rich_fully_valid_corpus(tmp_path: Path) -> None:
                 "  @fresh-code\n"
                 "  Scenario: Opening a fresh login URL signs the user in\n"
                 "    Given the user is not signed in\n"
-                '    When the user opens the login URL with payload:\n'
+                "    When the user opens the login URL with payload:\n"
                 '      """\n'
                 "      any doc string\n"
                 '      """\n'
@@ -495,7 +482,7 @@ def test_spec_unit_to_record_serializes_stable_field_order_and_kind_spelling(tmp
                 "\n"
                 "    @spent-code @edge-case\n"
                 "    Scenario Outline: Spent codes are refused\n"
-                "      When anyone presents \"<code>\"\n"
+                '      When anyone presents "<code>"\n'
                 "      Then authentication is refused\n"
                 "\n"
                 "      Examples:\n"

--- a/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
@@ -38,9 +38,7 @@ class SpecUnit(FrozenModel):
     steps: tuple[SpecStep, ...] = Field(
         description="The unit's own steps in order (empty for a Rule; Background steps are not folded in)"
     )
-    parent: str | None = Field(
-        description="Coordinate of the enclosing Rule for units nested under one, else None"
-    )
+    parent: str | None = Field(description="Coordinate of the enclosing Rule for units nested under one, else None")
 
 
 class SpecViolation(FrozenModel):

--- a/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
@@ -153,3 +153,22 @@ class CorpusExport(FrozenModel):
     )
     violations: tuple[SpecViolation, ...] = Field(description="All language violations found, in deterministic order")
     feature_file_count: int = Field(description="Count of .feature files seen during the scan")
+
+
+class WitnessMarker(FrozenModel):
+    """One ``@pytest.mark.witnesses`` application found in a Python test file."""
+
+    coordinate: str = Field(description="The coordinate the test declares it witnesses")
+    file: Path = Field(description="Python file carrying the marker")
+    line: int = Field(description="1-based line of the marker call")
+    partial: str | None = Field(
+        default=None, description="The partial= note (what the test does not cover), when given"
+    )
+
+
+class WitnessProblem(FrozenModel):
+    """One problem found while checking witnesses markers against the corpus."""
+
+    file: Path = Field(description="Python file the problem applies to")
+    line: int | None = Field(description="1-based line of the problem where available")
+    message: str = Field(description="Human-readable description of the problem")

--- a/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/data_types.py
@@ -60,3 +60,96 @@ class CorpusScan(FrozenModel):
     units: tuple[SpecUnit, ...] = Field(description="All representable units, in file order then document order")
     violations: tuple[SpecViolation, ...] = Field(description="All language violations found, in deterministic order")
     feature_file_count: int = Field(description="Count of .feature files seen during the scan")
+
+
+class SpecExamplesTable(FrozenModel):
+    """One Examples block of a Scenario Outline, with its table rendered as plain rows of cells."""
+
+    line: int = Field(description="1-based line of the Examples header")
+    header: tuple[str, ...] = Field(description="Header cell values in order")
+    rows: tuple[tuple[str, ...], ...] = Field(description="Body rows, each a tuple of cell values in order")
+
+
+class SpecProseFileKind(UpperCaseStrEnum):
+    """Which kind of prose file a piece of corpus context came from."""
+
+    OVERVIEW = auto()
+    SIDECAR = auto()
+
+
+class SpecProseFile(FrozenModel):
+    """One prose file relevant to a spec unit: a folder overview.md or a file's sidecar."""
+
+    path: Path = Field(description="Path to the prose file, rooted like the unit's file")
+    kind: SpecProseFileKind = Field(description="Whether this is a folder overview or a file sidecar")
+    content: str = Field(description="Full text content of the prose file")
+
+
+class ApplicableRuleScope(UpperCaseStrEnum):
+    """Where an applicable invariant comes from, per the language's scoping rules."""
+
+    CORPUS = auto()
+    FOLDER = auto()
+    FILE = auto()
+
+
+class ApplicableRule(FrozenModel):
+    """One invariant (Rule unit) that applies to a spec unit, with its scope resolution."""
+
+    coordinate: str = Field(description="The rule unit's coordinate")
+    name: str = Field(description="The rule's name as written after its keyword")
+    description: str = Field(description="The rule's description prose (dedented)")
+    file: Path = Field(description="Path to the file declaring the rule, rooted like the unit's file")
+    scope: ApplicableRuleScope = Field(
+        description="CORPUS from the root invariants.feature, FOLDER from a deeper invariants.feature, "
+        "FILE from a rule in the unit's own ordinary feature file"
+    )
+
+
+class ExportedEnclosingRule(FrozenModel):
+    """Summary of the Rule a unit is nested under, when it is a Rule child."""
+
+    coordinate: str = Field(description="The enclosing rule's coordinate")
+    name: str = Field(description="The enclosing rule's name")
+    description: str = Field(description="The enclosing rule's description prose (dedented)")
+
+
+class ExportedSpecUnit(FrozenModel):
+    """One spec unit with its full authoring context resolved: the enriched export record."""
+
+    coordinate: str = Field(description="The unit's coordinate")
+    kind: SpecUnitKind = Field(description="Structural kind of the unit")
+    name: str = Field(description="The unit's name as written after its keyword")
+    file: Path = Field(description="Path to the unit's .feature file, rooted at the corpus root as given")
+    line: int = Field(description="1-based line of the unit's declaration header")
+    tags: tuple[str, ...] = Field(description="All tags on the unit in order, without the '@' sigil")
+    parent: str | None = Field(description="Coordinate of the enclosing Rule for units nested under one, else None")
+    description: str = Field(description="The unit's own description prose (dedented)")
+    raw_steps: tuple[SpecStep, ...] = Field(description="The unit's own steps in order")
+    effective_steps: tuple[SpecStep, ...] = Field(
+        description="raw_steps with Background steps folded in (feature-level, then rule-level for Rule children)"
+    )
+    examples: tuple[SpecExamplesTable, ...] = Field(
+        description="Examples tables of a Scenario Outline (empty for other kinds)"
+    )
+    feature_name: str = Field(description="Name of the Feature the unit belongs to")
+    feature_description: str = Field(description="The Feature's description prose (dedented)")
+    rule: ExportedEnclosingRule | None = Field(
+        default=None, description="The enclosing Rule's summary for units nested under one, else None"
+    )
+    prose: tuple[SpecProseFile, ...] = Field(
+        description="Overview files from the corpus root down to the unit's folder, then the file's sidecar"
+    )
+    applicable_rules: tuple[ApplicableRule, ...] = Field(
+        description="Invariants applying to this unit, resolved root -> folder -> file"
+    )
+
+
+class CorpusExport(FrozenModel):
+    """The result of exporting a behavioral-spec corpus: enriched units plus language violations."""
+
+    units: tuple[ExportedSpecUnit, ...] = Field(
+        description="All representable units with resolved context, in file order then document order"
+    )
+    violations: tuple[SpecViolation, ...] = Field(description="All language violations found, in deterministic order")
+    feature_file_count: int = Field(description="Count of .feature files seen during the scan")

--- a/apps/minds/imbue/minds/core/behavioral_specs/export.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/export.py
@@ -23,10 +23,10 @@ from pydantic import Field
 from imbue.imbue_common.errors import SwitchError
 from imbue.imbue_common.frozen_model import FrozenModel
 from imbue.imbue_common.pure import pure
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinDocument
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinExamples
-from imbue.minds.core.behavioral_specs._gherkin import _GherkinStep
-from imbue.minds.core.behavioral_specs._gherkin import _parse_feature_file
+from imbue.minds.core.behavioral_specs._gherkin import GherkinDocument
+from imbue.minds.core.behavioral_specs._gherkin import GherkinExamples
+from imbue.minds.core.behavioral_specs._gherkin import GherkinStep
+from imbue.minds.core.behavioral_specs._gherkin import parse_feature_file
 from imbue.minds.core.behavioral_specs.corpus import scan_corpus
 from imbue.minds.core.behavioral_specs.corpus import spec_unit_kind_record_value
 from imbue.minds.core.behavioral_specs.data_types import ApplicableRule
@@ -88,18 +88,18 @@ def _dedent_description(description: str) -> str:
 
 
 @pure
-def _steps_of(gherkin_steps: tuple[_GherkinStep, ...]) -> tuple[SpecStep, ...]:
+def _steps_of(gherkin_steps: tuple[GherkinStep, ...]) -> tuple[SpecStep, ...]:
     return tuple(SpecStep(keyword=step.keyword.strip(), text=step.text) for step in gherkin_steps)
 
 
 @pure
-def _examples_table_of(examples: _GherkinExamples) -> SpecExamplesTable:
+def _examples_table_of(examples: GherkinExamples) -> SpecExamplesTable:
     header = () if examples.table_header is None else tuple(cell.value for cell in examples.table_header.cells)
     rows = tuple(tuple(cell.value for cell in row.cells) for row in examples.table_body)
     return SpecExamplesTable(line=examples.location.line, header=header, rows=rows)
 
 
-def _enrichment_from_document(document: _GherkinDocument, file: Path) -> _FileEnrichment:
+def _enrichment_from_document(document: GherkinDocument, file: Path) -> _FileEnrichment:
     """Pull the export context out of one parsed document.
 
     Callers only parse files that produced units during the corpus scan, so
@@ -160,7 +160,7 @@ def _enrich_unit_files(unit_files: tuple[Path, ...]) -> dict[Path, _FileEnrichme
     enrichment_by_file: dict[Path, _FileEnrichment] = {}
     for unit_file in unit_files:
         discarded_violations: list[SpecViolation] = []
-        document = _parse_feature_file(unit_file, unit_file.read_text(encoding="utf-8"), discarded_violations)
+        document = parse_feature_file(unit_file, unit_file.read_text(encoding="utf-8"), discarded_violations)
         if document is None:
             raise SwitchError(f"unit-bearing file {unit_file} failed to re-parse during export")
         enrichment_by_file[unit_file] = _enrichment_from_document(document, unit_file)

--- a/apps/minds/imbue/minds/core/behavioral_specs/export.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/export.py
@@ -1,0 +1,363 @@
+"""Enriched export of the behavioral-spec corpus.
+
+:func:`scan_corpus` extracts the bare units; this module resolves everything
+a consumer (a test-writing agent, a planner) needs around each unit: the
+unit's effective steps (Background folded in), Examples rows for Scenario
+Outlines, Feature/Rule descriptions, the prose context (folder overviews plus
+the file's sidecar), and the invariants that apply to the unit, resolved
+root -> folder -> file per the language's scoping rules (see the
+minds-behavioral-specs skill).
+
+The single entry point is :func:`export_corpus`; ``minds specs export``
+renders the result as JSONL, and ``minds specs plan --for-tmr`` wraps each
+record in a task packet.
+"""
+
+import textwrap
+from pathlib import Path
+from typing import Any
+from typing import Final
+
+from pydantic import Field
+
+from imbue.imbue_common.errors import SwitchError
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.pure import pure
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinDocument
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinExamples
+from imbue.minds.core.behavioral_specs._gherkin import _GherkinStep
+from imbue.minds.core.behavioral_specs._gherkin import _parse_feature_file
+from imbue.minds.core.behavioral_specs.corpus import scan_corpus
+from imbue.minds.core.behavioral_specs.corpus import spec_unit_kind_record_value
+from imbue.minds.core.behavioral_specs.data_types import ApplicableRule
+from imbue.minds.core.behavioral_specs.data_types import ApplicableRuleScope
+from imbue.minds.core.behavioral_specs.data_types import CorpusExport
+from imbue.minds.core.behavioral_specs.data_types import ExportedEnclosingRule
+from imbue.minds.core.behavioral_specs.data_types import ExportedSpecUnit
+from imbue.minds.core.behavioral_specs.data_types import SpecExamplesTable
+from imbue.minds.core.behavioral_specs.data_types import SpecProseFile
+from imbue.minds.core.behavioral_specs.data_types import SpecProseFileKind
+from imbue.minds.core.behavioral_specs.data_types import SpecStep
+from imbue.minds.core.behavioral_specs.data_types import SpecUnit
+from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
+from imbue.minds.core.behavioral_specs.data_types import SpecViolation
+
+# Version of the `minds specs export` JSONL record shape.
+EXPORT_RECORD_SCHEMA_VERSION: Final[int] = 1
+
+# Version of the `minds specs plan --for-tmr` task-packet shape (consumed by
+# the TMR task-file recipe, e.g. `mngr tmr-tasks`).
+TMR_TASK_PACKET_SCHEMA_VERSION: Final[int] = 1
+
+# The reserved filename whose Rules are folder/corpus-scoped invariants.
+_INVARIANTS_FILENAME: Final[str] = "invariants.feature"
+
+# The reserved basename of a folder's prose overview file.
+_OVERVIEW_FILENAME: Final[str] = "overview.md"
+
+
+class _UnitEnrichment(FrozenModel):
+    """AST detail for one unit beyond what SpecUnit carries."""
+
+    description: str = Field(description="The unit's description prose (dedented)")
+    examples: tuple[SpecExamplesTable, ...] = Field(description="Examples tables (Scenario Outline only)")
+
+
+class _FileEnrichment(FrozenModel):
+    """Per-file AST detail the export folds into each of the file's units."""
+
+    feature_name: str = Field(description="Name of the file's Feature")
+    feature_description: str = Field(description="The Feature's description prose (dedented)")
+    feature_background_steps: tuple[SpecStep, ...] = Field(
+        description="Steps of the file's feature-level Background (empty when none)"
+    )
+    unit_enrichment_by_line: dict[int, _UnitEnrichment] = Field(
+        description="Enrichment for every unit of the file, keyed by declaration line"
+    )
+    rule_background_steps_by_line: dict[int, tuple[SpecStep, ...]] = Field(
+        description="Rule-level Background steps, keyed by the enclosing Rule's declaration line"
+    )
+    enclosing_rule_line_by_child_line: dict[int, int] = Field(
+        description="Maps a Rule child's declaration line to its enclosing Rule's declaration line"
+    )
+
+
+@pure
+def _dedent_description(description: str) -> str:
+    return textwrap.dedent(description).strip()
+
+
+@pure
+def _steps_of(gherkin_steps: tuple[_GherkinStep, ...]) -> tuple[SpecStep, ...]:
+    return tuple(SpecStep(keyword=step.keyword.strip(), text=step.text) for step in gherkin_steps)
+
+
+@pure
+def _examples_table_of(examples: _GherkinExamples) -> SpecExamplesTable:
+    header = () if examples.table_header is None else tuple(cell.value for cell in examples.table_header.cells)
+    rows = tuple(tuple(cell.value for cell in row.cells) for row in examples.table_body)
+    return SpecExamplesTable(line=examples.location.line, header=header, rows=rows)
+
+
+def _enrichment_from_document(document: _GherkinDocument, file: Path) -> _FileEnrichment:
+    """Pull the export context out of one parsed document.
+
+    Callers only parse files that produced units during the corpus scan, so
+    the document always has a Feature here.
+    """
+    if document.feature is None:
+        raise SwitchError(f"unit-bearing file {file} re-parsed with no Feature declaration")
+    feature = document.feature
+    feature_background_steps: tuple[SpecStep, ...] = ()
+    unit_enrichment_by_line: dict[int, _UnitEnrichment] = {}
+    rule_background_steps_by_line: dict[int, tuple[SpecStep, ...]] = {}
+    enclosing_rule_line_by_child_line: dict[int, int] = {}
+    for child in feature.children:
+        if child.background is not None:
+            feature_background_steps = _steps_of(child.background.steps)
+        elif child.scenario is not None:
+            scenario = child.scenario
+            unit_enrichment_by_line[scenario.location.line] = _UnitEnrichment(
+                description=_dedent_description(scenario.description),
+                examples=tuple(_examples_table_of(examples) for examples in scenario.examples),
+            )
+        elif child.rule is not None:
+            rule = child.rule
+            unit_enrichment_by_line[rule.location.line] = _UnitEnrichment(
+                description=_dedent_description(rule.description),
+                examples=(),
+            )
+            for rule_child in rule.children:
+                if rule_child.background is not None:
+                    rule_background_steps_by_line[rule.location.line] = _steps_of(rule_child.background.steps)
+                elif rule_child.scenario is not None:
+                    child_scenario = rule_child.scenario
+                    unit_enrichment_by_line[child_scenario.location.line] = _UnitEnrichment(
+                        description=_dedent_description(child_scenario.description),
+                        examples=tuple(_examples_table_of(examples) for examples in child_scenario.examples),
+                    )
+                    enclosing_rule_line_by_child_line[child_scenario.location.line] = rule.location.line
+                else:
+                    raise SwitchError(f"Rule child envelope with no known node type in {file}")
+        else:
+            raise SwitchError(f"Feature child envelope with no known node type in {file}")
+    return _FileEnrichment(
+        feature_name=feature.name,
+        feature_description=_dedent_description(feature.description),
+        feature_background_steps=feature_background_steps,
+        unit_enrichment_by_line=unit_enrichment_by_line,
+        rule_background_steps_by_line=rule_background_steps_by_line,
+        enclosing_rule_line_by_child_line=enclosing_rule_line_by_child_line,
+    )
+
+
+def _enrich_unit_files(unit_files: tuple[Path, ...]) -> dict[Path, _FileEnrichment]:
+    """Re-parse every unit-bearing file and build its enrichment.
+
+    Parse failures cannot recur here (the corpus scan already parsed these
+    exact files successfully), so a failure is a bug, not data.
+    """
+    enrichment_by_file: dict[Path, _FileEnrichment] = {}
+    for unit_file in unit_files:
+        discarded_violations: list[SpecViolation] = []
+        document = _parse_feature_file(unit_file, unit_file.read_text(encoding="utf-8"), discarded_violations)
+        if document is None:
+            raise SwitchError(f"unit-bearing file {unit_file} failed to re-parse during export")
+        enrichment_by_file[unit_file] = _enrichment_from_document(document, unit_file)
+    return enrichment_by_file
+
+
+def _collect_prose(unit_file: Path, corpus_root: Path) -> tuple[SpecProseFile, ...]:
+    """Collect the prose context for a unit: overviews root -> folder, then the sidecar."""
+    folder_parts = unit_file.parent.relative_to(corpus_root).parts
+    prose: list[SpecProseFile] = []
+    for depth in range(len(folder_parts) + 1):
+        overview_path = corpus_root.joinpath(*folder_parts[:depth]) / _OVERVIEW_FILENAME
+        if overview_path.is_file():
+            prose.append(
+                SpecProseFile(
+                    path=overview_path,
+                    kind=SpecProseFileKind.OVERVIEW,
+                    content=overview_path.read_text(encoding="utf-8"),
+                )
+            )
+    sidecar_path = unit_file.with_suffix(".md")
+    if sidecar_path.is_file():
+        prose.append(
+            SpecProseFile(
+                path=sidecar_path,
+                kind=SpecProseFileKind.SIDECAR,
+                content=sidecar_path.read_text(encoding="utf-8"),
+            )
+        )
+    return tuple(prose)
+
+
+@pure
+def _applicable_rule_from_unit(
+    rule_unit: SpecUnit,
+    scope: ApplicableRuleScope,
+    enrichment_by_file: dict[Path, _FileEnrichment],
+) -> ApplicableRule:
+    description = enrichment_by_file[rule_unit.file].unit_enrichment_by_line[rule_unit.line].description
+    return ApplicableRule(
+        coordinate=rule_unit.coordinate,
+        name=rule_unit.name,
+        description=description,
+        file=rule_unit.file,
+        scope=scope,
+    )
+
+
+@pure
+def resolve_applicable_rules(
+    unit: SpecUnit,
+    corpus_root: Path,
+    rule_units_by_file: dict[Path, tuple[SpecUnit, ...]],
+    enrichment_by_file: dict[Path, _FileEnrichment],
+) -> tuple[ApplicableRule, ...]:
+    """Resolve the invariants applying to a unit, ordered root -> folder -> file.
+
+    A Rule in a folder's invariants.feature binds that folder and everything
+    below it (the corpus root's binds the whole corpus); a Rule in an ordinary
+    feature file binds that file's units. A unit never lists itself.
+    """
+    folder_parts = unit.file.parent.relative_to(corpus_root).parts
+    applicable: list[ApplicableRule] = []
+    for depth in range(len(folder_parts) + 1):
+        invariants_file = corpus_root.joinpath(*folder_parts[:depth]) / _INVARIANTS_FILENAME
+        scope = ApplicableRuleScope.CORPUS if depth == 0 else ApplicableRuleScope.FOLDER
+        for rule_unit in rule_units_by_file.get(invariants_file, ()):
+            if rule_unit.coordinate != unit.coordinate:
+                applicable.append(_applicable_rule_from_unit(rule_unit, scope, enrichment_by_file))
+    if unit.file.name != _INVARIANTS_FILENAME:
+        for rule_unit in rule_units_by_file.get(unit.file, ()):
+            if rule_unit.coordinate != unit.coordinate:
+                applicable.append(_applicable_rule_from_unit(rule_unit, ApplicableRuleScope.FILE, enrichment_by_file))
+    return tuple(applicable)
+
+
+def _export_unit(
+    unit: SpecUnit,
+    corpus_root: Path,
+    enrichment_by_file: dict[Path, _FileEnrichment],
+    rule_units_by_file: dict[Path, tuple[SpecUnit, ...]],
+    unit_by_coordinate: dict[str, SpecUnit],
+) -> ExportedSpecUnit:
+    enrichment = enrichment_by_file[unit.file]
+    unit_enrichment = enrichment.unit_enrichment_by_line[unit.line]
+    enclosing_rule_line = enrichment.enclosing_rule_line_by_child_line.get(unit.line)
+    rule_background_steps = (
+        enrichment.rule_background_steps_by_line.get(enclosing_rule_line, ())
+        if enclosing_rule_line is not None
+        else ()
+    )
+    effective_steps = enrichment.feature_background_steps + rule_background_steps + unit.steps
+    enclosing_rule: ExportedEnclosingRule | None = None
+    if unit.parent is not None and enclosing_rule_line is not None:
+        parent_unit = unit_by_coordinate[unit.parent]
+        enclosing_rule = ExportedEnclosingRule(
+            coordinate=parent_unit.coordinate,
+            name=parent_unit.name,
+            description=enrichment.unit_enrichment_by_line[enclosing_rule_line].description,
+        )
+    return ExportedSpecUnit(
+        coordinate=unit.coordinate,
+        kind=unit.kind,
+        name=unit.name,
+        file=unit.file,
+        line=unit.line,
+        tags=unit.tags,
+        parent=unit.parent,
+        description=unit_enrichment.description,
+        raw_steps=unit.steps,
+        effective_steps=effective_steps,
+        examples=unit_enrichment.examples,
+        feature_name=enrichment.feature_name,
+        feature_description=enrichment.feature_description,
+        rule=enclosing_rule,
+        prose=_collect_prose(unit.file, corpus_root),
+        applicable_rules=resolve_applicable_rules(unit, corpus_root, rule_units_by_file, enrichment_by_file),
+    )
+
+
+def export_corpus(corpus_root: Path) -> CorpusExport:
+    """Scan a behavioral-spec corpus and resolve the full authoring context of each unit.
+
+    Raises SpecCorpusRootNotFoundError if the root is not an existing directory.
+    """
+    scan = scan_corpus(corpus_root)
+    unit_files = tuple(sorted({unit.file for unit in scan.units}))
+    enrichment_by_file = _enrich_unit_files(unit_files)
+    rule_units_by_file: dict[Path, list[SpecUnit]] = {}
+    for unit in scan.units:
+        if unit.kind == SpecUnitKind.RULE:
+            rule_units_by_file.setdefault(unit.file, []).append(unit)
+    frozen_rule_units_by_file = {file: tuple(units) for file, units in rule_units_by_file.items()}
+    unit_by_coordinate = {unit.coordinate: unit for unit in scan.units}
+    exported_units = tuple(
+        _export_unit(unit, corpus_root, enrichment_by_file, frozen_rule_units_by_file, unit_by_coordinate)
+        for unit in scan.units
+    )
+    return CorpusExport(
+        units=exported_units,
+        violations=scan.violations,
+        feature_file_count=scan.feature_file_count,
+    )
+
+
+@pure
+def exported_unit_to_record(unit: ExportedSpecUnit) -> dict[str, Any]:
+    """Render an exported unit as the JSON object ``minds specs export`` emits (sans schema_version)."""
+    return {
+        "coordinate": unit.coordinate,
+        "kind": spec_unit_kind_record_value(unit.kind),
+        "name": unit.name,
+        "file": str(unit.file),
+        "line": unit.line,
+        "tags": list(unit.tags),
+        "parent": unit.parent,
+        "description": unit.description,
+        "raw_steps": [{"keyword": step.keyword, "text": step.text} for step in unit.raw_steps],
+        "effective_steps": [{"keyword": step.keyword, "text": step.text} for step in unit.effective_steps],
+        "examples": [
+            {"line": examples.line, "header": list(examples.header), "rows": [list(row) for row in examples.rows]}
+            for examples in unit.examples
+        ],
+        "feature": {"name": unit.feature_name, "description": unit.feature_description},
+        "rule": (
+            None
+            if unit.rule is None
+            else {
+                "coordinate": unit.rule.coordinate,
+                "name": unit.rule.name,
+                "description": unit.rule.description,
+            }
+        ),
+        "prose": [
+            {"path": str(prose.path), "kind": prose.kind.value.lower(), "content": prose.content}
+            for prose in unit.prose
+        ],
+        "applicable_rules": [
+            {
+                "coordinate": rule.coordinate,
+                "name": rule.name,
+                "description": rule.description,
+                "file": str(rule.file),
+                "scope": rule.scope.value.lower(),
+            }
+            for rule in unit.applicable_rules
+        ],
+    }
+
+
+@pure
+def exported_unit_to_tmr_task_packet(unit: ExportedSpecUnit) -> dict[str, Any]:
+    """Render an exported unit as a TMR task packet (consumed by `mngr tmr-tasks`)."""
+    return {
+        "schema_version": TMR_TASK_PACKET_SCHEMA_VERSION,
+        "id": unit.coordinate,
+        "display_id": unit.coordinate.replace(".", "-"),
+        "kind": spec_unit_kind_record_value(unit.kind),
+        "context": exported_unit_to_record(unit),
+    }

--- a/apps/minds/imbue/minds/core/behavioral_specs/export_test.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/export_test.py
@@ -209,24 +209,9 @@ def test_export_scopes_folder_invariants_to_their_subtree_only(tmp_path: Path) -
     root = write_spec_corpus(
         tmp_path / "specs",
         {
-            "invariants.feature": (
-                "Feature: Corpus invariants\n"
-                "\n"
-                "  @corpus-rule\n"
-                "  Rule: Holds everywhere\n"
-            ),
-            "alpha/invariants.feature": (
-                "Feature: Alpha invariants\n"
-                "\n"
-                "  @alpha-rule\n"
-                "  Rule: Holds under alpha\n"
-            ),
-            "alpha/beta/invariants.feature": (
-                "Feature: Beta invariants\n"
-                "\n"
-                "  @beta-rule\n"
-                "  Rule: Holds under beta\n"
-            ),
+            "invariants.feature": ("Feature: Corpus invariants\n\n  @corpus-rule\n  Rule: Holds everywhere\n"),
+            "alpha/invariants.feature": ("Feature: Alpha invariants\n\n  @alpha-rule\n  Rule: Holds under alpha\n"),
+            "alpha/beta/invariants.feature": ("Feature: Beta invariants\n\n  @beta-rule\n  Rule: Holds under beta\n"),
             "alpha/beta/deep.feature": "Feature: Deep\n\n  @deep-thing\n  Scenario: s\n    Given a\n",
             "alpha/shallow.feature": "Feature: Shallow\n\n  @shallow-thing\n  Scenario: s\n    Given a\n",
             "gamma/other.feature": "Feature: Other\n\n  @other-thing\n  Scenario: s\n    Given a\n",

--- a/apps/minds/imbue/minds/core/behavioral_specs/export_test.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/export_test.py
@@ -1,0 +1,326 @@
+"""Tests for the enriched behavioral-spec export.
+
+Corpora are synthetic (built under ``tmp_path`` via ``write_spec_corpus``).
+"""
+
+from pathlib import Path
+
+from imbue.minds.core.behavioral_specs.data_types import ApplicableRuleScope
+from imbue.minds.core.behavioral_specs.data_types import SpecProseFileKind
+from imbue.minds.core.behavioral_specs.data_types import SpecUnitKind
+from imbue.minds.core.behavioral_specs.export import export_corpus
+from imbue.minds.core.behavioral_specs.export import exported_unit_to_record
+from imbue.minds.core.behavioral_specs.export import exported_unit_to_tmr_task_packet
+from imbue.minds.core.behavioral_specs.testing import write_spec_corpus
+
+
+def _write_nested_corpus(root: Path) -> Path:
+    """A corpus exercising backgrounds, outlines, descriptions, prose, and every rule scope."""
+    return write_spec_corpus(
+        root,
+        {
+            "overview.md": "corpus-wide context\n",
+            "invariants.feature": (
+                "Feature: Corpus invariants\n"
+                "\n"
+                "  @never-leak\n"
+                "  Rule: Sessions never leak across users\n"
+                "    Rationale prose for the corpus invariant.\n"
+            ),
+            "authentication/overview.md": "authentication context\n",
+            "authentication/invariants.feature": (
+                "Feature: Authentication invariants\n"
+                "\n"
+                "  @single-use-codes\n"
+                "  Rule: A one-time code grants at most one session, ever\n"
+                "    Rationale prose for the folder invariant.\n"
+                "\n"
+                "    @spent-code-refused\n"
+                "    Example: A spent code cannot sign anyone in again\n"
+                "      Given the login URL has already been used\n"
+                "      Then authentication is refused\n"
+            ),
+            "authentication/signin.feature": (
+                "Feature: Sign-in with a one-time login code\n"
+                "  Feature description prose.\n"
+                "\n"
+                "  Background:\n"
+                "    Given a running desktop client\n"
+                "    And its terminal printed a login URL\n"
+                "\n"
+                "  @fresh-code\n"
+                "  Scenario: Opening a fresh login URL signs the user in\n"
+                "    Scenario description prose.\n"
+                "    Given the user is not signed in\n"
+                "    When the user opens the login URL\n"
+                "    Then the user is signed in\n"
+                "\n"
+                "  @missing-code\n"
+                "  Scenario Outline: Requests without a code are malformed\n"
+                '    When a request is made to "<path>"\n'
+                "    Then it is rejected\n"
+                "\n"
+                "    Examples:\n"
+                "      | path          |\n"
+                "      | /login        |\n"
+                "      | /authenticate |\n"
+                "\n"
+                "  @installation-bound\n"
+                "  Rule: Only tokens minted by this installation are accepted\n"
+                "    File-scoped rule prose.\n"
+            ),
+            "authentication/signin.md": "sidecar prose for signin.feature\n",
+        },
+    )
+
+
+def test_export_folds_background_into_effective_steps_and_keeps_raw_steps(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    assert export.violations == ()
+    fresh_code = next(unit for unit in export.units if unit.coordinate == "authentication.fresh-code")
+    assert [(step.keyword, step.text) for step in fresh_code.raw_steps] == [
+        ("Given", "the user is not signed in"),
+        ("When", "the user opens the login URL"),
+        ("Then", "the user is signed in"),
+    ]
+    assert [(step.keyword, step.text) for step in fresh_code.effective_steps] == [
+        ("Given", "a running desktop client"),
+        ("And", "its terminal printed a login URL"),
+        ("Given", "the user is not signed in"),
+        ("When", "the user opens the login URL"),
+        ("Then", "the user is signed in"),
+    ]
+
+
+def test_export_carries_descriptions_feature_and_prose(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    fresh_code = next(unit for unit in export.units if unit.coordinate == "authentication.fresh-code")
+    assert fresh_code.description == "Scenario description prose."
+    assert fresh_code.feature_name == "Sign-in with a one-time login code"
+    assert fresh_code.feature_description == "Feature description prose."
+    assert [(prose.kind, prose.path.name, prose.content) for prose in fresh_code.prose] == [
+        (SpecProseFileKind.OVERVIEW, "overview.md", "corpus-wide context\n"),
+        (SpecProseFileKind.OVERVIEW, "overview.md", "authentication context\n"),
+        (SpecProseFileKind.SIDECAR, "signin.md", "sidecar prose for signin.feature\n"),
+    ]
+    assert fresh_code.prose[0].path == root / "overview.md"
+    assert fresh_code.prose[1].path == root / "authentication" / "overview.md"
+
+
+def test_export_carries_examples_rows_for_scenario_outlines(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    outline = next(unit for unit in export.units if unit.coordinate == "authentication.missing-code")
+    assert outline.kind == SpecUnitKind.SCENARIO_OUTLINE
+    assert len(outline.examples) == 1
+    examples = outline.examples[0]
+    assert examples.header == ("path",)
+    assert examples.rows == (("/login",), ("/authenticate",))
+
+
+def test_export_resolves_applicable_rules_root_then_folder_then_file(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    fresh_code = next(unit for unit in export.units if unit.coordinate == "authentication.fresh-code")
+    assert [(rule.coordinate, rule.scope) for rule in fresh_code.applicable_rules] == [
+        ("never-leak", ApplicableRuleScope.CORPUS),
+        ("authentication.single-use-codes", ApplicableRuleScope.FOLDER),
+        ("authentication.installation-bound", ApplicableRuleScope.FILE),
+    ]
+    folder_rule = fresh_code.applicable_rules[1]
+    assert folder_rule.name == "A one-time code grants at most one session, ever"
+    assert folder_rule.description == "Rationale prose for the folder invariant."
+    assert folder_rule.file == root / "authentication" / "invariants.feature"
+
+
+def test_export_does_not_list_a_rule_as_its_own_applicable_rule(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    folder_rule = next(unit for unit in export.units if unit.coordinate == "authentication.single-use-codes")
+    assert [rule.coordinate for rule in folder_rule.applicable_rules] == ["never-leak"]
+    corpus_rule = next(unit for unit in export.units if unit.coordinate == "never-leak")
+    assert corpus_rule.applicable_rules == ()
+
+
+def test_export_links_rule_children_to_the_enclosing_rule(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+
+    child = next(unit for unit in export.units if unit.coordinate == "authentication.spent-code-refused")
+    assert child.parent == "authentication.single-use-codes"
+    assert child.rule is not None
+    assert child.rule.coordinate == "authentication.single-use-codes"
+    assert child.rule.name == "A one-time code grants at most one session, ever"
+    assert child.rule.description == "Rationale prose for the folder invariant."
+    # The illustrating child is bound by the corpus invariant and by the folder invariant it illustrates.
+    assert [rule.coordinate for rule in child.applicable_rules] == ["never-leak", "authentication.single-use-codes"]
+
+
+def test_export_folds_rule_background_into_rule_children(tmp_path: Path) -> None:
+    root = write_spec_corpus(
+        tmp_path / "specs",
+        {
+            "networking/tunnels.feature": (
+                "Feature: Tunnels\n"
+                "\n"
+                "  Background:\n"
+                "    Given a running forward server\n"
+                "\n"
+                "  @no-tls\n"
+                "  Rule: Tunnel endpoints never terminate TLS\n"
+                "\n"
+                "    Background:\n"
+                "      Given a connected tunnel\n"
+                "\n"
+                "    @plain-http\n"
+                "    Example: Plain HTTP passes through\n"
+                "      When a plain HTTP request crosses the tunnel\n"
+                "      Then it is forwarded untouched\n"
+            ),
+        },
+    )
+
+    export = export_corpus(root)
+
+    assert export.violations == ()
+    child = next(unit for unit in export.units if unit.coordinate == "networking.plain-http")
+    assert [(step.keyword, step.text) for step in child.effective_steps] == [
+        ("Given", "a running forward server"),
+        ("Given", "a connected tunnel"),
+        ("When", "a plain HTTP request crosses the tunnel"),
+        ("Then", "it is forwarded untouched"),
+    ]
+
+
+def test_export_scopes_folder_invariants_to_their_subtree_only(tmp_path: Path) -> None:
+    root = write_spec_corpus(
+        tmp_path / "specs",
+        {
+            "invariants.feature": (
+                "Feature: Corpus invariants\n"
+                "\n"
+                "  @corpus-rule\n"
+                "  Rule: Holds everywhere\n"
+            ),
+            "alpha/invariants.feature": (
+                "Feature: Alpha invariants\n"
+                "\n"
+                "  @alpha-rule\n"
+                "  Rule: Holds under alpha\n"
+            ),
+            "alpha/beta/invariants.feature": (
+                "Feature: Beta invariants\n"
+                "\n"
+                "  @beta-rule\n"
+                "  Rule: Holds under beta\n"
+            ),
+            "alpha/beta/deep.feature": "Feature: Deep\n\n  @deep-thing\n  Scenario: s\n    Given a\n",
+            "alpha/shallow.feature": "Feature: Shallow\n\n  @shallow-thing\n  Scenario: s\n    Given a\n",
+            "gamma/other.feature": "Feature: Other\n\n  @other-thing\n  Scenario: s\n    Given a\n",
+        },
+    )
+
+    export = export_corpus(root)
+
+    assert export.violations == ()
+    by_coordinate = {unit.coordinate: unit for unit in export.units}
+    assert [rule.coordinate for rule in by_coordinate["alpha.beta.deep-thing"].applicable_rules] == [
+        "corpus-rule",
+        "alpha.alpha-rule",
+        "alpha.beta.beta-rule",
+    ]
+    assert [rule.coordinate for rule in by_coordinate["alpha.shallow-thing"].applicable_rules] == [
+        "corpus-rule",
+        "alpha.alpha-rule",
+    ]
+    assert [rule.coordinate for rule in by_coordinate["gamma.other-thing"].applicable_rules] == ["corpus-rule"]
+
+
+def test_exported_unit_record_shape(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+    fresh_code = next(unit for unit in export.units if unit.coordinate == "authentication.fresh-code")
+    record = exported_unit_to_record(fresh_code)
+
+    assert list(record.keys()) == [
+        "coordinate",
+        "kind",
+        "name",
+        "file",
+        "line",
+        "tags",
+        "parent",
+        "description",
+        "raw_steps",
+        "effective_steps",
+        "examples",
+        "feature",
+        "rule",
+        "prose",
+        "applicable_rules",
+    ]
+    assert record["coordinate"] == "authentication.fresh-code"
+    assert record["kind"] == "scenario"
+    assert record["file"] == str(root / "authentication" / "signin.feature")
+    assert record["rule"] is None
+    assert record["feature"] == {
+        "name": "Sign-in with a one-time login code",
+        "description": "Feature description prose.",
+    }
+    assert record["prose"][0]["kind"] == "overview"
+    assert record["applicable_rules"][0] == {
+        "coordinate": "never-leak",
+        "name": "Sessions never leak across users",
+        "description": "Rationale prose for the corpus invariant.",
+        "file": str(root / "invariants.feature"),
+        "scope": "corpus",
+    }
+
+    outline = next(unit for unit in export.units if unit.coordinate == "authentication.missing-code")
+    outline_record = exported_unit_to_record(outline)
+    assert outline_record["examples"] == [{"line": 20, "header": ["path"], "rows": [["/login"], ["/authenticate"]]}]
+
+
+def test_tmr_task_packet_carries_coordinate_ids_and_export_context(tmp_path: Path) -> None:
+    root = _write_nested_corpus(tmp_path / "specs")
+
+    export = export_corpus(root)
+    fresh_code = next(unit for unit in export.units if unit.coordinate == "authentication.fresh-code")
+    packet = exported_unit_to_tmr_task_packet(fresh_code)
+
+    assert packet["schema_version"] == 1
+    assert packet["id"] == "authentication.fresh-code"
+    assert packet["display_id"] == "authentication-fresh-code"
+    assert packet["kind"] == "scenario"
+    assert packet["context"]["coordinate"] == "authentication.fresh-code"
+    assert packet["context"]["effective_steps"][0]["text"] == "a running desktop client"
+
+
+def test_export_passes_violations_through_and_still_exports_representable_units(tmp_path: Path) -> None:
+    root = write_spec_corpus(
+        tmp_path / "specs",
+        {
+            "good.feature": "Feature: G\n\n  @works\n  Scenario: s\n    Given a\n",
+            "untagged.feature": "Feature: U\n\n  Scenario: no identity\n    Given a\n",
+        },
+    )
+
+    export = export_corpus(root)
+
+    assert [unit.coordinate for unit in export.units] == ["works"]
+    assert len(export.violations) == 1
+    assert export.violations[0].is_unit_omitted is True

--- a/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
@@ -60,8 +60,10 @@ def _marker_from_call(call: ast.Call, file: Path) -> WitnessMarker | WitnessProb
         )
     partial: str | None = None
     for keyword in call.keywords:
-        if keyword.arg == "partial" and isinstance(keyword.value, ast.Constant) and isinstance(
-            keyword.value.value, str
+        if (
+            keyword.arg == "partial"
+            and isinstance(keyword.value, ast.Constant)
+            and isinstance(keyword.value.value, str)
         ):
             partial = keyword.value.value
     return WitnessMarker(coordinate=coordinate, file=file, line=call.lineno, partial=partial)
@@ -89,9 +91,7 @@ def find_witness_markers_in_source(source_text: str, file: Path) -> WitnessScan:
     for node in ast.walk(tree):
         calls: tuple[ast.Call, ...] = ()
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            calls = tuple(
-                decorator for decorator in node.decorator_list if _is_witnesses_call(decorator)
-            )
+            calls = tuple(decorator for decorator in node.decorator_list if _is_witnesses_call(decorator))
         elif isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets
         ):

--- a/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
@@ -9,6 +9,7 @@ mistyped link, and ``minds specs check-witnesses`` fails on it.
 """
 
 import ast
+import os
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -79,6 +80,22 @@ def _pytestmark_calls(value: ast.AST) -> tuple[ast.Call, ...]:
     return ()
 
 
+@pure
+def _witness_calls_of(node: ast.AST) -> tuple[ast.Call, ...]:
+    """Extract the witnesses-marker calls attached to one AST node (decorators or pytestmark)."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return tuple(
+            decorator
+            for decorator in node.decorator_list
+            if isinstance(decorator, ast.Call) and _is_witnesses_call(decorator)
+        )
+    if isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets
+    ):
+        return tuple(call for call in _pytestmark_calls(node.value) if _is_witnesses_call(call))
+    return ()
+
+
 def find_witness_markers_in_source(source_text: str, file: Path) -> WitnessScan:
     """Find every pytest.mark.witnesses application in one Python source.
 
@@ -89,14 +106,7 @@ def find_witness_markers_in_source(source_text: str, file: Path) -> WitnessScan:
     problems: list[WitnessProblem] = []
     tree = ast.parse(source_text, filename=str(file))
     for node in ast.walk(tree):
-        calls: tuple[ast.Call, ...] = ()
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            calls = tuple(decorator for decorator in node.decorator_list if _is_witnesses_call(decorator))
-        elif isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets
-        ):
-            calls = tuple(call for call in _pytestmark_calls(node.value) if _is_witnesses_call(call))
-        for call in calls:
+        for call in _witness_calls_of(node):
             result = _marker_from_call(call, file)
             if isinstance(result, WitnessMarker):
                 markers.append(result)
@@ -108,7 +118,8 @@ def find_witness_markers_in_source(source_text: str, file: Path) -> WitnessScan:
 def _iter_python_files(root: Path) -> list[Path]:
     """Yield every .py file under root, skipping hidden entries and __pycache__, sorted."""
     python_files: list[Path] = []
-    for folder, child_folder_names, file_names in root.walk(top_down=True):
+    for folder_str, child_folder_names, file_names in os.walk(root):
+        folder = Path(folder_str)
         child_folder_names[:] = sorted(
             name for name in child_folder_names if not name.startswith(".") and name != "__pycache__"
         )

--- a/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/witnesses.py
@@ -1,0 +1,159 @@
+"""Checking ``@pytest.mark.witnesses`` markers against the spec corpus.
+
+Tests back-link to spec units with ``@pytest.mark.witnesses("<coordinate>",
+partial=...)`` (see the minds-behavioral-specs skill). This module finds
+those markers in Python sources (as decorators and in ``pytestmark``
+assignments) and checks every referenced coordinate against the units of a
+scanned corpus: a marker naming a coordinate no unit claims is a stale or
+mistyped link, and ``minds specs check-witnesses`` fails on it.
+"""
+
+import ast
+from collections.abc import Sequence
+from pathlib import Path
+
+from pydantic import Field
+
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.imbue_common.pure import pure
+from imbue.minds.core.behavioral_specs.data_types import WitnessMarker
+from imbue.minds.core.behavioral_specs.data_types import WitnessProblem
+
+
+class WitnessScan(FrozenModel):
+    """The witnesses markers found in a set of Python files, plus any problems reading them."""
+
+    markers: tuple[WitnessMarker, ...] = Field(description="All witnesses markers found, in file order")
+    problems: tuple[WitnessProblem, ...] = Field(
+        description="Files that could not be parsed and markers with non-literal coordinates"
+    )
+
+
+@pure
+def _is_witnesses_call(node: ast.AST) -> bool:
+    """True for calls of exactly the form ``pytest.mark.witnesses(...)``."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "witnesses"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "mark"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "pytest"
+    )
+
+
+@pure
+def _marker_from_call(call: ast.Call, file: Path) -> WitnessMarker | WitnessProblem:
+    """Build a WitnessMarker from a witnesses call, or a problem if the coordinate is not literal."""
+    coordinate: str | None = None
+    if call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str):
+        coordinate = call.args[0].value
+    if coordinate is None:
+        return WitnessProblem(
+            file=file,
+            line=call.lineno,
+            message=(
+                "witnesses marker's first argument must be a coordinate string literal "
+                "(computed coordinates cannot be checked against the corpus)"
+            ),
+        )
+    partial: str | None = None
+    for keyword in call.keywords:
+        if keyword.arg == "partial" and isinstance(keyword.value, ast.Constant) and isinstance(
+            keyword.value.value, str
+        ):
+            partial = keyword.value.value
+    return WitnessMarker(coordinate=coordinate, file=file, line=call.lineno, partial=partial)
+
+
+@pure
+def _pytestmark_calls(value: ast.AST) -> tuple[ast.Call, ...]:
+    """Extract the call nodes of a pytestmark value: a single call or a list/tuple of calls."""
+    if isinstance(value, ast.Call):
+        return (value,)
+    if isinstance(value, (ast.List, ast.Tuple)):
+        return tuple(element for element in value.elts if isinstance(element, ast.Call))
+    return ()
+
+
+def find_witness_markers_in_source(source_text: str, file: Path) -> WitnessScan:
+    """Find every pytest.mark.witnesses application in one Python source.
+
+    Raises SyntaxError if the source cannot be parsed (callers decide whether
+    that is a problem to report).
+    """
+    markers: list[WitnessMarker] = []
+    problems: list[WitnessProblem] = []
+    tree = ast.parse(source_text, filename=str(file))
+    for node in ast.walk(tree):
+        calls: tuple[ast.Call, ...] = ()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            calls = tuple(
+                decorator for decorator in node.decorator_list if _is_witnesses_call(decorator)
+            )
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets
+        ):
+            calls = tuple(call for call in _pytestmark_calls(node.value) if _is_witnesses_call(call))
+        for call in calls:
+            result = _marker_from_call(call, file)
+            if isinstance(result, WitnessMarker):
+                markers.append(result)
+            else:
+                problems.append(result)
+    return WitnessScan(markers=tuple(markers), problems=tuple(problems))
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    """Yield every .py file under root, skipping hidden entries and __pycache__, sorted."""
+    python_files: list[Path] = []
+    for folder, child_folder_names, file_names in root.walk(top_down=True):
+        child_folder_names[:] = sorted(
+            name for name in child_folder_names if not name.startswith(".") and name != "__pycache__"
+        )
+        for file_name in sorted(file_names):
+            if file_name.endswith(".py") and not file_name.startswith("."):
+                python_files.append(folder / file_name)
+    return python_files
+
+
+def find_witness_markers_in_paths(paths: Sequence[Path]) -> WitnessScan:
+    """Find every witnesses marker under the given files/directories.
+
+    A path that is a file is scanned directly; a directory is walked
+    recursively. Unparseable files are reported as problems.
+    """
+    markers: list[WitnessMarker] = []
+    problems: list[WitnessProblem] = []
+    for path in paths:
+        python_files = [path] if path.is_file() else _iter_python_files(path)
+        for python_file in python_files:
+            try:
+                scan = find_witness_markers_in_source(python_file.read_text(encoding="utf-8"), python_file)
+            except SyntaxError:
+                problems.append(
+                    WitnessProblem(file=python_file, line=None, message="file could not be parsed as Python")
+                )
+                continue
+            markers.extend(scan.markers)
+            problems.extend(scan.problems)
+    return WitnessScan(markers=tuple(markers), problems=tuple(problems))
+
+
+@pure
+def check_witness_markers(
+    scan: WitnessScan,
+    valid_coordinates: frozenset[str],
+) -> tuple[WitnessProblem, ...]:
+    """Report every marker whose coordinate no corpus unit claims, after the scan's own problems."""
+    unknown = tuple(
+        WitnessProblem(
+            file=marker.file,
+            line=marker.line,
+            message=f"unknown coordinate '{marker.coordinate}': no unit in the spec corpus claims it",
+        )
+        for marker in scan.markers
+        if marker.coordinate not in valid_coordinates
+    )
+    return scan.problems + unknown

--- a/apps/minds/imbue/minds/core/behavioral_specs/witnesses_test.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/witnesses_test.py
@@ -11,10 +11,10 @@ def test_find_witness_markers_in_decorator_form(tmp_path: Path) -> None:
     source = (
         "import pytest\n"
         "\n"
-        "@pytest.mark.witnesses(\"authentication.fresh-code\")\n"
+        '@pytest.mark.witnesses("authentication.fresh-code")\n'
         "def test_signs_in() -> None: ...\n"
         "\n"
-        "@pytest.mark.witnesses(\"authentication.prefetch\", partial=\"does not assert the code stays unspent\")\n"
+        '@pytest.mark.witnesses("authentication.prefetch", partial="does not assert the code stays unspent")\n'
         "def test_prefetch() -> None: ...\n"
     )
 
@@ -31,10 +31,10 @@ def test_find_witness_markers_in_pytestmark_assignments(tmp_path: Path) -> None:
     source = (
         "import pytest\n"
         "\n"
-        "pytestmark = pytest.mark.witnesses(\"single-use-codes\")\n"
+        'pytestmark = pytest.mark.witnesses("single-use-codes")\n'
         "\n"
         "class TestSuite:\n"
-        "    pytestmark = [pytest.mark.witnesses(\"authentication.fresh-code\"), pytest.mark.acceptance]\n"
+        '    pytestmark = [pytest.mark.witnesses("authentication.fresh-code"), pytest.mark.acceptance]\n'
         "\n"
         "    def test_one(self) -> None: ...\n"
     )
@@ -52,7 +52,7 @@ def test_find_witness_markers_flags_non_literal_coordinates(tmp_path: Path) -> N
     source = (
         "import pytest\n"
         "\n"
-        "COORDINATE = \"authentication.fresh-code\"\n"
+        'COORDINATE = "authentication.fresh-code"\n'
         "\n"
         "@pytest.mark.witnesses(COORDINATE)\n"
         "def test_signs_in() -> None: ...\n"
@@ -67,13 +67,7 @@ def test_find_witness_markers_flags_non_literal_coordinates(tmp_path: Path) -> N
 
 
 def test_find_witness_markers_ignores_other_markers(tmp_path: Path) -> None:
-    source = (
-        "import pytest\n"
-        "\n"
-        "@pytest.mark.acceptance\n"
-        "@pytest.mark.timeout(30)\n"
-        "def test_unrelated() -> None: ...\n"
-    )
+    source = "import pytest\n\n@pytest.mark.acceptance\n@pytest.mark.timeout(30)\ndef test_unrelated() -> None: ...\n"
 
     scan = find_witness_markers_in_source(source, tmp_path / "test_other.py")
 
@@ -84,9 +78,9 @@ def test_find_witness_markers_ignores_other_markers(tmp_path: Path) -> None:
 def test_find_witness_markers_in_paths_walks_directories(tmp_path: Path) -> None:
     tree = tmp_path / "tests"
     (tree / "sub").mkdir(parents=True)
-    (tree / "test_a.py").write_text("import pytest\n\n@pytest.mark.witnesses(\"a.b\")\ndef test_a() -> None: ...\n")
+    (tree / "test_a.py").write_text('import pytest\n\n@pytest.mark.witnesses("a.b")\ndef test_a() -> None: ...\n')
     (tree / "sub" / "test_b.py").write_text(
-        "import pytest\n\n@pytest.mark.witnesses(\"c.d\")\ndef test_b() -> None: ...\n"
+        'import pytest\n\n@pytest.mark.witnesses("c.d")\ndef test_b() -> None: ...\n'
     )
     (tree / "__pycache__").mkdir()
     (tree / "__pycache__" / "test_cached.py").write_text("not even python {\n")
@@ -110,7 +104,7 @@ def test_find_witness_markers_in_paths_reports_unparseable_files(tmp_path: Path)
 
 
 def test_check_witness_markers_reports_unknown_coordinates(tmp_path: Path) -> None:
-    marker_source = "import pytest\n\n@pytest.mark.witnesses(\"authentication.typoo\")\ndef test_x() -> None: ...\n"
+    marker_source = 'import pytest\n\n@pytest.mark.witnesses("authentication.typoo")\ndef test_x() -> None: ...\n'
     test_file = tmp_path / "test_x.py"
     test_file.write_text(marker_source)
     scan = find_witness_markers_in_paths((test_file,))
@@ -125,7 +119,7 @@ def test_check_witness_markers_reports_unknown_coordinates(tmp_path: Path) -> No
 def test_check_witness_markers_accepts_known_coordinates_and_keeps_scan_problems(tmp_path: Path) -> None:
     test_file = tmp_path / "test_x.py"
     test_file.write_text(
-        "import pytest\n\n@pytest.mark.witnesses(\"authentication.fresh-code\")\ndef test_x() -> None: ...\n"
+        'import pytest\n\n@pytest.mark.witnesses("authentication.fresh-code")\ndef test_x() -> None: ...\n'
     )
     scan = find_witness_markers_in_paths((test_file,))
 

--- a/apps/minds/imbue/minds/core/behavioral_specs/witnesses_test.py
+++ b/apps/minds/imbue/minds/core/behavioral_specs/witnesses_test.py
@@ -1,0 +1,134 @@
+"""Tests for the witnesses-marker scan and coordinate check."""
+
+from pathlib import Path
+
+from imbue.minds.core.behavioral_specs.witnesses import check_witness_markers
+from imbue.minds.core.behavioral_specs.witnesses import find_witness_markers_in_paths
+from imbue.minds.core.behavioral_specs.witnesses import find_witness_markers_in_source
+
+
+def test_find_witness_markers_in_decorator_form(tmp_path: Path) -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.witnesses(\"authentication.fresh-code\")\n"
+        "def test_signs_in() -> None: ...\n"
+        "\n"
+        "@pytest.mark.witnesses(\"authentication.prefetch\", partial=\"does not assert the code stays unspent\")\n"
+        "def test_prefetch() -> None: ...\n"
+    )
+
+    scan = find_witness_markers_in_source(source, tmp_path / "test_auth.py")
+
+    assert scan.problems == ()
+    assert [(marker.coordinate, marker.line, marker.partial) for marker in scan.markers] == [
+        ("authentication.fresh-code", 3, None),
+        ("authentication.prefetch", 6, "does not assert the code stays unspent"),
+    ]
+
+
+def test_find_witness_markers_in_pytestmark_assignments(tmp_path: Path) -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "pytestmark = pytest.mark.witnesses(\"single-use-codes\")\n"
+        "\n"
+        "class TestSuite:\n"
+        "    pytestmark = [pytest.mark.witnesses(\"authentication.fresh-code\"), pytest.mark.acceptance]\n"
+        "\n"
+        "    def test_one(self) -> None: ...\n"
+    )
+
+    scan = find_witness_markers_in_source(source, tmp_path / "test_suite.py")
+
+    assert scan.problems == ()
+    assert [(marker.coordinate, marker.line) for marker in scan.markers] == [
+        ("single-use-codes", 3),
+        ("authentication.fresh-code", 6),
+    ]
+
+
+def test_find_witness_markers_flags_non_literal_coordinates(tmp_path: Path) -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "COORDINATE = \"authentication.fresh-code\"\n"
+        "\n"
+        "@pytest.mark.witnesses(COORDINATE)\n"
+        "def test_signs_in() -> None: ...\n"
+    )
+
+    scan = find_witness_markers_in_source(source, tmp_path / "test_auth.py")
+
+    assert scan.markers == ()
+    assert len(scan.problems) == 1
+    assert scan.problems[0].line == 5
+    assert "string literal" in scan.problems[0].message
+
+
+def test_find_witness_markers_ignores_other_markers(tmp_path: Path) -> None:
+    source = (
+        "import pytest\n"
+        "\n"
+        "@pytest.mark.acceptance\n"
+        "@pytest.mark.timeout(30)\n"
+        "def test_unrelated() -> None: ...\n"
+    )
+
+    scan = find_witness_markers_in_source(source, tmp_path / "test_other.py")
+
+    assert scan.markers == ()
+    assert scan.problems == ()
+
+
+def test_find_witness_markers_in_paths_walks_directories(tmp_path: Path) -> None:
+    tree = tmp_path / "tests"
+    (tree / "sub").mkdir(parents=True)
+    (tree / "test_a.py").write_text("import pytest\n\n@pytest.mark.witnesses(\"a.b\")\ndef test_a() -> None: ...\n")
+    (tree / "sub" / "test_b.py").write_text(
+        "import pytest\n\n@pytest.mark.witnesses(\"c.d\")\ndef test_b() -> None: ...\n"
+    )
+    (tree / "__pycache__").mkdir()
+    (tree / "__pycache__" / "test_cached.py").write_text("not even python {\n")
+    (tree / "not_a_test.txt").write_text("import pytest\n")
+
+    scan = find_witness_markers_in_paths((tree,))
+
+    assert scan.problems == ()
+    assert {marker.coordinate for marker in scan.markers} == {"a.b", "c.d"}
+
+
+def test_find_witness_markers_in_paths_reports_unparseable_files(tmp_path: Path) -> None:
+    bad_file = tmp_path / "test_broken.py"
+    bad_file.write_text("def test_broken(:\n")
+
+    scan = find_witness_markers_in_paths((bad_file,))
+
+    assert scan.markers == ()
+    assert len(scan.problems) == 1
+    assert "could not be parsed" in scan.problems[0].message
+
+
+def test_check_witness_markers_reports_unknown_coordinates(tmp_path: Path) -> None:
+    marker_source = "import pytest\n\n@pytest.mark.witnesses(\"authentication.typoo\")\ndef test_x() -> None: ...\n"
+    test_file = tmp_path / "test_x.py"
+    test_file.write_text(marker_source)
+    scan = find_witness_markers_in_paths((test_file,))
+
+    problems = check_witness_markers(scan, frozenset({"authentication.fresh-code"}))
+
+    assert len(problems) == 1
+    assert problems[0].line == 3
+    assert "unknown coordinate 'authentication.typoo'" in problems[0].message
+
+
+def test_check_witness_markers_accepts_known_coordinates_and_keeps_scan_problems(tmp_path: Path) -> None:
+    test_file = tmp_path / "test_x.py"
+    test_file.write_text(
+        "import pytest\n\n@pytest.mark.witnesses(\"authentication.fresh-code\")\ndef test_x() -> None: ...\n"
+    )
+    scan = find_witness_markers_in_paths((test_file,))
+
+    problems = check_witness_markers(scan, frozenset({"authentication.fresh-code"}))
+
+    assert problems == ()

--- a/apps/minds/imbue/minds/errors.py
+++ b/apps/minds/imbue/minds/errors.py
@@ -151,6 +151,12 @@ class SpecValidationFailedError(MindError):
     ...
 
 
+class WitnessCheckFailedError(MindError):
+    """Raised by ``minds specs check-witnesses`` when witnesses markers are malformed or unknown."""
+
+    ...
+
+
 class SpecListingIncompleteError(MindError):
     """Raised by ``minds specs list``/``query`` when some units could not be represented as records.
 

--- a/apps/minds/tmr/specs_mapper.j2
+++ b/apps/minds/tmr/specs_mapper.j2
@@ -1,0 +1,149 @@
+{# Minds spec-witnessing variant of the task-file mapper prompt. Renders
+   against the task-file mapper context: task_id, kind, context_json,
+   outcome_filename, publish_snippet. The task is one behavioral-spec unit
+   (from `minds specs plan --for-tmr`); the agent writes the cheapest
+   sufficient test witnessing it. -#}
+You are writing tests for the minds app (`apps/minds/`) that witness one unit
+of its behavioral-spec corpus (`apps/minds/specs/`): the desktop client and
+its `/api/v1` surface, Docker/remote workspaces, env provisioning, and the
+deployment/services suites.
+
+# The spec unit
+
+Your task is the spec unit with coordinate `{{ task_id }}` (kind: {{ kind }}).
+Its enriched export record is:
+
+```json
+{{ context_json }}
+```
+
+How to read it:
+
+- raw_steps are the unit's own steps; effective_steps fold the file's
+  Background in (feature-level, then rule-level for units nested under a
+  Rule). Test the EFFECTIVE behavior.
+- For a Scenario Outline (kind "scenario-outline"), examples carries the
+  table: one header and every body row. Cover EVERY row.
+- feature / rule carry the names and descriptions of the enclosing Feature
+  and (when nested) Rule.
+- prose carries the relevant overview.md files and the file's sidecar.
+- applicable_rules lists the invariants (Rules) binding this unit, resolved
+  corpus -> folder -> file. Your test must not violate them, and where a row
+  of behavior intersects an invariant, prefer asserting the invariant holds.
+
+The spec unit -- not the current implementation -- defines the correct
+behavior. If the implementation contradicts the spec, the spec wins as the
+statement of intended behavior (see "Tests-only" below for what to do about
+it).
+
+# Specs are read-only
+
+NEVER edit, move, rename, or delete anything under `apps/minds/specs/`. The
+corpus is the stable contract this work links against; the reducer rejects
+any branch that touches it.
+
+# Write the cheapest sufficient witness
+
+1. Find the code that implements the unit's behavior and look for existing
+   tests near it. Strongly prefer updating or extending an existing test
+   that already exercises the behavior over writing a new one.
+2. If no existing test can witness the unit, write ONE new test in the
+   closest existing test file (matching the file's fixtures and style).
+   Cheapest means: a unit/integration-level test using the shared fixtures
+   (temp_host_dir, temp_mngr_ctx, local_provider, and the helpers in the
+   nearest conftest.py / testing.py) -- never a Docker/Modal/deployment test
+   for behavior that can be observed in-process. Follow
+   apps/minds/docs/testing-overview.md.
+3. Every test you create or modify MUST carry the marker
+   `@pytest.mark.witnesses("{{ task_id }}")`. When the test does not cover
+   the whole unit, say exactly what it misses with
+   `partial="<what is not covered>"`. A test may witness several units, but
+   only add other coordinates when the test genuinely verifies them.
+4. Scenario Outlines become `@pytest.mark.parametrize` tests, one parameter
+   set per Examples row, covering every row.
+5. Run the tests you touched and make them pass:
+   `uv run pytest <node ids>`. Record each run in test_runs.
+
+# Tests-only by default
+
+Do NOT change implementation code to conform to the spec. Your commits may
+touch test files, conftest.py, and testing.py helpers only. If the
+implementation contradicts the spec unit -- the behavior the spec describes
+is not what the code does -- that is a gap, not something to fix here:
+
+1. Leave a comment at the relevant spot in the code, on its own line, in
+   exactly this form so a later step can find it:
+
+     # FIXME(tmr): <one-line description of the gap between spec and implementation>
+
+2. Record a change (typically ADD_TEST) with status "BLOCKED" and explain
+   the gap in summary_markdown.
+
+The same applies when the unit cannot be tested cheaply at all (it needs
+infrastructure a single test cannot stand up): do not paper over it with a
+brittle hack; flag it as BLOCKED with a FIXME(tmr) comment instead.
+
+# Committing your changes
+
+IMPORTANT: Each change kind MUST get its own separate commit. Changes of the
+same kind should be combined in one commit. The commit message MUST start
+with the kind in brackets. Examples:
+
+  [ADD_TEST] Witness authentication.fresh-code via the login redirect flow
+  [IMPROVE_TEST] Mark the existing session test as witnessing authentication.survives-restart
+
+The change kinds for this run are ADD_TEST (a new witness test) and
+IMPROVE_TEST (an existing test updated to witness the unit, e.g. by gaining
+the marker or missing assertions). Do NOT commit FIX_IMPL changes; gaps are
+BLOCKED outcomes, not implementation fixes.
+
+# Writing the result
+
+Write the result atomically to avoid races with the orchestrator reading it:
+1. First write to .test_output/{{ outcome_filename }}.draft (relative to the git repo root)
+2. Then rename (mv) the .draft file to .test_output/{{ outcome_filename }}
+
+The schema is:
+
+{"changes": {"ADD_TEST": {"status": "SUCCEEDED", "summary_markdown": "Added a parametrized witness for both Examples rows"}},
+ "errored": false,
+ "tests_passing_before": null,
+ "tests_passing_after": true,
+ "summary_markdown": "Added test_signin_witnesses_fresh_code; it passes.",
+ "test_runs": [
+   {"run_name": "<try_1>", "description_markdown": "initial run of the new witness test"}
+ ]}
+
+Fields:
+- changes: object keyed by change kind (ADD_TEST, IMPROVE_TEST). Each value
+  has status (SUCCEEDED, FAILED, BLOCKED) and summary_markdown. One entry
+  per kind -- do not duplicate kinds. A unit that is already fully witnessed
+  by an existing marked test needs no change: an empty changes object is a
+  correct, good outcome, NOT a failure.
+- errored: true only for infrastructure errors that prevented you from working.
+- tests_passing_before: were the touched tests passing before your changes
+  (null if none existed)?
+- tests_passing_after: are the touched tests passing now?
+- summary_markdown: overall markdown summary of what happened.
+- test_runs: list of objects, one per test run, in order. Each has run_name
+  and description_markdown.
+
+# Publishing the outputs archive
+
+After the outcome file is written, package the outputs and publish them
+where the orchestrator can find them. Run this from the git repo root:
+
+{{ publish_snippet }}
+
+This MUST be the very last step. The orchestrator polls for outputs.tar.gz
+and treats its appearance as the signal that you are done. The .tmp + rename
+sequence prevents the orchestrator from reading a half-written archive. Omit
+branch.bundle when you made no commits beyond the base branch.
+
+# Important: do not ask for user input
+
+For this initial request, do NOT ask the user for any input or clarification.
+Work autonomously. If something is unclear or you are blocked, produce a
+result with the appropriate change status set to "BLOCKED" and explain in
+the summary_markdown. If the user sends follow-up messages later, you may
+ask them questions at that point.

--- a/apps/minds/tmr/specs_reducer.j2
+++ b/apps/minds/tmr/specs_reducer.j2
@@ -1,0 +1,202 @@
+{# Minds spec-witnessing variant of the task-file reducer prompt. Renders
+   against the integrator context: inputs_dirname, mapper_outcome_filename,
+   reducer_outcome_filename, publish_snippet. Integrates the mapper branches
+   that added witness tests, then enforces the spec-corpus gates. -#}
+Integrate the witness-test branches from the spec-mapping agents whose
+outputs have been uploaded into ``{{ inputs_dirname }}/`` (a sibling of the
+current directory's contents, in your work_dir). Each subdirectory
+``{{ inputs_dirname }}/<agent_name>/`` contains the agent's
+``test_output/{{ mapper_outcome_filename }}`` and (when it made commits) a
+``branch.bundle``. Each agent wrote (or updated) tests witnessing one
+behavioral-spec unit of the minds corpus under ``apps/minds/specs/``.
+
+# Discover and fetch qualifying branches
+
+Run this from the git repo root to filter and fetch the branches whose
+agents reported real witness work (and didn't leave failing tests):
+
+```bash
+set -euo pipefail
+
+INPUTS_DIR="{{ inputs_dirname }}"
+FETCHED_BRANCHES=()
+
+should_pull() {
+    python3 - "$1" <<'PYEOF'
+import json, sys
+data = json.load(open(sys.argv[1]))
+if data.get("errored"):
+    sys.exit(1)
+changes = data.get("changes") or {}
+if not any((c or {}).get("status") == "SUCCEEDED" for c in changes.values()):
+    sys.exit(1)
+if data.get("tests_passing_after") is False:
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+bundle_branch() {
+    git bundle list-heads "$1" \
+        | awk 'NR==1 { sub(/^refs\/heads\//, "", $2); print $2 }'
+}
+
+for agent_dir in "$INPUTS_DIR"/*/; do
+    outcome="$agent_dir/test_output/{{ mapper_outcome_filename }}"
+    bundle="$agent_dir/branch.bundle"
+    [ -f "$outcome" ] || continue
+    [ -f "$bundle" ] || continue
+    if ! should_pull "$outcome"; then
+        echo "Skipping $agent_dir (did not meet the should-pull predicate)"
+        continue
+    fi
+    branch=$(bundle_branch "$bundle")
+    if [ -z "$branch" ]; then
+        echo "Skipping $agent_dir (could not read branch ref from bundle)"
+        continue
+    fi
+    echo "Fetching $branch from $bundle"
+    git fetch --no-tags "$bundle" "+$branch:$branch"
+    FETCHED_BRANCHES+=("$branch")
+done
+
+printf '%s\n' "${FETCHED_BRANCHES[@]}"
+```
+
+The branches you must integrate are exactly the printed ones. If no branches
+qualify, write an outcome describing that (no squashed commits) and proceed
+straight to publishing the outputs archive.
+
+# Integration strategy
+
+Use cherry-pick (NOT merge) to build a clean linear history.
+
+1. For each fetched branch, inspect the commits. They should be tagged
+   [ADD_TEST] or [IMPROVE_TEST] -- this run is tests-only.
+2. If any commit touches files outside test code (test files, conftest.py,
+   testing.py) -- above all any commit tagged [FIX_IMPL] or touching
+   production code -- do NOT cherry-pick it. Record the branch under
+   "failed" with the reason, and note it under "escalations".
+3. Cherry-pick the remaining commits and squash them into a SINGLE commit
+   with a message like: "[ADD_TEST] Witness tests for spec units (from N agents)".
+4. If a cherry-pick has conflicts, try to resolve them (two agents often
+   touched the same test file). If you cannot resolve a conflict for a
+   particular branch, skip it and record it as failed.
+5. After cherry-picking, record the squashed commit hash with `git rev-parse HEAD`.
+
+# The spec corpus is read-only
+
+No mapper branch may modify anything under ``apps/minds/specs/``. After
+integrating, verify:
+
+```bash
+git diff --name-only "$MNGR_GIT_BASE_BRANCH...HEAD" -- apps/minds/specs/
+```
+
+This MUST print nothing. If any spec file was touched, back those changes
+out (`git checkout "$MNGR_GIT_BASE_BRANCH" -- apps/minds/specs/` and amend
+the integration commit), and record an escalation naming the branch that did
+it.
+
+# Deduplicate the generated tests
+
+This is the only point in the pipeline where all generated tests are visible
+together. Read the tests the integrated branches added or modified:
+
+- If two branches wrote tests covering the same behavior (e.g. a scenario
+  and one row of a related outline, or two agents that both chose to extend
+  the same existing test), keep the better one and drop the other. Prefer
+  the test that covers more of its spec unit (fewer partial= notes).
+- Every generated or modified test must carry
+  `@pytest.mark.witnesses("<coordinate>")` for the unit it covers. Drop
+  markers that do not correspond to what the test actually verifies.
+- Keep each deduplication as its own commit prefixed `[NORMALIZE]`, and
+  record it under "normalizations".
+
+# Gate the integrated tree
+
+Before publishing, all of these MUST pass:
+
+1. Spec validation:
+
+   ```bash
+   uv run minds specs validate
+   ```
+
+2. The witnesses-coordinate check (fails on any marker naming a coordinate
+   no corpus unit claims):
+
+   ```bash
+   uv run minds specs check-witnesses
+   ```
+
+3. The blast-radius pytest subset: run the test files the integration
+   touched, with the unit/integration marker expression:
+
+   ```bash
+   TOUCHED=$(git diff --name-only "$MNGR_GIT_BASE_BRANCH...HEAD" -- '*_test.py' 'test_*.py')
+   uv run pytest $TOUCHED -m 'not acceptance and not release and not docker and not docker_sdk and not minds_deployment and not minds_services and not minds_snapshot_resume'
+   ```
+
+   If a merged test fails and you cannot fix it cheaply within test code,
+   drop that test (revert its hunk) and record the branch as failed with the
+   reason. Do NOT fix implementation code to make a witness pass: the gap
+   between spec and implementation is an escalation, not a fix here.
+
+Also collect any `# FIXME(tmr):` comments the mappers left:
+
+```bash
+grep -rn "FIXME(tmr):" . || true
+```
+
+Record each distinct one under "escalations" (they describe spec-vs-implementation
+gaps and shared setup blockers for the user; do not try to resolve them by
+changing implementation code).
+
+If a gate cannot run in this environment (e.g. pytest cannot collect because
+of a missing dependency), record it as an escalation rather than guessing.
+
+# Writing the outcome and publishing outputs
+
+After integrating, write the result atomically to avoid races with the
+orchestrator reading it:
+
+1. First write to .test_output/{{ reducer_outcome_filename }}.draft (relative to the git repo root)
+2. Then rename (mv) the .draft file to .test_output/{{ reducer_outcome_filename }}
+
+The schema is:
+
+{"squashed_branches": ["branch1", "branch2"],
+ "squashed_commit_hash": "abc1234",
+ "impl_priority": [],
+ "impl_commit_hashes": {},
+ "failed": ["branch3"],
+ "normalizations": [{"summary_markdown": "Dropped the duplicate fresh-code witness in favor of the parametrized one"}],
+ "escalations": [{"title": "spec gap: spent codes are not refused", "detail_markdown": "authentication.used-code: the implementation accepts a spent code twice; mappers recorded BLOCKED. See FIXME(tmr) in apps/minds/imbue/minds/desktop_client/auth.py."}]}
+
+Fields:
+- squashed_branches: branch names whose commits were squashed into the
+  integration commit
+- squashed_commit_hash: commit hash of the squashed commit (short is fine)
+- impl_priority / impl_commit_hashes: always empty for this run (tests-only)
+- failed: branch names that could not be integrated (conflicts, out-of-scope
+  edits, or tests that could not pass without implementation changes)
+- normalizations: deduplication and cleanup commits you applied (each with
+  summary_markdown). Omit or use [] if none.
+- escalations: spec-vs-implementation gaps and blockers to surface to the
+  user (each with title and detail_markdown). Omit or use [] if none.
+
+Then, finally, publish the outputs archive. Run this from the git repo root:
+
+{{ publish_snippet }}
+
+This MUST be the very last step. The orchestrator polls for outputs.tar.gz
+and treats its appearance as the signal that you are done. The .tmp + rename
+sequence prevents the orchestrator from reading a half-written archive.
+
+# Important: do not ask for user input
+
+For this initial request, do NOT ask the user for any input or clarification.
+Work autonomously. If a cherry-pick has conflicts you cannot resolve, skip
+that branch and record it as failed. If the user sends follow-up messages
+later, you may ask them questions at that point.

--- a/dev/changelog/danver-minds-specs-tmr.md
+++ b/dev/changelog/danver-minds-specs-tmr.md
@@ -1,0 +1,3 @@
+Added the root justfile recipe `tmr-minds-specs`, the canonical spec-witnessing TMR variant: it generates the task file with `minds specs plan --for-tmr` and runs `mngr tmr-tasks` with the minds spec-witnessing prompt pair (`apps/minds/tmr/specs_mapper.j2` / `specs_reducer.j2`) under the `tmr-minds-specs` variant name. Extra map-reduce flags pass through (e.g. `just tmr-minds-specs --provider modal --max-parallel-agents 8`).
+
+Updated the `minds-behavioral-specs` skill's tooling section to list the new `minds specs` subcommands (`export`, `plan --for-tmr`, `check-witnesses`).

--- a/justfile
+++ b/justfile
@@ -249,6 +249,17 @@ tmr-mngr *args:
 tmr-minds *args:
   uv run --project libs/mngr_tmr mngr tmr apps/minds --name tmr-minds --mapper-prompt apps/minds/tmr/mapper.j2 {{args}} -- -m 'release and not minds_deployment and not minds_services and not minds_snapshot_resume'
 
+# Spec-witnessing variant: one agent per behavioral-spec unit, writing the
+# cheapest sufficient witness test for it (see apps/minds/docs/behavioral-specs.md).
+# Extra map-reduce flags pass through, e.g.
+#   just tmr-minds-specs --provider modal --max-parallel-agents 8
+tmr-minds-specs *args:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  TASKS_FILE=$(mktemp /tmp/minds-spec-tasks.XXXXXX.jsonl)
+  uv run minds specs plan --for-tmr > "$TASKS_FILE"
+  uv run --project libs/mngr_tmr mngr tmr-tasks --tasks-file "$TASKS_FILE" --name tmr-minds-specs --mapper-prompt apps/minds/tmr/specs_mapper.j2 --reducer-prompt apps/minds/tmr/specs_reducer.j2 {{args}}
+
 # === minds deployment / services test orchestrator ===
 # Wraps apps/minds/scripts/test_deployments.py. See specs/minds-deployment-tests.md
 # and apps/minds/deployment_tests/README.md for the full design + usage.

--- a/libs/mngr/changelog/danver-minds-specs-tmr.md
+++ b/libs/mngr/changelog/danver-minds-specs-tmr.md
@@ -1,0 +1,1 @@
+Regenerated the CLI command docs for the new `mngr tmr-tasks` command (from the mngr-tmr plugin): `docs/commands/secondary/tmr-tasks.md`, with `tmr-tasks` added to SECONDARY_COMMANDS in `scripts/make_cli_docs.py`.

--- a/libs/mngr/docs/commands/secondary/tmr-tasks.md
+++ b/libs/mngr/docs/commands/secondary/tmr-tasks.md
@@ -1,0 +1,108 @@
+<!-- This file is auto-generated. Do not edit directly. -->
+<!-- To modify, edit the command's help metadata and run: uv run python scripts/make_cli_docs.py -->
+
+# mngr tmr-tasks
+
+**Synopsis:**
+
+```text
+mngr tmr-tasks --tasks-file <JSONL> --mapper-prompt <FILE> --reducer-prompt <FILE> [--name <VARIANT>] [--provider <PROVIDER>] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]
+```
+
+Fan out a JSONL task file to one agent per task and integrate their branches.
+
+This command runs the map-reduce framework over an explicit task file instead of pytest collection:
+
+1. Reads and validates --tasks-file: one JSON packet per line with
+   schema_version, id, optional display_id (used for agent/branch slugs),
+   kind, and a free-form context object.
+2. Launches one agent per task. The mapper prompt comes from --mapper-prompt
+   (required; there is no packaged default -- the task semantics live with
+   the producer of the task file), rendered with task_id, kind, context_json
+   (the packet's context as pretty JSON), outcome_filename, and
+   publish_snippet.
+3. Polls agents until all finish or individually time out; pulls each
+   agent's branch.bundle back into local branches.
+4. If any mapper produced outputs, launches a reducer agent with
+   --reducer-prompt to integrate the mapper branches.
+5. Generates the shared HTML report; mapper agents must write the same
+   testing_agent_outcome.json contract as `mngr tmr` mappers.
+
+The canonical producer is `minds specs plan --for-tmr`, which emits one
+packet per behavioral-spec unit; pair it with the minds spec-witnessing
+prompts at apps/minds/tmr/specs_mapper.j2 and apps/minds/tmr/specs_reducer.j2.
+
+**Usage:**
+
+```text
+mngr tmr-tasks [OPTIONS]
+```
+**Options:**
+
+## Common
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--format` | text | Output format (human, json, jsonl, FORMAT): Output format for results. When a template is provided, fields use standard python templating like 'name: {agent.name}' See below for available fields. | `human` |
+| `-q`, `--quiet` | boolean | Suppress all console output | `False` |
+| `-v`, `--verbose` | integer range | Increase verbosity (default: BUILD); -v for DEBUG, -vv for TRACE | `0` |
+| `--log-file` | path | Path to log file (overrides default ~/.mngr/events/logs/<timestamp>-<pid>.json) | None |
+| `--log-commands`, `--no-log-commands` | boolean | Log commands that were executed | None |
+| `--headless` | boolean | Disable all interactive behavior (prompts, TUI, editor). Also settable via MNGR_HEADLESS env var or 'headless' config key. | `False` |
+| `--safe` | boolean | Always query all providers during discovery (disable event-stream optimization). Use this when interfacing with mngr from multiple machines. | `False` |
+| `--plugin`, `--enable-plugin` | text | Enable a plugin [repeatable] | None |
+| `--disable-plugin` | text | Disable a plugin [repeatable] | None |
+| `-S`, `--setting` | text | Override a config setting for this invocation (KEY=VALUE, dot-separated paths; append __extend to the leaf key to extend list/dict/set fields) [repeatable] | None |
+| `-h`, `--help` | boolean | Show this message and exit. | `False` |
+
+## Other Options
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `--tasks-file` | file | JSONL task file: one packet per line with schema_version, id, optional display_id, kind, and a free-form context object handed to the mapper prompt template. | None |
+| `--name` | text | Variant name, used as the prefix for this run's agent/branch/host names. | `tmr-tasks` |
+| `--mapper-prompt` | file | Mapper prompt template (required): rendered with task_id, kind, context_json, outcome_filename, and publish_snippet. There is no packaged default because the task semantics live with the producer of the task file. | None |
+| `--reducer-prompt` | file | Reducer prompt template (required): rendered with inputs_dirname, mapper_outcome_filename, reducer_outcome_filename, and publish_snippet. | None |
+| `--agent-type` | text | Type of agent to launch for each task | `claude` |
+| `-t`, `--agent-template` | text | Create template to apply for mapper agents [repeatable, stacks in order] | None |
+| `--provider` | text | Provider for agent hosts (e.g. local, docker, modal). Used for both mappers and the reducer. | `local` |
+| `--env` | text | Environment variable KEY=VALUE to pass to agents [repeatable] | None |
+| `--label` | text | Agent label KEY=VALUE to attach to all launched agents [repeatable] | None |
+| `--snapshot` | text | Use an existing snapshot/image ID for all agents (skips building a fresh snapshot) | None |
+| `--max-parallel-launch` | integer | Maximum number of agents to launch concurrently (launch-time parallelism) | `10` |
+| `--agents-per-host` | integer | Number of agents sharing each remote host (ignored for local provider) | `4` |
+| `--max-parallel-agents` | integer | Maximum number of mappers running at any one time (0 = no limit). When set, mappers are launched incrementally as earlier ones finish. | `0` |
+| `--launch-delay` | float | Seconds to wait between launching each agent (avoids provider rate limits) | `2.0` |
+| `--poll-interval` | float | Seconds between polling cycles when waiting for agents to finish | `60.0` |
+| `--timeout` | float | Maximum seconds each mapper can run before being stopped (per-agent timeout) | `3600.0` |
+| `--reducer-timeout` | float | Maximum seconds to wait for the reducer agent to finish | `3600.0` |
+| `--output-dir` | path | Directory for the run's outputs (HTML report at index.html, per-agent artifacts) [default: <recipe>_<timestamp>/] | None |
+| `--source` | directory | Source directory for discovery and agent work dirs [default: current directory] | None |
+| `--reintegrate` | boolean | Re-read outcomes from a previous run, re-run the reducer, and regenerate the report. Skips discovery and mapper launching. The run to reintegrate is identified by --run-name. | `False` |
+| `--run-name` | text | The run name. For new runs, overrides the auto-generated UTC YYYYMMDDHHMMSS timestamp; must not collide with prior runs whose agents are still discoverable. For --reintegrate, identifies which previous run to reintegrate (required). | None |
+| `--additional-authorized-host` | text | SSH public key line to install in authorized_keys on each agent host (mappers, reducer, host pool, and snapshotter), allowing inbound SSH [repeatable] | None |
+
+## See Also
+
+- [mngr tmr](./tmr.md) - Run and fix tests in parallel using agents
+- [mngr list](../primary/list.md) - List agents
+
+## Examples
+
+**Fan out minds spec units to witness-test-writing agents**
+
+```bash
+$ minds specs plan --for-tmr > /tmp/spec-tasks.jsonl && mngr tmr-tasks --tasks-file /tmp/spec-tasks.jsonl --name tmr-minds-specs --mapper-prompt apps/minds/tmr/specs_mapper.j2 --reducer-prompt apps/minds/tmr/specs_reducer.j2
+```
+
+**Use Docker provider**
+
+```bash
+$ mngr tmr-tasks --provider docker --tasks-file tasks.jsonl ...
+```
+
+**Limit to 4 concurrent agents**
+
+```bash
+$ mngr tmr-tasks --max-parallel-agents 4 --tasks-file tasks.jsonl ...
+```

--- a/libs/mngr_tmr/README.md
+++ b/libs/mngr_tmr/README.md
@@ -32,3 +32,27 @@ Variant definitions live in the caller, not in a registry inside this package.
 The canonical flag sets are the root `justfile` recipes `tmr-mngr` / `tmr-minds`
 (which the `.github/workflows/tmr.yml` workflow inputs mirror). The minds variant
 ships a minds-tailored mapper prompt at `apps/minds/tmr/mapper.j2`.
+
+## Task-file runs (`mngr tmr-tasks`)
+
+`mngr tmr-tasks` is a sibling command that fans out an explicit JSONL task file
+instead of pytest collection. Each line is a task packet with `schema_version`,
+`id`, optional `display_id` (used for agent/branch slugs), `kind`, and a
+free-form `context` object. The file is validated up front (line-numbered
+errors, duplicate ids, unsupported schema versions), one agent is launched per
+task, and mapper/reducer branches come back as bundles exactly as in `mngr tmr`.
+
+There are no packaged prompt defaults: the task semantics live with the
+producer of the task file, so `--mapper-prompt` and `--reducer-prompt` are
+required. The mapper template renders with `task_id`, `kind`, `context_json`
+(the packet's context as pretty-printed JSON), `outcome_filename`, and
+`publish_snippet`; the reducer template renders with the same context as the
+packaged reducer. Mapper agents must write the same
+`testing_agent_outcome.json` contract as `mngr tmr` mappers so the shared HTML
+report can read it.
+
+The canonical producer is the minds behavioral-spec corpus:
+`minds specs plan --for-tmr` emits one packet per spec unit, and
+`apps/minds/tmr/specs_mapper.j2` / `specs_reducer.j2` anchor agents on writing
+witness tests for their unit (see `apps/minds/docs/behavioral-specs.md`). The
+root `justfile` recipe `tmr-minds-specs` wraps the pair.

--- a/libs/mngr_tmr/changelog/danver-minds-specs-tmr.md
+++ b/libs/mngr_tmr/changelog/danver-minds-specs-tmr.md
@@ -1,0 +1,9 @@
+Added `mngr tmr-tasks`, a task-file sibling of `mngr tmr`: instead of discovering tasks via pytest collection, it reads a JSONL task file -- one packet per line with `schema_version`, `id`, optional `display_id` (used for agent/branch slugs), `kind`, and a free-form `context` object -- validates it up front (line-numbered errors, duplicate ids, unsupported schema versions), and fans out one agent per task through the same `run_mapreduce` framework (branch bundles, reducer, HTML report).
+
+Mapper and reducer prompt templates are required (`--mapper-prompt` / `--reducer-prompt`; there are no packaged defaults because the task semantics live with the task-file producer). The mapper template renders with `task_id`, `kind`, `context_json` (the packet's context as pretty-printed JSON), `outcome_filename`, and `publish_snippet`; the reducer template reuses the integrator render context. Mapper agents must write the same `testing_agent_outcome.json` contract as `mngr tmr` mappers so the shared report can read it.
+
+Extracted the TMR branch-bundle retrieval (bundle application, local-branch check, reducer-branch finalization, and the `integrator_branch` event) from `recipe.py` into a shared `branch_bundles.py` so both recipes use it instead of duplicating.
+
+The report's `ChangeKind` gains `ADD_TEST` (counted as a non-impl change) for witness-test-writing runs.
+
+The canonical producer is the minds behavioral-spec corpus: `minds specs plan --for-tmr` emits the task file, and `apps/minds/tmr/specs_mapper.j2` / `specs_reducer.j2` are the prompt pair (documented in the README's new "Task-file runs" section and wrapped by the root justfile recipe `tmr-minds-specs`).

--- a/libs/mngr_tmr/imbue/mngr_tmr/branch_bundles.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/branch_bundles.py
@@ -1,0 +1,118 @@
+"""Branch-bundle retrieval for map-reduce recipes.
+
+Agents package their commits as an incremental git bundle
+(``git bundle create branch.bundle <base>..<branch>``) inside their outputs
+archive. The helpers here fetch such bundles back into the local source repo
+(idempotently), check whether a fetched branch landed, and emit the reducer
+branch event. They are shared by every recipe that pulls agent branches back
+(the test fan-out recipe, the task-file recipe).
+"""
+
+from pathlib import Path
+from typing import Final
+from typing import assert_never
+
+from loguru import logger
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.mngr.cli.output_helpers import emit_event
+from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.primitives import OutputFormat
+from imbue.mngr_mapreduce.data_types import AgentMetadata
+from imbue.mngr_mapreduce.data_types import MapReduceContext
+from imbue.mngr_mapreduce.data_types import ReducerInfo
+
+BRANCH_BUNDLE_NAME: Final[str] = "branch.bundle"
+
+
+def apply_branch_bundle(
+    source_dir: Path,
+    bundle_path: Path,
+    branch_name: str,
+    agent_name: str,
+    cg: ConcurrencyGroup,
+) -> bool:
+    """Fetch a branch from a bundle into the local source_dir repo.
+
+    The bundle was created with ``git bundle create ... <base>..<branch>``,
+    so it carries the ref under its branch name; the fetch refspec maps
+    that ref onto the same local branch name. Idempotent for repeated
+    invocations. Returns True on success.
+    """
+    result = cg.run_process_to_completion(
+        ["git", "fetch", "--no-tags", str(bundle_path), f"+{branch_name}:{branch_name}"],
+        cwd=source_dir,
+        is_checked_after=False,
+    )
+    if result.returncode != 0:
+        logger.warning(
+            "Failed to apply branch bundle for agent '{}' (branch {}): {}",
+            agent_name,
+            branch_name,
+            result.stderr.strip(),
+        )
+        return False
+    logger.info("Applied branch bundle for agent '{}' onto branch '{}'", agent_name, branch_name)
+    return True
+
+
+def has_local_branch(source_dir: Path, branch_name: str, cg: ConcurrencyGroup) -> bool:
+    """Check whether a git branch exists in the local source_dir repo."""
+    result = cg.run_process_to_completion(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+        cwd=source_dir,
+        is_checked_after=False,
+    )
+    return result.returncode == 0
+
+
+def apply_agent_branch_bundle_if_present(
+    source_dir: Path,
+    agent_dir: Path,
+    branch_name: str,
+    agent_name: str,
+    cg: ConcurrencyGroup,
+) -> bool:
+    """Apply an agent's extracted branch bundle when it published one. Returns True when applied."""
+    bundle = agent_dir / BRANCH_BUNDLE_NAME
+    if not bundle.is_file():
+        return False
+    return apply_branch_bundle(source_dir, bundle, branch_name, agent_name, cg)
+
+
+def reducer_branch_applied(
+    source_dir: Path,
+    reducer: AgentMetadata | None,
+    cg: ConcurrencyGroup,
+) -> bool:
+    """Did the reducer succeed and land a usable local branch?
+
+    Read from git rather than recipe-side state so the recipe stays stateless
+    (and ``render_report`` is safe to call repeatedly during polling).
+    """
+    if reducer is None or reducer.branch_name is None or reducer.error_summary is not None:
+        return False
+    return has_local_branch(source_dir, reducer.branch_name, cg)
+
+
+def emit_reducer_branch(branch_name: str, output_opts: OutputOptions) -> None:
+    """Emit the integrator branch name as a structured event when applicable."""
+    match output_opts.output_format:
+        case OutputFormat.JSON | OutputFormat.JSONL:
+            emit_event("integrator_branch", {"branch_name": branch_name}, output_opts.output_format)
+        case OutputFormat.HUMAN:
+            pass
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def finalize_reducer_branch(ctx: MapReduceContext, agent_dir: Path, info: ReducerInfo) -> None:
+    """Apply the reducer's extracted branch bundle and emit the branch event when it lands."""
+    bundle = agent_dir / BRANCH_BUNDLE_NAME
+    if not bundle.is_file():
+        logger.warning("Reducer agent '{}' did not produce a branch bundle", info.agent_name)
+        return
+    if not apply_branch_bundle(ctx.source_dir, bundle, info.branch_name, str(info.agent_name), ctx.cg):
+        return
+    if has_local_branch(ctx.source_dir, info.branch_name, ctx.cg):
+        emit_reducer_branch(info.branch_name, ctx.output_opts)

--- a/libs/mngr_tmr/imbue/mngr_tmr/branch_bundles_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/branch_bundles_test.py
@@ -1,0 +1,80 @@
+"""Unit tests for branch-bundle retrieval (shared by all map-reduce recipes)."""
+
+import subprocess
+from pathlib import Path
+
+from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.primitives import AgentId
+from imbue.mngr.primitives import AgentName
+from imbue.mngr.primitives import OutputFormat
+from imbue.mngr_mapreduce.data_types import MapReduceContext
+from imbue.mngr_mapreduce.data_types import ReducerInfo
+from imbue.mngr_tmr.branch_bundles import BRANCH_BUNDLE_NAME
+from imbue.mngr_tmr.branch_bundles import apply_agent_branch_bundle_if_present
+from imbue.mngr_tmr.branch_bundles import finalize_reducer_branch
+from imbue.mngr_tmr.branch_bundles import has_local_branch
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _make_repo_with_bundle(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create a repo with a feature branch, bundle it, and delete the local branch."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "--allow-empty", "-m", "base")
+    _git(repo, "checkout", "-b", "feature-branch")
+    _git(repo, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "--allow-empty", "-m", "work")
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    _git(repo, "bundle", "create", str(agent_dir / BRANCH_BUNDLE_NAME), "main..feature-branch")
+    _git(repo, "checkout", "main")
+    _git(repo, "branch", "-D", "feature-branch")
+    return repo, agent_dir, "feature-branch"
+
+
+def test_apply_agent_branch_bundle_fetches_the_branch(tmp_path: Path, cg: ConcurrencyGroup) -> None:
+    repo, agent_dir, branch_name = _make_repo_with_bundle(tmp_path)
+    assert not has_local_branch(repo, branch_name, cg)
+
+    applied = apply_agent_branch_bundle_if_present(repo, agent_dir, branch_name, "agent-1", cg)
+
+    assert applied is True
+    assert has_local_branch(repo, branch_name, cg)
+    # Idempotent: applying the same bundle again still succeeds.
+    assert apply_agent_branch_bundle_if_present(repo, agent_dir, branch_name, "agent-1", cg) is True
+
+
+def test_apply_agent_branch_bundle_returns_false_without_a_bundle(tmp_path: Path, cg: ConcurrencyGroup) -> None:
+    repo, _, branch_name = _make_repo_with_bundle(tmp_path)
+    empty_agent_dir = tmp_path / "empty-agent"
+    empty_agent_dir.mkdir()
+
+    applied = apply_agent_branch_bundle_if_present(repo, empty_agent_dir, branch_name, "agent-1", cg)
+
+    assert applied is False
+    assert not has_local_branch(repo, branch_name, cg)
+
+
+def test_finalize_reducer_branch_applies_the_bundle(tmp_path: Path, temp_mngr_ctx: MngrContext) -> None:
+    repo, agent_dir, branch_name = _make_repo_with_bundle(tmp_path)
+    ctx = MapReduceContext(
+        mngr_ctx=temp_mngr_ctx,
+        source_dir=repo,
+        run_name="20260101000000",
+        output_dir=tmp_path / "out",
+        output_opts=OutputOptions(output_format=OutputFormat.HUMAN),
+    )
+    info = ReducerInfo(
+        agent_id=AgentId.generate(),
+        agent_name=AgentName("reducer-1"),
+        branch_name=branch_name,
+    )
+
+    finalize_reducer_branch(ctx, agent_dir, info)
+
+    assert has_local_branch(repo, branch_name, ctx.cg)

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli.py
@@ -17,6 +17,8 @@ from imbue.mngr_mapreduce.cli import MapReduceCliOptions
 from imbue.mngr_mapreduce.cli import add_mapreduce_options
 from imbue.mngr_mapreduce.cli import run_mapreduce
 from imbue.mngr_tmr.recipe import TestMapReduceRecipe
+from imbue.mngr_tmr.task_file_recipe import TaskFileMapReduceRecipe
+from imbue.mngr_tmr.task_file_recipe import load_task_packets
 
 
 class TmrCliOptions(MapReduceCliOptions):
@@ -167,3 +169,107 @@ tests_passing_before/after booleans, and a markdown summary.""",
 ).register()
 
 add_pager_help_option(tmr)
+
+
+class TmrTasksCliOptions(MapReduceCliOptions):
+    """Options for the ``mngr tmr-tasks`` command (task-file specifics on top of the framework's)."""
+
+    name: str
+    tasks_file: str
+    mapper_prompt: str
+    reducer_prompt: str
+
+
+@click.command("tmr-tasks")
+@click.option(
+    "--tasks-file",
+    "tasks_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSONL task file: one packet per line with schema_version, id, optional display_id, kind, "
+    "and a free-form context object handed to the mapper prompt template.",
+)
+@click.option(
+    "--name",
+    default="tmr-tasks",
+    show_default=True,
+    help="Variant name, used as the prefix for this run's agent/branch/host names.",
+)
+@click.option(
+    "--mapper-prompt",
+    "mapper_prompt",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Mapper prompt template (required): rendered with task_id, kind, context_json, "
+    "outcome_filename, and publish_snippet. There is no packaged default because the task "
+    "semantics live with the producer of the task file.",
+)
+@click.option(
+    "--reducer-prompt",
+    "reducer_prompt",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Reducer prompt template (required): rendered with inputs_dirname, "
+    "mapper_outcome_filename, reducer_outcome_filename, and publish_snippet.",
+)
+@add_mapreduce_options
+@add_common_options
+@click.pass_context
+def tmr_tasks(ctx: click.Context, **kwargs: object) -> None:
+    mngr_ctx, output_opts, opts = setup_command_context(
+        ctx=ctx,
+        command_name="tmr-tasks",
+        command_class=TmrTasksCliOptions,
+    )
+    tasks_file = Path(opts.tasks_file)
+    recipe = TaskFileMapReduceRecipe(
+        name=opts.name,
+        packets=load_task_packets(tasks_file),
+        tasks_file=tasks_file,
+        mapper_prompt_path=Path(opts.mapper_prompt),
+        reducer_prompt_path=Path(opts.reducer_prompt),
+    )
+    run_mapreduce(recipe, opts, mngr_ctx, output_opts)
+
+
+CommandHelpMetadata(
+    key="tmr-tasks",
+    one_line_description="Fan out a JSONL task file to one agent per task and integrate their branches",
+    synopsis="mngr tmr-tasks --tasks-file <JSONL> --mapper-prompt <FILE> --reducer-prompt <FILE> [--name <VARIANT>] [--provider <PROVIDER>] [--env KEY=VALUE] [--label KEY=VALUE] [--timeout <SECS>] [--agent-type <TYPE>]",
+    description="""This command runs the map-reduce framework over an explicit task file instead of pytest collection:
+
+1. Reads and validates --tasks-file: one JSON packet per line with
+   schema_version, id, optional display_id (used for agent/branch slugs),
+   kind, and a free-form context object.
+2. Launches one agent per task. The mapper prompt comes from --mapper-prompt
+   (required; there is no packaged default -- the task semantics live with
+   the producer of the task file), rendered with task_id, kind, context_json
+   (the packet's context as pretty JSON), outcome_filename, and
+   publish_snippet.
+3. Polls agents until all finish or individually time out; pulls each
+   agent's branch.bundle back into local branches.
+4. If any mapper produced outputs, launches a reducer agent with
+   --reducer-prompt to integrate the mapper branches.
+5. Generates the shared HTML report; mapper agents must write the same
+   testing_agent_outcome.json contract as `mngr tmr` mappers.
+
+The canonical producer is `minds specs plan --for-tmr`, which emits one
+packet per behavioral-spec unit; pair it with the minds spec-witnessing
+prompts at apps/minds/tmr/specs_mapper.j2 and apps/minds/tmr/specs_reducer.j2.""",
+    examples=(
+        (
+            "Fan out minds spec units to witness-test-writing agents",
+            "minds specs plan --for-tmr > /tmp/spec-tasks.jsonl && "
+            "mngr tmr-tasks --tasks-file /tmp/spec-tasks.jsonl --name tmr-minds-specs "
+            "--mapper-prompt apps/minds/tmr/specs_mapper.j2 --reducer-prompt apps/minds/tmr/specs_reducer.j2",
+        ),
+        ("Use Docker provider", "mngr tmr-tasks --provider docker --tasks-file tasks.jsonl ..."),
+        ("Limit to 4 concurrent agents", "mngr tmr-tasks --max-parallel-agents 4 --tasks-file tasks.jsonl ..."),
+    ),
+    see_also=(
+        ("tmr", "Run and fix tests in parallel using agents"),
+        ("list", "List agents"),
+    ),
+).register()
+
+add_pager_help_option(tmr_tasks)

--- a/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/cli_test.py
@@ -14,6 +14,7 @@ from click.testing import Result
 
 from imbue.mngr_tmr.cli import _TmrCommand
 from imbue.mngr_tmr.cli import tmr
+from imbue.mngr_tmr.cli import tmr_tasks
 
 
 def test_cli_help(cli_runner: CliRunner) -> None:
@@ -122,3 +123,19 @@ def test_tmr_command_options_before_separator() -> None:
     assert captured["pytest_args"] == ("tests/",)
     assert captured["testing_flags"] == ("-m", "release")
     assert captured["provider"] == "docker"
+
+
+def test_tmr_tasks_help_surfaces_task_file_options(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(tmr_tasks, ["--help"])
+    assert result.exit_code == 0
+    assert "--tasks-file" in result.output
+    assert "--mapper-prompt" in result.output
+    assert "--reducer-prompt" in result.output
+    assert "--name" in result.output
+    assert "--provider" in result.output
+
+
+def test_tmr_tasks_requires_the_tasks_file_and_prompts(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(tmr_tasks, [])
+    assert result.exit_code != 0
+    assert "--tasks-file" in result.output

--- a/libs/mngr_tmr/imbue/mngr_tmr/plugin.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/plugin.py
@@ -4,9 +4,10 @@ import click
 
 from imbue.mngr import hookimpl
 from imbue.mngr_tmr.cli import tmr
+from imbue.mngr_tmr.cli import tmr_tasks
 
 
 @hookimpl
 def register_cli_commands() -> Sequence[click.Command] | None:
-    """Register the tmr command with mngr."""
-    return [tmr]
+    """Register the tmr and tmr-tasks commands with mngr."""
+    return [tmr, tmr_tasks]

--- a/libs/mngr_tmr/imbue/mngr_tmr/plugin_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/plugin_test.py
@@ -8,8 +8,8 @@ from imbue.mngr_tmr.plugin import register_cli_commands
 def test_register_cli_commands_returns_command() -> None:
     commands = register_cli_commands()
     assert commands is not None
-    assert len(commands) == 1
-    assert commands[0].name == "tmr"
+    assert len(commands) == 2
+    assert [command.name for command in commands] == ["tmr", "tmr-tasks"]
 
 
 def test_plugin_registers_with_pluggy(plugin_manager: pluggy.PluginManager) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/prompts.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/prompts.py
@@ -37,16 +37,8 @@ _MAPPER_TEMPLATE = "mapper.j2"
 _REDUCER_TEMPLATE = "reducer.j2"
 
 
-def _resolve_template(default_name: str, template_path: Path | None) -> Template:
-    """Return the Jinja template to render.
-
-    When ``template_path`` is None, use the packaged template named
-    ``default_name``. Otherwise load the override file, backing it with a
-    ``ChoiceLoader`` so the override may still ``{% extends %}`` or
-    ``{% include %}`` the packaged templates by their default names.
-    """
-    if template_path is None:
-        return _jinja_env.get_template(default_name)
+def _load_override_template(template_path: Path) -> Template:
+    """Load an override template file, backed by the packaged templates for extends/includes."""
     override_env = Environment(
         loader=ChoiceLoader(
             [
@@ -57,6 +49,19 @@ def _resolve_template(default_name: str, template_path: Path | None) -> Template
         autoescape=False,
     )
     return override_env.get_template(template_path.name)
+
+
+def _resolve_template(default_name: str, template_path: Path | None) -> Template:
+    """Return the Jinja template to render.
+
+    When ``template_path`` is None, use the packaged template named
+    ``default_name``. Otherwise load the override file, backing it with a
+    ``ChoiceLoader`` so the override may still ``{% extends %}`` or
+    ``{% include %}`` the packaged templates by their default names.
+    """
+    if template_path is None:
+        return _jinja_env.get_template(default_name)
+    return _load_override_template(template_path)
 
 
 # Bash that packages ``.test_output`` into the outputs archive. The agent
@@ -113,6 +118,30 @@ def build_test_agent_prompt(
         outcome_filename=TESTING_AGENT_OUTCOME_FILENAME,
         publish_snippet=_PUBLISH_OUTPUTS_SNIPPET,
         e2e_run_name=e2e_run_name,
+    )
+
+
+def build_task_file_mapper_prompt(
+    task_id: str,
+    kind: str,
+    context_json: str,
+    template_path: Path,
+) -> str:
+    """Build the mapper prompt for one task of a task-file recipe run.
+
+    There is no packaged default template: the caller (a variant such as the
+    minds spec-witnessing run) always supplies the template that anchors on
+    its task semantics. The template renders against ``task_id``, ``kind``,
+    ``context_json`` (the packet's context object as pretty-printed JSON),
+    ``outcome_filename``, and ``publish_snippet``.
+    """
+    template = _load_override_template(template_path)
+    return template.render(
+        task_id=task_id,
+        kind=kind,
+        context_json=context_json,
+        outcome_filename=TESTING_AGENT_OUTCOME_FILENAME,
+        publish_snippet=_PUBLISH_OUTPUTS_SNIPPET,
     )
 
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
@@ -8,6 +8,7 @@ from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.mngr_mapreduce.launching import REDUCER_INPUTS_DIRNAME
 from imbue.mngr_tmr.prompts import TESTING_AGENT_OUTCOME_FILENAME
 from imbue.mngr_tmr.prompts import build_integrator_prompt
+from imbue.mngr_tmr.prompts import build_task_file_mapper_prompt
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
 from imbue.mngr_tmr.recipe import CollectTestsError
 from imbue.mngr_tmr.recipe import collect_tests
@@ -92,6 +93,23 @@ def test_build_integrator_prompt_uses_override_template(tmp_path: Path) -> None:
     prompt = build_integrator_prompt(template_path=override)
     assert prompt.startswith("CUSTOM REDUCER reading ")
     assert REDUCER_INPUTS_DIRNAME in prompt
+
+
+def test_build_task_file_mapper_prompt_renders_the_packet_context(tmp_path: Path) -> None:
+    # The task-file mapper prompt has no packaged default: the override is the
+    # template, and it receives the packet fields plus the shared outcome/publish
+    # context.
+    template = tmp_path / "task_mapper.j2"
+    template.write_text("DO {{ task_id }} ({{ kind }})\n{{ context_json }}\n{{ outcome_filename }}\n")
+    prompt = build_task_file_mapper_prompt(
+        task_id="authentication.fresh-code",
+        kind="scenario",
+        context_json='{"coordinate": "authentication.fresh-code"}',
+        template_path=template,
+    )
+    assert prompt.startswith("DO authentication.fresh-code (scenario)")
+    assert '{"coordinate": "authentication.fresh-code"}' in prompt
+    assert TESTING_AGENT_OUTCOME_FILENAME in prompt
 
 
 def test_collect_tests_with_real_pytest(tmp_path: Path, cg: ConcurrencyGroup) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/prompts_test.py
@@ -87,6 +87,31 @@ def test_committed_minds_mapper_template_renders() -> None:
     assert "--mngr-e2e-run-name" not in prompt
 
 
+def test_committed_minds_specs_templates_render() -> None:
+    # The minds spec-witnessing variant ships apps/minds/tmr/specs_mapper.j2 and
+    # specs_reducer.j2; render them through the task-file builders to prove they
+    # are valid Jinja against the task-file render contexts.
+    repo_root = Path(__file__).resolve().parents[4]
+    mapper_template = repo_root / "apps" / "minds" / "tmr" / "specs_mapper.j2"
+    reducer_template = repo_root / "apps" / "minds" / "tmr" / "specs_reducer.j2"
+    if not mapper_template.is_file() or not reducer_template.is_file():
+        pytest.skip("apps/minds tree not present (running outside the monorepo checkout)")
+    mapper_prompt = build_task_file_mapper_prompt(
+        task_id="authentication.fresh-code",
+        kind="scenario",
+        context_json='{"coordinate": "authentication.fresh-code", "effective_steps": []}',
+        template_path=mapper_template,
+    )
+    assert "authentication.fresh-code" in mapper_prompt
+    assert "witnesses" in mapper_prompt
+    assert "apps/minds/specs" in mapper_prompt
+    assert TESTING_AGENT_OUTCOME_FILENAME in mapper_prompt
+    reducer_prompt = build_integrator_prompt(template_path=reducer_template)
+    assert REDUCER_INPUTS_DIRNAME in reducer_prompt
+    assert "check-witnesses" in reducer_prompt
+    assert "minds specs validate" in reducer_prompt
+
+
 def test_build_integrator_prompt_uses_override_template(tmp_path: Path) -> None:
     override = tmp_path / "custom_reducer.j2"
     override.write_text("CUSTOM REDUCER reading {{ inputs_dirname }}\n")

--- a/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
@@ -62,6 +62,16 @@ class InvalidRecipeNameError(MngrError, ValueError):
     ...
 
 
+def validate_recipe_name(value: str) -> str:
+    """Validate a recipe/variant name; usable as a pydantic field validator on recipe classes."""
+    if not _RECIPE_NAME_PATTERN.match(value):
+        raise InvalidRecipeNameError(
+            f"Invalid recipe name {value!r}: must start with an alphanumeric and contain only "
+            "alphanumerics, dashes, or underscores (it becomes a branch/agent/host name segment)."
+        )
+    return value
+
+
 def collect_tests(
     pytest_args: tuple[str, ...],
     source_dir: Path,
@@ -127,12 +137,7 @@ class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
     @field_validator("name")
     @classmethod
     def _validate_name(cls, value: str) -> str:
-        if not _RECIPE_NAME_PATTERN.match(value):
-            raise InvalidRecipeNameError(
-                f"Invalid recipe name {value!r}: must start with an alphanumeric and contain only "
-                "alphanumerics, dashes, or underscores (it becomes a branch/agent/host name segment)."
-            )
-        return value
+        return validate_recipe_name(value)
 
     def discover(self, ctx: MapReduceContext) -> list[MapReduceTask]:
         raw_ids = collect_tests(
@@ -194,7 +199,7 @@ class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
         )
         # Mirror to S3 (no-op without AWS creds) on every regeneration;
         # symmetric with the local file write.
-        _emit_report_url(maybe_upload_report(report_path, ctx.run_name), ctx.output_opts)
+        emit_report_url(maybe_upload_report(report_path, ctx.run_name), ctx.output_opts)
         return report_path
 
 
@@ -216,7 +221,7 @@ def _build_run_commands(
     return commands
 
 
-def _emit_report_url(url: str | None, output_opts: OutputOptions) -> None:
+def emit_report_url(url: str | None, output_opts: OutputOptions) -> None:
     """Emit the public URL of the report mirror, if upload occurred."""
     if url is None:
         return

--- a/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
@@ -30,12 +30,13 @@ from imbue.mngr_mapreduce.data_types import MapReduceRecipe
 from imbue.mngr_mapreduce.data_types import MapReduceTask
 from imbue.mngr_mapreduce.data_types import MapperInfo
 from imbue.mngr_mapreduce.data_types import ReducerInfo
+from imbue.mngr_tmr.branch_bundles import apply_agent_branch_bundle_if_present
+from imbue.mngr_tmr.branch_bundles import finalize_reducer_branch
+from imbue.mngr_tmr.branch_bundles import reducer_branch_applied
 from imbue.mngr_tmr.prompts import build_integrator_prompt
 from imbue.mngr_tmr.prompts import build_test_agent_prompt
 from imbue.mngr_tmr.report import generate_html_report
 from imbue.mngr_tmr.report_upload import maybe_upload_report
-
-_BRANCH_BUNDLE_NAME = "branch.bundle"
 
 _DEFAULT_RECIPE_NAME = "tmr"
 
@@ -84,61 +85,6 @@ def collect_tests(
 
     logger.info("Collected {} test(s)", len(test_ids))
     return test_ids
-
-
-def _apply_branch_bundle(
-    source_dir: Path,
-    bundle_path: Path,
-    branch_name: str,
-    agent_name: str,
-    cg: ConcurrencyGroup,
-) -> bool:
-    """Fetch a branch from a bundle into the local source_dir repo.
-
-    The bundle was created with ``git bundle create ... <base>..<branch>``,
-    so it carries the ref under its branch name; the fetch refspec maps
-    that ref onto the same local branch name. Idempotent for repeated
-    invocations. Returns True on success.
-    """
-    result = cg.run_process_to_completion(
-        ["git", "fetch", "--no-tags", str(bundle_path), f"+{branch_name}:{branch_name}"],
-        cwd=source_dir,
-        is_checked_after=False,
-    )
-    if result.returncode != 0:
-        logger.warning(
-            "Failed to apply branch bundle for agent '{}' (branch {}): {}",
-            agent_name,
-            branch_name,
-            result.stderr.strip(),
-        )
-        return False
-    logger.info("Applied branch bundle for agent '{}' onto branch '{}'", agent_name, branch_name)
-    return True
-
-
-def _has_local_branch(source_dir: Path, branch_name: str, cg: ConcurrencyGroup) -> bool:
-    """Check whether a git branch exists in the local source_dir repo."""
-    result = cg.run_process_to_completion(
-        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch_name}"],
-        cwd=source_dir,
-        is_checked_after=False,
-    )
-    return result.returncode == 0
-
-
-def _reducer_branch_applied(
-    ctx: MapReduceContext,
-    reducer: AgentMetadata | None,
-) -> bool:
-    """Did the reducer succeed and land a usable local branch?
-
-    Read from git rather than recipe-side state so the recipe stays stateless
-    (and ``render_report`` is safe to call repeatedly during polling).
-    """
-    if reducer is None or reducer.branch_name is None or reducer.error_summary is not None:
-        return False
-    return _has_local_branch(ctx.source_dir, reducer.branch_name, ctx.cg)
 
 
 class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
@@ -220,19 +166,10 @@ class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
         return build_integrator_prompt(template_path=self.reducer_prompt_path)
 
     def on_mapper_finalized(self, ctx: MapReduceContext, agent_dir: Path, info: MapperInfo) -> None:
-        bundle = agent_dir / _BRANCH_BUNDLE_NAME
-        if bundle.is_file():
-            _apply_branch_bundle(ctx.source_dir, bundle, info.branch_name, str(info.agent_name), ctx.cg)
+        apply_agent_branch_bundle_if_present(ctx.source_dir, agent_dir, info.branch_name, str(info.agent_name), ctx.cg)
 
     def on_reducer_finalized(self, ctx: MapReduceContext, agent_dir: Path, info: ReducerInfo) -> None:
-        bundle = agent_dir / _BRANCH_BUNDLE_NAME
-        if not bundle.is_file():
-            logger.warning("Reducer agent '{}' did not produce a branch bundle", info.agent_name)
-            return
-        if not _apply_branch_bundle(ctx.source_dir, bundle, info.branch_name, str(info.agent_name), ctx.cg):
-            return
-        if _has_local_branch(ctx.source_dir, info.branch_name, ctx.cg):
-            _emit_reducer_branch(info.branch_name, ctx.output_opts)
+        finalize_reducer_branch(ctx, agent_dir, info)
 
     def render_report(
         self,
@@ -243,7 +180,7 @@ class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
         # Only surface a "Push integrated branch" hint when the reducer's
         # bundle actually landed locally; otherwise the command would
         # reference a nonexistent branch.
-        applied = _reducer_branch_applied(ctx, reducer)
+        applied = reducer_branch_applied(ctx.source_dir, reducer, ctx.cg)
         run_commands = _build_run_commands(
             ctx.run_name,
             recipe_name=self.name,
@@ -277,17 +214,6 @@ def _build_run_commands(
     if integrated_branch is not None:
         commands.append(("Push integrated branch", f"git push origin {integrated_branch}"))
     return commands
-
-
-def _emit_reducer_branch(branch_name: str, output_opts: OutputOptions) -> None:
-    """Emit the integrator branch name as a structured event when applicable."""
-    match output_opts.output_format:
-        case OutputFormat.JSON | OutputFormat.JSONL:
-            emit_event("integrator_branch", {"branch_name": branch_name}, output_opts.output_format)
-        case OutputFormat.HUMAN:
-            pass
-        case _ as unreachable:
-            assert_never(unreachable)
 
 
 def _emit_report_url(url: str | None, output_opts: OutputOptions) -> None:

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -47,6 +47,7 @@ class ChangeKind(UpperCaseStrEnum):
     """What kind of change the agent attempted."""
 
     IMPROVE_TEST = auto()
+    ADD_TEST = auto()
     FIX_TEST = auto()
     FIX_IMPL = auto()
     FIX_TUTORIAL = auto()
@@ -209,7 +210,9 @@ _SECTION_COLORS: dict[ReportSection, str] = {
 
 _md = MarkdownIt()
 
-_NON_IMPL_CHANGE_KINDS = frozenset({ChangeKind.FIX_TEST, ChangeKind.IMPROVE_TEST, ChangeKind.FIX_TUTORIAL})
+_NON_IMPL_CHANGE_KINDS = frozenset(
+    {ChangeKind.FIX_TEST, ChangeKind.IMPROVE_TEST, ChangeKind.ADD_TEST, ChangeKind.FIX_TUTORIAL}
+)
 
 _CHANGE_STATUS_ICONS: dict[ChangeStatus, str] = {
     ChangeStatus.SUCCEEDED: "&#10003;",

--- a/libs/mngr_tmr/imbue/mngr_tmr/task_file_recipe.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/task_file_recipe.py
@@ -1,0 +1,186 @@
+"""The task-file map-reduce recipe: fan out a JSONL task file to one agent per task.
+
+Where the test fan-out recipe (:class:`TestMapReduceRecipe`) discovers its
+tasks by collecting pytest node ids, this recipe reads them from a task file:
+one JSON packet per line, each carrying an opaque ``id``, an optional
+``display_id`` (used for agent/branch slugs), a ``kind``, and a free-form
+``context`` object that is handed to the caller-supplied mapper prompt
+template as pretty-printed JSON. The producer side decides what a task means
+(for the minds spec-witnessing flow, ``minds specs plan --for-tmr`` emits one
+packet per spec unit); this recipe stays generic.
+
+There are no packaged prompt defaults: the caller passes ``--mapper-prompt``
+and ``--reducer-prompt`` templates that anchor on the task semantics.
+Branch-bundle retrieval, the HTML report, and the integrator outcome
+contract are shared with the test fan-out recipe.
+"""
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+from typing import Final
+
+from pydantic import Field
+from pydantic import ValidationError
+from pydantic import field_validator
+
+from imbue.imbue_common.errors import SwitchError
+from imbue.imbue_common.frozen_model import FrozenModel
+from imbue.mngr.errors import MngrError
+from imbue.mngr_mapreduce.data_types import AgentMetadata
+from imbue.mngr_mapreduce.data_types import MapReduceContext
+from imbue.mngr_mapreduce.data_types import MapReduceRecipe
+from imbue.mngr_mapreduce.data_types import MapReduceTask
+from imbue.mngr_mapreduce.data_types import MapperInfo
+from imbue.mngr_mapreduce.data_types import ReducerInfo
+from imbue.mngr_tmr.branch_bundles import apply_agent_branch_bundle_if_present
+from imbue.mngr_tmr.branch_bundles import finalize_reducer_branch
+from imbue.mngr_tmr.branch_bundles import reducer_branch_applied
+from imbue.mngr_tmr.prompts import build_integrator_prompt
+from imbue.mngr_tmr.prompts import build_task_file_mapper_prompt
+from imbue.mngr_tmr.recipe import emit_report_url
+from imbue.mngr_tmr.recipe import validate_recipe_name
+from imbue.mngr_tmr.report import generate_html_report
+from imbue.mngr_tmr.report_upload import maybe_upload_report
+
+# The only task-packet schema version this recipe accepts.
+TASK_PACKET_SCHEMA_VERSION: Final[int] = 1
+
+_DEFAULT_RECIPE_NAME = "tmr-tasks"
+
+
+class TaskPacketLoadError(MngrError, ValueError):
+    """Raised when a task file cannot be parsed into valid task packets."""
+
+    ...
+
+
+class TaskPacket(FrozenModel):
+    """One task of a task file: an opaque id plus a free-form context for the mapper prompt."""
+
+    schema_version: int = Field(description="Task-packet schema version (must match the recipe's)")
+    id: str = Field(min_length=1, description="Opaque task identifier passed back to build_mapper_prompt")
+    display_id: str | None = Field(default=None, description="Short form used for agent/branch slugs (defaults to id)")
+    kind: str = Field(min_length=1, description="Producer-defined task kind, passed to the mapper prompt")
+    context: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Producer-defined context object, handed to the mapper prompt template as JSON",
+    )
+
+
+def load_task_packets(tasks_file: Path) -> tuple[TaskPacket, ...]:
+    """Parse and validate a JSONL task file. Raises TaskPacketLoadError on any problem."""
+    try:
+        file_text = tasks_file.read_text(encoding="utf-8")
+    except OSError as e:
+        raise TaskPacketLoadError(f"Cannot read tasks file: {tasks_file}") from e
+    packets: list[TaskPacket] = []
+    seen_ids: set[str] = set()
+    for line_number, line in enumerate(file_text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            raw_packet = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise TaskPacketLoadError(f"{tasks_file}:{line_number}: invalid JSON: {e}") from e
+        try:
+            packet = TaskPacket.model_validate(raw_packet)
+        except ValidationError as e:
+            raise TaskPacketLoadError(f"{tasks_file}:{line_number}: invalid task packet: {e}") from e
+        if packet.schema_version != TASK_PACKET_SCHEMA_VERSION:
+            raise TaskPacketLoadError(
+                f"{tasks_file}:{line_number}: unsupported schema_version {packet.schema_version} "
+                f"(expected {TASK_PACKET_SCHEMA_VERSION})"
+            )
+        if packet.id in seen_ids:
+            raise TaskPacketLoadError(f"{tasks_file}:{line_number}: duplicate task id '{packet.id}'")
+        seen_ids.add(packet.id)
+        packets.append(packet)
+    if not packets:
+        raise TaskPacketLoadError(f"{tasks_file}: no task packets found")
+    return tuple(packets)
+
+
+class TaskFileMapReduceRecipe(MapReduceRecipe, FrozenModel):
+    """Run one agent per task of a JSONL task file, integrating their branches with a reducer.
+
+    Mapper prompts come from the caller-supplied template rendered with the
+    task's packet (id, kind, and context as JSON). Mapper branches come back
+    as ``branch.bundle`` files and are applied to the local source repo; the
+    reducer's branch is likewise fetched and emitted. The report reuses the
+    shared test-mapreduce HTML report, so mapper agents must write the same
+    outcome JSON contract as test-fan-out mappers.
+    """
+
+    name: str = Field(
+        default=_DEFAULT_RECIPE_NAME,
+        description="Variant name; prefixes this run's agent/branch/host names so distinct task files "
+        "stay separable and reviewable on their own.",
+    )
+    packets: tuple[TaskPacket, ...] = Field(description="The validated task packets to fan out")
+    tasks_file: Path = Field(description="The task file the packets were loaded from (used in report hints)")
+    mapper_prompt_path: Path = Field(description="Mapper prompt template (rendered with the task's packet)")
+    reducer_prompt_path: Path = Field(description="Reducer prompt template")
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        return validate_recipe_name(value)
+
+    def discover(self, ctx: MapReduceContext) -> list[MapReduceTask]:
+        return [MapReduceTask(id=packet.id, display_id=packet.display_id) for packet in self.packets]
+
+    def build_mapper_prompt(self, ctx: MapReduceContext, task: MapReduceTask) -> str:
+        packet = next((candidate for candidate in self.packets if candidate.id == task.id), None)
+        if packet is None:
+            raise SwitchError(f"task '{task.id}' is not one of this recipe's packets")
+        return build_task_file_mapper_prompt(
+            task_id=packet.id,
+            kind=packet.kind,
+            context_json=json.dumps(packet.context, indent=2, ensure_ascii=False),
+            template_path=self.mapper_prompt_path,
+        )
+
+    def build_reducer_prompt(self, ctx: MapReduceContext) -> str:
+        return build_integrator_prompt(template_path=self.reducer_prompt_path)
+
+    def on_mapper_finalized(self, ctx: MapReduceContext, agent_dir: Path, info: MapperInfo) -> None:
+        apply_agent_branch_bundle_if_present(ctx.source_dir, agent_dir, info.branch_name, str(info.agent_name), ctx.cg)
+
+    def on_reducer_finalized(self, ctx: MapReduceContext, agent_dir: Path, info: ReducerInfo) -> None:
+        finalize_reducer_branch(ctx, agent_dir, info)
+
+    def render_report(
+        self,
+        ctx: MapReduceContext,
+        agents: Sequence[AgentMetadata],
+        reducer: AgentMetadata | None,
+    ) -> Path | None:
+        applied = reducer_branch_applied(ctx.source_dir, reducer, ctx.cg)
+        report_path = generate_html_report(
+            agents=agents,
+            output_dir=ctx.output_dir,
+            integrator_metadata=reducer,
+            run_commands=self._build_run_commands(
+                ctx.run_name,
+                integrated_branch=reducer.branch_name if applied and reducer is not None else None,
+            ),
+        )
+        emit_report_url(maybe_upload_report(report_path, ctx.run_name), ctx.output_opts)
+        return report_path
+
+    def _build_run_commands(self, run_name: str, integrated_branch: str | None) -> list[tuple[str, str]]:
+        """Build the (label, command) hint pairs rendered at the bottom of the report."""
+        commands = [
+            ("List agents from this run", f"mngr ls --include 'labels.mapreduce_run_name == \"{run_name}\"'"),
+            (
+                "Reintegrate",
+                f"mngr tmr-tasks --tasks-file {self.tasks_file} --mapper-prompt {self.mapper_prompt_path} "
+                f"--reducer-prompt {self.reducer_prompt_path} --name {self.name} "
+                f"--reintegrate --run-name {run_name}",
+            ),
+        ]
+        if integrated_branch is not None:
+            commands.append(("Push integrated branch", f"git push origin {integrated_branch}"))
+        return commands

--- a/libs/mngr_tmr/imbue/mngr_tmr/task_file_recipe_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/task_file_recipe_test.py
@@ -1,0 +1,140 @@
+"""Unit tests for the task-file map-reduce recipe and its packet loading."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from imbue.imbue_common.errors import SwitchError
+from imbue.mngr.config.data_types import MngrContext
+from imbue.mngr.config.data_types import OutputOptions
+from imbue.mngr.primitives import OutputFormat
+from imbue.mngr_mapreduce.data_types import MapReduceContext
+from imbue.mngr_mapreduce.data_types import MapReduceTask
+from imbue.mngr_tmr.task_file_recipe import TaskFileMapReduceRecipe
+from imbue.mngr_tmr.task_file_recipe import TaskPacketLoadError
+from imbue.mngr_tmr.task_file_recipe import load_task_packets
+
+
+def _write_tasks_file(tasks_file: Path, packets: list[dict]) -> Path:
+    tasks_file.write_text("".join(json.dumps(packet) + "\n" for packet in packets))
+    return tasks_file
+
+
+def _valid_packet(task_id: str = "authentication.fresh-code") -> dict:
+    return {
+        "schema_version": 1,
+        "id": task_id,
+        "display_id": task_id.replace(".", "-"),
+        "kind": "scenario",
+        "context": {"coordinate": task_id, "effective_steps": []},
+    }
+
+
+def _make_ctx(temp_mngr_ctx: MngrContext, tmp_path: Path) -> MapReduceContext:
+    return MapReduceContext(
+        mngr_ctx=temp_mngr_ctx,
+        source_dir=tmp_path,
+        run_name="20260101000000",
+        output_dir=tmp_path / "out",
+        output_opts=OutputOptions(output_format=OutputFormat.HUMAN),
+    )
+
+
+def test_load_task_packets_reads_jsonl_and_skips_blank_lines(tmp_path: Path) -> None:
+    tasks_file = _write_tasks_file(tmp_path / "tasks.jsonl", [_valid_packet("a.one"), _valid_packet("a.two")])
+    tasks_file.write_text(tasks_file.read_text() + "\n\n")
+
+    packets = load_task_packets(tasks_file)
+
+    assert [packet.id for packet in packets] == ["a.one", "a.two"]
+    assert packets[0].display_id == "a-one"
+    assert packets[0].kind == "scenario"
+    assert packets[0].context == {"coordinate": "a.one", "effective_steps": []}
+
+
+def test_load_task_packets_rejects_invalid_json_with_line_number(tmp_path: Path) -> None:
+    tasks_file = tmp_path / "tasks.jsonl"
+    tasks_file.write_text(json.dumps(_valid_packet()) + "\nnot json\n")
+
+    with pytest.raises(TaskPacketLoadError, match=r"tasks\.jsonl:2: invalid JSON"):
+        load_task_packets(tasks_file)
+
+
+def test_load_task_packets_rejects_packets_missing_fields(tmp_path: Path) -> None:
+    tasks_file = _write_tasks_file(tmp_path / "tasks.jsonl", [{"schema_version": 1, "kind": "scenario"}])
+
+    with pytest.raises(TaskPacketLoadError, match=r"tasks\.jsonl:1: invalid task packet"):
+        load_task_packets(tasks_file)
+
+
+def test_load_task_packets_rejects_unsupported_schema_version(tmp_path: Path) -> None:
+    packet = _valid_packet()
+    packet["schema_version"] = 99
+    tasks_file = _write_tasks_file(tmp_path / "tasks.jsonl", [packet])
+
+    with pytest.raises(TaskPacketLoadError, match="unsupported schema_version 99"):
+        load_task_packets(tasks_file)
+
+
+def test_load_task_packets_rejects_duplicate_ids(tmp_path: Path) -> None:
+    tasks_file = _write_tasks_file(tmp_path / "tasks.jsonl", [_valid_packet("a.one"), _valid_packet("a.one")])
+
+    with pytest.raises(TaskPacketLoadError, match="duplicate task id 'a.one'"):
+        load_task_packets(tasks_file)
+
+
+def test_load_task_packets_rejects_an_empty_file(tmp_path: Path) -> None:
+    tasks_file = tmp_path / "tasks.jsonl"
+    tasks_file.write_text("\n")
+
+    with pytest.raises(TaskPacketLoadError, match="no task packets found"):
+        load_task_packets(tasks_file)
+
+
+def _make_recipe(tmp_path: Path, packets: list[dict], name: str = "tmr-specs") -> TaskFileMapReduceRecipe:
+    tasks_file = _write_tasks_file(tmp_path / "tasks.jsonl", packets)
+    mapper_prompt = tmp_path / "mapper.j2"
+    mapper_prompt.write_text("TASK {{ task_id }} ({{ kind }})\n{{ context_json }}\n{{ outcome_filename }}\n")
+    reducer_prompt = tmp_path / "reducer.j2"
+    reducer_prompt.write_text("REDUCE {{ inputs_dirname }}\n")
+    return TaskFileMapReduceRecipe(
+        name=name,
+        packets=load_task_packets(tasks_file),
+        tasks_file=tasks_file,
+        mapper_prompt_path=mapper_prompt,
+        reducer_prompt_path=reducer_prompt,
+    )
+
+
+def test_discover_maps_packets_to_tasks(tmp_path: Path, temp_mngr_ctx: MngrContext) -> None:
+    recipe = _make_recipe(tmp_path, [_valid_packet("a.one"), _valid_packet("a.two")])
+
+    tasks = recipe.discover(_make_ctx(temp_mngr_ctx, tmp_path))
+
+    assert [(task.id, task.display_id) for task in tasks] == [("a.one", "a-one"), ("a.two", "a-two")]
+
+
+def test_build_mapper_prompt_renders_the_packet_context(tmp_path: Path, temp_mngr_ctx: MngrContext) -> None:
+    recipe = _make_recipe(tmp_path, [_valid_packet("a.one")])
+
+    prompt = recipe.build_mapper_prompt(
+        _make_ctx(temp_mngr_ctx, tmp_path), MapReduceTask(id="a.one", display_id="a-one")
+    )
+
+    assert "TASK a.one (scenario)" in prompt
+    assert '"coordinate": "a.one"' in prompt
+    assert "testing_agent_outcome.json" in prompt
+
+
+def test_build_mapper_prompt_rejects_a_foreign_task(tmp_path: Path, temp_mngr_ctx: MngrContext) -> None:
+    recipe = _make_recipe(tmp_path, [_valid_packet("a.one")])
+
+    with pytest.raises(SwitchError):
+        recipe.build_mapper_prompt(_make_ctx(temp_mngr_ctx, tmp_path), MapReduceTask(id="a.other"))
+
+
+def test_recipe_name_validation_rejects_unsafe_slugs(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="Invalid recipe name"):
+        _make_recipe(tmp_path, [_valid_packet()], name="bad name!")

--- a/scripts/make_cli_docs.py
+++ b/scripts/make_cli_docs.py
@@ -92,6 +92,7 @@ SECONDARY_COMMANDS = {
     "schedule",
     "snapshot",
     "tmr",
+    "tmr-tasks",
     "transcript",
     "tutor",
     "robinhood",


### PR DESCRIPTION
## Summary

Stacked on #2530 (base: `danver/define-bdd-scenarios-authentication`). First slice of the behavioral-specs-to-TMR integration: the spec corpus becomes a producer of enriched TMR task packets, and a generic task-file recipe in mngr-tmr consumes them to fan out witness-test-writing agents. No audit/annotate-existing mode (explicitly deferred).

**Producer (apps/minds)**
- `minds specs export` -- read-only enriched JSONL per unit: schema_version, raw_steps + effective_steps (Background folded in), Examples rows for outlines, Feature/Rule descriptions, prose (overview chain + sidecar), and applicable invariants resolved root -> folder -> file. Invariant-scope logic lives in `imbue.minds.core.behavioral_specs.export` with unit tests; `list`/`query` output is unchanged.
- `minds specs plan --for-tmr` -- emits TMR task packets (id = coordinate, display_id = dashes, kind, context = export record). Scenarios + outlines by default; rules opt-in via `--include-rules`.
- `minds specs check-witnesses` -- AST scan of `@pytest.mark.witnesses` markers (decorator + pytestmark forms); unknown coordinates and non-literal markers fail.
- Minds prompt variants `apps/minds/tmr/specs_{mapper,reducer}.j2`: specs read-only, cheapest sufficient witness, witnesses markers, outlines become parametrized tests, tests-only by default with gaps as BLOCKED; reducer integrates branches and gates on specs-untouched, `specs validate`, `check-witnesses`, dedup, and the blast-radius pytest subset.

**Consumer (libs/mngr_tmr)**
- `mngr tmr-tasks --tasks-file <jsonl>` -- generic task-file recipe through `run_mapreduce`; validates packets (line-numbered errors, duplicate ids, unsupported schema versions). Prompt templates are caller-supplied (no packaged defaults).
- Branch-bundle retrieval extracted into `branch_bundles.py` (shared, no duplication); report `ChangeKind` gains `ADD_TEST`.

**Flow**: `uv run minds specs plan --for-tmr > tasks.jsonl && uv run mngr tmr-tasks --tasks-file tasks.jsonl --name tmr-minds-specs --mapper-prompt apps/minds/tmr/specs_mapper.j2 --reducer-prompt apps/minds/tmr/specs_reducer.j2` (wrapped by `just tmr-minds-specs`).

## Test plan
- Unit tests: export enrichment/scope resolution, witnesses scan/check, CLI subcommands, packet loading/validation, task-file recipe, bundle application (real git repos), template rendering.
- `uv run pytest apps/minds libs/mngr_tmr` -- all pass locally except 7 restic-binary-dependent tests (no `restic` on this machine; unrelated to this diff).
- Full suite via `just test-offload` (results below / CI).

🤖 Generated with Sculptor