### PR TITLE
Add dev skills: post-pr-to-slack, crispy-comments, address-pr-comments

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: address-pr-comments
+description: Address review comments on a pull request -- apply CLAUDE:/SCULPTOR:-prefixed instructions, and critically evaluate feedback from automated reviewers (Vet, Copilot, or any bot)
+disable-model-invocation: true
+allowed-tools: Bash(gh:*), Bash(git:*), Glob, Grep, Read, Edit, Write
+argument-hint: [pr-number]
+---
+
+# Address PR Comments
+
+Fetch comments from a pull request and act on the ones directed at an agent.
+There are two kinds, and they get different treatment:
+
+1. **Directed instructions** — comments prefixed with `CLAUDE:` or `SCULPTOR:`
+   (case-insensitive). These are a human steering the agent; apply them.
+2. **Automated reviewer feedback** — comments authored by an AI or automated
+   system: Vet, GitHub Copilot, or any bot account. These are suggestions, not
+   instructions; validate them critically before acting.
+
+Plain human discussion with neither prefix nor a bot author is out of scope —
+leave it alone.
+
+## Instructions
+
+1. Fetch the PR's comments via `gh` (see "Fetching comments" below). If a PR
+   number is provided, use it. Otherwise, resolve the current branch's PR with
+   `gh pr view --json number`.
+
+2. Partition the comments (including discussion notes and inline code
+   comments) into the two kinds above, and drop everything else:
+   - **Directed instructions**: body starts with `CLAUDE:` or `SCULPTOR:`
+     (case-insensitive).
+   - **Automated feedback**: the author is an automated system — `.user.type`
+     is `"Bot"`, the login ends in `[bot]` (e.g. `github-actions[bot]`,
+     `copilot-pull-request-reviewer[bot]`), or the author is a known automated
+     reviewer such as Vet. Judge by the author, not the wording.
+
+3. **For each directed instruction:**
+   - Read the referenced file (if it's an inline comment on a specific line)
+   - Understand what change is being requested
+   - Apply the requested change to the local codebase
+
+4. **For each piece of automated feedback, evaluate before applying.**
+   Automated reviewers lack full context: they misfire on intentional
+   patterns, house conventions, and constraints that live outside the diff.
+   Do not follow them blindly:
+   - Verify the claim against the actual code — read the file and enough
+     surrounding context to know whether the issue is real.
+   - Check it against the repo's own rules and conventions (CLAUDE.md, the
+     style guide, existing patterns nearby) and against the goals of this PR.
+   - Then act on your judgment: apply it if it holds up, skip it if it is a
+     false positive or conflicts with the repo's conventions or the PR's
+     intent, and defer to the user if it is a real trade-off you cannot settle
+     from the code alone.
+
+5. **Important restrictions:**
+   - Do NOT push any code
+   - Do NOT reply to the comments on GitHub
+   - Only make local changes
+
+6. **Summarize at the end**, listing every comment you considered and its
+   disposition: applied, skipped (with the reason), or needs a decision from
+   the user.
+
+## Fetching comments
+
+Fetch the PR's comments — both inline review comments and general discussion —
+with `gh`:
+
+- Inline review comments: `gh api --paginate "repos/{owner}/{repo}/pulls/<N>/comments"` — each has `.body`, `.path`, `.line` (or `.original_line`), and `.user` (`.login`, `.type`). `gh` substitutes `{owner}`/`{repo}` for the current repo.
+- General discussion: `gh api --paginate "repos/{owner}/{repo}/issues/<N>/comments"`.
+- PR reviews (top-level review bodies, where some bots put their findings): `gh api --paginate "repos/{owner}/{repo}/pulls/<N>/reviews"`.
+
+**Important:** the comment JSON can be large and may get truncated — save it to
+a temp file first, then parse with `jq` in a **separate** command (not chained
+with `&&`) to avoid shell-parsing issues with the jq expression.
+
+GitHub's REST comments have no resolved flag, so rely on the diff to see what's
+already done.

