### PR TITLE
Add codex harness enablement (codex-V1)

### DIFF
--- a/libs/mngr/imbue/mngr/agents/tui_agent.py
+++ b/libs/mngr/imbue/mngr/agents/tui_agent.py
@@ -26,6 +26,7 @@ from imbue.mngr.agents.tui_utils import SubmissionEvidenceProbe
 from imbue.mngr.agents.tui_utils import is_slash_command_message
 from imbue.mngr.agents.tui_utils import raise_for_unconfirmed_submission
 from imbue.mngr.agents.tui_utils import submit_message_and_confirm
+from imbue.mngr.agents.tui_utils import TUI_READY_TIMEOUT_SECONDS
 from imbue.mngr.agents.tui_utils import wait_for_paste_visible
 from imbue.mngr.agents.tui_utils import wait_for_tui_ready
 from imbue.mngr.hosts.tmux import TmuxWindowTarget
@@ -69,6 +70,17 @@ class InteractiveTuiAgent(SendKeysAgent[AgentConfigT]):
 
     def get_tui_ready_indicator(self) -> str | re.Pattern[str]:
         return self.TUI_READY_INDICATOR
+
+    def get_tui_ready_timeout_seconds(self) -> float:
+        """How long to poll for the TUI ready indicator before a send fails.
+
+        Defaults to the generic ``TUI_READY_TIMEOUT_SECONDS``. Subclasses whose
+        startup legitimately renders the composer late override this upward -- codex,
+        for instance, replays the entire rollout on resume before its header appears,
+        so a long conversation can need well past the 30s default; timing out there
+        turns a slow-but-fine resume into a hard send failure.
+        """
+        return TUI_READY_TIMEOUT_SECONDS
 
     @abstractmethod
     def _build_submission_evidence_probes(
@@ -134,7 +146,12 @@ class InteractiveTuiAgent(SendKeysAgent[AgentConfigT]):
         """
         with self._message_lock(), log_span("Sending message to agent {} (length={})", self.name, len(message)):
             self._preflight_send_message(self.tmux_target)
-            wait_for_tui_ready(self, self.tmux_target, self.get_tui_ready_indicator())
+            wait_for_tui_ready(
+                self,
+                self.tmux_target,
+                self.get_tui_ready_indicator(),
+                timeout_seconds=self.get_tui_ready_timeout_seconds(),
+            )
             self._warn_if_preexisting_input_text(self.tmux_target)
             self._send_tmux_literal_keys(self.tmux_target, message)
             wait_for_paste_visible(self, self.tmux_target, message)
@@ -197,4 +214,9 @@ class InteractiveTuiAgent(SendKeysAgent[AgentConfigT]):
         """
         super().wait_for_ready_signal(is_creating, start_action, timeout)
         if is_creating:
-            wait_for_tui_ready(self, self.tmux_target, self.get_tui_ready_indicator())
+            wait_for_tui_ready(
+                self,
+                self.tmux_target,
+                self.get_tui_ready_indicator(),
+                timeout_seconds=self.get_tui_ready_timeout_seconds(),
+            )

--- a/libs/mngr/imbue/mngr/agents/tui_utils.py
+++ b/libs/mngr/imbue/mngr/agents/tui_utils.py
@@ -37,8 +37,11 @@ from imbue.mngr.utils.polling import poll_until
 
 _SEND_MESSAGE_TIMEOUT_SECONDS: Final[float] = 15.0
 # This can take a while, especially on Modal -- the process needs to actually
-# start and render the TUI before the indicator appears.
-_TUI_READY_TIMEOUT_SECONDS: Final[float] = 30.0
+# start and render the TUI before the indicator appears. Public so an agent whose
+# startup renders the composer late (e.g. codex replays the whole rollout on resume
+# before its header appears) can override the wait upward via
+# ``InteractiveTuiAgent.get_tui_ready_timeout_seconds``.
+TUI_READY_TIMEOUT_SECONDS: Final[float] = 30.0
 # Default confirmation window: how long to poll for durable evidence that the
 # agent accepted the message. Needs to be fairly long: a message sent to a busy
 # codex/antigravity agent leaves no evidence until the prompt is dequeued at
@@ -184,7 +187,7 @@ def wait_for_tui_ready(
     agent: BaseAgent[Any],
     tmux_target: TmuxWindowTarget,
     indicator: str | re.Pattern[str],
-    timeout_seconds: float = _TUI_READY_TIMEOUT_SECONDS,
+    timeout_seconds: float = TUI_READY_TIMEOUT_SECONDS,
 ) -> None:
     """Wait until the TUI is ready by polling the pane for ``indicator``.
 

--- a/libs/mngr_codex/imbue/mngr_codex/codex_config.py
+++ b/libs/mngr_codex/imbue/mngr_codex/codex_config.py
@@ -78,6 +78,14 @@ SESSIONS_RELATIVE_PATH: str = Path(*CODEX_HOME_RELATIVE_PATH, "sessions").as_pos
 _CONFIG_FILENAME: str = "config.toml"
 _AUTH_FILENAME: str = "auth.json"
 _HOOKS_FILENAME: str = "hooks.json"
+# codex reads a global ``AGENTS.md`` from ``CODEX_HOME`` and concatenates it
+# *before* the project-root ``AGENTS.md`` (user/global instructions, then a
+# ``--- project-doc ---`` separator, then the project doc). We use it as codex's
+# private system-prompt channel -- the repo commits codex-only instructions at
+# ``<repo>/.codex/AGENTS.md`` (a path codex never reads) and provisioning copies
+# them here, so they reach codex without polluting the shared project ``AGENTS.md``
+# that every other harness also reads.
+_GLOBAL_INSTRUCTIONS_FILENAME: str = "AGENTS.md"
 # First-run NUX gate: codex skips the personality-migration prompt when this
 # marker file exists (it auto-writes one on a fresh home with no sessions, but
 # seeding it makes the silent-launch behavior explicit and order-independent).
@@ -104,6 +112,16 @@ def get_codex_auth_path(codex_home: Path) -> Path:
 def get_codex_hooks_path(codex_home: Path) -> Path:
     """Return the ``hooks.json`` path under ``codex_home``."""
     return codex_home / _HOOKS_FILENAME
+
+
+def get_codex_global_instructions_path(codex_home: Path) -> Path:
+    """Return codex's global ``AGENTS.md`` (user-scope instructions) path under ``codex_home``."""
+    return codex_home / _GLOBAL_INSTRUCTIONS_FILENAME
+
+
+def get_repo_codex_instructions_path(work_dir: Path) -> Path:
+    """Return the repo-committed codex instruction source at ``<work_dir>/.codex/AGENTS.md``."""
+    return work_dir / ".codex" / _GLOBAL_INSTRUCTIONS_FILENAME
 
 
 def get_codex_personality_migration_path(codex_home: Path) -> Path:
@@ -135,6 +153,14 @@ def get_codex_version_cache_path(codex_home: Path) -> Path:
 # in sync with the literal ``"active"`` that core checks and that the hook
 # scripts touch/remove.
 ACTIVE_MARKER_FILENAME: str = "active"
+
+# Marker file (in ``$MNGR_AGENT_STATE_DIR``) touched on every launch/resume by
+# ``assemble_command``. Its mtime is the boundary the system_interface activity
+# tracker compares transcript timestamps against: a transcript tail older than this
+# belongs to a turn a prior process abandoned mid-flight (e.g. a container restart
+# killed codex mid-tool), so the "Running.../Thinking..." indicator must not treat
+# that stale tail as live work. Mirrors mngr_claude's ``claude_process_started``.
+PROCESS_STARTED_MARKER_FILENAME: str = "codex_process_started"
 
 # Marker file (in ``$MNGR_AGENT_STATE_DIR``) present while codex is blocked on a
 # tool-approval dialog. The ``PermissionRequest`` hook touches it; ``PostToolUse``
@@ -301,6 +327,28 @@ def _tomlkit_to_plain_dict(value: Any) -> dict[str, Any]:
     return converted
 
 
+# Codex's plaintext TUI log -- the source of the ``codex.sse_event`` heartbeat that
+# the system_interface uses to drive the "Thinking..." indicator (codex's lifecycle
+# state is unreliable for that; the sse deltas are the real "generating now" signal).
+# We point ``log_dir`` at a DEDICATED subdir of CODEX_HOME rather than the default
+# ($CODEX_HOME/log), because codex deletes the default log file on every startup
+# (remove_legacy_tui_log_file) -- a custom dir is left alone. The tailer reads
+# ``<codex_home>/<TUI_LOG_DIR_NAME>/<TUI_LOG_FILENAME>``.
+TUI_LOG_DIR_NAME: str = "tui_log"
+TUI_LOG_FILENAME: str = "codex-tui.log"
+_LOG_DIR_KEY: str = "log_dir"
+
+# RUST_LOG for the codex process: the default tracing targets PLUS ``codex_otel=info``,
+# which is what makes codex emit ``codex.sse_event`` delta lines into the TUI log.
+# Setting RUST_LOG replaces codex's fallback wholesale, so the defaults are re-listed.
+RUST_LOG_VALUE: str = "codex_core=info,codex_tui=info,codex_rmcp_client=info,codex_otel=info"
+
+
+def get_codex_tui_log_dir(codex_home: Path) -> Path:
+    """Return the dedicated TUI-log directory under ``codex_home`` (codex's log_dir)."""
+    return codex_home / TUI_LOG_DIR_NAME
+
+
 @pure
 def build_codex_config(
     *,
@@ -310,6 +358,7 @@ def build_codex_config(
     approval_policy: str | None,
     trusted_projects: Sequence[str],
     config_overrides: Mapping[str, Any],
+    log_dir: str | None = None,
 ) -> dict[str, Any]:
     """Build a per-agent ``config.toml`` body (low -> high precedence).
 
@@ -345,6 +394,8 @@ def build_codex_config(
         config["sandbox_mode"] = sandbox_mode
     if approval_policy is not None:
         config["approval_policy"] = approval_policy
+    if log_dir is not None:
+        config[_LOG_DIR_KEY] = log_dir
     config["notice"] = dict(_NOTICE_SUPPRESSORS)
 
     projects: dict[str, Any] = {}

--- a/libs/mngr_codex/imbue/mngr_codex/plugin.py
+++ b/libs/mngr_codex/imbue/mngr_codex/plugin.py
@@ -146,6 +146,7 @@ from imbue.mngr_codex.codex_config import COMMON_TRANSCRIPT_SCRIPT_NAME
 from imbue.mngr_codex.codex_config import MARKER_LOCK_DIRNAME
 from imbue.mngr_codex.codex_config import MARKER_STATE_LIB_SCRIPT_NAME
 from imbue.mngr_codex.codex_config import PERMISSIONS_WAITING_FILENAME
+from imbue.mngr_codex.codex_config import PROCESS_STARTED_MARKER_FILENAME
 from imbue.mngr_codex.codex_config import RAW_TRANSCRIPT_SCRIPT_NAME
 from imbue.mngr_codex.codex_config import ROOT_ACTIVE_FILENAME
 from imbue.mngr_codex.codex_config import ROOT_SESSION_FILENAME
@@ -158,10 +159,14 @@ from imbue.mngr_codex.codex_config import build_codex_config
 from imbue.mngr_codex.codex_config import build_codex_hooks_config
 from imbue.mngr_codex.codex_config import extract_latest_codex_version
 from imbue.mngr_codex.codex_config import get_codex_auth_path
+from imbue.mngr_codex.codex_config import RUST_LOG_VALUE
 from imbue.mngr_codex.codex_config import get_codex_config_path
+from imbue.mngr_codex.codex_config import get_codex_tui_log_dir
+from imbue.mngr_codex.codex_config import get_codex_global_instructions_path
 from imbue.mngr_codex.codex_config import get_codex_home
 from imbue.mngr_codex.codex_config import get_codex_hooks_path
 from imbue.mngr_codex.codex_config import get_codex_personality_migration_path
+from imbue.mngr_codex.codex_config import get_repo_codex_instructions_path
 from imbue.mngr_codex.codex_config import get_codex_version_cache_path
 from imbue.mngr_codex.codex_config import is_codex_update_available
 from imbue.mngr_codex.codex_config import is_project_trusted
@@ -370,6 +375,18 @@ class CodexAgent(
     # (auth is a file), so the header box is a safe indicator: it appears only
     # with the rendered, ready composer.
     TUI_READY_INDICATOR: ClassVar[str] = "/model to change"
+
+    # Codex resume replays the *entire* rollout before the header/composer renders, so
+    # a long conversation's banner can appear well past the generic 30s default. That
+    # is a slow-but-fine resume, not a failure, so we wait longer here -- otherwise the
+    # readiness poll times out and turns the resume into a hard send failure. The
+    # system_interface send endpoint no longer blocks the user on this (it acks after a
+    # short budget and delivers in the background), so a longer wait costs the user
+    # nothing and just makes the eventual delivery reliable.
+    _TUI_READY_TIMEOUT_SECONDS: ClassVar[float] = 90.0
+
+    def get_tui_ready_timeout_seconds(self) -> float:
+        return self._TUI_READY_TIMEOUT_SECONDS
 
     def get_expected_process_name(self) -> str:
         # The codex CLI is a single Rust binary; ps/tmux show the literal name.
@@ -592,7 +609,9 @@ class CodexAgent(
 
         Provisions the auth.json symlink, config.toml (model/sandbox/approval +
         the credential-store pin + the trusted work-dir + notice suppressors +
-        overrides), hooks.json, and the personality-migration NUX-skip marker.
+        overrides), hooks.json, the personality-migration NUX-skip marker, and --
+        when the repo commits one at ``<work_dir>/.codex/AGENTS.md`` -- codex's
+        global ``AGENTS.md`` (its private system-prompt delta).
         ``host.write_text_file`` creates intermediate dirs; codex-owned
         ``sessions/`` is left intact across re-provision.
         """
@@ -607,6 +626,7 @@ class CodexAgent(
             approval_policy=approval_policy,
             trusted_projects=[canonical_work_dir],
             config_overrides=self.agent_config.config_overrides,
+            log_dir=str(get_codex_tui_log_dir(codex_home)),
         )
         config_path = get_codex_config_path(codex_home)
         with log_span("Writing per-agent codex config to {}", config_path):
@@ -615,6 +635,18 @@ class CodexAgent(
         hooks_path = get_codex_hooks_path(codex_home)
         with log_span("Installing codex hooks at {}", hooks_path):
             host.write_text_file(hooks_path, serialize_codex_hooks(build_codex_hooks_config()))
+
+        # Codex's private system-prompt delta: if the repo commits codex-only
+        # instructions at <work_dir>/.codex/AGENTS.md, copy them into
+        # CODEX_HOME/AGENTS.md so codex concatenates them ahead of the shared
+        # project-root AGENTS.md. Absent source -> nothing to inject (never blocks).
+        repo_codex_instructions_path = get_repo_codex_instructions_path(Path(canonical_work_dir))
+        if host.path_exists(repo_codex_instructions_path):
+            global_instructions_path = get_codex_global_instructions_path(codex_home)
+            with log_span("Installing codex global instructions at {}", global_instructions_path):
+                host.write_text_file(
+                    global_instructions_path, host.read_text_file(repo_codex_instructions_path)
+                )
 
         # Empty marker: codex skips the personality-migration prompt when it exists.
         host.write_text_file(get_codex_personality_migration_path(codex_home), "")
@@ -927,9 +959,13 @@ class CodexAgent(
         extra_str = (" " + " ".join(extra_args)) if extra_args else ""
 
         background_cmd = self._build_background_tasks_command()
-        mkdir_cmd = f"mkdir -p {shlex.quote(str(codex_home))}"
+        # Make the TUI-log dir too, so codex's file layer can open the heartbeat log.
+        mkdir_cmd = f"mkdir -p {shlex.quote(str(get_codex_tui_log_dir(codex_home)))}"
         cd_cmd = f"cd {shlex.quote(str(self.work_dir))}"
-        home_prefix = f"env CODEX_HOME={shlex.quote(str(codex_home))}"
+        # RUST_LOG=...,codex_otel=info makes codex write `codex.sse_event` delta lines
+        # into the TUI log (log_dir is set in config.toml); the system_interface tails
+        # those to drive "Thinking...". CODEX_HOME points codex at the per-agent home.
+        home_prefix = f"env CODEX_HOME={shlex.quote(str(codex_home))} RUST_LOG={shlex.quote(RUST_LOG_VALUE)}"
 
         # Resume the root conversation via `codex resume <id>`, shell-evaluated
         # because the stored command is replayed on each restart. `set --` / "$@"
@@ -956,10 +992,16 @@ class CodexAgent(
             f'rm -rf "{state}/{ACTIVE_MARKER_FILENAME}" "{state}/{ROOT_ACTIVE_FILENAME}" '
             f'"{state}/{SUBAGENTS_DIRNAME}" "{state}/{MARKER_LOCK_DIRNAME}" 2>/dev/null || true'
         )
+        # Stamp the process-start boundary on every launch/resume. The system_interface
+        # activity tracker compares transcript timestamps against this marker's mtime to
+        # ignore a tail left over from a turn a prior process abandoned mid-flight (which
+        # would otherwise pin "Running.../Thinking..." forever after a restart). Mirrors
+        # mngr_claude's `claude_process_started`. `|| true` so it can't block the launch.
+        process_started_cmd = f'touch "{state}/{PROCESS_STARTED_MARKER_FILENAME}" 2>/dev/null || true'
 
         return CommandString(
             f"{background_cmd} {mkdir_cmd} && {cd_cmd} "
-            f'&& {{ {reset_marker_cmd}; {resume_prelude}; {codex_invocation} "$@"{extra_str} ; }}'
+            f'&& {{ {reset_marker_cmd}; {process_started_cmd}; {resume_prelude}; {codex_invocation} "$@"{extra_str} ; }}'
         )
 
     def on_after_provisioning(


### PR DESCRIPTION
Cherry-picks the `codex-private-agents-md` branch onto fresh `main` via file selection (main touched none of these 4 files, so wholesale is clean). Companion PR: `default-workspace-template` `codex-V1` (#313).

## What's included
- **`mngr_codex/plugin.py` + `codex_config.py`** — inject the repo `.codex/AGENTS.md` as codex's global instructions; stamp the `codex_process_started` marker on every launch/resume; enable the codex TUI log + sse-event stream (`RUST_LOG` `codex_otel=info`).
  - Note: the TUI log is the raw real-time signal a future *upstream* activity fix would consume. It's enabled here but currently has no consumer on the dwt side (the sse-heartbeat watcher was dropped) — harmless, kept intentionally as the substrate for a higher-fidelity codex activity signal to be built here later.
- **`mngr/agents/tui_agent.py` + `tui_utils.py`** — make the TUI-ready timeout overridable so a cold codex resume (which replays the whole rollout) waits long enough instead of timing out.

## Contract
Pairs with the dwt `codex-V1` branch: shared `.codex/AGENTS.md`, the `codex_process_started` marker, and the `chat_codex` agent type. Land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)