### PR TITLE
minds: point undeployed-env and missing-psql failures at their fix

### DIFF
--- a/apps/minds/changelog/gabriel-minds-config-and-psql-guidance.md
+++ b/apps/minds/changelog/gabriel-minds-config-and-psql-guidance.md
@@ -1,0 +1,5 @@
+Two startup / deploy failures now explain how to fix themselves instead of surfacing a cryptic error.
+
+When `minds run` (including the desktop app, which passes the activated env's config path) is pointed at a client config file that does not exist, it no longer dies with a raw `Invalid value for '--config-file': File ... does not exist`. It now reports that the file is missing and, for a dev env, that its `client.toml` is only written by a successful deploy -- with the exact `minds env activate --deploy <name>` + `minds env deploy` commands to run. This is the common first-run wedge: activating a dev env with `--create` but never deploying it.
+
+When `minds env deploy` cannot find the `psql` binary, its guidance now covers the macOS case correctly. Homebrew's `libpq` is keg-only, so `brew install libpq` alone leaves `psql` off PATH; the message now says to add it explicitly (`export PATH="$(brew --prefix libpq)/bin:$PATH"`) rather than implying the install is sufficient.

--- a/apps/minds/imbue/minds/cli/run.py
+++ b/apps/minds/imbue/minds/cli/run.py
@@ -145,6 +145,31 @@ MINDS_API_PROXY_URL_ENV_VAR: Final[str] = "LATCHKEY_EXTENSION_MINDS_API_URL"
 MINDS_API_PROXY_KEY_ENV_VAR: Final[str] = "LATCHKEY_EXTENSION_MINDS_API_KEY"
 
 
+def _resolve_client_config_path(config_file: Path | None) -> Path:
+    """Validate the ``--config-file`` value, raising click errors with actionable guidance.
+
+    ``None`` means no env was activated. A path that does not resolve to a file means
+    the env's ``client.toml`` was never written -- almost always a dev env that was
+    activated (``--create``) but never deployed, which is the common first-run wedge:
+    ``client.toml`` is only produced by a successful ``minds env deploy``.
+    """
+    if config_file is None:
+        raise click.ClickException(
+            "No client config file is set. Activate an env first: "
+            '`eval "$(uv run minds env activate <name>)"` (e.g. '
+            "`dev-<your-user>`, `staging`, or `production`), then re-run."
+        )
+    if not config_file.is_file():
+        raise click.ClickException(
+            f"Client config file not found: {config_file}. For a dev env, its "
+            "client.toml is written only by a successful deploy -- run "
+            '`eval "$(uv run minds env activate --deploy <name>)"` then '
+            "`uv run minds env deploy`, then re-launch. For staging / production "
+            "the committed in-repo client.toml should already exist -- check your checkout."
+        )
+    return config_file
+
+
 @click.command()
 @click.option(
     "--host",
@@ -167,7 +192,7 @@ MINDS_API_PROXY_KEY_ENV_VAR: Final[str] = "LATCHKEY_EXTENSION_MINDS_API_KEY"
 @click.option(
     "--config-file",
     "config_file",
-    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     envvar="MINDS_CLIENT_CONFIG_PATH",
     help=(
@@ -187,12 +212,7 @@ def run(
     config_file: Path | None,
 ) -> None:
     """Run the minds bare-origin server with `mngr forward` as a subprocess."""
-    if config_file is None:
-        raise click.ClickException(
-            "No client config file is set. Activate an env first: "
-            '`eval "$(uv run minds env activate <name>)"` (e.g. '
-            "`dev-<your-user>`, `staging`, or `production`), then re-run."
-        )
+    client_config_path = _resolve_client_config_path(config_file)
     root_name = resolve_minds_root_name()
     data_directory = minds_data_dir_for(root_name)
     minds_config = MindsConfig(data_dir=data_directory)
@@ -236,7 +256,6 @@ def run(
         latchkey_plugin_data_dir=latchkey.plugin_data_dir,
         discovery_events_dir=get_discovery_events_dir(MngrConfig(default_host_dir=mngr_host_dir)),
     )
-    client_config_path = config_file
     client_env_config = load_client_config(client_config_path)
     connector_url_str = str(client_env_config.connector_url).rstrip("/")
     output_format: OutputFormat = ctx.obj.get("output_format", OutputFormat.HUMAN)

--- a/apps/minds/imbue/minds/cli/run_test.py
+++ b/apps/minds/imbue/minds/cli/run_test.py
@@ -39,7 +39,7 @@ def test_resolve_client_config_path_returns_existing_file(tmp_path: Path) -> Non
     assert _resolve_client_config_path(config) == config
 
 
-def test_resolve_client_config_path_rejects_unset_config(tmp_path: Path) -> None:
+def test_resolve_client_config_path_rejects_unset_config() -> None:
     """No activated env (``None``) is refused with activation guidance, not a stack trace."""
     with pytest.raises(click.ClickException) as excinfo:
         _resolve_client_config_path(None)

--- a/apps/minds/imbue/minds/cli/run_test.py
+++ b/apps/minds/imbue/minds/cli/run_test.py
@@ -4,10 +4,13 @@
 
 from pathlib import Path
 
+import click
+import pytest
 from flask import Flask
 
 from imbue.imbue_common.model_update import to_update
 from imbue.minds.cli.run import _StreamedPermissionRequestHandler
+from imbue.minds.cli.run import _resolve_client_config_path
 from imbue.minds.desktop_client.auth import FileAuthStore
 from imbue.minds.desktop_client.backend_resolver import MngrCliBackendResolver
 from imbue.minds.desktop_client.backend_resolver import ParsedAgentsResult
@@ -25,6 +28,39 @@ from imbue.mngr_latchkey.agent_setup import prepare_agent_latchkey
 from imbue.mngr_latchkey.store import permissions_path_for_host
 from imbue.mngr_latchkey.testing import FakeLatchkey
 from imbue.mngr_latchkey.testing import make_full_fake_latchkey
+
+# -- _resolve_client_config_path -------------------------------------------
+
+
+def test_resolve_client_config_path_returns_existing_file(tmp_path: Path) -> None:
+    config = tmp_path / "client.toml"
+    config.write_text("")
+
+    assert _resolve_client_config_path(config) == config
+
+
+def test_resolve_client_config_path_rejects_unset_config(tmp_path: Path) -> None:
+    """No activated env (``None``) is refused with activation guidance, not a stack trace."""
+    with pytest.raises(click.ClickException) as excinfo:
+        _resolve_client_config_path(None)
+    assert "env activate" in str(excinfo.value)
+
+
+def test_resolve_client_config_path_points_undeployed_env_at_deploy(tmp_path: Path) -> None:
+    """A set-but-missing client.toml (an activated-but-never-deployed dev env) points at deploy.
+
+    This is the wedge behind the raw ``Invalid value for '--config-file'`` click
+    error: the desktop client inherits ``MINDS_CLIENT_CONFIG_PATH`` for an env whose
+    ``client.toml`` a successful deploy never wrote.
+    """
+    missing = tmp_path / ".minds-dev-nobody" / "client.toml"
+
+    with pytest.raises(click.ClickException) as excinfo:
+        _resolve_client_config_path(missing)
+    message = str(excinfo.value)
+    assert "minds env deploy" in message
+    assert str(missing) in message
+
 
 # -- _StreamedPermissionRequestHandler -------------------------------------
 

--- a/apps/minds/imbue/minds/envs/migrations.py
+++ b/apps/minds/imbue/minds/envs/migrations.py
@@ -33,6 +33,7 @@ from pydantic import SecretStr
 from imbue.concurrency_group.concurrency_group import ConcurrencyGroup
 from imbue.imbue_common.logging import info_span
 from imbue.minds.envs.providers.neon_db import NeonProviderError
+from imbue.minds.envs.providers.neon_db import PSQL_INSTALL_GUIDANCE
 
 # psql shellout timeout per migration. Generous enough to absorb a slow
 # Neon cold-start; short enough that a real connectivity failure surfaces
@@ -58,10 +59,7 @@ def _psql_path() -> str:
     """Return the absolute path to ``psql`` or raise with operator-facing guidance."""
     path = shutil.which("psql")
     if path is None:
-        raise MigrationRunnerError(
-            "psql binary not on PATH; cannot run schema migrations. Install via "
-            "`apt install postgresql-client` (Debian/Ubuntu) or `brew install libpq` (macOS)."
-        )
+        raise MigrationRunnerError(f"psql binary not on PATH; cannot run schema migrations. {PSQL_INSTALL_GUIDANCE}")
     return path
 
 

--- a/apps/minds/imbue/minds/envs/providers/neon_db.py
+++ b/apps/minds/imbue/minds/envs/providers/neon_db.py
@@ -63,6 +63,15 @@ _LOCKED_RETRY_TOTAL_BUDGET_SECONDS: Final[float] = 120.0
 # minute.
 _PSQL_TIMEOUT_SECONDS: Final[float] = 60.0
 
+# Operator-facing guidance shown when the deploy can't find ``psql``. Shared by the
+# deploy paths that shell out to it. On macOS, Homebrew's libpq is keg-only, so
+# ``brew install libpq`` alone leaves ``psql`` off PATH -- it must be added explicitly.
+PSQL_INSTALL_GUIDANCE: Final[str] = (
+    "Install via `apt install postgresql-client` (Debian/Ubuntu), or on macOS "
+    "`brew install libpq` and add it to PATH (libpq is keg-only): "
+    '`export PATH="$(brew --prefix libpq)/bin:$PATH"`.'
+)
+
 # Default region for new per-env Neon projects. Matches where the
 # dev-tier org already lives; tier-shared projects (staging /
 # production) are operator-managed and not affected by this.
@@ -658,10 +667,7 @@ def wipe_neon_db_schema(dsn: SecretStr, *, parent_cg: ConcurrencyGroup) -> None:
     """
     psql_path = shutil.which("psql")
     if psql_path is None:
-        raise NeonProviderError(
-            "psql binary not on PATH; cannot wipe the Neon schema. Install via "
-            "`apt install postgresql-client` (Debian/Ubuntu) or `brew install libpq` (macOS)."
-        )
+        raise NeonProviderError(f"psql binary not on PATH; cannot wipe the Neon schema. {PSQL_INSTALL_GUIDANCE}")
     command = [
         psql_path,
         dsn.get_secret_value(),


### PR DESCRIPTION
## What

Two `minds` startup/deploy failures now explain how to fix themselves instead of surfacing a cryptic error. Both were hit in practice while bringing up a fresh dev env.

### App/`minds run` startup: missing client config
The `--config-file` option no longer uses `click.Path(exists=True, ...)`, which produced a raw `Invalid value for '--config-file': File ... does not exist` with no guidance. Validation moves into a small extracted helper `_resolve_client_config_path`, which raises a `ClickException` that:
- distinguishes "no env activated" (`None`) from "config file set but missing",
- for the missing case, explains that a dev env's `client.toml` is only written by a successful deploy, and gives the exact `minds env activate --deploy <name>` + `minds env deploy` commands.

This is the common first-run wedge: `minds env activate --create <name>` mkdirs the env root and exports `MINDS_CLIENT_CONFIG_PATH`, but `client.toml` doesn't exist until a deploy runs, so the app (which inherits that path) failed opaquely.

### `minds env deploy`: `psql` not on PATH (macOS)
The "psql binary not on PATH" guidance — shared by `migrations.py` and `neon_db.py` via a single new `PSQL_INSTALL_GUIDANCE` constant (previously duplicated) — now covers macOS correctly. Homebrew's `libpq` is **keg-only**, so `brew install libpq` succeeds but leaves `psql` off PATH. The old message implied the install was sufficient; it now says to add it explicitly:
```
export PATH="$(brew --prefix libpq)/bin:$PATH"
```

## Tests
- New unit tests for `_resolve_client_config_path` (existing file returns path; `None` → activation guidance; set-but-missing → deploy guidance): 3 passed.
- `ruff check`, `ruff format`, and `ty check` clean on the changed files.
- psql-guidance strings are not separately tested (per repo convention, no string-constant tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)