### PR TITLE
Author the mngr_forward behavioral-spec corpus (proxy + auth core)

### DIFF
--- a/dev/changelog/danver-mngr-forward-specs-fable.md
+++ b/dev/changelog/danver-mngr-forward-specs-fable.md
@@ -1,0 +1,1 @@
+Regenerate the root `uv.lock` for `libs/mngr_forward`'s new `imbue-mngr-specs` dev-group dependency, added so the forward plugin's live-corpus guard test can import the corpus-scanning tooling. No runtime dependency changes.

--- a/libs/mngr_forward/changelog/danver-mngr-forward-specs-fable.md
+++ b/libs/mngr_forward/changelog/danver-mngr-forward-specs-fable.md
@@ -1,0 +1,7 @@
+Add the forward plugin's behavioral-spec corpus at `libs/mngr_forward/specs/` -- the second corpus in the repo, following the language defined by the behavioral-specs skill and the `apps/minds/specs/` exemplar.
+
+The corpus covers the proxy + auth core: an `authentication/` area (sign-in with a one-time code, session lifetime and integrity, the pre-authorized path for an embedding host, the bare-origin home page, and the goto bridge onto workspace origins) and a `forwarding/` area (host-header routing, HTTP and WebSocket byte-forwarding semantics, backend error behavior, and the host-loopback refusal invariant), plus corpus-root invariants (single-use codes, no data without a session, unforgeable sessions, the session cookie never reaching agent code, no open redirects).
+
+The stdout envelope stream, discovery/resolution modes, reverse tunnels, and the CLI contract are deliberately deferred to future areas; the deferred envelope side channel is noted in `forwarding/backend-errors.md`.
+
+Add a live-corpus guard test (`test_spec_corpus.py`) asserting the corpus always validates against the spec language, with `imbue-mngr-specs` as a new dev-group dependency. Annotating tests with `witnesses` markers is deferred, matching the minds precedent.

--- a/libs/mngr_forward/imbue/mngr_forward/test_spec_corpus.py
+++ b/libs/mngr_forward/imbue/mngr_forward/test_spec_corpus.py
@@ -1,0 +1,24 @@
+"""Guard the live behavioral-spec corpus shipped at ``libs/mngr_forward/specs/``.
+
+This corpus is a forward-plugin artifact: it travels with the plugin (and any
+future spin-out), so this guard lives here rather than in the corpus-generic
+``mngr_specs`` tool. It fails if the corpus ever drifts out of conformance
+with the behavioral-spec language that ``mngr specs validate`` enforces.
+"""
+
+from pathlib import Path
+
+from imbue.mngr_specs.corpus import scan_corpus
+
+# The live corpus shipped in this repo (this test sits at
+# libs/mngr_forward/imbue/mngr_forward/, so parents[2] is libs/mngr_forward).
+_LIVE_CORPUS_ROOT = Path(__file__).resolve().parents[2] / "specs"
+
+
+def test_live_corpus_has_no_violations() -> None:
+    """The corpus at ``libs/mngr_forward/specs/`` always satisfies the spec-language rules."""
+    scan = scan_corpus(_LIVE_CORPUS_ROOT)
+
+    assert scan.violations == ()
+    # Guard against the root silently pointing at an empty or wrong directory.
+    assert len(scan.units) > 0

--- a/libs/mngr_forward/pyproject.toml
+++ b/libs/mngr_forward/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "pydantic>=2.0",
 ]
 
+[dependency-groups]
+dev = [
+    "imbue-mngr-specs==0.1.0",
+]
+
 [project.entry-points.mngr]
 forward = "imbue.mngr_forward.plugin"
 
@@ -36,6 +41,7 @@ exclude = ["*_test.py", "test_*.py", "**/conftest.py", "**/testing.py"]
 
 [tool.uv.sources]
 imbue-mngr = { workspace = true }
+imbue-mngr-specs = { workspace = true }
 imbue-common = { workspace = true }
 concurrency-group = { workspace = true }
 

