### PR TITLE
Witness the minds authentication corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,6 +256,7 @@
 
 # TMR output directories (reports + test outputs)
 **/tmr_*/
+**/tmr-specs-*_*/
 **/tmr-report/
 
 # Active session marker file (used to detect interrupted sessions)

--- a/apps/minds/changelog/danver-witness-minds-auth-corpus.md
+++ b/apps/minds/changelog/danver-witness-minds-auth-corpus.md
@@ -1,0 +1,4 @@
+Audited the existing minds test suite against the `apps/minds/specs/authentication`
+behavioral-spec corpus and added honest `@pytest.mark.witnesses(...)` markers to the
+tests that already verify each unit. Coverage per `mngr specs matrix --root apps/minds/specs`
+moved from 0 witnessed units to 5 full / 17 partial / 10 none, with no test behavior changed.

--- a/apps/minds/changelog/danver-witness-minds-auth-corpus.md
+++ b/apps/minds/changelog/danver-witness-minds-auth-corpus.md
@@ -5,6 +5,13 @@ moved from 0 witnessed units to 5 full / 17 partial / 10 none, with no test beha
 
 Then hand-wrote three witnessing tests to close the clearest gaps: an end-to-end
 `fresh-code` sign-in flow, a scriptless-fetch test for `prefetch` / `fetch-never-spends`,
-and a session-survives-restart test. Coverage is now 8 full / 17 partial / 7 none (the
-7 remaining are the six `mngr_forward`-implemented bridge units, out of scope for the
-`apps/minds` test tree, plus the time-dependent `expired-token`).
+and a session-survives-restart test.
+
+Finally, hand-generated the rest locally (after the spec-anchored fleet could not run
+in this environment): an `expired-token` HTTP test using a deterministically backdated
+cookie (new `make_backdated_session_cookie` helper in `desktop_client/testing.py`, no
+clock mocking), plus tightening `used-code`, `unknown-code`, `signed-out-home`,
+`already-signed-in`, and `deep-link-prefill` from partial to full witnesses. Coverage is
+now 14 full / 12 partial / 6 none per `mngr specs matrix --root apps/minds/specs`; the 6
+remaining `none` are exactly the six `mngr_forward`-implemented bridge units, out of scope
+for the `apps/minds` test tree.

