### PR TITLE
TMR: reducer-opened PR on reintegrate, and count failed mappers

### DIFF
--- a/.github/workflows/tmr-reintegrate.yml
+++ b/.github/workflows/tmr-reintegrate.yml
@@ -29,8 +29,9 @@ jobs:
       id-token: write
     env:
       MNGR_USER_ID: ${{ inputs.mngr_user_id != '' && inputs.mngr_user_id || 'tmr-ci' }}
-      # The automatic per-run token, used for `git push` + `gh pr create` on this
-      # same repo. Intentionally NOT migrated to Vault.
+      # The automatic per-run token, handed to the reducer agent (via
+      # --reducer-env below) which pushes the integrated branch and opens the
+      # PR. Intentionally NOT migrated to Vault.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -72,15 +73,29 @@ jobs:
           # already-launched ones by the tmr_run_name label), so --provider
           # is unused. The integrator runs locally on the runner and uses
           # ANTHROPIC_API_KEY directly.
+          #
+          # Like tmr.yml, the reducer opens the run's PR itself (via
+          # --reducer-env GH_TOKEN). --reducer-branch-suffix gives its branch a
+          # unique name (this workflow run's id) so the reintegration always
+          # opens a NEW PR rather than colliding with the original run's reducer
+          # branch, which shares this run name.
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           uv run --project libs/mngr_tmr mngr tmr -vv \
             -S 'agent_types.yolo.parent_type="claude"' \
             -S 'agent_types.yolo.cli_args=["--dangerously-skip-permissions"]' \
             --agent-type yolo \
             --reintegrate \
             --run-name "${{ inputs.run_name }}" \
+            --reducer-branch-suffix "r${{ github.run_id }}" \
             --env "MODAL_TOKEN_ID=${MODAL_TOKEN_ID}" \
             --env "MODAL_TOKEN_SECRET=${MODAL_TOKEN_SECRET}" \
             --env "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+            --reducer-env "GH_TOKEN=${GH_TOKEN}" \
+            --reducer-env "TMR_GITHUB_REPOSITORY=${{ github.repository }}" \
+            --reducer-env "TMR_BASE_BRANCH=${{ github.ref_name }}" \
+            --reducer-env "TMR_RUN_URL=${run_url}" \
+            --reducer-env "TMR_PR_LABEL=" \
+            --reducer-env "TMR_PR_ASSIGNEES=" \
             --output-dir tmr-report \
             --format jsonl \
             | tee tmr-report/events.jsonl
@@ -97,32 +112,7 @@ jobs:
           path: tmr-report/
           retention-days: 30
 
-      # Unlike tmr.yml, this workflow opens the PR itself. It passes no
-      # --reducer-env, so the reducer is not given a GH_TOKEN and its prompt
-      # omits the open-a-PR section entirely -- there is no double-open here.
-      - name: Push integrator branch and open PR
-        if: success()
-        run: |
-          set -euo pipefail
-          branch=$(jq -r 'select(.event == "integrator_branch") | .branch_name' < tmr-report/events.jsonl | tail -n 1)
-          if [ -z "$branch" ]; then
-            echo "Reintegration produced no integrator branch (no fixes to integrate); skipping PR."
-            exit 0
-          fi
-          echo "Integrator branch: $branch"
-          git push --set-upstream origin "$branch"
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          report_url=$(jq -r 'select(.event == "report_url") | .url' < tmr-report/events.jsonl | tail -n 1)
-          if [ -n "$report_url" ]; then
-            report_line="HTML report: $report_url (also attached as the \`tmr-report\` artifact on the workflow run)."
-          else
-            report_line="HTML report: attached as the \`tmr-report\` artifact on the workflow run; download and open \`index.html\`. (AWS credentials missing, so no s3 mirror was published.)"
-          fi
-          gh pr create \
-            --base "${{ github.ref_name }}" \
-            --head "$branch" \
-            --title "TMR re-integration of ${{ inputs.run_name }}: $branch" \
-            --body "Reintegration of TMR run \`${{ inputs.run_name }}\` from workflow run [#${{ github.run_id }}]($run_url).
-
-          $report_line" \
-            --draft
+      # The reducer opens the PR itself (see the "Open the pull request" section
+      # of reducer.j2), the same as the main tmr.yml workflow. --reducer-branch-suffix
+      # above keeps its branch distinct from the original run's, so this is always
+      # a fresh PR.