--- a/libs/mngr_forward/specs/authentication/goto-bridge.feature
+++ b/libs/mngr_forward/specs/authentication/goto-bridge.feature
@@ -1,0 +1,84 @@
+Feature: One sign-in opens every workspace origin
+  Each agent's UI is served on its own workspace origin, and browsers scope
+  cookies per origin -- so a bare-origin session does not authenticate a
+  workspace origin by itself. The goto bridge closes that gap without user
+  interaction: the bare origin's "/goto/<agent-id>/" route mints a
+  short-lived token tied to one agent and redirects the browser to that
+  agent's workspace origin, whose token-redemption endpoint verifies the
+  token, sets the workspace origin's own session cookie, and redirects on
+  to the destination.
+
+  Background:
+    Given a running forward proxy
+
+  @bridge-roundtrip
+  Scenario: Following the bridge lands the user signed in on the workspace origin
+    Given a signed-in user on the bare origin
+    And a known agent
+    When the user follows the goto bridge for that agent
+    Then the browser is redirected to that agent's workspace origin
+    And arrives signed in there, at the workspace path "/"
+    And the user was never asked for a credential
+
+  @bridge-destination
+  Scenario: A same-origin destination survives the bridge
+    Given a signed-in user on the bare origin
+    When they follow the goto bridge for an agent with a destination path "/some/page"
+    Then after the bridge they land on "/some/page" on that agent's workspace origin
+
+  @bridge-signed-out
+  Scenario: The bridge sends signed-out visitors to the bare-origin home
+    Given a user who is not signed in
+    When they request the goto bridge for any agent
+    Then they are redirected (HTTP 302) to the bare-origin home page "/"
+
+  @bridge-unparseable-agent
+  Scenario: A goto path that does not name a well-formed agent id is not found
+    Given a signed-in user
+    When they request the goto bridge for a malformed agent id
+    Then the response is HTTP 404
+
+  @token-bound-to-agent
+  Scenario: A bridge token is only good for the agent it was minted for
+    Given a bridge token minted for one agent
+    When it is presented on a different agent's workspace origin
+    Then it is refused (HTTP 403)
+    And no workspace-origin session is set
+
+  @token-expires
+  Scenario: A bridge token is short-lived
+    The token's validity window is seconds long, which keeps it effectively
+    one-shot: a token that leaks (in a history entry, a log, a copied URL)
+    is dead by the time anyone could replay it.
+
+    Given a bridge token minted for an agent
+    When it is presented on that agent's workspace origin after its short validity window has passed
+    Then it is refused (HTTP 403)
+    And no workspace-origin session is set
+
+  @token-invalid
+  Scenario: A forged or altered bridge token is refused
+    When a token not minted by this proxy, or altered in transit, is presented on a workspace origin
+    Then it is refused (HTTP 403)
+    And no workspace-origin session is set
+
+  @direct-navigation
+  Scenario: Direct navigation heals a missing workspace-origin session
+    Given a user who is signed in on the bare origin
+    But whose browser has no (or a stale) session for some workspace origin
+    When they navigate directly to that workspace origin in a browser
+    Then they are sent through the goto bridge for that agent
+    And end up in the workspace without being asked to sign in
+
+  @signed-out-workspace
+  Scenario: A fully signed-out visitor to a workspace origin ends at the sign-in prompt
+    Given a browser with no session of any kind
+    When it navigates to a workspace origin
+    Then it is redirected to the bare origin
+    And ends at the sign-in prompt
+
+  @non-html-refused
+  Scenario: Signed-out programmatic requests to a workspace origin are refused outright
+    Given a request with no valid session that does not accept HTML (an API call, an asset fetch)
+    When it reaches a workspace origin
+    Then it is refused (HTTP 403) with no redirect

--- a/libs/mngr_forward/specs/authentication/landing.feature
+++ b/libs/mngr_forward/specs/authentication/landing.feature
@@ -1,0 +1,26 @@
+Feature: The bare-origin home page
+  "/" on the bare origin is a minimal index of the agents the proxy knows,
+  gated by sign-in. It exists for the standalone browser user; an embedding
+  host application serves its own UI and does not use it.
+
+  @signed-out-home
+  Scenario: Signed-out visitors see the sign-in prompt
+    Given the user is not signed in
+    When they visit the bare-origin home page "/"
+    Then they see a sign-in prompt directing them to the login URL printed in the proxy's terminal
+    And the page reveals nothing about existing agents
+
+  @lists-known-agents
+  Scenario: Signed-in visitors see every known agent
+    Given a signed-in user
+    And the proxy knows about one or more agents
+    When they visit the bare-origin home page "/"
+    Then every known agent is listed
+    And each entry links to that agent's workspace through the goto bridge
+
+  @unroutable-still-listed
+  Scenario: Agents without a routable backend are listed but marked
+    Given a signed-in user
+    And a known agent whose backend is not yet known
+    When they visit the bare-origin home page "/"
+    Then that agent is listed but visibly marked as not yet routable

--- a/libs/mngr_forward/specs/authentication/overview.md
+++ b/libs/mngr_forward/specs/authentication/overview.md
@@ -1,0 +1,35 @@
+# Authentication
+
+Component: the bare-origin surface of the forward proxy -- sign-in with a
+one-time code, the session it establishes, the home page -- plus the goto
+bridge that carries that one session onto every workspace origin.
+
+The features in this folder cover sign-in (`signin`), session lifetime and
+integrity (`session`), the pre-authorized path an embedding host uses to
+skip the code flow (`preauth`), the bare-origin home page (`landing`), and
+the bridge (`goto-bridge`). The Rules in the corpus root's
+`invariants.feature` bind all of them.
+
+Two lifetimes matter throughout this area and are easy to confuse:
+
+- One-time codes live only in the proxy process's memory. A restart mints a
+  fresh code and forgets every code the previous run issued, spent or not,
+  so a code from a previous run can never re-authenticate a stale tab.
+- Sessions outlive the process. The cookie-signing key is persisted in the
+  proxy's state directory, so cookies issued before a restart continue to
+  verify afterward.
+
+The minds corpus (`apps/minds/specs/authentication/`) describes bordering
+territory -- the minds desktop client's own sign-in and its use of this
+proxy's bridge -- from that system's surface. Each corpus states shared
+constraints from its own perspective; neither defers to the other.
+
+## Out of scope
+
+- How the login URL reaches the user beyond "printed to the proxy's
+  terminal" (the stdout `login_url` event belongs to the planned `stream/`
+  area).
+- The embedding host's side of preauth: how it generates the value,
+  pre-sets it in its browser shell, or passes it to the proxy.
+- The Secure cookie attribute under the TLS serving mode (see the corpus
+  overview).