--- a/.claude/skills/crispy-comments/SKILL.md
+++ b/.claude/skills/crispy-comments/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: crispy-comments
+description: Prune code comments down to what helps future maintainers. Reviews comments on the current branch's diff and removes incidental history, defensive justification, and correctness arguments. Invoke with /crispy-comments.
+---
+
+# Crispy Comments
+
+This skill applies only to the current branch of the current repository. If this is invoked on `main` (or `master`), please confirm with the user whether they intend to run this on the entire repository.
+
+Review the comments added or changed in the diff. For each, ask: does this help future maintainers understand the code, or merely restate what the code plainly does or explain today's bug fix? Remove incidental history, defensive justification, and correctness arguments.
+
+Also remove comments that restate facts from the surrounding code that are likely to change — a count of subclasses, a list of variants, the call sites of a function. These pin the comment to a point in time and rot quickly. Follow DRY: Don't Repeat Yourself.
+
+Remove commented-out code outright — version control already remembers it.
+
+Remove ASCII-art banners and box-drawing section dividers. They add visual noise without conveying anything a plain one-line comment does not.
+
+## Source
+
+Copied from https://github.com/DanverImbue/crispy-comments (the canonical version of this skill). To update, re-copy SKILL.md from there.

--- a/.claude/skills/post-pr-to-slack/SKILL.md
+++ b/.claude/skills/post-pr-to-slack/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: post-pr-to-slack
+description: |
+  Post a one-line PR announcement to #project-minds-internal-product, and mark
+  it :merged: when the PR merges. Use whenever you open or meaningfully adjust
+  a PR in this repo.
+compatibility: |
+  Requires latchkey with a working Slack credential, plus `jq` and `gh`. Run
+  `scripts/slack_pr.sh check` to verify; see the latchkey skill to set it up.
+argument-hint: [pr-number | pr-url] [#channel]
+---
+
+# Post PR to Slack
+
+Announce this repo's pull requests in `#project-minds-internal-product` with a
+single standalone line, then mark each announcement `:merged:` once its PR
+merges. This file covers *when* to post and *what* the message should say; the
+Slack mechanics (channel lookup, posting, reacting) live in
+[`scripts/slack_pr.sh`](scripts/slack_pr.sh).
+
+The skill is agent-agnostic — it depends only on `latchkey`, `jq`, `gh`, and
+`bash`, not on any agent-specific tooling.
+
+## When to run
+
+- **When you open a PR for this repo.** After `gh pr create --base main`
+  succeeds, post to `#project-minds-internal-product`. This is a standing
+  instruction — just post; see [Authorization](#authorization).
+- **When you meaningfully adjust an open PR** — a force-push that changes the
+  approach, a scope change, or a retitle. Reply in the existing thread; don't
+  start a new top-level post. Skip trivial edits (typo fixes, rebases, minor doc
+  tweaks). If unsure, ask the user.
+- **When a PR merges** (you observe it, or the user says so). Add a `:merged:`
+  reaction to the original post. Do *not* post a separate "merged" message — the
+  reaction is the convention.
+
+## Inputs
+
+- **Channel** — `#project-minds-internal-product` for this repo's PRs unless
+  the user says otherwise.
+- **PR URL** — infer from git when not given:
+  - current branch: `gh pr view --json url -q .url`
+  - a specific PR: `gh pr view <number> --json url -q .url`
+- **One-line description** — draft from the PR title/body (see
+  [Drafting](#drafting-the-one-liner)). If the PR already has a crisp one-liner
+  (its title, or a `## Summary` bullet), reuse it verbatim so Slack and the PR
+  stay in lockstep.
+
+> The only PR-host-specific step is fetching the URL with `gh`. On a GitLab repo,
+> swap in `glab mr view --output json | jq -r .web_url`; everything else is the
+> same.
+
+## Setup
+
+Point a variable at the helper script and confirm Slack is reachable, once per
+session:
+
+```bash
+SLACK=.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+"$SLACK" check          # prints "slack ok: team '…' as '…'", or says how to fix auth
+```
+
+If the check fails, run `latchkey services info slack` and follow its setup (a
+browser login if supported, otherwise `latchkey auth set`). The script puts an
+nvm-installed `latchkey` back on `PATH` itself; if `check` still reports it
+missing, install it with `npm install -g latchkey`.
+
+## Steps — initial post
+
+1. **Read recent channel history** to match the house style (terse vs.
+   emoji-led, where the URL goes, capitalization), then **draft the line** per
+   [Drafting](#drafting-the-one-liner):
+
+   ```bash
+   "$SLACK" history '#project-minds-internal-product'
+   ```
+
+2. **Post it** and capture the message timestamp (`ts`). The text is sent
+   verbatim, so include the PR URL — Slack unfurls it into a preview:
+
+   ```bash
+   TEXT="Fix login crash when the token contains a colon  $PR_URL"
+   TS=$("$SLACK" post '#project-minds-internal-product' "$TEXT")
+   echo "posted ts=$TS"
+   ```
+
+   `slack_pr.sh` builds the JSON with `jq`, so backticks, quotes, or `&` in the
+   text are safe.
+
+3. **Report** the channel and `ts` back to the user, and remember the `ts` — the
+   merge-time `:merged:` step needs it.
+
+## Steps — adjusting an open PR
+
+If a post for this PR already exists (use the `ts` you remembered, or find it),
+reply in its thread — don't post a new top-level message for the same PR, which
+splits the discussion:
+
+```bash
+TS=$("$SLACK" find-ts '#project-minds-internal-product' "$PR_URL")
+"$SLACK" reply '#project-minds-internal-product' "$TS" "Revised approach: now …"
+```
+
+## Steps — PR merged
+
+```bash
+TS=$("$SLACK" find-ts '#project-minds-internal-product' "$PR_URL")
+"$SLACK" done '#project-minds-internal-product' "$TS"
+```
+
+`find-ts` matches the bare URL even when Slack has wrapped it in `<…>`. `done` is
+idempotent — an already-present `:merged:` counts as success. Don't post anything
+else; the reaction *is* the "merged" signal.
+
+## Drafting the one-liner
+
+The audience is teammates and future reviewers skimming the channel. The line
+must convey the PR's **one key outcome** and **read standalone** — no thread,
+repo, or commit-history context required. Lead with a verb in the channel's
+imperative style ("Fix X", "Migrate Y", "Speed up Z"). Draft it directly; if
+your harness lets you delegate prose to a smaller/faster model, you may, but
+it's not required.
+
+Check the draft against these guardrails:
+
+- **Outcome, not process.** Describe what the PR achieves in the codebase as it
+  now exists — not the bootstrap, onboarding, or workflow that produced it.
+- **Timeless.** No "follow-up commit does Y", "next we'll…", or "still to come".
+  Frame it as if every commit on the branch has already landed and is the new
+  normal. A channel post is a record, not a roadmap or a per-commit changelog.
+- **One sentence, one outcome.** No parenthetical hedging in a secondary change.
+  If a second change is genuinely co-equal, that's a sign it should be its own PR.
+- **Plain, not hype.** "Improve performance" — not "Massive perf win!" — unless
+  the channel actually talks that way.
+- Ends with the PR URL; no ticket IDs unless the channel uses them.
+
+## Authorization
+
+The `#project-minds-internal-product` post-and-`:merged:` flow is
+**pre-authorized** for this repo's PRs — this skill living in the repo *is* the
+standing instruction. Don't pause to ask "should I post this?" after
+`gh pr create` succeeds; just post. Posting and reacting are still visible to
+others, so **do** ask before any scope expansion: a different channel,
+@-mentioning people, a reaction other than `:merged:`, or posting for a PR in
+some other repo.
+
+## Notes
+
+- **Re-resolve the channel ID each invocation.** Looking up by name tolerates
+  renames; a cached ID can go stale across sessions.
+- **Track the `ts` of your initial post** in conversation memory so the
+  merge-time reaction doesn't have to scan history.
+- **Raw API / fallback.** Every call routes through `latchkey curl` against the
+  Slack Web API; the exact endpoints and payloads are in
+  [`scripts/slack_pr.sh`](scripts/slack_pr.sh) if you ever need to run them by
+  hand.

--- a/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
+++ b/.claude/skills/post-pr-to-slack/scripts/slack_pr.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# slack_pr.sh — Slack helpers for the post-pr-to-slack skill.
+#
+# Every request goes through `latchkey curl`, which injects the Slack
+# credential automatically (see the latchkey skill). JSON bodies are built with
+# jq so message text containing backticks, quotes, or & is escaped correctly.
+#
+# Commands:
+#   check                                verify latchkey + jq + a working Slack credential
+#   channel-id <name>                    print a channel's ID (paginates conversations.list)
+#   history <#name|ID> [limit]           print the text of recent messages (default 10)
+#   post <#name|ID> <text>               post a message; print its ts
+#   reply <#name|ID> <thread_ts> <text>  post a threaded reply; print its ts
+#   find-ts <#name|ID> <substring>       print ts of the latest message containing <substring>
+#   done <#name|ID> <ts>                 add the :merged: reaction (idempotent)
+#
+set -euo pipefail
+
+API="https://slack.com/api"
+
+die() { echo "slack_pr.sh: $*" >&2; exit 1; }
+
+# latchkey is usually an nvm-managed node binary. Non-login shells often don't
+# source nvm, so latchkey (and its node runtime) may be missing from PATH even
+# when installed. Add the install dir back if needed; a no-op when already found.
+if ! command -v latchkey >/dev/null 2>&1; then
+  for d in "$HOME"/.nvm/versions/node/*/bin "$HOME/.local/bin" /usr/local/bin /opt/homebrew/bin; do
+    [ -x "$d/latchkey" ] && { PATH="$d:$PATH"; break; }
+  done
+fi
+command -v latchkey >/dev/null 2>&1 || die "missing dependency: latchkey (npm install -g latchkey; see the latchkey skill)"
+command -v jq       >/dev/null 2>&1 || die "missing dependency: jq"
+
+# Fail loudly unless the JSON on stdin has ok:true; pass it through otherwise.
+check_ok() {
+  local json; json="$(cat)"
+  [ -n "$json" ] || die "empty response from Slack"
+  if [ "$(printf '%s' "$json" | jq -r '.ok')" != "true" ]; then
+    die "Slack API error: $(printf '%s' "$json" | jq -r '.error // "unknown"')"
+  fi
+  printf '%s' "$json"
+}
+
+slack_get()  { latchkey curl -s "$API/$1?${2:-}"; }
+slack_post() {
+  latchkey curl -s -X POST "$API/$1" \
+    -H 'Content-Type: application/json; charset=utf-8' \
+    -d "$2"
+}
+
+# Confirm the Slack credential actually works (read-only identity check).
+cmd_check() {
+  local resp; resp="$(latchkey curl -s -X POST "$API/auth.test")"
+  [ -n "$resp" ] || die "no response from Slack — is latchkey configured? (latchkey services info slack)"
+  if [ "$(printf '%s' "$resp" | jq -r '.ok')" = "true" ]; then
+    echo "slack ok: team '$(printf '%s' "$resp" | jq -r '.team')' as '$(printf '%s' "$resp" | jq -r '.user')'"
+  else
+    die "slack auth failed: $(printf '%s' "$resp" | jq -r '.error // "unknown"') — run: latchkey services info slack"
+  fi
+}
+
+# Resolve a #name (or bare name) to a channel ID, paginating the full list so
+# this tolerates renames and large workspaces (>1000 channels).
+channel_id() {
+  local want="${1#\#}" cursor="" page id
+  [ -n "$want" ] || die "usage: channel-id <name>"
+  while :; do
+    page="$(slack_get conversations.list \
+      "types=public_channel,private_channel&limit=1000&cursor=$cursor" | check_ok)"
+    id="$(printf '%s' "$page" | jq -r --arg n "$want" \
+      '[.channels[] | select(.name == $n) | .id][0] // ""')"
+    [ -n "$id" ] && { printf '%s\n' "$id"; return 0; }
+    cursor="$(printf '%s' "$page" | jq -r '.response_metadata.next_cursor // ""')"
+    [ -n "$cursor" ] || break
+  done
+  die "channel '#$want' not found (wrong name, or you are not a member)"
+}
+
+# A C…/G… argument is already a channel ID; anything else is a name to resolve.
+resolve() { case "$1" in C* | G*) printf '%s\n' "$1" ;; *) channel_id "$1" ;; esac; }
+
+cmd_history() {
+  [ $# -ge 1 ] || die "usage: history <#name|ID> [limit]"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=${2:-10}" | check_ok | jq -r '.messages[].text'
+}
+
+cmd_post() {
+  [ $# -eq 2 ] || die "usage: post <#name|ID> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg t "$2" '{channel: $c, text: $t, unfurl_links: true}')" \
+    | check_ok | jq -r '.ts'
+}
+
+cmd_reply() {
+  [ $# -eq 3 ] || die "usage: reply <#name|ID> <thread_ts> <text>"
+  local ch; ch="$(resolve "$1")"
+  slack_post chat.postMessage \
+    "$(jq -n --arg c "$ch" --arg th "$2" --arg t "$3" '{channel: $c, thread_ts: $th, text: $t}')" \
+    | check_ok | jq -r '.ts'
+}
+
+# Slack auto-links URLs as <url> in stored text, so match on the bare substring.
+cmd_find_ts() {
+  [ $# -eq 2 ] || die "usage: find-ts <#name|ID> <substring>"
+  local ch; ch="$(resolve "$1")"
+  slack_get conversations.history "channel=$ch&limit=200" | check_ok \
+    | jq -r --arg u "$2" '[.messages[] | select(.text | contains($u)) | .ts][0] // ""'
+}
+
+# Idempotent: a pre-existing :merged: (already_reacted) counts as success.
+cmd_done() {
+  [ $# -eq 2 ] || die "usage: done <#name|ID> <ts>"
+  local ch resp ok err
+  ch="$(resolve "$1")"
+  resp="$(slack_post reactions.add \
+    "$(jq -n --arg c "$ch" --arg ts "$2" '{channel: $c, timestamp: $ts, name: "merged"}')")"
+  [ -n "$resp" ] || die "empty response from reactions.add"
+  ok="$(printf '%s' "$resp" | jq -r '.ok')"
+  err="$(printf '%s' "$resp" | jq -r '.error // ""')"
+  [ "$ok" = "true" ] || [ "$err" = "already_reacted" ] || die "reactions.add failed: $err"
+  echo ok
+}
+
+[ $# -ge 1 ] || die "usage: slack_pr.sh <check|channel-id|history|post|reply|find-ts|done> ..."
+cmd="$1"; shift
+case "$cmd" in
+  check)      cmd_check "$@" ;;
+  channel-id) channel_id "$@" ;;
+  history)    cmd_history "$@" ;;
+  post)       cmd_post "$@" ;;
+  reply)      cmd_reply "$@" ;;
+  find-ts)    cmd_find_ts "$@" ;;
+  done)       cmd_done "$@" ;;
+  *)          die "unknown command: $cmd" ;;
+esac

--- a/dev/changelog/danver-add-dev-skills.md
+++ b/dev/changelog/danver-add-dev-skills.md
@@ -1,0 +1,7 @@
+Add three dev skills under `.claude/skills/`:
+
+- `post-pr-to-slack`: announce this repo's PRs in `#project-minds-internal-product` with a one-line message, and mark the announcement `:merged:` when the PR merges.
+
+- `crispy-comments`: prune code comments on the current branch down to what helps future maintainers (copied from its canonical repo, which is noted in the skill).
+
+- `address-pr-comments`: apply `CLAUDE:`/`SCULPTOR:`-prefixed PR comments, and critically evaluate feedback from automated reviewers (Vet, Copilot, or any bot) against the repo's conventions and the PR's goals rather than following it blindly.


### PR DESCRIPTION
## Summary

Three self-contained skills under `.claude/skills/`, added as plain copies (no sync mechanism — a little duplication over a little dependency):

- **post-pr-to-slack** — announce this repo's PRs in #project-minds-internal-product with a one-line message, and add a `:merged:` reaction when the PR merges. Slack mechanics go through latchkey via the bundled `scripts/slack_pr.sh`.
- **crispy-comments** — prune code comments on the current branch down to what helps future maintainers. Copied from its canonical repo (source noted in the skill).
- **address-pr-comments** — apply `CLAUDE:`/`SCULPTOR:`-prefixed PR comments as directed instructions, and critically evaluate feedback from automated reviewers (Vet, Copilot, or any bot): each claim is validated against the code, the repo's conventions, and the PR's goals rather than followed blindly.

## Testing

- `just test-offload`: 15811 passed, 0 failed
- `vet` over the branch diff: no issues
- Changelog gate: green (`dev/changelog/danver-add-dev-skills.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)