--- a/dev/changelog/mngr-tmr-reintegrate-pr.md
+++ b/dev/changelog/mngr-tmr-reintegrate-pr.md
@@ -1,0 +1,1 @@
+The TMR reintegrate workflow (`tmr-reintegrate.yml`) no longer opens the pull request itself. Like the main TMR workflow, it hands the reducer a `GH_TOKEN` (via `--reducer-env`) so the reducer opens the run's PR with the full findings in its body. It passes `--reducer-branch-suffix` set to the workflow run id so each reintegration opens a fresh PR from a distinct branch.

--- a/libs/mngr/changelog/mngr-tmr-reintegrate-pr.md
+++ b/libs/mngr/changelog/mngr-tmr-reintegrate-pr.md
@@ -1,0 +1,1 @@
+The generated `mngr tmr` CLI reference documents the new `--reducer-branch-suffix` option (suffixes the reducer's branch/agent/host names so a reintegration's pull request does not collide with the original run's reducer branch).

--- a/libs/mngr/docs/commands/secondary/tmr.md
+++ b/libs/mngr/docs/commands/secondary/tmr.md
@@ -103,6 +103,7 @@ mngr tmr [OPTIONS] [PYTEST_ARGS]...
 | `-t`, `--agent-template` | text | Create template to apply for mapper agents [repeatable, stacks in order] | None |
 | `--provider` | text | Provider for agent hosts (e.g. local, docker, modal). Used for both mappers and the reducer. | `local` |
 | `--reducer-env` | text | Environment variable KEY=VALUE to pass to the reducer ONLY, not to mappers. For credentials the reducer needs but mappers must not receive (e.g. a token that can push and open pull requests) [repeatable] | None |
+| `--reducer-branch-suffix` | text | Suffix appended to the reducer's branch/agent/host names. Set this on a reintegration so its pull request is opened from a branch that does not collide with the original run's reducer branch (the two share a run name). Blank for a normal run. | `` |
 | `--env` | text | Environment variable KEY=VALUE to pass to agents [repeatable] | None |
 | `--label` | text | Agent label KEY=VALUE to attach to all launched agents [repeatable] | None |
 | `--snapshot` | text | Use an existing snapshot/image ID for all agents (skips building a fresh snapshot) | None |

--- a/libs/mngr_mapreduce/changelog/mngr-tmr-reintegrate-pr.md
+++ b/libs/mngr_mapreduce/changelog/mngr-tmr-reintegrate-pr.md
@@ -1,0 +1,5 @@
+Added two framework hooks used by test map-reduce:
+
+- `--reducer-branch-suffix` appends a suffix to the reducer's branch, agent, and host names. A reintegration reuses the original run's name (to rediscover its mappers by label) but must open its pull request from a branch that does not collide with the original run's reducer branch; the suffix keeps them distinct.
+
+- A new `on_all_mappers_finalized` recipe hook fires once every mapper has finished, just before the reducer launches, with the full mapper set including failures. A recipe whose reducer reads the output directory as files can use it to reconcile the two views -- e.g. represent a failed mapper that produced no output so it is not silently absent.

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/cli.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/cli.py
@@ -93,6 +93,7 @@ class MapReduceCliOptions(CommonCliOptions):
     source: str | None
     reintegrate: bool
     run_name: str | None
+    reducer_branch_suffix: str
     additional_authorized_keys: tuple[str, ...]
 
 
@@ -200,6 +201,13 @@ def add_mapreduce_options(command: TDecorated) -> TDecorated:
         "--env",
         multiple=True,
         help="Environment variable KEY=VALUE to pass to agents [repeatable]",
+    )(command)
+    command = click.option(
+        "--reducer-branch-suffix",
+        default="",
+        help="Suffix appended to the reducer's branch/agent/host names. Set this on a reintegration so its "
+        "pull request is opened from a branch that does not collide with the original run's reducer branch "
+        "(the two share a run name). Blank for a normal run.",
     )(command)
     command = click.option(
         "--reducer-env",
@@ -367,6 +375,11 @@ def _run_reducer_phase(
     if not has_any_successful_mapper:
         return None
 
+    # Give the recipe the full mapper set (successes and failures alike) before
+    # the reducer reads the output dir, so failed mappers that produced no file
+    # can be represented rather than silently missing.
+    recipe.on_all_mappers_finalized(ctx, mapper_metadata)
+
     prompt = recipe.build_reducer_prompt(ctx)
     try:
         info, host = launch_reducer_agent(
@@ -376,6 +389,7 @@ def _run_reducer_phase(
             mngr_ctx=mngr_ctx,
             run_name=ctx.run_name,
             output_dir=ctx.output_dir,
+            branch_suffix=opts.reducer_branch_suffix,
         )
     except (MngrError, OSError, BaseExceptionGroup) as exc:
         logger.warning("Failed to launch reducer agent: {}", exc)

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/data_types.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/data_types.py
@@ -236,6 +236,17 @@ class MapReduceRecipe(ABC):
         """
         return None
 
+    def on_all_mappers_finalized(self, ctx: MapReduceContext, mapper_metadata: Sequence[AgentMetadata]) -> None:
+        """Called once every mapper has finished, just before the reducer launches.
+
+        Unlike ``on_mapper_finalized`` (per mapper that published outputs), this
+        sees the whole set, including mappers that failed and produced no output.
+        A recipe whose reducer reads the output dir as files can use this to
+        reconcile the two views -- e.g. write a placeholder for a failed mapper
+        so it is not silently absent. Default impl is a no-op.
+        """
+        return None
+
     @abstractmethod
     def render_report(
         self,

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching.py
@@ -83,6 +83,25 @@ def _make_mapper_identity(
     return AgentName(f"{recipe_name}-{run_name}-{suffix}"), f"{recipe_name}/{run_name}/{suffix}"
 
 
+def _make_reducer_identity(
+    recipe_name: str, run_name: str, branch_suffix: str = ""
+) -> tuple[AgentName, str, HostName]:
+    """Generate (agent_name, branch_name, host_name) for the reducer agent.
+
+    ``branch_suffix`` distinguishes reducers that share a ``run_name`` -- namely
+    a reintegration, which reuses the original run's name (to rediscover its
+    mappers by label) but must open its own pull request from a branch that does
+    not collide with the original run's reducer branch. A normal run passes no
+    suffix and keeps the historical ``<recipe>/<run>/reducer`` names.
+    """
+    stem = f"{recipe_name}-{run_name}-reducer"
+    branch = f"{recipe_name}/{run_name}/reducer"
+    if branch_suffix:
+        stem = f"{stem}-{branch_suffix}"
+        branch = f"{branch}-{branch_suffix}"
+    return AgentName(stem), branch, HostName(stem)
+
+
 def _make_launch_failure_metadata(
     task_id: str, agent_name: AgentName, branch_name: str, error: object
 ) -> AgentMetadata:
@@ -560,6 +579,7 @@ def launch_reducer_agent(
     mngr_ctx: MngrContext,
     run_name: str,
     output_dir: Path,
+    branch_suffix: str = "",
 ) -> tuple[ReducerInfo, OnlineHostInterface]:
     """Launch a reducer agent that consumes the per-mapper output directories.
 
@@ -572,9 +592,7 @@ def launch_reducer_agent(
     ``output_dir`` into ``<work_dir>/REDUCER_INPUTS_DIRNAME/`` and deliver
     the reducer prompt via ``send_message``.
     """
-    agent_name = AgentName(f"{recipe_name}-{run_name}-reducer")
-    branch_name = f"{recipe_name}/{run_name}/reducer"
-    host_name = HostName(f"{recipe_name}-{run_name}-reducer")
+    agent_name, branch_name, host_name = _make_reducer_identity(recipe_name, run_name, branch_suffix)
 
     logger.info("Launching reducer agent '{}'", agent_name)
     create_result = _create_agent(

--- a/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching_test.py
+++ b/libs/mngr_mapreduce/imbue/mngr_mapreduce/launching_test.py
@@ -14,6 +14,7 @@ from imbue.mngr_mapreduce.data_types import AgentKind
 from imbue.mngr_mapreduce.data_types import LaunchConfig
 from imbue.mngr_mapreduce.launching import ROLE_LABEL_KEY
 from imbue.mngr_mapreduce.launching import _build_agent_options
+from imbue.mngr_mapreduce.launching import _make_reducer_identity
 
 
 def _make_config(
@@ -160,3 +161,21 @@ def test_reducer_only_env_wins_on_key_collision() -> None:
 def test_reducer_env_unchanged_when_no_reducer_only_env_is_set() -> None:
     env = _env_for(AgentKind.REDUCER, env_options=SHARED_ENV)
     assert env == {"ANTHROPIC_API_KEY": "shared"}
+
+
+# --- reducer identity ---
+
+
+def test_reducer_identity_without_a_suffix() -> None:
+    agent, branch, host = _make_reducer_identity("tmr-mngr", "20260721085455")
+    assert agent == "tmr-mngr-20260721085455-reducer"
+    assert branch == "tmr-mngr/20260721085455/reducer"
+    assert host == "tmr-mngr-20260721085455-reducer"
+
+
+def test_reducer_suffix_distinguishes_a_reintegration() -> None:
+    """A reintegration reuses the run name but must not collide with the original branch."""
+    _, original, _ = _make_reducer_identity("tmr-mngr", "20260721085455")
+    _, reintegrated, _ = _make_reducer_identity("tmr-mngr", "20260721085455", "r12345")
+    assert reintegrated == "tmr-mngr/20260721085455/reducer-r12345"
+    assert reintegrated != original

--- a/libs/mngr_tmr/changelog/mngr-tmr-reintegrate-pr.md
+++ b/libs/mngr_tmr/changelog/mngr-tmr-reintegrate-pr.md
@@ -1,0 +1,5 @@
+TMR reintegration now opens its pull request the same way a normal run does, and the run's PR summary counts failed tests.
+
+Reintegrating a run (re-running the integrator over an already-completed run's outputs) previously had the *workflow* open a minimal PR, while a normal run had the reducer open a rich one. Now the reducer opens the PR in both cases, so a reintegration's PR carries the same mapper status breakdown and escalations table. The reintegration's reducer branch is suffixed with the workflow run id so it always opens a fresh PR rather than colliding with the original run's reducer branch (the two share a run name).
+
+Failed mappers -- those that never produced an outcome file because they failed to launch, timed out, or crashed -- are now represented in the reducer's inputs via a synthesized "errored" outcome. Before this, anything reading the output directory as files rather than orchestrator metadata (the reducer, and thus the PR's status breakdown) was blind to them, so a run with failures reported as if those tests did not exist. They now appear in the failed count.

--- a/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/recipe.py
@@ -36,6 +36,7 @@ from imbue.mngr_tmr.prompts import build_test_agent_prompt
 from imbue.mngr_tmr.report import EXTRACTED_TEST_OUTPUT_DIR
 from imbue.mngr_tmr.report import generate_html_report
 from imbue.mngr_tmr.report import load_integrator_outcome_file
+from imbue.mngr_tmr.report import synthesize_missing_mapper_outcomes
 from imbue.mngr_tmr.report_upload import maybe_upload_report
 from imbue.mngr_tmr.report_upload import report_url_for_run
 
@@ -239,6 +240,15 @@ class TestMapReduceRecipe(MapReduceRecipe, FrozenModel):
         bundle = agent_dir / _BRANCH_BUNDLE_NAME
         if bundle.is_file():
             _apply_branch_bundle(ctx.source_dir, bundle, info.branch_name, str(info.agent_name), ctx.cg)
+
+    def on_all_mappers_finalized(self, ctx: MapReduceContext, mapper_metadata: Sequence[AgentMetadata]) -> None:
+        # Failed mappers write no outcome file, so the reducer -- which reads the
+        # rsynced output dir as files -- would not see them and its PR summary
+        # would under-count failures. Synthesize an errored outcome for each so
+        # the failed tests are represented in the reducer's inputs and the PR.
+        written = synthesize_missing_mapper_outcomes(ctx.output_dir, mapper_metadata)
+        if written:
+            logger.info("Synthesized errored outcomes for {} failed mapper(s)", len(written))
 
     def on_reducer_finalized(self, ctx: MapReduceContext, agent_dir: Path, info: ReducerInfo) -> None:
         # The reducer opens the run's PR itself, so surface the URL it reported

--- a/libs/mngr_tmr/imbue/mngr_tmr/report.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report.py
@@ -365,6 +365,44 @@ def _outcome_path_for_integrator(output_dir: Path, agent_name: AgentName) -> Pat
     return output_dir / str(agent_name) / EXTRACTED_TEST_OUTPUT_DIR / INTEGRATOR_OUTCOME_FILENAME
 
 
+def synthesize_missing_mapper_outcomes(output_dir: Path, agents: Sequence[AgentMetadata]) -> list[AgentName]:
+    """Write a synthetic errored outcome for every failed mapper that produced none.
+
+    A mapper that failed to launch, timed out, or crashed never writes an outcome
+    file. Anything that reads the output dir as *files* rather than as
+    orchestrator metadata -- the reducer, whose PR summary and should-pull
+    predicate both count outcomes on disk -- is therefore blind to it, so a run
+    with failures reports as if those tests did not exist. Give each failed
+    mapper a minimal ``errored`` outcome so it is seen and counted as failed.
+
+    Only fills gaps: a mapper that already wrote an outcome is left untouched.
+    Returns the agent names a synthetic outcome was written for.
+    """
+    written: list[AgentName] = []
+    for meta in agents:
+        if meta.kind is not AgentKind.MAPPER or meta.error_summary is None:
+            continue
+        path = _outcome_path_for_testing_agent(output_dir, meta.agent_name)
+        if path.exists():
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "changes": {},
+                    "errored": True,
+                    "tests_passing_before": None,
+                    "tests_passing_after": None,
+                    "summary_markdown": meta.error_summary,
+                    "test_runs": [],
+                    "escalations": [],
+                }
+            )
+        )
+        written.append(meta.agent_name)
+    return written
+
+
 def load_testing_agent_outcome(agent_name: AgentName, output_dir: Path) -> TestResult | None:
     """Read and cache a testing agent's outcome from the extracted output dir.
 

--- a/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
+++ b/libs/mngr_tmr/imbue/mngr_tmr/report_test.py
@@ -22,6 +22,7 @@ from imbue.mngr_tmr.report import _render_markdown
 from imbue.mngr_tmr.report import generate_html_report
 from imbue.mngr_tmr.report import load_testing_agent_outcome
 from imbue.mngr_tmr.report import report_section_of
+from imbue.mngr_tmr.report import synthesize_missing_mapper_outcomes
 
 SUCCEEDED_FIX = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.SUCCEEDED, summary_markdown="fixed")}
 FAILED_FIX = {ChangeKind.FIX_TEST: Change(status=ChangeStatus.FAILED, summary_markdown="failed")}
@@ -624,3 +625,55 @@ def test_outcome_cache_is_keyed_by_output_dir(tmp_path: Path) -> None:
     assert from_first is not None and from_second is not None
     assert from_first.summary_markdown == "FROM-FIRST"
     assert from_second.summary_markdown == "FROM-SECOND"
+
+
+# --- synthesizing outcomes for failed mappers ---
+
+
+def _errored_mapper(name: str) -> AgentMetadata:
+    return AgentMetadata(
+        kind=AgentKind.MAPPER,
+        agent_name=AgentName(name),
+        task_id="tests/test_x.py::test_x",
+        branch_name=None,
+        error_summary="Agent timed out",
+    )
+
+
+def test_synthesize_writes_an_errored_outcome_for_a_failed_mapper(tmp_path: Path) -> None:
+    written = synthesize_missing_mapper_outcomes(tmp_path, [_errored_mapper("dead-agent")])
+    assert written == [AgentName("dead-agent")]
+    outcome = load_testing_agent_outcome(AgentName("dead-agent"), tmp_path)
+    assert outcome is not None
+    assert outcome.errored is True
+    assert outcome.summary_markdown == "Agent timed out"
+
+
+def test_synthesize_makes_a_failed_mapper_count_as_failed(tmp_path: Path) -> None:
+    """The whole point: the synthetic file lands the failed mapper in the FAILED section."""
+    synthesize_missing_mapper_outcomes(tmp_path, [_errored_mapper("dead-agent")])
+    outcome = load_testing_agent_outcome(AgentName("dead-agent"), tmp_path)
+    assert outcome is not None
+    row = TestMapReduceResult(test_node_id="t", agent_name=AgentName("dead-agent"), errored=outcome.errored)
+    assert report_section_of(row) == ReportSection.FAILED
+
+
+def test_synthesize_does_not_overwrite_a_real_outcome(tmp_path: Path) -> None:
+    """A mapper that both errored-in-metadata and left a real file keeps its file."""
+    name = AgentName("has-real-outcome")
+    _write_test_outcome(tmp_path, name, TestResult(summary_markdown="REAL", errored=False))
+    written = synthesize_missing_mapper_outcomes(tmp_path, [_errored_mapper(str(name))])
+    assert written == []
+    outcome = load_testing_agent_outcome(name, tmp_path)
+    assert outcome is not None
+    assert outcome.summary_markdown == "REAL"
+
+
+def test_synthesize_ignores_successful_mappers_and_the_reducer(tmp_path: Path) -> None:
+    ok_mapper = AgentMetadata(
+        kind=AgentKind.MAPPER, agent_name=AgentName("ok"), task_id="t", branch_name=None, error_summary=None
+    )
+    reducer = AgentMetadata(
+        kind=AgentKind.REDUCER, agent_name=AgentName("red"), task_id=None, branch_name="b", error_summary="boom"
+    )
+    assert synthesize_missing_mapper_outcomes(tmp_path, [ok_mapper, reducer]) == []


### PR DESCRIPTION
Follow-up to #2575 (reducer-authored PRs), addressing two gaps.

## Reintegration opens its PR the same way as a normal run

`mngr tmr --reintegrate` re-runs the integrator over an already-completed run's mapper outputs. After #2575 there was an asymmetry: the main `tmr.yml` had the **reducer** open a rich PR (mapper status breakdown + escalations table), but `tmr-reintegrate.yml` had the **workflow** open a minimal one via `gh pr create`.

Now the reducer opens the PR in both flows. The catch is that the reducer branch name is deterministic — `<variant>/<run>/reducer` — and reintegration reuses the original run name, so opening a new PR would collide with the original run's still-open PR. A new `--reducer-branch-suffix` (set to the workflow run id) gives the reintegration's reducer a distinct branch, so it always opens a **fresh** PR. The workflow's own `gh pr create` is deleted.

Per the design decision on this: reintegration always creates a new PR, leaving the original untouched.

## Failed mappers are now counted in the PR

A mapper that failed to launch, timed out, or crashed never writes an outcome file. The reducer reads its rsynced input directory as *files*, so it never saw those mappers — and the PR's status breakdown reported a run with failures as if those tests didn't exist.

A new framework hook, `on_all_mappers_finalized`, fires once with the full mapper set (successes and failures) just before the reducer launches. The TMR recipe implements it to synthesize a minimal `errored` outcome for each failed mapper, so they appear in the reducer's inputs and land in the failed count of both the PR summary and the report.

## Testing

`just test-quick` over `test_meta_ratchets.py libs/mngr_tmr libs/mngr_mapreduce libs/imbue_common scripts`: **809 passed**. New tests cover the reducer-identity helper and its suffix, and the failed-mapper synthesis (that it writes an errored outcome, that the outcome lands the mapper in the FAILED section, that it does not overwrite a real outcome, and that it ignores successful mappers and the reducer).

## Manual testing still needed

Same live-run caveats as #2575 (the reducer's push-and-open-PR path is prompt text), plus:

- [ ] A reintegration opens a **new** PR from the suffixed branch without colliding with the original run's PR.
- [ ] A run with a deliberately-failed mapper shows a non-zero **failed** count in the PR's status breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)