### PR TITLE
Give each manual bug report a unique Sentry fingerprint

### DIFF
--- a/libs/imbue_common/changelog/preston-fingerprint-bug-reports.md
+++ b/libs/imbue_common/changelog/preston-fingerprint-bug-reports.md
@@ -1,0 +1,1 @@
+Manually-submitted bug reports now carry a unique Sentry fingerprint ("manual-bug-report" + a fresh UUID), so each report becomes its own Sentry issue instead of all reports grouping into one catch-all issue. Per-report triage, assignment, and resolution now work; automated triage (open-seer) can treat each report as a distinct issue.

--- a/libs/imbue_common/imbue/imbue_common/sentry/core.py
+++ b/libs/imbue_common/imbue/imbue_common/sentry/core.py
@@ -1011,6 +1011,11 @@ def submit_manual_bug_report(
     event: Event = {
         "message": title,
         "level": "info",
+        # A unique fingerprint per report: without it Sentry groups every
+        # manual bug report (same message shape, same submission path) into
+        # one catch-all issue, making per-report triage, assignment, and
+        # resolution impossible.
+        "fingerprint": ["manual-bug-report", uuid.uuid4().hex],
         "tags": {MANUALLY_SUBMITTED_TAG: "true"},
         "extra": extra,
     }

--- a/libs/imbue_common/imbue/imbue_common/sentry/core_test.py
+++ b/libs/imbue_common/imbue/imbue_common/sentry/core_test.py
@@ -365,6 +365,12 @@ def test_submit_manual_bug_report_sends_tagged_event_even_when_reporting_disable
     assert tags["manually_submitted"] == "true"
     extra = cast(dict, event["extra"])
     assert extra["bug_report"]["description"] == "boom"
+    # Each report must land in its own Sentry issue: a unique fingerprint per
+    # submission, never the shared-message grouping (which produced one
+    # catch-all issue for every report ever filed).
+    fingerprint = cast(list, event["fingerprint"])
+    assert fingerprint[0] == "manual-bug-report"
+    assert len(fingerprint[1]) == 32
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Manually-submitted bug reports (submit_manual_bug_report in
libs/imbue_common/imbue/imbue_common/sentry/core.py) shared Sentry's default
message-based grouping, so every report ever filed collapsed into one
catch-all issue — MINDS-PRODUCTION-4 currently holds 68 unrelated complaints
(crashes, hangs, UI bugs) under one issue id. That makes per-report triage,
assignment, and resolution impossible, and it breaks automated triage
(open-seer) that assumes one issue ≈ one root cause: a fixer resolved the
issue's "recommended" event while other events in the same bucket described
entirely different bugs.

Each report now carries a unique fingerprint ("manual-bug-report" + a fresh
UUID), so every submission becomes its own Sentry issue with its own title,
assignee, and lifecycle.

Existing reports in the catch-all issue are unaffected (fingerprints apply at
event ingestion); MINDS-PRODUCTION-4 remains as the historical bucket and
should not be resolved wholesale.

## Test plan

- [x] Extended test_submit_manual_bug_report_sends_tagged_event_even_when_reporting_disabled to assert the fingerprint shape (29 passed in core_test.py)
- [ ] Full suite via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)