### PR TITLE
Stream kanpan board refreshes for instant, incremental updates

### DIFF
--- a/libs/mngr_kanpan/changelog/mngr-fast-kanpan.md
+++ b/libs/mngr_kanpan/changelog/mngr-fast-kanpan.md
@@ -1,0 +1,5 @@
+Kanpan refreshes now stream in: instead of waiting for the slowest data source (the GitHub PR/CI fetch) before the board updates, kanpan lists the agents, paints the board immediately, and then fills in each column the moment its data source returns.
+
+To keep the board from visibly reshuffling on every refresh, the initial paint is seeded from the last known values (rendered greyed-out as stale), so each agent stays in its previous section until fresh data lands and updates it in place. The first refresh of a session, which has no cached values yet, simply shows the agent list and fills in as sources return.
+
+The final board is unchanged: once every source has reported, a fresh value fully governs its column (a stale seeded value it does not reproduce is dropped), so the result matches the old all-at-once fetch. A source that errors keeps its last-known value on the board rather than blanking the column.

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/fetcher.py
@@ -1,9 +1,11 @@
 import json
 import tempfile
 import time
+from collections.abc import Callable
 from collections.abc import Sequence
 from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 from pathlib import Path
 from typing import Any
 
@@ -50,6 +52,71 @@ class FetchResult(FrozenModel):
     )
 
 