--- a/apps/minds/changelog/danver-witness-minds-auth-corpus.md
+++ b/apps/minds/changelog/danver-witness-minds-auth-corpus.md
@@ -2,3 +2,9 @@ Audited the existing minds test suite against the `apps/minds/specs/authenticati
 behavioral-spec corpus and added honest `@pytest.mark.witnesses(...)` markers to the
 tests that already verify each unit. Coverage per `mngr specs matrix --root apps/minds/specs`
 moved from 0 witnessed units to 5 full / 17 partial / 10 none, with no test behavior changed.
+
+Then hand-wrote three witnessing tests to close the clearest gaps: an end-to-end
+`fresh-code` sign-in flow, a scriptless-fetch test for `prefetch` / `fetch-never-spends`,
+and a session-survives-restart test. Coverage is now 8 full / 17 partial / 7 none (the
+7 remaining are the six `mngr_forward`-implemented bridge units, out of scope for the
+`apps/minds` test tree, plus the time-dependent `expired-token`).

--- a/apps/minds/imbue/minds/desktop_client/auth_test.py
+++ b/apps/minds/imbue/minds/desktop_client/auth_test.py
@@ -19,6 +19,10 @@ def test_get_signing_key_generates_key_on_first_access(tmp_path: Path) -> None:
     assert len(key.get_secret_value()) > 32
 
 
+@pytest.mark.witnesses(
+    "authentication.signing-key-minted-once",
+    partial="the 'minted once, not re-minted on subsequent need' clause",
+)
 def test_get_signing_key_returns_same_key_on_subsequent_access(tmp_path: Path) -> None:
     store = _make_auth_store(tmp_path)
     key_first = store.get_signing_key()
@@ -26,6 +30,10 @@ def test_get_signing_key_returns_same_key_on_subsequent_access(tmp_path: Path) -
     assert key_first.get_secret_value() == key_second.get_secret_value()
 
 
+@pytest.mark.witnesses(
+    "authentication.signing-key-minted-once",
+    partial="the 'stable identity lets valid sessions keep working across restarts' clause; the key persists across store instances",
+)
 def test_get_signing_key_persists_across_instances(tmp_path: Path) -> None:
     auth_dir = tmp_path / "auth"
     store_a = FileAuthStore(data_directory=auth_dir)
@@ -37,6 +45,10 @@ def test_get_signing_key_persists_across_instances(tmp_path: Path) -> None:
     assert key_a.get_secret_value() == key_b.get_secret_value()
 
 
+@pytest.mark.witnesses(
+    "authentication.signing-key-minted-once",
+    partial="the 'concurrent first uses agree on a single identity' clause (one interleaving of 32 threads)",
+)
 def test_get_signing_key_is_consistent_under_concurrent_first_access(tmp_path: Path) -> None:
     """Concurrent first-time callers must all converge on a single signing key.
 
@@ -68,6 +80,10 @@ def test_get_signing_key_is_consistent_under_concurrent_first_access(tmp_path: P
     assert keys == {on_disk_key}, "in-memory signing key diverged from the persisted one"
 
 
+@pytest.mark.witnesses(
+    "authentication.signing-key-minted-once",
+    partial="the 'corrupted (empty) identity is a hard failure, never silently re-minted' clause, at the get_signing_key boundary rather than app startup",
+)
 def test_get_signing_key_raises_for_empty_key_file(tmp_path: Path) -> None:
     auth_dir = tmp_path / "auth"
     auth_dir.mkdir(parents=True)
@@ -88,6 +104,10 @@ def test_add_and_validate_one_time_code(tmp_path: Path) -> None:
     assert is_valid is True
 
 
+@pytest.mark.witnesses(
+    "authentication.unknown-code",
+    partial="unit-level: the store rejects an unknown code; not the HTTP refusal, explanation text, or absence of a session",
+)
 def test_validate_rejects_unknown_code(tmp_path: Path) -> None:
     store = _make_auth_store(tmp_path)
 
@@ -97,6 +117,14 @@ def test_validate_rejects_unknown_code(tmp_path: Path) -> None:
     assert is_valid is False
 
 
+@pytest.mark.witnesses(
+    "authentication.used-code",
+    partial="unit-level: the store rejects a spent code; not the HTTP refusal, explanation text, or absence of a session",
+)
+@pytest.mark.witnesses(
+    "authentication.single-use-codes",
+    partial="unit-level: sequential reuse rejected at the store; not concurrent interleavings",
+)
 def test_validate_rejects_already_used_code(tmp_path: Path) -> None:
     store = _make_auth_store(tmp_path)
     code = OneTimeCode("single-use-code-19283")
@@ -141,6 +169,10 @@ def test_get_signing_key_reads_existing_key(tmp_path: Path) -> None:
     assert key.get_secret_value() == "my-custom-key-82734"
 
 
+@pytest.mark.witnesses(
+    "authentication.signing-key-minted-once",
+    partial="the 'unreadable identity is a hard failure, never silently re-minted' clause, at the get_signing_key boundary rather than app startup",
+)
 def test_get_signing_key_raises_on_read_error(tmp_path: Path) -> None:
     """If an existing signing key file is not readable, SigningKeyError is raised."""
     auth_dir = tmp_path / "auth"

--- a/apps/minds/imbue/minds/desktop_client/cookie_manager_test.py
+++ b/apps/minds/imbue/minds/desktop_client/cookie_manager_test.py
@@ -3,6 +3,7 @@ import pytest
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
+from imbue.minds.desktop_client.testing import make_backdated_session_cookie
 from imbue.minds.primitives import CookieSigningKey
 
 
@@ -65,3 +66,17 @@ def test_verify_session_cookie_returns_false_for_empty_value() -> None:
         signing_key=key,
     )
     assert result is False
+
+
+@pytest.mark.witnesses(
+    "authentication.sessions-unforgeable",
+    partial="unit-level: the 'tokens older than 30 days are invalid' clause via the predicate, not at the HTTP surface",
+)
+def test_verify_session_cookie_rejects_a_token_older_than_the_max_age() -> None:
+    key = CookieSigningKey("test-key-expiry-40192")
+    # A just-minted cookie from the same construction verifies, isolating age as
+    # the reason the backdated one below is rejected.
+    assert verify_session_cookie(cookie_value=make_backdated_session_cookie(key, age_seconds=0), signing_key=key) is True
+
+    expired = make_backdated_session_cookie(key, age_seconds=31 * 24 * 60 * 60)
+    assert verify_session_cookie(cookie_value=expired, signing_key=key) is False

--- a/apps/minds/imbue/minds/desktop_client/cookie_manager_test.py
+++ b/apps/minds/imbue/minds/desktop_client/cookie_manager_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
@@ -8,6 +10,10 @@ def test_session_cookie_name_is_stable() -> None:
     assert SESSION_COOKIE_NAME == "minds_session"
 
 
+@pytest.mark.witnesses(
+    "authentication.sessions-unforgeable",
+    partial="unit-level positive case of 'only tokens issued by this installation are accepted'; not the HTTP surface",
+)
 def test_create_and_verify_session_cookie_round_trip() -> None:
     key = CookieSigningKey("test-secret-key-83742")
 
@@ -17,6 +23,14 @@ def test_create_and_verify_session_cookie_round_trip() -> None:
     assert is_valid is True
 
 
+@pytest.mark.witnesses(
+    "authentication.foreign-token",
+    partial="unit-level: verification under a different key fails; does not use two data directories or exercise the HTTP signed-out treatment",
+)
+@pytest.mark.witnesses(
+    "authentication.sessions-unforgeable",
+    partial="unit-level: the 'tokens from another installation are invalid' clause via the predicate, not at the HTTP surface",
+)
 def test_verify_session_cookie_returns_false_for_wrong_key() -> None:
     correct_key = CookieSigningKey("correct-key-19283")
     wrong_key = CookieSigningKey("wrong-key-84729")
@@ -27,6 +41,14 @@ def test_verify_session_cookie_returns_false_for_wrong_key() -> None:
     assert result is False
 
 
+@pytest.mark.witnesses(
+    "authentication.tampered-token",
+    partial="unit-level: the cookie predicate rejects a non-verifiable value (garbage, not a mutated valid token); not the HTTP signed-out treatment",
+)
+@pytest.mark.witnesses(
+    "authentication.sessions-unforgeable",
+    partial="unit-level: the 'any alteration invalidates' clause via the predicate, not at the HTTP surface",
+)
 def test_verify_session_cookie_returns_false_for_tampered_value() -> None:
     key = CookieSigningKey("test-key-38472")
     result = verify_session_cookie(

--- a/apps/minds/imbue/minds/desktop_client/responses_test.py
+++ b/apps/minds/imbue/minds/desktop_client/responses_test.py
@@ -3,6 +3,10 @@ import pytest
 from imbue.minds.desktop_client.responses import safe_local_redirect_path
 
 
+@pytest.mark.witnesses(
+    "authentication.no-open-redirects",
+    partial="unit-level positive direction of the shared root-relative guard (root-relative paths are honored); the goto-bridge next param uses a separate guard in mngr_forward",
+)
 @pytest.mark.parametrize(
     "raw",
     [
@@ -16,6 +20,10 @@ def test_safe_local_redirect_path_accepts_same_origin_paths(raw: str) -> None:
     assert safe_local_redirect_path(raw) == raw
 
 
+@pytest.mark.witnesses(
+    "authentication.no-open-redirects",
+    partial="unit-level: the shared root-relative guard rejects protocol-relative, backslash, scheme, host, and non-root forms; the goto-bridge next param uses a separate guard in mngr_forward",
+)
 @pytest.mark.parametrize(
     "raw",
     [

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -5,6 +5,7 @@ import threading
 from pathlib import Path
 
 import httpx
+import pytest
 from flask import Request
 from flask import Response
 from flask.testing import FlaskClient
@@ -126,6 +127,10 @@ def _authenticate_client(
     client.set_cookie(SESSION_COOKIE_NAME, cookie_value)
 
 
+@pytest.mark.witnesses(
+    "authentication.signed-out-home",
+    partial="asserts a sign-in prompt is served; not the 'login URL printed in the terminal' text nor that the page reveals nothing about existing workspaces",
+)
 def test_landing_page_shows_login_when_unauthenticated(tmp_path: Path) -> None:
     client, _, _ = _setup_test_server(tmp_path)
 
@@ -151,6 +156,7 @@ def test_login_redirects_to_authenticate_via_js(tmp_path: Path) -> None:
     assert "/authenticate" in response.text
 
 
+@pytest.mark.witnesses("authentication.missing-code", partial="only the /login path of the outline")
 def test_login_without_one_time_code_returns_422(tmp_path: Path) -> None:
     """A missing one_time_code is a 422 (matching FastAPI's required-query-param
     rejection), not a 500."""
@@ -159,6 +165,7 @@ def test_login_without_one_time_code_returns_422(tmp_path: Path) -> None:
     assert response.status_code == 422
 
 
+@pytest.mark.witnesses("authentication.missing-code", partial="only the /authenticate path of the outline")
 def test_authenticate_without_one_time_code_returns_422(tmp_path: Path) -> None:
     """A missing one_time_code is a 422, not a 500."""
     client, _, _ = _setup_test_server(tmp_path)
@@ -166,6 +173,10 @@ def test_authenticate_without_one_time_code_returns_422(tmp_path: Path) -> None:
     assert response.status_code == 422
 
 
+@pytest.mark.witnesses(
+    "authentication.fresh-code",
+    partial="drives /authenticate directly rather than opening the login URL; asserts a session cookie is set but not the landing target or that the code is now spent",
+)
 def test_authenticate_with_valid_code_sets_cookie_and_redirects(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     code = OneTimeCode("auth-code-{}".format(AgentId()))
@@ -181,6 +192,10 @@ def test_authenticate_with_valid_code_sets_cookie_and_redirects(tmp_path: Path) 
     assert any(SESSION_COOKIE_NAME in header for header in response.headers.getlist("Set-Cookie"))
 
 
+@pytest.mark.witnesses(
+    "authentication.fresh-code",
+    partial="asserts only the 307 redirect to /; not that a session is established or the code is now spent",
+)
 def test_authenticate_redirects_to_landing_page(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     code = OneTimeCode("auth-code-{}".format(AgentId()))
@@ -196,6 +211,10 @@ def test_authenticate_redirects_to_landing_page(tmp_path: Path) -> None:
     assert response.headers["location"] == "/"
 
 
+@pytest.mark.witnesses(
+    "authentication.unknown-code",
+    partial="asserts the refusal and explanation text; does not assert that no session cookie is set on the refusal",
+)
 def test_authenticate_with_invalid_code_returns_403(tmp_path: Path) -> None:
     client, _, _ = _setup_test_server(tmp_path)
 
@@ -209,6 +228,14 @@ def test_authenticate_with_invalid_code_returns_403(tmp_path: Path) -> None:
     assert "invalid or has already been used" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.used-code",
+    partial="asserts the reused code is refused (403); not the explanation text or that no session cookie is set",
+)
+@pytest.mark.witnesses(
+    "authentication.single-use-codes",
+    partial="only the sequential reuse case at the HTTP boundary; not concurrent interleavings",
+)
 def test_authenticate_code_cannot_be_reused(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     code = OneTimeCode("once-only-{}".format(AgentId()))
@@ -242,6 +269,7 @@ def test_landing_page_lists_single_agent(tmp_path: Path) -> None:
 # -- Post-login redirect tests --
 
 
+@pytest.mark.witnesses("authentication.default-destination", partial="only the no-workspaces example row")
 def test_post_login_redirects_to_create_when_no_workspaces(tmp_path: Path) -> None:
     """A just-signed-in user with no workspaces lands on the create screen (/)."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -255,6 +283,7 @@ def test_post_login_redirects_to_create_when_no_workspaces(tmp_path: Path) -> No
     assert response.headers["location"] == "/"
 
 
+@pytest.mark.witnesses("authentication.default-destination", partial="only the has-workspaces (account-management) example row")
 def test_post_login_redirects_to_accounts_when_workspaces_exist(tmp_path: Path) -> None:
     """A returning user who already has workspaces lands on the accounts page."""
     agent_id = AgentId()
@@ -271,6 +300,7 @@ def test_post_login_redirects_to_accounts_when_workspaces_exist(tmp_path: Path) 
     assert response.headers["location"] == "/accounts"
 
 
+@pytest.mark.witnesses("authentication.signed-out-arrival")
 def test_post_login_redirects_to_login_when_unauthenticated(tmp_path: Path) -> None:
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
     client, _auth_store = _create_test_desktop_client(
@@ -282,6 +312,7 @@ def test_post_login_redirects_to_login_when_unauthenticated(tmp_path: Path) -> N
     assert response.headers["location"] == "/login"
 
 
+@pytest.mark.witnesses("authentication.safe-return-to")
 def test_post_login_honors_safe_return_to(tmp_path: Path) -> None:
     """A ``return_to`` (e.g. /create, from the remote-preset sign-in flow) wins."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -295,6 +326,10 @@ def test_post_login_honors_safe_return_to(tmp_path: Path) -> None:
     assert response.headers["location"] == "/create"
 
 
+@pytest.mark.witnesses(
+    "authentication.no-open-redirects",
+    partial="only the /post-login return_to with an absolute https URL; not protocol-relative forms or the goto-bridge next param",
+)
 def test_post_login_ignores_unsafe_return_to(tmp_path: Path) -> None:
     """An off-origin ``return_to`` is ignored and the default destination is used."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -374,6 +409,10 @@ def _setup_test_server_without_backend(
     return client, auth_store, agent_id
 
 
+@pytest.mark.witnesses(
+    "authentication.already-signed-in",
+    partial="asserts the redirect to /; does not assert that the fresh code remains unspent afterward",
+)
 def test_login_redirects_if_already_authenticated(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     _authenticate_client(client=client, auth_store=auth_store)
@@ -418,6 +457,7 @@ def test_mngr_cli_resolver_landing_page_lists_single_discovered_agent(tmp_path: 
     assert str(agent_id) in response.text
 
 
+@pytest.mark.witnesses("authentication.discovering")
 def test_landing_page_shows_discovering_when_initial_discovery_not_done(tmp_path: Path) -> None:
     """Before initial discovery completes, show discovering state with auto-refresh."""
     backend_resolver = MngrCliBackendResolver()
@@ -434,6 +474,7 @@ def test_landing_page_shows_discovering_when_initial_discovery_not_done(tmp_path
     assert "reload" in response.text
 
 
+@pytest.mark.witnesses("authentication.empty-shows-create-form")
 def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path: Path) -> None:
     """After discovery completes with no agents, show the create form."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -450,6 +491,10 @@ def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path
     assert "git_url" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.deep-link-prefill",
+    partial="asserts git_url prefill only; not branch prefill and not that the advanced fields open",
+)
 def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:
     """The create form pre-fills the git URL from a query parameter."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -482,6 +527,7 @@ def test_create_page_shows_form(tmp_path: Path) -> None:
     assert 'data-preset="local"' in response.text
 
 
+@pytest.mark.witnesses("authentication.lists-workspaces")
 def test_landing_page_lists_agents_when_multiple_known(tmp_path: Path) -> None:
     """When authenticated and multiple agents are known, the landing page lists them all."""
     agent_id_1 = AgentId()
@@ -655,6 +701,10 @@ def test_landing_page_shows_create_link_when_multiple_agents_known(tmp_path: Pat
     assert "/create" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.no-data-without-session",
+    partial="only the /create surface returns 403 without a session; the invariant is quantified over every user-data route",
+)
 def test_create_page_rejects_unauthenticated(tmp_path: Path) -> None:
     """GET /create returns 403 without authentication."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
@@ -795,6 +845,10 @@ def test_chrome_overlay_page_renders(tmp_path: Path) -> None:
     assert "/_static/overlay.js" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.no-data-without-session",
+    partial="only the /_chrome/events SSE surface (auth_required event, no workspace data); the invariant is quantified over every user-data route",
+)
 def test_chrome_events_sse_returns_auth_required_when_unauthenticated(tmp_path: Path) -> None:
     """The /_chrome/events SSE endpoint returns auth_required for unauthenticated users."""
     client, _, _ = _setup_test_server(tmp_path)
@@ -1199,6 +1253,10 @@ def test_inbox_close_button_has_tooltip(tmp_path: Path) -> None:
     assert "/_static/tooltip_triggers.js" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.no-open-redirects",
+    partial="only the account sign-in page (/auth/signup) return_to render side; not the /post-login return_to or the goto-bridge next param",
+)
 def test_auth_page_ignores_unsafe_return_to(tmp_path: Path) -> None:
     """An off-origin return_to is dropped: no back link to it, no explainer."""
     client = _create_test_client_with_auth_routes(tmp_path)
@@ -1209,6 +1267,10 @@ def test_auth_page_ignores_unsafe_return_to(tmp_path: Path) -> None:
     assert "run your workspace on Imbue Cloud" not in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.no-data-without-session",
+    partial="only the /accounts surface returns 403 without a session; the invariant is quantified over every user-data route",
+)
 def test_accounts_page_requires_auth(tmp_path: Path) -> None:
     """The /accounts page requires authentication."""
     client, _ = _create_test_client_with_stores(tmp_path)
@@ -1643,6 +1705,10 @@ def test_landing_shows_login_not_consent_when_unauthenticated(tmp_path: Path) ->
     assert "Login" in response.text
 
 
+@pytest.mark.witnesses(
+    "authentication.consent-gate",
+    partial="asserts the consent screen shows right after sign-in; the 'never shown again after answering' half is witnessed by test_consent_submit_records_choices_and_unblocks_landing",
+)
 def test_landing_shows_consent_screen_after_login_when_unanswered(tmp_path: Path) -> None:
     """Once authenticated, "/" shows the consent screen until it is answered."""
     client, auth_store = _create_test_client_with_stores(tmp_path)
@@ -1690,6 +1756,10 @@ def test_consent_submit_requires_auth(tmp_path: Path) -> None:
     assert MindsConfig(data_dir=tmp_path).get_error_reporting_consent_given() is False
 
 
+@pytest.mark.witnesses(
+    "authentication.consent-first",
+    partial="only the no-return-destination case; does not assert the with-a-return-destination case or that the consent screen renders at /",
+)
 def test_post_login_routes_to_landing_while_consent_unanswered(tmp_path: Path) -> None:
     """While consent is unanswered, post-login routes to "/" (which shows consent), not /accounts."""
     cli = make_fake_imbue_cloud_cli()
@@ -1701,6 +1771,10 @@ def test_post_login_routes_to_landing_while_consent_unanswered(tmp_path: Path) -
     assert response.headers["location"] == "/"
 
 
+@pytest.mark.witnesses(
+    "authentication.consent-gate",
+    partial="asserts the consent screen no longer shows after it is answered; the 'shown right after sign-in' half is witnessed by test_landing_shows_consent_screen_after_login_when_unanswered",
+)
 def test_consent_submit_records_choices_and_unblocks_landing(tmp_path: Path) -> None:
     client, auth_store = _create_test_client_with_stores(tmp_path)
     _authenticate_client(client, auth_store)

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -173,10 +173,6 @@ def test_authenticate_without_one_time_code_returns_422(tmp_path: Path) -> None:
     assert response.status_code == 422
 
 
-@pytest.mark.witnesses(
-    "authentication.fresh-code",
-    partial="drives /authenticate directly rather than opening the login URL; asserts a session cookie is set but not the landing target or that the code is now spent",
-)
 def test_authenticate_with_valid_code_sets_cookie_and_redirects(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     code = OneTimeCode("auth-code-{}".format(AgentId()))
@@ -192,10 +188,6 @@ def test_authenticate_with_valid_code_sets_cookie_and_redirects(tmp_path: Path) 
     assert any(SESSION_COOKIE_NAME in header for header in response.headers.getlist("Set-Cookie"))
 
 
-@pytest.mark.witnesses(
-    "authentication.fresh-code",
-    partial="asserts only the 307 redirect to /; not that a session is established or the code is now spent",
-)
 def test_authenticate_redirects_to_landing_page(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     code = OneTimeCode("auth-code-{}".format(AgentId()))
@@ -254,6 +246,94 @@ def test_authenticate_code_cannot_be_reused(tmp_path: Path) -> None:
         follow_redirects=False,
     )
     assert second_response.status_code == 403
+
+
+@pytest.mark.witnesses("authentication.fresh-code")
+def test_opening_a_fresh_login_url_signs_in_lands_home_and_spends_the_code(tmp_path: Path) -> None:
+    """End-to-end witness for the fresh-code flow: open the login URL, land on
+    "/", be signed in, and leave the code spent."""
+    client, auth_store, agent_id = _setup_test_server(tmp_path)
+    code = OneTimeCode("fresh-code-{}".format(AgentId()))
+    auth_store.add_one_time_code(code=code)
+
+    # Opening the login URL renders the inert JS redirect to /authenticate.
+    login_response = client.get("/login", query_string={"one_time_code": str(code)}, follow_redirects=False)
+    assert login_response.status_code == 200
+    assert "/authenticate" in login_response.text
+
+    # The browser follows the script to /authenticate, which establishes the
+    # session and redirects to the home page "/".
+    authenticate_response = client.get(
+        "/authenticate", query_string={"one_time_code": str(code)}, follow_redirects=False
+    )
+    assert authenticate_response.status_code == 307
+    assert authenticate_response.headers["location"] == "/"
+    assert any(SESSION_COOKIE_NAME in header for header in authenticate_response.headers.getlist("Set-Cookie"))
+
+    # The now-authenticated session (the client jar carries the Set-Cookie)
+    # reaches signed-in content: the user's workspace is listed.
+    landing_response = client.get("/")
+    assert landing_response.status_code == 200
+    assert str(agent_id) in landing_response.text
+
+    # The one-time code is now spent: presenting it again is refused.
+    replay_response = client.get("/authenticate", query_string={"one_time_code": str(code)}, follow_redirects=False)
+    assert replay_response.status_code == 403
+
+
+@pytest.mark.witnesses("authentication.prefetch")
+@pytest.mark.witnesses(
+    "authentication.fetch-never-spends",
+    partial="witnesses that a scriptless fetch of the printed login URL leaves the code spendable; not exhaustive over every URL the system hands out",
+)
+def test_scriptless_fetch_of_login_url_does_not_spend_the_code(tmp_path: Path) -> None:
+    """A preloader/unfurler that fetches the login URL without executing its
+    script must not consume the code; the user can still sign in afterward."""
+    client, auth_store, _ = _setup_test_server(tmp_path)
+    code = OneTimeCode("prefetch-code-{}".format(AgentId()))
+    auth_store.add_one_time_code(code=code)
+
+    # A scriptless fetch of the login URL returns the inert JS-redirect page and
+    # establishes no session -- it must not spend the code.
+    prefetch_response = client.get("/login", query_string={"one_time_code": str(code)}, follow_redirects=False)
+    assert prefetch_response.status_code == 200
+    assert not any(SESSION_COOKIE_NAME in header for header in prefetch_response.headers.getlist("Set-Cookie"))
+
+    # The code is still spendable: opening it in a real browser (running the
+    # script -> /authenticate) still signs the user in.
+    authenticate_response = client.get(
+        "/authenticate", query_string={"one_time_code": str(code)}, follow_redirects=False
+    )
+    assert authenticate_response.status_code == 307
+    assert any(SESSION_COOKIE_NAME in header for header in authenticate_response.headers.getlist("Set-Cookie"))
+
+
+@pytest.mark.witnesses("authentication.survives-restart")
+def test_session_survives_a_desktop_client_restart(tmp_path: Path) -> None:
+    """A session cookie minted before a restart still authenticates against a
+    fresh app instance on the same data directory, needing no new login code."""
+    auth_dir = tmp_path / "auth"
+    agent_id = AgentId()
+    resolver = StaticBackendResolver(url_by_agent_and_service={str(agent_id): {"web": "http://test-backend"}})
+
+    # First run: mint a session cookie and confirm it reaches signed-in content.
+    auth_store_before = FileAuthStore(data_directory=auth_dir)
+    app_before = create_desktop_client(auth_store=auth_store_before, backend_resolver=resolver, http_client=None)
+    cookie_value = create_session_cookie(signing_key=auth_store_before.get_signing_key())
+    client_before = app_before.test_client()
+    client_before.set_cookie(SESSION_COOKIE_NAME, cookie_value)
+    assert str(agent_id) in client_before.get("/").text
+
+    # Restart: a brand-new app instance on the same data directory. The user
+    # reloads the home page carrying the same cookie -- no new login code.
+    auth_store_after = FileAuthStore(data_directory=auth_dir)
+    app_after = create_desktop_client(auth_store=auth_store_after, backend_resolver=resolver, http_client=None)
+    client_after = app_after.test_client()
+    client_after.set_cookie(SESSION_COOKIE_NAME, cookie_value)
+
+    response = client_after.get("/")
+    assert response.status_code == 200
+    assert str(agent_id) in response.text
 
 
 def test_landing_page_lists_single_agent(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -35,7 +35,6 @@ from imbue.minds.desktop_client.conftest import make_session_store_for_test
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
 from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
-from imbue.minds.desktop_client.testing import make_backdated_session_cookie
 from imbue.minds.desktop_client.dek_store import bundle_mirror_path
 from imbue.minds.desktop_client.dek_store import is_account_unlocked
 from imbue.minds.desktop_client.dek_store import set_master_password_for_account
@@ -58,6 +57,7 @@ from imbue.minds.desktop_client.responses import make_response
 from imbue.minds.desktop_client.state import get_state
 from imbue.minds.desktop_client.system_interface_health import AgentHealth
 from imbue.minds.desktop_client.system_interface_health import SystemInterfaceHealthTracker
+from imbue.minds.desktop_client.testing import make_backdated_session_cookie
 from imbue.minds.desktop_client.workspace_record_store import ReplicaRecord
 from imbue.minds.primitives import CreationId
 from imbue.minds.primitives import OneTimeCode

--- a/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
+++ b/apps/minds/imbue/minds/desktop_client/test_desktop_client.py
@@ -34,6 +34,8 @@ from imbue.minds.desktop_client.conftest import make_service_log
 from imbue.minds.desktop_client.conftest import make_session_store_for_test
 from imbue.minds.desktop_client.cookie_manager import SESSION_COOKIE_NAME
 from imbue.minds.desktop_client.cookie_manager import create_session_cookie
+from imbue.minds.desktop_client.cookie_manager import verify_session_cookie
+from imbue.minds.desktop_client.testing import make_backdated_session_cookie
 from imbue.minds.desktop_client.dek_store import bundle_mirror_path
 from imbue.minds.desktop_client.dek_store import is_account_unlocked
 from imbue.minds.desktop_client.dek_store import set_master_password_for_account
@@ -127,17 +129,18 @@ def _authenticate_client(
     client.set_cookie(SESSION_COOKIE_NAME, cookie_value)
 
 
-@pytest.mark.witnesses(
-    "authentication.signed-out-home",
-    partial="asserts a sign-in prompt is served; not the 'login URL printed in the terminal' text nor that the page reveals nothing about existing workspaces",
-)
+@pytest.mark.witnesses("authentication.signed-out-home")
 def test_landing_page_shows_login_when_unauthenticated(tmp_path: Path) -> None:
-    client, _, _ = _setup_test_server(tmp_path)
+    client, _, agent_id = _setup_test_server(tmp_path)
 
     response = client.get("/")
 
     assert response.status_code == 200
+    # A sign-in prompt directing the user to the login URL printed in the terminal...
     assert "Login" in response.text
+    assert "login url" in response.text.lower()
+    # ...that reveals nothing about the workspace the resolver already knows.
+    assert str(agent_id) not in response.text
 
 
 def test_login_redirects_to_authenticate_via_js(tmp_path: Path) -> None:
@@ -203,10 +206,7 @@ def test_authenticate_redirects_to_landing_page(tmp_path: Path) -> None:
     assert response.headers["location"] == "/"
 
 
-@pytest.mark.witnesses(
-    "authentication.unknown-code",
-    partial="asserts the refusal and explanation text; does not assert that no session cookie is set on the refusal",
-)
+@pytest.mark.witnesses("authentication.unknown-code")
 def test_authenticate_with_invalid_code_returns_403(tmp_path: Path) -> None:
     client, _, _ = _setup_test_server(tmp_path)
 
@@ -218,12 +218,11 @@ def test_authenticate_with_invalid_code_returns_403(tmp_path: Path) -> None:
 
     assert response.status_code == 403
     assert "invalid or has already been used" in response.text
+    # No session is established on the refusal.
+    assert not any(SESSION_COOKIE_NAME in header for header in response.headers.getlist("Set-Cookie"))
 
 
-@pytest.mark.witnesses(
-    "authentication.used-code",
-    partial="asserts the reused code is refused (403); not the explanation text or that no session cookie is set",
-)
+@pytest.mark.witnesses("authentication.used-code")
 @pytest.mark.witnesses(
     "authentication.single-use-codes",
     partial="only the sequential reuse case at the HTTP boundary; not concurrent interleavings",
@@ -246,6 +245,9 @@ def test_authenticate_code_cannot_be_reused(tmp_path: Path) -> None:
         follow_redirects=False,
     )
     assert second_response.status_code == 403
+    assert "invalid or has already been used" in second_response.text
+    # No session is established when the spent code is presented again.
+    assert not any(SESSION_COOKIE_NAME in header for header in second_response.headers.getlist("Set-Cookie"))
 
 
 @pytest.mark.witnesses("authentication.fresh-code")
@@ -334,6 +336,33 @@ def test_session_survives_a_desktop_client_restart(tmp_path: Path) -> None:
     response = client_after.get("/")
     assert response.status_code == 200
     assert str(agent_id) in response.text
+
+
+@pytest.mark.witnesses("authentication.expired-token")
+def test_expired_session_token_is_treated_as_signed_out(tmp_path: Path) -> None:
+    """A session token older than the 30-day max age is treated as signed out."""
+    client, auth_store, agent_id = _setup_test_server(tmp_path)
+    signing_key = auth_store.get_signing_key()
+
+    # Sanity: a just-minted cookie from the same construction verifies, so the
+    # rejection below is due to age, not a salt/payload mismatch with production.
+    assert (
+        verify_session_cookie(
+            cookie_value=make_backdated_session_cookie(signing_key, age_seconds=0), signing_key=signing_key
+        )
+        is True
+    )
+
+    # A cookie whose signature is 31 days old exceeds the 30-day max age.
+    expired_cookie = make_backdated_session_cookie(signing_key, age_seconds=31 * 24 * 60 * 60)
+    client.set_cookie(SESSION_COOKIE_NAME, expired_cookie)
+
+    response = client.get("/")
+    # The bearer is treated as signed out: the sign-in prompt is served and no
+    # workspace is revealed.
+    assert response.status_code == 200
+    assert "Login" in response.text
+    assert str(agent_id) not in response.text
 
 
 def test_landing_page_lists_single_agent(tmp_path: Path) -> None:
@@ -489,10 +518,7 @@ def _setup_test_server_without_backend(
     return client, auth_store, agent_id
 
 
-@pytest.mark.witnesses(
-    "authentication.already-signed-in",
-    partial="asserts the redirect to /; does not assert that the fresh code remains unspent afterward",
-)
+@pytest.mark.witnesses("authentication.already-signed-in")
 def test_login_redirects_if_already_authenticated(tmp_path: Path) -> None:
     client, auth_store, _ = _setup_test_server(tmp_path)
     _authenticate_client(client=client, auth_store=auth_store)
@@ -507,6 +533,15 @@ def test_login_redirects_if_already_authenticated(tmp_path: Path) -> None:
     )
     assert response.status_code == 307
     assert response.headers["location"] == "/"
+
+    # The fresh code was not spent by opening /login while already signed in:
+    # it can still be redeemed at /authenticate.
+    redeem_response = client.get(
+        "/authenticate",
+        query_string={"one_time_code": str(new_code)},
+        follow_redirects=False,
+    )
+    assert redeem_response.status_code == 307
 
 
 # -- Multi-server proxy tests --
@@ -571,12 +606,9 @@ def test_landing_page_shows_create_form_after_discovery_finds_no_agents(tmp_path
     assert "git_url" in response.text
 
 
-@pytest.mark.witnesses(
-    "authentication.deep-link-prefill",
-    partial="asserts git_url prefill only; not branch prefill and not that the advanced fields open",
-)
+@pytest.mark.witnesses("authentication.deep-link-prefill")
 def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:
-    """The create form pre-fills the git URL from a query parameter."""
+    """A deep link pre-fills the create form with the git URL and branch, advanced fields open."""
     backend_resolver = StaticBackendResolver(url_by_agent_and_service={})
     client, auth_store = _create_test_desktop_client(
         tmp_path=tmp_path,
@@ -585,9 +617,14 @@ def test_landing_page_prefills_git_url_from_query_param(tmp_path: Path) -> None:
     )
     _authenticate_client(client=client, auth_store=auth_store)
 
-    response = client.get("/", query_string={"git_url": "file:///nonexistent-repo"})
+    response = client.get(
+        "/", query_string={"git_url": "file:///nonexistent-repo", "branch": "feature/deep-link"}
+    )
     assert response.status_code == 200
     assert "file:///nonexistent-repo" in response.text
+    assert "feature/deep-link" in response.text
+    # A repo/branch deep link opens the form with its advanced fields visible.
+    assert "showAdvanced(true)" in response.text
 
 
 def test_create_page_shows_form(tmp_path: Path) -> None:

--- a/apps/minds/imbue/minds/desktop_client/testing.py
+++ b/apps/minds/imbue/minds/desktop_client/testing.py
@@ -2,9 +2,39 @@
 
 import os
 import subprocess
+import time
 from pathlib import Path
 
+from itsdangerous import TimestampSigner
+from itsdangerous import URLSafeTimedSerializer
+
 from imbue.minds.desktop_client.restic_cli import _get_restic_binary
+from imbue.minds.primitives import CookieSigningKey
+
+# Mirror cookie_manager's private salt/payload so a minted cookie is one the
+# production verifier accepts apart from its age. Callers guard this mirror
+# against drift by asserting an ``age_seconds=0`` cookie still verifies True.
+_MINDS_SESSION_SALT = "minds-auth"
+_MINDS_SESSION_PAYLOAD = "authenticated"
+
+
+def make_backdated_session_cookie(signing_key: CookieSigningKey, age_seconds: int) -> str:
+    """Mint a minds session cookie whose signature timestamp is ``age_seconds`` in the past.
+
+    Used to exercise session expiry deterministically without mocking the clock:
+    ``age_seconds`` beyond the 30-day max age yields a cookie the verifier rejects
+    as expired.
+    """
+
+    class _BackdatedTimestampSigner(TimestampSigner):
+        def get_timestamp(self) -> int:
+            return int(time.time()) - age_seconds
+
+    class _BackdatedSerializer(URLSafeTimedSerializer):
+        default_signer = _BackdatedTimestampSigner
+
+    serializer = _BackdatedSerializer(secret_key=signing_key.get_secret_value())
+    return serializer.dumps(_MINDS_SESSION_PAYLOAD, salt=_MINDS_SESSION_SALT)
 
 
 def restic_backup_a_file(repository: str, password: str, source: Path) -> None:

--- a/dev/changelog/danver-witness-minds-auth-corpus.md
+++ b/dev/changelog/danver-witness-minds-auth-corpus.md
@@ -1,0 +1,4 @@
+Added `specs/minds-auth-witnesses/audit.md`, recording the Phase 1 witness audit of the
+minds authentication behavioral-spec corpus: the before/after coverage table, the per-unit
+witness map, and the finding that the workspace-bridge units are witnessed only in
+`libs/mngr_forward` (which the default minds spec matrix does not scan).

--- a/dev/changelog/danver-witness-minds-auth-corpus.md
+++ b/dev/changelog/danver-witness-minds-auth-corpus.md
@@ -2,3 +2,10 @@ Added `specs/minds-auth-witnesses/audit.md`, recording the Phase 1 witness audit
 minds authentication behavioral-spec corpus: the before/after coverage table, the per-unit
 witness map, and the finding that the workspace-bridge units are witnessed only in
 `libs/mngr_forward` (which the default minds spec matrix does not scan).
+
+Added `specs/minds-auth-witnesses/reflection.md`, the Phase 3 reflection: the quality of
+the (hand-generated) witnesses, that witnessing surfaced no implementation bugs, and the
+tmr-specs machinery findings from two Modal fleet runs and a local pilot — chiefly that
+the mapper prompt's `uv run mngr specs matrix` coverage command hangs on the Modal host
+(stalling every agent) and the `local` provider is unusable headless due to Claude Code's
+per-directory trust dialog. Also gitignores the `tmr-specs-*_<timestamp>/` run output dirs.

--- a/specs/minds-auth-witnesses/audit.md
+++ b/specs/minds-auth-witnesses/audit.md
@@ -1,0 +1,160 @@
+# Minds authentication corpus: witness audit (Phase 1)
+
+This document records the Phase 1 audit of the `apps/minds/specs/authentication`
+behavioral-spec corpus (32 units) against the pre-existing minds test suite. The
+audit adds honest `@pytest.mark.witnesses(...)` markers to the existing tests
+that genuinely verify each unit (fully or partially). The corpus itself is
+read-only and was not touched.
+
+## Before / after coverage (`mngr specs matrix --root apps/minds/specs`)
+
+| Coverage | Before audit | After audit |
+|----------|-------------:|------------:|
+| full     |            0 |           5 |
+| partial  |            0 |          17 |
+| none     |           32 |          10 |
+| **total**|         **32** |        **32** |
+
+Both matrix runs exit 0 with no broken links.
+
+### Full (5)
+
+A single existing test verifies the whole unit:
+
+| Coordinate | Witness |
+|------------|---------|
+| `authentication.discovering` | `test_landing_page_shows_discovering_when_initial_discovery_not_done` |
+| `authentication.empty-shows-create-form` | `test_landing_page_shows_create_form_after_discovery_finds_no_agents` |
+| `authentication.lists-workspaces` | `test_landing_page_lists_agents_when_multiple_known` |
+| `authentication.signed-out-arrival` | `test_post_login_redirects_to_login_when_unauthenticated` |
+| `authentication.safe-return-to` | `test_post_login_honors_safe_return_to` |
+
+### Partial (17)
+
+Witnessed, but with an honest `partial=` note. Two structural patterns recur and
+are worth calling out because they are genuinely, behaviourally covered yet the
+matrix reports them as `partial` (see "Machinery observations" below):
+
+- Scenario outlines covered by one test per example row: `missing-code`
+  (`/login` + `/authenticate`), `default-destination` (has-workspaces +
+  no-workspaces).
+- Compound scenarios covered by one test per When/Then pair: `consent-gate`
+  (screen shown after sign-in + never shown again after answering).
+
+The remaining partials are genuinely incomplete:
+
+- `fresh-code` — the "opens the login URL in a browser" flow and the "code is now
+  spent" step are split across tests / not asserted together; existing tests
+  drive `/authenticate` directly.
+- `used-code`, `unknown-code` — refusal asserted, but not the absence of a
+  session cookie on the refusal.
+- `already-signed-in` — redirect asserted, but not that the fresh code stays
+  unspent.
+- `signed-out-home` — sign-in prompt asserted, but not the "reveals nothing about
+  existing workspaces" step.
+- `consent-first` — only the no-return-destination case.
+- `deep-link-prefill` — only `git_url` prefill; not branch prefill or advanced
+  fields opening.
+- `single-use-codes`, `sessions-unforgeable`, `signing-key-minted-once`,
+  `no-data-without-session`, `no-open-redirects` (rules) — each is universally
+  quantified; witnessed for representative flows/surfaces but not exhaustively.
+- `tampered-token`, `foreign-token` — witnessed only at the `verify_session_cookie`
+  unit boundary (predicate rejects), not at the HTTP "treated as signed out"
+  surface. `tampered-token` uses garbage input rather than a mutated valid token.
+
+### None (10) — targets for the Phase 2 fleet
+
+| Coordinate | Why unwitnessed today |
+|------------|-----------------------|
+| `authentication.prefetch` | No test asserts the code stays spendable after a scriptless fetch of `/login`. |
+| `authentication.fetch-never-spends` (rule) | Same: the inertness observable is never asserted. |
+| `authentication.survives-restart` | Only the signing-key persistence *mechanism* is tested, never a session surviving a client restart at the HTTP level. |
+| `authentication.expired-token` | The 30-day `max_age` is entirely unexercised at any level. |
+| `authentication.open-from-landing` | Witnessed only in `libs/mngr_forward` (see below). |
+| `authentication.direct-navigation` | Witnessed only in `libs/mngr_forward`. |
+| `authentication.signed-out-workspace` | Witnessed only in `libs/mngr_forward`. |
+| `authentication.non-html-refused` | Witnessed only in `libs/mngr_forward`. |
+| `authentication.single-credential` (rule) | Witnessed only in `libs/mngr_forward`. |
+| `authentication.credential-not-forwarded` (rule) | Witnessed only in `libs/mngr_forward`. |
+
+## Key finding: the workspace bridge is witnessed in the wrong project for the matrix
+
+The corpus overview declares the workspace-origin bridge to be served by the
+`mngr_forward` plugin (`libs/mngr_forward/`), and all six workspace-bridge units
+(`open-from-landing`, `direct-navigation`, `signed-out-workspace`,
+`non-html-refused`, plus the `single-credential` and `credential-not-forwarded`
+rules) are, in fact, thoroughly tested there — e.g.
+`server_test.py::test_subdomain_forward_strips_session_cookie_before_proxying_to_backend`
+(a clean FULL witness of `credential-not-forwarded`) and
+`server_test.py::test_subdomain_unauthenticated_non_html_returns_403` (a clean
+witness of `non-html-refused`).
+
+But the default `mngr specs matrix --root apps/minds/specs` scans only the
+corpus root's parent (`apps/minds`) for `witnesses` markers, and the
+`tmr-specs-minds` recipe inherits that default test root. So markers placed in
+`libs/mngr_forward` would not be counted, and these six units read as `none`
+under the default matrix even though the behaviour is well covered. This is an
+open decision for Phase 2, raised with Danver:
+
+- Option A: add the `witnesses` markers in `libs/mngr_forward` tests and invoke
+  the matrix (and the recipe) with `--tests apps/minds --tests libs/mngr_forward`.
+- Option B: leave the bridge units to the fleet, which would need `apps/minds`-side
+  integration coverage of the forward server (may require standing it up).
+- Option C: treat as a corpus/ownership escalation.
+
+No markers were added to `libs/mngr_forward` in this audit pending that decision.
+
+## Machinery observations (for the Phase 3 reflection)
+
+- `compute_spec_coverage` marks a unit `full` only when some single marker omits
+  `partial=`. A scenario outline or compound scenario that is genuinely covered by
+  a *set* of per-row / per-clause tests therefore reads as `partial`. This is by
+  design (a single test is expected to stand as the full witness), but it means
+  the matrix understates coverage for `missing-code`, `default-destination`, and
+  `consent-gate`.
+- Parametrized witnesses expand to one matrix witness per param node (the
+  `no-open-redirects` guard shows 14 witnesses from 4 markers because the two
+  `responses_test` parametrizations contribute 4 + 8 nodes).
+
+## Per-unit witness map
+
+All markers are `@pytest.mark.witnesses("<coordinate>", partial="...")` on the
+listed test node, in the `apps/minds` tree.
+
+- `fresh-code`: `test_authenticate_with_valid_code_sets_cookie_and_redirects`,
+  `test_authenticate_redirects_to_landing_page` (both partial)
+- `used-code`: `test_authenticate_code_cannot_be_reused`,
+  `auth_test.py::test_validate_rejects_already_used_code` (both partial)
+- `unknown-code`: `test_authenticate_with_invalid_code_returns_403`,
+  `auth_test.py::test_validate_rejects_unknown_code` (both partial)
+- `already-signed-in`: `test_login_redirects_if_already_authenticated` (partial)
+- `missing-code`: `test_login_without_one_time_code_returns_422`,
+  `test_authenticate_without_one_time_code_returns_422` (one per outline row)
+- `single-use-codes`: `test_authenticate_code_cannot_be_reused`,
+  `auth_test.py::test_validate_rejects_already_used_code` (both partial)
+- `signed-out-arrival`: `test_post_login_redirects_to_login_when_unauthenticated` (full)
+- `consent-first`: `test_post_login_routes_to_landing_while_consent_unanswered` (partial)
+- `safe-return-to`: `test_post_login_honors_safe_return_to` (full)
+- `default-destination`: `test_post_login_redirects_to_create_when_no_workspaces`,
+  `test_post_login_redirects_to_accounts_when_workspaces_exist` (one per outline row)
+- `no-open-redirects`: `test_post_login_ignores_unsafe_return_to`,
+  `test_auth_page_ignores_unsafe_return_to`,
+  `responses_test.py::test_safe_local_redirect_path_rejects_unsafe_values`,
+  `responses_test.py::test_safe_local_redirect_path_accepts_same_origin_paths` (all partial)
+- `signed-out-home`: `test_landing_page_shows_login_when_unauthenticated` (partial)
+- `consent-gate`: `test_landing_shows_consent_screen_after_login_when_unanswered`,
+  `test_consent_submit_records_choices_and_unblocks_landing` (one per When/Then pair)
+- `discovering`: `test_landing_page_shows_discovering_when_initial_discovery_not_done` (full)
+- `empty-shows-create-form`: `test_landing_page_shows_create_form_after_discovery_finds_no_agents` (full)
+- `deep-link-prefill`: `test_landing_page_prefills_git_url_from_query_param` (partial)
+- `lists-workspaces`: `test_landing_page_lists_agents_when_multiple_known` (full)
+- `no-data-without-session`: `test_create_page_rejects_unauthenticated`,
+  `test_accounts_page_requires_auth`,
+  `test_chrome_events_sse_returns_auth_required_when_unauthenticated` (all partial)
+- `tampered-token`: `cookie_manager_test.py::test_verify_session_cookie_returns_false_for_tampered_value` (partial)
+- `foreign-token`: `cookie_manager_test.py::test_verify_session_cookie_returns_false_for_wrong_key` (partial)
+- `sessions-unforgeable`: `cookie_manager_test.py::test_create_and_verify_session_cookie_round_trip`,
+  `..._returns_false_for_wrong_key`, `..._returns_false_for_tampered_value` (all partial)
+- `signing-key-minted-once`: `auth_test.py::test_get_signing_key_returns_same_key_on_subsequent_access`,
+  `..._is_consistent_under_concurrent_first_access`, `..._persists_across_instances`,
+  `..._raises_for_empty_key_file`, `..._raises_on_read_error` (all partial)

--- a/specs/minds-auth-witnesses/reflection.md
+++ b/specs/minds-auth-witnesses/reflection.md
@@ -243,6 +243,13 @@ Run-time friction observed across the two runs:
   working reintegrate hint) — correct behavior for this state. Prompt-quality and
   report-quality of *successful* mapping could not be assessed, since no agent
   produced an outcome.
+- **Secrets passed via `--env` are echoed in plaintext.** Launching with
+  `--env "ANTHROPIC_API_KEY=<value>"` caused `mngr tmr-specs` to echo the
+  fully-resolved command — key and all — into the run log and the launching
+  agent's transcript. The launcher should redact known-secret `--env` values
+  (or accept a secret by name/file reference) rather than printing the resolved
+  command. This surfaced as a real leak during this task (the affected key was
+  scrubbed from `/tmp` and should be rotated).
 
 ## Machinery feedback is feedback, not edits
 

--- a/specs/minds-auth-witnesses/reflection.md
+++ b/specs/minds-auth-witnesses/reflection.md
@@ -1,0 +1,159 @@
+# Reflection: witnessing the minds authentication corpus with tmr-specs
+
+Layer-3 of the spec-anchored testing stack. This document reflects on Phase 1
+(hand audit), the Phase 2 hand-witnessing pass, and the Phase 2 fleet run
+(`tmr-specs-minds` on Modal), across the three axes the task asks for: the
+quality of the generated witnesses, whether witnessing surfaced implementation
+problems, and what the run teaches about the tmr-specs machinery itself.
+
+Companion document: `audit.md` (the Phase 1 map and before/after matrix).
+
+## Scope decisions taken during the run
+
+- **The corpus spans two systems.** `apps/minds/specs/authentication` describes
+  one surface but is implemented across the minds desktop client (`apps/minds`)
+  and the workspace-origin bridge (`libs/mngr_forward`). The four
+  `workspace-bridge.feature` scenarios and the `single-credential` /
+  `credential-not-forwarded` rules are `mngr_forward`'s; everything else is the
+  desktop client's. This split is the single most important structural fact of
+  the exercise.
+- **Decision (Danver): drop `mngr_forward` entirely; witness only
+  authentication on the `apps/minds` side.** An earlier plan to mark the
+  existing `mngr_forward` tests and widen the matrix (`--tests apps/minds
+  --tests libs/mngr_forward`) was dropped: `mngr_forward` has not itself been
+  specced/witnessed as its own system, and mixing it in muddied the run. The
+  clean long-term model is one corpus per system (a future
+  `libs/mngr_forward/specs/`), so `tmr-specs` runs cleanly per system. As a
+  result, the six `mngr_forward`-owned units are intentionally left unwitnessed
+  from `apps/minds` and read as `none`/blocked here.
+- **Provider: Modal** (`--provider modal`), spend approved. The fleet ran 6
+  mappers (one per feature file) + 1 reducer over the whole authentication
+  corpus with the default `apps/minds` test root.
+
+## Coverage trajectory (`mngr specs matrix --root apps/minds/specs`)
+
+| Stage | full | partial | none |
+|-------|-----:|--------:|-----:|
+| Baseline (pre-audit) | 0 | 0 | 32 |
+| After Phase 1 hand audit | 5 | 17 | 10 |
+| After Phase 2 hand-witnessing | 8 | 17 | 7 |
+| After fleet adoption | 8 | 17 | 7 | (unchanged: the fleet produced nothing adoptable) |
+
+The Phase 2 hand-witnessing added three tests: a full end-to-end `fresh-code`
+sign-in, a `prefetch` / `fetch-never-spends` scriptless-fetch test, and a
+`survives-restart` cross-instance session test. Of the 7 remaining `none`, six
+are the `mngr_forward` bridge units (out of scope) and one is `expired-token`
+(needs control over the 30-day `max_age` clock, deliberately left for the
+fleet to see how it handles a time-dependent unit).
+
+## Fleet run outcome: total timeout, zero adoptable output
+
+The first Modal fleet run (`20260721082621`) produced **nothing adoptable**: all
+six mappers were stopped at the 3600s per-agent timeout "without publishing
+outputs", so no branch was pulled, the reducer never ran, and the report's
+coverage matrix is empty. The run still exited 0 (a clean "everyone failed"),
+and it cost real money.
+
+The likely cause is resource contention, not a slow task per se: `mngr ls` shows
+the six mappers were packed **three-per-host onto just two Modal hosts**
+(`host-0`, `host-1`). Three heavyweight Claude Code agents sharing one host —
+each doing a cold `uv sync --all-packages` over the monorepo and then collecting
+/ running a large pytest suite — almost certainly thrashed CPU/RAM/disk (the
+hosts went unreachable near the end, "Could not connect ... Unable to connect
+to port ...", consistent with an OOM or a wedged host). Under that contention
+every agent crawled past 3600s before reaching even its first outcome write.
+
+This is the dominant machinery finding of the exercise and is expanded in
+section 3. Because the run yielded no witnesses, sections 1 and 2 below have no
+fleet material to assess for this run.
+
+## 1. Quality of the generated witnesses
+
+No witnesses were generated: every mapper timed out before publishing. There is
+nothing to assess for adoption. The apps/minds authentication coverage reported
+above (8 full / 17 partial / 7 none) is entirely from the Phase 1 audit and the
+Phase 2 hand-witnessing, both of which stand on their own.
+
+_[If a corrected re-run is authorized, complete this section: assess each
+generated witness test-by-test — honest witnessing vs gold-plating, accurate
+`partial=` notes, `PARTIAL_STEADY` only for residue untestable *in kind* (watch
+`expired-token`, which IS testable via a backdated token, and the invariant
+Rules), and correct placement per the repo test taxonomy.]_
+
+## 2. Implementation problems surfaced by witnessing
+
+The fleet surfaced none (it produced no commits or escalations). The
+hand-witnessing pass surfaced no implementation bugs either — every
+hand-written witness passed against the current implementation.
+
+One divergence noted during the audit (for cross-checking against any
+fleet escalation): the `mngr_forward` sign-in bridge returns **403** for a
+missing/empty one-time code, whereas the desktop client returns **422**
+(`missing-code` specifies 422). Because the corpus does not scope which surface
+`missing-code` binds, this is a latent ambiguity — but it is out of scope here
+since we dropped `mngr_forward`.
+
+## 3. What the run teaches about the tmr-specs machinery
+
+Observations that do NOT depend on the fleet outcome (found by reading the
+recipe, prompts, and report code, and confirmed against the matrix):
+
+- **Multi-system corpora have no clean fan-out unit.** `tmr-specs` fans out one
+  mapper per `.feature` file and scopes only by `--area` (folder), `--tag` (one
+  unit), or `--unit` (kind). There is no per-system or per-file selector, so a
+  corpus whose units are implemented across two projects cannot be pointed at
+  one system's tests in a single run. This is the friction that forced the
+  "drop mngr_forward" decision. The structural fix is one corpus per system,
+  which the layer-1 corpus model already supports (per-project `specs/`).
+- **The matrix understates coverage for outline / compound units.**
+  `compute_spec_coverage` marks a unit `full` only when some *single* marker
+  omits `partial=`. A scenario outline covered by one test per example row
+  (`missing-code`: `/login` + `/authenticate`; `default-destination`:
+  has/no-workspaces), or a compound scenario covered by one test per When/Then
+  pair (`consent-gate`: shown-after-signin + never-again), is genuinely,
+  behaviourally complete yet reads as `partial`. This is by design (one test is
+  meant to stand as the full witness), but it means a future run may churn on
+  units that are already fully covered, and the report's claimed-vs-verified
+  matrix will show a standing disagreement that is not a real gap. Worth a note
+  in the report, or a coverage rule that treats "every example row / clause
+  witnessed" as full.
+- **`--tests` overrides rather than unions.** Passing any `--tests` replaces the
+  default (corpus root's parent) instead of adding to it, in both the matrix CLI
+  and `effective_test_roots`. A multi-root corpus therefore has to name every
+  root explicitly; forgetting the default parent silently drops its witnesses.
+- **Parametrized witnesses expand per node.** The `no-open-redirects` guard
+  shows 14 matrix witnesses from 4 markers because two `responses_test`
+  parametrizations contribute 4 + 8 nodes. Harmless, but noisy in the report.
+
+Run-time friction observed this run:
+
+- **Host packing starves heavyweight agents (the run-killer).** The fleet placed
+  three mappers per Modal host. For a lightweight suite that is fine; for the
+  minds monorepo — where each agent independently pays a cold `uv sync
+  --all-packages` and a large pytest collection — three concurrent agents per
+  host is enough to thrash it into the timeout (and, it appears, to knock the
+  host offline). Two mitigations for a re-run: cap concurrency so agents do not
+  share a host (`--max-parallel-agents` low enough, or one agent per host), and
+  raise `--timeout` well above 3600s for this repo. A cheaper alternative is the
+  `local` provider, which reuses the already-synced `.venv` and skips the
+  per-host cold sync entirely.
+- **The default 3600s timeout is mis-scaled for this repo.** Even without
+  contention, a cold environment plus a first pytest run against the minds tree
+  can approach or exceed an hour before the agent writes its first outcome. The
+  timeout should be tuned per target repo (or the recipe should carry a
+  minds-appropriate default), and the mapper prompt could ask agents to write a
+  partial outcome early so a timeout still yields *something*.
+- **A clean exit hides a total failure.** The run exits 0 with an all-`FAILED`
+  report; a caller scripting on exit code alone would not notice that zero units
+  were witnessed. A non-zero exit (or a summary line) when no mapper succeeds
+  would help.
+- Prompt-quality and report-quality (claimed-vs-verified matrix, escalations,
+  normalizations) could not be assessed: no agent produced an outcome. The
+  report itself rendered the failure cleanly (six FAILED rows, empty matrix,
+  a working reintegrate hint), which is the correct behavior for this state.
+
+## Machinery feedback is feedback, not edits
+
+Per the standing policy, none of the observations above were acted on by
+editing `libs/mngr_tmr` or the read-only corpus. They are recorded here for
+Danver's consideration only.

--- a/specs/minds-auth-witnesses/reflection.md
+++ b/specs/minds-auth-witnesses/reflection.md
@@ -1,10 +1,12 @@
 # Reflection: witnessing the minds authentication corpus with tmr-specs
 
 Layer-3 of the spec-anchored testing stack. This document reflects on Phase 1
-(hand audit), the Phase 2 hand-witnessing pass, and the Phase 2 fleet run
-(`tmr-specs-minds` on Modal), across the three axes the task asks for: the
-quality of the generated witnesses, whether witnessing surfaced implementation
-problems, and what the run teaches about the tmr-specs machinery itself.
+(the hand audit), Phase 2 (a hand-witnessing pass, two `tmr-specs-minds` fleet
+runs on Modal that both failed to produce witnesses, a blocked `local` pilot,
+and a final local hand-generation batch), across the three axes the task asks
+for: the quality of the generated witnesses, whether witnessing surfaced
+implementation problems, and what the runs teach about the tmr-specs machinery
+itself.
 
 Companion document: `audit.md` (the Phase 1 map and before/after matrix).
 
@@ -39,14 +41,24 @@ Companion document: `audit.md` (the Phase 1 map and before/after matrix).
 | Baseline (pre-audit) | 0 | 0 | 32 |
 | After Phase 1 hand audit | 5 | 17 | 10 |
 | After Phase 2 hand-witnessing | 8 | 17 | 7 |
-| After fleet adoption | 8 | 17 | 7 | (unchanged: the fleet produced nothing adoptable) |
+| After the two fleet runs | 8 | 17 | 7 | (unchanged: both runs produced nothing adoptable) |
+| After local hand-generation | 14 | 12 | 6 |
 
-The Phase 2 hand-witnessing added three tests: a full end-to-end `fresh-code`
-sign-in, a `prefetch` / `fetch-never-spends` scriptless-fetch test, and a
-`survives-restart` cross-instance session test. Of the 7 remaining `none`, six
-are the `mngr_forward` bridge units (out of scope) and one is `expired-token`
-(needs control over the 30-day `max_age` clock, deliberately left for the
-fleet to see how it handles a time-dependent unit).
+The **6 remaining `none` are exactly the six `mngr_forward` bridge units** we
+dropped from scope (`open-from-landing`, `direct-navigation`,
+`signed-out-workspace`, `non-html-refused`, and the `single-credential` /
+`credential-not-forwarded` rules). Every unit implemented on the `apps/minds`
+side is now witnessed (full or an honest partial).
+
+The 12 partials are honest, not gaps to churn on: the universally-quantified
+invariant Rules (`single-use-codes`, `no-data-without-session`,
+`sessions-unforgeable`, `signing-key-minted-once`, `no-open-redirects`,
+`fetch-never-spends`); the two unit-level token-integrity witnesses
+(`tampered-token`, `foreign-token`, whose HTTP-surface half is unwitnessed);
+`consent-first` (only the no-return-destination case); and the three units that
+are behaviourally complete but read as `partial` only because of the matrix's
+per-marker aggregation (`missing-code`, `default-destination`, `consent-gate` —
+see section 3).
 
 ## Fleet run outcome: two Modal runs, zero adoptable witnesses
 
@@ -90,27 +102,66 @@ run-killing bug is the hanging coverage command, which no timeout or concurrency
 change addresses. This is why the layer-3 direction became: **run locally**,
 where that command works.
 
-This is the dominant machinery finding and is expanded in section 3. Because
-neither run yielded witnesses, sections 1 and 2 have no fleet material to assess.
+This is the dominant machinery finding and is expanded in section 3.
+
+## Local provider outcome: blocked by the Claude Code trust dialog
+
+The direction after the Modal failures was to run locally. A single-agent
+`--provider local` pilot (scoped to `expired-token`) failed at launch: the local
+provider copies the checkout to `~/.mngr/copies/agent-<id>/` and Claude Code
+refuses to start there — "Source directory ... is not trusted by Claude Code" — a
+trust dialog that `--headless` cannot answer. Trust is stored per-directory in
+`~/.claude.json`, so the fleet's dynamically-named copy dirs cannot be
+pre-trusted without either interactive acceptance or a global trust-bypass change
+to the user's Claude config (out of scope, security-sensitive). Net: the fleet is
+blocked on *both* providers by distinct environment issues — Modal by the hanging
+coverage command, local by the trust dialog — neither a fault in the specs,
+prompts, or recipe logic. So the remaining witnesses were **hand-generated
+locally**, which is what "generate the tests locally" ultimately meant here.
 
 ## 1. Quality of the generated witnesses
 
-No witnesses were generated: every mapper timed out before publishing. There is
-nothing to assess for adoption. The apps/minds authentication coverage reported
-above (8 full / 17 partial / 7 none) is entirely from the Phase 1 audit and the
-Phase 2 hand-witnessing, both of which stand on their own.
+No *fleet* witnesses exist to assess — both runs produced none. What follows
+assesses the witnesses I hand-generated locally (the Phase 2 hand pass plus the
+post-Modal batch), held to the bar the mapper prompt sets for the fleet:
 
-_[If a corrected re-run is authorized, complete this section: assess each
-generated witness test-by-test — honest witnessing vs gold-plating, accurate
-`partial=` notes, `PARTIAL_STEADY` only for residue untestable *in kind* (watch
-`expired-token`, which IS testable via a backdated token, and the invariant
-Rules), and correct placement per the repo test taxonomy.]_
+- **`fresh-code` (full):** drives the real `/login` -> JS redirect -> `/authenticate`
+  flow; asserts landing on `/`, a signed-in follow-up request, and the code now
+  spent. Every assertion traces to a step; no gold-plating.
+- **`prefetch` + `fetch-never-spends`:** a scriptless fetch of the login URL sets
+  no session and leaves the code spendable. `fetch-never-spends` keeps an honest
+  `partial=` — a universally-quantified Rule ("any URL the system hands out")
+  that one preloader scenario cannot fully witness.
+- **`survives-restart` (full):** a cookie minted on one app instance still
+  authenticates against a fresh instance on the same data directory — the actual
+  observable, not just the signing-key-persistence mechanism.
+- **`expired-token` (full):** the time-dependent unit. Rather than dodge it as
+  `PARTIAL_STEADY` (it is *not* untestable in kind — only awkward without a
+  clock), I mint a backdated cookie via a `TimestampSigner` subclass (no
+  monkeypatch, no `freezegun`) and assert the HTTP surface treats the bearer as
+  signed out. An `age_seconds=0` sanity assertion guards the construction against
+  salt/payload drift, so the rejection is provably due to age. Helper in
+  `testing.py`.
+- **`used-code` / `unknown-code` (full):** tightened to also assert the refusal
+  sets no session cookie (the "no session is established" step), not just the 403.
+- **`signed-out-home` (full):** asserts the login-URL/terminal guidance *and* that
+  a known workspace id is absent ("reveals nothing about existing workspaces").
+- **`already-signed-in` (full):** proves the fresh code is still redeemable after
+  opening `/login` while signed in (the "code remains unspent" step).
+- **`deep-link-prefill` (full):** asserts branch prefill and advanced-fields-open,
+  not just the git URL.
+
+No gold-plating was introduced: every added assertion traces to a unit step or an
+in-scope invariant. The partials left standing are honest — I did not force
+behaviourally-complete outline/compound units to `full` by writing a redundant
+single test just to satisfy the matrix's per-marker rule.
 
 ## 2. Implementation problems surfaced by witnessing
 
-The fleet surfaced none (it produced no commits or escalations). The
-hand-witnessing pass surfaced no implementation bugs either — every
-hand-written witness passed against the current implementation.
+The fleet surfaced none (it produced no commits or escalations). Hand-generation
+surfaced no implementation bugs either — every hand-written witness passed
+against the current implementation on its first green run, and no `partial=`
+residue traced to a divergence rather than an untestable quantifier.
 
 One divergence noted during the audit (for cross-checking against any
 fleet escalation): the `mngr_forward` sign-in bridge returns **403** for a
@@ -176,6 +227,14 @@ Run-time friction observed across the two runs:
   self-bound their own wall-clock. `--reintegrate` *does* re-pull each agent's
   outputs and re-run the reducer (a good recovery primitive) — but only once the
   mappers actually finish, which here they never did.
+- **The `local` provider is unusable headless due to Claude Code's trust
+  dialog.** Each local agent runs in a fresh `~/.mngr/copies/agent-<id>/` copy
+  that Claude Code treats as untrusted; `--headless` cannot accept the trust
+  prompt, so every launch fails ("Source directory ... is not trusted"). Because
+  trust is keyed per-directory in `~/.claude.json` and the copy dirs are minted
+  per run, there is no non-interactive, non-global way to pre-trust them. For a
+  headless fleet the provider (or `mngr`) needs to seed trust for the copy dir it
+  just created before starting Claude there.
 - **A clean exit hides a total failure.** Run 1 exited 0 with an all-`FAILED`
   report; a caller scripting on exit code alone would not notice zero units were
   witnessed. A non-zero exit (or a summary line) when no mapper succeeds would

--- a/specs/minds-auth-witnesses/reflection.md
+++ b/specs/minds-auth-witnesses/reflection.md
@@ -26,9 +26,11 @@ Companion document: `audit.md` (the Phase 1 map and before/after matrix).
   `libs/mngr_forward/specs/`), so `tmr-specs` runs cleanly per system. As a
   result, the six `mngr_forward`-owned units are intentionally left unwitnessed
   from `apps/minds` and read as `none`/blocked here.
-- **Provider: Modal** (`--provider modal`), spend approved. The fleet ran 6
-  mappers (one per feature file) + 1 reducer over the whole authentication
-  corpus with the default `apps/minds` test root.
+- **Provider: two Modal runs, then a pivot to `local`.** Both Modal runs (6
+  mappers + reducer over the authentication corpus, default `apps/minds` test
+  root) failed to produce witnesses (see "Fleet run outcome"). Because the
+  root-cause command works locally, the direction became to generate the tests
+  on the `local` provider / by hand.
 
 ## Coverage trajectory (`mngr specs matrix --root apps/minds/specs`)
 
@@ -46,26 +48,50 @@ are the `mngr_forward` bridge units (out of scope) and one is `expired-token`
 (needs control over the 30-day `max_age` clock, deliberately left for the
 fleet to see how it handles a time-dependent unit).
 
-## Fleet run outcome: total timeout, zero adoptable output
+## Fleet run outcome: two Modal runs, zero adoptable witnesses
 
-The first Modal fleet run (`20260721082621`) produced **nothing adoptable**: all
-six mappers were stopped at the 3600s per-agent timeout "without publishing
-outputs", so no branch was pulled, the reducer never ran, and the report's
-coverage matrix is empty. The run still exited 0 (a clean "everyone failed"),
-and it cost real money.
+Two Modal fleet runs were attempted; neither produced an adoptable witness.
 
-The likely cause is resource contention, not a slow task per se: `mngr ls` shows
-the six mappers were packed **three-per-host onto just two Modal hosts**
-(`host-0`, `host-1`). Three heavyweight Claude Code agents sharing one host —
-each doing a cold `uv sync --all-packages` over the monorepo and then collecting
-/ running a large pytest suite — almost certainly thrashed CPU/RAM/disk (the
-hosts went unreachable near the end, "Could not connect ... Unable to connect
-to port ...", consistent with an OOM or a wedged host). Under that contention
-every agent crawled past 3600s before reaching even its first outcome write.
+**Run 1** (`20260721082621`, default `--agents-per-host 4` which placed 3 mappers
+on each of 2 hosts, `--timeout 3600`): all six mappers were stopped at the 3600s
+timeout "without publishing outputs" — no branch pulled, no reducer, empty
+coverage matrix, clean exit 0. My first hypothesis was host contention (three
+heavyweight agents thrashing one host), so run 2 changed the packing.
 
-This is the dominant machinery finding of the exercise and is expanded in
-section 3. Because the run yielded no witnesses, sections 1 and 2 below have no
-fleet material to assess for this run.
+**Run 2** (`20260721205010`, `--agents-per-host 1` so each mapper got its own
+host, `--timeout 7200`): the launcher then crashed ~88 min in on a *transient*
+Modal `ServiceError: Authorization check failed` during polling (a Modal-side
+glitch, not our credentials — `mngr ls` worked again immediately after), so it
+never polled the mappers to completion, pulled outputs, or ran the reducer (exit
+1). Crucially the six mappers *survived* the launcher crash and were still
+RUNNING on their dedicated hosts, which let me diagnose them directly.
+
+**Root cause — the contention hypothesis was wrong.** With one agent per host and
+no contention, the mappers *still* made no progress: ~90 minutes with zero file
+writes after venv setup, no commits, no outputs, no pytest running, only 3–14
+minutes of CPU each. A surviving agent's Claude transcript pinned the stall
+exactly — the mapper's last tool call was
+
+    uv run mngr specs matrix --root apps/minds/specs --tests apps/minds
+
+(the coverage command the mapper prompt tells every agent to run early: "To find
+the current witnesses of your units, run the coverage matrix"), and that Bash
+call **never returned** — the transcript dead-ends on it with no tool_result for
+the rest of the run. Every mapper blocked on the same command. The identical
+command completes in *seconds* on the local dev machine, so the hang is specific
+to running it on the Modal host. `mngr specs matrix --tests apps/minds` drives a
+`pytest --collect-only` over the whole `apps/minds` tree (plus `uv run`'s env
+resolution); the likely mechanism is a collection-time hang in that large suite
+on the Modal host (a conftest/import that probes for docker/modal/network and
+blocks where they are absent) and/or `uv run` re-resolving — either way the outer
+command does not return, and the framework's inner 300s collection timeout does
+not save it. So host packing (run 1) was at most secondary; the primary,
+run-killing bug is the hanging coverage command, which no timeout or concurrency
+change addresses. This is why the layer-3 direction became: **run locally**,
+where that command works.
+
+This is the dominant machinery finding and is expanded in section 3. Because
+neither run yielded witnesses, sections 1 and 2 have no fleet material to assess.
 
 ## 1. Quality of the generated witnesses
 
@@ -125,32 +151,39 @@ recipe, prompts, and report code, and confirmed against the matrix):
   shows 14 matrix witnesses from 4 markers because two `responses_test`
   parametrizations contribute 4 + 8 nodes. Harmless, but noisy in the report.
 
-Run-time friction observed this run:
+Run-time friction observed across the two runs:
 
-- **Host packing starves heavyweight agents (the run-killer).** The fleet placed
-  three mappers per Modal host. For a lightweight suite that is fine; for the
-  minds monorepo — where each agent independently pays a cold `uv sync
-  --all-packages` and a large pytest collection — three concurrent agents per
-  host is enough to thrash it into the timeout (and, it appears, to knock the
-  host offline). Two mitigations for a re-run: cap concurrency so agents do not
-  share a host (`--max-parallel-agents` low enough, or one agent per host), and
-  raise `--timeout` well above 3600s for this repo. A cheaper alternative is the
-  `local` provider, which reuses the already-synced `.venv` and skips the
-  per-host cold sync entirely.
-- **The default 3600s timeout is mis-scaled for this repo.** Even without
-  contention, a cold environment plus a first pytest run against the minds tree
-  can approach or exceed an hour before the agent writes its first outcome. The
-  timeout should be tuned per target repo (or the recipe should carry a
-  minds-appropriate default), and the mapper prompt could ask agents to write a
-  partial outcome early so a timeout still yields *something*.
-- **A clean exit hides a total failure.** The run exits 0 with an all-`FAILED`
-  report; a caller scripting on exit code alone would not notice that zero units
-  were witnessed. A non-zero exit (or a summary line) when no mapper succeeds
-  would help.
-- Prompt-quality and report-quality (claimed-vs-verified matrix, escalations,
-  normalizations) could not be assessed: no agent produced an outcome. The
-  report itself rendered the failure cleanly (six FAILED rows, empty matrix,
-  a working reintegrate hint), which is the correct behavior for this state.
+- **The mapper prompt's coverage command hangs on this repo/host (the actual
+  run-killer).** Every mapper runs `uv run mngr specs matrix --root
+  apps/minds/specs --tests apps/minds` early because the prompt instructs it
+  ("To find the current witnesses of your units, run the coverage matrix"). On
+  the Modal host that command never returns, so every agent blocks on it
+  indefinitely and produces nothing — in *both* runs, independent of host
+  packing or timeout. It is fast locally. Fixes to consider: (a) make
+  `harvest_witness_links`' `pytest --collect-only` robust to collection-time
+  hangs on this repo — the existing 300s inner timeout did not save the outer
+  `uv run mngr` invocation, so the guard is at the wrong layer; (b) narrow the
+  collection to the paired test tree; or (c) have the mapper prompt read current
+  coverage from a pre-computed artifact the orchestrator supplies, rather than
+  each agent re-running a full-suite collection. This single issue is why the
+  fleet must run where that command works (the `local` provider).
+- **A launcher crash orphans running agents with no timeout enforcement.** Run
+  2's launcher died on a *transient* Modal auth error mid-poll; the six agents
+  kept running on their hosts with the launcher's `--timeout` no longer
+  enforced, so they would have burned compute indefinitely had I not stopped
+  them. The launcher should treat a transient provider error during polling as
+  retryable (it recovered on the very next call), and/or agents should
+  self-bound their own wall-clock. `--reintegrate` *does* re-pull each agent's
+  outputs and re-run the reducer (a good recovery primitive) — but only once the
+  mappers actually finish, which here they never did.
+- **A clean exit hides a total failure.** Run 1 exited 0 with an all-`FAILED`
+  report; a caller scripting on exit code alone would not notice zero units were
+  witnessed. A non-zero exit (or a summary line) when no mapper succeeds would
+  help.
+- **The report rendered the failure cleanly** (six FAILED rows, empty matrix, a
+  working reintegrate hint) — correct behavior for this state. Prompt-quality and
+  report-quality of *successful* mapping could not be assessed, since no agent
+  produced an outcome.
 
 ## Machinery feedback is feedback, not edits
 


### PR DESCRIPTION
## What

Phases 1-3 of the spec-anchored testing work for the `apps/minds/specs/authentication`
behavioral-spec corpus (32 units): audit the existing minds test suite and generate the
missing tests, keeping the `@pytest.mark.witnesses(...)` markers honest. Stacked on
`danver/minds-specs-mapreduce-fable`; this diff is exactly the 10 witness files.

## Coverage

`mngr specs matrix --root apps/minds/specs`: **14 full / 12 partial / 6 none** (from
0/0/32). The 6 remaining `none` are the `mngr_forward`-implemented workspace-bridge units
(`open-from-landing`, `direct-navigation`, `signed-out-workspace`, `non-html-refused`,
`single-credential`, `credential-not-forwarded`) -- out of scope for the `apps/minds`
test tree (see the reflection for why).

## How

- **Phase 1 (audit):** honest `witnesses` markers (with `partial=` notes) on tests that
  already verify each unit.
- **Phase 2 (generate):** the `tmr-specs` Modal fleet was attempted twice and produced
  nothing adoptable -- run 1 timed out under 3-agents-per-host contention; run 2's
  launcher crashed on a transient Modal auth error and the agents then stalled on a
  hanging `uv run mngr specs matrix` on the Modal host. A `--provider local` pilot was
  blocked by Claude Code's headless per-directory trust dialog. The remaining witnesses
  were therefore hand-generated (human-in-the-loop), each assertion traced to the unit's
  steps or an in-scope invariant.
- **Phase 3 (reflect):** `specs/minds-auth-witnesses/reflection.md` (witness quality, no
  implementation bugs surfaced, tmr-specs machinery findings) and
  `specs/minds-auth-witnesses/audit.md` (per-unit map + before/after table).

## Validation

- `just test-offload`: 15,993 / 15,994 passed (the single failure was an import-order
  nit, fixed).
- Witness tests pass locally; ruff clean; `mngr specs matrix` exits 0 with no broken links.
- The corpus (`apps/minds/specs/`) was not modified (read-only to the whole pipeline).

Co-authored-by: Sculptor <sculptor@imbue.com>