--- a/libs/mngr_forward/specs/authentication/preauth.feature
+++ b/libs/mngr_forward/specs/authentication/preauth.feature
@@ -1,0 +1,28 @@
+Feature: Pre-authorized sessions for an embedding host
+  A host application that spawns the proxy may configure an opaque preauth
+  cookie value at startup and pre-set that value in its own browser shell,
+  so the shell's first navigation is already signed in and the one-time-code
+  flow never runs.
+
+  Background:
+    Given a running forward proxy that was started with a preauth cookie value
+
+  @preauth-accepted
+  Scenario: Presenting the exact preauth value counts as signed in
+    Given a browser whose session cookie is exactly the configured preauth value
+    When it requests a signed-in page on the bare origin
+    Then it is treated as signed in
+    And no one-time code is spent
+
+  @preauth-on-workspace-origins
+  Scenario: The preauth value signs requests in on workspace origins too
+    Given a browser whose session cookie is exactly the configured preauth value
+    When it requests a page on a workspace origin
+    Then the request is treated as signed in on that origin
+
+  @preauth-near-miss
+  Scenario: Anything but the exact value falls back to signature verification
+    Given a browser whose session cookie differs from the preauth value in any way
+    And that cookie is not a signed token issued by this proxy
+    When it requests a signed-in page
+    Then it is treated as signed out

--- a/libs/mngr_forward/specs/authentication/session.feature
+++ b/libs/mngr_forward/specs/authentication/session.feature
@@ -1,0 +1,39 @@
+Feature: Session lifetime and integrity
+  A successful sign-in establishes a session carried by a signed cookie.
+  The proxy persists its cookie-signing key in its state directory, so
+  sessions outlive the process that issued them.
+
+  @survives-restart
+  Scenario: Sessions survive a forward-proxy restart
+    Given a signed-in user
+    When the forward proxy is stopped and started again
+    And the user reloads the bare-origin home page
+    Then they are still signed in
+    And they do not need a new login code
+
+  @tampered-token
+  Scenario: An altered session cookie is treated as signed out
+    Given a signed-in user
+    When their session cookie value is modified in any way
+    And they request a signed-in page
+    Then they are treated as signed out
+
+  @foreign-token
+  Scenario: A session minted under a different state directory is not accepted
+    Given a session cookie created by a forward proxy with a different state directory
+    When it is presented to this proxy
+    Then the bearer is treated as signed out
+
+  @expired-token
+  Scenario: Sessions expire after 30 days
+    Given a session cookie issued more than 30 days ago
+    When it is presented
+    Then the bearer is treated as signed out
+
+  @signing-key-minted-once
+  Rule: The signing identity is minted once and never silently replaced
+    The proxy mints its cookie-signing key on first need and reuses it on
+    every later run. An unreadable or empty key file is a hard error -- the
+    key is never silently re-minted, because that would invalidate every
+    live session without explanation. This is what lets valid sessions keep
+    working across restarts.

