### PR TITLE
Add first-class dev skills: post-pr-to-slack, crispy-comments, and a vendored-skills sync

### DIFF
--- a/.claude/skills/crispy-comments/SKILL.md
+++ b/.claude/skills/crispy-comments/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: crispy-comments
+description: Prune code comments down to what helps future maintainers. Reviews comments on the current branch's diff and removes incidental history, defensive justification, and correctness arguments. Invoke with /crispy-comments.
+---
+
+# Crispy Comments
+
+This skill applies only to the current branch of the current repository. If this is invoked on `main` (or `master`), please confirm with the user whether they intend to run this on the entire repository.
+
+Review the comments added or changed in the diff. For each, ask: does this help future maintainers understand the code, or merely restate what the code plainly does or explain today's bug fix? Remove incidental history, defensive justification, and correctness arguments.
+
+Also remove comments that restate facts from the surrounding code that are likely to change — a count of subclasses, a list of variants, the call sites of a function. These pin the comment to a point in time and rot quickly. Follow DRY: Don't Repeat Yourself.
+
+Remove commented-out code outright — version control already remembers it.
+
+Remove ASCII-art banners and box-drawing section dividers. They add visual noise without conveying anything a plain one-line comment does not.

--- a/.claude/skills/post-pr-to-slack/SKILL.md
+++ b/.claude/skills/post-pr-to-slack/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: post-pr-to-slack
+description: |
+  Post a one-line PR announcement to the repo's Slack merges channel, and mark
+  it :merged: when the PR merges. Use whenever you open or meaningfully adjust
+  a PR in a repo with a mapped channel (sculptor, mngr).
+compatibility: |
+  Requires latchkey with a working Slack credential, plus `jq` and `gh`. Run
+  `scripts/slack_pr.sh check` to verify; see the latchkey skill to set it up.
+argument-hint: [pr-number | pr-url] [#channel]
+---
+
+# Post PR to Slack
+
+Announce pull requests in the team's merges channel for the repo you are
+working in with a single standalone line, then mark each announcement
+`:merged:` once its PR merges. This file covers *when* to post, *where* (which
+channel belongs to which repo), and *what* the message should say; the Slack
+mechanics (channel lookup, posting, reacting) live in
+[`scripts/slack_pr.sh`](scripts/slack_pr.sh).
+
+The skill is agent-agnostic — it depends only on `latchkey`, `jq`, `gh`, and
+`bash`, not on any agent-specific tooling.
+
+## Channels
+
+The channel is determined by the repo's `origin` remote:
+
+| Repo                | Channel                           |
+| ------------------- | --------------------------------- |
+| `imbue-ai/sculptor` | `#project-sculptor-merges`        |
+| `imbue-ai/mngr`     | `#project-minds-internal-product` |
+
+For any repo not in this table there is no standing authorization — ask the
+user which channel to use (if any) before posting.
+
+## When to run
+
+- **When you open a PR in a mapped repo.** After `gh pr create --base main`
+  succeeds, post to the repo's channel. This is a standing instruction — just
+  post; see [Authorization](#authorization).
+- **When you meaningfully adjust an open PR** — a force-push that changes the
+  approach, a scope change, or a retitle. Reply in the existing thread; don't
+  start a new top-level post. Skip trivial edits (typo fixes, rebases, minor doc
+  tweaks). If unsure, ask the user.
+- **When a PR merges** (you observe it, or the user says so). Add a `:merged:`
+  reaction to the original post. Do *not* post a separate "merged" message — the
+  reaction is the convention.
+
+## Inputs
+
+- **Channel** — the repo's channel from [Channels](#channels) unless the user
+  says otherwise.
+- **PR URL** — infer from git when not given:
+  - current branch: `gh pr view --json url -q .url`
+  - a specific PR: `gh pr view <number> --json url -q .url`
+- **One-line description** — draft from the PR title/body (see
+  [Drafting](#drafting-the-one-liner)). If the PR already has a crisp one-liner
+  (its title, or a `## Summary` bullet), reuse it verbatim so Slack and the PR
+  stay in lockstep.
+
+> The only PR-host-specific step is fetching the URL with `gh`. On a GitLab repo,
+> swap in `glab mr view --output json | jq -r .web_url`; everything else is the
+> same.
+
+## Setup
+
+Point a variable at the helper script, resolve the repo's channel, and confirm
+Slack is reachable, once per session:
+
+```bash
+SLACK=.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+case "$(git remote get-url origin)" in
+  *imbue-ai/sculptor*) CHANNEL='#project-sculptor-merges' ;;
+  *imbue-ai/mngr*)     CHANNEL='#project-minds-internal-product' ;;
+  *)                   CHANNEL='' ;;  # unmapped repo — ask the user first
+esac
+"$SLACK" check          # prints "slack ok: team '…' as '…'", or says how to fix auth
+```
+
+If the check fails, run `latchkey services info slack` and follow its setup (a
+browser login if supported, otherwise `latchkey auth set`). The script puts an
+nvm-installed `latchkey` back on `PATH` itself; if `check` still reports it
+missing, install it with `npm install -g latchkey`.
+
+## Steps — initial post
+
+1. **Read recent channel history** to match the house style (terse vs.
+   emoji-led, where the URL goes, capitalization), then **draft the line** per
+   [Drafting](#drafting-the-one-liner):
+
+   ```bash
+   "$SLACK" history "$CHANNEL"
+   ```
+
+2. **Post it** and capture the message timestamp (`ts`). The text is sent
+   verbatim, so include the PR URL — Slack unfurls it into a preview:
+
+   ```bash
+   TEXT="Fix login crash when the token contains a colon  $PR_URL"
+   TS=$("$SLACK" post "$CHANNEL" "$TEXT")
+   echo "posted ts=$TS"
+   ```
+
+   `slack_pr.sh` builds the JSON with `jq`, so backticks, quotes, or `&` in the
+   text are safe.
+
+3. **Report** the channel and `ts` back to the user, and remember the `ts` — the
+   merge-time `:merged:` step needs it.
+
+## Steps — adjusting an open PR
+
+If a post for this PR already exists (use the `ts` you remembered, or find it),
+reply in its thread — don't post a new top-level message for the same PR, which
+splits the discussion:
+
+```bash
+TS=$("$SLACK" find-ts "$CHANNEL" "$PR_URL")
+"$SLACK" reply "$CHANNEL" "$TS" "Revised approach: now …"
+```
+
+## Steps — PR merged
+
+```bash
+TS=$("$SLACK" find-ts "$CHANNEL" "$PR_URL")
+"$SLACK" done "$CHANNEL" "$TS"
+```
+
+`find-ts` matches the bare URL even when Slack has wrapped it in `<…>`. `done` is
+idempotent — an already-present `:merged:` counts as success. Don't post anything
+else; the reaction *is* the "merged" signal.
+
+## Drafting the one-liner
+
+The audience is teammates and future reviewers skimming the channel. The line
+must convey the PR's **one key outcome** and **read standalone** — no thread,
+repo, or commit-history context required. Lead with a verb in the channel's
+imperative style ("Fix X", "Migrate Y", "Speed up Z"). Draft it directly; if
+your harness lets you delegate prose to a smaller/faster model, you may, but
+it's not required.
+
+Check the draft against these guardrails:
+
+- **Outcome, not process.** Describe what the PR achieves in the codebase as it
+  now exists — not the bootstrap, onboarding, or workflow that produced it.
+- **Timeless.** No "follow-up commit does Y", "next we'll…", or "still to come".
+  Frame it as if every commit on the branch has already landed and is the new
+  normal. A channel post is a record, not a roadmap or a per-commit changelog.
+- **One sentence, one outcome.** No parenthetical hedging in a secondary change.
+  If a second change is genuinely co-equal, that's a sign it should be its own PR.
+- **Plain, not hype.** "Improve performance" — not "Massive perf win!" — unless
+  the channel actually talks that way.
+- Ends with the PR URL; no ticket IDs unless the channel uses them.
+
+## Authorization
+
+The post-and-`:merged:` flow is **pre-authorized** for the repos in
+[Channels](#channels) — this skill living in the repo *is* the standing
+instruction. Don't pause to ask "should I post this?" after `gh pr create`
+succeeds; just post. Posting and reacting are still visible to others, so
+**do** ask before any scope expansion: a different channel, @-mentioning
+people, a reaction other than `:merged:`, or posting for a repo that has no
+entry in the channel table.
+
+## Notes
+
+- **Re-resolve the channel ID each invocation.** Looking up by name tolerates
+  renames; a cached ID can go stale across sessions.
+- **Track the `ts` of your initial post** in conversation memory so the
+  merge-time reaction doesn't have to scan history.
+- **Raw API / fallback.** Every call routes through `latchkey curl` against the
+  Slack Web API; the exact endpoints and payloads are in
+  [`scripts/slack_pr.sh`](scripts/slack_pr.sh) if you ever need to run them by
+  hand.
+- **Vendored copies.** The mngr monorepo vendors this skill into its
+  `.claude/skills/post-pr-to-slack/` (synced by `scripts/sync_vendored_skills.py`
+  there). This copy is canonical — land changes here, then re-sync downstream.

--- a/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+++ b/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# slack_pr.sh — Slack helpers for the post-pr-to-slack skill.
+#
+# Every request goes through `latchkey curl`, which injects the Slack
+# credential automatically (see the latchkey skill). JSON bodies are built with
+# jq so message text containing backticks, quotes, or & is escaped correctly.
+#
+# Commands:
+#   check                                verify latchkey + jq + a working Slack credential
+#   channel-id <name>                    print a channel's ID (paginates conversations.list)
+#   history <#name|ID> [limit]           print the text of recent messages (default 10)
+#   post <#name|ID> <text>               post a message; print its ts
+#   reply <#name|ID> <thread_ts> <text>  post a threaded reply; print its ts
+#   find-ts <#name|ID> <substring>       print ts of the latest message containing <substring>
+#   done <#name|ID> <ts>                 add the :merged: reaction (idempotent)
+#
+set -euo pipefail
+
+API="https://slack.com/api"
+
+die() { echo "slack_pr.sh: $*" >&2; exit 1; }
+
+# latchkey is usually an nvm-managed node binary. Non-login shells often don't
+# source nvm, so latchkey (and its node runtime) may be missing from PATH even
+# when installed. Add the install dir back if needed; a no-op when already found.
+if ! command -v latchkey >/dev/null 2>&1; then
+  for d in "$HOME"/.nvm/versions/node/*/bin "$HOME/.local/bin" /usr/local/bin /opt/homebrew/bin; do
+    [ -x "$d/latchkey" ] && { PATH="$d:$PATH"; break; }
+  done
+fi
+command -v latchkey >/dev/null 2>&1 || die "missing dependency: latchkey (npm install -g latchkey; see the latchkey skill)"
+command -v jq       >/dev/null 2>&1 || die "missing dependency: jq"
+
+# Fail loudly unless the JSON on stdin has ok:true; pass it through otherwise.
+check_ok() {
+  local json; json="$(cat)"
+  [ -n "$json" ] || die "empty response from Slack"
+  if [ "$(printf '%s' "$json" | jq -r '.ok')" != "true" ]; then
+    die "Slack API error: $(printf '%s' "$json" | jq -r '.error // "unknown"')"
+  fi
+  printf '%s' "$json"
+}
+
+slack_get()  { latchkey curl -s "$API/$1?${2:-}"; }
+slack_post() {
+  latchkey curl -s -X POST "$API/$1" \
+    -H 'Content-Type: application/json; charset=utf-8' \
+    -d "$2"
+}
+
+# Confirm the Slack credential actually works (read-only identity check).
+cmd_check() {
+  local resp; resp="$(latchkey curl -s -X POST "$API/auth.test")"
+  [ -n "$resp" ] || die "no response from Slack — is latchkey configured? (latchkey services info slack)"
+  if [ "$(printf '%s' "$resp" | jq -r '.ok')" = "true" ]; then
+    echo "slack ok: team '$(printf '%s' "$resp" | jq -r '.team')' as '$(printf '%s' "$resp" | jq -r '.user')'"
+  else
+    die "slack auth failed: $(printf '%s' "$resp" | jq -r '.error // "unknown"') — run: latchkey services info slack"
+  fi
+}
+
+# Resolve a #name (or bare name) to a channel ID, paginating the full list so
+# this tolerates renames and large workspaces (>1000 channels).
+channel_id() {
+  local want="${1#\#}" cursor="" page id
+  [ -n "$want" ] || die "usage: channel-id <name>"
+  while :; do
+    page="$(slack_get conversations.list \
+      "types=public_channel,private_channel&limit=1000&cursor=$cursor" | check_ok)"
+    id="$(printf '%s' "$page" | jq -r --arg n "$want" \
+      '[.channels[] | select(.name == $n) | .id][0] // ""')"
+    [ -n "$id" ] && { printf '%s\n' "$id"; return 0; }
+    cursor="$(printf '%s' "$page" | jq -r '.response_metadata.next_cursor // ""')"
+    [ -n "$cursor" ] || break
+  done
+  die "channel '#$want' not found (wrong name, or you are not a member)"
+}
+
+# A C…/G… argument is already a channel ID; anything else is a name to resolve.
+resolve() { case "$1" in C* | G*) printf '%s\n' "$1" ;; *) channel_id "$1" ;; esac; }
+
+cmd_history() {
+  [ $# -ge 1 ] || die "usage: history <#name|ID> [limit]"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=${2:-10}" | check_ok | jq -r '.messages[].text'
+}
+
+cmd_post() {
+  [ $# -eq 2 ] || die "usage: post <#name|ID> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg t "$2" '{channel: $c, text: $t, unfurl_links: true}')" \
+    | check_ok | jq -r '.ts'
+}
+
+cmd_reply() {
+  [ $# -eq 3 ] || die "usage: reply <#name|ID> <thread_ts> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg th "$2" --arg t "$3" '{channel: $c, thread_ts: $th, text: $t}')" \
+    | check_ok | jq -r '.ts'
+}
+
+# Slack auto-links URLs as <url> in stored text, so match on the bare substring.
+cmd_find_ts() {
+  [ $# -eq 2 ] || die "usage: find-ts <#name|ID> <substring>"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=200" | check_ok \
+    | jq -r --arg u "$2" '[.messages[] | select(.text | contains($u)) | .ts][0] // ""'
+}
+
+# Idempotent: a pre-existing :merged: (already_reacted) counts as success.
+cmd_done() {
+  [ $# -eq 2 ] || die "usage: done <#name|ID> <ts>"
+  local ch resp ok err
+  ch="$(resolve "$1")"
+  resp="$(slack_post reactions.add \
+    "$(jq -n --arg c "$ch" --arg ts "$2" '{channel: $c, timestamp: $ts, name: "merged"}')")"
+  [ -n "$resp" ] || die "empty response from reactions.add"
+  ok="$(printf '%s' "$resp" | jq -r '.ok')"
+  err="$(printf '%s' "$resp" | jq -r '.error // ""')"
+  [ "$ok" = "true" ] || [ "$err" = "already_reacted" ] || die "reactions.add failed: $err"
+  echo ok
+}
+
+[ $# -ge 1 ] || die "usage: slack_pr.sh <check|channel-id|history|post|reply|find-ts|done> ..."
+cmd="$1"; shift
+case "$cmd" in
+  check)      cmd_check "$@" ;;
+  channel-id) channel_id "$@" ;;
+  history)    cmd_history "$@" ;;
+  post)       cmd_post "$@" ;;
+  reply)      cmd_reply "$@" ;;
+  find-ts)    cmd_find_ts "$@" ;;
+  done)       cmd_done "$@" ;;
+  *)          die "unknown command: $cmd" ;;
+esac

--- a/.claude/vendored_skills.toml
+++ b/.claude/vendored_skills.toml
@@ -1,0 +1,22 @@
+# Claude Code skills vendored into .claude/skills/ from external repositories.
+#
+# Sync (or first-vendor) with:
+#     just sync-vendored-skills            # or: uv run python -m scripts.sync_vendored_skills
+#     just sync-vendored-skills --check    # report drift without changing files
+#
+# `commit` is the upstream commit last vendored (maintained by the sync script).
+# Sync refuses to overwrite a local copy whose `commit` is not found upstream
+# (e.g. it references an upstream change that has not merged yet); use --force
+# once upstream has intentionally diverged.
+
+[skills.crispy-comments]
+repo = "https://github.com/DanverImbue/crispy-comments"
+ref = "main"
+include = ["SKILL.md"]
+commit = "8514b31c0781f83cfc4b4ecdda585c00a4504304"
+
+[skills.post-pr-to-slack]
+repo = "https://github.com/imbue-ai/sculptor"
+ref = "main"
+path = ".claude/skills/post-pr-to-slack"
+commit = "c64c32fc27cdea14f22bb51ce068503cd3ad62c5"

--- a/dev/changelog/danver-add-dev-skills.md
+++ b/dev/changelog/danver-add-dev-skills.md
@@ -1,0 +1,7 @@
+Add first-class dev skills to the monorepo's `.claude/skills/`:
+
+- Bundle the `post-pr-to-slack` skill (canonical in `imbue-ai/sculptor`, generalized there to resolve the Slack channel per repo). PRs in this repo announce in `#project-minds-internal-product`; sculptor PRs keep `#project-sculptor-merges`.
+
+- Vendor the `crispy-comments` skill from its canonical repo (`DanverImbue/crispy-comments`).
+
+- Add `.claude/vendored_skills.toml` plus `scripts/sync_vendored_skills.py` (with a `just sync-vendored-skills` recipe) to refresh vendored skills from their upstream repos and record the pinned upstream commit per skill. Sync refuses to overwrite a local copy whose pinned commit is not found upstream (`--force` overrides); `--check` reports drift without changing files.

--- a/justfile
+++ b/justfile
@@ -203,6 +203,12 @@ test-quick args="":
 regenerate-agent-capabilities-doc:
   uv run python scripts/make_agent_capabilities_doc.py
 
+# Refresh the vendored Claude Code skills in .claude/skills/ from their upstream
+# repos, per .claude/vendored_skills.toml. Pass --check to report drift without
+# changing files; see the manifest header for details.
+sync-vendored-skills *args:
+  uv run python -m scripts.sync_vendored_skills {{args}}
+
 test-acceptance:
   # when running these locally, we set the max duration super high just so that we don't fail (which makes it harder to see the errors)
   PYTEST_MAX_DURATION_SECONDS=600 uv run pytest {{_parallel}} --no-cov -m "not release"

--- a/scripts/sync_vendored_skills.py
+++ b/scripts/sync_vendored_skills.py
@@ -1,0 +1,326 @@
+"""Vendor Claude Code skills from external git repos into .claude/skills/.
+
+The manifest at .claude/vendored_skills.toml lists each vendored skill: the
+upstream repo, the ref to track, an optional subdirectory (`path`) and
+top-level `include` list, and the upstream `commit` that was last vendored.
+This script refreshes the local copies from upstream and records the newly
+vendored commit back into the manifest.
+
+Run from the repo root::
+
+    uv run python -m scripts.sync_vendored_skills            # sync everything
+    uv run python -m scripts.sync_vendored_skills --check    # report drift only
+    uv run python -m scripts.sync_vendored_skills --skill crispy-comments
+
+Sync never overwrites a local copy whose pinned commit is not found in the
+upstream ref's recent history (e.g. the pin references a local change that has
+not been pushed or merged upstream yet); pass --force to override.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from collections.abc import Mapping
+from collections.abc import Sequence
+from enum import auto
+from pathlib import Path
+from typing import Final
+from typing import assert_never
+
+import click
+import tomlkit
+from pydantic import Field
+
+from imbue.imbue_common.enums import UpperCaseStrEnum
+from imbue.imbue_common.frozen_model import FrozenModel
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+MANIFEST_PATH: Final[Path] = REPO_ROOT / ".claude" / "vendored_skills.toml"
+SKILLS_DIR: Final[Path] = REPO_ROOT / ".claude" / "skills"
+
+# History depth fetched when syncing. The pinned commit must appear within this
+# window of the upstream ref for sync to overwrite the local copy without --force.
+CLONE_DEPTH: Final[int] = 50
+GIT_TIMEOUT_SECONDS: Final[float] = 600.0
+
+
+class VendoredSkillSyncError(Exception):
+    """Base error for vendored-skill sync failures."""
+
+
+class VendoredSkill(FrozenModel):
+    """One vendored skill entry from the manifest."""
+
+    name: str = Field(description="Directory name under .claude/skills/")
+    # str rather than AnyUrl: git remotes may be scp-like (git@host:path), which is not a URL.
+    repo: str = Field(description="Git URL of the upstream repository")
+    ref: str = Field(description="Upstream branch or tag to track")
+    path: str = Field(default=".", description="Subdirectory of the upstream repo containing the skill")
+    include: tuple[str, ...] | None = Field(
+        default=None,
+        description="Top-level entries of the skill directory to copy; None copies everything except .git*",
+    )
+    commit: str | None = Field(default=None, description="Upstream commit last vendored; None if never synced")
+
+
+class SkillSyncOutcome(UpperCaseStrEnum):
+    """What happened to (or is known about) one vendored skill."""
+
+    UP_TO_DATE = auto()
+    SYNCED = auto()
+    SKIPPED_LOCAL_AHEAD = auto()
+    # Check-mode-only outcomes:
+    NEVER_SYNCED = auto()
+    OUT_OF_DATE = auto()
+
+
+class SkillSyncResult(FrozenModel):
+    """Per-skill result of a sync or check run."""
+
+    skill_name: str = Field(description="Manifest name of the skill")
+    outcome: SkillSyncOutcome = Field(description="What happened to this skill")
+    remote_commit: str = Field(description="Upstream head commit of the tracked ref")
+    detail: str = Field(description="Human-readable elaboration; may be empty")
+
+
+def _run_git(git_args: Sequence[str], cwd: Path) -> str:
+    command = ["git", *git_args]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+    except subprocess.CalledProcessError as e:
+        raise VendoredSkillSyncError(f"`{' '.join(command)}` failed: {e.stderr.strip()}") from e
+    except subprocess.TimeoutExpired as e:
+        raise VendoredSkillSyncError(f"`{' '.join(command)}` timed out after {GIT_TIMEOUT_SECONDS}s") from e
+    return completed.stdout
+
+
+def load_manifest(manifest_path: Path) -> list[VendoredSkill]:
+    """Raises VendoredSkillSyncError if the manifest is missing, empty, or malformed."""
+    if not manifest_path.is_file():
+        raise VendoredSkillSyncError(f"Manifest not found: {manifest_path}")
+    raw_manifest = tomllib.loads(manifest_path.read_text())
+    skills_table = raw_manifest.get("skills")
+    if not isinstance(skills_table, dict) or not skills_table:
+        raise VendoredSkillSyncError(f"Manifest {manifest_path} must contain a non-empty [skills.<name>] table")
+    return [VendoredSkill.model_validate({"name": name, **entry}) for name, entry in skills_table.items()]
+
+
+def _resolve_remote_head_commit(skill: VendoredSkill) -> str:
+    output = _run_git(["ls-remote", skill.repo, skill.ref], REPO_ROOT)
+    for line in output.splitlines():
+        commit_sha, _, ref_name = line.partition("\t")
+        if ref_name in (f"refs/heads/{skill.ref}", f"refs/tags/{skill.ref}", skill.ref):
+            return commit_sha
+    raise VendoredSkillSyncError(f"Ref {skill.ref!r} not found in {skill.repo}")
+
+
+def _is_commit_present_in_clone(clone_dir: Path, commit_sha: str) -> bool:
+    completed = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit_sha}^{{commit}}"],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=GIT_TIMEOUT_SECONDS,
+    )
+    return completed.returncode == 0
+
+
+def _select_source_entries(source_dir: Path, skill: VendoredSkill) -> list[Path]:
+    if skill.include is None:
+        return sorted(entry for entry in source_dir.iterdir() if not entry.name.startswith(".git"))
+    selected_entries: list[Path] = []
+    for entry_name in skill.include:
+        entry = source_dir / entry_name
+        if not entry.exists():
+            raise VendoredSkillSyncError(
+                f"Include entry {entry_name!r} of skill {skill.name!r} not found in upstream {skill.repo}"
+            )
+        selected_entries.append(entry)
+    return selected_entries
+
+
+def _copy_skill_files(source_dir: Path, target_dir: Path, skill: VendoredSkill) -> None:
+    selected_entries = _select_source_entries(source_dir, skill)
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True)
+    for entry in selected_entries:
+        if entry.is_dir():
+            shutil.copytree(entry, target_dir / entry.name)
+        else:
+            shutil.copy2(entry, target_dir / entry.name)
+
+
+def sync_one_skill(skill: VendoredSkill, skills_dir: Path, is_forced: bool) -> SkillSyncResult:
+    """Bring the local copy of one skill up to the upstream ref head, guarding against clobbering local-only pins."""
+    remote_head_commit = _resolve_remote_head_commit(skill)
+    if skill.commit == remote_head_commit:
+        return SkillSyncResult(
+            skill_name=skill.name,
+            outcome=SkillSyncOutcome.UP_TO_DATE,
+            remote_commit=remote_head_commit,
+            detail="",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="vendored-skill-") as temp_dir:
+        clone_dir = Path(temp_dir) / "clone"
+        _run_git(
+            ["clone", "--quiet", "--depth", str(CLONE_DEPTH), "--branch", skill.ref, skill.repo, str(clone_dir)],
+            REPO_ROOT,
+        )
+
+        # Refuse to clobber a local copy whose pin is unknown upstream: that means the
+        # local copy carries changes (or tracks a commit) that upstream does not have yet.
+        if skill.commit is not None and not is_forced and not _is_commit_present_in_clone(clone_dir, skill.commit):
+            return SkillSyncResult(
+                skill_name=skill.name,
+                outcome=SkillSyncOutcome.SKIPPED_LOCAL_AHEAD,
+                remote_commit=remote_head_commit,
+                detail=(
+                    f"pinned commit {skill.commit[:12]} not found in the last {CLONE_DEPTH} commits of "
+                    f"{skill.repo}@{skill.ref}; local copy kept as-is (pass --force to overwrite)"
+                ),
+            )
+
+        source_dir = (clone_dir / skill.path).resolve()
+        if not source_dir.is_dir():
+            raise VendoredSkillSyncError(
+                f"Path {skill.path!r} of skill {skill.name!r} not found in upstream {skill.repo}@{skill.ref}"
+            )
+        _copy_skill_files(source_dir=source_dir, target_dir=skills_dir / skill.name, skill=skill)
+
+    return SkillSyncResult(
+        skill_name=skill.name,
+        outcome=SkillSyncOutcome.SYNCED,
+        remote_commit=remote_head_commit,
+        detail=f"vendored {remote_head_commit[:12]}",
+    )
+
+
+def check_one_skill(skill: VendoredSkill) -> SkillSyncResult:
+    """Compare the manifest pin against the upstream ref head without touching any files."""
+    remote_head_commit = _resolve_remote_head_commit(skill)
+    if skill.commit is None:
+        outcome = SkillSyncOutcome.NEVER_SYNCED
+        detail = "no pinned commit in the manifest; run a sync to vendor it"
+    elif skill.commit == remote_head_commit:
+        outcome = SkillSyncOutcome.UP_TO_DATE
+        detail = ""
+    else:
+        outcome = SkillSyncOutcome.OUT_OF_DATE
+        detail = f"pinned {skill.commit[:12]}, upstream {skill.ref} is at {remote_head_commit[:12]}"
+    return SkillSyncResult(skill_name=skill.name, outcome=outcome, remote_commit=remote_head_commit, detail=detail)
+
+
+def _update_manifest_pins(manifest_path: Path, commit_by_skill_name: Mapping[str, str]) -> None:
+    document = tomlkit.parse(manifest_path.read_text())
+    skills_table = document["skills"]
+    if not isinstance(skills_table, dict):
+        raise VendoredSkillSyncError(f"Manifest {manifest_path} has a malformed [skills] table")
+    for skill_name, commit_sha in commit_by_skill_name.items():
+        skill_entry = skills_table[skill_name]
+        if not isinstance(skill_entry, dict):
+            raise VendoredSkillSyncError(f"Manifest entry for skill {skill_name!r} is malformed")
+        skill_entry["commit"] = commit_sha
+    manifest_path.write_text(tomlkit.dumps(document))
+
+
+def run_sync(
+    manifest_path: Path,
+    skills_dir: Path,
+    is_check_only: bool,
+    is_forced: bool,
+    only_skill_names: Sequence[str],
+) -> list[SkillSyncResult]:
+    """Sync (or check) every manifest entry, updating manifest pins for skills that were synced."""
+    skills = load_manifest(manifest_path)
+    if only_skill_names:
+        known_names = {skill.name for skill in skills}
+        unknown_names = sorted(set(only_skill_names) - known_names)
+        if unknown_names:
+            raise VendoredSkillSyncError(f"Unknown skill(s) {unknown_names}; manifest has {sorted(known_names)}")
+        skills = [skill for skill in skills if skill.name in only_skill_names]
+
+    results: list[SkillSyncResult] = []
+    commit_by_synced_skill_name: dict[str, str] = {}
+    for skill in skills:
+        if is_check_only:
+            result = check_one_skill(skill)
+        else:
+            result = sync_one_skill(skill, skills_dir=skills_dir, is_forced=is_forced)
+        results.append(result)
+        if result.outcome is SkillSyncOutcome.SYNCED:
+            commit_by_synced_skill_name[skill.name] = result.remote_commit
+
+    if commit_by_synced_skill_name:
+        _update_manifest_pins(manifest_path, commit_by_synced_skill_name)
+    return results
+
+
+def _format_result_line(result: SkillSyncResult) -> str:
+    match result.outcome:
+        case SkillSyncOutcome.UP_TO_DATE:
+            status_text = "up to date"
+        case SkillSyncOutcome.SYNCED:
+            status_text = "synced"
+        case SkillSyncOutcome.SKIPPED_LOCAL_AHEAD:
+            status_text = "SKIPPED (local ahead of upstream)"
+        case SkillSyncOutcome.NEVER_SYNCED:
+            status_text = "NEVER SYNCED"
+        case SkillSyncOutcome.OUT_OF_DATE:
+            status_text = "OUT OF DATE"
+        case _ as unreachable:
+            assert_never(unreachable)
+    suffix = f" -- {result.detail}" if result.detail else ""
+    return f"{result.skill_name}: {status_text}{suffix}"
+
+
+@click.command()
+@click.option(
+    "--check",
+    "is_check_only",
+    is_flag=True,
+    help="Report drift against upstream without copying files or updating pins.",
+)
+@click.option(
+    "--force",
+    "is_forced",
+    is_flag=True,
+    help="Overwrite a local copy even when its pinned commit is not found upstream.",
+)
+@click.option(
+    "--skill",
+    "only_skill_names",
+    multiple=True,
+    help="Limit to the named skill(s) from the manifest; may be repeated.",
+)
+def main(is_check_only: bool, is_forced: bool, only_skill_names: tuple[str, ...]) -> None:
+    results = run_sync(
+        manifest_path=MANIFEST_PATH,
+        skills_dir=SKILLS_DIR,
+        is_check_only=is_check_only,
+        is_forced=is_forced,
+        only_skill_names=only_skill_names,
+    )
+    for result in results:
+        click.echo(_format_result_line(result))
+
+    is_drift_found = any(
+        result.outcome in (SkillSyncOutcome.NEVER_SYNCED, SkillSyncOutcome.OUT_OF_DATE) for result in results
+    )
+    if is_check_only and is_drift_found:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_vendored_skills_test.py
+++ b/scripts/sync_vendored_skills_test.py
@@ -1,0 +1,332 @@
+import os
+import textwrap
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from scripts.sync_vendored_skills import SkillSyncOutcome
+from scripts.sync_vendored_skills import VendoredSkillSyncError
+from scripts.sync_vendored_skills import _run_git
+from scripts.sync_vendored_skills import load_manifest
+from scripts.sync_vendored_skills import run_sync
+
+_TEST_GIT_IDENTITY = ("-c", "user.name=Vendored Skill Test", "-c", "user.email=vendored-skill-test@example.com")
+
+
+def _init_upstream_repo(repo_dir: Path) -> None:
+    repo_dir.mkdir(parents=True)
+    _run_git(["init", "--quiet", "-b", "main"], repo_dir)
+
+
+def _commit_files(repo_dir: Path, content_by_relative_path: dict[str, str]) -> str:
+    """Write files, commit them, and return the commit sha."""
+    for relative_path, content in content_by_relative_path.items():
+        file_path = repo_dir / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
+    _run_git(["add", *content_by_relative_path.keys()], repo_dir)
+    _run_git([*_TEST_GIT_IDENTITY, "commit", "--quiet", "-m", "Update skill files"], repo_dir)
+    return _run_git(["rev-parse", "HEAD"], repo_dir).strip()
+
+
+def _repo_url(repo_dir: Path) -> str:
+    # file:// (rather than a bare path) so `git clone --depth` does a real shallow clone.
+    return f"file://{repo_dir}"
+
+
+def _write_manifest(manifest_path: Path, body: str) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(textwrap.dedent(body))
+
+
+def test_sync_vendors_new_skill_and_records_pinned_commit(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    script_body = "#!/bin/sh\necho vendored-skill-test-8631\n"
+    upstream_commit = _commit_files(upstream_dir, {"SKILL.md": "# Skill\n", "scripts/run.sh": script_body})
+    (upstream_dir / "scripts/run.sh").chmod(0o755)
+    upstream_commit_with_mode = _commit_files(upstream_dir, {"scripts/run.sh": script_body + "# exec\n"})
+    assert upstream_commit != upstream_commit_with_mode
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SYNCED]
+    assert (skills_dir / "demo-skill" / "SKILL.md").read_text() == "# Skill\n"
+    copied_script = skills_dir / "demo-skill" / "scripts" / "run.sh"
+    assert copied_script.read_text().endswith("# exec\n")
+    assert os.stat(copied_script).st_mode & 0o111, "executable bit must be preserved"
+    recorded = tomllib.loads(manifest_path.read_text())
+    assert recorded["skills"]["demo-skill"]["commit"] == upstream_commit_with_mode
+
+
+def test_sync_skips_when_pinned_commit_is_unknown_upstream(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(upstream_dir, {"SKILL.md": "# Upstream version\n"})
+
+    unknown_pin = "0" * 40
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        commit = "{unknown_pin}"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+    local_skill_file = skills_dir / "demo-skill" / "SKILL.md"
+    local_skill_file.parent.mkdir(parents=True)
+    local_skill_file.write_text("# Local-only version\n")
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SKIPPED_LOCAL_AHEAD]
+    assert local_skill_file.read_text() == "# Local-only version\n"
+    recorded = tomllib.loads(manifest_path.read_text())
+    assert recorded["skills"]["demo-skill"]["commit"] == unknown_pin
+
+
+def test_sync_with_force_overwrites_despite_unknown_pin(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    upstream_commit = _commit_files(upstream_dir, {"SKILL.md": "# Upstream version\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        commit = "{"0" * 40}"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+    local_skill_file = skills_dir / "demo-skill" / "SKILL.md"
+    local_skill_file.parent.mkdir(parents=True)
+    local_skill_file.write_text("# Local-only version\n")
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=True, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SYNCED]
+    assert local_skill_file.read_text() == "# Upstream version\n"
+    recorded = tomllib.loads(manifest_path.read_text())
+    assert recorded["skills"]["demo-skill"]["commit"] == upstream_commit
+
+
+def test_sync_include_limits_copied_entries(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(
+        upstream_dir,
+        {"SKILL.md": "# Skill\n", "README.md": "# Readme\n", "install.sh": "#!/bin/sh\n"},
+    )
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        include = ["SKILL.md"]
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SYNCED]
+    copied_names = sorted(entry.name for entry in (skills_dir / "demo-skill").iterdir())
+    assert copied_names == ["SKILL.md"]
+
+
+def test_sync_removes_local_files_that_upstream_no_longer_has(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(upstream_dir, {"SKILL.md": "# Skill\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+    stale_file = skills_dir / "demo-skill" / "stale.md"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("# No longer upstream\n")
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SYNCED]
+    assert not stale_file.exists()
+    assert (skills_dir / "demo-skill" / "SKILL.md").is_file()
+
+
+def test_sync_reports_up_to_date_without_recopying_files(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    upstream_commit = _commit_files(upstream_dir, {"SKILL.md": "# Skill\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        commit = "{upstream_commit}"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+    local_skill_file = skills_dir / "demo-skill" / "SKILL.md"
+    local_skill_file.parent.mkdir(parents=True)
+    local_skill_file.write_text("# Locally edited\n")
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    # Freshness is judged by the pinned commit alone; a matching pin means no copy happens.
+    assert [result.outcome for result in results] == [SkillSyncOutcome.UP_TO_DATE]
+    assert local_skill_file.read_text() == "# Locally edited\n"
+
+
+def test_check_mode_reports_drift_without_copying(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    old_commit = _commit_files(upstream_dir, {"SKILL.md": "# Version 1\n"})
+    _commit_files(upstream_dir, {"SKILL.md": "# Version 2\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.never-synced-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+
+        [skills.stale-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        commit = "{old_commit}"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+    manifest_before = manifest_path.read_text()
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=True, is_forced=False, only_skill_names=())
+
+    outcome_by_name = {result.skill_name: result.outcome for result in results}
+    assert outcome_by_name == {
+        "never-synced-skill": SkillSyncOutcome.NEVER_SYNCED,
+        "stale-skill": SkillSyncOutcome.OUT_OF_DATE,
+    }
+    assert not skills_dir.exists(), "check mode must not create or copy any files"
+    assert manifest_path.read_text() == manifest_before, "check mode must not update pins"
+
+
+def test_sync_copies_only_the_configured_subdirectory(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(
+        upstream_dir,
+        {
+            ".claude/skills/demo-skill/SKILL.md": "# Nested skill\n",
+            "unrelated.py": "print('vendored-skill-test-2947')\n",
+        },
+    )
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        path = ".claude/skills/demo-skill"
+        """,
+    )
+    skills_dir = tmp_path / "skills"
+
+    results = run_sync(manifest_path, skills_dir, is_check_only=False, is_forced=False, only_skill_names=())
+
+    assert [result.outcome for result in results] == [SkillSyncOutcome.SYNCED]
+    copied_names = sorted(entry.name for entry in (skills_dir / "demo-skill").iterdir())
+    assert copied_names == ["SKILL.md"]
+    assert (skills_dir / "demo-skill" / "SKILL.md").read_text() == "# Nested skill\n"
+
+
+def test_run_sync_raises_on_unknown_skill_filter(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(upstream_dir, {"SKILL.md": "# Skill\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        """,
+    )
+
+    with pytest.raises(VendoredSkillSyncError, match="no-such-skill"):
+        run_sync(
+            manifest_path,
+            tmp_path / "skills",
+            is_check_only=True,
+            is_forced=False,
+            only_skill_names=("no-such-skill",),
+        )
+
+
+def test_load_manifest_raises_on_missing_skills_table(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "vendored_skills.toml"
+    manifest_path.write_text("# empty manifest\n")
+
+    with pytest.raises(VendoredSkillSyncError, match=r"\[skills\.<name>\]"):
+        load_manifest(manifest_path)
+
+
+def test_sync_raises_when_include_entry_is_missing_upstream(tmp_path: Path) -> None:
+    upstream_dir = tmp_path / "upstream"
+    _init_upstream_repo(upstream_dir)
+    _commit_files(upstream_dir, {"SKILL.md": "# Skill\n"})
+
+    manifest_path = tmp_path / "vendored_skills.toml"
+    _write_manifest(
+        manifest_path,
+        f"""\
+        [skills.demo-skill]
+        repo = "{_repo_url(upstream_dir)}"
+        ref = "main"
+        include = ["SKILL.md", "missing-file.md"]
+        """,
+    )
+
+    with pytest.raises(VendoredSkillSyncError, match="missing-file.md"):
+        run_sync(
+            manifest_path,
+            tmp_path / "skills",
+            is_check_only=False,
+            is_forced=False,
+            only_skill_names=(),
+        )


### PR DESCRIPTION
## Summary

- Bundle the `post-pr-to-slack` skill into `.claude/skills/`. The canonical copy lives in `imbue-ai/sculptor` and was generalized (on a companion sculptor branch) to resolve the Slack channel per repo: PRs here announce in #project-minds-internal-product; sculptor PRs keep #project-sculptor-merges.
- Vendor the `crispy-comments` skill from its canonical repo, DanverImbue/crispy-comments (SKILL.md only).
- Add a vendored-skills mechanism: `.claude/vendored_skills.toml` (per-skill upstream repo/ref/path/include + pinned commit) and `scripts/sync_vendored_skills.py` with a `just sync-vendored-skills` recipe. `--check` reports drift without changing files; sync refuses to overwrite a local copy whose pinned commit is not found upstream (pass `--force` to override), which protects the bundled post-pr-to-slack copy until the sculptor-side change merges.

## Companion change

`imbue-ai/sculptor` branch `danver/add-dev-skills` (commit c64c32fc, not yet pushed) generalizes the skill upstream. Until it merges, `just sync-vendored-skills --check` reports post-pr-to-slack as out of date and a plain sync intentionally skips it.

## Testing

- `just test-offload`: 15822 passed, 0 failed
- `just test-quick scripts/sync_vendored_skills_test.py`: 11 passed
- Live verification: `just sync-vendored-skills` vendored crispy-comments from GitHub and recorded its pin; the local-ahead guard correctly skipped post-pr-to-slack; `--check` exercised all drift states (up-to-date / out-of-date / never-synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)