+class FetchUpdate(FrozenModel):
+    """One incremental update posted by a streaming refresh.
+
+    ``stream_board_snapshot`` posts a sequence of these as its data sources
+    return. Each non-error update carries a full board ``snapshot`` that is
+    strictly more complete than the previous one (fresh source output layered
+    over the last-known cached values), so a consumer can simply render the
+    latest one it has drained.
+
+    ``cached_fields`` holds only the freshly computed fields -- never the seeded
+    cache values -- so the final update's ``cached_fields`` matches what a batch
+    ``fetch_board_snapshot`` would produce and is what gets persisted.
+    """
+
+    snapshot: BoardSnapshot | None = Field(
+        default=None, description="Full board snapshot to render; None only on a hard failure."
+    )
+    cached_fields: dict[AgentName, dict[str, FieldValue]] = Field(
+        default_factory=dict,
+        description="Freshly computed (unseeded) fields so far; authoritative on the final update.",
+    )
+    is_final: bool = Field(default=False, description="True on the last update of the stream.")
+    error: str | None = Field(
+        default=None, description="Hard-failure detail; set only on a final update whose fetch crashed."
+    )
+
+
+def _assemble_entries(
+    agents: tuple[AgentDetails, ...],
+    all_fields: dict[AgentName, dict[str, FieldValue]],
+) -> tuple[AgentBoardEntry, ...]:
+    """Build board entries from agents and their computed fields.
+
+    The muted bit rides on each AgentDetails (populated by kanpan's
+    agent_field_generators / offline_agent_field_generators during the
+    list_agents call), so it is sourced as resiliently as the agent list itself
+    and its ``created`` is now.
+    """
+    now = now_utc()
+    entries: list[AgentBoardEntry] = []
+    for agent in agents:
+        agent_fields = dict(all_fields.get(agent.name, {}))
+        is_agent_muted = is_muted(agent.plugin.get(PLUGIN_NAME, {}))
+        agent_fields[FIELD_MUTED] = BoolField(value=is_agent_muted, created=now)
+
+        cells = {key: field.display() for key, field in agent_fields.items()}
+        section = compute_section(agent_fields)
+        work_dir = _get_local_work_dir(agent)
+
+        entries.append(
+            AgentBoardEntry(
+                name=agent.name,
+                state=agent.state,
+                provider_name=agent.host.provider_name,
+                branch=agent.initial_branch,
+                work_dir=work_dir,
+                is_muted=is_agent_muted,
+                fields=agent_fields,
+                cells=cells,
+                section=section,
+            )
+        )
+    return tuple(entries)
+
+
 def fetch_board_snapshot(
     mngr_ctx: MngrContext,
     data_sources: Sequence[KanpanDataSource],
@@ -89,42 +156,128 @@ def fetch_board_snapshot(
                 all_fields[agent_name] = {}
             all_fields[agent_name].update(agent_fields)
 
-    # Build board entries. The muted bit rides on each AgentDetails (populated by
-    # kanpan's agent_field_generators / offline_agent_field_generators during the
-    # list_agents call above), so it is sourced as resiliently as the agent list
-    # itself and its `created` is now.
-    now = now_utc()
-    entries: list[AgentBoardEntry] = []
-    for agent in agents:
-        agent_fields = dict(all_fields.get(agent.name, {}))
-        is_agent_muted = is_muted(agent.plugin.get(PLUGIN_NAME, {}))
-        agent_fields[FIELD_MUTED] = BoolField(value=is_agent_muted, created=now)
-
-        cells = {key: field.display() for key, field in agent_fields.items()}
-        section = compute_section(agent_fields)
-        work_dir = _get_local_work_dir(agent)
-
-        entries.append(
-            AgentBoardEntry(
-                name=agent.name,
-                state=agent.state,
-                provider_name=agent.host.provider_name,
-                branch=agent.initial_branch,
-                work_dir=work_dir,
-                is_muted=is_agent_muted,
-                fields=agent_fields,
-                cells=cells,
-                section=section,
-            )
-        )
+    entries = _assemble_entries(agents, all_fields)
 
     elapsed = time.monotonic() - start_time
     snapshot = BoardSnapshot(
-        entries=tuple(entries),
+        entries=entries,
         errors=tuple(errors),
         fetch_time_seconds=elapsed,
     )
     return FetchResult(snapshot=snapshot, cached_fields=all_fields)
+
+
+def stream_board_snapshot(
+    mngr_ctx: MngrContext,
+    data_sources: Sequence[KanpanDataSource],
+    cached_fields: dict[AgentName, dict[str, FieldValue]],
+    post: Callable[[FetchUpdate], None],
+    include_filters: tuple[str, ...] = (),
+    exclude_filters: tuple[str, ...] = (),
+) -> None:
+    """Streaming full fetch: list agents, then fan out data sources, posting a
+    progressively more complete snapshot as each source returns.
+
+    Meant to run in a background thread. ``post`` is called once with a base
+    snapshot (agents in their last-known sections, seeded from ``cached_fields``
+    and rendered stale by their age), then once per data source as it returns,
+    and a final time with ``is_final=True``. On an unexpected failure a single
+    final update carrying ``error`` is posted instead, leaving the current board
+    for the consumer to preserve and retry.
+
+    The seeded cache values are display-only: ``cached_fields`` on each posted
+    update carries just the freshly computed fields, and once a source returns
+    its field keys are governed entirely by that fresh output (a stale seeded
+    value for one of its keys is dropped, even if the source failed and produced
+    nothing), so the final snapshot is identical to what ``fetch_board_snapshot``
+    would produce.
+    """
+    start_time = time.monotonic()
+    try:
+        errors: list[str] = []
+
+        result = list_agents(
+            mngr_ctx,
+            is_streaming=False,
+            error_behavior=ErrorBehavior.CONTINUE,
+            include_filters=include_filters,
+            exclude_filters=exclude_filters,
+        )
+        for error in result.errors:
+            errors.append(f"{error.exception_type}: {error.message}")
+        agents = tuple(result.agents)
+
+        # `display_fields` starts seeded from the previous cycle's cache so agents
+        # appear in their last-known sections immediately; the old `created` on
+        # those values renders them stale until fresh data lands. `fresh_fields`
+        # accumulates only freshly computed values and becomes the persisted cache.
+        display_fields: dict[AgentName, dict[str, FieldValue]] = {
+            agent.name: dict(cached_fields.get(agent.name, {})) for agent in agents
+        }
+        fresh_fields: dict[AgentName, dict[str, FieldValue]] = {}
+
+        if not data_sources:
+            _post_stream_update(post, agents, display_fields, fresh_fields, errors, start_time, is_final=True)
+            return
+
+        # Base snapshot: every agent visible at once, before any source returns.
+        _post_stream_update(post, agents, display_fields, fresh_fields, errors, start_time, is_final=False)
+
+        with ThreadPoolExecutor(max_workers=min(len(data_sources), 8)) as executor:
+            future_to_source: dict[
+                Future[tuple[dict[AgentName, dict[str, FieldValue]], Sequence[str]]], KanpanDataSource
+            ] = {
+                executor.submit(_compute_source_safely, source, agents, cached_fields, mngr_ctx): source
+                for source in data_sources
+            }
+            remaining = len(future_to_source)
+            for future in as_completed(future_to_source):
+                source = future_to_source[future]
+                source_fields, source_errors = future.result()
+                errors.extend(source_errors)
+                # This source's keys are now authoritative: drop any seeded value
+                # for them (even where the source produced nothing for an agent),
+                # then layer in the fresh output.
+                owned_keys = set(source.field_types.keys())
+                for agent_fields in display_fields.values():
+                    for key in owned_keys:
+                        agent_fields.pop(key, None)
+                for agent_name, agent_fields in source_fields.items():
+                    display_fields.setdefault(agent_name, {}).update(agent_fields)
+                    fresh_fields.setdefault(agent_name, {}).update(agent_fields)
+                remaining -= 1
+                _post_stream_update(
+                    post, agents, display_fields, fresh_fields, errors, start_time, is_final=(remaining == 0)
+                )
+    except Exception as e:
+        logger.debug("Streaming refresh failed: {}", e)
+        post(FetchUpdate(error=f"Refresh failed: {e}", is_final=True))
+
+
+def stream_local_snapshot(
+    mngr_ctx: MngrContext,
+    data_sources: Sequence[KanpanDataSource],
+    cached_fields: dict[AgentName, dict[str, FieldValue]],
+    post: Callable[[FetchUpdate], None],
+    include_filters: tuple[str, ...] = (),
+    exclude_filters: tuple[str, ...] = (),
+) -> None:
+    """Streaming local-only fetch: like ``stream_board_snapshot`` but runs only
+    non-remote sources.
+
+    Remote fields (PR, CI, ...) are carried forward implicitly through the
+    seeded cache: no remote source runs to claim their keys, so their last-known
+    values stay on the board (rendered stale by age) instead of being dropped.
+    """
+    local_sources = [s for s in data_sources if not s.is_remote]
+    stream_board_snapshot(
+        mngr_ctx,
+        local_sources,
+        cached_fields,
+        post,
+        include_filters=include_filters,
+        exclude_filters=exclude_filters,
+    )
 
 
 def fetch_local_snapshot(
@@ -155,6 +308,49 @@ def _get_local_work_dir(agent: AgentDetails) -> Path | None:
     return None
 
 
+def _compute_source_safely(
+    source: KanpanDataSource,
+    agents: tuple[AgentDetails, ...],
+    cached_fields: dict[AgentName, dict[str, FieldValue]],
+    mngr_ctx: MngrContext,
+) -> tuple[dict[AgentName, dict[str, FieldValue]], Sequence[str]]:
+    """Run one data source's ``compute``, turning any failure into an error string.
+
+    Data sources are pluggable, so a single misbehaving source must never crash
+    the refresh (batch or streaming). A failure is surfaced as an error message
+    and the source contributes no fields, exactly as if it had returned empty.
+    The broad catch is intentional: a source can raise anything, and none of it
+    should take down the board.
+    """
+    try:
+        return source.compute(agents, cached_fields, mngr_ctx)
+    except Exception as e:
+        logger.debug("Data source '{}' failed: {}", source.name, e)
+        return {}, [f"Data source '{source.name}' failed: {e}"]
+
+
+def _post_stream_update(
+    post: Callable[[FetchUpdate], None],
+    agents: tuple[AgentDetails, ...],
+    display_fields: dict[AgentName, dict[str, FieldValue]],
+    fresh_fields: dict[AgentName, dict[str, FieldValue]],
+    errors: Sequence[str],
+    start_time: float,
+    is_final: bool,
+) -> None:
+    """Assemble a board snapshot from the current display fields and post it.
+
+    ``display_fields`` drives what the board shows (seed layered under fresh
+    output); ``fresh_fields`` -- only the freshly computed values -- rides along
+    as ``cached_fields`` so the final update carries the authoritative cache.
+    """
+    entries = _assemble_entries(agents, display_fields)
+    elapsed = time.monotonic() - start_time
+    snapshot = BoardSnapshot(entries=entries, errors=tuple(errors), fetch_time_seconds=elapsed)
+    cached_copy = {name: dict(fields) for name, fields in fresh_fields.items()}
+    post(FetchUpdate(snapshot=snapshot, cached_fields=cached_copy, is_final=is_final))
+
+
 def _run_data_sources_parallel(
     data_sources: Sequence[KanpanDataSource],
     agents: tuple[AgentDetails, ...],
@@ -171,16 +367,12 @@ def _run_data_sources_parallel(
     with ThreadPoolExecutor(max_workers=min(len(data_sources), 8)) as executor:
         futures: dict[str, Future[tuple[dict[AgentName, dict[str, FieldValue]], Sequence[str]]]] = {}
         for source in data_sources:
-            futures[source.name] = executor.submit(source.compute, agents, cached_fields, mngr_ctx)
+            futures[source.name] = executor.submit(_compute_source_safely, source, agents, cached_fields, mngr_ctx)
 
         for source_name, future in futures.items():
-            try:
-                source_fields, source_errors = future.result()
-                results[source_name] = source_fields
-                all_errors.extend(source_errors)
-            except Exception as e:
-                all_errors.append(f"Data source '{source_name}' failed: {e}")
-                logger.debug("Data source '{}' failed: {}", source_name, e)
+            source_fields, source_errors = future.result()
+            results[source_name] = source_fields
+            all_errors.extend(source_errors)
 
     return results, all_errors
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
@@ -1,13 +1,16 @@
-"""Acceptance tests for fetch_board_snapshot and fetch_local_snapshot.
+"""Acceptance tests for the batch and streaming board fetchers.
 
-These tests exercise the full fetch pipeline with real agents created via the
-local provider, rather than mocking list_agents.
+These tests exercise the full fetch pipeline (fetch_board_snapshot,
+fetch_local_snapshot, stream_board_snapshot, stream_local_snapshot) with real
+agents created via the local provider, rather than mocking list_agents.
 
 To run these tests locally:
 
     just test libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
 """
 
+from collections.abc import Callable
+from collections.abc import Sequence
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -32,6 +35,7 @@ from imbue.mngr_kanpan.data_source import FIELD_COMMITS_AHEAD
 from imbue.mngr_kanpan.data_source import FIELD_MUTED
 from imbue.mngr_kanpan.data_source import FIELD_REPO_PATH
 from imbue.mngr_kanpan.data_source import FieldValue
+from imbue.mngr_kanpan.data_source import KanpanDataSource
 from imbue.mngr_kanpan.data_sources.git_info import CommitsAheadField
 from imbue.mngr_kanpan.data_sources.git_info import GitInfoDataSource
 from imbue.mngr_kanpan.data_sources.repo_paths import RepoPathField
@@ -40,8 +44,11 @@ from imbue.mngr_kanpan.data_types import AgentBoardEntry
 from imbue.mngr_kanpan.data_types import BoardSection
 from imbue.mngr_kanpan.data_types import BoardSnapshot
 from imbue.mngr_kanpan.fetcher import FetchResult
+from imbue.mngr_kanpan.fetcher import FetchUpdate
 from imbue.mngr_kanpan.fetcher import fetch_board_snapshot
 from imbue.mngr_kanpan.fetcher import fetch_local_snapshot
+from imbue.mngr_kanpan.fetcher import stream_board_snapshot
+from imbue.mngr_kanpan.fetcher import stream_local_snapshot
 from imbue.mngr_kanpan.fetcher import toggle_agent_mute
 
 
@@ -81,6 +88,51 @@ class _FakeRemoteDataSource:
             },
             [],
         )
+
+
+class _FakeEmptyRepoPathSource:
+    """A local source that owns the repo_path key but produces nothing.
+
+    Used to verify that once a source returns successfully, a stale seeded value
+    for one of its keys is dropped even when the source emitted nothing for the
+    agent.
+    """
+
+    @property
+    def name(self) -> str:
+        return "fake_empty_repo_path"
+
+    @property
+    def is_remote(self) -> bool:
+        return False
+
+    @property
+    def columns(self) -> dict[str, str]:
+        return {FIELD_REPO_PATH: "FAKE"}
+
+    @property
+    def field_types(self) -> dict[str, TypeAdapter[FieldValue]]:
+        return {FIELD_REPO_PATH: TypeAdapter(RepoPathField)}
+
+    def compute(
+        self,
+        agents: tuple[AgentDetails, ...],
+        cached_fields: dict[AgentName, dict[str, FieldValue]],
+        mngr_ctx: MngrContext,
+    ) -> tuple[dict[AgentName, dict[str, FieldValue]], list[str]]:
+        return {}, []
+
+
+def _collect_stream_updates(
+    stream_fn: Callable[..., None],
+    mngr_ctx: MngrContext,
+    sources: Sequence[KanpanDataSource],
+    cached_fields: dict[AgentName, dict[str, FieldValue]] | None = None,
+) -> list[FetchUpdate]:
+    """Run a streaming fetch synchronously, collecting every posted update in order."""
+    updates: list[FetchUpdate] = []
+    stream_fn(mngr_ctx, sources, cached_fields or {}, updates.append)
+    return updates
 
 
 @pytest.fixture
@@ -261,6 +313,165 @@ def test_fetch_local_snapshot_skips_remote_sources(
     assert FIELD_COMMITS_AHEAD in entry.fields
     # repo_path would only come from the remote source, so it should be absent
     assert FIELD_REPO_PATH not in entry.fields
+
+
+# =============================================================================
+# stream_board_snapshot / stream_local_snapshot
+# =============================================================================
+
+
+@pytest.mark.acceptance
+def test_stream_board_snapshot_no_sources_posts_single_final(temp_mngr_ctx: MngrContext) -> None:
+    """With no data sources, a single final update is posted."""
+    updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [])
+    assert len(updates) == 1
+    assert updates[0].is_final is True
+    assert updates[0].snapshot is not None
+    assert updates[0].snapshot.entries == ()
+
+
+@pytest.mark.acceptance
+@pytest.mark.tmux
+def test_stream_board_snapshot_posts_base_before_source_result(
+    local_host: Host,
+    work_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """The agent is visible in the first (base) update, before the source returns."""
+    agent = create_test_agent_state(local_host, work_dir, "stream-base-agent")
+    agent.set_labels({"remote": "git@github.com:org/myrepo.git"})
+    updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [RepoPathsDataSource()])
+
+    # base (not final) + one per source (final).
+    assert len(updates) == 2
+    base, final = updates
+    assert base.is_final is False
+    assert final.is_final is True
+
+    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-base-agent")]
+    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-base-agent")]
+    # The base snapshot shows the agent but not yet the source's repo_path.
+    assert FIELD_REPO_PATH not in base_entry.fields
+    # The final snapshot carries the freshly computed repo_path.
+    final_repo = final_entry.fields[FIELD_REPO_PATH]
+    assert isinstance(final_repo, RepoPathField)
+    assert final_repo.path == "org/myrepo"
+
+
+@pytest.mark.acceptance
+@pytest.mark.tmux
+def test_stream_board_snapshot_seeds_base_from_cache_then_replaces(
+    local_host: Host,
+    work_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """Option A: the base render seeds cached values, which fresh output replaces.
+
+    The seeded value never leaks into the persisted cache -- the final update's
+    cached_fields carries only freshly computed data.
+    """
+    agent = create_test_agent_state(local_host, work_dir, "stream-seed-agent")
+    agent.set_labels({"remote": "git@github.com:org/myrepo.git"})
+    seeded = {
+        AgentName("stream-seed-agent"): {
+            FIELD_REPO_PATH: RepoPathField(path="old/seeded", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        }
+    }
+    updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [RepoPathsDataSource()], seeded)
+
+    base, final = updates[0], updates[-1]
+    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-seed-agent")]
+    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-seed-agent")]
+
+    base_repo = base_entry.fields[FIELD_REPO_PATH]
+    assert isinstance(base_repo, RepoPathField)
+    assert base_repo.path == "old/seeded"
+
+    final_repo = final_entry.fields[FIELD_REPO_PATH]
+    assert isinstance(final_repo, RepoPathField)
+    assert final_repo.path == "org/myrepo"
+
+    # No seed leakage into the persisted cache.
+    persisted = final.cached_fields[AgentName("stream-seed-agent")][FIELD_REPO_PATH]
+    assert isinstance(persisted, RepoPathField)
+    assert persisted.path == "org/myrepo"
+
+
+@pytest.mark.acceptance
+@pytest.mark.tmux
+def test_stream_board_snapshot_drops_seeded_key_when_source_returns_nothing(
+    local_host: Host,
+    work_dir: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """A successful source governs its key entirely: a stale seed is dropped."""
+    create_test_agent_state(local_host, work_dir, "stream-drop-agent")
+    seeded = {
+        AgentName("stream-drop-agent"): {
+            FIELD_REPO_PATH: RepoPathField(path="old/seeded", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        }
+    }
+    updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [_FakeEmptyRepoPathSource()], seeded)
+
+    base, final = updates[0], updates[-1]
+    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-drop-agent")]
+    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-drop-agent")]
+    # Seeded in the base render, dropped once the owning source returned empty.
+    assert FIELD_REPO_PATH in base_entry.fields
+    assert FIELD_REPO_PATH not in final_entry.fields
+    assert AgentName("stream-drop-agent") not in final.cached_fields
+
+
+@pytest.mark.acceptance
+@pytest.mark.tmux
+def test_stream_board_snapshot_final_matches_batch(
+    local_host: Host,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """The final streamed snapshot matches what the batch fetch produces."""
+    agent = create_test_agent_state(local_host, temp_git_repo, "stream-parity-agent")
+    agent.set_labels({"remote": "git@github.com:org/myrepo.git"})
+    sources: list[KanpanDataSource] = [RepoPathsDataSource(), GitInfoDataSource()]
+
+    batch = fetch_board_snapshot(temp_mngr_ctx, sources, {})
+    final = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, sources)[-1]
+
+    batch_entry = {e.name: e for e in batch.snapshot.entries}[AgentName("stream-parity-agent")]
+    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-parity-agent")]
+    assert set(final_entry.fields.keys()) == set(batch_entry.fields.keys())
+    assert final_entry.section == batch_entry.section
+    assert set(final.cached_fields.keys()) == set(batch.cached_fields.keys())
+
+
+@pytest.mark.acceptance
+@pytest.mark.tmux
+def test_stream_local_snapshot_carries_forward_remote_fields_via_seed(
+    local_host: Host,
+    temp_git_repo: Path,
+    temp_mngr_ctx: MngrContext,
+) -> None:
+    """A local streaming refresh keeps remote fields (skipped sources) via the seed."""
+    create_test_agent_state(local_host, temp_git_repo, "stream-local-agent")
+    seeded = {
+        AgentName("stream-local-agent"): {
+            FIELD_REPO_PATH: RepoPathField(path="seed/repo", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
+        }
+    }
+    updates = _collect_stream_updates(
+        stream_local_snapshot,
+        temp_mngr_ctx,
+        [GitInfoDataSource(), _FakeRemoteDataSource()],
+        seeded,
+    )
+
+    final_entry = {e.name: e for e in updates[-1].snapshot.entries}[AgentName("stream-local-agent")]
+    # The remote (repo_path) source is skipped, so its seeded value is carried forward.
+    carried = final_entry.fields[FIELD_REPO_PATH]
+    assert isinstance(carried, RepoPathField)
+    assert carried.path == "seed/repo"
+    # The local git source still ran and produced a fresh commits_ahead field.
+    assert FIELD_COMMITS_AHEAD in final_entry.fields
 
 
 # =============================================================================

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/test_fetcher_acceptance.py
@@ -135,6 +135,12 @@ def _collect_stream_updates(
     return updates
 
 
+def _entries_by_name(update: FetchUpdate) -> dict[AgentName, AgentBoardEntry]:
+    """Index a non-error update's board entries by agent name."""
+    assert update.snapshot is not None
+    return {entry.name: entry for entry in update.snapshot.entries}
+
+
 @pytest.fixture
 def local_host(local_provider: LocalProviderInstance) -> Host:
     """Create a local Host via the local provider."""
@@ -348,8 +354,8 @@ def test_stream_board_snapshot_posts_base_before_source_result(
     assert base.is_final is False
     assert final.is_final is True
 
-    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-base-agent")]
-    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-base-agent")]
+    base_entry = _entries_by_name(base)[AgentName("stream-base-agent")]
+    final_entry = _entries_by_name(final)[AgentName("stream-base-agent")]
     # The base snapshot shows the agent but not yet the source's repo_path.
     assert FIELD_REPO_PATH not in base_entry.fields
     # The final snapshot carries the freshly computed repo_path.
@@ -372,7 +378,7 @@ def test_stream_board_snapshot_seeds_base_from_cache_then_replaces(
     """
     agent = create_test_agent_state(local_host, work_dir, "stream-seed-agent")
     agent.set_labels({"remote": "git@github.com:org/myrepo.git"})
-    seeded = {
+    seeded: dict[AgentName, dict[str, FieldValue]] = {
         AgentName("stream-seed-agent"): {
             FIELD_REPO_PATH: RepoPathField(path="old/seeded", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
         }
@@ -380,8 +386,8 @@ def test_stream_board_snapshot_seeds_base_from_cache_then_replaces(
     updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [RepoPathsDataSource()], seeded)
 
     base, final = updates[0], updates[-1]
-    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-seed-agent")]
-    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-seed-agent")]
+    base_entry = _entries_by_name(base)[AgentName("stream-seed-agent")]
+    final_entry = _entries_by_name(final)[AgentName("stream-seed-agent")]
 
     base_repo = base_entry.fields[FIELD_REPO_PATH]
     assert isinstance(base_repo, RepoPathField)
@@ -406,7 +412,7 @@ def test_stream_board_snapshot_drops_seeded_key_when_source_returns_nothing(
 ) -> None:
     """A successful source governs its key entirely: a stale seed is dropped."""
     create_test_agent_state(local_host, work_dir, "stream-drop-agent")
-    seeded = {
+    seeded: dict[AgentName, dict[str, FieldValue]] = {
         AgentName("stream-drop-agent"): {
             FIELD_REPO_PATH: RepoPathField(path="old/seeded", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
         }
@@ -414,8 +420,8 @@ def test_stream_board_snapshot_drops_seeded_key_when_source_returns_nothing(
     updates = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, [_FakeEmptyRepoPathSource()], seeded)
 
     base, final = updates[0], updates[-1]
-    base_entry = {e.name: e for e in base.snapshot.entries}[AgentName("stream-drop-agent")]
-    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-drop-agent")]
+    base_entry = _entries_by_name(base)[AgentName("stream-drop-agent")]
+    final_entry = _entries_by_name(final)[AgentName("stream-drop-agent")]
     # Seeded in the base render, dropped once the owning source returned empty.
     assert FIELD_REPO_PATH in base_entry.fields
     assert FIELD_REPO_PATH not in final_entry.fields
@@ -438,7 +444,7 @@ def test_stream_board_snapshot_final_matches_batch(
     final = _collect_stream_updates(stream_board_snapshot, temp_mngr_ctx, sources)[-1]
 
     batch_entry = {e.name: e for e in batch.snapshot.entries}[AgentName("stream-parity-agent")]
-    final_entry = {e.name: e for e in final.snapshot.entries}[AgentName("stream-parity-agent")]
+    final_entry = _entries_by_name(final)[AgentName("stream-parity-agent")]
     assert set(final_entry.fields.keys()) == set(batch_entry.fields.keys())
     assert final_entry.section == batch_entry.section
     assert set(final.cached_fields.keys()) == set(batch.cached_fields.keys())
@@ -453,7 +459,7 @@ def test_stream_local_snapshot_carries_forward_remote_fields_via_seed(
 ) -> None:
     """A local streaming refresh keeps remote fields (skipped sources) via the seed."""
     create_test_agent_state(local_host, temp_git_repo, "stream-local-agent")
-    seeded = {
+    seeded: dict[AgentName, dict[str, FieldValue]] = {
         AgentName("stream-local-agent"): {
             FIELD_REPO_PATH: RepoPathField(path="seed/repo", created=datetime(2020, 1, 1, tzinfo=timezone.utc))
         }
@@ -465,7 +471,7 @@ def test_stream_local_snapshot_carries_forward_remote_fields_via_seed(
         seeded,
     )
 
-    final_entry = {e.name: e for e in updates[-1].snapshot.entries}[AgentName("stream-local-agent")]
+    final_entry = _entries_by_name(updates[-1])[AgentName("stream-local-agent")]
     # The remote (repo_path) source is skipped, so its seeded value is carried forward.
     carried = final_entry.fields[FIELD_REPO_PATH]
     assert isinstance(carried, RepoPathField)

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui.py
@@ -1,4 +1,5 @@
 import os
+import queue
 import subprocess
 import time
 from collections.abc import Callable
@@ -59,13 +60,13 @@ from imbue.mngr_kanpan.data_types import MarkableBuiltinRole
 from imbue.mngr_kanpan.data_types import SECTION_PREFIX
 from imbue.mngr_kanpan.data_types import SECTION_SUFFIX
 from imbue.mngr_kanpan.data_types import STALENESS_FRACTION_OF_REFRESH_INTERVAL
-from imbue.mngr_kanpan.fetcher import FetchResult
+from imbue.mngr_kanpan.fetcher import FetchUpdate
 from imbue.mngr_kanpan.fetcher import collect_data_sources
 from imbue.mngr_kanpan.fetcher import compute_section
-from imbue.mngr_kanpan.fetcher import fetch_board_snapshot
-from imbue.mngr_kanpan.fetcher import fetch_local_snapshot
 from imbue.mngr_kanpan.fetcher import load_field_cache
 from imbue.mngr_kanpan.fetcher import save_field_cache
+from imbue.mngr_kanpan.fetcher import stream_board_snapshot
+from imbue.mngr_kanpan.fetcher import stream_local_snapshot
 from imbue.mngr_kanpan.fetcher import toggle_agent_mute
 
 DEFAULT_REFRESH_INTERVAL_SECONDS: float = 600.0
@@ -352,7 +353,14 @@ class _KanpanState(MutableModel):
     footer_right: Any  # urwid Text widget (right side of footer)
     loop: Any = None  # urwid MainLoop, set after construction
     spinner_index: int = 0
-    refresh_future: Future[FetchResult] | None = None
+    # The in-flight streaming refresh: `refresh_future` is the background thread
+    # running stream_board_snapshot (the "a refresh is running" marker, held until
+    # the final update is applied), `refresh_queue` is the thread-safe channel it
+    # posts incremental FetchUpdates on. Both are cleared together in
+    # `_finalize_refresh`.
+    refresh_future: Future[None] | None = None
+    # queue.Queue[FetchUpdate] the background stream posts on; set while in flight.
+    refresh_queue: Any = None
     # In-memory cache of fields from previous refresh cycle
     cached_fields: dict[AgentName, dict[str, FieldValue]] = {}
     executor: ThreadPoolExecutor | None = None
@@ -1702,35 +1710,44 @@ def _on_deferred_refresh(loop: MainLoop, state: _KanpanState) -> None:
 
 
 def _start_local_refresh(loop: MainLoop, state: _KanpanState) -> None:
-    """Start a local-only background refresh (no GitHub API calls)."""
+    """Start a local-only streaming refresh (no GitHub API calls).
+
+    Remote fields (PR, CI) are carried forward via the seeded cache -- see
+    `stream_local_snapshot` -- so the board keeps its last-known PR sections
+    while the fast local columns update.
+    """
     if state.refresh_future is not None:
         return
-    if state.executor is None:
-        state.executor = ThreadPoolExecutor(max_workers=1)
-    state.refresh_is_local_only = True
-    state.refresh_future = state.executor.submit(
-        fetch_local_snapshot,
-        state.mngr_ctx,
-        state.data_sources,
-        state.cached_fields,
-        state.include_filters,
-        state.exclude_filters,
-    )
-    _render_footer(state)
-    _ensure_animation_running(state)
-    _schedule_refresh_poll(loop, state)
+    _launch_refresh(loop, state, stream_local_snapshot, is_local_only=True)
 
 
 def _start_refresh(loop: MainLoop, state: _KanpanState) -> None:
-    """Start a full background refresh and begin the spinner animation."""
+    """Start a full streaming refresh and begin the spinner animation."""
+    _launch_refresh(loop, state, stream_board_snapshot, is_local_only=False)
+
+
+def _launch_refresh(
+    loop: MainLoop,
+    state: _KanpanState,
+    stream_fn: Callable[..., None],
+    is_local_only: bool,
+) -> None:
+    """Submit a streaming fetch and begin polling its update queue.
+
+    `stream_fn` posts incremental FetchUpdates onto `refresh_queue` as each data
+    source returns; `_poll_refresh_completion` drains and applies them.
+    """
     if state.executor is None:
         state.executor = ThreadPoolExecutor(max_workers=1)
-    state.refresh_is_local_only = False
+    state.refresh_is_local_only = is_local_only
+    update_queue: queue.Queue[FetchUpdate] = queue.Queue()
+    state.refresh_queue = update_queue
     state.refresh_future = state.executor.submit(
-        fetch_board_snapshot,
+        stream_fn,
         state.mngr_ctx,
         state.data_sources,
         state.cached_fields,
+        update_queue.put,
         state.include_filters,
         state.exclude_filters,
     )
@@ -1740,64 +1757,84 @@ def _start_refresh(loop: MainLoop, state: _KanpanState) -> None:
 
 
 def _schedule_refresh_poll(loop: MainLoop, state: _KanpanState) -> None:
-    """Schedule the next refresh-completion poll."""
+    """Schedule the next refresh-update poll."""
     loop.set_alarm_in(SPINNER_INTERVAL_SECONDS, _poll_refresh_completion, state)
 
 
 def _poll_refresh_completion(loop: MainLoop, state: _KanpanState) -> None:
-    """Alarm callback: poll the in-flight refresh and finish it when done.
+    """Alarm callback: drain any streamed updates and apply them.
 
-    The spinner glyph is animated by `_on_animation_tick`; this loop only watches
-    for completion so the footer has a single writer.
+    The spinner glyph is animated by `_on_animation_tick`; this loop only drains
+    the update queue so the footer has a single writer.
     """
-    if state.refresh_future is None:
+    if state.refresh_queue is None:
         return
 
-    if state.refresh_future.done():
-        _finish_refresh(loop, state)
+    updates = _drain_refresh_updates(state.refresh_queue)
+    if not updates:
+        _schedule_refresh_poll(loop, state)
         return
 
-    _schedule_refresh_poll(loop, state)
+    _apply_stream_updates(loop, state, updates)
 
 
-def _finish_refresh(loop: MainLoop, state: _KanpanState) -> None:
-    """Complete a background refresh: update snapshot and display."""
-    if state.refresh_future is None:
-        return
+def _drain_refresh_updates(update_queue: "queue.Queue[FetchUpdate]") -> list[FetchUpdate]:
+    """Drain all FetchUpdates currently queued, without blocking.
 
+    There is a single consumer (the urwid main thread), so `not empty()`
+    guarantees the following `get_nowait()` succeeds -- the background producer
+    only ever adds items.
+    """
+    updates: list[FetchUpdate] = []
+    while not update_queue.empty():
+        updates.append(update_queue.get_nowait())
+    return updates
+
+
+def _apply_stream_updates(loop: MainLoop, state: _KanpanState, updates: list[FetchUpdate]) -> None:
+    """Render the most complete drained update and finalize on the last one.
+
+    Streamed updates are cumulative (each snapshot is a superset of the previous),
+    so only the last one is rendered; the intermediate ones it superseded are
+    skipped to avoid rebuilding the board several times in one tick.
+    """
     was_local_only = state.refresh_is_local_only
-    failed = False
-    try:
-        fetch_result = state.refresh_future.result()
-        new_snapshot = fetch_result.snapshot
-        # Update in-memory field cache only for full refreshes: local-only refreshes do not
-        # produce remote fields (PR, CI, etc.), so overwriting would lose the remote data that
-        # the next full refresh needs as its cached_fields input.
-        if not was_local_only:
-            state.cached_fields = fetch_result.cached_fields
-            save_field_cache(state.mngr_ctx, state.cached_fields)
-        # For local-only refreshes, carry forward fields from previous snapshot
-        if was_local_only and state.snapshot is not None:
-            new_snapshot = _carry_forward_fields(state.snapshot, new_snapshot)
-        state.snapshot = new_snapshot
-    except Exception as e:
-        failed = True
-        logger.debug("Refresh failed: {}", e)
-        if state.snapshot is not None:
-            state.snapshot = state.snapshot.model_copy_update(
-                to_update(
-                    state.snapshot.field_ref().errors,
-                    (*state.snapshot.errors, f"Refresh failed: {e}"),
-                ),
-            )
-    finally:
-        state.refresh_future = None
-        state.refresh_is_local_only = False
-        if not was_local_only:
-            state.last_refresh_time = time.monotonic()
+    last = updates[-1]
 
-    _refresh_display(state)
-    _prune_orphaned_marks(state)
+    if last.error is not None:
+        # Hard failure: keep the current board, surface the error, and retry.
+        if state.snapshot is not None:
+            state.snapshot = _append_snapshot_error(state.snapshot, last.error)
+        _refresh_display(state)
+        _prune_orphaned_marks(state)
+        _finalize_refresh(loop, state, failed=True)
+        return
+
+    if last.snapshot is not None:
+        state.snapshot = last.snapshot
+        # Persist the field cache only for full refreshes, and only once the fetch
+        # is complete: local-only refreshes carry remote fields forward via the
+        # seed, so their (unseeded) cached_fields omit PR/CI and must not overwrite.
+        if last.is_final and not was_local_only:
+            state.cached_fields = last.cached_fields
+            save_field_cache(state.mngr_ctx, state.cached_fields)
+        _refresh_display(state)
+        _prune_orphaned_marks(state)
+
+    if last.is_final:
+        _finalize_refresh(loop, state, failed=False)
+    else:
+        _schedule_refresh_poll(loop, state)
+
+
+def _finalize_refresh(loop: MainLoop, state: _KanpanState, failed: bool) -> None:
+    """Clear the in-flight refresh state and schedule the next cycle (or a retry)."""
+    was_local_only = state.refresh_is_local_only
+    state.refresh_future = None
+    state.refresh_queue = None
+    state.refresh_is_local_only = False
+    if not was_local_only:
+        state.last_refresh_time = time.monotonic()
 
     if state.snapshot is not None and not was_local_only:
         state.last_fetch_seconds = state.snapshot.fetch_time_seconds
@@ -1807,41 +1844,18 @@ def _finish_refresh(loop: MainLoop, state: _KanpanState) -> None:
     if failed:
         _request_refresh(loop, state, state.retry_cooldown_seconds)
     elif was_local_only:
+        # A local-only refresh does not schedule the next periodic full refresh;
+        # the standing auto-refresh alarm already covers that.
         pass
     else:
         _schedule_next_refresh(loop, state)
 
 
 @pure
-def _carry_forward_fields(old: BoardSnapshot, new: BoardSnapshot) -> BoardSnapshot:
-    """Carry forward field data from a previous full snapshot for local-only refreshes.
-
-    Local-only refreshes only run git_info and repo_paths. Other fields (PR, CI, etc.)
-    are carried forward from the previous snapshot.
-    """
-    old_by_name = {entry.name: entry for entry in old.entries}
-    updated_entries: list[AgentBoardEntry] = []
-    for entry in new.entries:
-        old_entry = old_by_name.get(entry.name)
-        if old_entry is not None:
-            # Merge: new fields override old, but keep old fields not produced by local sources
-            merged_fields = dict(old_entry.fields)
-            merged_fields.update(entry.fields)
-            merged_cells = {key: field.display() for key, field in merged_fields.items()}
-            section = compute_section(merged_fields)
-            ref = entry.field_ref()
-            updated = entry.model_copy_update(
-                to_update(ref.fields, merged_fields),
-                to_update(ref.cells, merged_cells),
-                to_update(ref.section, section),
-            )
-            updated_entries.append(updated)
-        else:
-            updated_entries.append(entry)
-    return BoardSnapshot(
-        entries=tuple(updated_entries),
-        errors=new.errors,
-        fetch_time_seconds=new.fetch_time_seconds,
+def _append_snapshot_error(snapshot: BoardSnapshot, message: str) -> BoardSnapshot:
+    """Return `snapshot` with `message` appended to its errors (shown at board bottom)."""
+    return snapshot.model_copy_update(
+        to_update(snapshot.field_ref().errors, (*snapshot.errors, message)),
     )
 
 

--- a/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
+++ b/libs/mngr_kanpan/imbue/mngr_kanpan/tui_test.py
@@ -1,6 +1,7 @@
 """Unit tests for the kanpan TUI."""
 
 import io
+import queue
 import subprocess
 import threading
 from concurrent.futures import Future
@@ -44,9 +45,9 @@ from imbue.mngr_kanpan.data_types import KanpanCommand
 from imbue.mngr_kanpan.data_types import KanpanPluginConfig
 from imbue.mngr_kanpan.data_types import MarkableBuiltinCommand
 from imbue.mngr_kanpan.data_types import MarkableBuiltinRole
+from imbue.mngr_kanpan.fetcher import FetchUpdate
 from imbue.mngr_kanpan.testing import make_board_snapshot
 from imbue.mngr_kanpan.testing import make_mngr_ctx_with_config
-from imbue.mngr_kanpan.testing import make_pr_field
 from imbue.mngr_kanpan.tui import BOARD_SECTION_ORDER
 from imbue.mngr_kanpan.tui import PEEK_BODY_HEIGHT
 from imbue.mngr_kanpan.tui import _BUILTIN_COLUMN_DEFS
@@ -63,6 +64,7 @@ from imbue.mngr_kanpan.tui import _FieldCellMarkupFn
 from imbue.mngr_kanpan.tui import _FieldCellTextFn
 from imbue.mngr_kanpan.tui import _KanpanInputHandler
 from imbue.mngr_kanpan.tui import _KanpanState
+from imbue.mngr_kanpan.tui import _apply_stream_updates
 from imbue.mngr_kanpan.tui import _assemble_column_defs
 from imbue.mngr_kanpan.tui import _batch_item_label
 from imbue.mngr_kanpan.tui import _build_agent_row
@@ -74,18 +76,19 @@ from imbue.mngr_kanpan.tui import _build_legend_bindings
 from imbue.mngr_kanpan.tui import _build_mark_palette
 from imbue.mngr_kanpan.tui import _build_peek_panel
 from imbue.mngr_kanpan.tui import _cancel_peek_alarm
-from imbue.mngr_kanpan.tui import _carry_forward_fields
 from imbue.mngr_kanpan.tui import _clear_focus
 from imbue.mngr_kanpan.tui import _close_peek
 from imbue.mngr_kanpan.tui import _compute_board_column_widths
 from imbue.mngr_kanpan.tui import _compute_footer_display
 from imbue.mngr_kanpan.tui import _dispatch_command
+from imbue.mngr_kanpan.tui import _drain_refresh_updates
 from imbue.mngr_kanpan.tui import _ensure_peek_executor
 from imbue.mngr_kanpan.tui import _ensure_peek_reply_executor
 from imbue.mngr_kanpan.tui import _execute_marks
 from imbue.mngr_kanpan.tui import _execute_next_in_batch
 from imbue.mngr_kanpan.tui import _field_cell_markup
 from imbue.mngr_kanpan.tui import _field_cell_text
+from imbue.mngr_kanpan.tui import _finalize_refresh
 from imbue.mngr_kanpan.tui import _find_entry_by_name
 from imbue.mngr_kanpan.tui import _finish_batch_execution
 from imbue.mngr_kanpan.tui import _flatten_markup_to_attr
@@ -514,6 +517,115 @@ def test_render_footer_is_single_writer_no_flicker() -> None:
     assert second.startswith("  Running deploy on agent-a")
 
 
+# =============================================================================
+# Streaming refresh: draining and applying incremental updates
+# =============================================================================
+
+
+def test_drain_refresh_updates_drains_all_in_order() -> None:
+    update_queue: queue.Queue[FetchUpdate] = queue.Queue()
+    first = FetchUpdate(snapshot=make_board_snapshot(entries=()), is_final=False)
+    second = FetchUpdate(snapshot=make_board_snapshot(entries=()), is_final=True)
+    update_queue.put(first)
+    update_queue.put(second)
+    drained = _drain_refresh_updates(update_queue)
+    assert drained == [first, second]
+    # The queue is now empty; a second drain yields nothing.
+    assert _drain_refresh_updates(update_queue) == []
+
+
+def test_apply_stream_updates_nonfinal_keeps_refresh_in_flight() -> None:
+    state = _make_state()
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    snapshot = make_board_snapshot(entries=(_make_entry(name="a"),))
+    _apply_stream_updates(loop, state, [FetchUpdate(snapshot=snapshot, is_final=False)])
+    # The base snapshot is rendered, but the refresh stays in flight and another
+    # poll is scheduled.
+    assert state.snapshot is snapshot
+    assert state.refresh_future is not None
+    assert state.refresh_queue is not None
+    assert loop._alarm_tracker.call_count == 1
+
+
+def test_apply_stream_updates_coalesces_to_last_snapshot(tmp_path: Path) -> None:
+    state = _make_state()
+    state.mngr_ctx = cast(Any, SimpleNamespace(profile_dir=tmp_path))
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    partial = make_board_snapshot(entries=(_make_entry(name="a"),))
+    complete = make_board_snapshot(entries=(_make_entry(name="a"), _make_entry(name="b")))
+    _apply_stream_updates(
+        loop,
+        state,
+        [FetchUpdate(snapshot=partial, is_final=False), FetchUpdate(snapshot=complete, is_final=True)],
+    )
+    # Only the last (most complete) update is rendered.
+    assert state.snapshot is complete
+
+
+def test_apply_stream_updates_final_finalizes_and_clears_in_flight(tmp_path: Path) -> None:
+    state = _make_state()
+    state.mngr_ctx = cast(Any, SimpleNamespace(profile_dir=tmp_path))
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    snapshot = make_board_snapshot(entries=(_make_entry(name="a"),))
+    _apply_stream_updates(loop, state, [FetchUpdate(snapshot=snapshot, cached_fields={}, is_final=True)])
+    assert state.snapshot is snapshot
+    assert state.refresh_future is None
+    assert state.refresh_queue is None
+
+
+def test_apply_stream_updates_error_preserves_board_and_appends_error() -> None:
+    old_snapshot = make_board_snapshot(entries=(_make_entry(name="a"),))
+    state = _make_state(snapshot=old_snapshot)
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    _apply_stream_updates(loop, state, [FetchUpdate(error="boom", is_final=True)])
+    # The prior board is preserved (its single entry survives) and the error is
+    # surfaced at the bottom of the board.
+    assert state.snapshot is not None
+    assert len(state.snapshot.entries) == 1
+    assert any("boom" in err for err in state.snapshot.errors)
+    # The failed refresh is finalized (no longer in flight).
+    assert state.refresh_future is None
+    assert state.refresh_queue is None
+
+
+def test_finalize_refresh_full_clears_state() -> None:
+    state = _make_state(snapshot=make_board_snapshot(entries=()))
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    state.refresh_is_local_only = False
+    _finalize_refresh(loop, state, failed=False)
+    assert state.refresh_future is None
+    assert state.refresh_queue is None
+    assert state.last_refresh_time > 0.0
+
+
+def test_finalize_refresh_local_only_does_not_stamp_refresh_time() -> None:
+    state = _make_state(snapshot=make_board_snapshot(entries=()))
+    loop = _make_mock_loop()
+    state.loop = loop
+    state.refresh_future = cast(Any, object())
+    state.refresh_queue = cast(Any, object())
+    state.refresh_is_local_only = True
+    _finalize_refresh(loop, state, failed=False)
+    # A local-only refresh must not advance the full-refresh cooldown clock.
+    assert state.last_refresh_time == 0.0
+    assert state.refresh_future is None
+
+
 def test_update_snapshot_mute() -> None:
     entry = _make_entry(is_muted=False)
     state = _make_state(snapshot=make_board_snapshot(entries=(entry,)))
@@ -837,60 +949,6 @@ def test_build_agent_row_muted_section_overrides_stale() -> None:
     widths = _compute_board_column_widths((entry,), column_defs)
     row = _build_agent_row(entry, widths, column_defs, now=now, staleness_threshold_seconds=1800.0)
     assert _ci_widget_attr(row) == "muted"
-
-
-# =============================================================================
-# Carry forward fields
-# =============================================================================
-
-
-def test_carry_forward_fields_merges() -> None:
-    old_entry = _make_entry(
-        name="a",
-        fields={
-            "pr": make_pr_field(created=datetime(2027, 1, 1, 0, 0, 7, tzinfo=timezone.utc)),
-            "commits_ahead": CommitsAheadField(
-                count=3, has_work_dir=True, created=datetime(2027, 1, 1, 0, 0, 8, tzinfo=timezone.utc)
-            ),
-        },
-        cells={
-            "pr": make_pr_field(created=datetime(2027, 1, 1, 0, 0, 9, tzinfo=timezone.utc)).display(),
-            "commits_ahead": CommitsAheadField(
-                count=3, has_work_dir=True, created=datetime(2027, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
-            ).display(),
-        },
-    )
-    new_entry = _make_entry(
-        name="a",
-        fields={
-            "commits_ahead": CommitsAheadField(
-                count=5, has_work_dir=True, created=datetime(2027, 1, 1, 0, 0, 11, tzinfo=timezone.utc)
-            )
-        },
-        cells={
-            "commits_ahead": CommitsAheadField(
-                count=5, has_work_dir=True, created=datetime(2027, 1, 1, 0, 0, 12, tzinfo=timezone.utc)
-            ).display()
-        },
-    )
-    old_snapshot = make_board_snapshot(entries=(old_entry,))
-    new_snapshot = make_board_snapshot(entries=(new_entry,))
-    result = _carry_forward_fields(old_snapshot, new_snapshot)
-    merged = result.entries[0]
-    assert "pr" in merged.fields
-    assert "commits_ahead" in merged.fields
-    ca_field = merged.fields["commits_ahead"]
-    assert isinstance(ca_field, CommitsAheadField)
-    assert ca_field.count == 5
-
-
-def test_carry_forward_fields_new_agent() -> None:
-    new_entry = _make_entry(name="new-agent")
-    old_snapshot = make_board_snapshot(entries=())
-    new_snapshot = make_board_snapshot(entries=(new_entry,))
-    result = _carry_forward_fields(old_snapshot, new_snapshot)
-    assert len(result.entries) == 1
-    assert result.entries[0].name == AgentName("new-agent")
 
 
 # =============================================================================


### PR DESCRIPTION
## What

Makes `mngr kanpan` refreshes feel fast. Instead of blocking the whole board on the slowest data source (the GitHub PR/CI fetch), kanpan now lists the agents, paints the board immediately, and fills in each column the moment its data source returns.

## How

- `stream_board_snapshot` / `stream_local_snapshot` (fetcher.py) run in a background thread and `post` a progressively more complete `FetchUpdate` onto a queue as each data source finishes. The urwid main loop drains the queue each poll tick and re-renders (`_launch_refresh` / `_poll_refresh_completion` / `_apply_stream_updates` / `_finalize_refresh` in tui.py).
- The initial paint is **seeded from the last-known cached values** (rendered stale by their age), so agents stay in their previous PR sections and only update in place when fresh data lands — the board no longer collapses to a flat list on every refresh.
- Once every source has reported, a fresh value fully governs its column (a stale seeded value it does not reproduce is dropped), so the final board is byte-for-byte what the old all-at-once fetch produced. There's an acceptance test asserting stream-final == batch.
- This subsumes the old local-refresh `_carry_forward_fields`: a local-only refresh simply runs no remote source, so PR/CI keys are never reclaimed and their seeded values persist. That function and its tests are removed.
- Batch and streaming source runs now share one `_compute_source_safely` helper — a single point where a misbehaving data source is caught.

## Testing

- `just test-quick libs/mngr_kanpan` (unit + integration, non-tmux): 478 passed.
- `test_fetcher_acceptance.py` (real agents via local provider): 17 passed, including 6 new streaming tests (base-before-source, seed-then-replace, seed-drop, stream==batch parity, local carry-forward).
- New tui unit tests for the drain/apply/finalize path.
- Manual tmux smoke test of the live TUI: board paints immediately, stays populated in its sections mid-refresh (footer shows `Refreshing`), settles to `Refreshed just now`.
- `vet` (agentic): no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)