--- a/libs/mngr_forward/specs/authentication/signin.feature
+++ b/libs/mngr_forward/specs/authentication/signin.feature
@@ -1,0 +1,71 @@
+Feature: Sign-in with a one-time login code
+  At startup the forward proxy mints a fresh one-time code and prints the
+  login URL to its terminal. Opening that URL in a browser is the only way
+  to establish a session in a browser that has none.
+
+  Background:
+    Given a running forward proxy
+    And its terminal printed a login URL with a fresh one-time code
+
+  @fresh-code
+  Scenario: Opening a fresh login URL signs the user in
+    Given the user is not signed in
+    When the user opens the login URL in a browser
+    Then the browser lands on the bare-origin home page "/"
+    And the user is signed in
+    And the one-time code is now spent
+
+  @used-code
+  Scenario: A spent code cannot sign anyone in again
+    Given the login URL has already been used to sign in
+    When anyone presents the same code for authentication again
+    Then authentication is refused (HTTP 403), explaining the code is invalid or already used
+    And no session is established
+
+  @unknown-code
+  Scenario: A code the proxy never issued is refused
+    Given the user is not signed in
+    When they present a made-up code for authentication
+    Then authentication is refused (HTTP 403), explaining the code is invalid or already used
+    And no session is established
+
+  @blank-code
+  Scenario: A blank code is refused like an invalid one
+    When a sign-in request carries an empty or whitespace-only code
+    Then authentication is refused (HTTP 403), explaining the code is invalid or already used
+    And no session is established
+
+  @prefetch
+  Scenario: Fetching the login URL without executing scripts does not spend the code
+    Given the user is not signed in
+    When something fetches the login URL without executing its scripts (a link preloader, a chat-app unfurler, a browser prerenderer)
+    Then the code remains unspent
+    And the user can still sign in later by opening the same URL in a real browser
+
+  @already-signed-in
+  Scenario: Opening a login URL while already signed in does not spend the code
+    Given the user is already signed in
+    When they open a login URL carrying a fresh code
+    Then they are redirected to the bare-origin home page "/"
+    And the code remains unspent
+
+  @missing-code
+  Scenario Outline: Sign-in requests without a code are malformed input, not server errors
+    When a request is made to "<path>" with no one-time code parameter
+    Then it is rejected as malformed input (HTTP 422)
+
+    Examples:
+      | path          |
+      | /login        |
+      | /authenticate |
+
+  @codes-die-with-process
+  Scenario: One-time codes do not outlive the process that minted them
+    Codes live only in the proxy's memory, so a code from a previous run --
+    leaked, prefetched, or simply never used -- can never sign anyone in
+    after a restart. Sessions are what persist across restarts.
+
+    Given the printed login URL has not been used
+    When the forward proxy is stopped and started again
+    Then its terminal prints a new login URL with a different code
+    And presenting the previous run's code for authentication is refused

--- a/libs/mngr_forward/specs/forwarding/backend-errors.feature
+++ b/libs/mngr_forward/specs/forwarding/backend-errors.feature
@@ -1,0 +1,57 @@
+Feature: When the backend cannot answer
+  On the workspace-origin HTTP path the proxy distinguishes backend
+  failures by what the client can usefully do next. A backend that does
+  not exist yet or cannot be reached is a wait-and-retry condition
+  (HTTP 503); a backend that accepted the connection but never answered
+  within the proxy's timeout is a gateway timeout (HTTP 504); a response
+  that was cut off after it began is a lost response (HTTP 502).
+
+  Background:
+    Given a running forward proxy
+    And a signed-in user
+
+  @unavailable-503
+  Scenario Outline: An unavailable backend answers 503, shaped for the caller
+    Given a known agent whose backend <condition>
+    When a request <accept> arrives for that agent's workspace origin
+    Then the response is HTTP 503 <shape>
+
+    Examples:
+      | condition          | accept              | shape                             |
+      | is not yet known   | accepting HTML      | with the "Loading workspace" page |
+      | is not yet known   | not accepting HTML  | with a plain body and no redirect |
+      | cannot be reached  | accepting HTML      | with the "Loading workspace" page |
+      | cannot be reached  | not accepting HTML  | with a plain body and no redirect |
+
+  @loading-page-self-heals
+  Scenario: The loading page waits and enters the workspace by itself
+    Given a browser showing the "Loading workspace" page for an agent
+    When the agent's backend starts answering
+    Then the page notices on its own and loads the workspace
+    And the user never has to reload manually
+
+  @wedged-backend
+  Scenario: A backend that accepts but never answers yields 504
+    Given a known agent whose backend is routable
+    When the backend accepts a forwarded request but does not answer within the proxy's timeout
+    Then the client receives HTTP 504
+
+  @mid-response-loss
+  Scenario: A response lost partway through yields 502
+    For ordinary (non-stream) requests the proxy relays the response only
+    once it has arrived in full, so a backend that dies partway through
+    producing one still results in a clean error status.
+
+    Given a known agent whose backend is routable
+    When the backend's connection is lost partway through its response to a forwarded request
+    Then the client receives HTTP 502
+
+  @stream-ends
+  Scenario: An event stream that loses its backend simply ends
+    Once a stream's status and headers have been delivered they cannot be
+    revised, so a mid-stream loss cannot become an error status; the stream
+    ends and reconnecting is the client's concern.
+
+    Given a client receiving an event stream through the proxy
+    When the backend connection is lost mid-stream
+    Then the stream ends

--- a/libs/mngr_forward/specs/forwarding/backend-errors.md
+++ b/libs/mngr_forward/specs/forwarding/backend-errors.md
@@ -1,0 +1,30 @@
+# Backend errors: the stdout side channel
+
+The scenarios in `backend-errors.feature` state only what the requesting
+client observes. Each of these failure paths (and the loopback refusal in
+this folder's `invariants.feature`, and the WebSocket failure closes in
+`websockets.feature`) additionally emits a machine-readable failure event
+on the proxy's stdout envelope stream -- a `system_interface_backend_failure`
+payload whose reason distinguishes a backend that was never resolved, a
+connection that could not be established, a response lost mid-stream, and
+a backend that answered with a non-success status. Embedding consumers
+(the minds desktop client) drive their recovery behavior from those events
+rather than from the HTTP responses, which their users never see directly.
+
+That stdout contract is deliberately not specified in this corpus yet. It
+belongs to a planned `stream/` area covering the whole envelope stream:
+the `login_url` and `listening` startup events, `resolver_snapshot`,
+`reverse_tunnel_established`, the backend-failure events, and the
+passthrough of discovery and per-agent event lines. Until that area
+lands, the payload schemas in `imbue/mngr_forward/data_types.py` are the
+reference for the stream's shape.
+
+Two calibration notes for readers of the scenarios:
+
+- The proxy's patience for a backend that accepted a connection but has
+  not answered ("the proxy's timeout") is 30 seconds today; the normative
+  content is that a wedged backend yields a gateway timeout rather than
+  waiting forever.
+- The "Loading workspace" page re-checks the workspace by background
+  polling rather than by reloading itself, so an embedding host's overlay
+  UI does not lose focus once per tick while a workspace boots.

--- a/libs/mngr_forward/specs/forwarding/http-forwarding.feature
+++ b/libs/mngr_forward/specs/forwarding/http-forwarding.feature
@@ -1,0 +1,51 @@
+Feature: HTTP byte-forwarding
+  An authenticated request to a routable agent's workspace origin is passed
+  through to the agent's backend, and the backend's answer is passed back,
+  with as little interpretation as possible. The proxy adds behavior only
+  at the security boundary (the session cookie, per the corpus invariants)
+  and when no backend answer exists at all.
+
+  Background:
+    Given a running forward proxy
+    And a signed-in user
+    And a known agent whose backend is routable
+
+  @request-preserved
+  Scenario: The request reaches the backend as sent
+    When the user's client sends a request to the agent's workspace origin
+    Then the backend receives the same method, path, query string, headers, and body
+    But the Host header names the backend rather than the workspace origin
+    And the proxy's session cookie is not among the forwarded cookies
+
+  @response-preserved
+  Scenario: The backend's answer returns to the client as produced
+    Transport framing headers (transfer-encoding, content-encoding,
+    content-length) are re-derived by the proxy's own transport; everything
+    else passes through.
+
+    When the backend answers a forwarded request
+    Then the client receives the backend's status code, headers, and body unchanged
+
+  @redirects-not-followed
+  Scenario: Backend redirects go to the client, not the proxy
+    When the backend answers with a redirect
+    Then the client receives that redirect itself
+    And the proxy does not follow it
+
+  @sse-streamed
+  Scenario: Event streams flow incrementally
+    When the user's client requests an event stream (accepting "text/event-stream")
+    Then bytes from the backend are delivered to the client as they arrive
+    And the proxy does not wait for the response to complete
+
+  @errors-pass-through
+  Rule: Backend responses are never reinterpreted
+    A non-success status produced by the backend is the backend's answer,
+    and the proxy forwards it unchanged -- it never replaces a backend
+    error with a page of its own. The proxy's own error responses occur
+    only when no backend answer exists.
+
+    @backend-error-forwarded
+    Example: A backend error page reaches the client as the backend produced it
+      When the backend answers a forwarded request with an error status and body of its own
+      Then the client receives exactly that status and body

--- a/libs/mngr_forward/specs/forwarding/invariants.feature
+++ b/libs/mngr_forward/specs/forwarding/invariants.feature
@@ -1,0 +1,24 @@
+Feature: Forwarding invariants
+  These properties hold for every request and connection on every workspace
+  origin, across all of this folder's flows.
+
+  @never-serves-host-loopback
+  Rule: The proxy never silently serves its own machine's loopback in place of an agent
+    An agent's registered backend address may be a loopback address. For an
+    agent that lives on its own host (a container or a remote machine),
+    that address is only meaningful on the agent's host: dialing it from
+    the proxy's machine when no route to the agent's host is established
+    would serve whatever happens to be listening on that port locally --
+    content that is not the agent's, and possibly another program's
+    entirely. In that situation the proxy refuses to dial and treats the
+    agent as unavailable. An explicit operator opt-in exists for setups
+    that intentionally run agents directly on the proxy's machine.
+
+    @loopback-refused
+    Example: A loopback backend with no route to the agent's host is treated as unavailable
+      Given a signed-in user
+      And a known agent whose registered backend address is a loopback address
+      And no route to the agent's own host is established
+      When a request arrives for that agent's workspace origin
+      Then nothing is dialed on the proxy's machine
+      And the client is answered as if the backend were unreachable (HTTP 503)

--- a/libs/mngr_forward/specs/forwarding/overview.md
+++ b/libs/mngr_forward/specs/forwarding/overview.md
@@ -1,0 +1,19 @@
+# Forwarding
+
+Component: the workspace-origin request path of the forward proxy -- how
+the Host header routes a request to an agent, how HTTP requests and
+WebSocket connections are byte-forwarded to that agent's backend, and what
+clients observe when the backend cannot answer.
+
+An agent's backend is taken as given here: either its address is known and
+reachable ("routable"), known but unreachable, or not yet known. How the
+proxy learns and updates those addresses belongs to the planned
+`discovery/` area. Likewise, the transport used to reach a remote agent's
+host is out of scope except where it changes what a client observes -- a
+failure to establish that transport is indistinguishable, by design, from
+an unreachable backend.
+
+Forwarding failures also have a machine-readable side channel on the
+proxy's stdout, which embedding consumers use instead of the HTTP
+responses; that contract is deliberately not specified in this area yet.
+See `backend-errors.md`.

--- a/libs/mngr_forward/specs/forwarding/routing.feature
+++ b/libs/mngr_forward/specs/forwarding/routing.feature
@@ -1,0 +1,36 @@
+Feature: Host-header routing
+  One listen port serves two kinds of origin, and the Host header decides
+  which. A host of the form "agent-<id>.localhost" -- where <id> is a
+  well-formed 32-hex-character agent id, with an optional port, and with
+  "127.0.0.1" accepted as a synonym for "localhost" -- names a workspace
+  origin for that agent. Every other host, including near misses on the
+  agent form, is served as the bare origin and nothing is forwarded.
+
+  @workspace-host-forms
+  Scenario Outline: Hosts naming a well-formed agent id are workspace origins
+    When a request arrives with Host "<host>"
+    Then it is handled as a workspace-origin request for the agent named in the host
+
+    Examples:
+      | host                                                  |
+      | agent-2f6c0d9c41f24d47a89f6f2f61b3a8d1.localhost      |
+      | agent-2f6c0d9c41f24d47a89f6f2f61b3a8d1.localhost:8421 |
+      | agent-2f6c0d9c41f24d47a89f6f2f61b3a8d1.127.0.0.1:8421 |
+
+  @other-hosts-are-bare-origin
+  Scenario Outline: Every other host is served as the bare origin
+    A near miss on the agent form -- a hex id of the wrong length, a
+    non-hex id -- is not a workspace origin; only a well-formed agent id
+    counts.
+
+    When a request arrives with Host "<host>"
+    Then it is served by the bare origin
+    And nothing is forwarded to any backend
+
+    Examples:
+      | host                       |
+      | localhost:8421             |
+      | agent-0f3c.localhost       |
+      | agent-workspace.localhost  |
+      | foo.localhost              |
+      | example.com                |

--- a/libs/mngr_forward/specs/forwarding/websockets.feature
+++ b/libs/mngr_forward/specs/forwarding/websockets.feature
@@ -1,0 +1,44 @@
+Feature: WebSocket forwarding
+  Workspace origins forward WebSocket connections the same way they forward
+  HTTP: an authenticated connection is connected through to the agent's
+  backend and relayed in both directions. There is no bare-origin WebSocket
+  surface. Close codes are the contract here -- a programmatic client can
+  distinguish a routing failure, an authentication failure, and the two
+  kinds of backend failure by code alone.
+
+  @ws-relay
+  Scenario: An authenticated WebSocket is relayed both ways
+    Given a signed-in user
+    And a known agent whose backend is routable
+    When the user's client opens a WebSocket to the agent's workspace origin
+    Then a connection is established with the agent's backend at the same path and query
+    And the subprotocol the backend negotiates is the one offered to the client
+    And text and binary messages are relayed unchanged in both directions
+    And when either side closes, the other side is closed too
+
+  @ws-unknown-host
+  Scenario: A WebSocket to a non-workspace host is closed at once
+    When a WebSocket connection is opened with a host that is not a workspace origin
+    Then it is closed with code 4004
+
+  @ws-not-authenticated
+  Scenario: A WebSocket without a valid session is closed before any backend contact
+    Given a known agent
+    When a WebSocket without a valid session is opened to that agent's workspace origin
+    Then it is closed with code 4003
+    And the backend is never contacted
+
+  @ws-backend-not-routable
+  Scenario: A WebSocket to an agent whose backend is not yet known is closed as try-again
+    Given a signed-in user
+    And a known agent whose backend is not yet known
+    When a WebSocket is opened to that agent's workspace origin
+    Then it is closed with code 1013
+
+  @ws-backend-unreachable
+  Scenario: A WebSocket whose backend cannot be reached is closed as a backend failure
+    Given a signed-in user
+    And a known agent whose backend is routable
+    But neither the backend nor the route to the agent's host can actually be reached
+    When a WebSocket is opened to that agent's workspace origin
+    Then it is closed with code 1011

--- a/libs/mngr_forward/specs/invariants.feature
+++ b/libs/mngr_forward/specs/invariants.feature
@@ -1,0 +1,75 @@
+Feature: Forward proxy invariants
+  These properties hold across every origin the proxy serves, every route,
+  and all interleavings of requests -- including flows no scenario in this
+  corpus describes.
+
+  @single-use-codes
+  Rule: A one-time code grants at most one session, ever
+    Over its whole lifetime, each one-time code is spent at most once, and
+    only by the authentication step that establishes a session. Every later
+    presentation of the same code is refused; no sequence or interleaving of
+    requests can spend a code twice or sign in twice from one code.
+    Rationale: the login URL is written in plain text to a terminal (and,
+    for an embedding host, to the proxy's stdout stream); single use bounds
+    the damage of that exposure.
+
+  @fetch-never-spends
+  Rule: Merely fetching a URL never spends a code
+    Spending a code requires executing the sign-in page's script. Any URL
+    the proxy hands out (the printed login URL, links in rendered pages) is
+    inert under plain fetching, so preloaders, unfurlers, and prerenderers
+    cannot consume a code on the user's behalf.
+
+  @no-data-without-session
+  Rule: No agent data or backend content without a session
+    A request without a valid session never observes agent ids, the agent
+    list, or any byte of any backend's response. The only things an
+    unauthenticated request may receive are the sign-in machinery itself
+    ("/login", "/authenticate"), a sign-in prompt, a redirect toward
+    sign-in or through the bridge that leads there, or an outright refusal.
+    The shape of the refusal varies by surface (a sign-in page, a redirect,
+    an HTTP 403, a WebSocket close); the invariant is the absence of data,
+    not the refusal shape.
+
+  @sessions-unforgeable
+  Rule: Sessions are unforgeable, tamper-evident, and bounded
+    Only session cookies signed by this proxy's persisted signing key --
+    or exactly equal to the preauth value the proxy was started with, if
+    any -- are accepted. Any alteration of a cookie invalidates it. Cookies
+    signed under another state directory are invalid here. Cookies older
+    than 30 days are invalid.
+
+  @single-credential
+  Rule: The session is the only credential the user ever handles
+    One sign-in grants access to every agent the proxy serves, current and
+    future. No flow ever asks the user for a second, per-agent credential;
+    the bridge tokens that carry a session across origins are minted and
+    redeemed without user interaction.
+
+  @credential-not-forwarded
+  Rule: The session credential never reaches agent code
+    The session cookie is stripped from every request before it is
+    forwarded to an agent's backend; all other cookies pass through
+    untouched. Code running inside an agent never observes the credential
+    that guards all the other agents.
+
+    @only-cookie-stripped-entirely
+    Example: A lone session cookie leaves no cookie header behind
+      Given a signed-in request to a workspace origin whose only cookie is the session cookie
+      When the request is forwarded to the agent's backend
+      Then the forwarded request carries no cookie header at all
+
+  @no-open-redirects
+  Rule: User-supplied destinations never leave the origin
+    Every redirect destination that arrives from the outside (the "next"
+    parameter on the goto bridge and on the workspace origin's
+    token-redemption endpoint) is honored only when it is a root-relative
+    path on the same origin -- a single leading "/", no scheme, no host,
+    and not a protocol-relative form ("//host", "/\host"). Anything else
+    is ignored and the default destination "/" is used. No open redirects.
+
+    @unsafe-next-ignored
+    Example: A cross-origin destination is replaced with the default
+      Given a signed-in user
+      When they follow the goto bridge for an agent with a destination of "//evil.example/path"
+      Then the destination actually used is "/"

--- a/libs/mngr_forward/specs/overview.md
+++ b/libs/mngr_forward/specs/overview.md
@@ -1,0 +1,62 @@
+# mngr forward
+
+Component: the `mngr forward` proxy (`libs/mngr_forward/`) -- a local
+HTTP/WebSocket proxy that serves each agent's web UI on its own
+`agent-<id>.localhost` origin and byte-forwards every request to that
+agent's backend, behind a single sign-in. It runs standalone for a browser
+user, or as a child process of an embedding host application (the minds
+desktop client), which pre-authorizes its own browser shell and consumes
+the proxy's stdout event stream.
+
+The corpus currently covers two areas. `authentication/` describes how a
+browser or embedding host acquires a session and how that one session opens
+every workspace origin. `forwarding/` describes what happens to requests on
+workspace origins: routing, byte-forwarding, and failure behavior. The
+Rules in the root `invariants.feature` bind the whole corpus.
+
+## Glossary
+
+- **forward proxy**: the process started by `mngr forward`. One listen port
+  serves the bare origin and every workspace origin.
+- **bare origin**: `localhost:<port>` -- the origin that carries sign-in,
+  the home page, and the goto bridge.
+- **workspace origin**: `agent-<id>.localhost:<port>` -- one origin per
+  agent; requests here are forwarded to that agent's backend.
+- **one-time code**: a secret minted fresh at each process start. The proxy
+  prints a **login URL** (`http://localhost:<port>/login?one_time_code=<code>`)
+  to its terminal; opening it is the only way to establish a session in a
+  browser that has none.
+- **session**: the signed-in state of a browser on one origin, carried by a
+  signed `mngr_forward_session` cookie. Browsers scope cookies per origin,
+  so the bare-origin session is bridged to each workspace origin
+  automatically (the goto bridge); the user signs in once.
+- **preauth cookie**: an opaque value an embedding host application may
+  configure at proxy startup and pre-set in its own browser shell; a request
+  presenting exactly that value as its session cookie counts as signed in.
+- **goto bridge**: the bare origin's `/goto/<agent-id>/` route, which
+  converts a valid bare-origin session into a workspace-origin session
+  without user interaction.
+- **agent**: an entity the proxy forwards for. A "known agent" is one that
+  discovery has told the proxy about.
+- **backend**: the per-agent HTTP server the proxy forwards a workspace
+  origin's requests to. An agent's backend is "routable" once the proxy
+  knows its address and can reach it. How addresses are discovered is out
+  of scope here; these specs treat backend state as given.
+
+## Out of scope
+
+- The CLI contract: flag validation, port selection and fallback,
+  `--open-browser`, configuration defaults.
+- The stdout envelope stream (`login_url`, `listening`, `resolver_snapshot`,
+  backend-failure events, observe/event passthrough) -- a planned `stream/`
+  area.
+- Discovery and backend resolution: observe modes, agent/event filters, the
+  `--no-observe` snapshot, service-map cache seeding, `SIGHUP` handling --
+  a planned `discovery/` area.
+- Reverse tunnels (`--reverse`) -- a planned `tunnels/` area.
+- The TLS/HTTP-2 serving mode (`--use-http2`). When enabled, client-facing
+  URLs use `https` and session cookies are marked Secure; behavior is
+  otherwise identical. Scenarios are written for the default plain-HTTP
+  mode.
+- The transport used to reach a remote agent's host (SSH tunneling), except
+  where it changes what a client observes.

--- a/uv.lock
+++ b/uv.lock
@@ -2434,6 +2434,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "imbue-mngr-specs" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click" },
@@ -2453,6 +2458,9 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "websockets", specifier = ">=13" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "imbue-mngr-specs", editable = "libs/mngr_specs" }]
 
 [[package]]
 name = "imbue-mngr-gcp"


### PR DESCRIPTION
Closes [MIND-127](https://linear.app/imbue/issue/MIND-127/mngr-specs-for-mngr-forward).

Adds the second behavioral-spec corpus in the repo, at `libs/mngr_forward/specs/`, describing the externally observable behavior of the `mngr forward` proxy in the language defined by the behavioral-specs skill (stacked on #2530, which delivers the language, the `mngr specs` CLI, and the `apps/minds/specs/` exemplar).

## What is in the corpus (58 units, validates clean)

- **Corpus root**: `overview.md` (component, glossary, out-of-scope) and `invariants.feature` with the cross-cutting security rules: single-use codes, fetch-never-spends, no data without a session, unforgeable/tamper-evident/bounded sessions, single credential, the session cookie never reaching agent code, and no open redirects.
- **`authentication/`**: sign-in with a one-time login code (including codes dying with the process while sessions survive restarts), session lifetime and integrity, the preauth path an embedding host uses to skip the code flow, the bare-origin home page, and the goto bridge that opens every workspace origin from one sign-in (bridge round-trip, token audience/expiry/forgery, self-healing direct navigation).
- **`forwarding/`**: host-header routing (well-formed 32-hex agent hosts vs. everything else), HTTP byte-forwarding semantics (request/response fidelity, redirects not followed, SSE streamed), WebSocket forwarding with its close-code contract (4004/4003/1013/1011), backend error behavior (503 loading page + self-heal, 502, 504), and the host-loopback refusal invariant.

Every scenario and invariant traces to observed behavior in the code and its tests; protocol details (status codes, close codes) are included where programmatic consumers rely on them.

## Deliberately deferred

Per the scoping interview: the stdout envelope stream (`stream/`, [MIND-130](https://linear.app/imbue/issue/MIND-130)), discovery/resolution modes (`discovery/`, [MIND-131](https://linear.app/imbue/issue/MIND-131)), and reverse tunnels (`tunnels/`, [MIND-132](https://linear.app/imbue/issue/MIND-132)) are future corpus areas; the CLI contract stays unspecified for now. The envelope side channel of forwarding failures is documented as follow-up work in `forwarding/backend-errors.md`. Annotating existing tests with `witnesses` markers is deferred, matching the minds precedent; [MIND-133](https://linear.app/imbue/issue/MIND-133) tracks the authentication area's markers as its own PR.

## Supporting changes

- `test_spec_corpus.py`: live-corpus guard test mirroring `apps/minds/imbue/minds/test_spec_corpus.py`, asserting the corpus always satisfies the spec-language rules.
- `pyproject.toml`: `imbue-mngr-specs` added as a dev-group dependency (test-only; the published wheel is unaffected), with the corresponding `uv.lock` update.
- Changelog entry under `libs/mngr_forward/changelog/`.

## Verification

- `uv run mngr specs validate --root libs/mngr_forward/specs` -- OK, 58 units across 11 feature files.
- `uv run mngr specs matrix --root libs/mngr_forward/specs` -- runs clean (all coverage `none`, as expected with witnesses deferred).
- `just test-quick "libs/mngr_forward -m 'not acceptance and not release'"` -- 276 passed, 0 failed.
- Full suite left to CI (local `just test-offload` was unavailable in this environment: no Modal credentials in the shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




